### PR TITLE
Fix an AMP validation issue where an AMP extension was included multiple times

### DIFF
--- a/assets/src/edit-story/output/element.js
+++ b/assets/src/edit-story/output/element.js
@@ -36,6 +36,7 @@ function OutputElement({ element }) {
   return (
     <WithMask
       element={element}
+      box={box}
       id={'el-' + id}
       className="wrapper"
       style={{

--- a/assets/src/edit-story/output/getUsedAmpExtensions.js
+++ b/assets/src/edit-story/output/getUsedAmpExtensions.js
@@ -40,15 +40,17 @@ const getUsedAmpExtensions = (pages) => {
     },
   ];
 
+  const ampVideo = {
+    name: 'amp-video',
+    src: 'https://cdn.ampproject.org/v0/amp-video-0.1.js',
+  };
+
   for (const { elements } of pages) {
     for (const { type } of elements) {
       switch (type) {
         // Todo: eventually check for amp-fit-text if ever added.
         case 'video':
-          extensions.push({
-            name: 'amp-video',
-            src: 'https://cdn.ampproject.org/v0/amp-video-0.1.js',
-          });
+          extensions.push(ampVideo);
           break;
         default:
           break;

--- a/assets/src/edit-story/output/test/getUsedAmpExtensions.js
+++ b/assets/src/edit-story/output/test/getUsedAmpExtensions.js
@@ -42,7 +42,7 @@ describe('getUsedAmpExtensions', () => {
     );
   });
 
-  it('should include the amp-video script if there are videos', () => {
+  it('should include the amp-video script if there is a video', () => {
     const pages = [
       {
         elements: [{ type: 'video' }],
@@ -51,6 +51,36 @@ describe('getUsedAmpExtensions', () => {
 
     const actual = getUsedAmpExtensions(pages);
 
+    expect(actual).toHaveLength(3);
+    expect(actual).toStrictEqual(
+      expect.arrayContaining([
+        {
+          name: 'amp-video',
+          src: 'https://cdn.ampproject.org/v0/amp-video-0.1.js',
+        },
+      ])
+    );
+  });
+
+  it('should include the amp-video script only once if there are multiple videos', () => {
+    const pages = [
+      {
+        elements: [{ type: 'video' }],
+      },
+      {
+        elements: [{ type: 'text' }],
+      },
+      {
+        elements: [{ type: 'video' }],
+      },
+      {
+        elements: [{ type: 'video' }],
+      },
+    ];
+
+    const actual = getUsedAmpExtensions(pages);
+
+    expect(actual).toHaveLength(3);
     expect(actual).toStrictEqual(
       expect.arrayContaining([
         {


### PR DESCRIPTION
To verify:

Insert multiple pages with a video on each page. The amp-video extension script should only be included once.