### PR TITLE
Remove unnecessary eslint-disable comments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -65,7 +65,8 @@
     "import/order": [ "error", { "groups": [ "builtin", [ "external", "unknown" ], "internal", "parent", "sibling", "index" ] } ],
     "jsdoc/check-indentation": "error",
     "@wordpress/dependency-group": "error",
-    "@wordpress/react-no-unsafe-timeout": "error"
+    "@wordpress/react-no-unsafe-timeout": "error",
+    "eslint-comments/no-unused-disable": "error"
   },
   "overrides": [
     {

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -44,12 +44,10 @@ function DisplayElement( { element } ) {
 	const { actions: { getBox } } = useUnits();
 
 	const { id, type } = element;
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const { Display } = getDefinitionForType( type );
 
 	const wrapperRef = useRef( null );
 
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const box = getBox( element );
 
 	useTransformHandler( id, ( transform ) => {

--- a/assets/src/edit-story/components/canvas/editElement.js
+++ b/assets/src/edit-story/components/canvas/editElement.js
@@ -41,10 +41,8 @@ function EditElement( { element } ) {
 	const { type } = element;
 	const { actions: { getBox } } = useUnits();
 
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const { Edit } = getDefinitionForType( type );
 
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const box = getBox( element );
 
 	return (

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -62,7 +62,6 @@ function FrameElement( { element } ) {
 
 	const isSelected = selectedElements.includes( id );
 
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const box = getBox( element );
 
 	return (

--- a/assets/src/edit-story/elements/image/display.js
+++ b/assets/src/edit-story/elements/image/display.js
@@ -48,7 +48,6 @@ function ImageDisplay( {
 } ) {
 	const imageRef = useRef( null );
 
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const imgProps = getImgProps( width, height, scale, focalX, focalY, origRatio );
 
 	useTransformHandler( id, ( transform ) => {

--- a/assets/src/edit-story/utils/useDoubleClick.js
+++ b/assets/src/edit-story/utils/useDoubleClick.js
@@ -19,11 +19,6 @@
  */
 import { useCallback, useEffect, useState } from '@wordpress/element';
 
-// Disable reason: Should not check indentation in code samples inside
-// markdown, but it does.
-
-/* eslint-disable jsdoc/check-indentation */
-
 /**
  * This hook creates a handler to use for double click listening
  * on a node, where single clicks are also relevant. Default timeout
@@ -94,8 +89,6 @@ const useDoubleClick = ( onSingleClick, onDoubleClick, ms = null ) => {
 
 	return getHandler;
 };
-
-/* eslint-enable jsdoc/check-indentation */
 
 export default useDoubleClick;
 


### PR DESCRIPTION
Turns out `eslint-comments/no-unused-disable` wasn’t actually used.

This is the same as when running `npx eslint --report-unused-disable-directives assets/src`