### PR TITLE
Editor page resize and units conversion

### DIFF
--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -47,10 +47,10 @@ const Editor = styled.div`
 		/ minmax(${ LIBRARY_MIN_WIDTH }px, ${ LIBRARY_MAX_WIDTH }px) 1fr minmax(${ INSPECTOR_MIN_WIDTH }px, ${ INSPECTOR_MAX_WIDTH }px);
 `;
 
-// @todo: set `overflow: hidden;` once page size is responsive.
 const Area = styled.div`
 	grid-area: ${ ( { area } ) => area };
 	position: relative;
+	overflow: hidden;
 	z-index: ${ ( { area } ) => area === 'canv' ? 1 : 2 };
 	overflow: hidden;
 `;

--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -52,7 +52,6 @@ const Area = styled.div`
 	position: relative;
 	overflow: hidden;
 	z-index: ${ ( { area } ) => area === 'canv' ? 1 : 2 };
-	overflow: hidden;
 `;
 
 function Layout() {

--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -20,6 +20,11 @@
 import styled from 'styled-components';
 
 /**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import EditLayer from './editLayer';
@@ -27,6 +32,7 @@ import DisplayLayer from './displayLayer';
 import FramesLayer from './framesLayer';
 import NavLayer from './navLayer';
 import SelectionCanvas from './selectionCanvas';
+import { useLayoutParams, useLayoutParamsCssVars } from './layout';
 
 const Background = styled.div`
 	background-color: ${ ( { theme } ) => theme.colors.bg.v1 };
@@ -37,8 +43,15 @@ const Background = styled.div`
 `;
 
 function CanvasLayout() {
+	const backgroundRef = useRef( null );
+
+	useLayoutParams( backgroundRef );
+	const layoutParamsCss = useLayoutParamsCssVars();
+
 	return (
-		<Background>
+		<Background
+			ref={ backgroundRef }
+			style={ layoutParamsCss }>
 			<SelectionCanvas>
 				<DisplayLayer />
 				<NavLayer />

--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -28,6 +28,8 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { useStory } from '../../app';
+import { PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
+import UnitsProvider from '../../units/unitsProvider';
 import useEditingElement from './useEditingElement';
 import useCanvasSelectionCopyPaste from './useCanvasSelectionCopyPaste';
 import Context from './context';
@@ -35,9 +37,7 @@ import Context from './context';
 function CanvasProvider( { children } ) {
 	const [ lastSelectionEvent, setLastSelectionEvent ] = useState( null );
 
-	// @todo: most likely can be simplified/redone once we deal with changing
-	// page size and offsets. We can simply pass the page's boundaries here
-	// instead of the whole element.
+	const [ pageSize, setPageSize ] = useState( { width: PAGE_WIDTH, height: PAGE_HEIGHT } );
 	const [ pageContainer, setPageContainer ] = useState( null );
 
 	const {
@@ -123,6 +123,7 @@ function CanvasProvider( { children } ) {
 			editingElementState,
 			isEditing: Boolean( editingElement ),
 			lastSelectionEvent,
+			pageSize,
 		},
 		actions: {
 			setPageContainer,
@@ -134,12 +135,15 @@ function CanvasProvider( { children } ) {
 			selectIntersection,
 			registerTransformHandler,
 			pushTransform,
+			setPageSize,
 		},
 	};
 
 	return (
 		<Context.Provider value={ state }>
-			{ children }
+			<UnitsProvider pageSize={ pageSize }>
+				{ children }
+			</UnitsProvider>
 		</Context.Provider>
 	);
 }

--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -28,7 +28,7 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { useStory } from '../../app';
-import { PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
+import { DEFAULT_EDITOR_PAGE_WIDTH, DEFAULT_EDITOR_PAGE_HEIGHT } from '../../constants';
 import UnitsProvider from '../../units/unitsProvider';
 import useEditingElement from './useEditingElement';
 import useCanvasSelectionCopyPaste from './useCanvasSelectionCopyPaste';
@@ -37,7 +37,10 @@ import Context from './context';
 function CanvasProvider( { children } ) {
 	const [ lastSelectionEvent, setLastSelectionEvent ] = useState( null );
 
-	const [ pageSize, setPageSize ] = useState( { width: PAGE_WIDTH, height: PAGE_HEIGHT } );
+	const [ pageSize, setPageSize ] = useState( {
+		width: DEFAULT_EDITOR_PAGE_WIDTH,
+		height: DEFAULT_EDITOR_PAGE_HEIGHT,
+	} );
 	const [ pageContainer, setPageContainer ] = useState( null );
 
 	const {

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -82,6 +82,7 @@ function Carousel() {
 	const openModal = useCallback( () => setIsGridViewOpen( true ), [ setIsGridViewOpen ] );
 	const closeModal = useCallback( () => setIsGridViewOpen( false ), [ setIsGridViewOpen ] );
 
+	// QQQQ: useResizeObserver
 	useLayoutEffect( () => {
 		const observer = new ResizeObserver( ( entries ) => {
 			for ( const entry of entries ) {

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -66,11 +66,6 @@ function DisplayElement( { element } ) {
 		}
 	} );
 
-	// QQQQQ
-	if ( type !== 'image' ) {
-		return null;
-	}
-
 	return (
 		<Wrapper
 			ref={ wrapperRef }

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
 
 /**
  * WordPress dependencies
@@ -29,7 +28,9 @@ import { useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { getDefinitionForType } from '../../elements';
-import { ElementWithPosition, ElementWithSize, ElementWithRotation, getBox } from '../../elements/shared';
+import { ElementWithPosition, ElementWithSize, ElementWithRotation } from '../../elements/shared';
+import StoryPropTypes from '../../types';
+import { useUnits } from '../../units';
 import useTransformHandler from './useTransformHandler';
 
 const Wrapper = styled.div`
@@ -39,27 +40,17 @@ const Wrapper = styled.div`
 	contain: layout paint;
 `;
 
-function DisplayElement( {
-	element: {
-		id,
-		type,
-		x,
-		y,
-		width,
-		height,
-		rotationAngle,
-		isFullbleed,
-		...rest
-	},
-} ) {
+function DisplayElement( { element } ) {
+	const { actions: { getBox } } = useUnits();
+
+	const { id, type } = element;
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const { Display } = getDefinitionForType( type );
 
 	const wrapperRef = useRef( null );
 
-	const box = getBox( { x, y, width, height, rotationAngle, isFullbleed } );
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const props = { ...box, ...rest, id };
+	const box = getBox( element );
 
 	useTransformHandler( id, ( transform ) => {
 		const target = wrapperRef.current;
@@ -75,18 +66,23 @@ function DisplayElement( {
 		}
 	} );
 
+	// QQQQQ
+	if ( type !== 'image' ) {
+		return null;
+	}
+
 	return (
 		<Wrapper
 			ref={ wrapperRef }
 			{ ...box }
 		>
-			<Display { ...props } />
+			<Display element={ element } box={ box } />
 		</Wrapper>
 	);
 }
 
 DisplayElement.propTypes = {
-	element: PropTypes.object.isRequired,
+	element: StoryPropTypes.element.isRequired,
 };
 
 export default DisplayElement;

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -27,7 +27,7 @@ import useCanvas from './useCanvas';
 import DisplayElement from './displayElement';
 import { Layer, PageArea } from './layout';
 
-const DisplayPageArea = styled( PageArea ).attrs( { className: 'container', overflow: false } )`
+const DisplayPageArea = styled( PageArea ).attrs( { className: 'container', overflowAllowed: false } )`
 	background-color: ${ ( { theme } ) => theme.colors.fg.v1 };
 `;
 

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -41,7 +41,7 @@ function DisplayLayer() {
 	} = useCanvas();
 
 	return (
-		<Layer pointerEvents={ false }>
+		<Layer pointerEvents="none">
 			<DisplayPageArea ref={ setPageContainer }>
 				{ currentPage && currentPage.elements.map( ( { id, ...rest } ) => {
 					if ( editingElement === id ) {

--- a/assets/src/edit-story/components/canvas/editElement.js
+++ b/assets/src/edit-story/components/canvas/editElement.js
@@ -24,7 +24,8 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { getDefinitionForType } from '../../elements';
-import { ElementWithPosition, ElementWithSize, ElementWithRotation, getBox } from '../../elements/shared';
+import { ElementWithPosition, ElementWithSize, ElementWithRotation } from '../../elements/shared';
+import { useUnits } from '../../units';
 
 // Background color is used to make the edited element more prominent and
 // easier to see.
@@ -36,32 +37,22 @@ const Wrapper = styled.div`
 	background-color: ${ ( { theme } ) => theme.colors.whiteout };
 `;
 
-function EditElement( {
-	element: {
-		id,
-		type,
-		x,
-		y,
-		width,
-		height,
-		rotationAngle,
-		isFullbleed,
-		...rest
-	},
-} ) {
+function EditElement( { element } ) {
+	const { type } = element;
+	const { actions: { getBox } } = useUnits();
+
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const { Edit } = getDefinitionForType( type );
 
-	const box = getBox( { x, y, width, height, rotationAngle, isFullbleed } );
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const props = { ...box, ...rest, id };
+	const box = getBox( element );
 
 	return (
 		<Wrapper
 			{ ...box }
 			onMouseDown={ ( evt ) => evt.stopPropagation() }
 		>
-			<Edit { ...props } />
+			<Edit element={ element } box={ box } />
 		</Wrapper>
 	);
 }

--- a/assets/src/edit-story/components/canvas/editLayer.js
+++ b/assets/src/edit-story/components/canvas/editLayer.js
@@ -55,7 +55,7 @@ function EditLayer( {} ) {
 	const { editModeGrayout } = getDefinitionForType( editingElement.type );
 
 	return (
-		<LayerWithGrayout grayout={ editModeGrayout } pointerEvents={ false }>
+		<LayerWithGrayout grayout={ editModeGrayout } pointerEvents="none">
 			<EditPageArea>
 				<EditElement element={ editingElement } />
 			</EditPageArea>

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -30,7 +30,8 @@ import { useLayoutEffect, useRef } from '@wordpress/element';
  */
 import { getDefinitionForType } from '../../elements';
 import { useStory } from '../../app';
-import { ElementWithPosition, ElementWithSize, ElementWithRotation, getBox } from '../../elements/shared';
+import { ElementWithPosition, ElementWithSize, ElementWithRotation } from '../../elements/shared';
+import { useUnits } from '../../units';
 import useCanvas from './useCanvas';
 
 const Wrapper = styled.div`
@@ -46,42 +47,27 @@ const Wrapper = styled.div`
 	}
 `;
 
-function FrameElement( {
-	element: {
-		id,
-		type,
-		x,
-		y,
-		width,
-		height,
-		rotationAngle,
-		isFullbleed,
-		...rest
-	},
-} ) {
+function FrameElement( { element } ) {
+	const { id, type } = element;
 	const { Frame } = getDefinitionForType( type );
-	const element = useRef();
+	const elementRef = useRef();
 
-	const {
-		actions: { setNodeForElement, handleSelectElement },
-	} = useCanvas();
-
-	const {
-		state: { selectedElements },
-	} = useStory();
+	const { actions: { setNodeForElement, handleSelectElement } } = useCanvas();
+	const { state: { selectedElements } } = useStory();
+	const { actions: { getBox } } = useUnits();
 
 	useLayoutEffect( () => {
-		setNodeForElement( id, element.current );
+		setNodeForElement( id, elementRef.current );
 	}, [ id, setNodeForElement ] );
 
 	const isSelected = selectedElements.includes( id );
 
-	const box = getBox( { x, y, width, height, rotationAngle, isFullbleed } );
-	const props = { ...box, ...rest, id };
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const box = getBox( element );
 
 	return (
 		<Wrapper
-			ref={ element }
+			ref={ elementRef }
 			{ ...box }
 			onMouseDown={ ( evt ) => {
 				if ( ! isSelected ) {
@@ -91,7 +77,7 @@ function FrameElement( {
 			} }
 		>
 			{ Frame && (
-				<Frame { ...props } />
+				<Frame element={ element } box={ box } />
 			) }
 		</Wrapper>
 	);

--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -28,7 +28,7 @@ import { Layer, PageArea } from './layout';
 import FrameElement from './frameElement';
 import Selection from './selection';
 
-const FramesPageArea = withOverlay( styled( PageArea ).attrs( { className: 'container', pointerEvents: true } )`
+const FramesPageArea = withOverlay( styled( PageArea ).attrs( { className: 'container', pointerEvents: 'initial' } )`
 	background-color: ${ ( { theme } ) => theme.colors.fg.v1 };
 ` );
 
