### PR TITLE
Fix default text-align value for text elements

### DIFF
--- a/assets/src/edit-story/elements/text/index.js
+++ b/assets/src/edit-story/elements/text/index.js
@@ -39,7 +39,7 @@ export const defaultAttributes = {
   color: '#000000',
   letterSpacing: 0,
   lineHeight: 1.3,
-  textAlign: 'none',
+  textAlign: 'initial',
   textDecoration: 'none',
   padding: {
     vertical: 0,


### PR DESCRIPTION
`none` is not valid CSS. `initial` would be more appropriate.