### PR TITLE
Fix AMP validation errors for elements without masks

### DIFF
--- a/assets/src/edit-story/masks/output.js
+++ b/assets/src/edit-story/masks/output.js
@@ -63,7 +63,6 @@ export default function WithMask({
         style={{
           ...(fill ? FILL_STYLE : {}),
           ...style,
-          clipPath: `url(#${maskId})`,
         }}
         {...rest}
       >

--- a/assets/src/edit-story/masks/test/output.js
+++ b/assets/src/edit-story/masks/test/output.js
@@ -20,6 +20,27 @@
 import WithMask from '../output';
 
 describe('WithMask', () => {
+  it('should produce valid AMP output when no mask is set', async () => {
+    const props = {
+      element: {
+        id: '123',
+        type: 'text',
+        x: 50,
+        y: 100,
+        height: 1920,
+        width: 1080,
+        rotationAngle: 0,
+      },
+      box: { width: 1080, height: 1920, x: 50, y: 100, rotationAngle: 0 },
+    };
+
+    await expect(
+      <WithMask {...props}>
+        <p>{'Hello World'}</p>
+      </WithMask>
+    ).toBeValidAMPStoryElement();
+  });
+
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should produce valid AMP output', async () => {
     const props = {
@@ -47,6 +68,7 @@ describe('WithMask', () => {
         fill: { type: 'solid', color: { r: 255, g: 255, b: 255 } },
         style: {},
       },
+      box: { width: 1080, height: 1920, x: 50, y: 100, rotationAngle: 0 },
     };
 
     await expect(


### PR DESCRIPTION
As previously reported at https://xwp.slack.com/archives/CCCAUAH6F/p1583955941035200

Prevents an error where `clip-path: url(#undefined)` was being output because `maskId` doesn't exist for non-masked elements.

To verify:

1. Create new story with text element
1. Publish & preview story
1. Story should be valid AMP