### PR TITLE
Use correct vendor prefix for clip-path property

### DIFF
--- a/assets/src/edit-story/masks/output.js
+++ b/assets/src/edit-story/masks/output.js
@@ -83,7 +83,7 @@ export default function WithMask({
         ...style,
         clipPath: `url(#${maskId})`,
         // stylelint-disable-next-line property-no-vendor-prefix
-        webkitClipPath: `url(#${maskId})`,
+        WebkitClipPath: `url(#${maskId})`,
       }}
       {...rest}
     >


### PR DESCRIPTION
This is a bit of an exception in how React expects the naming.

Prevents warning in dev tools.

Follow-up to #689 / #727.