### PR TITLE
Changed tab focus style to only appear when focus is needed

### DIFF
--- a/assets/src/edit-story/components/library/panes/shared.js
+++ b/assets/src/edit-story/components/library/panes/shared.js
@@ -54,7 +54,7 @@ const Tab = styled.li.attrs(({ isActive }) => ({
       isActive ? theme.colors.bg.v4 : rgba(theme.colors.bg.v0, 0.2)};
   }
 
-  &:focus {
+  &:focus-visible {
     outline: none;
     background: ${({ theme }) => theme.colors.action};
   }


### PR DESCRIPTION
One line fix: This makes it so that the very bold focus style for tabs only appears on `:focus-visible`, which the UA determines (not on mouse use). This behavior is something that @samitron7 wanted.