### PR TITLE
Update font weights names, select nearest font weights changing font family

### DIFF
--- a/assets/src/edit-story/app/font/fontProvider.js
+++ b/assets/src/edit-story/app/font/fontProvider.js
@@ -66,15 +66,15 @@ function FontProvider({ children }) {
   const getFontWeight = useCallback(
     (name) => {
       const fontWeightNames = {
-        100: __('Hairline', 'web-stories'),
-        200: __('Thin', 'web-stories'),
+        100: __('Thin', 'web-stories'),
+        200: __('Extra-light', 'web-stories'),
         300: __('Light', 'web-stories'),
-        400: __('Normal', 'web-stories'),
+        400: __('Regular', 'web-stories'),
         500: __('Medium', 'web-stories'),
-        600: __('Semi bold', 'web-stories'),
+        600: __('Semi-bold', 'web-stories'),
         700: __('Bold', 'web-stories'),
-        800: __('Extra bold', 'web-stories'),
-        900: __('Super bold', 'web-stories'),
+        800: __('Extra-bold', 'web-stories'),
+        900: __('Black', 'web-stories'),
       };
 
       const defaultFontWeights = [{ name: fontWeightNames[400], value: 400 }];

--- a/assets/src/edit-story/components/panels/textStyle/font.js
+++ b/assets/src/edit-story/components/panels/textStyle/font.js
@@ -73,19 +73,14 @@ function FontControls({ selectedElements, pushUpdate }) {
                 ({ value: weight }) => weight
               );
 
-              // The default weight is 400 or empty if there are none available.
-              let defaultWeight = fontWeightsArr?.length ? 400 : '';
-              // If the font doesn't have 400 as an option, let's take the first available option.
-              if (
-                fontWeightsArr?.length &&
-                !fontWeightsArr.includes(defaultWeight.toString())
-              ) {
-                defaultWeight = fontWeightsArr[0];
-              }
               const newFontWeight =
-                fontWeightsArr && fontWeightsArr.includes(String(fontWeight))
-                  ? fontWeight
-                  : defaultWeight;
+                fontWeightsArr &&
+                fontWeightsArr.reduce((a, b) =>
+                  Math.abs(parseInt(b) - fontWeight) <
+                  Math.abs(parseInt(a) - fontWeight)
+                    ? b
+                    : a
+                );
               pushUpdate(
                 {
                   fontFamily: value,

--- a/assets/src/edit-story/components/panels/textStyle/font.js
+++ b/assets/src/edit-story/components/panels/textStyle/font.js
@@ -73,6 +73,8 @@ function FontControls({ selectedElements, pushUpdate }) {
                 ({ value: weight }) => weight
               );
 
+              // Find the nearest font weight from the available font weight list
+              // If no fontweightsArr available then will return undefined
               const newFontWeight =
                 fontWeightsArr &&
                 fontWeightsArr.reduce((a, b) =>


### PR DESCRIPTION
Fixes #670 

- Update font weight names
- Select nearest font weights when changing font family

Check the latest comments for this issues.
https://github.com/google/web-stories-wp/issues/670#issuecomment-606974412