### PR TITLE
Template Animations: Added float-on animation (#618)

### DIFF
--- a/assets/src/dashboard/animations/configs/floatOn.js
+++ b/assets/src/dashboard/animations/configs/floatOn.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { DIRECTION } from '../constants';
+
+export default function (direction) {
+  const translateFrames = {
+    [DIRECTION.TOP_TO_BOTTOM]: {
+      transform: ['translateY(-100%)', 'translateY(0%)'],
+    },
+    [DIRECTION.BOTTOM_TO_TOP]: {
+      transform: ['translateY(100%)', 'translateY(0%)'],
+    },
+    [DIRECTION.LEFT_TO_RIGHT]: {
+      transform: ['translateX(-100%)', 'translateX(0%)'],
+    },
+    [DIRECTION.RIGHT_TO_LEFT]: {
+      transform: ['translateX(100%)', 'translateX(0%)'],
+    },
+  };
+
+  const keyframes = {
+    ...(translateFrames[direction] || translateFrames[DIRECTION.BOTTOM_TO_TOP]),
+    opacity: [0, 1],
+  };
+
+  return {
+    fill: 'forwards',
+    keyframes,
+  };
+}

--- a/assets/src/dashboard/animations/configs/index.js
+++ b/assets/src/dashboard/animations/configs/index.js
@@ -20,10 +20,12 @@
 import { ANIMATION_TYPE } from '../constants';
 import getBlinkOnConfig from './blinkOn';
 import getBounceConfig from './bounce';
+import getFloatOnConfig from './floatOn';
 import getSpinConfig from './spin';
 
 export default {
   [ANIMATION_TYPE.BLINK_ON]: getBlinkOnConfig,
   [ANIMATION_TYPE.BOUNCE]: getBounceConfig,
+  [ANIMATION_TYPE.FLOAT_ON]: getFloatOnConfig,
   [ANIMATION_TYPE.SPIN]: getSpinConfig,
 };

--- a/assets/src/dashboard/animations/constants.js
+++ b/assets/src/dashboard/animations/constants.js
@@ -15,8 +15,9 @@
  */
 
 export const ANIMATION_TYPE = {
-  BLINK_ON: 'blink-on',
+  BLINK_ON: 'blinkOn',
   BOUNCE: 'bounce',
+  FLOAT_ON: 'floatOn',
   SPIN: 'spin',
 };
 
@@ -24,4 +25,11 @@ export const SPIN_TYPE = {
   CLOCKWISE: 'clockwise',
   COUNTER_CLOCKWISE: 'counterClockwise',
   PING_PONG: 'pingPong',
+};
+
+export const DIRECTION = {
+  TOP_TO_BOTTOM: 'topToBottom',
+  BOTTOM_TO_TOP: 'bottomToTop',
+  LEFT_TO_RIGHT: 'leftToRight',
+  RIGHT_TO_LEFT: 'rightToLeft',
 };

--- a/assets/src/dashboard/animations/stories/floatOn.js
+++ b/assets/src/dashboard/animations/stories/floatOn.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { AnimatorOutput, AnimationOutput, WithAnimation } from '../animator';
+import { ANIMATION_TYPE, DIRECTION } from '../constants';
+import getAnimationConfigs from '../configs';
+import getInitialStyleFromKeyframes from '../utils/getInitialStyleFromKeyframes';
+
+export default {
+  title: 'Dashboard/Animations/FloatOn',
+};
+
+const FloatOn = ({ direction }) => {
+  const name = ANIMATION_TYPE.FLOAT_ON;
+  const { keyframes, ...config } = getAnimationConfigs[name](direction);
+
+  const label = 'Animate';
+  const text =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam vel dui erat. Curabitur sit amet venenatis felis. In ac ornare lacus. Integer vitae lacus a lectus eleifend finibus.';
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <AnimationOutput id={name} keyframes={keyframes} {...config} />
+      <AnimatorOutput
+        id={`${name}-anim`}
+        animation={name}
+        config={{
+          selector: `#anim`,
+          duration: 650,
+          easing: 'ease-out',
+        }}
+      />
+      <button on={`tap:${name}-anim.restart`}>{label}</button>
+      <WithAnimation
+        id="anim"
+        style={{
+          position: 'absolute',
+          top: '50px',
+          left: '100px',
+          width: '200px',
+          ...getInitialStyleFromKeyframes(keyframes),
+        }}
+      >
+        <div>{text}</div>
+      </WithAnimation>
+    </div>
+  );
+};
+
+FloatOn.propTypes = {
+  direction: PropTypes.string,
+};
+
+export const _default = () => {
+  return <FloatOn />;
+};
+
+export const TopToBottom = () => {
+  return <FloatOn direction={DIRECTION.TOP_TO_BOTTOM} />;
+};
+
+export const LeftToRight = () => {
+  return <FloatOn direction={DIRECTION.LEFT_TO_RIGHT} />;
+};
+
+export const RightToLeft = () => {
+  return <FloatOn direction={DIRECTION.RIGHT_TO_LEFT} />;
+};


### PR DESCRIPTION
This PR adds a very simple `floatOn` animation to our library of template animations.

Bottom to top:
![float-on-default](https://user-images.githubusercontent.com/40646372/77693590-d4281c80-6f65-11ea-928e-0e8379091d5b.gif)

Top to bottom:
![float-on-top-to-bottom](https://user-images.githubusercontent.com/40646372/77693597-d5f1e000-6f65-11ea-9c69-2a91fc2a0bb6.gif)

Left to right:
![float-on-left-to-right](https://user-images.githubusercontent.com/40646372/77693606-d8ecd080-6f65-11ea-8231-519ed86f3290.gif)

Right to left:
![float-on-right-to-left](https://user-images.githubusercontent.com/40646372/77693611-db4f2a80-6f65-11ea-9a71-03eee25b2818.gif)
