### PR TITLE
WIP: Feature/547 dashboard ui components

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -18,6 +18,7 @@ module.exports = {
   stories: [
     './stories/**/*.js',
     '../assets/src/edit-story/**/stories/*.(js|mdx)',
+    '../assets/src/dashboard/**/stories/*.(js|mdx)',
   ],
   addons: [
     '@storybook/addon-a11y/register',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -30,6 +30,9 @@ import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import theme, { GlobalStyle } from '../assets/src/edit-story/theme';
 import { GlobalStyle as CropMoveableGlobalStyle } from '../assets/src/edit-story/components/movable/cropStyle';
 import { GlobalStyle as ModalGlobalStyle } from '../assets/src/edit-story/components/modal';
+import dashboardTheme, {
+  GlobalStyle as DashboardGlobalStyle,
+} from '../assets/src/dashboard/theme';
 
 // @todo: Find better way to mock these.
 const wp = {};
@@ -59,11 +62,24 @@ addParameters({
 addDecorator(withA11y);
 addDecorator(withKnobs);
 
-addDecorator((story) => (
-  <ThemeProvider theme={theme}>
-    <GlobalStyle />
-    <CropMoveableGlobalStyle />
-    <ModalGlobalStyle />
-    {story()}
-  </ThemeProvider>
-));
+addDecorator((story, { id }) => {
+  const useDashboardTheme = id.startsWith('dashboard');
+
+  if (useDashboardTheme) {
+    return (
+      <ThemeProvider theme={dashboardTheme}>
+        <DashboardGlobalStyle />
+        {story()}
+      </ThemeProvider>
+    );
+  }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+      <CropMoveableGlobalStyle />
+      <ModalGlobalStyle />
+      {story()}
+    </ThemeProvider>
+  );
+});

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -34,19 +34,19 @@ const StyledButton = styled.button`
   align-items: center;
   cursor: pointer;
   padding: 0;
-  background-color: ${({ type }) =>
-    type === BUTTON_TYPES.PRIMARY ? '#2979FF' : 'transparent'};
-  color: #fff;
+  background-color: ${({ theme, type }) =>
+    type === BUTTON_TYPES.PRIMARY ? theme.colors.bluePrimary : 'transparent'};
+  color: ${({ theme }) => theme.colors.white};
   opacity: ${({ isCta }) => (isCta ? '1' : '0.75')};
-  text-shadow: ${({ type }) =>
-    type === BUTTON_TYPES.SECONDARY && '0px 1px 1px rgba(0, 0, 0, 0.55)'};
+  text-shadow: ${({ theme, type }) =>
+    type === BUTTON_TYPES.SECONDARY && theme.text.shadow};
 
   &:focus,
   &:active,
   &:hover {
     opacity: 1;
-    text-shadow: ${({ type }) =>
-      type === BUTTON_TYPES.SECONDARY && '0px 1px 1px rgba(0, 0, 0, 1)'};
+    text-shadow: ${({ theme, type }) =>
+      type === BUTTON_TYPES.SECONDARY && theme.text.shadow};
   }
   &:disabled {
     pointer-events: none;

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types'; // import styled from 'styled-components';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { BUTTON_TYPES } from '../../constants';
+
+const StyledButton = styled.button`
+  border-radius: 100px;
+  border: 1px solid transparent;
+  display: flex;
+  min-width: 132px;
+  min-height: 40px;
+  align-items: center;
+  cursor: pointer;
+  padding: 0;
+  background-color: ${({ type }) =>
+    type === BUTTON_TYPES.PRIMARY ? '#2979FF' : 'transparent'};
+  color: #fff;
+  opacity: ${({ isCta }) => (isCta ? '1' : '0.75')};
+  text-shadow: ${({ type }) =>
+    type === BUTTON_TYPES.SECONDARY && '0px 1px 1px rgba(0, 0, 0, 0.55)'};
+
+  &:focus,
+  &:active,
+  &:hover {
+    opacity: 1;
+    text-shadow: ${({ type }) =>
+      type === BUTTON_TYPES.SECONDARY && '0px 1px 1px rgba(0, 0, 0, 1)'};
+  }
+  &:disabled {
+    pointer-events: none;
+    opacity: 0.3;
+  }
+`;
+
+const StyledChildren = styled.span`
+  padding: 10px 24px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 20px;
+  align-self: center;
+  margin: auto;
+`;
+
+const Button = ({
+  children,
+  isDisabled,
+  isCta,
+  onClick,
+  type = BUTTON_TYPES.PRIMARY,
+  ...rest
+}) => {
+  return (
+    <StyledButton
+      disabled={isDisabled}
+      onClick={onClick}
+      type={type}
+      isCta={isCta}
+      {...rest}
+    >
+      <StyledChildren>{children}</StyledChildren>
+    </StyledButton>
+  );
+};
+
+Button.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func.isRequired,
+  isCta: PropTypes.bool,
+  isDisabled: PropTypes.bool,
+  type: PropTypes.oneOf(Object.values(BUTTON_TYPES)),
+};
+
+export default Button;

--- a/assets/src/dashboard/components/button/stories/index.js
+++ b/assets/src/dashboard/components/button/stories/index.js
@@ -54,6 +54,7 @@ const LongContainer = styled.div`
 `;
 const LongButton = styled(Button)`
   width: 90%;
+  height: 100px;
 `;
 export const _LongButton = () => {
   return (
@@ -84,6 +85,7 @@ const SecondaryButtonContainer = styled.div`
 
 const LargerFontChild = styled.span`
   font-size: 22px;
+  margin: 10px auto;
 `;
 
 export const Button2 = () => {

--- a/assets/src/dashboard/components/button/stories/index.js
+++ b/assets/src/dashboard/components/button/stories/index.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import { boolean, select, text } from '@storybook/addon-knobs';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../';
+import { BUTTON_TYPES } from '../../../constants';
+
+export default {
+  title: 'Dashboard/Components/Button',
+  component: Button,
+};
+
+export const _default = () => {
+  return (
+    <Button
+      isCta={boolean('isCta')}
+      isDisabled={boolean('isDisabled')}
+      onClick={action('clicked')}
+      type={select(
+        'type',
+        { primary: BUTTON_TYPES.PRIMARY, secondary: BUTTON_TYPES.SECONDARY },
+        BUTTON_TYPES.PRIMARY
+      )}
+    >
+      {text('children', 'Default Button Demo')}
+    </Button>
+  );
+};
+
+const LongContainer = styled.div`
+  width: 300px;
+`;
+const LongButton = styled(Button)`
+  width: 90%;
+`;
+export const _LongButton = () => {
+  return (
+    <LongContainer>
+      <LongButton
+        isCta={boolean('isCta')}
+        isDisabled={boolean('isDisabled')}
+        onClick={action('clicked')}
+        type={select(
+          'type',
+          { primary: BUTTON_TYPES.PRIMARY, secondary: BUTTON_TYPES.SECONDARY },
+          BUTTON_TYPES.PRIMARY
+        )}
+      >
+        {text('children', 'Open in editor')}
+      </LongButton>
+    </LongContainer>
+  );
+};
+
+const SecondaryButtonContainer = styled.div`
+  width: 400px;
+  height: 200px;
+  display: flex;
+  justify-content: space-around;
+  background-color: black;
+`;
+
+const LargerFontChild = styled.span`
+  font-size: 22px;
+`;
+
+export const Button2 = () => {
+  return (
+    <SecondaryButtonContainer>
+      <Button
+        isCta={boolean('isCta', true)}
+        isDisabled={boolean('isDisabled')}
+        onClick={action('clicked')}
+        type={select(
+          'type',
+          { primary: BUTTON_TYPES.PRIMARY, secondary: BUTTON_TYPES.SECONDARY },
+          BUTTON_TYPES.SECONDARY
+        )}
+      >
+        <LargerFontChild>{text('children', 'View Details')}</LargerFontChild>
+      </Button>
+    </SecondaryButtonContainer>
+  );
+};

--- a/assets/src/dashboard/constants.js
+++ b/assets/src/dashboard/constants.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const BUTTON_TYPES = {
+  PRIMARY: 'primary',
+  SECONDARY: 'secondary',
+};

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { createGlobalStyle, ThemeContext } from 'styled-components';
+import { useContext } from 'react';
+
+export const GlobalStyle = createGlobalStyle`
+	*,
+	*::after,
+	*::before {
+		box-sizing: border-box;
+	}
+`;
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+const theme = {
+  colors: {
+    gray900: '#1A1D1F',
+    gray800: '#2C3033',
+    gray700: '#3F454A',
+    gray600: '#4F575F',
+    gray500: '#606B74',
+    gray400: '#6D7A85',
+    gray300: '#848D96',
+    gray200: '#9AA1A9',
+    gray100: '#B8BCBF',
+    gray75: '#D9DBDD',
+    gray50: '#EEEEEE',
+    // gray25: '#F7F7F7', gray25 is duplicated, it looks like F6F6 wins out in the docs, keeping this here for now for reference.
+    gray25: '#F6F6F6',
+    white: '#fff',
+    bluePrimary: '#2979FF',
+    blueLight: '#EAF2FF',
+  },
+  text: {
+    shadow: '0px 1px 1px rgba(0, 0, 0, 1)',
+  },
+};
+
+export default theme;

--- a/assets/src/edit-story/components/library/panes/media/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaElement.js
@@ -82,12 +82,7 @@ const MediaElement = ({
   height: requestedHeight,
   onInsert,
 }) => {
-  const {
-    src,
-    type,
-    width: originalWidth,
-    height: originalHeight,
-  } = resource;
+  const { src, type, width: originalWidth, height: originalHeight } = resource;
   const oRatio =
     originalWidth && originalHeight ? originalWidth / originalHeight : 1;
   const width = requestedWidth || requestedHeight / oRatio;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2836,6 +2836,36 @@
         "util-deprecate": "^1.0.2"
       }
     },
+    "@storybook/addon-actions": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-5.3.14.tgz",
+      "integrity": "sha512-4lKrTMzw/r6VQiBY24v72WC3jibW7pc9BIJgtPpTmTUQWTxPnkmxDfT81pV4BjS1GFH9VCnU6f5fWK+5lrQlsw==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "5.3.14",
+        "@storybook/api": "5.3.14",
+        "@storybook/client-api": "5.3.14",
+        "@storybook/components": "5.3.14",
+        "@storybook/core-events": "5.3.14",
+        "@storybook/theming": "5.3.14",
+        "core-js": "^3.0.1",
+        "fast-deep-equal": "^2.0.1",
+        "global": "^4.3.2",
+        "polished": "^3.3.1",
+        "prop-types": "^15.7.2",
+        "react": "^16.8.3",
+        "react-inspector": "^4.0.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
+      }
+    },
     "@storybook/addon-backgrounds": {
       "version": "5.3.14",
       "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-5.3.14.tgz",
@@ -6725,7 +6755,7 @@
           }
         },
         "prettier": {
-          "version": "npm:prettier@1.19.1",
+          "version": "npm:wp-prettier@1.19.1",
           "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
           "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
           "dev": true
@@ -15089,6 +15119,16 @@
       "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==",
       "dev": true
     },
