### PR TITLE
Dashboard: Dropdown Component

### DIFF
--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -19,13 +19,13 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 /**
  * Internal dependencies
  */
 import { ReactComponent as DropDownArrow } from '../../icons/drop-down-arrow.svg';
 import { ReactComponent as DropUpArrow } from '../../icons/drop-up-arrow.svg';
-
+import useFocusOut from '../../utils/useFocusOut';
 import PopoverMenu from '../popover-menu';
 
 const DropdownContainer = styled.div`
@@ -93,23 +93,11 @@ const Dropdown = ({
   const [showMenu, setShowMenu] = useState(false);
   const dropdownRef = useRef();
 
-  const handleOutsideClick = (e) => {
-    if (
-      dropdownRef.current &&
-      !dropdownRef.current.contains(e.target) &&
-      showMenu === true
-    ) {
-      setShowMenu(false);
-    }
-  };
+  const handleFocusOut = useCallback(() => {
+    setShowMenu(false);
+  }, []);
 
-  useEffect(() => {
-    document.addEventListener('click', handleOutsideClick);
-
-    return () => {
-      document.removeEventListener('click', handleOutsideClick);
-    };
-  });
+  useFocusOut(dropdownRef, handleFocusOut);
 
   const handleInnerDropdownClick = () => {
     if (!disabled) {

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -29,7 +29,7 @@ import useFocusOut from '../../utils/useFocusOut';
 import PopoverMenu from '../popover-menu';
 
 const DropdownContainer = styled.div`
-  position: relative;
+  position: static;
 `;
 
 const Label = styled.label`
@@ -39,7 +39,8 @@ const Label = styled.label`
 
 export const InnerDropdown = styled.button`
   align-items: center;
-  background-color: ${({ theme }) => theme.colors.gray25};
+  background-color: ${({ theme, transparent }) =>
+    transparent ? 'transparent' : theme.colors.gray25};
   border-radius: 4px;
   border: 1px solid transparent;
   color: ${({ theme }) => theme.colors.gray600};
@@ -52,6 +53,7 @@ export const InnerDropdown = styled.button`
   justify-content: space-between;
   letter-spacing: ${({ theme }) => theme.fonts.dropdown.letterSpacing};
   line-height: ${({ theme }) => theme.fonts.dropdown.lineHeight};
+  margin-right: 10px;
   padding: 10px 16px;
   width: 100%;
 
@@ -88,6 +90,7 @@ const Dropdown = ({
   onChange,
   value,
   placeholder,
+  transparent,
   ...rest
 }) => {
   const [showMenu, setShowMenu] = useState(false);
@@ -131,6 +134,7 @@ const Dropdown = ({
           onClick={handleInnerDropdownClick}
           isOpen={showMenu}
           disabled={disabled}
+          transparent={transparent}
         >
           <InnerDropdownText>{currentLabel}</InnerDropdownText>
           <DropdownIcon>
@@ -160,6 +164,7 @@ Dropdown.propTypes = {
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
+  transparent: PropTypes.bool,
 };
 
 export default Dropdown;

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -23,6 +23,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 /**
  * Internal dependencies
  */
+import { ReactComponent as DropDownArrow } from '../../icons/drop-down-arrow.svg';
+import { ReactComponent as DropUpArrow } from '../../icons/drop-up-arrow.svg';
+
 import PopoverMenu from '../popover-menu';
 
 const DropdownContainer = styled.div`
@@ -67,7 +70,16 @@ const InnerDropdownText = styled.span`
   white-space: nowrap;
 `;
 
