### PR TITLE
Infinite scroll in Media

### DIFF
--- a/assets/src/edit-story/app/api/apiProvider.js
+++ b/assets/src/edit-story/app/api/apiProvider.js
@@ -105,10 +105,10 @@ function APIProvider({ children }) {
   );
 
   const getMedia = useCallback(
-    ({ mediaType, searchTerm, page }) => {
+    ({ mediaType, searchTerm, pagingNum }) => {
       let apiPath = media;
       const perPage = 100;
-      apiPath = addQueryArgs(apiPath, { per_page: perPage, page });
+      apiPath = addQueryArgs(apiPath, { per_page: perPage, page: pagingNum });
 
       if (mediaType) {
         apiPath = addQueryArgs(apiPath, { media_type: mediaType });
@@ -120,8 +120,8 @@ function APIProvider({ children }) {
 
       return apiFetch({ path: apiPath, parse: false }).then(
         async (response) => {
-          const json = await response.json();
-          const data = json.map(
+          const jsonArray = await response.json();
+          const data = jsonArray.map(
             ({
               id,
               guid: { rendered: src },

--- a/assets/src/edit-story/app/api/apiProvider.js
+++ b/assets/src/edit-story/app/api/apiProvider.js
@@ -105,10 +105,10 @@ function APIProvider({ children }) {
   );
 
   const getMedia = useCallback(
-    ({ mediaType, searchTerm }) => {
+    ({ mediaType, searchTerm, page }) => {
       let apiPath = media;
       const perPage = 100;
-      apiPath = addQueryArgs(apiPath, { per_page: perPage });
+      apiPath = addQueryArgs(apiPath, { per_page: perPage, page });
 
       if (mediaType) {
         apiPath = addQueryArgs(apiPath, { media_type: mediaType });
@@ -118,30 +118,35 @@ function APIProvider({ children }) {
         apiPath = addQueryArgs(apiPath, { search: searchTerm });
       }
 
-      return apiFetch({ path: apiPath }).then((data) =>
-        data.map(
-          ({
-            id,
-            guid: { rendered: src },
-            media_details: {
-              width: oWidth,
-              height: oHeight,
-              length_formatted: lengthFormatted,
-            },
-            mime_type: mimeType,
-            featured_media: posterId,
-            featured_media_src: poster,
-          }) => ({
-            id,
-            posterId,
-            poster,
-            src,
-            oWidth,
-            oHeight,
-            mimeType,
-            lengthFormatted,
-          })
-        )
+      return apiFetch({ path: apiPath, parse: false }).then(
+        async (response) => {
+          const json = await response.json();
+          const data = json.map(
+            ({
+              id,
+              guid: { rendered: src },
+              media_details: {
+                width: oWidth,
+                height: oHeight,
+                length_formatted: lengthFormatted,
+              },
+              mime_type: mimeType,
+              featured_media: posterId,
+              featured_media_src: poster,
+            }) => ({
+              id,
+              posterId,
+              poster,
+              src,
+              oWidth,
+              oHeight,
+              mimeType,
+              lengthFormatted,
+            })
+          );
+
+          return { data, headers: response.headers };
+        }
       );
     },
     [media]

--- a/assets/src/edit-story/app/media/mediaProvider.js
+++ b/assets/src/edit-story/app/media/mediaProvider.js
@@ -31,7 +31,7 @@ import Context from './context';
 function MediaProvider({ children }) {
   const { state, actions } = useMediaReducer();
   const { uploadVideoFrame } = useUploadVideoFrame();
-  const { page, mediaType, searchTerm } = state;
+  const { pagingNum, mediaType, searchTerm } = state;
   const {
     fetchMediaStart,
     fetchMediaSuccess,
@@ -39,7 +39,7 @@ function MediaProvider({ children }) {
     resetFilters,
     setMediaType,
     setSearchTerm,
-    setPage,
+    setNextPage,
   } = actions;
 
   const {
@@ -47,16 +47,16 @@ function MediaProvider({ children }) {
   } = useAPI();
 
   const fetchMedia = useCallback(
-    ({ page: p = 1 } = {}) => {
-      fetchMediaStart({ page: p });
-      getMedia({ mediaType, searchTerm, page: p })
+    ({ pagingNum: p = 1 } = {}) => {
+      fetchMediaStart({ pagingNum: p });
+      getMedia({ mediaType, searchTerm, pagingNum: p })
         .then(({ data, headers }) => {
           const totalPages = parseInt(headers.get('X-WP-TotalPages'));
           fetchMediaSuccess({
             media: data,
             mediaType,
             searchTerm,
-            page: p,
+            pagingNum: p,
             totalPages,
           });
         })
@@ -74,19 +74,19 @@ function MediaProvider({ children }) {
 
   const resetWithFetch = useCallback(() => {
     resetFilters();
-    if (!mediaType && !searchTerm && page === 1) {
+    if (!mediaType && !searchTerm && pagingNum === 1) {
       fetchMedia();
     }
-  }, [fetchMedia, mediaType, page, resetFilters, searchTerm]);
+  }, [fetchMedia, mediaType, pagingNum, resetFilters, searchTerm]);
 
   useEffect(() => {
-    fetchMedia({ page });
-  }, [fetchMedia, mediaType, searchTerm, page]);
+    fetchMedia({ pagingNum });
+  }, [fetchMedia, mediaType, searchTerm, pagingNum]);
 
   const context = {
     state,
     actions: {
-      setPage,
+      setNextPage,
       setMediaType,
       setSearchTerm,
       fetchMedia,

--- a/assets/src/edit-story/app/media/mediaProvider.js
+++ b/assets/src/edit-story/app/media/mediaProvider.js
@@ -72,7 +72,7 @@ function MediaProvider({ children }) {
     ]
   );
 
-  const resetAfterUpload = useCallback(() => {
+  const resetWithFetch = useCallback(() => {
     resetFilters();
     if (!mediaType && !searchTerm && page === 1) {
       fetchMedia();
@@ -91,7 +91,7 @@ function MediaProvider({ children }) {
       setSearchTerm,
       fetchMedia,
       resetFilters,
-      resetAfterUpload,
+      resetWithFetch,
       uploadVideoFrame,
     },
   };

--- a/assets/src/edit-story/app/media/useMediaReducer/actions.js
+++ b/assets/src/edit-story/app/media/useMediaReducer/actions.js
@@ -19,18 +19,20 @@
  */
 import * as types from './types';
 
-export const fetchMediaStart = (dispatch) => () => {
-  dispatch({ type: types.FETCH_MEDIA_START });
+export const fetchMediaStart = (dispatch) => ({ page }) => {
+  dispatch({ type: types.FETCH_MEDIA_START, payload: { page } });
 };
 
 export const fetchMediaSuccess = (dispatch) => ({
   media,
   mediaType,
   searchTerm,
+  page,
+  totalPages,
 }) => {
   dispatch({
     type: types.FETCH_MEDIA_SUCCESS,
-    payload: { media, mediaType, searchTerm },
+    payload: { media, mediaType, searchTerm, page, totalPages },
   });
 };
 
@@ -48,4 +50,8 @@ export const setSearchTerm = (dispatch) => ({ searchTerm }) => {
 
 export const setMediaType = (dispatch) => ({ mediaType }) => {
   dispatch({ type: types.SET_MEDIA_TYPE, payload: { mediaType } });
+};
+
+export const setPage = (dispatch) => ({ page }) => {
+  dispatch({ type: types.SET_PAGE, payload: { page } });
 };

--- a/assets/src/edit-story/app/media/useMediaReducer/actions.js
+++ b/assets/src/edit-story/app/media/useMediaReducer/actions.js
@@ -19,20 +19,20 @@
  */
 import * as types from './types';
 
-export const fetchMediaStart = (dispatch) => ({ page }) => {
-  dispatch({ type: types.FETCH_MEDIA_START, payload: { page } });
+export const fetchMediaStart = (dispatch) => ({ pagingNum }) => {
+  dispatch({ type: types.FETCH_MEDIA_START, payload: { pagingNum } });
 };
 
 export const fetchMediaSuccess = (dispatch) => ({
   media,
   mediaType,
   searchTerm,
-  page,
+  pagingNum,
   totalPages,
 }) => {
   dispatch({
     type: types.FETCH_MEDIA_SUCCESS,
-    payload: { media, mediaType, searchTerm, page, totalPages },
+    payload: { media, mediaType, searchTerm, pagingNum, totalPages },
   });
 };
 
@@ -52,6 +52,6 @@ export const setMediaType = (dispatch) => ({ mediaType }) => {
   dispatch({ type: types.SET_MEDIA_TYPE, payload: { mediaType } });
 };
 
-export const setPage = (dispatch) => ({ page }) => {
-  dispatch({ type: types.SET_PAGE, payload: { page } });
+export const setNextPage = (dispatch) => () => {
+  dispatch({ type: types.SET_NEXT_PAGE });
 };

--- a/assets/src/edit-story/app/media/useMediaReducer/reducer.js
+++ b/assets/src/edit-story/app/media/useMediaReducer/reducer.js
@@ -21,9 +21,20 @@ import * as types from './types';
 
 export const INITIAL_STATE = {
   media: [],
+  page: 1,
+  totalPages: 1,
+  hasMore: true,
   mediaType: '',
   searchTerm: '',
   isMediaLoading: false,
+  isMediaLoaded: false,
+};
+
+const resetOnFilterChange = {
+  page: 1,
+  totalPages: null,
+  hasMore: true,
+  media: [],
   isMediaLoaded: false,
 };
 
@@ -38,11 +49,15 @@ function reducer(state, { type, payload }) {
     }
 
     case types.FETCH_MEDIA_SUCCESS: {
-      const { media, mediaType, searchTerm } = payload;
+      const { media, mediaType, searchTerm, page, totalPages } = payload;
       if (mediaType === state.mediaType && searchTerm === state.searchTerm) {
+        const hasMore = page < totalPages;
         return {
           ...state,
-          media,
+          media: [...state.media, ...media],
+          page,
+          totalPages,
+          hasMore,
           isMediaLoaded: true,
           isMediaLoading: false,
         };
@@ -53,7 +68,6 @@ function reducer(state, { type, payload }) {
     case types.FETCH_MEDIA_ERROR: {
       return {
         ...state,
-        media: [],
         isMediaLoaded: true,
         isMediaLoading: false,
       };
@@ -62,6 +76,7 @@ function reducer(state, { type, payload }) {
     case types.RESET_FILTERS: {
       return {
         ...state,
+        ...resetOnFilterChange,
         searchTerm: '',
         mediaType: '',
       };
@@ -69,17 +84,29 @@ function reducer(state, { type, payload }) {
 
     case types.SET_SEARCH_TERM: {
       const { searchTerm } = payload;
+      if (searchTerm === state.searchTerm) return state;
       return {
         ...state,
+        ...resetOnFilterChange,
         searchTerm,
       };
     }
 
     case types.SET_MEDIA_TYPE: {
       const { mediaType } = payload;
+      if (mediaType === state.mediaType) return state;
       return {
         ...state,
+        ...resetOnFilterChange,
         mediaType,
+      };
+    }
+
+    case types.SET_PAGE: {
+      const { page } = payload;
+      return {
+        ...state,
+        page,
       };
     }
 

--- a/assets/src/edit-story/app/media/useMediaReducer/reducer.js
+++ b/assets/src/edit-story/app/media/useMediaReducer/reducer.js
@@ -84,6 +84,7 @@ function reducer(state, { type, payload }) {
       if (mediaType === state.mediaType) return state;
       return {
         ...INITIAL_STATE,
+        searchTerm: state.searchTerm,
         mediaType,
       };
     }

--- a/assets/src/edit-story/app/media/useMediaReducer/reducer.js
+++ b/assets/src/edit-story/app/media/useMediaReducer/reducer.js
@@ -30,14 +30,6 @@ export const INITIAL_STATE = {
   isMediaLoaded: false,
 };
 
-const resetOnFilterChange = {
-  page: 1,
-  totalPages: null,
-  hasMore: true,
-  media: [],
-  isMediaLoaded: false,
-};
-
 function reducer(state, { type, payload }) {
   switch (type) {
     case types.FETCH_MEDIA_START: {
@@ -74,20 +66,15 @@ function reducer(state, { type, payload }) {
     }
 
     case types.RESET_FILTERS: {
-      return {
-        ...state,
-        ...resetOnFilterChange,
-        searchTerm: '',
-        mediaType: '',
-      };
+      return { ...INITIAL_STATE };
     }
 
     case types.SET_SEARCH_TERM: {
       const { searchTerm } = payload;
       if (searchTerm === state.searchTerm) return state;
       return {
-        ...state,
-        ...resetOnFilterChange,
+        ...INITIAL_STATE,
+        mediaType: state.mediaType,
         searchTerm,
       };
     }
@@ -96,8 +83,7 @@ function reducer(state, { type, payload }) {
       const { mediaType } = payload;
       if (mediaType === state.mediaType) return state;
       return {
-        ...state,
-        ...resetOnFilterChange,
+        ...INITIAL_STATE,
         mediaType,
       };
     }

--- a/assets/src/edit-story/app/media/useMediaReducer/reducer.js
+++ b/assets/src/edit-story/app/media/useMediaReducer/reducer.js
@@ -21,7 +21,7 @@ import * as types from './types';
 
 export const INITIAL_STATE = {
   media: [],
-  page: 1,
+  pagingNum: 1,
   totalPages: 1,
   hasMore: true,
   mediaType: '',
@@ -41,13 +41,13 @@ function reducer(state, { type, payload }) {
     }
 
     case types.FETCH_MEDIA_SUCCESS: {
-      const { media, mediaType, searchTerm, page, totalPages } = payload;
+      const { media, mediaType, searchTerm, pagingNum, totalPages } = payload;
       if (mediaType === state.mediaType && searchTerm === state.searchTerm) {
-        const hasMore = page < totalPages;
+        const hasMore = pagingNum < totalPages;
         return {
           ...state,
           media: [...state.media, ...media],
-          page,
+          pagingNum,
           totalPages,
           hasMore,
           isMediaLoaded: true,
@@ -89,11 +89,10 @@ function reducer(state, { type, payload }) {
       };
     }
 
-    case types.SET_PAGE: {
-      const { page } = payload;
+    case types.SET_NEXT_PAGE: {
       return {
         ...state,
-        page,
+        pagingNum: state.pagingNum + 1,
       };
     }
 

--- a/assets/src/edit-story/app/media/useMediaReducer/types.js
+++ b/assets/src/edit-story/app/media/useMediaReducer/types.js
@@ -20,3 +20,4 @@ export const FETCH_MEDIA_ERROR = 'FETCH_MEDIA_ERROR';
 export const RESET_FILTERS = 'RESET_FILTERS';
 export const SET_SEARCH_TERM = 'SET_SEARCH_TERM';
 export const SET_MEDIA_TYPE = 'SET_MEDIA_TYPE';
+export const SET_PAGE = 'SET_PAGE';

--- a/assets/src/edit-story/app/media/useMediaReducer/types.js
+++ b/assets/src/edit-story/app/media/useMediaReducer/types.js
@@ -20,4 +20,4 @@ export const FETCH_MEDIA_ERROR = 'FETCH_MEDIA_ERROR';
 export const RESET_FILTERS = 'RESET_FILTERS';
 export const SET_SEARCH_TERM = 'SET_SEARCH_TERM';
 export const SET_MEDIA_TYPE = 'SET_MEDIA_TYPE';
-export const SET_PAGE = 'SET_PAGE';
+export const SET_NEXT_PAGE = 'SET_NEXT_PAGE';

--- a/assets/src/edit-story/app/uploader/useUploader.js
+++ b/assets/src/edit-story/app/uploader/useUploader.js
@@ -27,7 +27,7 @@ import { useMedia } from '../media';
 
 function useUploader(refreshLibrary = true) {
   const {
-    actions: { resetFilters },
+    actions: { resetAfterUpload },
   } = useMedia();
   const {
     actions: { uploadMedia },
@@ -72,7 +72,7 @@ function useUploader(refreshLibrary = true) {
 
     const promise = uploadMedia(file, additionalData);
     if (refreshLibrary) {
-      promise.finally(resetFilters);
+      promise.finally(resetAfterUpload);
     }
     return promise;
   };

--- a/assets/src/edit-story/app/uploader/useUploader.js
+++ b/assets/src/edit-story/app/uploader/useUploader.js
@@ -27,7 +27,7 @@ import { useMedia } from '../media';
 
 function useUploader(refreshLibrary = true) {
   const {
-    actions: { resetAfterUpload },
+    actions: { resetWithFetch },
   } = useMedia();
   const {
     actions: { uploadMedia },
@@ -72,7 +72,7 @@ function useUploader(refreshLibrary = true) {
 
     const promise = uploadMedia(file, additionalData);
     if (refreshLibrary) {
-      promise.finally(resetAfterUpload);
+      promise.finally(resetWithFetch);
     }
     return promise;
   };

--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { useRef } from 'react';
 import styled from 'styled-components';
 import { rgba } from 'polished';
 
@@ -32,6 +33,7 @@ import { __ } from '@wordpress/i18n';
 import { useConfig } from '../../../../app/config';
 import { useMedia } from '../../../../app/media';
 import { useMediaPicker } from '../../../mediaPicker';
+import useIntersectionEffect from '../../../../utils/useIntersectionEffect';
 import { MainButton, Title, SearchInput, Header } from '../../common';
 import useLibrary from '../../useLibrary';
 import { Pane } from '../shared';
@@ -44,9 +46,12 @@ import {
 import MediaElement from './mediaElement';
 
 const Container = styled.div`
+  grid-area: infinitescroll;
   display: grid;
   grid-gap: 10px;
   grid-template-columns: 1fr 1fr;
+  overflow: auto;
+  padding: 15px 1em 0 1em;
 `;
 
 const Column = styled.div``;
@@ -54,12 +59,13 @@ const Column = styled.div``;
 const Message = styled.div`
   color: ${({ theme }) => theme.colors.fg.v1};
   font-size: 16px;
+  padding: 1em;
 `;
 
 const FilterButtons = styled.div`
   border-bottom: 1px solid ${({ theme }) => rgba(theme.colors.fg.v1, 0.1)};
   padding: 18px 0;
-  margin: 10px 0 15px;
+  margin: 10px 0 0 0;
 `;
 
 const FilterButton = styled.button`
@@ -74,6 +80,26 @@ const FilterButton = styled.button`
   text-transform: uppercase;
 `;
 
+const Padding = styled.div`
+  grid-area: header;
+  padding: 1em 1em 0 1em;
+`;
+
+const StyledPane = styled(Pane)`
+  height: 100%;
+  padding: 0;
+  overflow: hidden;
+`;
+
+const Inner = styled.div`
+  height: 100%;
+  display: grid;
+  grid:
+    'header   ' auto
+    'infinitescroll' 1fr
+    / 1fr;
+`;
+
 const FILTERS = [
   { filter: '', name: __('All', 'web-stories') },
   { filter: 'image', name: __('Images', 'web-stories') },
@@ -86,8 +112,22 @@ const PREVIEW_SIZE = 150;
 
 function MediaPane(props) {
   const {
-    state: { media, isMediaLoading, isMediaLoaded, mediaType, searchTerm },
-    actions: { resetFilters, setMediaType, setSearchTerm },
+    state: {
+      page,
+      hasMore,
+      media,
+      isMediaLoading,
+      isMediaLoaded,
+      mediaType,
+      searchTerm,
+    },
+    actions: {
+      setPage,
+      resetAfterUpload,
+      setMediaType,
+      setSearchTerm,
+      uploadVideoFrame,
+    },
   } = useMedia();
 
   const {
@@ -101,7 +141,7 @@ function MediaPane(props) {
     actions: { insertElement },
   } = useLibrary();
 
-  const onClose = resetFilters;
+  const onClose = resetAfterUpload;
 
   /**
    * Callback of select in media picker to insert media element.
@@ -165,67 +205,91 @@ function MediaPane(props) {
     )
     .map((attachment) => getResourceFromAttachment(attachment));
 
+  const refContainer = useRef();
+  const refContainerFooter = useRef();
+
+  useIntersectionEffect(
+    refContainerFooter,
+    (entry) => {
+      if (!isMediaLoaded || isMediaLoading) return;
+      if (!hasMore) return;
+      if (!entry.isIntersecting) return;
+
+      setPage({ page: page + 1 });
+    },
+    {
+      root: refContainer,
+      rootMargin: '0px 0px 0px 0px',
+    },
+    [page, hasMore, isMediaLoading, isMediaLoaded]
+  );
+
   return (
-    <Pane id={paneId} {...props}>
-      <Header>
-        <Title>
-          {__('Media', 'web-stories')}
-          {(!isMediaLoaded || isMediaLoading) && <Spinner />}
-        </Title>
-        <MainButton onClick={openMediaPicker}>
-          {__('Upload', 'web-stories')}
-        </MainButton>
-      </Header>
+    <StyledPane id={paneId} {...props}>
+      <Inner>
+        <Padding>
+          <Header>
+            <Title>
+              {__('Media', 'web-stories')}
+              {(!isMediaLoaded || isMediaLoading) && <Spinner />}
+            </Title>
+            <MainButton onClick={openMediaPicker}>
+              {__('Upload', 'web-stories')}
+            </MainButton>
+          </Header>
 
-      <SearchInput
-        value={searchTerm}
-        placeholder={__('Search media...', 'web-stories')}
-        onChange={onSearch}
-      />
+          <SearchInput
+            value={searchTerm}
+            placeholder={__('Search media...', 'web-stories')}
+            onChange={onSearch}
+          />
 
-      <FilterButtons>
-        {FILTERS.map(({ filter, name }, index) => (
-          <FilterButton
-            key={index}
-            active={filter === mediaType}
-            onClick={onFilter(filter)}
-          >
-            {name}
-          </FilterButton>
-        ))}
-      </FilterButtons>
+          <FilterButtons>
+            {FILTERS.map(({ filter, name }, index) => (
+              <FilterButton
+                key={index}
+                active={filter === mediaType}
+                onClick={onFilter(filter)}
+              >
+                {name}
+              </FilterButton>
+            ))}
+          </FilterButtons>
+        </Padding>
 
-      {isMediaLoaded && !media.length ? (
-        <Message>{__('No media found', 'web-stories')}</Message>
-      ) : (
-        <Container>
-          <Column>
-            {resources
-              .filter((_, index) => isEven(index))
-              .map((resource) => (
-                <MediaElement
-                  resource={resource}
-                  key={resource.src}
-                  width={PREVIEW_SIZE}
-                  onInsert={insertMediaElement}
-                />
-              ))}
-          </Column>
-          <Column>
-            {resources
-              .filter((_, index) => !isEven(index))
-              .map((resource) => (
-                <MediaElement
-                  resource={resource}
-                  key={resource.src}
-                  width={PREVIEW_SIZE}
-                  onInsert={insertMediaElement}
-                />
-              ))}
-          </Column>
-        </Container>
-      )}
-    </Pane>
+        {isMediaLoaded && !media.length ? (
+          <Message>{__('No media found', 'web-stories')}</Message>
+        ) : (
+          <Container ref={refContainer}>
+            <Column>
+              {resources
+                .filter((_, index) => isEven(index))
+                .map((resource, i) => (
+                  <MediaElement
+                    resource={resource}
+                    key={i}
+                    width={PREVIEW_SIZE}
+                    onInsert={insertMediaElement}
+                  />
+                ))}
+            </Column>
+            <Column>
+              {resources
+                .filter((_, index) => !isEven(index))
+                .map((resource, i) => (
+                  <MediaElement
+                    resource={resource}
+                    key={i}
+                    width={PREVIEW_SIZE}
+                    onInsert={insertMediaElement}
+                  />
+                ))}
+            </Column>
+            {hasMore && <div ref={refContainerFooter}>{'Loading...'}</div>}
+          </Container>
+        )}
+      </Inner>
+    </StyledPane>
   );
 }
 

--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -218,7 +218,7 @@ function MediaPane(props) {
       setPage({ page: page + 1 });
     },
     {
-      root: refContainer,
+      root: refContainer.current,
       rootMargin: '0px 0px 0px 0px',
     },
     [page, hasMore, isMediaLoading, isMediaLoaded]

--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -123,7 +123,7 @@ function MediaPane(props) {
     },
     actions: {
       setPage,
-      resetAfterUpload,
+      resetWithFetch,
       setMediaType,
       setSearchTerm,
       uploadVideoFrame,
@@ -141,7 +141,7 @@ function MediaPane(props) {
     actions: { insertElement },
   } = useLibrary();
 
-  const onClose = resetAfterUpload;
+  const onClose = resetWithFetch;
 
   /**
    * Callback of select in media picker to insert media element.

--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -113,7 +113,6 @@ const PREVIEW_SIZE = 150;
 function MediaPane(props) {
   const {
     state: {
-      page,
       hasMore,
       media,
       isMediaLoading,
@@ -122,7 +121,7 @@ function MediaPane(props) {
       searchTerm,
     },
     actions: {
-      setPage,
+      setNextPage,
       resetWithFetch,
       setMediaType,
       setSearchTerm,
@@ -212,16 +211,16 @@ function MediaPane(props) {
     refContainerFooter,
     {
       root: refContainer,
-      rootMargin: '0px 0px 0px 0px',
+      rootMargin: '0px 0px 300px 0px',
     },
     (entry) => {
       if (!isMediaLoaded || isMediaLoading) return;
       if (!hasMore) return;
       if (!entry.isIntersecting) return;
 
-      setPage({ page: page + 1 });
+      setNextPage();
     },
-    [page, hasMore, isMediaLoading, isMediaLoaded]
+    [hasMore, isMediaLoading, isMediaLoaded]
   );
 
   return (

--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -210,16 +210,16 @@ function MediaPane(props) {
 
   useIntersectionEffect(
     refContainerFooter,
+    {
+      root: refContainer,
+      rootMargin: '0px 0px 0px 0px',
+    },
     (entry) => {
       if (!isMediaLoaded || isMediaLoading) return;
       if (!hasMore) return;
       if (!entry.isIntersecting) return;
 
       setPage({ page: page + 1 });
-    },
-    {
-      root: refContainer.current,
-      rootMargin: '0px 0px 0px 0px',
     },
     [page, hasMore, isMediaLoading, isMediaLoaded]
   );

--- a/assets/src/edit-story/utils/useIntersectionEffect.js
+++ b/assets/src/edit-story/utils/useIntersectionEffect.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import IntersectionObserver from 'intersection-observer-polyfill';
+
+/**
+ * @param {!{current: ?Element}} ref Target node ref.
+ * @param {function(entry: IntersectionObserverEntry)} handler The intersection
+ * handler.
+ * @param {?Object: IntersectionObserverInit} options The IntersectionObserver options.
+ * @param {!Array=} deps The effect's dependencies.
+ */
+function useIntersectionEffect(ref, handler, options = {}, deps = undefined) {
+  useEffect(
+    () => {
+      const node = ref.current;
+      const usingRoot = 'root' in options;
+      if (usingRoot) {
+        options.root = options.root.current;
+      }
+      if (!node || (usingRoot && !options.root)) {
+        return;
+      }
+
+      const observer = new IntersectionObserver((entries) => {
+        const last = entries.length > 0 ? entries[entries.length - 1] : null;
+        if (last) {
+          handler(last);
+        }
+      }, options);
+
+      observer.observe(node);
+
+      // eslint-disable-next-line consistent-return
+      return () => observer.disconnect();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    deps || []
+  );
+}
+
+export default useIntersectionEffect;

--- a/assets/src/edit-story/utils/useIntersectionEffect.js
+++ b/assets/src/edit-story/utils/useIntersectionEffect.js
@@ -21,16 +21,19 @@ import { useEffect } from 'react';
 
 /**
  * @param {!{current: ?Element}} ref Target node ref.
+ * @param {?Object} options The IntersectionObserver options, root is a ref not node.
  * @param {function(IntersectionObserverEntry)} handler The intersection
  * handler.
- * @param {?Object} options The IntersectionObserver options.
  * @param {!Array=} deps The effect's dependencies.
  */
-function useIntersectionEffect(ref, handler, options = {}, deps = undefined) {
+function useIntersectionEffect(ref, options = {}, handler, deps = undefined) {
   useEffect(
     () => {
       const node = ref.current;
       const usingRoot = 'root' in options;
+      if (usingRoot) {
+        options.root = options.root.current;
+      }
       if (!node || (usingRoot && !options.root)) {
         return;
       }

--- a/assets/src/edit-story/utils/useIntersectionEffect.js
+++ b/assets/src/edit-story/utils/useIntersectionEffect.js
@@ -18,13 +18,13 @@
  * External dependencies
  */
 import { useEffect } from 'react';
-import IntersectionObserver from 'intersection-observer-polyfill';
+const IntersectionObserver = require('intersection-observer-polyfill/dist/IntersectionObserver');
 
 /**
  * @param {!{current: ?Element}} ref Target node ref.
- * @param {function(entry: IntersectionObserverEntry)} handler The intersection
+ * @param {function(IntersectionObserverEntry)} handler The intersection
  * handler.
- * @param {?Object: IntersectionObserverInit} options The IntersectionObserver options.
+ * @param {?Object} options The IntersectionObserver options.
  * @param {!Array=} deps The effect's dependencies.
  */
 function useIntersectionEffect(ref, handler, options = {}, deps = undefined) {

--- a/assets/src/edit-story/utils/useIntersectionEffect.js
+++ b/assets/src/edit-story/utils/useIntersectionEffect.js
@@ -31,9 +31,6 @@ function useIntersectionEffect(ref, handler, options = {}, deps = undefined) {
     () => {
       const node = ref.current;
       const usingRoot = 'root' in options;
-      if (usingRoot) {
-        options.root = options.root.current;
-      }
       if (!node || (usingRoot && !options.root)) {
         return;
       }

--- a/assets/src/edit-story/utils/useIntersectionEffect.js
+++ b/assets/src/edit-story/utils/useIntersectionEffect.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import { useEffect } from 'react';
-const IntersectionObserver = require('intersection-observer-polyfill/dist/IntersectionObserver');
 
 /**
  * @param {!{current: ?Element}} ref Target node ref.
@@ -39,7 +38,7 @@ function useIntersectionEffect(ref, handler, options = {}, deps = undefined) {
         return;
       }
 
-      const observer = new IntersectionObserver((entries) => {
+      const observer = new window.IntersectionObserver((entries) => {
         const last = entries.length > 0 ? entries[entries.length - 1] : null;
         if (last) {
           handler(last);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14897,6 +14897,11 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
+    "intersection-observer-polyfill": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer-polyfill/-/intersection-observer-polyfill-0.1.0.tgz",
+      "integrity": "sha1-+e+OWm8+DoFz0MD9tWPkep3aIzw="
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14897,11 +14897,6 @@
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
     },
-    "intersection-observer-polyfill": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/intersection-observer-polyfill/-/intersection-observer-polyfill-0.1.0.tgz",
-      "integrity": "sha1-+e+OWm8+DoFz0MD9tWPkep3aIzw="
-    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "draft-js-export-html": "^1.4.1",
     "draft-js-import-html": "^1.4.1",
     "draftjs-filters": "^2.3.0",
+    "intersection-observer-polyfill": "^0.1.0",
     "mousetrap": "^1.6.5",
     "polished": "^3.4.4",
     "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "draft-js-export-html": "^1.4.1",
     "draft-js-import-html": "^1.4.1",
     "draftjs-filters": "^2.3.0",
-    "intersection-observer-polyfill": "^0.1.0",
     "mousetrap": "^1.6.5",
     "polished": "^3.4.4",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
This adds infinite scroll to the Media gallery (https://github.com/google/web-stories-wp/issues/23).

Next steps (can be included in this PR):

1. Lazy load images - right now we have `loading="lazy"` which works in [Chrome/Edge, soon FF](https://caniuse.com/#search=lazy%20images), we can utilize IntersectionObserver to build our own solution. 
This solution loads as many pages as needed to fill the whole viewport. For example with per_page=2 and rootMargin: 400px it will load ~10 pages to fill the viewport and then load one row (2 images) as you start scrolling down - not sure if it's useful but it's there "for free" (for per_page=100 it will load 100 one time - as expected in AC).

2. Keyboard support - be able to see all images with arrows.

3. UX, loading states.
