### PR TITLE
Open the preview in the same tab

### DIFF
--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -60,7 +60,7 @@ function PreviewButton() {
    */
   const openPreviewLink = () => {
     const previewLink = addQueryArgs(link, { preview: 'true' });
-    window.open(previewLink, '_blank');
+    window.open(previewLink, 'story-preview');
   };
   return (
     <Outline onClick={openPreviewLink} isDisabled={isSaving}>


### PR DESCRIPTION
Fixes https://github.com/google/web-stories-wp/issues/267

After testing, this little change looks very helpful (just a small issue with FF described below).

Chrome/Safari/Edge - they behave the same:
1. The preview tab/window is brought to the front
2. They keep the last viewed page (in preview)

Firefox does none of this (tab in the background, always starts on the first page).

We can fix 1. with `.focus()` on the newly opened window (works in current FF).

No idea about an easy way to achieve 2., but we can do something else if that's desired:
Preview the currently edited page (by using `#page=${currentPageId}` + some fixes to reload the page on FF because it's stale that way)