### PR TITLE
Text edit mode fixes and start on some tests

### DIFF
--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -124,6 +124,12 @@ function CanvasProvider({ children }) {
     ) {
       clearEditing();
     }
+    if (
+      lastSelectedElementId.current &&
+      !selectedElementIds.includes(lastSelectedElementId.current)
+    ) {
+      lastSelectedElementId.current = null;
+    }
   }, [editingElement, selectedElementIds, clearEditing]);
 
   useCanvasSelectionCopyPaste(pageContainer);

--- a/assets/src/edit-story/components/canvas/editElement.js
+++ b/assets/src/edit-story/components/canvas/editElement.js
@@ -19,7 +19,6 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useEffect, useRef } from 'react';
 
 /**
  * Internal dependencies
@@ -43,24 +42,16 @@ const Wrapper = styled.div`
 `;
 
 function EditElement({ element }) {
-  const ref = useRef(null);
   const { id, type } = element;
   const {
     actions: { getBox },
   } = useUnits();
 
   const { Edit } = getDefinitionForType(type);
-
   const box = getBox(element);
-
-  useEffect(() => {
-    ref.current.focus();
-  }, []);
 
   return (
     <Wrapper
-      ref={ref}
-      tabIndex="0"
       aria-labelledby={`layer-${id}`}
       {...box}
       onMouseDown={(evt) => evt.stopPropagation()}

--- a/assets/src/edit-story/components/canvas/editLayer.js
+++ b/assets/src/edit-story/components/canvas/editLayer.js
@@ -23,6 +23,7 @@ import { useRef } from 'react';
 /**
  * Internal dependencies
  */
+import StoryPropTypes from '../../types';
 import { getDefinitionForType } from '../../elements';
 import { useKeyDownEffect } from '../keyboard';
 import { useStory } from '../../app';
