### PR TITLE
Fixed behavior for selected elements

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -18,6 +18,12 @@
         "ignoreTypes": ["overlay", "container"]
       }
     ],
+    "property-no-vendor-prefix": [
+      true,
+      {
+        "ignoreProperties": ["clip-path"]
+      }
+    ],
     "unit-no-unknown": [
       true,
       {

--- a/assets/src/edit-story/components/canvas/multiSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/multiSelectionMovable.js
@@ -24,7 +24,7 @@ import { useRef, useEffect, useState } from 'react';
  * Internal dependencies
  */
 import Movable from '../movable';
-import { useStory } from '../../app/story';
+import { useStory, useDropTargets } from '../../app';
 import objectWithout from '../../utils/objectWithout';
 import { useTransform } from '../transform';
 import { useUnits } from '../../units';
@@ -52,6 +52,9 @@ function MultiSelectionMovable({ selectedElements }) {
   const {
     actions: { pushTransform },
   } = useTransform();
+  const {
+    state: { draggingResource },
+  } = useDropTargets();
 
   const [isDragging, setIsDragging] = useState(false);
   const [canSnap, setCanSnap] = useState(true);
@@ -176,15 +179,17 @@ function MultiSelectionMovable({ selectedElements }) {
     resetMoveable();
   };
 
+  const hideHandles = isDragging || Boolean(draggingResource);
+
   return (
     <Movable
-      className={`default-movable ${isDragging ? 'dragging' : ''}`}
+      className={`default-movable ${hideHandles ? 'hide-handles' : ''}`}
       ref={moveable}
       zIndex={0}
       target={targetList.map(({ node }) => node)}
       draggable={true}
-      resizable={!isDragging}
-      rotatable={!isDragging}
+      resizable={!hideHandles}
+      rotatable={!hideHandles}
       onDragGroup={({ events }) => {
         events.forEach(({ target, beforeTranslate }, i) => {
           const sFrame = frames[i];
@@ -194,7 +199,9 @@ function MultiSelectionMovable({ selectedElements }) {
         });
       }}
       onDragGroupStart={({ events }) => {
-        setIsDragging(true);
+        if (!isDragging) {
+          setIsDragging(true);
+        }
         onGroupEventStart({ events, isDrag: true });
       }}
       onDragGroupEnd={({ targets }) => {

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -61,8 +61,8 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
     actions: { pushTransform },
   } = useTransform();
   const {
-    state: { activeDropTargetId },
-    actions: { handleDrag, handleDrop, setDraggingResource },
+    state: { activeDropTargetId, draggingResource },
+    actions: { handleDrag, handleDrop, setDraggingResource, isDropSource },
   } = useDropTargets();
 
   const otherNodes = Object.values(
@@ -79,25 +79,27 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
   }, [pushEvent]);
 
   useEffect(() => {
-    if (moveable.current) {
-      // If we have persistent event then let's use that, ensuring the targets match.
-      if (
-        latestEvent.current &&
-        targetEl.contains(latestEvent.current.target) &&
-        actionsEnabled
-      ) {
-        moveable.current.moveable.dragStart(latestEvent.current);
-      }
-      moveable.current.updateRect();
+    if (!moveable.current) {
+      return;
     }
+    // If we have persistent event then let's use that, ensuring the targets match.
+    if (
+      latestEvent.current &&
+      targetEl.contains(latestEvent.current.target) &&
+      actionsEnabled
+    ) {
+      moveable.current.moveable.dragStart(latestEvent.current);
+    }
+    moveable.current.updateRect();
   }, [targetEl, moveable, actionsEnabled]);
 
   // Update moveable with whatever properties could be updated outside moveable
   // itself.
   useEffect(() => {
-    if (moveable.current) {
-      moveable.current.updateRect();
+    if (!moveable.current) {
+      return;
     }
+    moveable.current.updateRect();
   });
 
   // ⌘ key disables snapping
@@ -161,29 +163,33 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
     [setIsDragging, setDraggingResource, resetMoveable]
   );
 
-  const { resizeRules = {}, updateForResizeEvent } = getDefinitionForType(
-    selectedElement.type
-  );
+  const {
+    resizeRules = {},
+    updateForResizeEvent,
+    isMaskable,
+  } = getDefinitionForType(selectedElement.type);
 
-  const canSnap = !isDragging || (isDragging && !activeDropTargetId);
+  const canSnap =
+    !snapDisabled && (!isDragging || (isDragging && !activeDropTargetId));
+  const hideHandles = (isDragging && isMaskable) || Boolean(draggingResource);
 
   return (
     <Movable
-      className={`default-movable ${isDragging ? 'dragging' : ''}`}
+      className={`default-movable ${hideHandles ? 'hide-handles' : ''}`}
       zIndex={0}
       ref={moveable}
       target={targetEl}
       draggable={actionsEnabled}
-      resizable={actionsEnabled && !isDragging}
-      rotatable={actionsEnabled && !isDragging}
+      resizable={actionsEnabled && !hideHandles}
+      rotatable={actionsEnabled && !hideHandles}
       onDrag={({ target, beforeTranslate, clientX, clientY }) => {
-        if (!isDragging) {
-          setIsDragging(true);
+        setIsDragging(true);
+        if (isDropSource(selectedElement.type)) {
           setDraggingResource(selectedElement.resource);
         }
         frame.translate = beforeTranslate;
         setTransformStyle(target);
-        if (selectedElement.resource) {
+        if (isDropSource(selectedElement.type)) {
           handleDrag(
             selectedElement.resource,
             clientX,
@@ -196,7 +202,7 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
       onDragStart={({ set }) => {
         set(frame.translate);
       }}
-      onDragEnd={async ({ target }) => {
+      onDragEnd={({ target }) => {
         // When dragging finishes, set the new properties based on the original + what moved meanwhile.
         const [deltaX, deltaY] = frame.translate;
         if (deltaX !== 0 || deltaY !== 0) {
@@ -205,8 +211,8 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
             y: selectedElement.y + editorToDataY(deltaY),
           };
           updateSelectedElements({ properties });
-          if (selectedElement.resource) {
-            await handleDrop(selectedElement.resource, selectedElement.id);
+          if (isDropSource(selectedElement.type)) {
+            handleDrop(selectedElement.resource, selectedElement.id);
           }
         }
         resetDragging(target);
@@ -292,22 +298,16 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
       pinchable={true}
       keepRatio={isResizingFromCorner}
       renderDirections={getRenderDirections(resizeRules)}
-      snappable={canSnap && !snapDisabled}
-      snapCenter={canSnap && !snapDisabled}
+      snappable={canSnap}
+      snapCenter={canSnap}
       horizontalGuidelines={
-        canSnap && !snapDisabled && actionsEnabled
-          ? [0, canvasHeight / 2, canvasHeight]
-          : []
+        canSnap && actionsEnabled ? [0, canvasHeight / 2, canvasHeight] : []
       }
       verticalGuidelines={
-        canSnap && !snapDisabled && actionsEnabled
-          ? [0, canvasWidth / 2, canvasWidth]
-          : []
+        canSnap && actionsEnabled ? [0, canvasWidth / 2, canvasWidth] : []
       }
-      elementGuidelines={
-        canSnap && !snapDisabled && actionsEnabled ? otherNodes : []
-      }
-      snapGap={canSnap && !snapDisabled}
+      elementGuidelines={canSnap && actionsEnabled ? otherNodes : []}
+      snapGap={canSnap}
       isDisplaySnapDigit={true}
     />
   );

--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -162,11 +162,15 @@ function createElementForCanvas(
 
   const element = createNewElement(type, {
     ...attrs,
-    resource: {
-      ...resource,
-      width,
-      height,
-    },
+    ...(resource
+      ? {
+          resource: {
+            ...resource,
+            width,
+            height,
+          },
+        }
+      : {}),
     x,
     y,
     width,

--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -162,15 +162,13 @@ function createElementForCanvas(
 
   const element = createNewElement(type, {
     ...attrs,
-    ...(resource
-      ? {
-          resource: {
-            ...resource,
-            width,
-            height,
-          },
-        }
-      : {}),
+    ...(Boolean(resource) && {
+      resource: {
+        ...resource,
+        width,
+        height,
+      },
+    }),
     x,
     y,
     width,

--- a/assets/src/edit-story/components/movable/moveStyle.js
+++ b/assets/src/edit-story/components/movable/moveStyle.js
@@ -69,8 +69,8 @@ export const GlobalStyle = createGlobalStyle`
 		height: 16px;
 	}
 
-	.default-movable.dragging .moveable-line.moveable-rotation-line,
-	.default-movable.dragging .moveable-line.moveable-direction {
+	.default-movable.hide-handles .moveable-line.moveable-rotation-line,
+	.default-movable.hide-handles .moveable-line.moveable-direction {
 		display: none;
 	}
 `;

--- a/assets/src/edit-story/masks/frame.js
+++ b/assets/src/edit-story/masks/frame.js
@@ -91,7 +91,7 @@ function WithDropTarget({ element, children, hover }) {
           vectorEffect="non-scaling-stroke"
           strokeWidth="4"
           fill="none"
-          stroke="#0063F9"
+          stroke="#0063F9AA"
           strokeLinecap="round"
           strokeLinejoin="round"
           d={mask?.path}

--- a/assets/src/edit-story/masks/frame.js
+++ b/assets/src/edit-story/masks/frame.js
@@ -91,7 +91,7 @@ function WithDropTarget({ element, children, hover }) {
           vectorEffect="non-scaling-stroke"
           strokeWidth="4"
           fill="none"
-          stroke="#0063F9AA"
+          stroke="#0063F9"
           strokeLinecap="round"
           strokeLinejoin="round"
           d={mask?.path}

--- a/assets/src/edit-story/masks/output.js
+++ b/assets/src/edit-story/masks/output.js
@@ -29,7 +29,7 @@ import PropTypes from 'prop-types';
  */
 import StoryPropTypes from '../types';
 import getTransformFlip from '../elements/shared/getTransformFlip';
-import { getElementMask, MaskTypes } from '.';
+import { getElementMask } from '.';
 
 const FILL_STYLE = {
   position: 'absolute',
@@ -57,7 +57,7 @@ export default function WithMask({
       : transformFlip;
   }
 
-  if (!mask?.type || (isBackground && mask.type !== MaskTypes.RECTANGLE)) {
+  if (!mask?.type || isBackground) {
     return (
       <div
         style={{
@@ -81,13 +81,9 @@ export default function WithMask({
       style={{
         ...(fill ? FILL_STYLE : {}),
         ...style,
-        ...(!isBackground
-          ? {
-              clipPath: `url(#${maskId})`,
-              // stylelint-disable-next-line property-no-vendor-prefix
-              WebkitClipPath: `url(#${maskId})`,
-            }
-          : {}),
+        clipPath: `url(#${maskId})`,
+        // stylelint-disable-next-line property-no-vendor-prefix
+        webkitClipPath: `url(#${maskId})`,
       }}
       {...rest}
     >

--- a/assets/src/edit-story/masks/output.js
+++ b/assets/src/edit-story/masks/output.js
@@ -82,8 +82,8 @@ export default function WithMask({
         ...(fill ? FILL_STYLE : {}),
         ...style,
         clipPath: `url(#${maskId})`,
-        // stylelint-disable-next-line property-no-vendor-prefix
-        webkitClipPath: `url(#${maskId})`,
+        // stylelint-disable-next-line
+        WebkitClipPath: `url(#${maskId})`,
       }}
       {...rest}
     >


### PR DESCRIPTION
Closes #920

### Changes
- While dragging, only hide selection box for maskable elements (fixes behavior where text selection box was hidden and snap lines appeared out of context)
- Hide selection box for drop targets to clearly show which elements are drop targets
- Removes need for rectangular masks in output (#920)
- Minor cleanups and consolidation of variables