### PR TITLE
Reduce timing difference for entering text edit mode.

### DIFF
--- a/assets/src/edit-story/elements/text/frame.js
+++ b/assets/src/edit-story/elements/text/frame.js
@@ -100,7 +100,7 @@ function TextFrame({ element: { id, content, ...rest }, wrapperRef }) {
     const handleMouseUp = (evt) => {
       const timingDifference = window.performance.now() - clickTime;
 
-      if (timingDifference > 300) {
+      if (timingDifference > 150) {
         // Only short clicks count.
         return;
       }


### PR DESCRIPTION
Fixes #729 

Reduces timing difference to stop entering edit mode when dragging.

In my testing, even a bit slower than normal click almost never exceeded 150, however, very short dragging was around 250.

Changed the value to 150 which seems to be short enough not to trigger when dragging but long enough even for a bit "slower" click.