### PR TITLE
Adding google sans import and setting up initial theme for dashboard

### DIFF
--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -19,12 +19,23 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * External dependencies
+ */
+import { ThemeProvider } from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import theme, { GlobalStyle } from '../theme';
+
 function App() {
   return (
-    <div>
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
       <h1>{__('Dashboard', 'web-stories')}</h1>
       <p>{__('Coming soon', 'web-stories')}</p>
-    </div>
+    </ThemeProvider>
   );
 }
 

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { createGlobalStyle, ThemeContext } from 'styled-components';
+import { useContext } from 'react';
+
+/**
+ * Internal dependencies
+ */
+export const GlobalStyle = createGlobalStyle`
+  @import url(//fonts.googleapis.com/css?family=Google+Sans);
+	*,
+	*::after,
+	*::before {
+		box-sizing: border-box;
+    }
+    
+    h1 {
+      font-family: 'Google Sans', 'Roboto', sans-serif;
+    }
+`;
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+const theme = {
+  fonts: {
+    heading1: {
+      family: 'Google Sans',
+      size: '38px',
+      lineHeight: '53px',
+      letterSpacing: '-0.005em',
+    },
+    body1: {
+      family: 'Roboto',
+      size: '16px',
+      lineHeight: '24px',
+      letterSpacing: '0.00625em',
+    },
+    body2: {
+      family: 'Roboto',
+      size: '14px',
+      lineHeight: '16px',
+      letterSpacing: '0.0142em',
+    },
+    tab: {
+      family: 'Google Sans',
+      size: '14px',
+      lineHeight: '20px',
+      weight: '500',
+    },
+    label: {
+      family: 'Roboto',
+      size: '15px',
+      lineHeight: '18px',
+      weight: '400',
+    },
+  },
+};
+
+export default theme;


### PR DESCRIPTION
Adding Google Sans font for use in dashboard. Part of initial set up work for Dashboard, reference #547. Includes initial boiler plate for styled component globals and theme usage to enable testing of font usability. 

the h1 in the global styles is temporary just to show the change worked.

To test:
- see that the h1 on  wp-admin/edit.php?post_type=web-story&page=stories-dashboard is now using Google Sans 


![Screen Shot 2020-03-12 at 11 02 03 AM](https://user-images.githubusercontent.com/10720454/76553916-293a3d80-6452-11ea-8ae1-93b05126b774.png)