-const DropdownIcon = styled.span``;
+const DropdownIcon = styled.span`
+  display: flex;
+  align-items: center;
+  height: 100%;
+  & > svg {
+    color: ${({ theme }) => theme.colors.gray300};
+    width: 10px;
+    height: 5px;
+  }
+`;
 
 const Dropdown = ({
   ariaLabel,
@@ -124,7 +136,6 @@ const Dropdown = ({
     return value ? getCurrentLabel() : placeholder;
   }, [value, placeholder, items]);
 
-  // TODO Add Icon and remove || placeholder
   return (
     <DropdownContainer ref={dropdownRef} {...rest}>
       <Label aria-label={ariaLabel}>
@@ -134,7 +145,9 @@ const Dropdown = ({
           disabled={disabled}
         >
           <InnerDropdownText>{currentLabel}</InnerDropdownText>
-          <DropdownIcon>{'||'}</DropdownIcon>
+          <DropdownIcon>
+            {showMenu ? <DropUpArrow /> : <DropDownArrow />}
+          </DropdownIcon>
         </InnerDropdown>
       </Label>
 

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { useEffect, useMemo, useRef, useState } from 'react';
+/**
+ * Internal dependencies
+ */
+import PopoverMenu from '../popover-menu';
+
+const DropdownContainer = styled.div`
+  position: relative;
+`;
+
+const Label = styled.label`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const InnerDropdown = styled.button`
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.gray25};
+  border-radius: 4px;
+  border: 1px solid transparent;
+  color: ${({ theme }) => theme.colors.gray600};
+  cursor: ${({ disabled }) => (disabled ? 'inherit' : 'pointer')};
+  display: flex;
+  font-family: ${({ theme }) => theme.fonts.dropdown.family};
+  font-size: ${({ theme }) => theme.fonts.dropdown.size};
+  font-weight: ${({ theme }) => theme.fonts.dropdown.weight};
+  height: 40px;
+  justify-content: space-between;
+  letter-spacing: ${({ theme }) => theme.fonts.dropdown.letterSpacing};
+  line-height: ${({ theme }) => theme.fonts.dropdown.lineHeight};
+  padding: 10px 16px;
+  width: 100%;
+
+  &:disabled {
+    color: ${({ theme }) => theme.colors.gray400};
+  }
+`;
+InnerDropdown.propTypes = {
+  disabled: PropTypes.bool,
+  isOpen: PropTypes.bool,
+};
+
+const InnerDropdownText = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const DropdownIcon = styled.span``;
+
+const Dropdown = ({
+  ariaLabel,
+  items,
+  disabled,
+  onChange,
+  value,
+  placeholder,
+  ...rest
+}) => {
+  const [showMenu, setShowMenu] = useState(false);
+  const dropdownRef = useRef();
+
+  const handleOutsideClick = (e) => {
+    if (
+      dropdownRef.current &&
+      !dropdownRef.current.contains(e.target) &&
+      showMenu === true
+    ) {
+      setShowMenu(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('click', handleOutsideClick);
+
+    return () => {
+      document.removeEventListener('click', handleOutsideClick);
+    };
+  });
+
+  const handleInnerDropdownClick = () => {
+    if (!disabled) {
+      setShowMenu(!showMenu);
+    }
+  };
+
+  const handleMenuItemSelect = (item) => {
+    if (!item.value) {
+      return;
+    }
+    if (onChange) {
+      onChange(item);
+    }
+    setShowMenu(false);
+  };
+
+  const currentLabel = useMemo(() => {
+    const getCurrentLabel = () => {
+      const grouping = [items.find((item) => item.value === value)];
+      return grouping[0].label;
+    };
+
+    return value ? getCurrentLabel() : placeholder;
+  }, [value, placeholder, items]);
+
+  // TODO Add Icon and remove || placeholder
+  return (
+    <DropdownContainer ref={dropdownRef} {...rest}>
+      <Label aria-label={ariaLabel}>
+        <InnerDropdown
+          onClick={handleInnerDropdownClick}
+          isOpen={showMenu}
+          disabled={disabled}
+        >
+          <InnerDropdownText>{currentLabel}</InnerDropdownText>
+          <DropdownIcon>{'||'}</DropdownIcon>
+        </InnerDropdown>
+      </Label>
+
+      <PopoverMenu
+        isOpen={showMenu}
+        items={items}
+        onSelect={handleMenuItemSelect}
+      />
+    </DropdownContainer>
+  );
+};
+
+Dropdown.propTypes = {
+  ariaLabel: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
+    })
+  ),
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func,
+  placeholder: PropTypes.string,
+};
+
+export default Dropdown;

--- a/assets/src/dashboard/components/dropdown/stories/index.js
+++ b/assets/src/dashboard/components/dropdown/stories/index.js
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import { boolean, text } from '@storybook/addon-knobs';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import Dropdown from '../';
+
+const demoItems = [
+  { value: '1', label: 'one' },
+  { value: 'foo', label: 'two' },
+  { value: 'bar', label: 'three' },
+];
+
+const DropdownWrapper = styled.div`
+  width: 400px;
+`;
+
+const FillerContainer = styled.div`
+  width: 800px;
+  height: 900px;
+  background-color: lightblue;
+  margin-top: 20px;
+`;
+
+export default {
+  title: 'Dashboard/Components/Dropdown',
+  component: Dropdown,
+};
+
+export const _default = () => {
+  const [value, setValue] = useState();
+
+  return (
+    <DropdownWrapper>
+      <Dropdown
+        ariaLabel={text('ariaLabel', 'my dropdown description')}
+        items={demoItems}
+        disabled={boolean('disabled')}
+        value={value}
+        placeholder={text('placeholder', 'Select Value')}
+        onChange={(item) => {
+          action(`clicked on dropdown item ${item.value}`)(item);
+          setValue(item.value);
+        }}
+      />
+      <FillerContainer />
+    </DropdownWrapper>
+  );
+};

--- a/assets/src/dashboard/components/dropdown/stories/index.js
+++ b/assets/src/dashboard/components/dropdown/stories/index.js
@@ -34,7 +34,7 @@ const demoItems = [
 ];
 
 const DropdownWrapper = styled.div`
-  width: 400px;
+  width: 200px;
 `;
 
 const FillerContainer = styled.div`

--- a/assets/src/dashboard/components/dropdown/stories/index.js
+++ b/assets/src/dashboard/components/dropdown/stories/index.js
@@ -64,6 +64,7 @@ export const _default = () => {
           action(`clicked on dropdown item ${item.value}`)(item);
           setValue(item.value);
         }}
+        transparent={boolean('transparent')}
       />
       <FillerContainer />
     </DropdownWrapper>

--- a/assets/src/dashboard/components/dropdown/test/dropdown.js
+++ b/assets/src/dashboard/components/dropdown/test/dropdown.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import theme from '../../../theme';
+
+import Dropdown from '../';
+
+const wrapper = (children) => {
+  return render(<ThemeProvider theme={theme}>{children}</ThemeProvider>);
+};
+
+describe('Dropdown', () => {
+  const demoItems = [
+    { value: '1', label: 'one' },
+    { value: 'foo', label: 'two' },
+    { value: false, label: 'invalid option' },
+    { value: 'bar', label: 'three' },
+  ];
+  const onClickMock = jest.fn();
+
+  it('should render a <Dropdown /> by default', () => {
+    const { getByRole } = wrapper(
+      <Dropdown
+        placeholder="placeholder text"
+        ariaLabel="my dropdown test"
+        value={false}
+        onChange={onClickMock}
+        items={demoItems}
+        isOpen={false}
+      />
+    );
+
+    const DropdownButton = getByRole('button');
+    const DropdownPopoverMenu = getByRole('list');
+
+    expect(DropdownButton).toBeDefined();
+
+    expect(DropdownPopoverMenu).toBeDefined();
+  });
+});

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -17,3 +17,5 @@
 export { default as NavigationBar } from './navigation-bar';
 export { default as Button } from './button';
 export { ViewHeader } from './typography';
+export { default as PopoverMenu } from './popover-menu';
+export { default as Dropdown } from './dropdown';

--- a/assets/src/dashboard/components/popover-menu/index.js
+++ b/assets/src/dashboard/components/popover-menu/index.js
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { useEffect, useState, useRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { KEYS } from '../../constants';
+
+export const DROPDOWN_MENU_DIRECTIONS = {
+  UP: 'up',
+  DOWN: 'down',
+  LEFT: 'left',
+  RIGHT: 'right',
+};
+
+export const Menu = styled.ul`
+  align-items: flex-start;
+  background-color: ${({ theme }) => theme.colors.white};
+  border-radius: 8px;
+  box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  margin: 20px 0;
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
+  transform: ${({ isOpen }) =>
+    isOpen ? 'translate3d(0, 0, 0)' : 'translate3d(0, -1rem, 0)'};
+  z-index: ${({ theme }) => theme.zIndex.popoverMenu};
+  width: 100%;
+`;
+Menu.propTypes = {
+  isOpen: PropTypes.bool,
+};
+
+export const MenuItem = styled.li`
+  padding: 14px 16px;
+  background: ${({ isHovering, theme }) =>
+    isHovering ? theme.colors.gray50 : 'none'};
+  color: ${({ theme }) => theme.colors.gray700};
+  cursor: ${({ isDisabled }) => (isDisabled ? 'default' : 'pointer')};
+  display: flex;
+  font-family: ${({ theme }) => theme.fonts.popoverMenu.family};
+  font-size: ${({ theme }) => theme.fonts.popoverMenu.size};
+  line-height: ${({ theme }) => theme.fonts.popoverMenu.lineHeight};
+  font-weight: ${({ theme }) => theme.fonts.popoverMenu.weight};
+  letter-spacing: ${({ theme }) => theme.fonts.popoverMenu.letterSpacing};
+  width: 100%;
+`;
+
+MenuItem.propTypes = {
+  isDisabled: PropTypes.bool,
+  isHovering: PropTypes.bool,
+};
+
+const MenuItemContent = styled.span`
+  align-self: flex-start;
+  height: 100%;
+  margin: auto 0;
+`;
+
+const PopoverMenu = ({ className, isOpen, items, onSelect }) => {
+  const [hoveredIndex, setHoveredIndex] = useState(0);
+  const listRef = useRef(null);
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (isOpen) {
+      const handleKeyDown = (event) => {
+        switch (event.key) {
+          case KEYS.UP:
+            event.preventDefault();
+            if (hoveredIndex > 0) {
+              setHoveredIndex(hoveredIndex - 1);
+              if (listRef.current) {
+                listRef.current.scrollToItem(hoveredIndex - 1);
+              }
+            }
+            break;
+
+          case KEYS.DOWN:
+            event.preventDefault();
+            if (hoveredIndex < items.length - 1) {
+              setHoveredIndex(hoveredIndex + 1);
+              if (listRef.current) {
+                listRef.current.scrollToItem(hoveredIndex + 1);
+              }
+            }
+            break;
+
+          case KEYS.ENTER:
+            event.preventDefault();
+            if (onSelect) {
+              onSelect(items[hoveredIndex]);
+            }
+            break;
+
+          default:
+            break;
+        }
+      };
+
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [hoveredIndex, items, onSelect, isOpen]);
+
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollToItem(0);
+    }
+    setHoveredIndex(0);
+  }, [items]);
+
+  const renderMenuItem = (item, index) => {
+    const itemIsDisabled = !item.value && item.value !== 0;
+    return (
+      <MenuItem
+        key={`${item.value}_${index}`}
+        isHovering={index === hoveredIndex}
+        onClick={() => !itemIsDisabled && onSelect && onSelect(item)}
+        onMouseEnter={() => setHoveredIndex(index)}
+        isDisabled={itemIsDisabled}
+      >
+        <MenuItemContent>{item.label}</MenuItemContent>
+      </MenuItem>
+    );
+  };
+
+  return (
+    <Menu className={className} isOpen={isOpen}>
+      {items.map((item, index) => {
+        return renderMenuItem(item, index);
+      })}
+    </Menu>
+  );
+};
+
+PopoverMenu.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
+      label: PropTypes.string,
+    })
+  ).isRequired,
+
+  className: PropTypes.string,
+  isOpen: PropTypes.bool,
+  onSelect: PropTypes.func,
+};
+
+export default PopoverMenu;

