### PR TITLE
Add dev-only useWhyDidYouUpdate hook

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,6 +50,9 @@
         "target": "./assets/src/edit-story/migration/migrations",
         "from": "./assets/src/edit-story",
         "except": [ "./migration/migrations" ]
+      }, {
+        "target": "./assets/src/edit-story",
+        "from": "./assets/src/edit-story/utils/useWhyDidYouUpdate.js"
       } ]
     } ],
     "no-restricted-properties": "error",

--- a/assets/src/edit-story/utils/useWhyDidYouUpdate.js
+++ b/assets/src/edit-story/utils/useWhyDidYouUpdate.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from 'react';
+
+/**
+ * Hook to see which prop changes are causing a component to re-render.
+ *
+ * Only used for development, and removed
+ *
+ * @see https://github.com/gragland/usehooks
+ *
+ * @param {string} name Component name.
+ * @param {Object} props Component props.
+ */
+function useWhyDidYouUpdate(name, props) {
+  const previousProps = useRef();
+
+  useEffect(() => {
+    if (previousProps.current) {
+      const allKeys = Object.keys({ ...previousProps.current, ...props });
+      const changesObj = {};
+
+      allKeys.forEach((key) => {
+        if (previousProps.current[key] !== props[key]) {
+          changesObj[key] = {
+            from: previousProps.current[key],
+            to: props[key],
+          };
+        }
+      });
+
+      if (Object.keys(changesObj).length) {
+        // eslint-disable-next-line no-console
+        console.log('[why-did-you-update]', name, changesObj);
+      }
+    }
+
+    previousProps.current = props;
+  });
+}
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+export default isDevelopment ? useWhyDidYouUpdate : () => {};

--- a/assets/src/edit-story/utils/useWhyDidYouUpdate.js
+++ b/assets/src/edit-story/utils/useWhyDidYouUpdate.js
@@ -22,7 +22,7 @@ import { useEffect, useRef } from 'react';
 /**
  * Hook to see which prop changes are causing a component to re-render.
  *
- * Only used for development, and removed
+ * Only used for development, and removed for production builds.
  *
  * @see https://github.com/gragland/usehooks
  *


### PR DESCRIPTION
As per Slack discussion with @barklund.

Not sure if we want this in, but if we do, this code does the following:

* Adds new `useWhyDidYouUpdate` hook
* No-ops for production builds
* Adds ESLint rule to flag errors when importing the hook, making sure it's not left in by accident.