### PR TITLE
Dashboard: Bookmark Chip UI Component 

### DIFF
--- a/assets/src/dashboard/components/bookmark-chip/index.js
+++ b/assets/src/dashboard/components/bookmark-chip/index.js
@@ -46,16 +46,16 @@ const chipSize = {
 };
 
 const ChipContainer = styled.button`
-  box-shadow: ${({ theme }) => theme.chip.shadow};
+  align-items: center;
   background-color: ${({ theme }) => theme.colors.white};
-  color: ${({ theme }) => theme.colors.gray500};
+  border: 1px solid none;
   border-radius: ${({ theme }) => theme.border.buttonRadius};
-  border: 1px solid transparent;
-  height: ${({ chipType }) => chipSize[chipType].container};
-  width: ${({ chipType }) => chipSize[chipType].container};
+  box-shadow: ${({ theme }) => theme.chip.shadow};
+  color: ${({ theme }) => theme.colors.gray500};
   cursor: pointer;
   display: flex;
-  align-items: center;
+  height: ${({ chipType }) => chipSize[chipType].container};
+  width: ${({ chipType }) => chipSize[chipType].container};
 
   &:focus,
   &:active,
@@ -68,20 +68,20 @@ const ChipContainer = styled.button`
   }
 
   &:disabled {
-    opacity: 0.5;
     color: ${({ theme }) => theme.colors.gray500};
+    opacity: 0.5;
     pointer-events: none;
   }
 
   & > svg {
     margin: auto;
-    width: ${({ chipType }) => chipSize[chipType].icon.width};
     height: ${({ chipType }) => chipSize[chipType].icon.height};
+    width: ${({ chipType }) => chipSize[chipType].icon.width};
   }
 `;
 
 ChipContainer.propTypes = {
-  isSmall: PropTypes.bool,
+  chipType: PropTypes.oneOf(Object.values(CHIP_TYPES)),
 };
 
 const BookmarkChip = ({

--- a/assets/src/dashboard/components/bookmark-chip/index.js
+++ b/assets/src/dashboard/components/bookmark-chip/index.js
@@ -91,7 +91,11 @@ const BookmarkChip = ({
 }) => {
   return (
     <ChipContainer isBookmarked={isBookmarked} chipType={chipType} {...rest}>
-      {isBookmarked ? <BookmarkFill /> : <BookmarkOutline />}
+      {isBookmarked ? (
+        <BookmarkFill data-testid={'is-bookmarked'} />
+      ) : (
+        <BookmarkOutline data-testid={'not-bookmarked'} />
+      )}
     </ChipContainer>
   );
 };

--- a/assets/src/dashboard/components/bookmark-chip/index.js
+++ b/assets/src/dashboard/components/bookmark-chip/index.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types'; // import styled from 'styled-components';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+
+import { KEYBOARD_USER_SELECTOR, CHIP_TYPES } from '../../constants';
+import { ReactComponent as BookmarkFill } from '../../icons/bookmark-fill.svg';
+import { ReactComponent as BookmarkOutline } from '../../icons/bookmark-outline.svg';
+
+const chipSize = {
+  [CHIP_TYPES.STANDARD]: {
+    container: '40px',
+    icon: {
+      height: '18px',
+      width: '14px',
+    },
+  },
+  [CHIP_TYPES.SMALL]: {
+    container: '32px',
+    icon: {
+      height: '14px',
+      width: '10px',
+    },
+  },
+};
+
+const ChipContainer = styled.button`
+  box-shadow: ${({ theme }) => theme.chip.shadow};
+  background-color: ${({ theme }) => theme.colors.white};
+  color: ${({ theme }) => theme.colors.gray500};
+  border-radius: ${({ theme }) => theme.border.buttonRadius};
+  border: 1px solid transparent;
+  height: ${({ chipType }) => chipSize[chipType].container};
+  width: ${({ chipType }) => chipSize[chipType].container};
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+
+  &:focus,
+  &:active,
+  &:hover {
+    color: ${({ theme }) => theme.colors.gray600};
+  }
+
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    border-color: ${({ theme }) => theme.colors.action};
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    color: ${({ theme }) => theme.colors.gray500};
+    pointer-events: none;
+  }
+
+  & > svg {
+    margin: auto;
+    width: ${({ chipType }) => chipSize[chipType].icon.width};
+    height: ${({ chipType }) => chipSize[chipType].icon.height};
+  }
+`;
+
+ChipContainer.propTypes = {
+  isSmall: PropTypes.bool,
+};
+
+const BookmarkChip = ({
+  isBookmarked,
+  chipType = CHIP_TYPES.STANDARD,
+  ...rest
+}) => {
+  return (
+    <ChipContainer isBookmarked={isBookmarked} chipType={chipType} {...rest}>
+      {isBookmarked ? <BookmarkFill /> : <BookmarkOutline />}
+    </ChipContainer>
+  );
+};
+
+BookmarkChip.propTypes = {
+  isBookmarked: PropTypes.bool,
+  chipType: PropTypes.oneOf(Object.values(CHIP_TYPES)),
+};
+
+export default BookmarkChip;

--- a/assets/src/dashboard/components/bookmark-chip/index.js
+++ b/assets/src/dashboard/components/bookmark-chip/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types'; // import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**

--- a/assets/src/dashboard/components/bookmark-chip/stories/index.js
+++ b/assets/src/dashboard/components/bookmark-chip/stories/index.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import { boolean, text, select } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import BookmarkChip from '../';
+import { CHIP_TYPES } from '../../../constants';
+
+export default {
+  title: 'Dashboard/Components/BookmarkChip',
+  component: BookmarkChip,
+};
+
+export const _default = () => {
+  return (
+    <BookmarkChip
+      isBookmarked={boolean('isBookmarked')}
+      aria-label={text(
+        'aria-label',
+        'the label of my bookmark chip i want used for aria'
+      )}
+      disabled={boolean('disabled')}
+      onClick={action('clicked')}
+      chipType={select(
+        'chipType',
+        {
+          small: CHIP_TYPES.SMALL,
+          standard: CHIP_TYPES.STANDARD,
+        },
+        'standard'
+      )}
+    />
+  );
+};

--- a/assets/src/dashboard/components/bookmark-chip/test/bookmark-chip.js
+++ b/assets/src/dashboard/components/bookmark-chip/test/bookmark-chip.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import theme from '../../../theme';
+
+import BookmarkChip from '../';
+
+const wrapper = (children) => {
+  return render(<ThemeProvider theme={theme}>{children}</ThemeProvider>);
+};
+
+describe('BookmarkChip', () => {
+  it('should render a bookmark chip', () => {
+    const { getByRole } = wrapper(<BookmarkChip />);
+
+    expect(getByRole('button')).toBeDefined();
+  });
+});

--- a/assets/src/dashboard/components/bookmark-chip/test/bookmark-chip.js
+++ b/assets/src/dashboard/components/bookmark-chip/test/bookmark-chip.js
@@ -32,9 +32,23 @@ const wrapper = (children) => {
 };
 
 describe('BookmarkChip', () => {
-  it('should render a bookmark chip', () => {
+  it('should render a <BookmarkChip />', () => {
     const { getByRole } = wrapper(<BookmarkChip />);
 
     expect(getByRole('button')).toBeDefined();
+  });
+
+  it('should render `not-bookmarked` when `isBookmarked` is false', () => {
+    const { queryByTestId } = wrapper(<BookmarkChip />);
+
+    expect(queryByTestId('not-bookmarked')).toBeDefined();
+    expect(queryByTestId('is-bookmarked')).toBeNull();
+  });
+
+  it('should render `is-bookmarked` when `isBookmarked` is true', () => {
+    const { queryByTestId } = wrapper(<BookmarkChip isBookmarked={true} />);
+
+    expect(queryByTestId('is-bookmarked')).toBeDefined();
+    expect(queryByTestId('not-bookmarked')).toBeNull();
   });
 });

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -15,6 +15,7 @@
  */
 
 export { default as NavigationBar } from './navigation-bar';
+export { default as BookmarkChip } from './bookmark-chip';
 export { default as Button } from './button';
 export { default as PopoverMenu } from './popover-menu';
 export { default as Dropdown } from './dropdown';

--- a/assets/src/dashboard/constants.js
+++ b/assets/src/dashboard/constants.js
@@ -25,6 +25,11 @@ export const BUTTON_TYPES = {
   SECONDARY: 'secondary',
 };
 
+export const CHIP_TYPES = {
+  STANDARD: 'standard',
+  SMALL: 'small',
+};
+
 export const DROPDOWN_TYPES = {
   TRANSPARENT_MENU: 'transparentMenu',
   MENU: 'menu',

--- a/assets/src/dashboard/icons/bookmark-fill.svg
+++ b/assets/src/dashboard/icons/bookmark-fill.svg
@@ -1,3 +1,3 @@
 <svg width="14" height="18" viewBox="0 0 14 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 0H2C0.9 0 0.0100002 0.9 0.0100002 2L0 18L7 15L14 18V2C14 0.9 13.1 0 12 0Z" fill="black"/>
+<path d="M12 0H2C0.9 0 0.0100002 0.9 0.0100002 2L0 18L7 15L14 18V2C14 0.9 13.1 0 12 0Z" fill="currentColor"/>
 </svg>

--- a/assets/src/dashboard/icons/bookmark-outline.svg
+++ b/assets/src/dashboard/icons/bookmark-outline.svg
@@ -1,3 +1,3 @@
 <svg width="14" height="18" viewBox="0 0 14 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 0H2C0.9 0 0.0100002 0.9 0.0100002 2L0 18L7 15L14 18V2C14 0.9 13.1 0 12 0ZM12 15L7 12.82L2 15V2H12V15Z" fill="black"/>
+<path d="M12 0H2C0.9 0 0.0100002 0.9 0.0100002 2L0 18L7 15L14 18V2C14 0.9 13.1 0 12 0ZM12 15L7 12.82L2 15V2H12V15Z" fill="currentColor"/>
 </svg>

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -98,6 +98,9 @@ const theme = {
   text: {
     shadow: '0px 1px 1px rgba(0, 0, 0, 1)',
   },
+  chip: {
+    shadow: '0px 1px 3px rgba(0, 0, 0, 0.2)',
+  },
   boxShadow: {
     expandedTypeahead:
       '0px 0.181152px 2.29372px rgba(0, 0, 0, 0.031357), 0px 0.500862px 5.15978px rgba(0, 0, 0, 0.045),0px 1.20588px 8.99337px rgba(0, 0, 0, 0.058643), 0px 4px 17px rgba(0, 0, 0, 0.09)',


### PR DESCRIPTION
# Overview 
Adds <BookmarkChip /> to dashboard components.  
Figma has size variants so I made a `STANDARD` and `SMALL` `chipType` to toggle between the two until we determine the size shift is otherwise set.  Took some liberty of adjusting the icon size to stay at whole numbers, suspect this may change after Sam takes a pass at the spacing, but this is cleaner than how figma has it with the .8px settings. Also set a 'disabled' style - not sure this would ever be disabled? but just incase. 

## Testing 
Check out storybook, see that you can: 
- use `isBookmarked` to get the filled in icon. 
- use `chipType` to toggle the sizing 
- disabled is just the default attribute buttons can handle 

![bookmark chip demo](https://user-images.githubusercontent.com/10720454/77704973-a51ca580-6f7b-11ea-9f1b-43212e9be0f4.gif)
