### PR TITLE
Ensure that all text components and measurer work use the same CSS/markup

### DIFF
--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -107,7 +107,7 @@ function DisplayElement({ element }) {
   });
 
   return (
-    <Wrapper ref={wrapperRef} {...box}>
+    <Wrapper ref={wrapperRef} data-element-id={id} {...box}>
       <WithMask
         element={element}
         fill={true}

--- a/assets/src/edit-story/components/panels/textStyle/textStyle.js
+++ b/assets/src/edit-story/components/panels/textStyle/textStyle.js
@@ -83,7 +83,11 @@ function StylePanel({ selectedElements, pushUpdate }) {
         <ExpandedNumeric
           data-testid="text.letterSpacing"
           ariaLabel={__('Letter-spacing', 'web-stories')}
-          value={letterSpacing ? Math.round(letterSpacing * 100) : 0}
+          value={
+            typeof letterSpacing === 'number'
+              ? Math.round(letterSpacing * 100)
+              : 0
+          }
           suffix={<HorizontalOffset />}
           symbol="%"
           onChange={(value) =>

--- a/assets/src/edit-story/elements/shared/index.js
+++ b/assets/src/edit-story/elements/shared/index.js
@@ -66,12 +66,12 @@ export const elementWithFont = css`
   font-weight: ${({ fontWeight }) => fontWeight};
 `;
 
-export const elementWithStyle = css`
+export const elementWithTextParagraphStyle = css`
+  margin: ${({ margin }) => margin || 0};
   padding: ${({ padding }) =>
     padding ? `${padding.vertical}px ${padding.horizontal}px` : '0'};
   line-height: ${({ lineHeight }) => lineHeight};
-  letter-spacing: ${({ letterSpacing }) =>
-    letterSpacing ? letterSpacing + 'em' : null};
+  letter-spacing: ${({ letterSpacing }) => letterSpacing};
   text-align: ${({ textAlign }) => textAlign};
   text-decoration: ${({ textDecoration }) => textDecoration};
 `;

--- a/assets/src/edit-story/elements/shared/index.js
+++ b/assets/src/edit-story/elements/shared/index.js
@@ -66,10 +66,12 @@ export const elementWithFont = css`
   font-weight: ${({ fontWeight }) => fontWeight};
 `;
 
+/**
+ * See generateParagraphTextStyle for the full set of properties.
+ */
 export const elementWithTextParagraphStyle = css`
   margin: ${({ margin }) => margin || 0};
-  padding: ${({ padding }) =>
-    padding ? `${padding.vertical}px ${padding.horizontal}px` : '0'};
+  padding: ${({ padding }) => padding || 0};
   line-height: ${({ lineHeight }) => lineHeight};
   letter-spacing: ${({ letterSpacing }) => letterSpacing};
   text-align: ${({ textAlign }) => textAlign};

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -30,39 +30,22 @@ import {
   elementWithFont,
   elementWithBackgroundColor,
   elementWithFontColor,
-  elementWithStyle,
+  elementWithTextParagraphStyle,
 } from '../shared';
 import StoryPropTypes from '../../types';
 import { useTransformHandler } from '../../components/transform';
-import { draftMarkupToContent, generateFontFamily } from './util';
+import { draftMarkupToContent, generateParagraphTextStyle } from './util';
 
 const Element = styled.p`
-	margin: 0;
 	${elementFillContent}
 	${elementWithFont}
 	${elementWithBackgroundColor}
 	${elementWithFontColor}
-	${elementWithStyle}
+	${elementWithTextParagraphStyle}
 `;
 
 function TextDisplay({
-  element: {
-    id,
-    bold,
-    content,
-    color,
-    backgroundColor,
-    fontFamily,
-    fontFallback,
-    fontSize,
-    fontWeight,
-    fontStyle,
-    letterSpacing,
-    lineHeight,
-    padding,
-    textAlign,
-    textDecoration,
-  },
+  element: { id, bold, content, color, backgroundColor, ...rest },
 }) {
   const ref = useRef(null);
 
@@ -73,24 +56,13 @@ function TextDisplay({
   const props = {
     color,
     backgroundColor,
-    fontFamily: generateFontFamily(fontFamily, fontFallback),
-    fontFallback,
-    fontStyle,
-    fontSize: dataToEditorY(fontSize),
-    fontWeight,
-    letterSpacing,
-    lineHeight,
-    padding: {
-      horizontal: dataToEditorX(padding.horizontal),
-      vertical: dataToEditorY(padding.vertical),
-    },
-    textAlign,
-    textDecoration,
+    ...generateParagraphTextStyle(rest, dataToEditorX, dataToEditorY),
   };
   const {
     actions: { maybeEnqueueFontStyle },
   } = useFont();
 
+  const { fontFamily } = rest;
   useEffect(() => {
     maybeEnqueueFontStyle(fontFamily);
   }, [fontFamily, maybeEnqueueFontStyle]);

--- a/assets/src/edit-story/elements/text/edit.js
+++ b/assets/src/edit-story/elements/text/edit.js
@@ -41,7 +41,7 @@ import {
   elementWithFont,
   elementWithBackgroundColor,
   elementWithFontColor,
-  elementWithStyle,
+  elementWithTextParagraphStyle,
 } from '../shared';
 import StoryPropTypes from '../../types';
 import calcRotatedResizeOffset from '../../utils/calcRotatedResizeOffset';
@@ -51,6 +51,7 @@ import {
   getHandleKeyCommand,
   getSelectionForAll,
   getSelectionForOffset,
+  generateParagraphTextStyle,
 } from './util';
 
 // Wrapper bounds the text editor within the element bounds. The resize
@@ -77,7 +78,7 @@ const Wrapper = styled.div`
 // it can be used for height measurement.
 const TextBox = styled.div`
 	${elementWithFont}
-	${elementWithStyle}
+	${elementWithTextParagraphStyle}
 	${elementWithBackgroundColor}
 	${elementWithFontColor}
 
@@ -89,46 +90,17 @@ const TextBox = styled.div`
 `;
 
 function TextEdit({
-  element: {
-    id,
-    bold,
-    content,
-    color,
-    backgroundColor,
-    fontFamily,
-    fontFallback,
-    fontSize,
-    fontWeight,
-    fontStyle,
-    letterSpacing,
-    lineHeight,
-    opacity,
-    padding,
-    textAlign,
-    textDecoration,
-  },
+  element: { id, bold, content, color, backgroundColor, opacity, ...rest },
   box: { x, y, height, rotationAngle },
 }) {
   const {
     actions: { dataToEditorX, dataToEditorY, editorToDataX, editorToDataY },
   } = useUnits();
   const textProps = {
+    ...generateParagraphTextStyle(rest, dataToEditorX, dataToEditorY),
     color,
     backgroundColor,
-    fontFamily,
-    fontFallback,
-    fontStyle,
-    fontSize: dataToEditorY(fontSize),
-    fontWeight,
-    textAlign,
-    letterSpacing,
-    lineHeight,
     opacity,
-    padding: {
-      horizontal: dataToEditorX(padding.horizontal),
-      vertical: dataToEditorY(padding.vertical),
-    },
-    textDecoration,
   };
   const wrapperRef = useRef(null);
   const textBoxRef = useRef(null);
@@ -249,6 +221,7 @@ function TextEdit({
     wrapper.style.height = `${editorHeightRef.current}px`;
   }, [editorState]);
 
+  const { fontFamily } = rest;
   useEffect(() => {
     maybeEnqueueFontStyle(fontFamily);
   }, [fontFamily, maybeEnqueueFontStyle]);

--- a/assets/src/edit-story/elements/text/frame.js
+++ b/assets/src/edit-story/elements/text/frame.js
@@ -28,41 +28,28 @@ import getCaretCharacterOffsetWithin from '../../utils/getCaretCharacterOffsetWi
 import { useStory } from '../../app';
 import { useCanvas } from '../../components/canvas';
 import { useUnits } from '../../units';
-import { elementFillContent, elementWithFont } from '../shared';
+import {
+  elementFillContent,
+  elementWithFont,
+  elementWithTextParagraphStyle,
+} from '../shared';
 import StoryPropTypes from '../../types';
-import { generateFontFamily } from './util';
+import { generateParagraphTextStyle } from './util';
 
 const Element = styled.p`
-  margin: 0;
   ${elementFillContent}
   ${elementWithFont}
+  ${elementWithTextParagraphStyle}
 
 	opacity: 0;
   user-select: none;
 `;
 
-function TextFrame({
-  element: {
-    id,
-    content,
-    fontFamily,
-    fontFallback,
-    fontSize,
-    fontWeight,
-    fontStyle,
-  },
-  wrapperRef,
-}) {
+function TextFrame({ element: { id, content, ...rest }, wrapperRef }) {
   const {
-    actions: { dataToEditorY },
+    actions: { dataToEditorX, dataToEditorY },
   } = useUnits();
-  const props = {
-    fontFamily: generateFontFamily(fontFamily, fontFallback),
-    fontFallback,
-    fontStyle,
-    fontSize: dataToEditorY(fontSize),
-    fontWeight,
-  };
+  const props = generateParagraphTextStyle(rest, dataToEditorX, dataToEditorY);
   const {
     state: { selectedElementIds },
   } = useStory();

--- a/assets/src/edit-story/elements/text/test/output.js
+++ b/assets/src/edit-story/elements/text/test/output.js
@@ -24,6 +24,15 @@ import { renderToStaticMarkup } from 'react-dom/server';
  */
 import TextOutput from '../output';
 
+function renderViaString(...args) {
+  // Render an element via string to test that Output templates do not use
+  // forbidden dependencies.
+  const html = renderToStaticMarkup(...args);
+  const div = document.createElement('div');
+  div.innerHTML = html;
+  return div.firstElementChild;
+}
+
 describe('TextOutput', () => {
   it('should return HTML Output based on the params', () => {
     const element = {
@@ -62,16 +71,26 @@ describe('TextOutput', () => {
       box: { width: 1080 },
     };
 
-    const output = renderToStaticMarkup(
+    const output = renderViaString(
       <TextOutput
         element={element}
         box={{ width: 1080, height: 1920, x: 50, y: 100, rotationAngle: 0 }}
       />
     );
-    expect(output).toStrictEqual(
-      '<p class="fill" style="font-size:0.83333%;letter-spacing:1.3em;padding:0% 0%;text-align:left;text-decoration:none;white-space:pre-wrap;background-color:rgba(255,0,0,0.3);color:rgba(255,255,255,0.5)">Content</p>'
-    );
+    expect(output.tagName).toBe('P');
+    expect(output.innerHTML).toBe('Content');
+    expect(output.className).toBe('fill');
+    expect(output.style.whiteSpace).toBe('pre-wrap');
+    expect(output.style.padding).toBe('0% 0%');
+    expect(output.style.margin).toBe('0px');
+    expect(output.style.color).toBe('rgba(255, 255, 255, 0.5)');
+    expect(output.style.backgroundColor).toBe('rgba(255, 0, 0, 0.3)');
+    expect(output.style.fontSize).toBe('0.83333%');
+    expect(output.style.letterSpacing).toBe('1.3em');
+    expect(output.style.textAlign).toBe('left');
+    expect(output.style.textDecoration).toBe('none');
   });
+
   it('should apply <strong> tags if bold', () => {
     const element = {
       id: '123',
@@ -109,16 +128,15 @@ describe('TextOutput', () => {
       bold: true,
     };
 
-    const output = renderToStaticMarkup(
+    const output = renderViaString(
       <TextOutput
         element={element}
         box={{ width: 1080, height: 1920, x: 50, y: 100, rotationAngle: 0 }}
       />
     );
-    expect(output).toStrictEqual(
-      '<p class="fill" style="font-size:0.83333%;letter-spacing:1.3em;padding:0% 0%;text-align:left;text-decoration:none;white-space:pre-wrap;background-color:rgba(255,0,0,0.3);color:rgba(255,255,255,0.5)"><strong>Content</strong></p>'
-    );
+    expect(output.innerHTML).toBe('<strong>Content</strong>');
   });
+
   it('should produce valid AMP output', async () => {
     const props = {
       element: {

--- a/assets/src/edit-story/elements/text/test/output.js
+++ b/assets/src/edit-story/elements/text/test/output.js
@@ -80,15 +80,17 @@ describe('TextOutput', () => {
     expect(output.tagName).toBe('P');
     expect(output.innerHTML).toBe('Content');
     expect(output.className).toBe('fill');
-    expect(output.style.whiteSpace).toBe('pre-wrap');
-    expect(output.style.padding).toBe('0% 0%');
-    expect(output.style.margin).toBe('0px');
-    expect(output.style.color).toBe('rgba(255, 255, 255, 0.5)');
-    expect(output.style.backgroundColor).toBe('rgba(255, 0, 0, 0.3)');
-    expect(output.style.fontSize).toBe('0.83333%');
-    expect(output.style.letterSpacing).toBe('1.3em');
-    expect(output.style.textAlign).toBe('left');
-    expect(output.style.textDecoration).toBe('none');
+    expect(output.style).toMatchObject({
+      whiteSpace: 'pre-wrap',
+      padding: '0% 0%',
+      margin: '0px',
+      color: 'rgba(255, 255, 255, 0.5)',
+      backgroundColor: 'rgba(255, 0, 0, 0.3)',
+      fontSize: '0.83333%',
+      letterSpacing: '1.3em',
+      textAlign: 'left',
+      textDecoration: 'none',
+    });
   });
 
   it('should apply <strong> tags if bold', () => {

--- a/assets/src/edit-story/elements/text/util.js
+++ b/assets/src/edit-story/elements/text/util.js
@@ -20,6 +20,48 @@
 import { RichUtils, SelectionState } from 'draft-js';
 import { filterEditorState } from 'draftjs-filters';
 
+/**
+ * @param {Object} element Text element properties.
+ * @param {function(number):any} dataToStyleX Converts a x-unit to CSS.
+ * @param {function(number):any} dataToStyleY Converts a y-unit to CSS.
+ * @return {Object} The map of text style properties and values.
+ */
+export function generateParagraphTextStyle(
+  element,
+  dataToStyleX,
+  dataToStyleY
+) {
+  const {
+    fontFamily,
+    fontFallback,
+    fontSize,
+    fontStyle,
+    fontWeight,
+    lineHeight,
+    letterSpacing,
+    padding,
+    textAlign,
+    textDecoration,
+  } = element;
+  return {
+    whiteSpace: 'pre-wrap',
+    margin: 0,
+    fontFamily: generateFontFamily(fontFamily, fontFallback),
+    fontFallback,
+    fontSize: dataToStyleY(fontSize),
+    fontStyle,
+    fontWeight,
+    lineHeight,
+    letterSpacing: `${typeof letterSpacing === 'number' ? letterSpacing : 0}em`,
+    textAlign,
+    textDecoration,
+    padding: {
+      horizontal: dataToStyleX(padding?.horizontal || 0),
+      vertical: dataToStyleY(padding?.vertical || 0),
+    },
+  };
+}
+
 export function getSelectionForAll(content) {
   const firstBlock = content.getFirstBlock();
   const lastBlock = content.getLastBlock();

--- a/assets/src/edit-story/elements/text/util.js
+++ b/assets/src/edit-story/elements/text/util.js
@@ -55,10 +55,9 @@ export function generateParagraphTextStyle(
     letterSpacing: `${typeof letterSpacing === 'number' ? letterSpacing : 0}em`,
     textAlign,
     textDecoration,
-    padding: {
-      horizontal: dataToStyleX(padding?.horizontal || 0),
-      vertical: dataToStyleY(padding?.vertical || 0),
-    },
+    padding: `${dataToStyleY(padding?.vertical || 0)}px ${dataToStyleX(
+      padding?.horizontal || 0
+    )}px`,
   };
 }
 

--- a/assets/src/edit-story/utils/textMeasurements.js
+++ b/assets/src/edit-story/utils/textMeasurements.js
@@ -113,14 +113,5 @@ function changed(node, element) {
   if (!node.firstElementChild || !lastElement) {
     return true;
   }
-  return !shallowEquals(lastElement, element);
-}
-
-function shallowEquals(o1, o2) {
-  const keys1 = Object.keys(o1);
-  const keys2 = Object.keys(o2);
-  if (keys1.length !== keys2.length) {
-    return false;
-  }
-  return keys1.every((k) => o1[k] === o2[k]);
+  return lastElement !== element;
 }


### PR DESCRIPTION
As much as possible text display, frame, editor, output and measurer should work with the same exact styling and markup.