### PR TITLE
Auto-select entire input field on focus

### DIFF
--- a/assets/src/edit-story/components/form/color/opacityPreview.js
+++ b/assets/src/edit-story/components/form/color/opacityPreview.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
@@ -30,6 +30,7 @@ import { _x, __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { PatternPropType } from '../../../types';
+import useFocusAndSelect from '../../../utils/useFocusAndSelect';
 import getPreviewText from './getPreviewText';
 import getPreviewOpacity from './getPreviewOpacity';
 import ColorBox from './colorBox';
@@ -49,9 +50,9 @@ function OpacityPreview({ value, onChange }) {
   const hasPreviewText = Boolean(getPreviewText(value));
   const postfix = _x('%', 'Percentage', 'web-stories');
   const [inputValue, setInputValue] = useState('');
-  const [hasPostfix, setHasPostfix] = useState(true);
-  const enablePostfix = useCallback(() => setHasPostfix(true), []);
-  const disablePostfix = useCallback(() => setHasPostfix(false), []);
+  const ref = useRef();
+
+  const { isFocused, handleFocusOut, handleFocusIn } = useFocusAndSelect(ref);
 
   // Allow any input, but only persist non-NaN values up-chain
   const handleChange = useCallback(
@@ -72,21 +73,22 @@ function OpacityPreview({ value, onChange }) {
 
   // However on blur, restore to last persisted value
   const handleBlur = useCallback(() => {
-    enablePostfix();
+    handleFocusOut();
     updateFromValue();
-  }, [enablePostfix, updateFromValue]);
+  }, [handleFocusOut, updateFromValue]);
 
   useEffect(() => updateFromValue(), [updateFromValue, value]);
 
   return (
     <Input
+      ref={ref}
       type="text"
       aria-label={__('Opacity', 'web-stories')}
       isVisible={hasPreviewText}
       onBlur={handleBlur}
-      onFocus={disablePostfix}
+      onFocus={handleFocusIn}
       onChange={handleChange}
-      value={hasPostfix ? `${inputValue}${postfix}` : inputValue}
+      value={`${inputValue}${isFocused ? '' : postfix}`}
     />
   );
 }

--- a/assets/src/edit-story/components/form/color/opacityPreview.js
+++ b/assets/src/edit-story/components/form/color/opacityPreview.js
@@ -52,7 +52,7 @@ function OpacityPreview({ value, onChange }) {
   const [inputValue, setInputValue] = useState('');
   const ref = useRef();
 
-  const { isFocused, handleFocusOut, handleFocusIn } = useFocusAndSelect(ref);
+  const { focused, handleFocus, handleBlur } = useFocusAndSelect(ref);
 
   // Allow any input, but only persist non-NaN values up-chain
   const handleChange = useCallback(
@@ -71,12 +71,6 @@ function OpacityPreview({ value, onChange }) {
     [value]
   );
 
-  // However on blur, restore to last persisted value
-  const handleBlur = useCallback(() => {
-    handleFocusOut();
-    updateFromValue();
-  }, [handleFocusOut, updateFromValue]);
-
   useEffect(() => updateFromValue(), [updateFromValue, value]);
 
   return (
@@ -85,10 +79,13 @@ function OpacityPreview({ value, onChange }) {
       type="text"
       aria-label={__('Opacity', 'web-stories')}
       isVisible={hasPreviewText}
-      onBlur={handleBlur}
-      onFocus={handleFocusIn}
+      onBlur={() => {
+        handleBlur();
+        updateFromValue();
+      }}
+      onFocus={handleFocus}
       onChange={handleChange}
-      value={`${inputValue}${isFocused ? '' : postfix}`}
+      value={`${inputValue}${focused ? '' : postfix}`}
     />
   );
 }

--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -20,7 +20,7 @@
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { rgba } from 'polished';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef } from 'react';
 
 /**
  * WordPress dependencies
@@ -30,6 +30,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import useFocusAndSelect from '../../utils/useFocusAndSelect';
 import Input from './input';
 import MULTIPLE_VALUE from './multipleValue';
 
@@ -77,15 +78,10 @@ function Numeric({
 }) {
   const isMultiple = value === MULTIPLE_VALUE;
   const placeholder = isMultiple ? __('multiple', 'web-stories') : '';
-  const [focused, setFocus] = useState(false);
   const [dot, setDot] = useState(false);
   const ref = useRef();
 
-  useEffect(() => {
-    if (focused && ref.current) {
-      ref.current.select();
-    }
-  }, [focused]);
+  const { isFocused, handleFocusIn, handleFocusOut } = useFocusAndSelect(ref);
 
   return (
     <Container
@@ -104,7 +100,7 @@ function Numeric({
         value={
           isMultiple
             ? ''
-            : `${value}${dot ? DECIMAL_POINT : ''}${focused ? '' : symbol}`
+            : `${value}${dot ? DECIMAL_POINT : ''}${isFocused ? '' : symbol}`
         }
         aria-label={ariaLabel}
         disabled={disabled}
@@ -130,9 +126,9 @@ function Numeric({
           if (onBlur) {
             onBlur();
           }
-          setFocus(false);
+          handleFocusOut();
         }}
-        onFocus={() => setFocus(true)}
+        onFocus={handleFocusIn}
       />
       {suffix}
     </Container>

--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -81,7 +81,7 @@ function Numeric({
   const [dot, setDot] = useState(false);
   const ref = useRef();
 
-  const { isFocused, handleFocusIn, handleFocusOut } = useFocusAndSelect(ref);
+  const { focused, handleFocus, handleBlur } = useFocusAndSelect(ref);
 
   return (
     <Container
@@ -100,7 +100,7 @@ function Numeric({
         value={
           isMultiple
             ? ''
-            : `${value}${dot ? DECIMAL_POINT : ''}${isFocused ? '' : symbol}`
+            : `${value}${dot ? DECIMAL_POINT : ''}${focused ? '' : symbol}`
         }
         aria-label={ariaLabel}
         disabled={disabled}
@@ -126,9 +126,9 @@ function Numeric({
           if (onBlur) {
             onBlur();
           }
-          handleFocusOut();
+          handleBlur();
         }}
-        onFocus={handleFocusIn}
+        onFocus={handleFocus}
       />
       {suffix}
     </Container>

--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -20,7 +20,7 @@
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { rgba } from 'polished';
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 /**
  * WordPress dependencies
@@ -79,6 +79,13 @@ function Numeric({
   const placeholder = isMultiple ? __('multiple', 'web-stories') : '';
   const [focused, setFocus] = useState(false);
   const [dot, setDot] = useState(false);
+  const ref = useRef();
+
+  useEffect(() => {
+    if (focused && ref.current) {
+      ref.current.select();
+    }
+  }, [focused]);
 
   return (
     <Container
@@ -89,6 +96,7 @@ function Numeric({
       {label}
       {prefix}
       <StyledInput
+        ref={ref}
         placeholder={placeholder}
         prefix={prefix}
         suffix={suffix}

--- a/assets/src/edit-story/utils/useFocusAndSelect.js
+++ b/assets/src/edit-story/utils/useFocusAndSelect.js
@@ -20,21 +20,21 @@
 import { useEffect, useState, useCallback } from 'react';
 
 function useFocusAndSelect(ref) {
-  const [isFocused, setIsFocused] = useState(false);
+  const [focused, setFocused] = useState(false);
 
-  const handleFocusIn = useCallback(() => setIsFocused(true), []);
-  const handleFocusOut = useCallback(() => setIsFocused(false), []);
+  const handleFocus = useCallback(() => setFocused(true), []);
+  const handleBlur = useCallback(() => setFocused(false), []);
 
   useEffect(() => {
-    if (isFocused && ref.current) {
+    if (focused && ref.current) {
       ref.current.select();
     }
-  }, [isFocused, ref]);
+  }, [focused, ref]);
 
   return {
-    isFocused,
-    handleFocusIn,
-    handleFocusOut,
+    focused,
+    handleFocus,
+    handleBlur,
   };
 }
 

--- a/assets/src/edit-story/utils/useFocusAndSelect.js
+++ b/assets/src/edit-story/utils/useFocusAndSelect.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useEffect, useState, useCallback } from 'react';
+
+function useFocusAndSelect(ref) {
+  const [isFocused, setIsFocused] = useState(false);
+
+  const handleFocusIn = useCallback(() => setIsFocused(true), []);
+  const handleFocusOut = useCallback(() => setIsFocused(false), []);
+
+  useEffect(() => {
+    if (isFocused && ref.current) {
+      ref.current.select();
+    }
+  }, [isFocused, ref]);
+
+  return {
+    isFocused,
+    handleFocusIn,
+    handleFocusOut,
+  };
+}
+
+export default useFocusAndSelect;


### PR DESCRIPTION
Fixes #736.

This ensures selection of entire text field on focus. This makes it work for symbol-postfixed inputs when tabbing to them.

But more than that, it actually also selects the entire text field when mouse clicking into a text field. I think this is actually good behaviour.

If desired, we can loosen this effect to only occur on keyboard focus changes and not mouse focus changes.

**Demo** – first focusing by mouse, then by pressing (<kbd>shift</kbd> +) <kbd>tab</kbd>:
![focusselect](https://user-images.githubusercontent.com/637548/77671119-86a7b180-6f5d-11ea-9633-c284091aebcb.gif)