@@ -45,18 +46,12 @@ const EditPageArea = withOverlay(styled(PageArea).attrs({
 `);
 
 function EditLayer({}) {
-  const ref = useRef(null);
   const {
     state: { currentPage },
   } = useStory();
   const {
     state: { editingElement: editingElementId },
-    actions: { clearEditing },
   } = useCanvas();
-
-  useKeyDownEffect(ref, { key: 'esc', editable: true }, () => clearEditing(), [
-    clearEditing,
-  ]);
 
   const editingElement =
     editingElementId &&
@@ -67,15 +62,31 @@ function EditLayer({}) {
     return null;
   }
 
-  const { editModeGrayout } = getDefinitionForType(editingElement.type);
+  return <EditLayerForElement element={editingElement} />;
+}
+
+function EditLayerForElement({ element }) {
+  const ref = useRef(null);
+  const { editModeGrayout } = getDefinitionForType(element.type);
+
+  const {
+    actions: { clearEditing },
+  } = useCanvas();
+  useKeyDownEffect(ref, { key: 'esc', editable: true }, () => clearEditing(), [
+    clearEditing,
+  ]);
 
   return (
     <LayerWithGrayout ref={ref} grayout={editModeGrayout} pointerEvents="none">
       <EditPageArea>
-        <EditElement element={editingElement} />
+        <EditElement element={element} />
       </EditPageArea>
     </LayerWithGrayout>
   );
 }
+
+EditLayerForElement.propTypes = {
+  element: StoryPropTypes.element.isRequired,
+};
 
 export default EditLayer;

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -98,7 +98,7 @@ function FrameElement({ element }) {
         showTooltip={selectedElementIds.length === 1 && isSelected}
       >
         <WithElementMask element={element} fill={true}>
-          {Frame && <Frame element={element} box={box} />}
+          {Frame && <Frame wrapperRef={elementRef} element={element} box={box} />}
         </WithElementMask>
       </WithLink>
     </Wrapper>

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -18,12 +18,12 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
 import { useLayoutEffect, useRef } from 'react';
 
 /**
  * Internal dependencies
  */
+import StoryPropTypes from '../../types';
 import { getDefinitionForType } from '../../elements';
 import { useStory } from '../../app';
 import {
@@ -98,7 +98,9 @@ function FrameElement({ element }) {
         showTooltip={selectedElementIds.length === 1 && isSelected}
       >
         <WithElementMask element={element} fill={true}>
-          {Frame && <Frame wrapperRef={elementRef} element={element} box={box} />}
+          {Frame && (
+            <Frame wrapperRef={elementRef} element={element} box={box} />
+          )}
         </WithElementMask>
       </WithLink>
     </Wrapper>
@@ -106,7 +108,7 @@ function FrameElement({ element }) {
 }
 
 FrameElement.propTypes = {
-  element: PropTypes.object.isRequired,
+  element: StoryPropTypes.element.isRequired,
 };
 
 export default FrameElement;

--- a/assets/src/edit-story/components/canvas/test/_utils.js
+++ b/assets/src/edit-story/components/canvas/test/_utils.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { ThemeProvider } from 'styled-components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import FrameElement from '../frameElement';
+import CanvasProvider from '../canvasProvider';
+import ConfigProvider from '../../../app/config/configProvider';
+import StoryContext from '../../../app/story/context';
+import theme from '../../../theme';
+import useEditingElement from '../useEditingElement';
+
+jest.mock('../useEditingElement');
+
+export function TestFrameElement({
+  element,
+  configContext: inputConfigContext,
+  storyContext: inputStoryContext,
+  editingElementContext: inputEditingElementContext,
+}) {
+  const configContext = {
+    ...inputConfigContext,
+    allowedMimeTypes: {
+      image: [],
+      video: [],
+      ...(inputConfigContext && inputConfigContext.allowedMimeTypes),
+    },
+  };
+  const storyContext = {
+    ...inputStoryContext,
+    state: {
+      selectedElements: [],
+      selectedElementIds: [],
+      ...(inputStoryContext && inputStoryContext.state),
+    },
+    actions: {
+      toggleElementInSelection: () => {},
+      setSelectedElementsById: () => {},
+      ...(inputStoryContext && inputStoryContext.actions),
+    },
+  };
+  const editingElementContext = {
+    nodesById: {},
+    setNodeForElement: () => {},
+    setEditingElementWithState: () => {},
+    ...inputEditingElementContext,
+  };
+  useEditingElement.mockImplementation(() => editingElementContext);
+  return (
+    <ThemeProvider theme={theme}>
+      <ConfigProvider config={configContext}>
+        <StoryContext.Provider value={storyContext}>
+          <CanvasProvider>
+            <FrameElement element={element} />
+          </CanvasProvider>
+        </StoryContext.Provider>
+      </ConfigProvider>
+    </ThemeProvider>
+  );
+}
+
+TestFrameElement.propTypes = {
+  element: PropTypes.object.isRequired,
+  configContext: PropTypes.object,
+  storyContext: PropTypes.object,
+  editingElementContext: PropTypes.object,
+};

--- a/assets/src/edit-story/components/canvas/test/frameElement.test.js
+++ b/assets/src/edit-story/components/canvas/test/frameElement.test.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { TestFrameElement } from './_utils';
+
+describe('FrameElement selection', () => {
+  let setSelectedElementsById;
+  let toggleElementInSelection;
+  let storyContext;
+
+  beforeEach(() => {
+    setSelectedElementsById = jest.fn();
+    toggleElementInSelection = jest.fn();
+    storyContext = {
+      actions: {
+        setSelectedElementsById,
+        toggleElementInSelection,
+      },
+    };
+  });
+
+  it('should select unselected element on mousedown', () => {
+    const element = {
+      id: '1',
+      type: 'text',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 80,
+      rotationAngle: 0,
+      fontSize: 20,
+      content: 'hello world',
+    };
+    const { container } = render(
+      <TestFrameElement storyContext={storyContext} element={element} />
+    );
+
+    // Fire a mousedown event.
+    const wrapper = container.querySelector('[data-element-id="1"]');
+    fireEvent.mouseDown(wrapper);
+    expect(setSelectedElementsById).toHaveBeenCalledWith({ elementIds: ['1'] });
+  });
+
+  it('should select unselected element on focus', () => {
+    const element = {
+      id: '1',
+      type: 'text',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 80,
+      rotationAngle: 0,
+      fontSize: 20,
+      content: 'hello world',
+    };
+    const { container } = render(
+      <TestFrameElement storyContext={storyContext} element={element} />
+    );
+
+    // Fire a mousedown event.
+    const wrapper = container.querySelector('[data-element-id="1"]');
+    fireEvent.focus(wrapper);
+    expect(setSelectedElementsById).toHaveBeenCalledWith({ elementIds: ['1'] });
+  });
+
+  it('should not select on mousedown if already selected', () => {
+    const element = {
+      id: '1',
+      type: 'text',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 80,
+      rotationAngle: 0,
+      fontSize: 20,
+      content: 'hello world',
+    };
+    storyContext = {
+      ...storyContext,
+      state: {
+        selectedElementIds: [element.id],
+      },
+    };
+    const { container } = render(
+      <TestFrameElement storyContext={storyContext} element={element} />
+    );
+
+    // Fire a mousedown event.
+    const wrapper = container.querySelector('[data-element-id="1"]');
+    fireEvent.mouseDown(wrapper);
+    expect(setSelectedElementsById).not.toHaveBeenCalled();
+  });
+
+  it('should toggle selection on mousedown with shift', () => {
+    const element = {
+      id: '1',
+      type: 'text',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 80,
+      rotationAngle: 0,
+      fontSize: 20,
+      content: 'hello world',
+    };
+    const { container } = render(
+      <TestFrameElement storyContext={storyContext} element={element} />
+    );
+
+    // Fire a mousedown event with shift.
+    const wrapper = container.querySelector('[data-element-id="1"]');
+    fireEvent.mouseDown(wrapper, { shiftKey: true });
+    expect(toggleElementInSelection).toHaveBeenCalledWith({ elementId: '1' });
+  });
+});

--- a/assets/src/edit-story/components/canvas/useEditingElement.js
+++ b/assets/src/edit-story/components/canvas/useEditingElement.js
@@ -17,23 +17,26 @@
 /**
  * External dependencies
  */
-import { useState, useCallback } from 'react';
+import { useReducer, useCallback, useState } from 'react';
 
 function useEditingElement() {
-  const [editingElement, setEditingElement] = useState(null);
-  const [editingElementState, setEditingElementState] = useState({});
+  const [state, dispatch] = useReducer(reducer, {
+    editingElement: null,
+    editingElementState: {},
+  });
   const [nodesById, setNodesById] = useState({});
 
-  const clearEditing = useCallback(() => setEditingElement(null), []);
+  const clearEditing = useCallback(
+    () => dispatch({ editingElement: null }),
+    []
+  );
 
   const setEditingElementWithoutState = useCallback((id) => {
-    setEditingElement(id);
-    setEditingElementState({});
+    dispatch({ editingElement: id });
   }, []);
 
-  const setEditingElementWithState = useCallback((id, state) => {
-    setEditingElement(id);
-    setEditingElementState(state);
+  const setEditingElementWithState = useCallback((id, editingState) => {
+    dispatch({ editingElement: id, editingElementState: editingState });
   }, []);
 
   const setNodeForElement = useCallback(
@@ -41,6 +44,7 @@ function useEditingElement() {
     [setNodesById]
   );
 
+  const { editingElement, editingElementState } = state;
   return {
     nodesById,
     editingElement,
@@ -49,6 +53,14 @@ function useEditingElement() {
     setEditingElementWithoutState,
     clearEditing,
     setNodeForElement,
+  };
+}
+
+function reducer(state, { editingElement, editingElementState = {} }) {
+  return {
+    ...state,
+    editingElement,
+    editingElementState,
   };
 }
 

--- a/assets/src/edit-story/elements/text/frame.js
+++ b/assets/src/edit-story/elements/text/frame.js
@@ -17,8 +17,9 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useRef, useEffect, useCallback, useState } from 'react';
+import { useRef, useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -37,7 +38,7 @@ const Element = styled.p`
   ${elementWithFont}
 
 	opacity: 0;
-  user-select: ${({ canSelect }) => (canSelect ? 'initial' : 'none')};
+  user-select: none;
 `;
 
 function TextFrame({
@@ -50,6 +51,7 @@ function TextFrame({
     fontWeight,
     fontStyle,
   },
+  wrapperRef,
 }) {
   const {
     actions: { dataToEditorY },
@@ -66,88 +68,80 @@ function TextFrame({
   } = useStory();
 
   const {
-    actions: { setEditingElement, setEditingElementWithState },
+    actions: { setEditingElementWithState },
   } = useCanvas();
   const isElementSelected = selectedElementIds.includes(id);
   const isElementOnlySelection =
     isElementSelected && selectedElementIds.length === 1;
-  const [hasFocus, setHasFocus] = useState(false);
+
+  const elementRef = useRef();
+
   useEffect(() => {
-    if (isElementOnlySelection) {
-      const timeout = window.setTimeout(setHasFocus, 300, true);
-      return () => {
-        window.clearTimeout(timeout);
-      };
+    if (!isElementOnlySelection) {
+      return undefined;
     }
 
-    clickTime.current = 0;
-    setHasFocus(false);
-    return undefined;
-  }, [isElementOnlySelection]);
+    const wrapper = wrapperRef.current;
+    const element = elementRef.current;
 
-  const clickTime = useRef();
-  const handleMouseDown = useCallback(() => {
-    clickTime.current = window.performance.now();
-  }, []);
-  const handleMouseUp = useCallback(
-    (evt) => {
-      const timingDifference = window.performance.now() - clickTime.current;
-      if (timingDifference > 100) {
-        // Only short clicks count
+    let clickTime = 0;
+
+    const handleKeyDown = (evt) => {
+      if (evt.metaKey || evt.altKey || evt.ctrlKey) {
+        // Some modifier (except shift) was pressed. Ignore and bubble
         return;
       }
+
+      if (evt.key === 'Enter') {
+        // Enter editing without writing or selecting anything
+        setEditingElementWithState(id, { selectAll: true });
+        evt.stopPropagation();
+        // Make sure no actual Enter is pressed
+        evt.preventDefault();
+      } else if (/^\w$/.test(evt.key)) {
+        // TODO: in above check all printable characters across alphabets, no just a-z0-9 as \w is
+        // Enter editing and clear content (first letter will be correctly inserted from keyup)
+        setEditingElementWithState(id, { clearContent: true });
+        evt.stopPropagation();
+      }
+    };
+
+    const handleMouseDown = () => {
+      clickTime = window.performance.now();
+    };
+
+    const handleMouseUp = (evt) => {
+      const timingDifference = window.performance.now() - clickTime;
+
+      if (timingDifference > 300) {
+        // Only short clicks count.
+        return;
+      }
+
       // Enter editing mode and place cursor at current selection offset
       evt.stopPropagation();
       setEditingElementWithState(id, {
         offset: getCaretCharacterOffsetWithin(
-          element.current,
+          elementRef.current,
           evt.clientX,
           evt.clientY
         ),
       });
-    },
-    [id, setEditingElementWithState]
-  );
+    };
 
-  const handleKeyDown = (evt) => {
-    if (evt.metaKey || evt.altKey || evt.ctrlKey) {
-      // Some modifier (except shift) was pressed. Ignore and bubble
-      return;
-    }
-
-    if (evt.key === 'Enter') {
-      // Enter editing without writing or selecting anything
-      setEditingElement(id);
-      evt.stopPropagation();
-      // Make sure no actual Enter is pressed
-      evt.preventDefault();
-    } else if (/^\w$/.test(evt.key)) {
-      // TODO: in above check all printable characters across alphabets, no just a-z0-9 as \w is
-      // Enter editing and clear content (first letter will be correctly inserted from keyup)
-      setEditingElementWithState(id, { clearContent: true });
-      evt.stopPropagation();
-    }
-
-    // ignore everything else and bubble.
-  };
-
-  if (hasFocus) {
-    props.onKeyDown = handleKeyDown;
-    props.onMouseDown = handleMouseDown;
-    props.onMouseUp = handleMouseUp;
-  }
-
-  const element = useRef();
-  useEffect(() => {
-    if (isElementOnlySelection && element.current) {
-      element.current.focus();
-    }
-  }, [isElementOnlySelection]);
+    wrapper.addEventListener('keydown', handleKeyDown);
+    element.addEventListener('mousedown', handleMouseDown);
+    element.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      wrapper.removeEventListener('keydown', handleKeyDown);
+      element.removeEventListener('mousedown', handleMouseDown);
+      element.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [id, wrapperRef, isElementOnlySelection, setEditingElementWithState]);
 
   return (
     <Element
-      canSelect={hasFocus}
-      ref={element}
+      ref={elementRef}
       dangerouslySetInnerHTML={{ __html: content }}
       {...props}
     />
@@ -156,6 +150,7 @@ function TextFrame({
 
 TextFrame.propTypes = {
   element: StoryPropTypes.elements.text.isRequired,
+  wrapperRef: PropTypes.object.isRequired,
 };
 
 export default TextFrame;

--- a/assets/src/edit-story/elements/text/test/frame.test.js
+++ b/assets/src/edit-story/elements/text/test/frame.test.js
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, fireEvent, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { TestFrameElement } from '../../../components/canvas/test/_utils';
+
+jest.useFakeTimers();
+
+describe('TextFrame: enter edit mode', () => {
+  let element;
+  let storyContext;
+  let setEditingElementWithState;
+  let editingElementContext;
+
+  beforeEach(() => {
+    element = {
+      id: '1',
+      type: 'text',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 80,
+      rotationAngle: 0,
+      fontSize: 20,
+      content: 'hello world',
+    };
+
+    storyContext = {};
+    setEditingElementWithState = jest.fn();
+    editingElementContext = { setEditingElementWithState };
+  });
+
+  function setSelected() {
+    storyContext = {
+      ...storyContext,
+      state: {
+        selectedElements: [element],
+        selectedElementIds: [element.id],
+      },
+    };
+  }
+
+  it('should go to edit mode on a single click when selected', () => {
+    setSelected();
+    const { queryByText } = render(
+      <TestFrameElement
+        storyContext={storyContext}
+        editingElementContext={editingElementContext}
+        element={element}
+      />
+    );
+
+    const frame = queryByText(element.content);
+
+    act(() => jest.runOnlyPendingTimers());
+
+    fireEvent.mouseDown(frame);
+    fireEvent.mouseUp(frame);
+
+    expect(
+      editingElementContext.setEditingElementWithState
+    ).toHaveBeenCalledWith('1', { offset: 0 });
+  });
+
+  it('should go to edit mode on enter key', () => {
+    setSelected();
+    const { container } = render(
+      <TestFrameElement
+        storyContext={storyContext}
+        editingElementContext={editingElementContext}
+        element={element}
+      />
+    );
+
+    // Find the focusable target.
+    const target = container.querySelector('[tabindex="0"]');
+
+    act(() => jest.runOnlyPendingTimers());
+
+    // Fire "Enter" keydown.
+    fireEvent.keyDown(target, { key: 'Enter' });
+
+    expect(
+      editingElementContext.setEditingElementWithState
+    ).toHaveBeenCalledWith('1', { selectAll: true });
+  });
+
+  it('should go to edit mode on a character key', () => {
+    setSelected();
+    const { container } = render(
+      <TestFrameElement
+        storyContext={storyContext}
+        editingElementContext={editingElementContext}
+        element={element}
+      />
+    );
+
+    // Find the focusable target.
+    const target = container.querySelector('[tabindex="0"]');
+
+    act(() => jest.runOnlyPendingTimers());
+
+    // Fire "d" keydown.
+    fireEvent.keyDown(target, { key: 'd' });
+
+    expect(
+      editingElementContext.setEditingElementWithState
+    ).toHaveBeenCalledWith('1', { clearContent: true });
+  });
+});

--- a/assets/src/edit-story/elements/text/util.js
+++ b/assets/src/edit-story/elements/text/util.js
@@ -17,8 +17,38 @@
 /**
  * External dependencies
  */
-import { RichUtils } from 'draft-js';
+import { RichUtils, SelectionState } from 'draft-js';
 import { filterEditorState } from 'draftjs-filters';
+
+export function getSelectionForAll(content) {
+  const firstBlock = content.getFirstBlock();
+  const lastBlock = content.getLastBlock();
+  return new SelectionState({
+    anchorKey: firstBlock.getKey(),
+    anchorOffset: 0,
+    focusKey: lastBlock.getKey(),
+    focusOffset: lastBlock.getLength(),
+  });
+}
+
+export function getSelectionForOffset(content, offset) {
+  const blocks = content.getBlocksAsArray();
+  let countdown = offset;
+  for (let i = 0; i < blocks.length && countdown >= 0; i++) {
+    const block = blocks[i];
+    const length = block.getLength();
+    if (countdown <= length) {
+      const selection = new SelectionState({
+        anchorKey: block.getKey(),
+        anchorOffset: countdown,
+      });
+      return selection;
+    }
+    // +1 char for the delimiter.
+    countdown -= length + 1;
+  }
+  return null;
+}
 
 export function getFilteredState(editorState, oldEditorState) {
   const shouldFilterPaste =

--- a/assets/src/edit-story/utils/getCaretCharacterOffsetWithin.js
+++ b/assets/src/edit-story/utils/getCaretCharacterOffsetWithin.js
@@ -39,18 +39,22 @@
 function getCaretCharacterOffsetWithin(element, clientX, clientY) {
   const doc = element.ownerDocument || element.document;
   const win = doc.defaultView || doc.parentWindow;
-  let sel;
   if (typeof win.getSelection !== 'undefined') {
-    sel = win.getSelection();
-    if (sel.rangeCount > 0) {
-      let range = win.getSelection().getRangeAt(0);
-      if (clientX && clientY) {
-        if (doc.caretPositionFromPoint) {
-          range = document.caretPositionFromPoint(clientX, clientY);
-        } else if (doc.caretRangeFromPoint) {
-          range = document.caretRangeFromPoint(clientX, clientY);
-        }
+    let range;
+    if (clientX && clientY) {
+      if (doc.caretPositionFromPoint) {
+        range = document.caretPositionFromPoint(clientX, clientY);
+      } else if (doc.caretRangeFromPoint) {
+        range = document.caretRangeFromPoint(clientX, clientY);
       }
+    }
+    if (!range) {
+      const sel = win.getSelection();
+      if (sel.rangeCount > 0) {
+        range = win.getSelection().getRangeAt(0);
+      }
+    }
+    if (range) {
       const preCaretRange = range.cloneRange();
       preCaretRange.selectNodeContents(element);
       preCaretRange.setEnd(range.endContainer, range.endOffset);
@@ -58,7 +62,7 @@ function getCaretCharacterOffsetWithin(element, clientX, clientY) {
     }
   }
 
-  sel = doc.selection;
+  const sel = doc.selection;
   if (sel && sel.type !== 'Control') {
     const textRange = sel.createRange();
     if (clientX && clientY) {


### PR DESCRIPTION
Fixes: #386.

Changes:
* Focus management moved from `EditElement` to each element's `Edit` component, b/c the edit element wrapper has no actions of its own.
* `useEditingElement` is switched to use `reducer` for both editing ID and state to avoid any problems with sync flush.
* The `text/edit.js` is overhauled. Most of initializing side effects are replaces by the `useMemo` to calculate both: initial state and selection.
* The `text/frame.js` is changed in how it handles mouse and keyboard events. But changes are mostly insignificant.

