### PR TITLE
Fix multi-select bug including background element

### DIFF
--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/selectElement.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/selectElement.js
@@ -37,6 +37,14 @@ function selectElement(state, { elementId }) {
     return state;
   }
 
+  // If bg element was already the (only) selection, set selection to new element only
+  if (state.selection.includes(currentPage.backgroundElementId)) {
+    return {
+      ...state,
+      selection: [elementId],
+    };
+  }
+
   return {
     ...state,
     selection: [...state.selection, elementId],

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/toggleElement.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/toggleElement.js
@@ -38,18 +38,31 @@ function toggleElement(state, { elementId }) {
   const isBackgroundElement = currentPage.backgroundElementId === elementId;
   const hasExistingSelection = state.selection.length > 0;
 
-  // The bg element can't be added to non-empty selection
-  if (!wasSelected && isBackgroundElement && hasExistingSelection) {
-    return state;
+  // If it wasn't selected, we're adding the element to the selection.
+  if (!wasSelected) {
+    // The bg element can't be added to non-empty selection
+    if (isBackgroundElement && hasExistingSelection) {
+      return state;
+    }
+
+    // If bg element was already the (only) selection, set selection to new element only
+    if (state.selection.includes(currentPage.backgroundElementId)) {
+      return {
+        ...state,
+        selection: [elementId],
+      };
+    }
+
+    return {
+      ...state,
+      selection: [...state.selection, elementId],
+    };
   }
 
-  const newSelection = wasSelected
-    ? state.selection.filter((id) => id !== elementId)
-    : [...state.selection, elementId];
-
+  // Otherwise just filter out from current selection
   return {
     ...state,
-    selection: newSelection,
+    selection: state.selection.filter((id) => id !== elementId),
   };
 }
 

--- a/assets/src/edit-story/app/story/useStoryReducer/test/addElementToSelection.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/addElementToSelection.js
@@ -80,4 +80,26 @@ describe('addElementToSelection', () => {
     const failedAttempt = addElementToSelection({ elementId: 'e1' });
     expect(failedAttempt).toStrictEqual(initialState);
   });
+
+  it('should remove background element from selection if adding a new one', () => {
+    const { restore, addElementToSelection } = setupReducer();
+
+    // Set an initial state with bg element selected
+    restore({
+      pages: [
+        {
+          id: '111',
+          backgroundElementId: 'e1',
+          elements: [{ id: 'e1' }, { id: 'e2' }, { id: 'e3' }],
+        },
+      ],
+      current: '111',
+      selection: ['e1'],
+    });
+
+    // Add a new element to selection - should expunge bg element from selection
+    const { selection } = addElementToSelection({ elementId: 'e2' });
+    expect(selection).not.toContain('e1');
+    expect(selection).toContain('e2');
+  });
 });

--- a/assets/src/edit-story/app/story/useStoryReducer/test/toggleElementInSelection.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/toggleElementInSelection.js
@@ -80,4 +80,26 @@ describe('toggleElementInSelection', () => {
     const failedAttempt = toggleElementInSelection({ elementId: 'e1' });
     expect(failedAttempt).toStrictEqual(initialState);
   });
+
+  it('should remove background element from selection if adding a new one', () => {
+    const { restore, toggleElementInSelection } = setupReducer();
+
+    // Set an initial state with bg element selected
+    restore({
+      pages: [
+        {
+          id: '111',
+          backgroundElementId: 'e1',
+          elements: [{ id: 'e1' }, { id: 'e2' }, { id: 'e3' }],
+        },
+      ],
+      current: '111',
+      selection: ['e1'],
+    });
+
+    // Add a new element to selection - should expunge bg element from selection
+    const { selection } = toggleElementInSelection({ elementId: 'e2' });
+    expect(selection).not.toContain('e1');
+    expect(selection).toContain('e2');
+  });
 });


### PR DESCRIPTION
Multi-selection can never include the background-element, but if you selected the bg first, it was possible. This PR fixes that.

Fixes #363.