+    "is-dom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-dom/-/is-dom-1.1.0.tgz",
+      "integrity": "sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==",
+      "dev": true,
+      "requires": {
+        "is-object": "^1.0.1",
+        "is-window": "^1.0.2"
+      }
+    },
     "is-expression": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
@@ -15188,6 +15228,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
       "dev": true
     },
     "is-observable": {
@@ -15311,6 +15357,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz",
       "integrity": "sha512-SNPgMLz9JzPccD3nPctcj8sZlX9DAMJSKH8bP7Z6bohCwuNgX8xbWr1eTAYXX9Vpi/aSn8Y1akL9WgM3t43YNQ==",
+      "dev": true
+    },
+    "is-window": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
+      "integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0=",
       "dev": true
     },
     "is-windows": {
@@ -21142,6 +21194,17 @@
       "dev": true,
       "requires": {
         "prop-types": "^15.5.8"
+      }
+    },
+    "react-inspector": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-4.0.1.tgz",
+      "integrity": "sha512-xSiM6CE79JBqSj8Fzd9dWBHv57tLTH7OM57GP3VrE5crzVF3D5Khce9w1Xcw75OAbvrA0Mi2vBneR1OajKmXFg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "is-dom": "^1.0.9",
+        "prop-types": "^15.6.1"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@babel/core": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@prettier/plugin-xml": "^0.7.2",
+    "@storybook/addon-actions": "^5.2.8",
     "@storybook/addon-a11y": "^5.3.14",
     "@storybook/addon-backgrounds": "^5.3.14",
     "@storybook/addon-docs": "^5.3.14",


### PR DESCRIPTION
Adds config for storybook to allow dashboard and story editor to coexist with separate themes and global styles. 

Dashboard button component w/ storybook demos. 

[Theme colors added from figma](https://www.figma.com/file/hUTw97921an0e3uU28JoDn/Google-Stories---Product-(Copy)?node-id=1575%3A111807)

