### PR TITLE
Send fake event when adding new element to page

### DIFF
--- a/assets/src/edit-story/components/canvas/useFocusCanvas.js
+++ b/assets/src/edit-story/components/canvas/useFocusCanvas.js
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+
 function useFocusCanvas() {
-  const focusCanvas = () => {
+  const focusCanvas = useCallback(() => {
     setTimeout(() => {
       const evt = new window.FocusEvent('focusout');
       window.document.dispatchEvent(evt);
     });
-  };
+  }, []);
   return focusCanvas();
 }
 

--- a/assets/src/edit-story/components/canvas/useFocusCanvas.js
+++ b/assets/src/edit-story/components/canvas/useFocusCanvas.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function useFocusCanvas() {
+  const focusCanvas = () => {
+    setTimeout(() => {
+      const evt = new window.FocusEvent('focusout');
+      window.document.dispatchEvent(evt);
+    });
+  };
+  return focusCanvas();
+}
+
+export default useFocusCanvas;

--- a/assets/src/edit-story/components/canvas/useFocusCanvas.js
+++ b/assets/src/edit-story/components/canvas/useFocusCanvas.js
@@ -26,7 +26,7 @@ function useFocusCanvas() {
       window.document.dispatchEvent(evt);
     });
   }, []);
-  return focusCanvas();
+  return focusCanvas;
 }
 
 export default useFocusCanvas;

--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -83,6 +83,11 @@ function useInsertElement() {
           }
         }, 0);
       }
+      // When done, send fake focusout event to document to force focus to new element
+      setTimeout(() => {
+        const evt = new window.FocusEvent('focusout');
+        window.document.dispatchEvent(evt);
+      }, 1);
       return element;
     },
     [addElement, setBackgroundElement, currentPage, backfillResource]

--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -24,6 +24,7 @@ import { useCallback } from 'react';
  */
 import { DEFAULT_DPR, PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
 import { createNewElement, getDefinitionForType } from '../../elements';
+import useFocusCanvas from '../../components/canvas/useFocusCanvas';
 import { dataPixels } from '../../units';
 import { useMedia, useStory } from '../../app';
 import { DEFAULT_MASK } from '../../masks';
@@ -56,6 +57,8 @@ function useInsertElement() {
     [uploadVideoPoster]
   );
 
+  const focusCanvas = useFocusCanvas();
+
   /**
    * @param {string} type The element's type.
    * @param {Object} props The element's initial properties.
@@ -83,14 +86,16 @@ function useInsertElement() {
           }
         }, 0);
       }
-      // When done, send fake focusout event to document to force focus to new element
-      setTimeout(() => {
-        const evt = new window.FocusEvent('focusout');
-        window.document.dispatchEvent(evt);
-      }, 1);
+      focusCanvas();
       return element;
     },
-    [addElement, setBackgroundElement, currentPage, backfillResource]
+    [
+      addElement,
+      setBackgroundElement,
+      currentPage,
+      backfillResource,
+      focusCanvas,
+    ]
   );
 
   return insertElement;


### PR DESCRIPTION
This fixes one case of #738 (and fixes #511).

As the canvas already [has some logic in place to detect focus changes and restore focus to currently selected element](https://github.com/google/web-stories-wp/blob/master/assets/src/edit-story/components/canvas/useCanvasKeys.js#L44-L68), I wanted to reuse that logic when adding a new element.

So I simply send a fake `focusout` event whenever a new element is added - and it magically works! It's very hacky, but hey 🤷‍♂.

It works both for:

* clicking an element in the media library
* dragging an element from the media library
* dragging an element from the local computer to the editor directly on page