### PR TITLE
Exit edit mode on link change

### DIFF
--- a/assets/src/edit-story/components/panels/link/index.js
+++ b/assets/src/edit-story/components/panels/link/index.js
@@ -47,6 +47,7 @@ import Dialog from '../../dialog';
 import theme from '../../../theme';
 import useBatchingCallback from '../../../utils/useBatchingCallback';
 import { Plain } from '../../button';
+import { useCanvas } from '../../canvas';
 import LinkInfoDialog from './infoDialog';
 
 const BrandIconText = styled.span`
@@ -69,6 +70,10 @@ const InfoIcon = styled(Info)`
 `;
 
 function LinkPanel({ selectedElements, pushUpdateForObject }) {
+  const {
+    actions: { clearEditing },
+  } = useCanvas();
+
   const selectedElement = selectedElements[0];
   const { isFill } = selectedElement;
   const inferredLinkType = useMemo(() => inferLinkType(selectedElement), [
@@ -128,6 +133,8 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
 
   const handleChange = useCallback(
     (properties, submit) => {
+      clearEditing();
+
       if (properties.url) {
         populateMetadata(properties.url);
       }
@@ -141,7 +148,13 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
         submit
       );
     },
-    [populateMetadata, pushUpdateForObject, inferredLinkType, defaultLink]
+    [
+      clearEditing,
+      pushUpdateForObject,
+      inferredLinkType,
+      defaultLink,
+      populateMetadata,
+    ]
   );
 
   const handleChangeIcon = useCallback(


### PR DESCRIPTION
Fixes #733

If we want more global behavior we can:
1. hook into [inspector/design/updateProperties.js](https://github.com/google/web-stories-wp/blob/c8d129e881cf7851891474e34275d5de31fbb581/assets/src/edit-story/components/inspector/design/updateProperties.js) and maintain a list of keys that can be edited without leaving the edit mode and for the rest trigger `clearEditing`.
2. hook into `updateElementsById` - but that's maybe too much.