### PR TITLE
Improve typing feedback on panels while rendering on canvas

### DIFF
--- a/assets/src/edit-story/components/inspector/design/useDesignPanels.js
+++ b/assets/src/edit-story/components/inspector/design/useDesignPanels.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { useCallback, useMemo } from 'react';
+import { debounce } from 'throttle-debounce';
 
 /**
  * Internal dependencies
@@ -34,12 +35,12 @@ function useDesignPanels() {
   const panels = useMemo(() => getPanels(selectedElements), [selectedElements]);
 
   const onSetProperties = useCallback(
-    (newPropertiesOrUpdater) => {
+    debounce(300, (newPropertiesOrUpdater) => {
       updateSelectedElements({
         properties: (currentProperties) =>
           calcProperties(currentProperties, newPropertiesOrUpdater),
       });
-    },
+    }),
     [updateSelectedElements]
   );
 

--- a/assets/src/edit-story/components/panels/layerStyle.js
+++ b/assets/src/edit-story/components/panels/layerStyle.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import styled from 'styled-components';
 
 /**
@@ -53,6 +53,18 @@ function LayerStylePanel({ selectedElements, onSetProperties }) {
     onSetProperties(state);
     evt.preventDefault();
   };
+  const handleOpacityChange = useCallback(
+    (value) =>
+      setState((originalState) => {
+        const update = {
+          ...originalState,
+          opacity: isNaN(value) || value === '' ? '' : parseFloat(value),
+        };
+        onSetProperties(update);
+        return update;
+      }),
+    [onSetProperties]
+  );
   return (
     <SimplePanel
       name="layerStyle"
@@ -64,12 +76,7 @@ function LayerStylePanel({ selectedElements, onSetProperties }) {
           suffix={__('Opacity', 'web-stories')}
           symbol={_x('%', 'Percentage', 'web-stories')}
           value={state.opacity}
-          onChange={(value) =>
-            setState({
-              ...state,
-              opacity: isNaN(value) || value === '' ? '' : parseFloat(value),
-            })
-          }
+          onChange={handleOpacityChange}
           min="1"
           max="100"
         />

--- a/assets/src/edit-story/components/panels/link.js
+++ b/assets/src/edit-story/components/panels/link.js
@@ -108,13 +108,26 @@ function LinkPanel({ selectedElements, onSetProperties }) {
     onSetProperties(state);
     evt.preventDefault();
   };
+  const handleLinkChange = useCallback(
+    (evt) => {
+      const { value: url } = evt.target;
+      setState((originalState) => {
+        const update = {
+          ...originalState,
+          link: { ...originalState.link, url },
+        };
+        onSetProperties(update);
+        return update;
+      });
+    },
+    [onSetProperties]
+  );
   const canLink = selectedElements.length === 1 && !isFill;
   const populateMetadata = useCallback(
     debounce(300, async (/** url */) => {
       // TODO(wassgha): Implement getting the page metadata
     })
   );
-
   useEffect(() => {
     if (state.link?.url) {
       populateMetadata(state.link?.url);
@@ -138,13 +151,7 @@ function LinkPanel({ selectedElements, onSetProperties }) {
           <Input
             type="text"
             disabled={!canLink}
-            onChange={(evt) => {
-              const { value: url } = evt.target;
-              setState({
-                ...state,
-                link: { ...state.link, url },
-              });
-            }}
+            onChange={handleLinkChange}
             onBlur={(evt) =>
               evt.target.form.dispatchEvent(new window.Event('submit'))
             }


### PR DESCRIPTION
Fixes #494 
Fixes #432  

As discussed in #494, this PR proposal to add a defer pattern in order to reduce expensive processing while rendering on canvas and typing on panels which creates a bad experience typing. 