### PR TITLE
Rename fullbleed to fill

### DIFF
--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -124,9 +124,9 @@ function SingleSelectionMovable( {
 			zIndex={ 0 }
 			ref={ moveable }
 			target={ targetEl }
-			draggable={ ! selectedElement.isFullbleed }
-			resizable={ ! selectedElement.isFullbleed }
-			rotatable={ ! selectedElement.isFullbleed }
+			draggable={ ! selectedElement.isFill }
+			resizable={ ! selectedElement.isFill }
+			rotatable={ ! selectedElement.isFill }
 			onDrag={ ( { target, beforeTranslate } ) => {
 				frame.translate = beforeTranslate;
 				setTransformStyle( target );

--- a/assets/src/edit-story/components/panels/fill.js
+++ b/assets/src/edit-story/components/panels/fill.js
@@ -32,31 +32,31 @@ import { ActionButton } from '../button';
 import { SimplePanel } from './panel';
 import getCommonValue from './utils/getCommonValue';
 
-function FullbleedPanel( { selectedElements, onSetProperties } ) {
-	// The x/y/w/h/r are kept unchanged so that toggling fullbleed will return
-	// the element to the previous non-fullbleed position/size.
-	const isFullbleed = getCommonValue( selectedElements, 'isFullbleed' );
-	const [ state, setState ] = useState( { isFullbleed } );
+function FillPanel( { selectedElements, onSetProperties } ) {
+	// The x/y/w/h/r are kept unchanged so that toggling fill will return
+	// the element to the previous non-fill position/size.
+	const isFill = getCommonValue( selectedElements, 'isFill' );
+	const [ state, setState ] = useState( { isFill } );
 	useEffect( () => {
-		setState( { isFullbleed } );
-	}, [ isFullbleed ] );
+		setState( { isFill } );
+	}, [ isFill ] );
 	const handleClick = ( ) => {
-		const newState = { isFullbleed: ! state.isFullbleed };
+		const newState = { isFill: ! state.isFill };
 		setState( newState );
 		onSetProperties( newState );
 	};
 	return (
-		<SimplePanel name="fullbleed" title={ __( 'Fullbleed', 'web-stories' ) }>
+		<SimplePanel name="fill" title={ __( 'Fill', 'web-stories' ) }>
 			<ActionButton onClick={ handleClick }>
-				{ state.isFullbleed ? __( 'Unset as fullbleed', 'web-stories' ) : __( 'Set as fullbleed', 'web-stories' ) }
+				{ state.isFill ? __( 'Unset as fill', 'web-stories' ) : __( 'Set as fill', 'web-stories' ) }
 			</ActionButton>
 		</SimplePanel>
 	);
 }
 
-FullbleedPanel.propTypes = {
+FillPanel.propTypes = {
 	selectedElements: PropTypes.array.isRequired,
 	onSetProperties: PropTypes.func.isRequired,
 };
 
-export default FullbleedPanel;
+export default FillPanel;

--- a/assets/src/edit-story/components/panels/index.js
+++ b/assets/src/edit-story/components/panels/index.js
@@ -21,7 +21,7 @@ import { elementTypes } from '../../elements';
 import ActionsPanel from './actions';
 import ColorPanel from './color';
 import BackgroundColorPanel from './backgroundColor';
-import FullbleedPanel from './fullbleed';
+import FillPanel from './fill';
 import FontPanel from './font';
 import RotationPanel from './rotationAngle';
 import SizePanel from './size';
@@ -41,7 +41,7 @@ const ROTATION_ANGLE = 'rotationAngle';
 const TEXT = 'text';
 const SIZE = 'size';
 const POSITION = 'position';
-const FULLBLEED = 'fullbleed';
+const FILL = 'fill';
 const BACKGROUND_COLOR = 'backgroundColor';
 const STYLE = 'style';
 const VIDEO_POSTER = 'videoPoster';
@@ -57,7 +57,7 @@ export const PanelTypes = {
 	STYLE,
 	TEXT,
 	ROTATION_ANGLE,
-	FULLBLEED,
+	FILL,
 	VIDEO_POSTER,
 };
 
@@ -86,7 +86,7 @@ export function getPanels( elements ) {
 				case SCALE: return { type, Panel: ScalePanel };
 				case ROTATION_ANGLE: return { type, Panel: RotationPanel };
 				case SIZE: return { type, Panel: SizePanel };
-				case FULLBLEED: return { type, Panel: FullbleedPanel };
+				case FILL: return { type, Panel: FillPanel };
 				case BACKGROUND_COLOR: return { type, Panel: BackgroundColorPanel };
 				case COLOR: return { type, Panel: ColorPanel };
 				case FONT: return { type, Panel: FontPanel };

--- a/assets/src/edit-story/components/panels/position.js
+++ b/assets/src/edit-story/components/panels/position.js
@@ -35,7 +35,7 @@ import getCommonValue from './utils/getCommonValue';
 function PositionPanel( { selectedElements, onSetProperties } ) {
 	const x = getCommonValue( selectedElements, 'x' );
 	const y = getCommonValue( selectedElements, 'y' );
-	const isFullbleed = getCommonValue( selectedElements, 'isFullbleed' );
+	const isFill = getCommonValue( selectedElements, 'isFill' );
 	const [ state, setState ] = useState( { x, y } );
 	useEffect( () => {
 		setState( { x, y } );
@@ -52,7 +52,7 @@ function PositionPanel( { selectedElements, onSetProperties } ) {
 				isMultiple={ x === '' }
 				onChange={ ( value ) => setState( { ...state, x: isNaN( value ) || value === '' ? '' : parseFloat( value ) } ) }
 				postfix={ _x( 'px', 'pixels, the measurement of size', 'web-stories' ) }
-				disabled={ isFullbleed }
+				disabled={ isFill }
 			/>
 			<InputGroup
 				label={ _x( 'Y', 'The Y axis', 'web-stories' ) }
@@ -60,7 +60,7 @@ function PositionPanel( { selectedElements, onSetProperties } ) {
 				isMultiple={ y === '' }
 				onChange={ ( value ) => setState( { ...state, y: isNaN( value ) || value === '' ? '' : parseFloat( value ) } ) }
 				postfix={ _x( 'px', 'pixels, the measurement of size', 'web-stories' ) }
-				disabled={ isFullbleed }
+				disabled={ isFill }
 			/>
 		</SimplePanel>
 	);

--- a/assets/src/edit-story/components/panels/rotationAngle.js
+++ b/assets/src/edit-story/components/panels/rotationAngle.js
@@ -34,7 +34,7 @@ import getCommonValue from './utils/getCommonValue';
 
 function RotationPanel( { selectedElements, onSetProperties } ) {
 	const rotationAngle = getCommonValue( selectedElements, 'rotationAngle' );
-	const isFullbleed = getCommonValue( selectedElements, 'isFullbleed' );
+	const isFill = getCommonValue( selectedElements, 'isFill' );
 	const [ state, setState ] = useState( { rotationAngle } );
 	useEffect( () => {
 		setState( { rotationAngle } );
@@ -51,7 +51,7 @@ function RotationPanel( { selectedElements, onSetProperties } ) {
 				isMultiple={ rotationAngle === '' }
 				onChange={ ( value ) => setState( { ...state, rotationAngle: isNaN( value ) || value === '' ? '' : parseFloat( value ) } ) }
 				postfix={ _x( 'deg', 'Degrees, 0 - 360. ', 'web-stories' ) }
-				disabled={ isFullbleed }
+				disabled={ isFill }
 			/>
 		</SimplePanel>
 	);

--- a/assets/src/edit-story/components/panels/size.js
+++ b/assets/src/edit-story/components/panels/size.js
@@ -35,7 +35,7 @@ import getCommonValue from './utils/getCommonValue';
 function SizePanel( { selectedElements, onSetProperties } ) {
 	const width = getCommonValue( selectedElements, 'width' );
 	const height = getCommonValue( selectedElements, 'height' );
-	const isFullbleed = getCommonValue( selectedElements, 'isFullbleed' );
+	const isFill = getCommonValue( selectedElements, 'isFill' );
 	const [ state, setState ] = useState( { width, height } );
 	const [ lockRatio, setLockRatio ] = useState( true );
 	useEffect( () => {
@@ -61,7 +61,7 @@ function SizePanel( { selectedElements, onSetProperties } ) {
 					} );
 				} }
 				postfix={ _x( 'px', 'pixels, the measurement of size', 'web-stories' ) }
-				disabled={ isFullbleed }
+				disabled={ isFill }
 			/>
 			<InputGroup
 				label={ __( 'Height', 'web-stories' ) }
@@ -77,7 +77,7 @@ function SizePanel( { selectedElements, onSetProperties } ) {
 					} );
 				} }
 				postfix={ _x( 'px', 'pixels, the measurement of size', 'web-stories' ) }
-				disabled={ isFullbleed }
+				disabled={ isFill }
 			/>
 			<InputGroup
 				type="checkbox"
@@ -87,7 +87,7 @@ function SizePanel( { selectedElements, onSetProperties } ) {
 				onChange={ ( value ) => {
 					setLockRatio( value );
 				} }
-				disabled={ isFullbleed }
+				disabled={ isFill }
 			/>
 		</SimplePanel>
 	);

--- a/assets/src/edit-story/elements/image/edit.js
+++ b/assets/src/edit-story/elements/image/edit.js
@@ -71,7 +71,7 @@ const CropImg = styled.img`
 `;
 
 function ImageEdit( {
-	element: { id, src, origRatio, scale, focalX, focalY, isFullbleed },
+	element: { id, src, origRatio, scale, focalX, focalY, isFill },
 	box: { x, y, width, height, rotationAngle },
 } ) {
 	const [ fullImage, setFullImage ] = useState( null );
@@ -92,7 +92,7 @@ function ImageEdit( {
 				<CropImg ref={ setCroppedImage } draggable={ false } src={ src } { ...imgProps } />
 			</CropBox>
 
-			{ ! isFullbleed && cropBox && croppedImage && (
+			{ ! isFill && cropBox && croppedImage && (
 				<EditCropMovable
 					setProperties={ setProperties }
 					cropBox={ cropBox }

--- a/assets/src/edit-story/elements/image/index.js
+++ b/assets/src/edit-story/elements/image/index.js
@@ -40,5 +40,5 @@ export const panels = [
 	PanelTypes.POSITION,
 	PanelTypes.SCALE,
 	PanelTypes.ROTATION_ANGLE,
-	PanelTypes.FULLBLEED,
+	PanelTypes.FILL,
 ];

--- a/assets/src/edit-story/elements/image/preview.js
+++ b/assets/src/edit-story/elements/image/preview.js
@@ -32,12 +32,12 @@ import { getCommonAttributes } from '../shared';
 /**
  * Returns AMP HTML for saving into post content for displaying in the FE.
  */
-function ImagePreview( { id, src, width, height, x, y, rotationAngle, isFullbleed } ) {
+function ImagePreview( { id, src, width, height, x, y, rotationAngle, isFill } ) {
 	const props = {
 		layout: 'fill',
 		src,
 		style: {
-			objectFit: isFullbleed ? 'cover' : null,
+			objectFit: isFill ? 'cover' : null,
 			width: '100%',
 			height: '100%',
 		},
@@ -47,7 +47,7 @@ function ImagePreview( { id, src, width, height, x, y, rotationAngle, isFullblee
 	};
 	const style = getCommonAttributes( { width, height, x, y, rotationAngle } );
 	// @todo This is missing focal point handling which will be resolved separately.
-	if ( isFullbleed ) {
+	if ( isFill ) {
 		style.top = 0;
 		style.left = 0;
 		style.width = '100%';
@@ -69,7 +69,7 @@ ImagePreview.propTypes = {
 	x: PropTypes.number.isRequired,
 	y: PropTypes.number.isRequired,
 	rotationAngle: PropTypes.number.isRequired,
-	isFullbleed: PropTypes.bool,
+	isFill: PropTypes.bool,
 };
 
 export default ImagePreview;

--- a/assets/src/edit-story/elements/image/save.js
+++ b/assets/src/edit-story/elements/image/save.js
@@ -27,7 +27,7 @@ import { getCommonAttributes } from '../shared';
 /**
  * Returns AMP HTML for saving into post content for displaying in the FE.
  */
-function ImageSave( { id, src, width, height, x, y, rotationAngle, isFullbleed } ) {
+function ImageSave( { id, src, width, height, x, y, rotationAngle, isFill } ) {
 	const props = {
 		layout: 'fill',
 		src,
@@ -37,7 +37,7 @@ function ImageSave( { id, src, width, height, x, y, rotationAngle, isFullbleed }
 	};
 	const style = getCommonAttributes( { width, height, x, y, rotationAngle } );
 	// @todo This is missing focal point handling which will be resolved separately.
-	if ( isFullbleed ) {
+	if ( isFill ) {
 		style.top = 0;
 		style.left = 0;
 		style.width = '100%';
@@ -46,7 +46,7 @@ function ImageSave( { id, src, width, height, x, y, rotationAngle, isFullbleed }
 
 	return (
 		<div style={ { ...style } } { ...wrapperProps }>
-			<amp-img className={ isFullbleed ? 'full-bleed' : '' } { ...props } />
+			<amp-img className={ isFill ? 'full-bleed' : '' } { ...props } />
 		</div>
 	);
 }
@@ -59,7 +59,7 @@ ImageSave.propTypes = {
 	x: PropTypes.number.isRequired,
 	y: PropTypes.number.isRequired,
 	rotationAngle: PropTypes.number.isRequired,
-	isFullbleed: PropTypes.bool,
+	isFill: PropTypes.bool,
 };
 
 export default ImageSave;

--- a/assets/src/edit-story/elements/square/index.js
+++ b/assets/src/edit-story/elements/square/index.js
@@ -33,4 +33,5 @@ export const panels = [
 	PanelTypes.POSITION,
 	PanelTypes.BACKGROUND_COLOR,
 	PanelTypes.ROTATION_ANGLE,
+	PanelTypes.FILL,
 ];

--- a/assets/src/edit-story/elements/video/index.js
+++ b/assets/src/edit-story/elements/video/index.js
@@ -39,4 +39,5 @@ export const panels = [
 	PanelTypes.SCALE,
 	PanelTypes.ROTATION_ANGLE,
 	PanelTypes.VIDEO_POSTER,
+	PanelTypes.FILL,
 ];

--- a/assets/src/edit-story/migration/migrate.js
+++ b/assets/src/edit-story/migration/migrate.js
@@ -20,10 +20,12 @@
 import { DATA_VERSION } from './dataVersion';
 import storyDataArrayToObject from './migrations/v0001_storyDataArrayToObject';
 import dataPixelTo1080 from './migrations/v0002_dataPixelTo1080';
+import fullbleedToFill from './migrations/v0003_fullbleedToFill';
 
 const MIGRATIONS = {
 	1: [ storyDataArrayToObject ],
 	2: [ dataPixelTo1080 ],
+	3: [ fullbleedToFill ],
 };
 
 function migrate( storyData, version ) {

--- a/assets/src/edit-story/migration/migrations/test/v0003_fullbleedToFill.js
+++ b/assets/src/edit-story/migration/migrations/test/v0003_fullbleedToFill.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import fullbleedToFill from '../v0003_fullbleedToFill';
+
+describe( 'fullbleedToFill', () => {
+	it( 'should fullbleed to fill', () => {
+		expect( fullbleedToFill( {
+			_test: 'story',
+			pages: [
+				{
+					_test: 'page1',
+					elements: [
+						{
+							_test: 'element1',
+							isFullbleed: true,
+						},
+						{
+							_test: 'element2',
+							isFullbleed: false,
+						},
+					],
+				},
+				{
+					_test: 'page2',
+					elements: [],
+				},
+			],
+		} ) ).toStrictEqual( {
+			_test: 'story',
+			pages: [
+				{
+					_test: 'page1',
+					elements: [
+						{
+							_test: 'element1',
+							isFill: true,
+						},
+						{
+							_test: 'element2',
+							isFill: false,
+						},
+					],
+				},
+				{
+					_test: 'page2',
+					elements: [],
+				},
+			],
+		} );
+	} );
+} );

--- a/assets/src/edit-story/migration/migrations/v0003_fullbleedToFill.js
+++ b/assets/src/edit-story/migration/migrations/v0003_fullbleedToFill.js
@@ -14,4 +14,25 @@
  * limitations under the License.
  */
 
-export const DATA_VERSION = 3;
+function fullbleedToFill( { pages, ...rest } ) {
+	return {
+		pages: pages.map( reducePage ),
+		...rest,
+	};
+}
+
+function reducePage( { elements, ...rest } ) {
+	return {
+		elements: elements.map( updateElement ),
+		...rest,
+	};
+}
+
+function updateElement( { isFullbleed, ...rest } ) {
+	return {
+		isFill: isFullbleed,
+		...rest,
+	};
+}
+
+export default fullbleedToFill;

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -13,7 +13,7 @@ export const StoryElementPropsTypes = {
 	width: PropTypes.number.isRequired,
 	height: PropTypes.number.isRequired,
 	rotationAngle: PropTypes.number.isRequired,
-	isFullbleed: PropTypes.bool.isRequired,
+	isFill: PropTypes.bool.isRequired,
 };
 
 StoryPropTypes.size = PropTypes.exact( {

--- a/assets/src/edit-story/units/dimensions.js
+++ b/assets/src/edit-story/units/dimensions.js
@@ -76,19 +76,19 @@ export function editorToDataY( y, pageHeight ) {
  * Converts the element's position, width, and rotation) to the "box" in the
  * "editor" coordinate space.
  *
- * @param {{x:number, y:number, width:number, height:number, rotationAngle:number, isFullbleed:boolean}} element The
+ * @param {{x:number, y:number, width:number, height:number, rotationAngle:number, isFill:boolean}} element The
  * element's position, width, and rotation. See `StoryPropTypes.element`.
  * @param {number} pageWidth The basis value for the page's width in the "editor" space.
  * @param {number} pageHeight The basis value for the page's height in the "editor" space.
  * @return {{x:number, y:number, width:number, height:number, rotationAngle:number}} The
  * "box" in the editor space.
  */
-export function getBox( { x, y, width, height, rotationAngle, isFullbleed }, pageWidth, pageHeight ) {
+export function getBox( { x, y, width, height, rotationAngle, isFill }, pageWidth, pageHeight ) {
 	return {
-		x: dataToEditorX( isFullbleed ? 0 : x, pageWidth ),
-		y: dataToEditorY( isFullbleed ? 0 : y, pageHeight ),
-		width: dataToEditorX( isFullbleed ? PAGE_WIDTH : width, pageWidth ),
-		height: dataToEditorY( isFullbleed ? PAGE_HEIGHT : height, pageHeight ),
-		rotationAngle: isFullbleed ? 0 : rotationAngle,
+		x: dataToEditorX( isFill ? 0 : x, pageWidth ),
+		y: dataToEditorY( isFill ? 0 : y, pageHeight ),
+		width: dataToEditorX( isFill ? PAGE_WIDTH : width, pageWidth ),
+		height: dataToEditorY( isFill ? PAGE_HEIGHT : height, pageHeight ),
+		rotationAngle: isFill ? 0 : rotationAngle,
 	};
 }


### PR DESCRIPTION
Fullbleed name will be used in the "background media" context (see #25). The "fill" layout is represented in the UI as:

![image](https://user-images.githubusercontent.com/726049/73567012-42df7280-441a-11ea-88c7-891cde8f2858.png)
