### PR TITLE
[ON HOLD] Template Animation: Added reveal animation.

### DIFF
--- a/assets/src/dashboard/animations/animator/output.js
+++ b/assets/src/dashboard/animations/animator/output.js
@@ -19,9 +19,26 @@
  */
 import PropTypes from 'prop-types';
 
-function WithAnimation({ id, style, children }) {
-  return (
-    <div id={id} style={style}>
+/**
+ * Internal dependencies
+ */
+import { ANIMATION_TYPE } from '../constants';
+
+function WithAnimation({
+  id,
+  animationType,
+  animationStyle,
+  containerStyle,
+  children,
+}) {
+  return animationType === ANIMATION_TYPE.REVEAL ? (
+    <div style={{ overflow: 'hidden', ...containerStyle }}>
+      <div id={id} style={{ width: '100%', height: '100%', ...animationStyle }}>
+        {children}
+      </div>
+    </div>
+  ) : (
+    <div id={id} style={{ ...containerStyle, ...animationStyle }}>
       {children}
     </div>
   );
@@ -29,11 +46,18 @@ function WithAnimation({ id, style, children }) {
 
 WithAnimation.propTypes = {
   id: PropTypes.string,
-  style: PropTypes.object,
+  animationType: PropTypes.string.isRequired,
+  animationStyle: PropTypes.object,
+  containerStyle: PropTypes.object,
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]).isRequired,
+};
+
+WithAnimation.defaultProps = {
+  animationStyle: {},
+  containerStyle: {},
 };
 
 export default WithAnimation;

--- a/assets/src/dashboard/animations/configs/index.js
+++ b/assets/src/dashboard/animations/configs/index.js
@@ -20,10 +20,12 @@
 import { ANIMATION_TYPE } from '../constants';
 import getBlinkOnConfig from './blinkOn';
 import getBounceConfig from './bounce';
+import getRevealConfig from './reveal';
 import getSpinConfig from './spin';
 
 export default {
   [ANIMATION_TYPE.BLINK_ON]: getBlinkOnConfig,
   [ANIMATION_TYPE.BOUNCE]: getBounceConfig,
+  [ANIMATION_TYPE.REVEAL]: getRevealConfig,
   [ANIMATION_TYPE.SPIN]: getSpinConfig,
 };

--- a/assets/src/dashboard/animations/configs/reveal.js
+++ b/assets/src/dashboard/animations/configs/reveal.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-export const ANIMATION_TYPE = {
-  BLINK_ON: 'blinkOn',
-  BOUNCE: 'bounce',
-  REVEAL: 'reveal',
-  SPIN: 'spin',
-};
-
-export const SPIN_TYPE = {
-  CLOCKWISE: 'clockwise',
-  COUNTER_CLOCKWISE: 'counterClockwise',
-  PING_PONG: 'pingPong',
-};
+export default function () {
+  return {
+    fill: 'forwards',
+    keyframes: {
+      transform: ['translateY(100%)', 'translateY(0%)'],
+    },
+  };
+}

--- a/assets/src/dashboard/animations/stories/blinkOn.js
+++ b/assets/src/dashboard/animations/stories/blinkOn.js
@@ -76,9 +76,11 @@ export const _default = () => {
           <WithAnimation
             key={id}
             id={`anim-${id}`}
-            style={{
+            containerStyle={{
               width: '50px',
               height: '50px',
+            }}
+            animationStyle={{
               ...getInitialStyleFromKeyframes(keyframes),
             }}
           >

--- a/assets/src/dashboard/animations/stories/bounce.js
+++ b/assets/src/dashboard/animations/stories/bounce.js
@@ -45,10 +45,13 @@ export const _default = () => {
         {label}
       </button>
       <WithAnimation
-        id={`anim-solo`}
-        style={{
+        id="anim-solo"
+        animationType={name}
+        containerStyle={{
           width: '50px',
           height: '50px',
+        }}
+        animationStyle={{
           ...getInitialStyleFromKeyframes(keyframes),
         }}
       >
@@ -98,10 +101,13 @@ export const Cascading = () => {
           <WithAnimation
             id={`anim-${id}`}
             key={index}
-            style={{
+            animationType={name}
+            containerStyle={{
               width,
               height: '50px',
               marginBottom: '10px',
+            }}
+            animationStyle={{
               ...getInitialStyleFromKeyframes(keyframes),
             }}
           >

--- a/assets/src/dashboard/animations/stories/reveal.js
+++ b/assets/src/dashboard/animations/stories/reveal.js
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { AnimatorOutput, AnimationOutput, WithAnimation } from '../animator';
+import { ANIMATION_TYPE } from '../constants';
+import getAnimationConfigs from '../configs';
+import getInitialStyleFromKeyframes from '../utils/getInitialStyleFromKeyframes';
+
+export default {
+  title: 'Dashboard/Animations/Reveal',
+};
+
+export const _default = () => {
+  const name = ANIMATION_TYPE.REVEAL;
+  const label = 'Animate';
+
+  const { keyframes, ...config } = getAnimationConfigs[name]();
+
+  const words = ['More', 'Stories'];
+
+  return (
+    <>
+      <button
+        style={{ marginBottom: '10px' }}
+        on={`tap:${name}-reveal.restart`}
+      >
+        {label}
+      </button>
+      <div style={{ padding: '20px', position: 'relative' }}>
+        <AnimationOutput id={name} keyframes={keyframes} {...config} />
+        <AnimatorOutput
+          id={`${name}-reveal`}
+          animation={name}
+          config={words.map((word, index) => ({
+            selector: `#anim-${word}`,
+            easing: 'ease-in-out',
+            duration: 600,
+            delay: index * 50,
+          }))}
+        />
+        {words.map((word, index) => (
+          <WithAnimation
+            key={index}
+            id={`anim-${word}`}
+            animationType={name}
+            containerStyle={{
+              width: '200px',
+              height: '100px',
+              fontSize: '48px',
+              textTransform: 'uppercase',
+              position: 'absolute',
+              top: `${50 * index}px`,
+              zIndex: index,
+            }}
+            animationStyle={{
+              width: '100%',
+              height: '100%',
+              ...getInitialStyleFromKeyframes(keyframes),
+            }}
+          >
+            {word}
+          </WithAnimation>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export const Vertical = () => {
+  const name = ANIMATION_TYPE.REVEAL;
+  const label = 'Animate';
+
+  const { keyframes, ...config } = getAnimationConfigs[name]();
+
+  const words = ['Fashion', 'On the Go'];
+
+  return (
+    <>
+      <button
+        style={{ marginBottom: '10px' }}
+        on={`tap:${name}-reveal.restart`}
+      >
+        {label}
+      </button>
+      <div style={{ padding: '20px', position: 'relative' }}>
+        <AnimationOutput id={name} keyframes={keyframes} {...config} />
+        <AnimatorOutput
+          id={`${name}-reveal`}
+          animation={name}
+          config={words.map((__, index) => ({
+            selector: `#anim-el${index}`,
+            easing: 'ease-in-out',
+            duration: 800,
+            delay: index * 100,
+          }))}
+        />
+        {words.map((word, index) => (
+          <WithAnimation
+            key={index}
+            id={`anim-el${index}`}
+            animationType={name}
+            containerStyle={{
+              width: '300px',
+              height: '100px',
+              fontSize: '48px',
+              textTransform: 'uppercase',
+              position: 'absolute',
+              top: '100px',
+              left: `${-100 + 50 * index}px`,
+              zIndex: index,
+              transform: 'rotate(-90deg)',
+            }}
+            animationStyle={{
+              width: '100%',
+              height: '100%',
+              ...getInitialStyleFromKeyframes(keyframes),
+            }}
+          >
+            {word}
+          </WithAnimation>
+        ))}
+      </div>
+    </>
+  );
+};

--- a/assets/src/dashboard/animations/stories/spin.js
+++ b/assets/src/dashboard/animations/stories/spin.js
@@ -90,9 +90,12 @@ const Spin = ({ name, color, keyframes, animationConfig, animatorConfig }) => {
         </h1>
         <WithAnimation
           id="anim-spin"
-          style={{
+          animationType={name}
+          containerStyle={{
             width: '50px',
             height: '50px',
+          }}
+          animationStyle={{
             ...getInitialStyleFromKeyframes(keyframes),
           }}
         >


### PR DESCRIPTION
This PR adds the `reveal` animation and refactors `WithAnimation` a little bit to accommodate for `reveal`.

---
Normal:
![reveal-normal](https://user-images.githubusercontent.com/40646372/77486903-26463200-6dee-11ea-8739-3b778a79427c.gif)

To the left:
![reveal-vertical](https://user-images.githubusercontent.com/40646372/77486905-28a88c00-6dee-11ea-803c-956e938c30d3.gif)
