### PR TITLE
Background overlay/scrim

### DIFF
--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/addPage.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/addPage.js
@@ -48,6 +48,7 @@ function addPage(state, { page, position }) {
   const newPage = {
     elements: [],
     backgroundElementId: null,
+    backgroundOverlay: null,
     ...page,
   };
 

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/addPage.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/addPage.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { isInsideRange } from './utils';
 
 /**
@@ -48,7 +49,7 @@ function addPage(state, { page, position }) {
   const newPage = {
     elements: [],
     backgroundElementId: null,
-    backgroundOverlay: null,
+    backgroundOverlay: OverlayType.NONE,
     ...page,
   };
 

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/deleteElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/deleteElements.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { intersect } from './utils';
 
 /**
@@ -74,7 +75,7 @@ function deleteElements(state, { elementIds }) {
     idsToDelete.includes(oldPage.backgroundElementId)
   ) {
     newPage.backgroundElementId = null;
-    newPage.backgroundOverlay = null;
+    newPage.backgroundOverlay = OverlayType.NONE;
   }
 
   const newPages = [

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/deleteElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/deleteElements.js
@@ -74,6 +74,7 @@ function deleteElements(state, { elementIds }) {
     idsToDelete.includes(oldPage.backgroundElementId)
   ) {
     newPage.backgroundElementId = null;
+    newPage.backgroundOverlay = null;
   }
 
   const newPages = [

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/setBackgroundElement.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/setBackgroundElement.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { moveArrayElement } from './utils';
 
 /**
@@ -61,7 +62,7 @@ function setBackgroundElement(state, { elementId }) {
       ...page,
       elements: updatedElements,
       backgroundElementId: null,
-      backgroundOverlay: null,
+      backgroundOverlay: OverlayType.NONE,
     };
   } else {
     // Does the element even exist or is it already background

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/setBackgroundElement.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/setBackgroundElement.js
@@ -61,6 +61,7 @@ function setBackgroundElement(state, { elementId }) {
       ...page,
       elements: updatedElements,
       backgroundElementId: null,
+      backgroundOverlay: null,
     };
   } else {
     // Does the element even exist or is it already background
@@ -107,6 +108,7 @@ function setBackgroundElement(state, { elementId }) {
     newPage = {
       ...page,
       backgroundElementId: elementId,
+      backgroundOverlay: null,
       elements: newElements,
     };
   }

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/setBackgroundElement.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/setBackgroundElement.js
@@ -109,7 +109,7 @@ function setBackgroundElement(state, { elementId }) {
     newPage = {
       ...page,
       backgroundElementId: elementId,
-      backgroundOverlay: null,
+      backgroundOverlay: OverlayType.NONE,
       elements: newElements,
     };
   }

--- a/assets/src/edit-story/app/story/useStoryReducer/test/addElementToSelection.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/addElementToSelection.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { setupReducer } from './_utils';
 
 describe('addElementToSelection', () => {
@@ -69,6 +70,7 @@ describe('addElementToSelection', () => {
         {
           id: '111',
           backgroundElementId: 'e1',
+          backgroundOverlay: OverlayType.NONE,
           elements: [{ id: 'e1' }, { id: 'e2' }, { id: 'e3' }],
         },
       ],
@@ -90,6 +92,7 @@ describe('addElementToSelection', () => {
         {
           id: '111',
           backgroundElementId: 'e1',
+          backgroundOverlay: OverlayType.NONE,
           elements: [{ id: 'e1' }, { id: 'e2' }, { id: 'e3' }],
         },
       ],

--- a/assets/src/edit-story/app/story/useStoryReducer/test/addPage.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/addPage.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { setupReducer } from './_utils';
 
 describe('addPage', () => {
@@ -30,6 +31,7 @@ describe('addPage', () => {
         id: '123',
         elements: [],
         backgroundElementId: null,
+        backgroundOverlay: OverlayType.NONE,
       },
     ]);
   });

--- a/assets/src/edit-story/app/story/useStoryReducer/test/arrangeElement.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/arrangeElement.js
@@ -18,6 +18,7 @@
  * Internal dependencies
  */
 import { LAYER_DIRECTIONS } from '../../../../constants';
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { setupReducer } from './_utils';
 
 describe('arrangeElement', () => {
@@ -233,6 +234,7 @@ function getInitialState(extraProps) {
     pages: [
       {
         backgroundElementId: null,
+        backgroundOverlay: OverlayType.NONE,
         id: '111',
         elements: [{ id: '123' }, { id: '234' }, { id: '345' }, { id: '456' }],
         ...extraProps,

--- a/assets/src/edit-story/app/story/useStoryReducer/test/arrangeSelection.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/arrangeSelection.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { setupReducer } from './_utils';
 
 describe('arrangeSelection', () => {
@@ -65,6 +66,7 @@ function getInitialState(selection) {
     pages: [
       {
         backgroundElementId: null,
+        backgroundOverlay: OverlayType.NONE,
         id: '111',
         elements: [{ id: '123' }, { id: '234' }, { id: '345' }, { id: '456' }],
       },

--- a/assets/src/edit-story/app/story/useStoryReducer/test/clearBackgroundElement.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/clearBackgroundElement.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { setupReducer } from './_utils';
 
 describe('clearBackgroundElement', () => {
@@ -30,6 +31,7 @@ describe('clearBackgroundElement', () => {
           id: '111',
           elements: [{ id: '123' }, { id: '456' }, { id: '789' }],
           backgroundElementId: '123',
+          backgroundOverlay: OverlayType.NONE,
         },
       ],
       current: '111',
@@ -41,6 +43,7 @@ describe('clearBackgroundElement', () => {
     expect(result.pages[0]).toStrictEqual({
       id: '111',
       backgroundElementId: null,
+      backgroundOverlay: OverlayType.NONE,
       elements: [{ id: '123' }, { id: '456' }, { id: '789' }],
     });
   });

--- a/assets/src/edit-story/app/story/useStoryReducer/test/deleteElementById.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/deleteElementById.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { setupReducer } from './_utils';
 
 describe('deleteElementById', () => {
@@ -85,6 +86,7 @@ describe('deleteElementById', () => {
       pages: [
         {
           backgroundElementId: '123',
+          backgroundOverlay: OverlayType.NONE,
           id: '111',
           elements: [{ id: '123' }, { id: '456' }],
         },
@@ -98,7 +100,12 @@ describe('deleteElementById', () => {
     expect(result).toStrictEqual({
       ...initialState,
       pages: [
-        { backgroundElementId: null, id: '111', elements: [{ id: '456' }] },
+        {
+          backgroundElementId: null,
+          backgroundOverlay: OverlayType.NONE,
+          id: '111',
+          elements: [{ id: '456' }],
+        },
       ],
       selection: ['456'],
     });

--- a/assets/src/edit-story/app/story/useStoryReducer/test/setBackgroundElement.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/setBackgroundElement.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { setupReducer } from './_utils';
 
 describe('setBackgroundElement', () => {
@@ -30,6 +31,7 @@ describe('setBackgroundElement', () => {
           id: '111',
           elements: [{ id: '123' }, { id: '456' }, { id: '789' }],
           backgroundElementId: null,
+          backgroundOverlay: OverlayType.NONE,
         },
       ],
       current: '111',
@@ -42,6 +44,7 @@ describe('setBackgroundElement', () => {
     expect(result.pages[0]).toStrictEqual({
       id: '111',
       backgroundElementId: '456',
+      backgroundOverlay: OverlayType.NONE,
       elements: [
         { id: '456', isBackground: true },
         { id: '123' },
@@ -60,6 +63,7 @@ describe('setBackgroundElement', () => {
           id: '111',
           elements: [{ id: '123' }, { id: '456' }, { id: '789' }],
           backgroundElementId: null,
+          backgroundOverlay: OverlayType.NONE,
         },
       ],
       current: '111',
@@ -86,6 +90,7 @@ describe('setBackgroundElement', () => {
             { id: '789' },
           ],
           backgroundElementId: '123',
+          backgroundOverlay: OverlayType.NONE,
         },
       ],
       current: '111',
@@ -112,6 +117,7 @@ describe('setBackgroundElement', () => {
             { id: '789' },
           ],
           backgroundElementId: '123',
+          backgroundOverlay: OverlayType.NONE,
         },
       ],
       current: '111',
@@ -139,6 +145,7 @@ describe('setBackgroundElement', () => {
               { id: '789' },
             ],
             backgroundElementId: '123',
+            backgroundOverlay: OverlayType.NONE,
           },
         ],
         current: '111',
@@ -151,6 +158,7 @@ describe('setBackgroundElement', () => {
       expect(result.pages[0]).toStrictEqual({
         id: '111',
         backgroundElementId: '789',
+        backgroundOverlay: OverlayType.NONE,
         elements: [{ id: '789', isBackground: true }, { id: '456' }],
       });
     });
@@ -169,6 +177,7 @@ describe('setBackgroundElement', () => {
               { id: '789' },
             ],
             backgroundElementId: '123',
+            backgroundOverlay: OverlayType.NONE,
           },
         ],
         current: '111',
@@ -181,6 +190,7 @@ describe('setBackgroundElement', () => {
       expect(result.pages[0]).toStrictEqual({
         id: '111',
         backgroundElementId: '789',
+        backgroundOverlay: OverlayType.NONE,
         elements: [{ id: '789', isBackground: true }, { id: '456' }],
       });
       expect(result.selection).toStrictEqual([]);

--- a/assets/src/edit-story/app/story/useStoryReducer/test/setSelectedElementsById.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/setSelectedElementsById.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { setupReducer } from './_utils';
 
 describe('setSelectedElementsById', () => {
@@ -101,6 +102,7 @@ describe('setSelectedElementsById', () => {
         {
           id: '111',
           backgroundElementId: 'e1',
+          backgroundOverlay: OverlayType.NONE,
           elements: [{ id: 'e1' }, { id: 'e2' }, { id: 'e3' }],
         },
       ],

--- a/assets/src/edit-story/app/story/useStoryReducer/test/toggleElementInSelection.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/toggleElementInSelection.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { OverlayType } from '../../../../utils/backgroundOverlay';
 import { setupReducer } from './_utils';
 
 describe('toggleElementInSelection', () => {
@@ -69,6 +70,7 @@ describe('toggleElementInSelection', () => {
         {
           id: '111',
           backgroundElementId: 'e1',
+          backgroundOverlay: OverlayType.NONE,
           elements: [{ id: 'e1' }, { id: 'e2' }, { id: 'e3' }],
         },
       ],
@@ -90,6 +92,7 @@ describe('toggleElementInSelection', () => {
         {
           id: '111',
           backgroundElementId: 'e1',
+          backgroundOverlay: OverlayType.NONE,
           elements: [{ id: 'e1' }, { id: 'e2' }, { id: 'e3' }],
         },
       ],

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -33,6 +33,8 @@ import StoryPropTypes from '../../types';
 import { useTransformHandler } from '../transform';
 import { useUnits } from '../../units';
 import WithMask from '../../masks/display';
+import { useStory } from '../../app';
+import { generateOverlayStyles } from '../../utils/backgroundOverlay';
 
 const Wrapper = styled.div`
 	${elementWithPosition}
@@ -41,10 +43,21 @@ const Wrapper = styled.div`
 	contain: layout paint;
 `;
 
+const BackgroundOverlay = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+`;
+
 function DisplayElement({ element }) {
   const {
     actions: { getBox },
   } = useUnits();
+  const {
+    state: { currentPage },
+  } = useStory();
 
   const [replacement, setReplacement] = useState(null);
 
@@ -56,7 +69,7 @@ function DisplayElement({ element }) {
       }
     : null;
 
-  const { id, opacity, type } = element;
+  const { id, opacity, type, isBackground } = element;
   const { Display } = getDefinitionForType(type);
   const { Display: Replacement } =
     getDefinitionForType(replacement?.type) || {};
@@ -103,6 +116,11 @@ function DisplayElement({ element }) {
           <Replacement element={replacementElement} box={box} />
         )}
       </WithMask>
+      {Boolean(isBackground) && Boolean(currentPage.backgroundOverlay) && (
+        <BackgroundOverlay
+          style={generateOverlayStyles(currentPage.backgroundOverlay)}
+        />
+      )}
     </Wrapper>
   );
 }

--- a/assets/src/edit-story/components/form/switch.js
+++ b/assets/src/edit-story/components/form/switch.js
@@ -27,6 +27,11 @@ import { rgba } from 'polished';
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { KEYBOARD_USER_SELECTOR } from '../../utils/keyboardOnlyOutline';
+
 const SwitchContainer = styled.div`
   appearance: none;
   position: relative;
@@ -79,7 +84,7 @@ const Label = styled.label`
     opacity: 0.3;
 	`}
 
-  &:focus-within ~ span {
+  ${KEYBOARD_USER_SELECTOR} &:focus-within ~ span {
     background-color: ${({ theme }) => theme.colors.action};
   }
 `;

--- a/assets/src/edit-story/components/form/toggleButton.js
+++ b/assets/src/edit-story/components/form/toggleButton.js
@@ -34,6 +34,24 @@ const MarkSpan = styled.span`
   align-items: center;
 `;
 
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  user-select: none;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Label = styled.span`
+  color: ${({ theme }) => rgba(theme.colors.fg.v1, 0.54)};
+  font-family: ${({ theme }) => theme.fonts.body2.family};
+  font-size: ${({ theme }) => theme.fonts.body2.size};
+  line-height: ${({ theme }) => theme.fonts.body2.lineHeight};
+  letter-spacing: ${({ theme }) => theme.fonts.body2.letterSpacing};
+  margin-top: 8px;
+`;
+
 const ContainerLabel = styled.label`
   display: flex;
   position: relative;
@@ -57,8 +75,8 @@ const ContainerLabel = styled.label`
 
   svg {
     color: ${({ theme }) => theme.colors.mg.v2};
-    width: ${({ IconWidth }) => IconWidth}px;
-    height: ${({ IconHeight }) => IconHeight}px;
+    width: ${({ iconWidth }) => iconWidth}px;
+    height: ${({ iconHeight }) => iconHeight}px;
   }
 `;
 
@@ -68,29 +86,29 @@ function ToggleButton({
   icon,
   uncheckedIcon,
   onChange,
-  boxed,
-  expand,
-  IconWidth,
-  IconHeight,
+  iconWidth,
+  iconHeight,
+  label,
   ...rest
 }) {
   return (
-    <ContainerLabel
-      expand={expand}
-      boxed={boxed}
-      disabled={disabled}
-      value={value}
-      IconWidth={IconWidth}
-      IconHeight={IconHeight}
-    >
-      <CheckBoxInput
-        checked={value}
-        onChange={() => onChange(!value)}
+    <Container>
+      <ContainerLabel
         disabled={disabled}
-        {...rest}
-      />
-      <MarkSpan>{value ? icon : uncheckedIcon || icon}</MarkSpan>
-    </ContainerLabel>
+        value={value}
+        iconWidth={iconWidth}
+        iconHeight={iconHeight}
+      >
+        <CheckBoxInput
+          checked={value}
+          onChange={() => onChange(!value)}
+          disabled={disabled}
+          {...rest}
+        />
+        <MarkSpan>{value ? icon : uncheckedIcon || icon}</MarkSpan>
+      </ContainerLabel>
+      {Boolean(label) && <Label>{label}</Label>}
+    </Container>
   );
 }
 
@@ -99,21 +117,21 @@ ToggleButton.propTypes = {
   onChange: PropTypes.func.isRequired,
   icon: PropTypes.node,
   uncheckedIcon: PropTypes.node,
+  label: PropTypes.string,
   disabled: PropTypes.bool,
-  boxed: PropTypes.bool,
-  expand: PropTypes.bool,
-  IconHeight: PropTypes.number,
-  IconWidth: PropTypes.number,
+  iconHeight: PropTypes.number,
+  iconWidth: PropTypes.number,
 };
 
 ToggleButton.defaultProps = {
   icon: null,
   uncheckedIcon: null,
+  label: null,
   disabled: false,
   boxed: false,
   expand: false,
-  IconWidth: 14,
-  IconHeight: 9,
+  iconWidth: 14,
+  iconHeight: 9,
 };
 
 export default ToggleButton;

--- a/assets/src/edit-story/components/panels/backgroundOverlay.js
+++ b/assets/src/edit-story/components/panels/backgroundOverlay.js
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 
 /**
@@ -28,46 +28,23 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { Row } from '../form';
-import { ReactComponent as OverlayNoneIcon } from '../../icons/overlay_none.svg';
-import { ReactComponent as OverlaySolidIcon } from '../../icons/overlay_solid.svg';
-import { ReactComponent as OverlayLinearIcon } from '../../icons/overlay_linear.svg';
-import { ReactComponent as OverlayRadialIcon } from '../../icons/overlay_radial.svg';
 import ToggleButton from '../form/toggleButton';
+import { useStory } from '../../app';
+import { OverlayPreset, OverlayType } from '../../utils/backgroundOverlay';
 import { SimplePanel } from './panel';
 
-const OverlayType = {
-  NONE: 'none',
-  SOLID: 'solid',
-  LINEAR: 'linear',
-  RADIAL: 'radial',
-};
-
-const OverlayPreset = {
-  [OverlayType.NONE]: {
-    label: __('None', 'web-stories'),
-    icon: <OverlayNoneIcon />,
-  },
-  [OverlayType.SOLID]: {
-    label: __('Solid', 'web-stories'),
-    icon: <OverlaySolidIcon />,
-  },
-  [OverlayType.LINEAR]: {
-    label: __('Linear', 'web-stories'),
-    icon: <OverlayLinearIcon />,
-  },
-  [OverlayType.GRADIENT]: {
-    label: __('Radial', 'web-stories'),
-    icon: <OverlayRadialIcon />,
-  },
-};
-
-function BackgroundOverlayPanel({ selectedElements, onSetProperties }) {
-  const { overlay: initOverlay } = selectedElements[0];
-  const [overlay, setOverlay] = useState(initOverlay || OverlayType.NONE);
+function BackgroundOverlayPanel() {
+  const {
+    state: { currentPage },
+    actions: { updateCurrentPageProperties },
+  } = useStory();
+  const [overlay, setOverlay] = useState(
+    currentPage.backgroundOverlay || OverlayType.NONE
+  );
 
   useEffect(() => {
-    onSetProperties({ overlay });
-  }, [onSetProperties, overlay]);
+    updateCurrentPageProperties({ properties: { backgroundOverlay: overlay } });
+  }, [updateCurrentPageProperties, overlay]);
 
   return (
     <SimplePanel name="backgroundOverlay" title={__('Overlay', 'web-stories')}>
@@ -82,6 +59,8 @@ function BackgroundOverlayPanel({ selectedElements, onSetProperties }) {
               value={overlay === type}
               isMultiple={false}
               onChange={() => setOverlay(type)}
+              iconWidth={22}
+              iconHeight={16}
             />
           );
         })}
@@ -90,9 +69,6 @@ function BackgroundOverlayPanel({ selectedElements, onSetProperties }) {
   );
 }
 
-BackgroundOverlayPanel.propTypes = {
-  selectedElements: PropTypes.array.isRequired,
-  onSetProperties: PropTypes.func.isRequired,
-};
+BackgroundOverlayPanel.propTypes = {};
 
 export default BackgroundOverlayPanel;

--- a/assets/src/edit-story/components/panels/backgroundOverlay.js
+++ b/assets/src/edit-story/components/panels/backgroundOverlay.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Row } from '../form';
+import { ReactComponent as OverlayNoneIcon } from '../../icons/overlay_none.svg';
+import { ReactComponent as OverlaySolidIcon } from '../../icons/overlay_solid.svg';
+import { ReactComponent as OverlayLinearIcon } from '../../icons/overlay_linear.svg';
+import { ReactComponent as OverlayRadialIcon } from '../../icons/overlay_radial.svg';
+import ToggleButton from '../form/toggleButton';
+import { SimplePanel } from './panel';
+
+const OverlayType = {
+  NONE: 'none',
+  SOLID: 'solid',
+  LINEAR: 'linear',
+  RADIAL: 'radial',
+};
+
+const OverlayPreset = {
+  [OverlayType.NONE]: {
+    label: __('None', 'web-stories'),
+    icon: <OverlayNoneIcon />,
+  },
+  [OverlayType.SOLID]: {
+    label: __('Solid', 'web-stories'),
+    icon: <OverlaySolidIcon />,
+  },
+  [OverlayType.LINEAR]: {
+    label: __('Linear', 'web-stories'),
+    icon: <OverlayLinearIcon />,
+  },
+  [OverlayType.GRADIENT]: {
+    label: __('Radial', 'web-stories'),
+    icon: <OverlayRadialIcon />,
+  },
+};
+
+function BackgroundOverlayPanel({ selectedElements, onSetProperties }) {
+  const { overlay: initOverlay } = selectedElements[0];
+  const [overlay, setOverlay] = useState(initOverlay || OverlayType.NONE);
+
+  useEffect(() => {
+    onSetProperties({ overlay });
+  }, [onSetProperties, overlay]);
+
+  return (
+    <SimplePanel name="backgroundOverlay" title={__('Overlay', 'web-stories')}>
+      <Row>
+        {Object.keys(OverlayPreset).map((type) => {
+          const { label, icon } = OverlayPreset[type];
+          return (
+            <ToggleButton
+              key={type}
+              icon={icon}
+              label={label}
+              value={overlay === type}
+              isMultiple={false}
+              onChange={() => setOverlay(type)}
+            />
+          );
+        })}
+      </Row>
+    </SimplePanel>
+  );
+}
+
+BackgroundOverlayPanel.propTypes = {
+  selectedElements: PropTypes.array.isRequired,
+  onSetProperties: PropTypes.func.isRequired,
+};
+
+export default BackgroundOverlayPanel;

--- a/assets/src/edit-story/components/panels/index.js
+++ b/assets/src/edit-story/components/panels/index.js
@@ -20,6 +20,7 @@
 import { elementTypes } from '../../elements';
 import PageBackgroundPanel from './pageBackground';
 import BackgroundSizePositionPanel from './backgroundSizePosition';
+import BackgroundOverlayPanel from './backgroundOverlay';
 import LinkPanel from './link';
 import LayerStylePanel from './layerStyle';
 import SizePositionPanel from './sizePosition';
@@ -32,6 +33,7 @@ export { default as ColorPresetPanel } from './colorPreset';
 
 const BACKGROUND_SIZE_POSITION = 'backgroundSizePosition';
 const BACKGROUND_DISPLAY = 'backgroundDisplay';
+const BACKGROUND_OVERLAY = 'backgroundOverlay';
 const LAYER_STYLE = 'layerStyle';
 const LINK = 'link';
 const TEXT = 'text';
@@ -45,6 +47,7 @@ const NO_SELECTION = 'noselection';
 export const PanelTypes = {
   BACKGROUND_SIZE_POSITION,
   BACKGROUND_DISPLAY,
+  BACKGROUND_OVERLAY,
   SIZE_POSITION,
   STYLE,
   LAYER_STYLE,
@@ -77,6 +80,7 @@ export function getPanels(elements) {
       { type: BACKGROUND_SIZE_POSITION, Panel: BackgroundSizePositionPanel },
       { type: LAYER_STYLE, Panel: LayerStylePanel },
       { type: BACKGROUND_DISPLAY, Panel: BackgroundDisplayPanel },
+      { type: BACKGROUND_OVERLAY, Panel: BackgroundOverlayPanel },
     ];
     // If the selected element's type is video, display poster panel, too.
     if ('video' === elements[0].type) {
@@ -99,6 +103,9 @@ export function getPanels(elements) {
         case LAYER_STYLE:
           return { type, Panel: LayerStylePanel };
         case BACKGROUND_DISPLAY:
+          // Only display when isBackground.
+          return null;
+        case BACKGROUND_OVERLAY:
           // Only display when isBackground.
           return null;
         case SIZE_POSITION:

--- a/assets/src/edit-story/components/panels/textStyle/textStyle.js
+++ b/assets/src/edit-story/components/panels/textStyle/textStyle.js
@@ -166,16 +166,16 @@ function StylePanel({ selectedElements, onSetProperties }) {
           icon={<BoldIcon />}
           value={state.bold || false}
           isMultiple={false}
-          IconWidth={9}
-          IconHeight={10}
+          iconWidth={9}
+          iconHeight={10}
           onChange={(value) => setState({ ...state, bold: value })}
         />
         <ToggleButton
           icon={<ItalicIcon />}
           value={state.fontStyle === 'italic'}
           isMultiple={false}
-          IconWidth={10}
-          IconHeight={10}
+          iconWidth={10}
+          iconHeight={10}
           onChange={(value) =>
             setState({ ...state, fontStyle: value ? 'italic' : 'normal' })
           }
@@ -184,8 +184,8 @@ function StylePanel({ selectedElements, onSetProperties }) {
           icon={<UnderlineIcon />}
           value={state.textDecoration === 'underline'}
           isMultiple={false}
-          IconWidth={8}
-          IconHeight={21}
+          iconWidth={8}
+          iconHeight={21}
           onChange={(value) =>
             setState({ ...state, textDecoration: value ? 'underline' : 'none' })
           }

--- a/assets/src/edit-story/icons/overlay_linear.svg
+++ b/assets/src/edit-story/icons/overlay_linear.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="22" viewBox="0 0 16 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0H16V22H0V0Z" fill="url(#paint0_linear)"/>
+<path d="M0.25 0.25H15.75V21.75H0.25V0.25Z" stroke="white" stroke-opacity="0.2" stroke-width="0.5"/>
+<defs>
+<linearGradient id="paint0_linear" x1="8" y1="3.58824" x2="8" y2="20" gradientUnits="userSpaceOnUse">
+<stop stop-opacity="0"/>
+<stop offset="1"/>
+</linearGradient>
+</defs>
+</svg>

--- a/assets/src/edit-story/icons/overlay_none.svg
+++ b/assets/src/edit-story/icons/overlay_none.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="22" viewBox="0 0 16 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.25 0.25H15.75V21.75H0.25V0.25Z" stroke="white" stroke-opacity="0.2" stroke-width="0.5"/>
+<path d="M4 5L12 16" stroke="white"/>
+</svg>

--- a/assets/src/edit-story/icons/overlay_radial.svg
+++ b/assets/src/edit-story/icons/overlay_radial.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="22" viewBox="0 0 16 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="16" height="22" fill="url(#paint0_radial)"/>
+<rect x="0.25" y="0.25" width="15.5" height="21.5" stroke="white" stroke-opacity="0.2" stroke-width="0.5"/>
+<defs>
+<radialGradient id="paint0_radial" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(8 11.5) rotate(-90) scale(10.5 15.5127)">
+<stop stop-opacity="0"/>
+<stop offset="1" stop-opacity="0.69"/>
+</radialGradient>
+</defs>
+</svg>

--- a/assets/src/edit-story/icons/overlay_solid.svg
+++ b/assets/src/edit-story/icons/overlay_solid.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="22" viewBox="0 0 16 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0H16V22H0V0Z" fill="black" fill-opacity="0.5"/>
+<path d="M0.25 0.25H15.75V21.75H0.25V0.25Z" stroke="white" stroke-opacity="0.2" stroke-width="0.5"/>
+</svg>

--- a/assets/src/edit-story/output/page.js
+++ b/assets/src/edit-story/output/page.js
@@ -20,7 +20,7 @@
 import StoryPropTypes from '../types';
 import generatePatternStyles from '../utils/generatePatternStyles';
 import { PAGE_WIDTH, PAGE_HEIGHT } from '../constants';
-import { generateOverlayStyles } from '../utils/backgroundOverlay';
+import { generateOverlayStyles, OverlayType } from '../utils/backgroundOverlay';
 import OutputElement from './element';
 
 function OutputPage({ page }) {
@@ -69,7 +69,7 @@ function OutputPage({ page }) {
             <OutputElement key={'el-' + element.id} element={element} />
           ))}
         </div>
-        {backgroundOverlay && backgroundOverlay !== 'none' && (
+        {backgroundOverlay && backgroundOverlay !== OverlayType.NONE && (
           <div
             className="page-background-overlay-area"
             style={{ ...backgroundOverlayStyles }}

--- a/assets/src/edit-story/output/page.js
+++ b/assets/src/edit-story/output/page.js
@@ -20,10 +20,17 @@
 import StoryPropTypes from '../types';
 import generatePatternStyles from '../utils/generatePatternStyles';
 import { PAGE_WIDTH, PAGE_HEIGHT } from '../constants';
+import { generateOverlayStyles } from '../utils/backgroundOverlay';
 import OutputElement from './element';
 
 function OutputPage({ page }) {
-  const { id, backgroundColor, elements, backgroundElementId } = page;
+  const {
+    id,
+    backgroundColor,
+    elements,
+    backgroundElementId,
+    backgroundOverlay,
+  } = page;
   // Aspect-ratio constraints.
   const aspectRatioStyles = {
     width: `calc(100 * var(--story-page-vw))`, // 100vw
@@ -35,6 +42,7 @@ function OutputPage({ page }) {
       PAGE_WIDTH}))`,
   };
   const backgroundStyles = generatePatternStyles(backgroundColor);
+  const backgroundOverlayStyles = generateOverlayStyles(backgroundOverlay);
   const backgroundNonFullbleedElements = elements.filter(
     (element) =>
       element.id === backgroundElementId &&
@@ -61,6 +69,12 @@ function OutputPage({ page }) {
             <OutputElement key={'el-' + element.id} element={element} />
           ))}
         </div>
+        {backgroundOverlay && backgroundOverlay !== 'none' && (
+          <div
+            className="page-background-overlay-area"
+            style={{ ...backgroundOverlayStyles }}
+          />
+        )}
         <div className="page-safe-area" style={aspectRatioStyles}>
           {regularElements.map((element) => (
             <OutputElement key={'el-' + element.id} element={element} />

--- a/assets/src/edit-story/output/styles.js
+++ b/assets/src/edit-story/output/styles.js
@@ -20,7 +20,9 @@ function CustomStyles() {
       amp-custom=""
       dangerouslySetInnerHTML={{
         __html: `
-              .page-background-area, .page-safe-area {
+              .page-background-area,
+              .page-background-overlay-area,
+              .page-safe-area {
                 position: absolute;
                 overflow: hidden;
                 margin: auto;

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -96,7 +96,7 @@ StoryPropTypes.page = PropTypes.shape({
   elements: PropTypes.arrayOf(PropTypes.shape(StoryPropTypes.element)),
   backgroundElementId: PropTypes.string,
   backgroundColor: PatternPropType,
-  backgroundOverlay: PatternPropType,
+  backgroundOverlay: PropTypes.oneOf(['none', 'solid', 'linear', 'radial']),
 });
 
 StoryPropTypes.imageResource = PropTypes.shape({

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -18,6 +18,10 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+/**
+ * Internal dependencies
+ */
+import { OverlayType } from './utils/backgroundOverlay';
 
 export const HexPropType = PropTypes.shape({
   r: PropTypes.number.isRequired,
@@ -96,7 +100,7 @@ StoryPropTypes.page = PropTypes.shape({
   elements: PropTypes.arrayOf(PropTypes.shape(StoryPropTypes.element)),
   backgroundElementId: PropTypes.string,
   backgroundColor: PatternPropType,
-  backgroundOverlay: PropTypes.oneOf(['none', 'solid', 'linear', 'radial']),
+  backgroundOverlay: PropTypes.oneOf(Object.values(OverlayType)),
 });
 
 StoryPropTypes.imageResource = PropTypes.shape({

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -96,6 +96,7 @@ StoryPropTypes.page = PropTypes.shape({
   elements: PropTypes.arrayOf(PropTypes.shape(StoryPropTypes.element)),
   backgroundElementId: PropTypes.string,
   backgroundColor: PatternPropType,
+  backgroundOverlay: PatternPropType,
 });
 
 StoryPropTypes.imageResource = PropTypes.shape({
@@ -195,7 +196,6 @@ StoryPropTypes.elements.shape = PropTypes.shape({
 StoryPropTypes.elements.background = PropTypes.shape({
   ...StoryLayerPropTypes,
   inner: StoryPropTypes.element,
-  overlay: PatternPropType,
 });
 
 export default StoryPropTypes;

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -195,6 +195,7 @@ StoryPropTypes.elements.shape = PropTypes.shape({
 StoryPropTypes.elements.background = PropTypes.shape({
   ...StoryLayerPropTypes,
   inner: StoryPropTypes.element,
+  overlay: PatternPropType,
 });
 
 export default StoryPropTypes;

--- a/assets/src/edit-story/utils/backgroundOverlay.js
+++ b/assets/src/edit-story/utils/backgroundOverlay.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ReactComponent as OverlayNoneIcon } from '../icons/overlay_none.svg';
+import { ReactComponent as OverlaySolidIcon } from '../icons/overlay_solid.svg';
+import { ReactComponent as OverlayLinearIcon } from '../icons/overlay_linear.svg';
+import { ReactComponent as OverlayRadialIcon } from '../icons/overlay_radial.svg';
+import generatePatternStyles from './generatePatternStyles';
+
+export const OverlayType = {
+  NONE: 'none',
+  SOLID: 'solid',
+  LINEAR: 'linear',
+  RADIAL: 'radial',
+};
+
+export const OverlayPreset = {
+  [OverlayType.NONE]: {
+    label: __('None', 'web-stories'),
+    icon: <OverlayNoneIcon />,
+  },
+  [OverlayType.SOLID]: {
+    label: __('Solid', 'web-stories'),
+    icon: <OverlaySolidIcon />,
+  },
+  [OverlayType.LINEAR]: {
+    label: __('Linear', 'web-stories'),
+    icon: <OverlayLinearIcon />,
+  },
+  [OverlayType.RADIAL]: {
+    label: __('Radial', 'web-stories'),
+    icon: <OverlayRadialIcon />,
+  },
+};
+
+/**
+ * Generate CSS styles for background overlay types.
+ *
+ * @param {OverlayType} type Type of the background overlay
+ * @return {Object} CSS declaration as object.
+ */
+export function generateOverlayStyles(type = OverlayType.NONE) {
+  if (type === OverlayType.NONE) {
+    return { background: 'none' };
+  }
+  return generatePatternStyles({
+    type,
+    color: { r: 0, g: 0, b: 0, a: 0.3 },
+    rotation: 0.5,
+    stops:
+      type === 'radial'
+        ? [
+            { color: { r: 0, g: 0, b: 0, a: 0 }, position: 0.3 },
+            { color: { r: 0, g: 0, b: 0, a: 0.8 }, position: 0.8 },
+          ]
+        : [
+            { color: { r: 0, g: 0, b: 0, a: 0.9 }, position: 0 },
+            { color: { r: 0, g: 0, b: 0, a: 0 }, position: 0.6 },
+          ],
+  });
+}


### PR DESCRIPTION
Closes #482 

![ezgif com-video-to-gif (26)](https://user-images.githubusercontent.com/591655/76895381-1f974800-684d-11ea-9bbc-8c4ae075438f.gif)

### Changes
- Adds ability to show labels on toggle buttons
- Implements toggles for switching between four presets of background overlays (none, solid, linear and radial)
- Implements the overlays into the output pipeline