### PR TITLE
Dequeue forms.css for editor and dashboard

### DIFF
--- a/assets/src/dashboard/style.css
+++ b/assets/src/dashboard/style.css
@@ -48,3 +48,9 @@ body.web-story_page_dashboard #web-stories-dashboard .loading-message {
 body.web-story_page_dashboard #wpfooter {
   display: none;
 }
+
+/* Copied from forms.css in WordPress, avoids issues with "Collapse menu" button */
+
+button {
+  font-size: inherit;
+}

--- a/assets/src/edit-story/style.css
+++ b/assets/src/edit-story/style.css
@@ -49,3 +49,9 @@ body.edit-story #edit-story .components-spinner {
   float: none;
   margin: 0 11px;
 }
+
+/* Copied from forms.css in WordPress, avoids issues with "Collapse menu" button */
+
+button {
+  font-size: inherit;
+}

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -128,5 +128,11 @@ class Dashboard {
 			[],
 			$version
 		);
+
+		// Dequeue forms.css, see https://github.com/google/web-stories-wp/issues/349
+		wp_styles()->registered['wp-admin']->deps = array_diff(
+			wp_styles()->registered['wp-admin']->deps,
+			[ 'forms' ]
+		);
 	}
 }

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -338,6 +338,12 @@ class Story_Post_Type {
 			[],
 			$version
 		);
+
+		// Dequeue forms.css, see https://github.com/google/web-stories-wp/issues/349
+		wp_styles()->registered['wp-admin']->deps = array_diff(
+			wp_styles()->registered['wp-admin']->deps,
+			[ 'forms' ]
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #349.

Next step would be to get rid of some high-specificity rules in our CSS that we added because of this.