### PR TITLE
Disallow masking for background.

### DIFF
--- a/assets/src/edit-story/masks/display.js
+++ b/assets/src/edit-story/masks/display.js
@@ -44,7 +44,7 @@ export default function WithMask({
   ...rest
 }) {
   const mask = getElementMask(element);
-  const { flip } = element;
+  const { flip, isBackground } = element;
 
   const transformFlip = getTransformFlip(flip);
   if (transformFlip && applyFlip) {
@@ -53,7 +53,7 @@ export default function WithMask({
       : transformFlip;
   }
 
-  if (!mask?.type) {
+  if (!mask?.type || isBackground) {
     return (
       <div
         style={{

--- a/assets/src/edit-story/masks/frame.js
+++ b/assets/src/edit-story/masks/frame.js
@@ -129,9 +129,10 @@ WithDropTarget.propTypes = {
 
 export default function WithMask({ element, fill, style, children, ...rest }) {
   const [hover, setHover] = useState(false);
+  const { isBackground } = element;
 
   const mask = getElementMask(element);
-  if (!mask?.type) {
+  if (!mask?.type || isBackground) {
     return (
       <div
         style={{

--- a/assets/src/edit-story/masks/output.js
+++ b/assets/src/edit-story/masks/output.js
@@ -83,7 +83,7 @@ export default function WithMask({
         ...style,
         clipPath: `url(#${maskId})`,
         // stylelint-disable-next-line property-no-vendor-prefix
-        webkitClipPath: `url(#${maskId})`,
+        WebkitClipPath: `url(#${maskId})`,
       }}
       {...rest}
     >

--- a/assets/src/edit-story/masks/output.js
+++ b/assets/src/edit-story/masks/output.js
@@ -48,7 +48,7 @@ export default function WithMask({
   ...rest
 }) {
   const mask = getElementMask(element);
-  const { flip } = element;
+  const { flip, isBackground } = element;
 
   const transformFlip = getTransformFlip(flip);
   if (transformFlip) {
@@ -57,7 +57,7 @@ export default function WithMask({
       : transformFlip;
   }
 
-  if (!mask?.type) {
+  if (!mask?.type || isBackground) {
     return (
       <div
         style={{
@@ -83,7 +83,7 @@ export default function WithMask({
         ...style,
         clipPath: `url(#${maskId})`,
         // stylelint-disable-next-line property-no-vendor-prefix
-        WebkitClipPath: `url(#${maskId})`,
+        webkitClipPath: `url(#${maskId})`,
       }}
       {...rest}
     >

--- a/assets/src/edit-story/masks/test/output.js
+++ b/assets/src/edit-story/masks/test/output.js
@@ -15,9 +15,15 @@
  */
 
 /**
+ * External dependencies
+ */
+import { renderToStaticMarkup } from 'react-dom/server';
+
+/**
  * Internal dependencies
  */
 import WithMask from '../output';
+import { MaskTypes } from '../index';
 
 describe('WithMask', () => {
   it('should produce valid AMP output when no mask is set', async () => {
@@ -39,6 +45,84 @@ describe('WithMask', () => {
         <p>{'Hello World'}</p>
       </WithMask>
     ).toBeValidAMPStoryElement();
+  });
+
+  it('should not add mask for background element', async () => {
+    const props = {
+      element: {
+        id: '123',
+        isBackground: true,
+        type: 'image',
+        mimeType: 'image/png',
+        scale: 1,
+        origRatio: 9 / 16,
+        x: 50,
+        y: 100,
+        height: 1920,
+        width: 1080,
+        rotationAngle: 0,
+        resource: {
+          type: 'image',
+          mimeType: 'image/png',
+          src: 'https://example.com/image.png',
+          height: 1920,
+          width: 1080,
+        },
+        mask: {
+          type: MaskTypes.HEART,
+          fill: { type: 'solid', color: { r: 255, g: 255, b: 255 } },
+          style: {},
+        },
+      },
+      box: { width: 1080, height: 1920, x: 50, y: 100, rotationAngle: 0 },
+    };
+
+    const content = renderToStaticMarkup(
+      <WithMask {...props}>
+        <p>{'Hello World'}</p>
+      </WithMask>
+    );
+
+    await expect(content).not.toContain(MaskTypes.HEART);
+  });
+
+  it('should add mask for shaped image element', async () => {
+    const props = {
+      element: {
+        id: '123',
+        isBackground: false,
+        type: 'image',
+        mimeType: 'image/png',
+        scale: 1,
+        origRatio: 9 / 16,
+        x: 50,
+        y: 100,
+        height: 1920,
+        width: 1080,
+        rotationAngle: 0,
+        resource: {
+          type: 'image',
+          mimeType: 'image/png',
+          src: 'https://example.com/image.png',
+          height: 1920,
+          width: 1080,
+        },
+        mask: {
+          type: MaskTypes.HEART,
+          fill: { type: 'solid', color: { r: 255, g: 255, b: 255 } },
+          style: {},
+        },
+      },
+      box: { width: 1080, height: 1920, x: 50, y: 100, rotationAngle: 0 },
+    };
+
+    const content = renderToStaticMarkup(
+      <WithMask {...props}>
+        <p>{'Hello World'}</p>
+      </WithMask>
+    );
+
+    await expect(content).toContain(MaskTypes.HEART);
   });
 
   // eslint-disable-next-line jest/no-disabled-tests


### PR DESCRIPTION
Fixes #796 

Background media should not be masked, it should always cover the full area.

If the user wants to add a "background shape" for some reason, Fill feature can be used.