### PR TITLE
Properly add API key as env var

### DIFF
--- a/.github/workflows/update-google-fonts.yml
+++ b/.github/workflows/update-google-fonts.yml
@@ -11,7 +11,8 @@ jobs:
         with:
           node-version: '10.x'
       - name: Update list of Google Fonts
-        id: vars
+        env:
+          GOOGLE_FONTS_API_KEY: ${{ secrets.GOOGLE_FONTS_API_KEY }}
         run: |
           npm install
           npm run download-fonts


### PR DESCRIPTION
Realized that the Google Fonts API key wasn't actually exposed to the GitHub action.

See https://github.com/google/web-stories-wp/runs/423037035 for the failed run.