### PR TITLE
Storybook Actions Set Up

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -22,6 +22,7 @@ module.exports = {
   ],
   addons: [
     '@storybook/addon-a11y/register',
+    '@storybook/addon-actions',
     '@storybook/addon-docs',
     '@storybook/addon-knobs/register',
     '@storybook/addon-storysource/register',


### PR DESCRIPTION
Forgot a config to set actions up in storybook for use. This adds it. You can see it in action in storybook, it's getting used on the dashboard button component, as seen here: 

![action panel](https://user-images.githubusercontent.com/10720454/76876108-aee13300-682e-11ea-88f8-2a28351dde4a.gif)
