### PR TITLE
Upgrades react-moveable

### DIFF
--- a/assets/src/edit-story/components/canvas/multiSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/multiSelectionMovable.js
@@ -156,12 +156,8 @@ function MultiSelectionMovable( { selectedElements } ) {
 			target={ targetList.map( ( { node } ) => node ) }
 
 			draggable={ true }
-			// Making resizable depend on state caused a bug where the
-			// center of gravity for rotation moves to the top left,
-			// see https://github.com/daybrush/moveable/issues/168
-			// once fixed these should change to !isDragging
-			resizable={ true /** should be !isDragging */ }
-			rotatable={ isDragging }
+			resizable={ ! isDragging }
+			rotatable={ ! isDragging }
 
 			onDragGroup={ ( { events } ) => {
 				events.forEach( ( { target, beforeTranslate }, i ) => {

--- a/assets/src/edit-story/components/movable/moveStyle.js
+++ b/assets/src/edit-story/components/movable/moveStyle.js
@@ -64,6 +64,8 @@ export const GlobalStyle = createGlobalStyle`
 
 	.default-movable.moveable-control-box .moveable-line.moveable-rotation-line {
 		background: #4285f4 !important;
-		width: 2px;
+		width: 1px;
+		top: -16px;
+		height: 16px;
 	}
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1716,6 +1716,12 @@
         "@egjs/list-differ": "^1.0.0"
       }
     },
+    "@egjs/component": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@egjs/component/-/component-2.1.2.tgz",
+      "integrity": "sha512-7tnPiqxbSZ0porzlm0+/O3qZdanMj0zOq0sb17wQXuaRG49XKKKJaO+SacGnZDqf308N5hzJ0m9fZ4+j+VBvXA==",
+      "dev": true
+    },
     "@egjs/list-differ": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@egjs/list-differ/-/list-differ-1.0.0.tgz",
@@ -2571,6 +2577,15 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
+      }
+    },
+    "@scena/dragscroll": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@scena/dragscroll/-/dragscroll-0.2.1.tgz",
+      "integrity": "sha512-8WrABWGvaALt0xMgesVZuA9Utt1q3zmGyqzWT22W1gfeKwVriqHTVldUQZevWIpgpnpIJtIW+/xFVsLtpmMsSA==",
+      "dev": true,
+      "requires": {
+        "@egjs/component": "^2.1.2"
       }
     },
     "@storybook/addon-a11y": {
@@ -19141,9 +19156,9 @@
       }
     },
     "react-moveable": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.16.6.tgz",
-      "integrity": "sha512-RtUBk5bSWER8UL0aE9ZXWTSCw6ZDRA51FjO5a2AnVM3y6wzpaXXuL9rF9qOJdGIb25bfVuHVjbdPAlym1NJBrg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.17.0.tgz",
+      "integrity": "sha512-KLNqJNLxOjd4dOuAHI95yZkgcK7WUtV2dUkm6PA14VjW+dys4IwMfuqUoG9/hFHAu08Uw0WV96f/zMVFtGoJ7A==",
       "dev": true,
       "requires": {
         "@daybrush/drag": "^0.12.0",
@@ -19151,8 +19166,9 @@
         "@egjs/agent": "^2.1.5",
         "@egjs/children-differ": "^1.0.0",
         "@moveable/matrix": "^0.3.1",
+        "@scena/dragscroll": "^0.2.1",
         "framework-utils": "^0.3.4",
-        "react-css-styled": "^0.1.3"
+        "react-css-styled": "^0.1.4"
       }
     },
     "react-outside-click-handler": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "postcss-loader": "^3.0.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
-    "react-moveable": "^0.16.6",
+    "react-moveable": "^0.17.0",
     "styled-components": "^5.0.0",
     "stylelint": "^13.0.0",
     "stylelint-config-recommended": "^3.0.0",


### PR DESCRIPTION
### Changes
- Upgrades `react-moveable` to `0.17.0`
- Fixes hiding control handles when dragging a multi-selection
- Fixes styling for the rotation handle (now sits closer to the object as in the design mocks)
- Adds support for rotated system bounds (needs to be implemented on our end, pending documentation on https://github.com/daybrush/moveable/issues/163 )