### PR TITLE
Actually leverage variable analysis sniffs

### DIFF
--- a/includes/REST_API/Fonts_Controller.php
+++ b/includes/REST_API/Fonts_Controller.php
@@ -166,7 +166,7 @@ class Fonts_Controller extends WP_REST_Controller {
 	 *
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_items_permissions_check( $request ) {
+	public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		return current_user_can( 'edit_posts' );
 	}
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -26,6 +26,8 @@
 		</properties>
 	</rule>
 
+  <rule ref="VariableAnalysis.CodeAnalysis.VariableAnalysis" />
+
 	<!-- Check for cross-version support for PHP 5.6 and higher. -->
 	<config name="testVersion" value="5.6-" />
 	<rule ref="PHPCompatibilityWP" />


### PR DESCRIPTION
We use `sirbrillig/phpcs-variable-analysis` but with the repo transfer its usage might have slipped out of `phpcs.xml`. Let's actually make use of it. 