### PR TITLE
Fold WordPress admin menu by default

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -521,6 +521,7 @@ class Story_Post_Type {
 
 		$class .= ' edit-story';
 
+		// Overrides regular WordPress behavior by collapsing the admin menu by default.
 		if ( false === strpos( $class, 'folded' ) ) {
 			$class .= ' folded';
 		}

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -519,7 +519,11 @@ class Story_Post_Type {
 			return $class;
 		}
 
-		$class .= ' edit-story ';
+		$class .= ' edit-story';
+
+		if ( false === strpos( $class, 'folded' ) ) {
+			$class .= ' folded';
+		}
 
 		return $class;
 	}


### PR DESCRIPTION
When opening the editor the admin menu will be folded like this:

<img width="1680" alt="Screenshot 2020-03-05 at 10 09 46" src="https://user-images.githubusercontent.com/841956/75965748-8588e480-5ec9-11ea-8dc7-1e0582bf16e2.png">

Users can unfold it using the arrow toggle in the menu, but it will be folded again when refreshing the screen.