--- a/assets/src/dashboard/components/popover-menu/index.js
+++ b/assets/src/dashboard/components/popover-menu/index.js
@@ -24,7 +24,7 @@ import { useEffect, useState, useRef } from 'react';
 /**
  * Internal dependencies
  */
-import { KEYS } from '../../constants';
+import { KEYS, Z_INDEX } from '../../constants';
 
 export const DROPDOWN_MENU_DIRECTIONS = {
   UP: 'up',
@@ -48,7 +48,7 @@ export const Menu = styled.ul`
   pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
   transform: ${({ isOpen }) =>
     isOpen ? 'translate3d(0, 0, 0)' : 'translate3d(0, -1rem, 0)'};
-  z-index: ${({ theme }) => theme.zIndex.popoverMenu};
+  z-index: ${Z_INDEX.POPOVER_MENU};
   width: 100%;
 `;
 Menu.propTypes = {

--- a/assets/src/dashboard/components/popover-menu/stories/index.js
+++ b/assets/src/dashboard/components/popover-menu/stories/index.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import PopoverMenu from '../';
+
+const demoItems = [
+  { value: '1', label: 'one' },
+  { value: 'foo', label: 'two' },
+  { value: false, label: 'invalid option' },
+  { value: 'bar', label: 'three' },
+  {
+    value: 'edge_case',
+    label: 'i am a very very very very very very very long label',
+  },
+];
+
+export default {
+  title: 'Dashboard/Components/PopoverMenu',
+  component: PopoverMenu,
+};
+const PopoverWrapper = styled.div`
+  width: 200px;
+  position: relative;
+`;
+
+export const _default = () => (
+  <PopoverWrapper>
+    <PopoverMenu
+      items={demoItems}
+      dividers={boolean('dividers')}
+      isOpen={boolean('isOpen', true)}
+      onSelect={(item) => {
+        action(`clicked on dropdown item ${item.value}`)(item);
+      }}
+    />
+  </PopoverWrapper>
+);

--- a/assets/src/dashboard/components/popover-menu/test/popover-menu.js
+++ b/assets/src/dashboard/components/popover-menu/test/popover-menu.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import theme from '../../../theme';
+
+import PopoverMenu from '../';
+
+const wrapper = (children) => {
+  return render(<ThemeProvider theme={theme}>{children}</ThemeProvider>);
+};
+
+describe('PopoverMenu', () => {
+  const demoItems = [
+    { value: '1', label: 'one' },
+    { value: 'foo', label: 'two' },
+    { value: false, label: 'invalid option' },
+    { value: 'bar', label: 'three' },
+  ];
+  const onClickMock = jest.fn();
+
+  it('should render a <PopoverMenu />', () => {
+    const { getByText } = wrapper(
+      <PopoverMenu onSelect={onClickMock} items={demoItems} isOpen />
+    );
+
+    expect(getByText('one')).toBeDefined();
+  });
+
+  it('should simulate a click on one of the items', () => {
+    const { getByText } = wrapper(
+      <PopoverMenu onSelect={onClickMock} items={demoItems} isOpen />
+    );
+
+    const menuItem = getByText('two');
+
+    fireEvent.click(menuItem);
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not allow click on item that has false value', () => {
+    const { getByText } = wrapper(
+      <PopoverMenu onSelect={onClickMock} items={demoItems} isOpen />
+    );
+
+    const menuItem = getByText('invalid option');
+
+    fireEvent.click(menuItem);
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assets/src/dashboard/constants.js
+++ b/assets/src/dashboard/constants.js
@@ -20,5 +20,11 @@ export const BUTTON_TYPES = {
   SECONDARY: 'secondary',
 };
 
+export const KEYS = {
+  ENTER: 'Enter',
+  UP: 'ArrowUp',
+  DOWN: 'ArrowDown',
+};
+
 export const KEYBOARD_USER_CLASS = `useskeyboard`;
 export const KEYBOARD_USER_SELECTOR = `.${KEYBOARD_USER_CLASS}`;

--- a/assets/src/dashboard/constants.js
+++ b/assets/src/dashboard/constants.js
@@ -28,3 +28,7 @@ export const KEYS = {
 
 export const KEYBOARD_USER_CLASS = `useskeyboard`;
 export const KEYBOARD_USER_SELECTOR = `.${KEYBOARD_USER_CLASS}`;
+
+export const Z_INDEX = {
+  POPOVER_MENU: 10,
+};

--- a/assets/src/dashboard/icons/drop-down-arrow-blue.svg
+++ b/assets/src/dashboard/icons/drop-down-arrow-blue.svg
@@ -1,3 +1,0 @@
-<svg width="10" height="5" viewBox="0 0 10 5" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0 0L5 5L10 0H0Z" fill="#2979FF"/>
-</svg>

--- a/assets/src/dashboard/icons/drop-down-arrow.svg
+++ b/assets/src/dashboard/icons/drop-down-arrow.svg
@@ -1,3 +1,3 @@
 <svg width="10" height="5" viewBox="0 0 10 5" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0 0L5 5L10 0H0Z" fill="black"/>
+<path d="M0 0L5 5L10 0H0Z" fill="currentColor"/>
 </svg>

--- a/assets/src/dashboard/icons/drop-up-arrow.svg
+++ b/assets/src/dashboard/icons/drop-up-arrow.svg
@@ -1,3 +1,3 @@
 <svg width="10" height="5" viewBox="0 0 10 5" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0 5L5 0L10 5H0Z" fill="black"/>
+<path d="M0 5L5 0L10 5H0Z" fill="currentColor"/>
 </svg>

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -106,6 +106,23 @@ const theme = {
       lineHeight: '20px',
       letterSpacing: '0.01em',
     },
+    popoverMenu: {
+      family: "'Google Sans', Sans Serif",
+      size: '14px',
+      lineHeight: '20px',
+      weight: '400',
+      letterSpacing: '0.01em',
+    },
+    dropdown: {
+      family: "'Google Sans', Sans Serif",
+      size: '14px',
+      lineHeight: '20px',
+      weight: '500',
+      letterSpacing: '0.01em',
+    },
+  },
+  zIndex: {
+    popoverMenu: 10,
   },
 };
 

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -121,9 +121,6 @@ const theme = {
       letterSpacing: '0.01em',
     },
   },
-  zIndex: {
-    popoverMenu: 10,
-  },
 };
 
 export default theme;

--- a/assets/src/dashboard/utils/useFocusOut.js
+++ b/assets/src/dashboard/utils/useFocusOut.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useLayoutEffect } from 'react';
+
+function useFocusOut(ref, callback, deps) {
+  useLayoutEffect(() => {
+    const node = ref.current;
+    if (!node) {
+      return undefined;
+    }
+
+    const onFocusOut = (evt) => {
+      // If focus moves somewhere outside the node, callback time!
+      if (evt.relatedTarget && !node.contains(evt.relatedTarget)) {
+        callback();
+      }
+    };
+
+    const onDocumentClick = (evt) => {
+      // If something outside the target node is clicked, callback time!
+      const isInDocument = node.ownerDocument.contains(evt.target);
+      const isInNode = node.contains(evt.target);
+      if (!isInNode && isInDocument) {
+        callback();
+      }
+    };
+
+    node.addEventListener('focusout', onFocusOut);
+    node.ownerDocument.addEventListener('click', onDocumentClick);
+
+    return () => {
+      node.removeEventListener('focusout', onFocusOut);
+      node.ownerDocument.removeEventListener('click', onDocumentClick);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps || []);
+}
+
+export default useFocusOut;

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -136,7 +136,7 @@ class Dashboard {
 			$version
 		);
 
-		// Dequeue forms.css, see https://github.com/google/web-stories-wp/issues/349
+		// Dequeue forms.css, see https://github.com/google/web-stories-wp/issues/349 .
 		wp_styles()->registered['wp-admin']->deps = array_diff(
 			wp_styles()->registered['wp-admin']->deps,
 			[ 'forms' ]

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -339,7 +339,7 @@ class Story_Post_Type {
 			$version
 		);
 
-		// Dequeue forms.css, see https://github.com/google/web-stories-wp/issues/349
+		// Dequeue forms.css, see https://github.com/google/web-stories-wp/issues/349 .
 		wp_styles()->registered['wp-admin']->deps = array_diff(
 			wp_styles()->registered['wp-admin']->deps,
 			[ 'forms' ]


### PR DESCRIPTION
# Overview
Dashboard dropdown (and popover menu!) ui components 

## Summary 
- Two components are needed to make the custom dropdown a reality: the replacement select menu (a button) and the popover menu (list) 
- separating these two so that the popover can potentially be used outside of the dropdown specific use case. 

## Testing
- run storybook and see Dashboard/Components/Dropdown and Dashboard/Components/PopoverMenu. 
- Play with the knobs to see different states. 
- Run through with your keyboard and see that you don't get trapped and that it works as expected. 

![dropdowndemo](https://user-images.githubusercontent.com/10720454/77017575-146d1680-6938-11ea-9929-8462d1d9b48a.gif)

## To do later 
- set selected item(s) display on popover 
- screen reader a11y

See #547.