### PR TITLE
Fix forms events in Firefox

### DIFF
--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -121,7 +121,9 @@ function Numeric({
         }}
         onBlur={(evt) => {
           if (evt.target.form) {
-            evt.target.form.dispatchEvent(new window.Event('submit'));
+            evt.target.form.dispatchEvent(
+              new window.Event('submit', { cancelable: true })
+            );
           }
           if (onBlur) {
             onBlur();

--- a/assets/src/edit-story/components/form/text.js
+++ b/assets/src/edit-story/components/form/text.js
@@ -113,7 +113,9 @@ function TextInput({
         onChange={(evt) => onChange(evt.target.value, evt)}
         onBlur={(evt) => {
           if (evt.target.form) {
-            evt.target.form.dispatchEvent(new window.Event('submit'));
+            evt.target.form.dispatchEvent(
+              new window.Event('submit', { cancelable: true })
+            );
           }
           if (onBlur) {
             onBlur();
@@ -125,7 +127,9 @@ function TextInput({
           onClick={(evt) => {
             onChange('');
             if (evt.target.form) {
-              evt.target.form.dispatchEvent(new window.Event('submit'));
+              evt.target.form.dispatchEvent(
+                new window.Event('submit', { cancelable: true })
+              );
             }
             if (onBlur) {
               onBlur();

--- a/assets/src/edit-story/components/inspector/design/designPanel.js
+++ b/assets/src/edit-story/components/inspector/design/designPanel.js
@@ -118,7 +118,7 @@ function DesignPanel({
     setTimeout(() => {
       const form = formRef.current;
       if (form) {
-        form.dispatchEvent(new window.Event('submit'));
+        form.dispatchEvent(new window.Event('submit', { cancelable: true }));
       }
     });
   }, []);


### PR DESCRIPTION
Fixes https://github.com/google/web-stories-wp/issues/871

By default `cancelable=false` so [this](https://github.com/google/web-stories-wp/blob/c8d129e881cf7851891474e34275d5de31fbb581/assets/src/edit-story/components/inspector/design/designPanel.js#L104) is not working right now.

https://developer.mozilla.org/en-US/docs/Web/API/Event/Event