### PR TITLE
Fix drop targets on background element + disable opacity for backgrounds

### DIFF
--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -116,6 +116,7 @@ function DisplayElement({ element, previewMode }) {
         style={{
           opacity: opacity ? opacity / 100 : null,
         }}
+        previewMode={previewMode}
       >
         <Display element={element} previewMode={previewMode} box={box} />
         {!previewMode && (

--- a/assets/src/edit-story/components/panels/index.js
+++ b/assets/src/edit-story/components/panels/index.js
@@ -81,15 +81,20 @@ export function getPanels(elements) {
   // Only display background panel in case of background element.
   if (isBackground) {
     const panels = [
-      { type: BACKGROUND_SIZE_POSITION, Panel: BackgroundSizePositionPanel },
-      { type: LAYER_STYLE, Panel: LayerStylePanel },
       { type: BACKGROUND_OVERLAY, Panel: BackgroundOverlayPanel },
       { type: BACKGROUND_DISPLAY, Panel: BackgroundDisplayPanel },
     ];
     // If the selected element's type is video / image , display accessibility panel, too.
     if ('shape' === elements[0].type) {
       panels.unshift({ type: SHAPE_STYLE, Panel: ShapeStylePanel });
-    } else if ('video' === elements[0].type) {
+    } else {
+      panels.unshift({
+        type: BACKGROUND_SIZE_POSITION,
+        Panel: BackgroundSizePositionPanel,
+      });
+    }
+
+    if ('video' === elements[0].type) {
       panels.push({ type: VIDEO_OPTIONS, Panel: VideoOptionsPanel });
       panels.push({
         type: VIDEO_ACCESSIBILITY,

--- a/assets/src/edit-story/components/panels/shapeStyle.js
+++ b/assets/src/edit-story/components/panels/shapeStyle.js
@@ -33,6 +33,7 @@ import getCommonValue from './utils/getCommonValue';
 
 function ShapeStylePanel({ selectedElements, pushUpdate }) {
   const backgroundColor = getCommonValue(selectedElements, 'backgroundColor');
+  const isBackground = getCommonValue(selectedElements, 'isBackground');
 
   return (
     <SimplePanel name="style" title={__('Style', 'web-stories')}>
@@ -43,6 +44,7 @@ function ShapeStylePanel({ selectedElements, pushUpdate }) {
           isMultiple={backgroundColor === ''}
           onChange={(value) => pushUpdate({ backgroundColor: value }, true)}
           label={__('Background color', 'web-stories')}
+          hasOpacity={!isBackground}
         />
       </Row>
     </SimplePanel>

--- a/assets/src/edit-story/masks/display.js
+++ b/assets/src/edit-story/masks/display.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
  */
 import StoryPropTypes from '../types';
 import getTransformFlip from '../elements/shared/getTransformFlip';
-import { getElementMask } from './';
+import { getElementMask, MaskTypes } from './';
 
 const FILL_STYLE = {
   position: 'absolute',
@@ -53,7 +53,7 @@ export default function WithMask({
       : transformFlip;
   }
 
-  if (!mask?.type || isBackground) {
+  if (!mask?.type || (isBackground && mask.type !== MaskTypes.RECTANGLE)) {
     return (
       <div
         style={{

--- a/assets/src/edit-story/masks/display.js
+++ b/assets/src/edit-story/masks/display.js
@@ -80,7 +80,7 @@ export default function WithMask({
       style={{
         ...(fill ? FILL_STYLE : {}),
         ...style,
-        clipPath: `url(#${maskId})`,
+        ...(!isBackground ? { clipPath: `url(#${maskId})` } : {}),
       }}
       {...rest}
     >

--- a/assets/src/edit-story/masks/display.js
+++ b/assets/src/edit-story/masks/display.js
@@ -41,6 +41,7 @@ export default function WithMask({
   children,
   box,
   applyFlip = true,
+  previewMode = false,
   ...rest
 }) {
   const mask = getElementMask(element);
@@ -70,7 +71,9 @@ export default function WithMask({
   // @todo: Chrome cannot do inline clip-path using data: URLs.
   // See https://bugs.chromium.org/p/chromium/issues/detail?id=1041024.
 
-  const maskId = `mask-${mask.type}-${element.id}-display`;
+  const maskId = `mask-${mask.type}-${element.id}-display${
+    previewMode ? '-preview' : ''
+  }`;
 
   return (
     <div
@@ -104,4 +107,5 @@ WithMask.propTypes = {
   fill: PropTypes.bool,
   children: StoryPropTypes.children.isRequired,
   box: StoryPropTypes.box.isRequired,
+  previewMode: PropTypes.bool,
 };

--- a/assets/src/edit-story/masks/frame.js
+++ b/assets/src/edit-story/masks/frame.js
@@ -26,7 +26,7 @@ import { useRef, useEffect, useState } from 'react';
  */
 import StoryPropTypes from '../types';
 import { useDropTargets } from '../app';
-import { getElementMask } from './';
+import { getElementMask, MaskTypes } from './';
 
 const FILL_STYLE = {
   position: 'absolute',
@@ -132,7 +132,7 @@ export default function WithMask({ element, fill, style, children, ...rest }) {
   const { isBackground } = element;
 
   const mask = getElementMask(element);
-  if (!mask?.type || isBackground) {
+  if (!mask?.type || (isBackground && mask.type !== MaskTypes.RECTANGLE)) {
     return (
       <div
         style={{

--- a/assets/src/edit-story/masks/frame.js
+++ b/assets/src/edit-story/masks/frame.js
@@ -156,7 +156,7 @@ export default function WithMask({ element, fill, style, children, ...rest }) {
       style={{
         ...(fill ? FILL_STYLE : {}),
         ...style,
-        clipPath: `url(#${maskId})`,
+        ...(!isBackground ? { clipPath: `url(#${maskId})` } : {}),
       }}
       {...rest}
       onPointerOver={() => setHover(true)}

--- a/assets/src/edit-story/masks/output.js
+++ b/assets/src/edit-story/masks/output.js
@@ -29,7 +29,7 @@ import PropTypes from 'prop-types';
  */
 import StoryPropTypes from '../types';
 import getTransformFlip from '../elements/shared/getTransformFlip';
-import { getElementMask } from '.';
+import { getElementMask, MaskTypes } from '.';
 
 const FILL_STYLE = {
   position: 'absolute',
@@ -57,7 +57,7 @@ export default function WithMask({
       : transformFlip;
   }
 
-  if (!mask?.type || isBackground) {
+  if (!mask?.type || (isBackground && mask.type !== MaskTypes.RECTANGLE)) {
     return (
       <div
         style={{

--- a/assets/src/edit-story/masks/output.js
+++ b/assets/src/edit-story/masks/output.js
@@ -81,9 +81,13 @@ export default function WithMask({
       style={{
         ...(fill ? FILL_STYLE : {}),
         ...style,
-        clipPath: `url(#${maskId})`,
-        // stylelint-disable-next-line property-no-vendor-prefix
-        webkitClipPath: `url(#${maskId})`,
+        ...(!isBackground
+          ? {
+              clipPath: `url(#${maskId})`,
+              // stylelint-disable-next-line property-no-vendor-prefix
+              WebkitClipPath: `url(#${maskId})`,
+            }
+          : {}),
       }}
       {...rest}
     >


### PR DESCRIPTION
Closes #882 
Re-opens #796

### Changes
- Reverts part of #827 by allowing rectangles to be a valid background mask to temporarily re-enable drop targets
- Disables opacity controls for shapes, images and videos that are background elements
- Prevents "Remove as background element" on the default background object (white rectangle)
- Fixes a duplicate ID issue that caused an e2e test to fail