### PR TITLE
Only collect JS coverage when prompted to

### DIFF
--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -32,7 +32,6 @@ module.exports = {
 	coveragePathIgnorePatterns: [ '/node_modules/', '<rootDir>/build/' ],
 	coverageReporters: [ 'lcov' ],
 	coverageDirectory: '<rootDir>/build/logs',
-	collectCoverage: true,
 	collectCoverageFrom: [
 		'<rootDir>/assets/src/edit-story/**/*.js',
 		'!**/test/**',


### PR DESCRIPTION
Instead of always running Jest code coverage, only do so when passing `--collectCoverage` to speed up things.