### PR TITLE
Switch tab to design when selection is changing

### DIFF
--- a/assets/src/edit-story/components/inspector/inspectorProvider.js
+++ b/assets/src/edit-story/components/inspector/inspectorProvider.js
@@ -18,13 +18,14 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useCallback, useState, useRef } from 'react';
+import { useCallback, useState, useRef, useEffect } from 'react';
 
 /**
  * Internal dependencies
  */
 import { useAPI } from '../../app/api';
 import useResizeEffect from '../../utils/useResizeEffect';
+import { useStory } from '../../app/story';
 import Context from './context';
 
 const DESIGN = 'design';
@@ -35,6 +36,10 @@ function InspectorProvider({ children }) {
   const {
     actions: { getAllStatuses, getAllUsers },
   } = useAPI();
+  const {
+    state: { selectedElementIds, currentPage },
+  } = useStory();
+
   const [tab, setTab] = useState(DESIGN);
   const [users, setUsers] = useState([]);
   const [statuses, setStatuses] = useState([]);
@@ -51,6 +56,20 @@ function InspectorProvider({ children }) {
   useResizeEffect(inspectorContentRef, ({ height }) =>
     setInspectorContentHeight(height)
   );
+
+  useEffect(() => {
+    if (selectedElementIds.length > 0 && tab === DOCUMENT) {
+      setTab(DESIGN);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedElementIds]);
+
+  useEffect(() => {
+    if (tab === DOCUMENT) {
+      setTab(DESIGN);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPage]);
 
   const loadStatuses = useCallback(() => {
     if (!isStatusesLoading && statuses.length === 0) {

--- a/assets/src/edit-story/components/inspector/inspectorProvider.js
+++ b/assets/src/edit-story/components/inspector/inspectorProvider.js
@@ -45,6 +45,7 @@ function InspectorProvider({ children }) {
   const [statuses, setStatuses] = useState([]);
   const [inspectorContentHeight, setInspectorContentHeight] = useState(null);
   const inspectorContentRef = useRef();
+  const tabRef = useRef(tab);
 
   const [isUsersLoading, setIsUsersLoading] = useState(false);
   const [isStatusesLoading, setIsStatusesLoading] = useState(false);
@@ -58,17 +59,19 @@ function InspectorProvider({ children }) {
   );
 
   useEffect(() => {
-    if (selectedElementIds.length > 0 && tab === DOCUMENT) {
+    tabRef.current = tab;
+  }, [tab]);
+
+  useEffect(() => {
+    if (selectedElementIds.length > 0 && tabRef.current === DOCUMENT) {
       setTab(DESIGN);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedElementIds]);
 
   useEffect(() => {
-    if (tab === DOCUMENT) {
+    if (tabRef.current === DOCUMENT) {
       setTab(DESIGN);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentPage]);
 
   const loadStatuses = useCallback(() => {


### PR DESCRIPTION
Fixes #716

Switches Document tab back to Design tab.

The original issue covers adding a new element only, however, when the editor is manipulating the elements, it's likely that the Design panel is more beneficial.