### PR TITLE
Template Animation: Added move and repeater animation (#618)

### DIFF
--- a/assets/src/dashboard/animations/configs/index.js
+++ b/assets/src/dashboard/animations/configs/index.js
@@ -17,17 +17,19 @@
 /**
  * Internal dependencies
  */
-import { ANIMATION_TYPE } from '../constants';
+import { ANIMATION_TYPES } from '../constants';
 import getBlinkOnConfig from './blinkOn';
 import getBounceConfig from './bounce';
 import getFlipConfig from './flip';
 import getFloatOnConfig from './floatOn';
+import getMoveConfig from './move';
 import getSpinConfig from './spin';
 
 export default {
-  [ANIMATION_TYPE.BLINK_ON]: getBlinkOnConfig,
-  [ANIMATION_TYPE.BOUNCE]: getBounceConfig,
-  [ANIMATION_TYPE.FLIP]: getFlipConfig,
-  [ANIMATION_TYPE.FLOAT_ON]: getFloatOnConfig,
-  [ANIMATION_TYPE.SPIN]: getSpinConfig,
+  [ANIMATION_TYPES.BLINK_ON]: getBlinkOnConfig,
+  [ANIMATION_TYPES.BOUNCE]: getBounceConfig,
+  [ANIMATION_TYPES.FLIP]: getFlipConfig,
+  [ANIMATION_TYPES.FLOAT_ON]: getFloatOnConfig,
+  [ANIMATION_TYPES.MOVE]: getMoveConfig,
+  [ANIMATION_TYPES.SPIN]: getSpinConfig,
 };

--- a/assets/src/dashboard/animations/configs/move.js
+++ b/assets/src/dashboard/animations/configs/move.js
@@ -14,29 +14,13 @@
  * limitations under the License.
  */
 
-export const ANIMATION_TYPES = {
-  BLINK_ON: 'blinkOn',
-  BOUNCE: 'bounce',
-  FLIP: 'flip',
-  FLOAT_ON: 'floatOn',
-  MOVE: 'move',
-  SPIN: 'spin',
-};
+export default function (config) {
+  const { offsetX = 0, offsetY = 0 } = config;
 
-export const ROTATION = {
-  CLOCKWISE: 'clockwise',
-  COUNTER_CLOCKWISE: 'counterClockwise',
-  PING_PONG: 'pingPong',
-};
-
-export const DIRECTION = {
-  TOP_TO_BOTTOM: 'topToBottom',
-  BOTTOM_TO_TOP: 'bottomToTop',
-  LEFT_TO_RIGHT: 'leftToRight',
-  RIGHT_TO_LEFT: 'rightToLeft',
-};
-
-export const AXIS = {
-  X: 'x',
-  Y: 'y',
-};
+  return {
+    fill: 'forwards',
+    keyframes: {
+      transform: [`translate(${offsetX}px, ${offsetY}px)`, 'translate(0%, 0%)'],
+    },
+  };
+}

--- a/assets/src/dashboard/animations/stories/blinkOn.js
+++ b/assets/src/dashboard/animations/stories/blinkOn.js
@@ -18,7 +18,7 @@
  * Internal dependencies
  */
 import { AnimatorOutput, AnimationOutput, WithAnimation } from '../animator';
-import { ANIMATION_TYPE } from '../constants';
+import { ANIMATION_TYPES } from '../constants';
 import getAnimationConfigs from '../configs';
 import getInitialStyleFromKeyframes from '../utils/getInitialStyleFromKeyframes';
 
@@ -27,7 +27,7 @@ export default {
 };
 
 export const _default = () => {
-  const name = ANIMATION_TYPE.BLINK_ON;
+  const name = ANIMATION_TYPES.BLINK_ON;
   const label = 'Animate';
 
   const elementConfigs = [

--- a/assets/src/dashboard/animations/stories/bounce.js
+++ b/assets/src/dashboard/animations/stories/bounce.js
@@ -18,7 +18,7 @@
  * Internal dependencies
  */
 import { AnimatorOutput, AnimationOutput, WithAnimation } from '../animator';
-import { ANIMATION_TYPE } from '../constants';
+import { ANIMATION_TYPES } from '../constants';
 import getAnimationConfigs from '../configs';
 import getInitialStyleFromKeyframes from '../utils/getInitialStyleFromKeyframes';
 
@@ -27,7 +27,7 @@ export default {
 };
 
 export const _default = () => {
-  const name = ANIMATION_TYPE.BOUNCE;
+  const name = ANIMATION_TYPES.BOUNCE;
   const { keyframes, ...config } = getAnimationConfigs[name]();
   const label = 'Animate';
 
@@ -61,7 +61,7 @@ export const _default = () => {
 };
 
 export const Cascading = () => {
-  const name = ANIMATION_TYPE.BOUNCE;
+  const name = ANIMATION_TYPES.BOUNCE;
   const { keyframes, ...config } = getAnimationConfigs[name]();
   const elementConfigs = [
     { id: 'e1', color: 'red', width: '50px' },

--- a/assets/src/dashboard/animations/stories/flip.js
+++ b/assets/src/dashboard/animations/stories/flip.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { AnimatorOutput, AnimationOutput, WithAnimation } from '../animator';
-import { ANIMATION_TYPE, ROTATION, AXIS, DIRECTION } from '../constants';
+import { ANIMATION_TYPES, ROTATION, AXIS, DIRECTION } from '../constants';
 import theme from '../../theme';
 import getAnimationConfigs from '../configs';
 import getInitialStyleFromKeyframes from '../utils/getInitialStyleFromKeyframes';
@@ -37,7 +37,7 @@ const Flip = ({ name, duration, content, containerStyle, direction }) => {
   const delay = 100;
   const label = 'Animate';
 
-  const floatOnName = ANIMATION_TYPE.FLOAT_ON;
+  const floatOnName = ANIMATION_TYPES.FLOAT_ON;
   const { keyframes: floatKeyframes, ...floatConfig } = getAnimationConfigs[
     floatOnName
   ](direction);
@@ -133,7 +133,7 @@ Flip.propTypes = {
 };
 
 export const _default = () => {
-  const name = ANIMATION_TYPE.FLIP;
+  const name = ANIMATION_TYPES.FLIP;
   const content = [
     {
       id: 'el1',
@@ -187,7 +187,7 @@ export const _default = () => {
 };
 
 export const Vertical = () => {
-  const name = ANIMATION_TYPE.FLIP;
+  const name = ANIMATION_TYPES.FLIP;
   const content = [
     {
       id: 'el1',

--- a/assets/src/dashboard/animations/stories/floatOn.js
+++ b/assets/src/dashboard/animations/stories/floatOn.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { AnimatorOutput, AnimationOutput, WithAnimation } from '../animator';
-import { ANIMATION_TYPE, DIRECTION } from '../constants';
+import { ANIMATION_TYPES, DIRECTION } from '../constants';
 import getAnimationConfigs from '../configs';
 import getInitialStyleFromKeyframes from '../utils/getInitialStyleFromKeyframes';
 
@@ -32,7 +32,7 @@ export default {
 };
 
 const FloatOn = ({ direction }) => {
-  const name = ANIMATION_TYPE.FLOAT_ON;
+  const name = ANIMATION_TYPES.FLOAT_ON;
   const { keyframes, ...config } = getAnimationConfigs[name](direction);
 
   const label = 'Animate';

--- a/assets/src/dashboard/animations/stories/move.js
+++ b/assets/src/dashboard/animations/stories/move.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { AnimatorOutput, AnimationOutput, WithAnimation } from '../animator';
+import { ANIMATION_TYPES } from '../constants';
+import getAnimationConfigs from '../configs';
+import getInitialStyleFromKeyframes from '../utils/getInitialStyleFromKeyframes';
+
+export default {
+  title: 'Dashboard/Animations/Move',
+};
+
+export const _default = () => {
+  const name = ANIMATION_TYPES.MOVE;
+  const label = 'Animate';
+
+  const { keyframes, ...config } = getAnimationConfigs[name]({
+    offsetX: -100,
+    offsetY: 200,
+  });
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <AnimationOutput id={name} keyframes={keyframes} {...config} />
+      <AnimatorOutput
+        id={`${name}-anim`}
+        config={{
+          selector: `#anim`,
+          animation: name,
+          duration: 800,
+          easing: 'ease-in-out',
+        }}
+      />
+      <button style={{ marginBottom: '10px' }} on={`tap:${name}-anim.restart`}>
+        {label}
+      </button>
+      <WithAnimation
+        id="anim"
+        style={{
+          width: '50px',
+          height: '50px',
+          position: 'absolute',
+          top: '50px',
+          left: '100px',
+          ...getInitialStyleFromKeyframes(keyframes),
+        }}
+      >
+        <div
+          style={{ width: '100%', height: '100%', backgroundColor: 'orange' }}
+        />
+      </WithAnimation>
+    </div>
+  );
+};
+
+export const Repeater = () => {
+  const name = ANIMATION_TYPES.MOVE;
+  const label = 'Animate';
+  const delay = 100;
+  const increment = 200;
+
+  const { keyframes, ...config } = getAnimationConfigs[name]({
+    offsetX: -100,
+    offsetY: -100,
+  });
+
+  const elements = [
+    { id: 'el1', color: 'red' },
+    { id: 'el2', color: 'orange' },
+    { id: 'el3', color: 'green' },
+    { id: 'el4', color: 'blue' },
+  ];
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <AnimationOutput id={name} keyframes={keyframes} {...config} />
+      <AnimatorOutput
+        id={`${name}-anim`}
+        config={elements.map(({ id }, index) => ({
+          selector: `#anim-${id}`,
+          animation: name,
+          duration: 800,
+          delay: delay + increment * index,
+          easing: 'ease-in-out',
+        }))}
+      />
+      <button style={{ marginBottom: '10px' }} on={`tap:${name}-anim.restart`}>
+        {label}
+      </button>
+      {elements.map(({ id, color }, index) => (
+        <WithAnimation
+          key={id}
+          id={`anim-${id}`}
+          style={{
+            width: '100px',
+            height: '200px',
+            position: 'absolute',
+            top: '150px',
+            left: '100px',
+            zIndex: 10 - index,
+            ...getInitialStyleFromKeyframes(keyframes),
+          }}
+        >
+          <div
+            style={{ width: '100%', height: '100%', backgroundColor: color }}
+          />
+        </WithAnimation>
+      ))}
+    </div>
+  );
+};

--- a/assets/src/dashboard/animations/stories/spin.js
+++ b/assets/src/dashboard/animations/stories/spin.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { AnimatorOutput, AnimationOutput, WithAnimation } from '../animator';
-import { ANIMATION_TYPE, ROTATION } from '../constants';
+import { ANIMATION_TYPES, ROTATION } from '../constants';
 import getAnimationConfigs from '../configs';
 import getInitialStyleFromKeyframes from '../utils/getInitialStyleFromKeyframes';
 
@@ -112,7 +112,7 @@ Spin.propTypes = {
 };
 
 export const _default = () => {
-  const name = ANIMATION_TYPE.SPIN;
+  const name = ANIMATION_TYPES.SPIN;
   const { keyframes, ...config } = getAnimationConfigs[name]();
 
   return (
@@ -133,7 +133,7 @@ export const _default = () => {
 };
 
 export const defaultCounterClockwise = () => {
-  const name = ANIMATION_TYPE.SPIN;
+  const name = ANIMATION_TYPES.SPIN;
   const { keyframes, ...config } = getAnimationConfigs[name](
     ROTATION.COUNTER_CLOCKWISE
   );
@@ -156,7 +156,7 @@ export const defaultCounterClockwise = () => {
 };
 
 export const fastToSlowClockwise = () => {
-  const name = ANIMATION_TYPE.SPIN;
+  const name = ANIMATION_TYPES.SPIN;
   const { keyframes, ...config } = getAnimationConfigs[name]();
 
   return (
@@ -183,7 +183,7 @@ export const fastToSlowClockwise = () => {
 };
 
 export const fastToSlowCounterClockwise = () => {
-  const name = ANIMATION_TYPE.SPIN;
+  const name = ANIMATION_TYPES.SPIN;
   const { keyframes, ...config } = getAnimationConfigs[name](
     ROTATION.COUNTER_CLOCKWISE
   );
@@ -212,7 +212,7 @@ export const fastToSlowCounterClockwise = () => {
 };
 
 export const pingPongSpin = () => {
-  const name = ANIMATION_TYPE.SPIN;
+  const name = ANIMATION_TYPES.SPIN;
   const { keyframes, ...config } = getAnimationConfigs[name](
     ROTATION.PING_PONG
   );


### PR DESCRIPTION
This PR adds the `move` animation and `repeater` (which is just a permutation of `move`.

Move animation:
![move-default](https://user-images.githubusercontent.com/40646372/77969837-9138b280-729f-11ea-877d-b98942d866b1.gif)

Repeater animation:
![repeater-default](https://user-images.githubusercontent.com/40646372/77969841-939b0c80-729f-11ea-9607-9a74a85a25cb.gif)
