### PR TITLE
Dashboard: root font-size converted to use rems

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -31,10 +31,9 @@ import theme, { GlobalStyle } from '../assets/src/edit-story/theme';
 import { GlobalStyle as CropMoveableGlobalStyle } from '../assets/src/edit-story/components/movable/cropStyle';
 import { GlobalStyle as ModalGlobalStyle } from '../assets/src/edit-story/components/modal';
 
-import dashboardTheme, {
-  GlobalStyle as DashboardGlobalStyle,
-} from '../assets/src/dashboard/theme';
+import dashboardTheme from '../assets/src/dashboard/theme';
 import DashboardKeyboardOnlyOutline from '../assets/src/dashboard/utils/keyboardOnlyOutline';
+import DashboardStyleSheet from '../assets/src/dashboard/style.css';
 
 // @todo: Find better way to mock these.
 const wp = {};
@@ -69,11 +68,13 @@ addDecorator((story, { id }) => {
 
   if (useDashboardTheme) {
     return (
-      <ThemeProvider theme={dashboardTheme}>
-        <DashboardGlobalStyle />
-        <DashboardKeyboardOnlyOutline />
-        {story()}
-      </ThemeProvider>
+      <>
+        <link rel="stylesheet" href={DashboardStyleSheet} />
+        <ThemeProvider theme={dashboardTheme}>
+          <DashboardKeyboardOnlyOutline />
+          {story()}
+        </ThemeProvider>
+      </>
     );
   }
 

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -22,7 +22,7 @@ import { ThemeProvider } from 'styled-components';
 /**
  * Internal dependencies
  */
-import theme, { GlobalStyle } from '../theme';
+import theme from '../theme';
 import KeyboardOnlyOutline from '../utils/keyboardOnlyOutline';
 import { NavigationBar } from '../components';
 import { Route, RouterProvider } from './router';
@@ -32,7 +32,6 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <RouterProvider>
-        <GlobalStyle />
         <KeyboardOnlyOutline />
         <NavigationBar />
         <Route exact path="/" component={<MyStoriesView />} />

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -29,11 +29,11 @@ const StyledButton = styled.button`
   align-items: center;
   color: ${({ theme }) => theme.colors.white};
   cursor: pointer;
-  border: 1px solid transparent;
+  border: 0.1rem solid transparent;
   border-radius: ${({ theme }) => theme.border.buttonRadius};
   display: flex;
-  height: 40px;
-  min-width: 132px;
+  height: 4rem;
+  min-width: 1.32rem;
   opacity: 0.75;
   padding: 0;
 
@@ -80,7 +80,7 @@ const StyledChildren = styled.span`
   font-weight: ${({ theme }) => theme.fonts.button.weight};
   line-height: ${({ theme }) => theme.fonts.button.lineHeight};
   margin: auto;
-  padding: 10px 24px;
+  padding: 1rem 2.4rem;
 `;
 
 const Button = ({

--- a/assets/src/dashboard/components/button/stories/index.js
+++ b/assets/src/dashboard/components/button/stories/index.js
@@ -53,7 +53,7 @@ export const _default = () => {
 };
 
 const LongContainer = styled.div`
-  width: 300px;
+  width: 30rem;
 `;
 const LongButton = styled(Button)`
   width: 90%;
@@ -81,8 +81,8 @@ export const _LongButton = () => {
 };
 
 const SecondaryButtonContainer = styled.div`
-  width: 400px;
-  height: 200px;
+  width: 40rem;
+  height: 20rem;
   display: flex;
   align-items: center;
   justify-content: space-around;
@@ -90,7 +90,7 @@ const SecondaryButtonContainer = styled.div`
 `;
 
 const LargerFontChild = styled.span`
-  font-size: 22px;
+  font-size: 2.2rem;
 `;
 
 export const SecondaryButton = () => {

--- a/assets/src/dashboard/components/navigation-bar.js
+++ b/assets/src/dashboard/components/navigation-bar.js
@@ -35,15 +35,15 @@ import Button from './button';
 const Nav = styled.nav`
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid #eee;
+  border-bottom: ${({ theme }) => `0.1rem solid ${theme.colors.gray50}`};
   display: flex;
   flex-direction: row;
-  padding: 20px;
+  padding: 2rem;
 `;
 
 const WebStoriesLogo = styled(WebStoriesLogoSVG)`
-  width: 37px;
-  height: 28px;
+  width: 3.7rem;
+  height: 2.8rem;
 `;
 
 const LinksContainer = styled.div`
@@ -52,7 +52,7 @@ const LinksContainer = styled.div`
   justify-content: space-between;
 
   button {
-    margin-left: 40px;
+    margin-left: 4rem;
   }
 `;
 
@@ -62,7 +62,7 @@ const Link = styled.a`
   line-height: ${({ theme }) => theme.fonts.tab.lineHeight};
   letter-spacing: ${({ theme }) => theme.fonts.tab.letterSpacing};
   text-decoration: none;
-  margin-left: 40px;
+  margin-left: 4rem;
   color: ${({ theme, active }) =>
     active ? theme.colors.gray900 : theme.colors.gray500};
 `;

--- a/assets/src/dashboard/components/pill/index.js
+++ b/assets/src/dashboard/components/pill/index.js
@@ -31,13 +31,15 @@ const PillLabel = styled.label`
   display: inline-flex;
   justify-content: center;
   margin: auto;
-  padding: 6px 16px;
+  padding: 0.6rem 1.6rem;
   background-color: ${({ theme, isSelected }) =>
     isSelected ? theme.colors.blueLight : theme.colors.white};
   color: ${({ theme, isSelected }) =>
     isSelected ? theme.colors.bluePrimary : theme.colors.gray600};
   border: ${({ theme, isSelected }) =>
-    isSelected ? '1px solid transparent' : `1px solid ${theme.colors.gray50}`};
+    isSelected
+      ? '0.1rem solid transparent'
+      : `0.1rem solid ${theme.colors.gray50}`};
   border-radius: ${({ theme }) => theme.border.buttonRadius};
   font-family: ${({ theme }) => theme.fonts.pill.family};
   font-weight: ${({ theme }) => theme.fonts.pill.weight};

--- a/assets/src/dashboard/components/pill/stories/index.js
+++ b/assets/src/dashboard/components/pill/stories/index.js
@@ -63,17 +63,17 @@ const categoryDemoData = [
 ];
 
 const DemoFieldSet = styled.fieldset`
-  width: 550px;
+  width: 55rem;
   margin: 0;
   border: none;
   > label {
-    margin: 0 16px 0 0;
+    margin: 0 1.6rem 0 0;
   }
 `;
 
 const IconSpan = styled.span`
   color: purple;
-  margin-right: 5px;
+  margin-right: 0.5rem;
 `;
 
 export const _default = () => {

--- a/assets/src/dashboard/components/typography.js
+++ b/assets/src/dashboard/components/typography.js
@@ -25,5 +25,5 @@ export const ViewHeader = styled.h1`
   line-height: ${({ theme }) => theme.fonts.heading1.lineHeight};
   letter-spacing: ${({ theme }) => theme.fonts.heading1.letterSpacing};
   font-weight: bold;
-  margin: 40px 20px;
+  margin: 4rem 2rem;
 `;

--- a/assets/src/dashboard/style.css
+++ b/assets/src/dashboard/style.css
@@ -20,9 +20,22 @@
  * Hides all controls that interfere with the dashboard UI.
  */
 
+*,
+*::after,
+*::before {
+  box-sizing: border-box;
+}
+
+html {
+  box-sizing: border-box;
+  font-size: 62.5%; /* root font size is 10px */
+}
+
 body {
   background: #fff;
-  color: #1a1d1f;
+  color: #1a1d1f; /* theme.colors.gray900 */
+  font-family: 'Google Sans', Sans Serif;
+  font-size: 1.4rem;
 }
 
 #screen-meta,

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -17,16 +17,8 @@
 /**
  * External dependencies
  */
-import { createGlobalStyle, ThemeContext } from 'styled-components';
+import { ThemeContext } from 'styled-components';
 import { useContext } from 'react';
-
-export const GlobalStyle = createGlobalStyle`
-	*,
-	*::after,
-	*::before {
-		box-sizing: border-box;
-    }
-`;
 
 export function useTheme() {
   return useContext(ThemeContext);
@@ -56,54 +48,54 @@ const theme = {
     selection: '#44aaff',
   },
   border: {
-    buttonRadius: '100px',
+    buttonRadius: '10rem',
   },
   text: {
-    shadow: '0px 1px 1px rgba(0, 0, 0, 1)',
+    shadow: '0 0.1rem 0.1rem rgba(0, 0, 0, 1)',
   },
   fonts: {
     heading1: {
       family: 'Google Sans',
-      size: '38px',
-      lineHeight: '53px',
+      size: '3.8rem',
+      lineHeight: '5.3rem',
       letterSpacing: '-0.005em',
     },
     body1: {
       family: 'Roboto',
-      size: '16px',
-      lineHeight: '24px',
+      size: '1.6rem',
+      lineHeight: '2.4rem',
       letterSpacing: '0.00625em',
     },
     body2: {
       family: 'Roboto',
-      size: '14px',
-      lineHeight: '16px',
+      size: '1.4rem',
+      lineHeight: '1.6rem',
       letterSpacing: '0.0142em',
     },
     tab: {
       family: 'Google Sans',
-      size: '14px',
-      lineHeight: '20px',
+      size: '1.4rem',
+      lineHeight: '2rem',
       letterSpacing: '0.01em',
       weight: '500',
     },
     label: {
       family: 'Roboto',
-      size: '15px',
-      lineHeight: '18px',
+      size: '1.5rem',
+      lineHeight: '1.8rem',
       weight: '400',
     },
     button: {
       family: "'Google Sans', Sans Serif",
-      size: '14px',
-      lineHeight: '20px',
+      size: '1.4rem',
+      lineHeight: '2rem',
       weight: '500',
     },
     pill: {
       family: "'Google Sans', Sans Serif",
       weight: 500,
-      size: '14px',
-      lineHeight: '20px',
+      size: '1.4rem',
+      lineHeight: '2rem',
       letterSpacing: '0.01em',
     },
   },


### PR DESCRIPTION
# Overview 
After getting the lay of the app decided to do a little preemptive clean up so that we can use rems instead of pixels. This PR adds `font-size: 62.5%;` to the styles.css at the html level so that 1rem equals 10px, which will allow our styles to be responsive if the user has a custom default font size set. 

## Updates 
- Adding html font size of 62.5% so that we can use rem (1rem = 10px). 
- Converting px usage in dashboard to rem. 
- Moving globalStyles to stylesheet to remove need for both since they are both global ways of adding styling.
- Adding stylesheet to dashboard section of storybook

## Testing
- There should be no visible changes here, spin up localhost admin dashboard and storybook and see that components and content are all still displaying at their set sizes. 