### PR TITLE
Fix Firefox alignment issues on numeric fields.

### DIFF
--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -37,7 +37,8 @@ import MULTIPLE_VALUE from './multipleValue';
 const DECIMAL_POINT = (1.1).toLocaleString().substring(1, 2);
 
 const StyledInput = styled(Input)`
-  width: 100%;
+  flex: 1 1 auto;
+  width: 0;
   border: none;
   padding-right: ${({ suffix }) => (Boolean(suffix) ? 6 : 0)}px;
   padding-left: ${({ prefix, label }) => (prefix || label ? 6 : 0)}px;
@@ -91,47 +92,45 @@ function Numeric({
     >
       {label}
       {prefix}
-      <div>
-        <StyledInput
-          ref={ref}
-          placeholder={placeholder}
-          prefix={prefix}
-          suffix={suffix}
-          label={label}
-          value={
-            isMultiple
-              ? ''
-              : `${value}${dot ? DECIMAL_POINT : ''}${focused ? '' : symbol}`
+      <StyledInput
+        ref={ref}
+        placeholder={placeholder}
+        prefix={prefix}
+        suffix={suffix}
+        label={label}
+        value={
+          isMultiple
+            ? ''
+            : `${value}${dot ? DECIMAL_POINT : ''}${focused ? '' : symbol}`
+        }
+        aria-label={ariaLabel}
+        disabled={disabled}
+        {...rest}
+        onChange={(evt) => {
+          const newValue = evt.target.value;
+          if (newValue === '') {
+            onChange('', evt);
+          } else {
+            setDot(float && newValue[newValue.length - 1] === DECIMAL_POINT);
+            const valueAsNumber = float
+              ? parseFloat(newValue)
+              : parseInt(newValue);
+            if (!isNaN(valueAsNumber)) {
+              onChange(valueAsNumber, evt);
+            }
           }
-          aria-label={ariaLabel}
-          disabled={disabled}
-          {...rest}
-          onChange={(evt) => {
-            const newValue = evt.target.value;
-            if (newValue === '') {
-              onChange('', evt);
-            } else {
-              setDot(float && newValue[newValue.length - 1] === DECIMAL_POINT);
-              const valueAsNumber = float
-                ? parseFloat(newValue)
-                : parseInt(newValue);
-              if (!isNaN(valueAsNumber)) {
-                onChange(valueAsNumber, evt);
-              }
-            }
-          }}
-          onBlur={(evt) => {
-            if (evt.target.form) {
-              evt.target.form.dispatchEvent(new window.Event('submit'));
-            }
-            if (onBlur) {
-              onBlur();
-            }
-            handleBlur();
-          }}
-          onFocus={handleFocus}
-        />
-      </div>
+        }}
+        onBlur={(evt) => {
+          if (evt.target.form) {
+            evt.target.form.dispatchEvent(new window.Event('submit'));
+          }
+          if (onBlur) {
+            onBlur();
+          }
+          handleBlur();
+        }}
+        onFocus={handleFocus}
+      />
       {suffix}
     </Container>
   );

--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -91,45 +91,47 @@ function Numeric({
     >
       {label}
       {prefix}
-      <StyledInput
-        ref={ref}
-        placeholder={placeholder}
-        prefix={prefix}
-        suffix={suffix}
-        label={label}
-        value={
-          isMultiple
-            ? ''
-            : `${value}${dot ? DECIMAL_POINT : ''}${focused ? '' : symbol}`
-        }
-        aria-label={ariaLabel}
-        disabled={disabled}
-        {...rest}
-        onChange={(evt) => {
-          const newValue = evt.target.value;
-          if (newValue === '') {
-            onChange('', evt);
-          } else {
-            setDot(float && newValue[newValue.length - 1] === DECIMAL_POINT);
-            const valueAsNumber = float
-              ? parseFloat(newValue)
-              : parseInt(newValue);
-            if (!isNaN(valueAsNumber)) {
-              onChange(valueAsNumber, evt);
+      <div>
+        <StyledInput
+          ref={ref}
+          placeholder={placeholder}
+          prefix={prefix}
+          suffix={suffix}
+          label={label}
+          value={
+            isMultiple
+              ? ''
+              : `${value}${dot ? DECIMAL_POINT : ''}${focused ? '' : symbol}`
+          }
+          aria-label={ariaLabel}
+          disabled={disabled}
+          {...rest}
+          onChange={(evt) => {
+            const newValue = evt.target.value;
+            if (newValue === '') {
+              onChange('', evt);
+            } else {
+              setDot(float && newValue[newValue.length - 1] === DECIMAL_POINT);
+              const valueAsNumber = float
+                ? parseFloat(newValue)
+                : parseInt(newValue);
+              if (!isNaN(valueAsNumber)) {
+                onChange(valueAsNumber, evt);
+              }
             }
-          }
-        }}
-        onBlur={(evt) => {
-          if (evt.target.form) {
-            evt.target.form.dispatchEvent(new window.Event('submit'));
-          }
-          if (onBlur) {
-            onBlur();
-          }
-          handleBlur();
-        }}
-        onFocus={handleFocus}
-      />
+          }}
+          onBlur={(evt) => {
+            if (evt.target.form) {
+              evt.target.form.dispatchEvent(new window.Event('submit'));
+            }
+            if (onBlur) {
+              onBlur();
+            }
+            handleBlur();
+          }}
+          onFocus={handleFocus}
+        />
+      </div>
       {suffix}
     </Container>
   );

--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -37,8 +37,9 @@ import MULTIPLE_VALUE from './multipleValue';
 const DECIMAL_POINT = (1.1).toLocaleString().substring(1, 2);
 
 const StyledInput = styled(Input)`
+  width: 100%;
   flex: 1 1 auto;
-  width: 0;
+  min-width: 0;
   border: none;
   padding-right: ${({ suffix }) => (Boolean(suffix) ? 6 : 0)}px;
   padding-left: ${({ prefix, label }) => (prefix || label ? 6 : 0)}px;


### PR DESCRIPTION
Fixes #873.
 
![Screen Shot 2020-03-31 at 14 37 59](https://user-images.githubusercontent.com/1680157/78057968-f5ba4700-735d-11ea-9c35-8626168d1ce8.png)

cc @swissspidy I was not able to reproduce the tooltip alignment issue, can you add some steps to reproduce that on the Issue? Thanks.