### PR TITLE
Use different indent size for PHP code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,7 @@ indent_size = 2
 
 [*.php]
 indent_style = tab
+indent_size = 4
 
 [*.md]
 trim_trailing_whitespace = false


### PR DESCRIPTION
Changes it back to what we had before adopting Prettier for JS code.