@@ -36,7 +36,7 @@ function FramesLayer() {
 	const { state: { currentPage } } = useStory();
 
 	return (
-		<Layer pointerEvents={ false }>
+		<Layer pointerEvents="none">
 			<FramesPageArea>
 				{ currentPage && currentPage.elements.map( ( { id, ...rest } ) => {
 					return (

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -34,10 +34,15 @@ import useCanvas from './useCanvas';
 
 const MENU_HEIGHT = 48;
 const MIN_CAROUSEL_HEIGHT = 80;
+
+const MEDIUM_EDITOR_PAGE_WIDTH = 268;
+const MEDIUM_EDITOR_PAGE_HEIGHT = 476;
+const SMALL_EDITOR_PAGE_WIDTH = 223;
+const SMALL_EDITOR_PAGE_HEIGHT = 396;
 const ALLOWED_PAGE_SIZES = [
 	[ DEFAULT_EDITOR_PAGE_WIDTH, DEFAULT_EDITOR_PAGE_HEIGHT ],
-	[ 268, 476 ],
-	[ 223, 396 ],
+	[ MEDIUM_EDITOR_PAGE_WIDTH, MEDIUM_EDITOR_PAGE_HEIGHT ],
+	[ SMALL_EDITOR_PAGE_WIDTH, SMALL_EDITOR_PAGE_HEIGHT ],
 ];
 
 // @todo: the menu and carousel heights are not correct until we make a var-size

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -33,10 +33,11 @@ import useCanvas from './useCanvas';
  */
 
 const MENU_HEIGHT = 48;
-const MIN_CAROUSEL_HEIGHT = 65;
+const MIN_CAROUSEL_HEIGHT = 80;
 const ALLOWED_PAGE_SIZES = [
 	[ PAGE_WIDTH, PAGE_HEIGHT ],
 	[ 268, 476 ],
+	[ 223, 396 ],
 ];
 
 // @todo: the menu and carousel heights are not correct until we make a var-size

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -23,7 +23,7 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { DEFAULT_EDITOR_PAGE_WIDTH, DEFAULT_EDITOR_PAGE_HEIGHT, HEADER_HEIGHT, PAGE_NAV_WIDTH } from '../../constants';
-import PointerEventsCss from '../../utils/pointerEventsCss';
+import pointerEventsCss from '../../utils/pointerEventsCss';
 import useResizeEffect from '../../utils/useResizeEffect';
 import useCanvas from './useCanvas';
 
@@ -43,7 +43,7 @@ const ALLOWED_PAGE_SIZES = [
 // @todo: the menu and carousel heights are not correct until we make a var-size
 // page.
 const Layer = styled.div`
-	${ PointerEventsCss }
+	${ pointerEventsCss }
 
 	position: absolute;
 	top: 0;
@@ -63,7 +63,7 @@ const Layer = styled.div`
 `;
 
 const Area = styled.div`
-	${ PointerEventsCss }
+	${ pointerEventsCss }
 
 	grid-area: ${ ( { area } ) => area };
 	overflow: ${ ( { overflowAllowed } ) => overflowAllowed ? 'visible' : 'hidden' };

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { PAGE_NAV_WIDTH, PAGE_WIDTH, PAGE_HEIGHT, HEADER_HEIGHT } from '../../constants';
+import { DEFAULT_EDITOR_PAGE_WIDTH, DEFAULT_EDITOR_PAGE_HEIGHT, HEADER_HEIGHT, PAGE_NAV_WIDTH } from '../../constants';
 import PointerEventsCss from '../../utils/pointerEventsCss';
 import useResizeEffect from '../../utils/useResizeEffect';
 import useCanvas from './useCanvas';
@@ -35,7 +35,7 @@ import useCanvas from './useCanvas';
 const MENU_HEIGHT = 48;
 const MIN_CAROUSEL_HEIGHT = 80;
 const ALLOWED_PAGE_SIZES = [
-	[ PAGE_WIDTH, PAGE_HEIGHT ],
+	[ DEFAULT_EDITOR_PAGE_WIDTH, DEFAULT_EDITOR_PAGE_HEIGHT ],
 	[ 268, 476 ],
 	[ 223, 396 ],
 ];

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -66,7 +66,7 @@ const Area = styled.div`
 	${ PointerEventsCss }
 
 	grid-area: ${ ( { area } ) => area };
-	overflow: ${ ( { overflow } ) => overflow ? 'visible' : 'hidden' };
+	overflow: ${ ( { overflowAllowed } ) => overflowAllowed ? 'visible' : 'hidden' };
 	position: relative;
 	width: 100%;
 	height: 100%;
@@ -74,13 +74,13 @@ const Area = styled.div`
 
 // Page area is not `overflow:hidden` by default to allow different clipping
 // mechanisms.
-const PageArea = styled( Area ).attrs( { area: 'page', overflow: true } )``;
+const PageArea = styled( Area ).attrs( { area: 'page', overflowAllowed: true } )``;
 
-const HeadArea = styled( Area ).attrs( { area: 'head', overflow: false } )``;
+const HeadArea = styled( Area ).attrs( { area: 'head', overflowAllowed: false } )``;
 
-const MenuArea = styled( Area ).attrs( { area: 'menu', overflow: false } )``;
+const MenuArea = styled( Area ).attrs( { area: 'menu', overflowAllowed: false } )``;
 
-const NavArea = styled( Area ).attrs( { overflow: false } )`
+const NavArea = styled( Area ).attrs( { overflowAllowed: false } )`
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -90,7 +90,7 @@ const NavPrevArea = styled( NavArea ).attrs( { area: 'prev' } )``;
 
 const NavNextArea = styled( NavArea ).attrs( { area: 'next' } )``;
 
-const CarouselArea = styled( Area ).attrs( { area: 'carousel', overflow: false } )``;
+const CarouselArea = styled( Area ).attrs( { area: 'carousel', overflowAllowed: false } )``;
 
 /**
  * @param {!{current: ?Element}} containerRef

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -24,11 +24,20 @@ import styled from 'styled-components';
  */
 import { PAGE_NAV_WIDTH, PAGE_WIDTH, PAGE_HEIGHT, HEADER_HEIGHT } from '../../constants';
 import PointerEventsCss from '../../utils/pointerEventsCss';
+import useResizeEffect from '../../utils/useResizeEffect';
+import useCanvas from './useCanvas';
 
 /**
  * @file See https://user-images.githubusercontent.com/726049/72654503-bfffe780-3944-11ea-912c-fc54d68b6100.png
  * for the layering details.
  */
+
+const MENU_HEIGHT = 48;
+const MIN_CAROUSEL_HEIGHT = 65;
+const ALLOWED_PAGE_SIZES = [
+	[ PAGE_WIDTH, PAGE_HEIGHT ],
+	[ 268, 476 ],
+];
 
 // @todo: the menu and carousel heights are not correct until we make a var-size
 // page.
@@ -45,11 +54,11 @@ const Layer = styled.div`
 	grid:
 		"head      head      head      head      head    " ${ HEADER_HEIGHT }px
 		".         .         .         .         .       " 1fr
-		".         prev      page      next      .       " ${ PAGE_HEIGHT }px
-		".         .         menu      .         .       " 48px
+		".         prev      page      next      .       " var(--page-height-px)
+		".         .         menu      .         .       " ${ MENU_HEIGHT }px
 		".         .         .         .         .       " 1fr
-		"carousel  carousel  carousel  carousel  carousel" 65px
-		/ 1fr ${ PAGE_NAV_WIDTH }px ${ PAGE_WIDTH }px ${ PAGE_NAV_WIDTH }px 1fr;
+		"carousel  carousel  carousel  carousel  carousel" ${ MIN_CAROUSEL_HEIGHT }px
+		/ 1fr ${ PAGE_NAV_WIDTH }px var(--page-width-px) ${ PAGE_NAV_WIDTH }px 1fr;
 `;
 
 const Area = styled.div`
@@ -82,6 +91,39 @@ const NavNextArea = styled( NavArea ).attrs( { area: 'next' } )``;
 
 const CarouselArea = styled( Area ).attrs( { area: 'carousel', overflow: false } )``;
 
+/**
+ * @param {!{current: ?Element}} containerRef
+ */
+function useLayoutParams( containerRef ) {
+	const { actions: { setPageSize } } = useCanvas();
+
+	useResizeEffect( containerRef, ( { width, height } ) => {
+		// See Layer's `grid` CSS above. Per the layout, the maximum available
+		// space for the page is:
+		const maxWidth = width - ( PAGE_NAV_WIDTH * 2 );
+		const maxHeight = height - HEADER_HEIGHT - MENU_HEIGHT - MIN_CAROUSEL_HEIGHT;
+
+		// Find the first size that fits within the [maxWidth, maxHeight].
+		let bestSize = ALLOWED_PAGE_SIZES[ ALLOWED_PAGE_SIZES.length - 1 ];
+		for ( let i = 0; i < ALLOWED_PAGE_SIZES.length; i++ ) {
+			const size = ALLOWED_PAGE_SIZES[ i ];
+			if ( size[ 0 ] <= maxWidth && size[ 1 ] <= maxHeight ) {
+				bestSize = size;
+				break;
+			}
+		}
+		setPageSize( { width: bestSize[ 0 ], height: bestSize[ 1 ] } );
+	} );
+}
+
+function useLayoutParamsCssVars() {
+	const { state: { pageSize } } = useCanvas();
+	return {
+		'--page-width-px': `${ pageSize.width }px`,
+		'--page-height-px': `${ pageSize.height }px`,
+	};
+}
+
 export {
 	Layer,
 	PageArea,
@@ -90,4 +132,6 @@ export {
 	NavPrevArea,
 	NavNextArea,
 	CarouselArea,
+	useLayoutParams,
+	useLayoutParamsCssVars,
 };

--- a/assets/src/edit-story/components/canvas/multiSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/multiSelectionMovable.js
@@ -31,6 +31,7 @@ import Movable from '../movable';
 import { useStory } from '../../app/story';
 import calculateFitTextFontSize from '../../utils/calculateFitTextFontSize';
 import { useUnits } from '../../units';
+import { MIN_FONT_SIZE, MAX_FONT_SIZE } from '../../constants';
 import useCanvas from './useCanvas';
 
 const CORNER_HANDLES = [ 'nw', 'ne', 'sw', 'se' ];
@@ -48,7 +49,12 @@ function MultiSelectionMovable( { selectedElements, nodesById } ) {
 
 	const { actions: { updateElementsById } } = useStory();
 	const { actions: { pushTransform } } = useCanvas();
-	const { actions: { editorToDataX, editorToDataY } } = useUnits();
+	const { actions: { dataToEditorY, editorToDataX, editorToDataY } } = useUnits();
+
+	const minMaxFontSize = {
+		minFontSize: dataToEditorY( MIN_FONT_SIZE ),
+		maxFontSize: dataToEditorY( MAX_FONT_SIZE ),
+	};
 
 	// Create targets list including nodes and also necessary attributes.
 	const targetList = selectedElements.map( ( element ) => ( {
@@ -129,7 +135,7 @@ function MultiSelectionMovable( { selectedElements, nodesById } ) {
 				properties.height = editorToDataY( editorHeight );
 				const isText = 'text' === targetList[ i ].type;
 				if ( isText ) {
-					properties.fontSize = editorToDataY( calculateFitTextFontSize( target.firstChild, editorHeight, editorWidth ) );
+					properties.fontSize = editorToDataY( calculateFitTextFontSize( target.firstChild, editorHeight, editorWidth, minMaxFontSize ) );
 				}
 			}
 			updateElementsById( { elementIds: [ targetList[ i ].id ], properties } );
@@ -193,7 +199,7 @@ function MultiSelectionMovable( { selectedElements, nodesById } ) {
 					target.style.height = `${ height }px`;
 					if ( isText ) {
 						// For text: update font size, too.
-						target.style.fontSize = calculateFitTextFontSize( target.firstChild, height, width );
+						target.style.fontSize = calculateFitTextFontSize( target.firstChild, height, width, minMaxFontSize );
 					}
 					sFrame.translate = drag.beforeTranslate;
 					sFrame.resize = [ width, height ];

--- a/assets/src/edit-story/components/canvas/multiSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/multiSelectionMovable.js
@@ -130,7 +130,8 @@ function MultiSelectionMovable( { selectedElements, nodesById } ) {
 			if ( isRotate ) {
 				properties.rotationAngle = frame.rotate;
 			}
-			if ( isResize && editorWidth !== 0 && editorHeight !== 0 ) {
+			const didResize = editorWidth !== 0 && editorHeight !== 0;
+			if ( isResize && didResize ) {
 				properties.width = editorToDataX( editorWidth );
 				properties.height = editorToDataY( editorHeight );
 				const isText = 'text' === targetList[ i ].type;

--- a/assets/src/edit-story/components/canvas/navLayer.js
+++ b/assets/src/edit-story/components/canvas/navLayer.js
@@ -32,11 +32,11 @@ import {
 
 function NavLayer() {
 	return (
-		<Layer pointerEvents={ false } onMouseDown={ ( evt ) => evt.stopPropagation() }>
-			<HeadArea pointerEvents={ true }>
+		<Layer pointerEvents="none" onMouseDown={ ( evt ) => evt.stopPropagation() }>
+			<HeadArea pointerEvents="initial">
 				<Header />
 			</HeadArea>
-			<MenuArea pointerEvents={ true }>
+			<MenuArea pointerEvents="initial">
 				<PageMenu />
 			</MenuArea>
 			<NavPrevArea>
@@ -45,7 +45,7 @@ function NavLayer() {
 			<NavNextArea>
 				<PageNav />
 			</NavNextArea>
-			<CarouselArea pointerEvents={ true }>
+			<CarouselArea pointerEvents="initial">
 				<Carousel />
 			</CarouselArea>
 		</Layer>

--- a/assets/src/edit-story/components/canvas/selectionCanvas.js
+++ b/assets/src/edit-story/components/canvas/selectionCanvas.js
@@ -29,9 +29,10 @@ import { useEffect, useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { useStory } from '../../app';
-import useCanvas from '../canvas/useCanvas';
 import withOverlay from '../overlay/withOverlay';
 import InOverlay from '../overlay';
+import { useUnits } from '../../units';
+import useCanvas from './useCanvas';
 
 const LassoMode = {
 	OFF: 0,
@@ -58,13 +59,9 @@ const Lasso = styled.div`
 `;
 
 function SelectionCanvas( { children } ) {
-	const {
-		actions: { clearSelection },
-	} = useStory();
-	const {
-		state: { pageContainer },
-		actions: { clearEditing, selectIntersection },
-	} = useCanvas();
+	const { actions: { clearSelection } } = useStory();
+	const { state: { pageContainer }, actions: { clearEditing, selectIntersection } } = useCanvas();
+	const { actions: { editorToDataX, editorToDataY } } = useUnits();
 
 	const overlayRef = useRef( null );
 	const lassoRef = useRef( null );
@@ -132,9 +129,11 @@ function SelectionCanvas( { children } ) {
 
 	const onMouseUp = ( ) => {
 		if ( lassoModeRef.current === LassoMode.ON ) {
-			const [ ox, oy, width, height ] = getLassoBox();
-			const x = ox - pageContainer.offsetLeft;
-			const y = oy - pageContainer.offsetTop;
+			const [ lx, ly, lwidth, lheight ] = getLassoBox();
+			const x = editorToDataX( lx - pageContainer.offsetLeft );
+			const y = editorToDataY( ly - pageContainer.offsetTop );
+			const width = editorToDataX( lwidth );
+			const height = editorToDataY( lheight );
 			clearSelection();
 			clearEditing();
 			selectIntersection( { x, y, width, height } );

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -179,15 +179,17 @@ function SingleSelectionMovable( {
 				setTransformStyle( target );
 			} }
 			onResizeEnd={ ( { target } ) => {
-				if ( frame.resize[ 0 ] !== 0 && frame.resize[ 1 ] !== 0 ) {
+				const editorWidth = frame.resize[ 0 ];
+				const editorHeight = frame.resize[ 1 ];
+				if ( editorWidth !== 0 && editorHeight !== 0 ) {
 					const properties = {
-						width: editorToDataX( frame.resize[ 0 ] ),
-						height: editorToDataY( frame.resize[ 1 ] ),
+						width: editorToDataX( editorWidth ),
+						height: editorToDataY( editorHeight ),
 						x: selectedElement.x + editorToDataX( frame.translate[ 0 ] ),
 						y: selectedElement.y + editorToDataY( frame.translate[ 1 ] ),
 					};
 					if ( shouldAdjustFontSize ) {
-						properties.fontSize = calculateFitTextFontSize( target.firstChild, properties.height, properties.width );
+						properties.fontSize = editorToDataY( calculateFitTextFontSize( target.firstChild, editorHeight, editorWidth ) );
 					}
 					updateSelectedElements( { properties } );
 				}

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -137,10 +137,11 @@ function SingleSelectionMovable( {
 			} }
 			onDragEnd={ ( { target } ) => {
 				// When dragging finishes, set the new properties based on the original + what moved meanwhile.
-				if ( frame.translate[ 0 ] !== 0 && frame.translate[ 1 ] !== 0 ) {
+				const [ deltaX, deltaY ] = frame.translate;
+				if ( deltaX !== 0 && deltaY !== 0 ) {
 					const properties = {
-						x: selectedElement.x + editorToDataX( frame.translate[ 0 ] ),
-						y: selectedElement.y + editorToDataY( frame.translate[ 1 ] ),
+						x: selectedElement.x + editorToDataX( deltaX ),
+						y: selectedElement.y + editorToDataY( deltaY ),
 					};
 					updateSelectedElements( { properties } );
 				}
@@ -185,14 +186,14 @@ function SingleSelectionMovable( {
 				setTransformStyle( target );
 			} }
 			onResizeEnd={ ( { target } ) => {
-				const editorWidth = frame.resize[ 0 ];
-				const editorHeight = frame.resize[ 1 ];
+				const [ editorWidth, editorHeight ] = frame.resize;
+				const [ deltaX, deltaY ] = frame.translate;
 				if ( editorWidth !== 0 && editorHeight !== 0 ) {
 					const properties = {
 						width: editorToDataX( editorWidth ),
 						height: editorToDataY( editorHeight ),
-						x: selectedElement.x + editorToDataX( frame.translate[ 0 ] ),
-						y: selectedElement.y + editorToDataY( frame.translate[ 1 ] ),
+						x: selectedElement.x + editorToDataX( deltaX ),
+						y: selectedElement.y + editorToDataY( deltaY ),
 					};
 					if ( shouldAdjustFontSize ) {
 						properties.fontSize = editorToDataY( calculateFitTextFontSize( target.firstChild, editorHeight, editorWidth, minMaxFontSize ) );

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -27,11 +27,11 @@ import { useRef, useEffect, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { getBox } from '../../elements/shared';
 import { useStory } from '../../app';
 import Movable from '../movable';
 import calculateFitTextFontSize from '../../utils/calculateFitTextFontSize';
 import getAdjustedElementDimensions from '../../utils/getAdjustedElementDimensions';
+import { useUnits } from '../../units';
 import useCanvas from './useCanvas';
 
 const ALL_HANDLES = [ 'n', 's', 'e', 'w', 'nw', 'ne', 'sw', 'se' ];
@@ -46,6 +46,7 @@ function SingleSelectionMovable( {
 
 	const { actions: { updateSelectedElements } } = useStory();
 	const { actions: { pushTransform } } = useCanvas();
+	const { actions: { getBox, editorToDataX, editorToDataY } } = useUnits();
 
 	const latestEvent = useRef();
 
@@ -131,7 +132,10 @@ function SingleSelectionMovable( {
 			onDragEnd={ ( { target } ) => {
 				// When dragging finishes, set the new properties based on the original + what moved meanwhile.
 				if ( frame.translate[ 0 ] !== 0 && frame.translate[ 1 ] !== 0 ) {
-					const properties = { x: selectedElement.x + frame.translate[ 0 ], y: selectedElement.y + frame.translate[ 1 ] };
+					const properties = {
+						x: selectedElement.x + editorToDataX( frame.translate[ 0 ] ),
+						y: selectedElement.y + editorToDataY( frame.translate[ 1 ] ),
+					};
 					updateSelectedElements( { properties } );
 				}
 				resetMoveable( target );
@@ -177,10 +181,10 @@ function SingleSelectionMovable( {
 			onResizeEnd={ ( { target } ) => {
 				if ( frame.resize[ 0 ] !== 0 && frame.resize[ 1 ] !== 0 ) {
 					const properties = {
-						width: frame.resize[ 0 ],
-						height: frame.resize[ 1 ],
-						x: selectedElement.x + frame.translate[ 0 ],
-						y: selectedElement.y + frame.translate[ 1 ],
+						width: editorToDataX( frame.resize[ 0 ] ),
+						height: editorToDataY( frame.resize[ 1 ] ),
+						x: selectedElement.x + editorToDataX( frame.translate[ 0 ] ),
+						y: selectedElement.y + editorToDataY( frame.translate[ 1 ] ),
 					};
 					if ( shouldAdjustFontSize ) {
 						properties.fontSize = calculateFitTextFontSize( target.firstChild, properties.height, properties.width );
@@ -197,7 +201,7 @@ function SingleSelectionMovable( {
 				setTransformStyle( target );
 			} }
 			onRotateEnd={ ( { target } ) => {
-				const properties = { rotationAngle: frame.rotate };
+				const properties = { rotationAngle: Math.round( frame.rotate ) };
 				updateSelectedElements( { properties } );
 				resetMoveable( target );
 			} }

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -32,6 +32,7 @@ import Movable from '../movable';
 import calculateFitTextFontSize from '../../utils/calculateFitTextFontSize';
 import getAdjustedElementDimensions from '../../utils/getAdjustedElementDimensions';
 import { useUnits } from '../../units';
+import { MIN_FONT_SIZE, MAX_FONT_SIZE } from '../../constants';
 import useCanvas from './useCanvas';
 
 const ALL_HANDLES = [ 'n', 's', 'e', 'w', 'nw', 'ne', 'sw', 'se' ];
@@ -46,7 +47,12 @@ function SingleSelectionMovable( {
 
 	const { actions: { updateSelectedElements } } = useStory();
 	const { actions: { pushTransform } } = useCanvas();
-	const { actions: { getBox, editorToDataX, editorToDataY } } = useUnits();
+	const { actions: { getBox, dataToEditorY, editorToDataX, editorToDataY } } = useUnits();
+
+	const minMaxFontSize = {
+		minFontSize: dataToEditorY( MIN_FONT_SIZE ),
+		maxFontSize: dataToEditorY( MAX_FONT_SIZE ),
+	};
 
 	const latestEvent = useRef();
 
@@ -174,7 +180,7 @@ function SingleSelectionMovable( {
 				frame.resize = [ newWidth, newHeight ];
 				frame.translate = drag.beforeTranslate;
 				if ( shouldAdjustFontSize ) {
-					target.style.fontSize = calculateFitTextFontSize( target.firstChild, height, width );
+					target.style.fontSize = calculateFitTextFontSize( target.firstChild, height, width, minMaxFontSize );
 				}
 				setTransformStyle( target );
 			} }
@@ -189,7 +195,7 @@ function SingleSelectionMovable( {
 						y: selectedElement.y + editorToDataY( frame.translate[ 1 ] ),
 					};
 					if ( shouldAdjustFontSize ) {
-						properties.fontSize = editorToDataY( calculateFitTextFontSize( target.firstChild, editorHeight, editorWidth ) );
+						properties.fontSize = editorToDataY( calculateFitTextFontSize( target.firstChild, editorHeight, editorWidth, minMaxFontSize ) );
 					}
 					updateSelectedElements( { properties } );
 				}

--- a/assets/src/edit-story/components/library/shapeLibrary.js
+++ b/assets/src/edit-story/components/library/shapeLibrary.js
@@ -27,13 +27,13 @@ function MediaLibrary( { onInsert } ) {
 	return (
 		<>
 			<button
-				onClick={ () => onInsert( 'square', { backgroundColor: '#ff0000', width: 10, height: 5, x: 5, y: 5, rotationAngle: 0 } ) }
+				onClick={ () => onInsert( 'square', { backgroundColor: '#ff0000', width: 30, height: 15, x: 5, y: 5, rotationAngle: 0 } ) }
 			>
 				{ __( 'Insert small red square', 'web-stories' ) }
 			</button>
 			<br />
 			<button
-				onClick={ () => onInsert( 'square', { backgroundColor: '#0000ff', width: 30, height: 15, x: 5, y: 35, rotationAngle: 0 } ) }
+				onClick={ () => onInsert( 'square', { backgroundColor: '#0000ff', width: 100, height: 80, x: 5, y: 35, rotationAngle: 0 } ) }
 			>
 				{ __( 'Insert big blue square', 'web-stories' ) }
 			</button>

--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -35,7 +35,7 @@ function MovableWithRef( { ...moveableProps }, ref ) {
 	return (
 		<InOverlay
 			zIndex={ DEFAULT_Z_INDEX }
-			pointerEvents={ true }
+			pointerEvents="initial"
 			render={ ( { container } ) => {
 				return (
 					<Moveable

--- a/assets/src/edit-story/components/overlay/index.js
+++ b/assets/src/edit-story/components/overlay/index.js
@@ -27,11 +27,11 @@ import { forwardRef, useContext, createPortal } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import PointerEventsCss from '../../utils/pointerEventsCss';
+import pointerEventsCss from '../../utils/pointerEventsCss';
 import Context from './context';
 
 const Wrapper = styled.div`
-	${ PointerEventsCss }
+	${ pointerEventsCss }
 	position: absolute;
 	top: 0;
 	left: 0;

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -24,12 +24,11 @@ export const PAGE_NAV_PADDING = 60;
 export const PAGE_NAV_BUTTON_WIDTH = 40;
 export const PAGE_NAV_WIDTH = PAGE_NAV_PADDING + PAGE_NAV_BUTTON_WIDTH;
 
-//QQQQQ: also need to update all onInsert
-// @todo: Common 9:16 resolutions are 900:1600, 1080:1920.
+// @todo: use 1080:1920 for data coords.
 export const PAGE_WIDTH = 412;
 export const PAGE_HEIGHT = 732;
-export const DEFAULT_EDITOR_PAGE_HEIGHT = 412;
-export const DEFAULT_EDITOR_PAGE_WIDTH = 732;
+export const DEFAULT_EDITOR_PAGE_WIDTH = 412;
+export const DEFAULT_EDITOR_PAGE_HEIGHT = 732;
 
 // @todo Confirm real min-max font sizes.
 export const MIN_FONT_SIZE = 12;

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -24,8 +24,12 @@ export const PAGE_NAV_PADDING = 60;
 export const PAGE_NAV_BUTTON_WIDTH = 40;
 export const PAGE_NAV_WIDTH = PAGE_NAV_PADDING + PAGE_NAV_BUTTON_WIDTH;
 
+//QQQQQ: also need to update all onInsert
+// @todo: Common 9:16 resolutions are 900:1600, 1080:1920.
 export const PAGE_WIDTH = 412;
 export const PAGE_HEIGHT = 732;
+export const DEFAULT_EDITOR_PAGE_HEIGHT = 412;
+export const DEFAULT_EDITOR_PAGE_WIDTH = 732;
 
 // @todo Confirm real min-max font sizes.
 export const MIN_FONT_SIZE = 12;

--- a/assets/src/edit-story/elements/image/display.js
+++ b/assets/src/edit-story/elements/image/display.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -30,6 +29,7 @@ import { useRef } from '@wordpress/element';
  */
 import { ElementFillContent } from '../shared';
 import { useTransformHandler } from '../../components/canvas';
+import StoryPropTypes from '../../types';
 import { ImageWithScale, getImgProps, getImageWithScaleCss } from './util';
 
 const Element = styled.div`
@@ -42,7 +42,10 @@ const Img = styled.img`
 	${ ImageWithScale }
 `;
 
-function ImageDisplay( { id, src, origRatio, width, height, scale, focalX, focalY } ) {
+function ImageDisplay( {
+	element: { id, src, origRatio, scale, focalX, focalY },
+	box: { width, height },
+} ) {
 	const imageRef = useRef( null );
 
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
@@ -69,20 +72,8 @@ function ImageDisplay( { id, src, origRatio, width, height, scale, focalX, focal
 }
 
 ImageDisplay.propTypes = {
-	id: PropTypes.string.isRequired,
-	src: PropTypes.string.isRequired,
-	origRatio: PropTypes.number.isRequired,
-	width: PropTypes.number.isRequired,
-	height: PropTypes.number.isRequired,
-	scale: PropTypes.number,
-	focalX: PropTypes.number,
-	focalY: PropTypes.number,
-};
-
-ImageDisplay.defaultProps = {
-	scale: null,
-	focalX: null,
-	focalY: null,
+	element: StoryPropTypes.elements.image.isRequired,
+	box: StoryPropTypes.box.isRequired,
 };
 
 export default ImageDisplay;

--- a/assets/src/edit-story/elements/image/edit.js
+++ b/assets/src/edit-story/elements/image/edit.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -30,6 +29,7 @@ import { useCallback, useState } from '@wordpress/element';
  */
 import { ElementFillContent } from '../shared';
 import { useStory } from '../../app';
+import StoryPropTypes from '../../types';
 import { getImgProps, ImageWithScale } from './util';
 import EditPanMovable from './editPanMovable';
 import EditCropMovable from './editCropMovable';
@@ -70,7 +70,10 @@ const CropImg = styled.img`
 	${ ImageWithScale }
 `;
 
-function ImageEdit( { id, src, origRatio, width, height, x, y, scale, focalX, focalY, rotationAngle, isFullbleed } ) {
+function ImageEdit( {
+	element: { id, src, origRatio, scale, focalX, focalY, isFullbleed },
+	box: { x, y, width, height, rotationAngle },
+} ) {
 	const [ fullImage, setFullImage ] = useState( null );
 	const [ croppedImage, setCroppedImage ] = useState( null );
 	const [ cropBox, setCropBox ] = useState( null );
@@ -132,24 +135,8 @@ function ImageEdit( { id, src, origRatio, width, height, x, y, scale, focalX, fo
 }
 
 ImageEdit.propTypes = {
-	id: PropTypes.string.isRequired,
-	src: PropTypes.string.isRequired,
-	origRatio: PropTypes.number.isRequired,
-	width: PropTypes.number.isRequired,
-	height: PropTypes.number.isRequired,
-	x: PropTypes.number.isRequired,
-	y: PropTypes.number.isRequired,
-	rotationAngle: PropTypes.number.isRequired,
-	isFullbleed: PropTypes.bool,
-	scale: PropTypes.number,
-	focalX: PropTypes.number,
-	focalY: PropTypes.number,
-};
-
-ImageEdit.defaultProps = {
-	scale: null,
-	focalX: null,
-	focalY: null,
+	element: StoryPropTypes.elements.image.isRequired,
+	box: StoryPropTypes.box.isRequired,
 };
 
 export default ImageEdit;

--- a/assets/src/edit-story/elements/image/editCropMovable.js
+++ b/assets/src/edit-story/elements/image/editCropMovable.js
@@ -28,6 +28,7 @@ import { useEffect, useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import Movable from '../../components/movable';
+import { useUnits } from '../../units';
 import { getFocalFromOffset } from './util';
 
 function EditCropMovable( {
@@ -35,6 +36,8 @@ function EditCropMovable( {
 	x, y,
 	offsetX, offsetY, imgWidth, imgHeight,
 } ) {
+	const { actions: { editorToDataX, editorToDataY } } = useUnits();
+
 	const moveableRef = useRef();
 	const cropRef = useRef( [ 0, 0, 0, 0 ] );
 
@@ -77,10 +80,10 @@ function EditCropMovable( {
 				const resizeFocalX = getFocalFromOffset( resizeWidth, imgWidth, offsetX + tx );
 				const resizeFocalY = getFocalFromOffset( resizeHeight, imgHeight, offsetY + ty );
 				setProperties( {
-					x: x + tx,
-					y: y + ty,
-					width: resizeWidth,
-					height: resizeHeight,
+					x: editorToDataX( x + tx ),
+					y: editorToDataY( y + ty ),
+					width: editorToDataX( resizeWidth ),
+					height: editorToDataY( resizeHeight ),
 					scale: resizeScale,
 					focalX: resizeFocalX,
 					focalY: resizeFocalY,

--- a/assets/src/edit-story/elements/image/frame.js
+++ b/assets/src/edit-story/elements/image/frame.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -31,12 +30,13 @@ import { useCallback } from '@wordpress/element';
 import { useCanvas } from '../../components/canvas';
 import useDoubleClick from '../../utils/useDoubleClick';
 import { ElementFillContent } from '../shared';
+import StoryPropTypes from '../../types';
 
 const Element = styled.div`
 	${ ElementFillContent }
 `;
 
-function ImageFrame( { id } ) {
+function ImageFrame( { element: { id } } ) {
 	const {
 		actions: { setEditingElement },
 	} = useCanvas();
@@ -49,7 +49,7 @@ function ImageFrame( { id } ) {
 }
 
 ImageFrame.propTypes = {
-	id: PropTypes.string.isRequired,
+	element: StoryPropTypes.elements.image.isRequired,
 };
 
 export default ImageFrame;

--- a/assets/src/edit-story/elements/image/index.js
+++ b/assets/src/edit-story/elements/image/index.js
@@ -26,6 +26,9 @@ export { default as Save } from './save';
 export { default as TextContent } from './textContent';
 
 export const defaultAttributes = {
+	scale: 100,
+	focalX: 50,
+	focalY: 50,
 };
 
 export const hasEditMode = true;

--- a/assets/src/edit-story/elements/image/scalePanel.js
+++ b/assets/src/edit-story/elements/image/scalePanel.js
@@ -82,7 +82,7 @@ const ResetButton = styled.button`
 
 function ScalePanel( { setProperties, width, height, x, y, scale } ) {
 	return (
-		<InOverlay zIndex={ Z_INDEX_CANVAS.FLOAT_PANEL } pointerEvents={ true } >
+		<InOverlay zIndex={ Z_INDEX_CANVAS.FLOAT_PANEL } pointerEvents="initial" >
 			<Container x={ x } y={ y } width={ width } height={ height } >
 				<Range
 					value={ scale }

--- a/assets/src/edit-story/elements/index.js
+++ b/assets/src/edit-story/elements/index.js
@@ -18,10 +18,12 @@
  * External dependencies
  */
 import uuid from 'uuid/v4';
+
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */

--- a/assets/src/edit-story/elements/shared.js
+++ b/assets/src/edit-story/elements/shared.js
@@ -23,7 +23,6 @@ import { css } from 'styled-components';
  * Internal dependencies
  */
 import getPercentageFromPixels from '../utils/getPercentageFromPixels';
-import { PAGE_HEIGHT, PAGE_WIDTH } from '../constants';
 
 export const ElementFillContent = css`
 	position: absolute;
@@ -85,14 +84,3 @@ export const getCommonAttributes = ( ( { width, height, x, y, rotationAngle } ) 
 		height: getPercentageFromPixels( height, 'y' ) + '%',
 	};
 } );
-
-// QQQQ: migrate to useUnits() everywhere and remove.
-export function getBox( { x, y, width, height, rotationAngle, isFullbleed } ) {
-	return {
-		x: isFullbleed ? 0 : x,
-		y: isFullbleed ? 0 : y,
-		width: isFullbleed ? PAGE_WIDTH : width,
-		height: isFullbleed ? PAGE_HEIGHT : height,
-		rotationAngle: isFullbleed ? 0 : rotationAngle,
-	};
-}

--- a/assets/src/edit-story/elements/shared.js
+++ b/assets/src/edit-story/elements/shared.js
@@ -86,6 +86,7 @@ export const getCommonAttributes = ( ( { width, height, x, y, rotationAngle } ) 
 	};
 } );
 
+// QQQQ: migrate to useUnits() everywhere and remove.
 export function getBox( { x, y, width, height, rotationAngle, isFullbleed } ) {
 	return {
 		x: isFullbleed ? 0 : x,

--- a/assets/src/edit-story/elements/square/display.js
+++ b/assets/src/edit-story/elements/square/display.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -27,13 +26,14 @@ import {
 	ElementFillContent,
 	ElementWithBackgroundColor,
 } from '../shared';
+import StoryPropTypes from '../../types';
 
 const Element = styled.div`
 	${ ElementFillContent }
 	${ ElementWithBackgroundColor }
 `;
 
-function SquareDisplay( { backgroundColor } ) {
+function SquareDisplay( { element: { backgroundColor } } ) {
 	const props = {
 		backgroundColor,
 	};
@@ -43,7 +43,7 @@ function SquareDisplay( { backgroundColor } ) {
 }
 
 SquareDisplay.propTypes = {
-	backgroundColor: PropTypes.string,
+	element: StoryPropTypes.elements.square.isRequired,
 };
 
 export default SquareDisplay;

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -28,6 +28,7 @@ import { useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import { useFont } from '../../app';
+import { useUnits } from '../../units';
 import {
 	ElementFillContent,
 	ElementWithFont,
@@ -63,13 +64,14 @@ function TextDisplay( {
 		textAlign,
 	},
 } ) {
+	const { actions: { dataToEditorY } } = useUnits();
 	const props = {
 		color,
 		backgroundColor,
 		fontFamily: generateFontFamily( fontFamily, fontFallback ),
 		fontFallback,
 		fontStyle,
-		fontSize,
+		fontSize: dataToEditorY( fontSize ),
 		fontWeight,
 		letterSpacing,
 		lineHeight,

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -36,6 +35,7 @@ import {
 	ElementWithFontColor,
 	ElementWithStyle,
 } from '../shared';
+import StoryPropTypes from '../../types';
 import { generateFontFamily } from './util';
 
 const Element = styled.p`
@@ -48,18 +48,20 @@ const Element = styled.p`
 `;
 
 function TextDisplay( {
-	content,
-	color,
-	backgroundColor,
-	fontFamily,
-	fontFallback,
-	fontSize,
-	fontWeight,
-	fontStyle,
-	letterSpacing,
-	lineHeight,
-	padding,
-	textAlign,
+	element: {
+		content,
+		color,
+		backgroundColor,
+		fontFamily,
+		fontFallback,
+		fontSize,
+		fontWeight,
+		fontStyle,
+		letterSpacing,
+		lineHeight,
+		padding,
+		textAlign,
+	},
 } ) {
 	const props = {
 		color,
@@ -91,21 +93,7 @@ function TextDisplay( {
 }
 
 TextDisplay.propTypes = {
-	content: PropTypes.string,
-	color: PropTypes.string,
-	backgroundColor: PropTypes.string,
-	fontFamily: PropTypes.string,
-	fontFallback: PropTypes.array,
-	fontSize: PropTypes.number,
-	fontWeight: PropTypes.number,
-	fontStyle: PropTypes.string,
-	letterSpacing: PropTypes.oneOfType( [
-		PropTypes.string,
-		PropTypes.number,
-	] ),
-	lineHeight: PropTypes.number,
-	padding: PropTypes.number,
-	textAlign: PropTypes.string,
+	element: StoryPropTypes.elements.text.isRequired,
 };
 
 export default TextDisplay;

--- a/assets/src/edit-story/elements/text/edit.js
+++ b/assets/src/edit-story/elements/text/edit.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Editor, EditorState, SelectionState } from 'draft-js';
 import { stateFromHTML } from 'draft-js-import-html';
@@ -40,6 +39,7 @@ import {
 	ElementWithFontColor,
 	ElementWithStyle,
 } from '../shared';
+import StoryPropTypes from '../../types';
 import { getFilteredState, getHandleKeyCommand } from './util';
 
 const Element = styled.div`
@@ -64,21 +64,25 @@ const Element = styled.div`
 `;
 
 function TextEdit( {
-	id,
-	content,
-	color,
-	backgroundColor,
-	width,
-	height,
-	fontFamily,
-	fontFallback,
-	fontSize,
-	fontWeight,
-	fontStyle,
-	letterSpacing,
-	lineHeight,
-	padding,
-	textAlign,
+	element: {
+		id,
+		content,
+		color,
+		backgroundColor,
+		fontFamily,
+		fontFallback,
+		fontSize,
+		fontWeight,
+		fontStyle,
+		letterSpacing,
+		lineHeight,
+		padding,
+		textAlign,
+	},
+	box: {
+		width,
+		height,
+	},
 } ) {
 	const props = {
 		color,
@@ -181,24 +185,8 @@ function TextEdit( {
 }
 
 TextEdit.propTypes = {
-	id: PropTypes.string.isRequired,
-	content: PropTypes.string,
-	color: PropTypes.string,
-	backgroundColor: PropTypes.string,
-	fontFamily: PropTypes.string,
-	fontFallback: PropTypes.array,
-	fontSize: PropTypes.number,
-	fontWeight: PropTypes.number,
-	fontStyle: PropTypes.string,
-	letterSpacing: PropTypes.oneOfType( [
-		PropTypes.string,
-		PropTypes.number,
-	] ),
-	lineHeight: PropTypes.number,
-	padding: PropTypes.number,
-	width: PropTypes.number.isRequired,
-	height: PropTypes.number.isRequired,
-	textAlign: PropTypes.string,
+	element: StoryPropTypes.elements.text.isRequired,
+	box: StoryPropTypes.box.isRequired,
 };
 
 export default TextEdit;

--- a/assets/src/edit-story/elements/text/edit.js
+++ b/assets/src/edit-story/elements/text/edit.js
@@ -32,6 +32,7 @@ import { useState, useEffect, useLayoutEffect, useRef, useCallback } from '@word
  */
 import { useStory, useFont } from '../../app';
 import { useCanvas } from '../../components/canvas';
+import { useUnits } from '../../units';
 import {
 	ElementFillContent,
 	ElementWithFont,
@@ -84,13 +85,14 @@ function TextEdit( {
 		height,
 	},
 } ) {
+	const { actions: { dataToEditorY } } = useUnits();
 	const props = {
 		color,
 		backgroundColor,
 		fontFamily,
 		fontFallback,
 		fontStyle,
-		fontSize,
+		fontSize: dataToEditorY( fontSize ),
 		fontWeight,
 		textAlign,
 		letterSpacing,

--- a/assets/src/edit-story/elements/text/frame.js
+++ b/assets/src/edit-story/elements/text/frame.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -34,17 +33,14 @@ import { useCanvas } from '../../components/canvas';
 import {
 	ElementFillContent,
 	ElementWithFont,
-	ElementWithBackgroundColor,
-	ElementWithFontColor,
 } from '../shared';
+import StoryPropTypes from '../../types';
 import { generateFontFamily } from './util';
 
 const Element = styled.p`
 	margin: 0;
 	${ ElementFillContent }
 	${ ElementWithFont }
-	${ ElementWithBackgroundColor }
-	${ ElementWithFontColor }
 
 	opacity: 0;
 	user-select: ${ ( { canSelect } ) => canSelect ? 'initial' : 'none' };
@@ -54,17 +50,23 @@ const Element = styled.p`
 	}
 `;
 
-function TextFrame( { id, content, color, backgroundColor, width, height, fontFamily, fontFallback, fontSize, fontWeight, fontStyle } ) {
+function TextFrame( {
+	element: {
+		id,
+		content,
+		fontFamily,
+		fontFallback,
+		fontSize,
+		fontWeight,
+		fontStyle,
+	},
+} ) {
 	const props = {
-		color,
-		backgroundColor,
 		fontFamily: generateFontFamily( fontFamily, fontFallback ),
 		fontFallback,
 		fontStyle,
 		fontSize,
 		fontWeight,
-		width,
-		height,
 	};
 	const {
 		state: { selectedElementIds },
@@ -151,18 +153,7 @@ function TextFrame( { id, content, color, backgroundColor, width, height, fontFa
 }
 
 TextFrame.propTypes = {
-	id: PropTypes.string.isRequired,
-	content: PropTypes.string,
-	color: PropTypes.string,
-	backgroundColor: PropTypes.string,
-	fontFamily: PropTypes.string,
-	fontFallback: PropTypes.array,
-	fontSize: PropTypes.number,
-	fontWeight: PropTypes.number,
-	fontStyle: PropTypes.string,
-	width: PropTypes.number.isRequired,
-	height: PropTypes.number.isRequired,
-	setClickHandler: PropTypes.func,
+	element: StoryPropTypes.elements.text.isRequired,
 };
 
 export default TextFrame;

--- a/assets/src/edit-story/elements/text/frame.js
+++ b/assets/src/edit-story/elements/text/frame.js
@@ -30,6 +30,7 @@ import { useRef, useEffect, useCallback, useState } from '@wordpress/element';
 import getCaretCharacterOffsetWithin from '../../utils/getCaretCharacterOffsetWithin';
 import { useStory } from '../../app';
 import { useCanvas } from '../../components/canvas';
+import { useUnits } from '../../units';
 import {
 	ElementFillContent,
 	ElementWithFont,
@@ -61,11 +62,12 @@ function TextFrame( {
 		fontStyle,
 	},
 } ) {
+	const { actions: { dataToEditorY } } = useUnits();
 	const props = {
 		fontFamily: generateFontFamily( fontFamily, fontFallback ),
 		fontFallback,
 		fontStyle,
-		fontSize,
+		fontSize: dataToEditorY( fontSize ),
 		fontWeight,
 	};
 	const {

--- a/assets/src/edit-story/elements/text/index.js
+++ b/assets/src/edit-story/elements/text/index.js
@@ -32,7 +32,6 @@ export const defaultAttributes = {
 	fontSize: 14,
 	fontStyle: 'normal',
 	color: '#000000',
-	backgroundColor: '#ffffff',
 	letterSpacing: 'normal',
 	lineHeight: 1.3,
 	textAlign: 'initial',

--- a/assets/src/edit-story/elements/video/display.js
+++ b/assets/src/edit-story/elements/video/display.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -29,21 +28,22 @@ import { useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import { ElementFillContent } from '../shared';
+import StoryPropTypes from '../../types';
 import useUploadVideoFrame from '../../utils/useUploadVideoFrame';
 
 const Element = styled.video`
 	${ ElementFillContent }
 `;
 
-function VideoDisplay( props ) {
-	const {
-		mimeType,
+function VideoDisplay( {
+	element: {
+		id,
 		src,
+		mimeType,
 		videoId,
 		posterId,
-		id,
-	} = props;
-
+	},
+} ) {
 	const { uploadVideoFrame } = useUploadVideoFrame( { videoId, src, id } );
 	useEffect( () => {
 		if ( videoId && ! posterId ) {
@@ -52,21 +52,14 @@ function VideoDisplay( props ) {
 	}, [ videoId, posterId, uploadVideoFrame ] );
 
 	return (
-		<Element { ...props } >
+		<Element>
 			<source src={ src } type={ mimeType } />
 		</Element>
 	);
 }
 
 VideoDisplay.propTypes = {
-	controls: PropTypes.bool,
-	autoPlay: PropTypes.bool,
-	loop: PropTypes.bool,
-	mimeType: PropTypes.string.isRequired,
-	src: PropTypes.string.isRequired,
-	videoId: PropTypes.number.isRequired,
-	posterId: PropTypes.number,
-	id: PropTypes.string.isRequired,
+	element: StoryPropTypes.elements.video.isRequired,
 };
 
 export default VideoDisplay;

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+const StoryPropTypes = {};
+
+export const StoryElementPropsTypes = {
+	id: PropTypes.string.isRequired,
+	type: PropTypes.string.isRequired,
+	x: PropTypes.number.isRequired,
+	y: PropTypes.number.isRequired,
+	width: PropTypes.number.isRequired,
+	height: PropTypes.number.isRequired,
+	rotationAngle: PropTypes.number.isRequired,
+	isFullbleed: PropTypes.bool.isRequired,
+};
+
+StoryPropTypes.size = PropTypes.exact( {
+	width: PropTypes.number.isRequired,
+	height: PropTypes.number.isRequired,
+} );
+
+StoryPropTypes.box = PropTypes.exact( {
+	x: PropTypes.number.isRequired,
+	y: PropTypes.number.isRequired,
+	width: PropTypes.number.isRequired,
+	height: PropTypes.number.isRequired,
+	rotationAngle: PropTypes.number.isRequired,
+} );
+
+StoryPropTypes.children = PropTypes.oneOfType( [
+	PropTypes.arrayOf( PropTypes.node ),
+	PropTypes.node,
+] );
+
+StoryPropTypes.page = PropTypes.shape( {
+	id: PropTypes.string.isRequired,
+} );
+
+StoryPropTypes.element = PropTypes.shape( StoryElementPropsTypes );
+
+StoryPropTypes.elements = {};
+
+StoryPropTypes.elements.image = PropTypes.shape( {
+	...StoryElementPropsTypes,
+	src: PropTypes.string.isRequired,
+	origRatio: PropTypes.number.isRequired,
+	scale: PropTypes.number.isRequired,
+	focalX: PropTypes.number,
+	focalY: PropTypes.number,
+} );
+
+export default StoryPropTypes;

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -51,4 +51,37 @@ StoryPropTypes.elements.image = PropTypes.shape( {
 	focalY: PropTypes.number,
 } );
 
+StoryPropTypes.elements.video = PropTypes.shape( {
+	...StoryElementPropsTypes,
+	mimeType: PropTypes.string.isRequired,
+	src: PropTypes.string.isRequired,
+	loop: PropTypes.bool,
+	videoId: PropTypes.number.isRequired,
+	posterId: PropTypes.number,
+} );
+
+StoryPropTypes.elements.text = PropTypes.shape( {
+	...StoryElementPropsTypes,
+	content: PropTypes.string,
+	color: PropTypes.string,
+	backgroundColor: PropTypes.string,
+	fontFamily: PropTypes.string,
+	fontFallback: PropTypes.array,
+	fontSize: PropTypes.number,
+	fontWeight: PropTypes.number,
+	fontStyle: PropTypes.string,
+	letterSpacing: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.number,
+	] ),
+	lineHeight: PropTypes.number,
+	padding: PropTypes.number,
+	textAlign: PropTypes.string,
+} );
+
+StoryPropTypes.elements.square = PropTypes.shape( {
+	...StoryElementPropsTypes,
+	backgroundColor: PropTypes.string,
+} );
+
 export default StoryPropTypes;

--- a/assets/src/edit-story/units/context.js
+++ b/assets/src/edit-story/units/context.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+export default createContext( { actions: {}, state: {} } );

--- a/assets/src/edit-story/units/dimensions.js
+++ b/assets/src/edit-story/units/dimensions.js
@@ -1,0 +1,94 @@
+
+/**
+ * Internal dependencies
+ */
+import { PAGE_WIDTH, PAGE_HEIGHT } from '../constants';
+
+/**
+ * Rounds the pixel value to the max allowed precision in the "data" space.
+ *
+ * @param {number} v The value to be rounded.
+ * @return {number} The value rounded to the "data" space precision.
+ */
+export function dataPixels( v ) {
+	return Number( v.toFixed( 0 ) );
+}
+
+/**
+ * Rounds the pixel value to the max allowed precision in the "editor" space.
+ *
+ * @param {number} v The value to be rounded.
+ * @return {number} The value rounded to the "editor" space precision.
+ */
+export function editorPixels( v ) {
+	return Number( v.toFixed( 5 ) );
+}
+
+/**
+ * Converts a "data" pixel value to the value in the "editor" space along
+ * the horizontal (X) dimension.
+ *
+ * @param {number} x The value to be converted.
+ * @param {number} pageWidth The basis value for the page's width in the "editor" space.
+ * @return {number} The value in the "editor" space.
+ */
+export function dataToEditorX( x, pageWidth ) {
+	return editorPixels( x * pageWidth / PAGE_WIDTH );
+}
+
+/**
+ * Converts a "data" pixel value to the value in the "editor" space along
+ * the vertical (Y) dimension.
+ *
+ * @param {number} y The value to be converted.
+ * @param {number} pageHeight The basis value for the page's height in the "editor" space.
+ * @return {number} The value in the "editor" space.
+ */
+export function dataToEditorY( y, pageHeight ) {
+	return editorPixels( y * pageHeight / PAGE_HEIGHT );
+}
+
+/**
+ * Converts a "editor" pixel value to the value in the "data" space along
+ * the horizontal (X) dimension.
+ *
+ * @param {number} x The value to be converted.
+ * @param {number} pageWidth The basis value for the page's width in the "editor" space.
+ * @return {number} The value in the "data" space.
+ */
+export function editorToDataX( x, pageWidth ) {
+	return dataPixels( x * PAGE_WIDTH / pageWidth );
+}
+
+/**
+ * Converts a "editor" pixel value to the value in the "data" space along
+ * the vertical (Y) dimension.
+ *
+ * @param {number} y The value to be converted.
+ * @param {number} pageHeight The basis value for the page's height in the "editor" space.
+ * @return {number} The value in the "data" space.
+ */
+export function editorToDataY( y, pageHeight ) {
+	return dataPixels( y * PAGE_HEIGHT / pageHeight );
+}
+
+/**
+ * Converts the element's position, width, and rotation) to the "box" in the
+ * "editor" coordinate space.
+ *
+ * @param {{x:number, y:number, width:number, height:number, rotationAngle:number, isFullbleed:boolean}} element The
+ * element's position, width, and rotation. See `StoryPropTypes.element`.
+ * @param {number} pageWidth The basis value for the page's width in the "editor" space.
+ * @param {number} pageHeight The basis value for the page's height in the "editor" space.
+ * @return {{x:number, y:number, width:number, height:number, rotationAngle:number}} The
+ * "box" in the editor space.
+ */
+export function getBox( { x, y, width, height, rotationAngle, isFullbleed }, pageWidth, pageHeight ) {
+	return {
+		x: dataToEditorX( isFullbleed ? 0 : x, pageWidth ),
+		y: dataToEditorY( isFullbleed ? 0 : y, pageHeight ),
+		width: dataToEditorX( isFullbleed ? PAGE_WIDTH : width, pageWidth ),
+		height: dataToEditorY( isFullbleed ? PAGE_HEIGHT : height, pageHeight ),
+		rotationAngle: isFullbleed ? 0 : rotationAngle,
+	};
+}

--- a/assets/src/edit-story/units/index.js
+++ b/assets/src/edit-story/units/index.js
@@ -1,0 +1,1 @@
+export { default as useUnits } from './useUnits';

--- a/assets/src/edit-story/units/unitsProvider.js
+++ b/assets/src/edit-story/units/unitsProvider.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import StoryPropTypes from '../types';
+import Context from './context';
+import {
+	dataToEditorX,
+	dataToEditorY,
+	editorToDataX,
+	editorToDataY,
+	getBox,
+} from './dimensions';
+
+function UnitsProvider( { pageSize, children } ) {
+	const { width: pageWidth, height: pageHeight } = pageSize;
+	const state = useMemo(
+		() => ( {
+			state: {
+				pageSize: { width: pageWidth, height: pageHeight },
+			},
+			actions: {
+				dataToEditorX: ( x ) => dataToEditorX( x, pageWidth ),
+				dataToEditorY: ( y ) => dataToEditorY( y, pageHeight ),
+				editorToDataX: ( x ) => editorToDataX( x, pageWidth ),
+				editorToDataY: ( y ) => editorToDataY( y, pageHeight ),
+				getBox: ( element ) => getBox( element, pageWidth, pageHeight ),
+			},
+		} ),
+		[ pageWidth, pageHeight ] );
+
+	return (
+		<Context.Provider value={ state }>
+			{ children }
+		</Context.Provider>
+	);
+}
+
+UnitsProvider.propTypes = {
+	pageSize: StoryPropTypes.size.isRequired,
+	children: StoryPropTypes.children.isRequired,
+};
+
+export default UnitsProvider;

--- a/assets/src/edit-story/units/useUnits.js
+++ b/assets/src/edit-story/units/useUnits.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Context from './context';
+
+function useUnits() {
+	return useContext( Context );
+}
+
+export default useUnits;

--- a/assets/src/edit-story/utils/calculateFitTextFontSize.js
+++ b/assets/src/edit-story/utils/calculateFitTextFontSize.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * Internal dependencies
- */
-import { MIN_FONT_SIZE, MAX_FONT_SIZE } from '../constants';
-
-/**
  * Calculates font size that fits to the text element based on the element's size.
  * Replicates amp-fit-text's logic in the editor.
  *
@@ -31,10 +26,7 @@ import { MIN_FONT_SIZE, MAX_FONT_SIZE } from '../constants';
  *
  * @return {number|boolean} Calculated font size. False if calculation wasn't possible.
  */
-function calculateFitTextFontSize( measurer, expectedHeight, expectedWidth ) {
-	let maxFontSize = MAX_FONT_SIZE;
-	let minFontSize = MIN_FONT_SIZE;
-
+function calculateFitTextFontSize( measurer, expectedHeight, expectedWidth, { minFontSize, maxFontSize } ) {
 	// Return false if calculation is not possible due to width and height missing, e.g. in disabled preview.
 	if ( ! measurer.offsetHeight || ! measurer.offsetWidth ) {
 		return false;
@@ -72,7 +64,7 @@ function calculateFitTextFontSize( measurer, expectedHeight, expectedWidth ) {
 
 	// Binomial search for the best font size.
 	while ( maxFontSize - minFontSize > 1 ) {
-		const mid = Math.floor( ( minFontSize + maxFontSize ) / 2 );
+		const mid = ( minFontSize + maxFontSize ) / 2;
 		measurer.style.fontSize = mid + 'px';
 		const currentHeight = measurer.offsetHeight;
 		const currentWidth = measurer.offsetWidth;

--- a/assets/src/edit-story/utils/pointerEventsCss.js
+++ b/assets/src/edit-story/utils/pointerEventsCss.js
@@ -21,10 +21,7 @@ import { css } from 'styled-components';
 
 const PointerEventsCss = css`
 	${ ( { pointerEvents } ) => {
-		if ( typeof pointerEvents === 'boolean' ) {
-			return `pointer-events: ${ pointerEvents ? 'initial' : 'none' };`;
-		}
-		if ( typeof pointerEvents === 'string' && pointerEvents ) {
+		if ( pointerEvents && typeof pointerEvents === 'string' ) {
 			return `pointer-events: ${ pointerEvents };`;
 		}
 		return '';

--- a/assets/src/edit-story/utils/pointerEventsCss.js
+++ b/assets/src/edit-story/utils/pointerEventsCss.js
@@ -19,7 +19,7 @@
  */
 import { css } from 'styled-components';
 
-const PointerEventsCss = css`
+const pointerEventsCss = css`
 	${ ( { pointerEvents } ) => {
 		if ( pointerEvents && typeof pointerEvents === 'string' ) {
 			return `pointer-events: ${ pointerEvents };`;
@@ -28,4 +28,4 @@ const PointerEventsCss = css`
 	} }
 `;
 
-export default PointerEventsCss;
+export default pointerEventsCss;

--- a/assets/src/edit-story/utils/useResizeEffect.js
+++ b/assets/src/edit-story/utils/useResizeEffect.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import ResizeObserver from 'resize-observer-polyfill';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * @param {!{current: ?Element}} ref Target node ref.
+ * @param {function( {width: number, height: number} )} handler The resize
+ * handler.
+ * @param {!Array=} deps The effect's dependencies.
+ */
+function useResizeEffect( ref, handler, deps = undefined ) {
+	useEffect(
+		() => {
+			const node = ref.current;
+			if ( ! node ) {
+				return null;
+			}
+
+			const observer = new ResizeObserver( ( entries ) => {
+				const last = entries.length > 0 ? entries[ entries.length - 1 ] : null;
+				if ( last ) {
+					const { width, height } = last.contentRect;
+					handler( { width, height } );
+				}
+			} );
+
+			observer.observe( node );
+
+			return () => observer.disconnect();
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		deps || [],
+	);
+}
+
+export default useResizeEffect;


### PR DESCRIPTION
## Summary

Moved from https://github.com/ampproject/amp-wp/pull/4169

Partial for #27.

TODO: 

- [x] Migrate all element types
- [x] Migrate multi-selection movable
- [x] Migrate carousel to use `useResizeEffect` hook
- [x] Remove old APIs

This PR does the following:

* Implements breakpoints for a couple of different allowed sizes of the "page" area.
* Uses `units` system to convert between "data" and "editor" pixels.
* Migrates element templates to use `{element, box, ...}` shape to allow use of both data and physical pixels as necessary.
* Cleans up typing a little.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
