### PR TITLE
Use data coordinate system everywhere and auto-sizing

### DIFF
--- a/assets/src/edit-story/components/canvas/canvasUploadDropTarget.js
+++ b/assets/src/edit-story/components/canvas/canvasUploadDropTarget.js
@@ -55,11 +55,7 @@ function CanvasUploadDropTarget({ children }) {
       files.forEach((file) => {
         uploadFile(file).then((res) => {
           const resource = getResourceFromUploadAPI(res);
-          insertElement(resource.type, {
-            resource,
-            width: resource.width,
-            height: resource.height,
-          });
+          insertElement(resource.type, { resource });
         });
       });
     },

--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -35,6 +35,7 @@ import { useMediaPicker } from '../../../mediaPicker';
 import { MainButton, Title, SearchInput, Header } from '../../common';
 import useLibrary from '../../useLibrary';
 import { Pane } from '../shared';
+import { DEFAULT_DPR, PAGE_WIDTH } from '../../../../constants';
 import paneId from './paneId';
 import {
   getResourceFromMediaPicker,
@@ -79,7 +80,9 @@ const FILTERS = [
   { filter: 'video', name: __('Video', 'web-stories') },
 ];
 
-const DEFAULT_WIDTH = 150;
+// By default, the element should be 50% of the page.
+const DEFAULT_ELEMENT_WIDTH = PAGE_WIDTH / 2;
+const PREVIEW_SIZE = 150;
 
 function MediaPane(props) {
   const {
@@ -107,11 +110,7 @@ function MediaPane(props) {
    */
   const onSelect = (mediaPickerEl) => {
     const resource = getResourceFromMediaPicker(mediaPickerEl);
-    const oRatio =
-      resource.width && resource.height ? resource.width / resource.height : 1;
-    const height = DEFAULT_WIDTH / oRatio;
-
-    insertMediaElement(resource, DEFAULT_WIDTH, height);
+    insertMediaElement(resource);
   };
 
   const openMediaPicker = useMediaPicker({
@@ -141,19 +140,11 @@ function MediaPane(props) {
    * Insert element such image, video and audio into the editor.
    *
    * @param {Object} resource Resource object
-   * @param {number} width Width that element is inserted into editor.
-   * @param {number} height Height that element is inserted into editor.
    * @return {null|*} Return onInsert or null.
    */
-  const insertMediaElement = (resource, width, height) => {
-    return insertElement(resource.type, {
-      resource,
-      width,
-      height,
-      x: 5,
-      y: 5,
-      rotationAngle: 0,
-    });
+  const insertMediaElement = (resource) => {
+    const width = Math.min(resource.width * DEFAULT_DPR, DEFAULT_ELEMENT_WIDTH);
+    return insertElement(resource.type, { resource, width });
   };
 
   /**
@@ -215,7 +206,7 @@ function MediaPane(props) {
                 <MediaElement
                   resource={resource}
                   key={resource.src}
-                  width={DEFAULT_WIDTH}
+                  width={PREVIEW_SIZE}
                   onInsert={insertMediaElement}
                 />
               ))}
@@ -227,7 +218,7 @@ function MediaPane(props) {
                 <MediaElement
                   resource={resource}
                   key={resource.src}
-                  width={DEFAULT_WIDTH}
+                  width={PREVIEW_SIZE}
                   onInsert={insertMediaElement}
                 />
               ))}

--- a/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
+++ b/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
@@ -32,8 +32,11 @@ import useLibrary from '../../useLibrary';
 import createSolid from '../../../../utils/createSolid';
 import { Section, Title, SearchInput, Header } from '../../common';
 import { Pane } from '../shared';
+import { PAGE_WIDTH } from '../../../../constants';
 import paneId from './paneId';
 
+// By default, the element should be 33% of the page.
+const DEFAULT_ELEMENT_WIDTH = PAGE_WIDTH / 3;
 const PREVIEW_SIZE = 36;
 
 const SectionContent = styled.div`
@@ -74,11 +77,7 @@ function ShapesPane(props) {
               onClick={() => {
                 insertElement('shape', {
                   backgroundColor: createSolid(51, 51, 51),
-                  width: 200,
-                  height: 200,
-                  x: 5,
-                  y: 5,
-                  rotationAngle: 0,
+                  width: DEFAULT_ELEMENT_WIDTH,
                   mask: {
                     type: mask.type,
                   },

--- a/assets/src/edit-story/components/library/panes/text/textPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textPane.js
@@ -22,46 +22,41 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { DEFAULT_EDITOR_PAGE_HEIGHT } from '../../../../constants';
+import { PAGE_WIDTH } from '../../../../constants';
 import createSolid from '../../../../utils/createSolid';
-import { editorToDataY } from '../../../../units/dimensions';
+import { dataFontEm } from '../../../../units';
 import { Section, MainButton, Title, SearchInput, Header } from '../../common';
 import { FontPreview } from '../../text';
 import useLibrary from '../../useLibrary';
 import { Pane } from '../shared';
 import paneId from './paneId';
 
+// By default, the element should be 50% of the page.
+const DEFAULT_ELEMENT_WIDTH = PAGE_WIDTH / 2;
+
 const PRESETS = [
   {
     id: 'heading',
     title: __('Heading', 'web-stories'),
-    fontSize: 48,
+    fontSize: dataFontEm(3),
     fontWeight: 800,
     fontFamily: 'Ubuntu',
   },
   {
     id: 'subheading',
     title: __('Subheading', 'web-stories'),
-    fontSize: 32,
+    fontSize: dataFontEm(2),
     fontWeight: 500,
     fontFamily: 'Ubuntu',
   },
   {
     id: 'body-text',
     title: __('Body text', 'web-stories'),
-    fontSize: 16,
+    fontSize: dataFontEm(1),
     fontWeight: 'normal',
     fontFamily: 'Ubuntu',
   },
 ];
-
-const DEFAULT_TEXT_TRANSFORM = {
-  width: 50,
-  height: 20,
-  x: 5,
-  y: 5,
-  rotationAngle: 0,
-};
 
 function TextPane(props) {
   const {
@@ -76,7 +71,7 @@ function TextPane(props) {
             insertElement('text', {
               content: __('Text', 'web-stories'),
               color: createSolid(0, 0, 0),
-              ...DEFAULT_TEXT_TRANSFORM,
+              width: DEFAULT_ELEMENT_WIDTH,
             })
           }
         >
@@ -97,12 +92,8 @@ function TextPane(props) {
               insertElement('text', {
                 content: __('Text', 'web-stories'),
                 color: createSolid(0, 0, 0),
-                ...DEFAULT_TEXT_TRANSFORM,
+                width: DEFAULT_ELEMENT_WIDTH,
                 ...preset,
-                fontSize: editorToDataY(
-                  preset.fontSize,
-                  DEFAULT_EDITOR_PAGE_HEIGHT
-                ),
               })
             }
           />

--- a/assets/src/edit-story/components/library/panes/text/textPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textPane.js
@@ -38,14 +38,14 @@ const PRESETS = [
   {
     id: 'heading',
     title: __('Heading', 'web-stories'),
-    fontSize: dataFontEm(3),
+    fontSize: dataFontEm(2),
     fontWeight: 800,
     fontFamily: 'Ubuntu',
   },
   {
     id: 'subheading',
     title: __('Subheading', 'web-stories'),
-    fontSize: dataFontEm(2),
+    fontSize: dataFontEm(1.5),
     fontWeight: 500,
     fontFamily: 'Ubuntu',
   },

--- a/assets/src/edit-story/components/library/panes/text/textTab.js
+++ b/assets/src/edit-story/components/library/panes/text/textTab.js
@@ -31,9 +31,15 @@ import { __ } from '@wordpress/i18n';
 import createSolid from '../../../../utils/createSolid';
 import useLibrary from '../../useLibrary';
 import { Tab } from '../shared';
+import { PAGE_WIDTH } from '../../../../constants';
+import { dataFontEm } from '../../../../units';
 import paneId from './paneId';
 import { ReactComponent as TextIcon } from './text.svg';
 import { ReactComponent as TextAddIcon } from './text_add.svg';
+
+// By default, the element should be 50% of the page.
+const DEFAULT_ELEMENT_WIDTH = PAGE_WIDTH / 2;
+const DEFAULT_FONT_SIZE = dataFontEm(2);
 
 const AnimatedTextIcon = styled(({ isSecondary, ...rest }) => (
   // Necessary because of https://github.com/styled-components/styled-components/pull/2093
@@ -81,13 +87,8 @@ function TextTab(props) {
     insertElement('text', {
       content: __('Double-click to edit...', 'web-stories'),
       color: createSolid(0, 0, 0),
-      fontSize: 100,
-      backgroundColor: createSolid(255, 255, 255),
-      width: 300,
-      height: 100,
-      x: 50,
-      y: 20,
-      rotationAngle: 0,
+      fontSize: DEFAULT_FONT_SIZE,
+      width: DEFAULT_ELEMENT_WIDTH,
     });
   };
   const { isActive } = props;

--- a/assets/src/edit-story/components/library/text/fontPreview.js
+++ b/assets/src/edit-story/components/library/text/fontPreview.js
@@ -31,6 +31,9 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useFont } from '../../../app';
+import { DEFAULT_EDITOR_PAGE_HEIGHT, PAGE_HEIGHT } from '../../../constants';
+
+const PREVIEW_EM_SCALE = DEFAULT_EDITOR_PAGE_HEIGHT / PAGE_HEIGHT;
 
 const Preview = styled.div`
   position: relative;
@@ -45,7 +48,7 @@ const Preview = styled.div`
 
 const Text = styled.span`
   background: none;
-  font-size: ${({ fontSize }) => fontSize}px;
+  font-size: ${({ fontSize }) => fontSize * PREVIEW_EM_SCALE}px;
   font-weight: ${({ fontWeight }) => fontWeight};
   font-family: ${({ fontFamily }) => fontFamily};
   color: ${({ theme }) => theme.colors.fg.v1};

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -30,6 +30,12 @@ export const PAGE_HEIGHT = 1920;
 export const DEFAULT_EDITOR_PAGE_WIDTH = 412;
 export const DEFAULT_EDITOR_PAGE_HEIGHT = 732;
 
+// Default device pixel ratio.
+export const DEFAULT_DPR = 0.5;
+
+// Default 1em value for font size.
+export const DEFAULT_EM = PAGE_HEIGHT * 0.02186;
+
 // @todo Confirm real min-max font sizes.
 export const MIN_FONT_SIZE = 30;
 export const MAX_FONT_SIZE = 200;

--- a/assets/src/edit-story/units/dimensions.js
+++ b/assets/src/edit-story/units/dimensions.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { PAGE_WIDTH, PAGE_HEIGHT } from '../constants';
+import { PAGE_WIDTH, PAGE_HEIGHT, DEFAULT_EM } from '../constants';
 
 /**
  * Rounds the pixel value to the max allowed precision in the "data" space.
@@ -27,6 +27,16 @@ import { PAGE_WIDTH, PAGE_HEIGHT } from '../constants';
  */
 export function dataPixels(v) {
   return Number(v.toFixed(0));
+}
+
+/**
+ * Returns the font size in the "data" space for the specified "em" value.
+ *
+ * @param {number} v The "em" value. E.g. 2 for "2em".
+ * @return {number} The font size for the specified "em" value.
+ */
+export function dataFontEm(v) {
+  return dataPixels(v * DEFAULT_EM);
 }
 
 /**

--- a/assets/src/edit-story/units/index.js
+++ b/assets/src/edit-story/units/index.js
@@ -23,4 +23,5 @@ export {
   dataToEditorY,
   editorToDataX,
   editorToDataY,
+  dataFontEm,
 } from './dimensions';

--- a/assets/src/edit-story/utils/textMeasurements.js
+++ b/assets/src/edit-story/utils/textMeasurements.js
@@ -78,7 +78,7 @@ function getOrCreateMeasurer({
     fontStyle,
     fontWeight,
     fontSize: `${fontSize}px`,
-    lineHeight,
+    lineHeight: lineHeight || 'normal',
     letterSpacing: `${letterSpacing ? letterSpacing + 'em' : null}`,
     textAlign,
     padding: `${padding ? padding : '0'}%`,


### PR DESCRIPTION
Blocked by https://github.com/google/web-stories-wp/pull/538

Two major changes:

1. All units are always assigned using the "data" space to reduce conversions between the two systems.
2. Width and height can be auto-calculated. I was able to reuse the existing resize logic for moveables for this.
