### PR TITLE
Use createInterpolateElement to avoid string concatenation for localized strings

### DIFF
--- a/assets/src/edit-story/components/panels/link/infoDialog.js
+++ b/assets/src/edit-story/components/panels/link/infoDialog.js
@@ -23,6 +23,7 @@ import styled from 'styled-components';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { __experimentalCreateInterpolateElement as createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -64,13 +65,14 @@ function LinkInfoDialog() {
   return (
     <>
       <span>
-        {__('Select any element ', 'web-stories')}
-        <b>
-          {__('(excluding a background or fullbleed element)', 'web-stories')}
-        </b>
-        {__(
-          ' and enter a web address. Drag your element around to convert between a 2 tap and 1 tap link.',
-          'web-stories'
+        {createInterpolateElement(
+          __(
+            'Select any element <b>(excluding a background or fullbleed element)</b>  and enter a web address. Drag your element around to convert between a 2 tap and 1 tap link.',
+            'web-stories'
+          ),
+          {
+            b: <b />,
+          }
         )}
       </span>
       <InfoPaneContainer>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@wordpress/api-fetch": "^3.11.0",
     "@wordpress/components": "^9.2.3",
+    "@wordpress/element": "^2.11.0",
     "@wordpress/i18n": "^3.9.0",
     "colorthief": "^2.3.0",
     "draft-js": "^0.11.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,13 +31,19 @@ const defaultConfig = require('@wordpress/scripts/config/webpack.config');
 const DependencyExtractionWebpackPlugin = require('@wordpress/dependency-extraction-webpack-plugin');
 
 /**
- * Prevents externalizing React, ReactDOM, and ReactDOMServer.
+ * Prevents externalizing certain packages.
  *
  * @param {string} request Requested module
- * @return {(string|undefined)} Script global
+ * @return {(string|undefined|boolean)} Script global
  */
 function requestToExternal(request) {
-  if (['react', 'react-dom', 'react-dom/server'].includes(request)) {
+  const packages = [
+    'react',
+    'react-dom',
+    'react-dom/server',
+    '@wordpress/element',
+  ];
+  if (packages.includes(request)) {
     return false;
   }
 


### PR DESCRIPTION
`createInterpolateElement` is the only thing we really need from `@wordpress/element` nowadays.

See #706.