### PR TITLE
Use regex for svgo’s currentColor replacement

### DIFF
--- a/.svgo.yml
+++ b/.svgo.yml
@@ -2,4 +2,4 @@ plugins:
   - removeViewBox: false
   - removeDimensions: true
   - convertColors:
-      currentColor: true
+      currentColor: /\b(?!url|none)/i


### PR DESCRIPTION
Only replace the color if it’s not “none” (default) or using pattern fills (using `url(…)`).

Before:

![Screenshot 2020-02-13 at 14 25 07](https://user-images.githubusercontent.com/841956/74439641-e8f49900-4e6c-11ea-8c6e-d0bdd1ed368d.png)

After:

![Screenshot 2020-02-13 at 14 24 18](https://user-images.githubusercontent.com/841956/74439649-ec882000-4e6c-11ea-9521-c3f8cb661193.png)

See #244.