### PR TITLE
Explicitly add package to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@wordpress/eslint-plugin": "^3.3.0",
     "@wordpress/i18n": "^3.8.0",
     "@wordpress/scripts": "^6.2.0",
+    "@wordpress/url": "^2.9.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^25.1.0",
     "babel-loader": "^8.0.6",


### PR DESCRIPTION
The `@wordpress/url` package (more specifically: `addQueryArgs`) is used in a few places. Let's make that more explicit.

An alternative would be to just use the [`URL` interface](https://developer.mozilla.org/en-US/docs/Web/API/URL) instead.