### PR TITLE
Fix multiple warnings and proptype issues

### DIFF
--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -73,6 +73,10 @@ function DisplayElement({ element, previewMode }) {
         ...element,
         type: replacement.type,
         resource: replacement,
+        scale: element.scale || 100,
+        focalX: element.focalX || 50,
+        focalY: element.focalY || 50,
+        isFill: element.isFill || false,
       }
     : null;
 

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -54,6 +54,12 @@ const Wrapper = styled.div`
 	}
 `;
 
+const EmptyFrame = styled.div`
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+`;
+
 function FrameElement({ element }) {
   const { id, type } = element;
   const { Frame, isMaskable } = getDefinitionForType(type);
@@ -109,7 +115,9 @@ function FrameElement({ element }) {
         <WithMask element={element} fill={true}>
           {Frame ? (
             <Frame wrapperRef={elementRef} element={element} box={box} />
-          ) : null}
+          ) : (
+            <EmptyFrame />
+          )}
         </WithMask>
       </WithLink>
     </Wrapper>

--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -98,7 +98,20 @@ function useInsertElement() {
  */
 function createElementForCanvas(
   type,
-  { resource, x, y, width, height, rotationAngle, mask, ...rest }
+  {
+    resource,
+    x,
+    y,
+    width,
+    height,
+    mask,
+    rotationAngle = 0,
+    scale = 100,
+    focalX = 50,
+    focalY = 50,
+    isFill = false,
+    ...rest
+  }
 ) {
   const {
     defaultAttributes,
@@ -167,13 +180,18 @@ function createElementForCanvas(
         ...resource,
         width,
         height,
+        alt: resource.alt || '',
       },
     }),
     x,
     y,
     width,
     height,
-    rotationAngle: rotationAngle || 0,
+    rotationAngle,
+    scale,
+    focalX,
+    focalY,
+    isFill,
     ...(isMaskable
       ? {
           mask: mask || DEFAULT_MASK,

--- a/assets/src/edit-story/components/dropTargets/provider.js
+++ b/assets/src/edit-story/components/dropTargets/provider.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 
 /**
  * Internal dependencies
@@ -77,6 +77,11 @@ function DropTargetsProvider({ children }) {
     return DROP_TARGET_ALLOWED_TYPES.includes(type);
   };
 
+  const activeDropTarget = useMemo(
+    () => currentPage?.elements.find((el) => el.id === activeDropTargetId),
+    [activeDropTargetId, currentPage]
+  );
+
   /**
    * Dragging elements
    */
@@ -128,9 +133,24 @@ function DropTargetsProvider({ children }) {
       if (!activeDropTargetId || activeDropTargetId === selfId) {
         return;
       }
+
+      const {
+        scale = 100,
+        focalX = 50,
+        focalY = 50,
+        isFill = false,
+      } = activeDropTarget;
+
       updateElementById({
         elementId: activeDropTargetId,
-        properties: { resource, type: resource.type },
+        properties: {
+          resource,
+          type: resource.type,
+          scale,
+          focalX,
+          focalY,
+          isFill,
+        },
       });
 
       // Reset styles on visisble elements
@@ -156,6 +176,7 @@ function DropTargetsProvider({ children }) {
       setActiveDropTargetId(null);
     },
     [
+      activeDropTarget,
       activeDropTargetId,
       currentPage,
       dropTargets,

--- a/assets/src/edit-story/elements/media/edit.js
+++ b/assets/src/edit-story/elements/media/edit.js
@@ -143,7 +143,7 @@ function MediaEdit({ element, box }) {
         </FadedVideo>
       )}
       <CropBox ref={setCropBox}>
-        <WithMask element={element} fill={true} applyFlip={false}>
+        <WithMask element={element} fill={true} applyFlip={false} box={box}>
           {isImage && <CropImage {...cropMediaProps} />}
           {isVideo && (
             <CropVideo {...cropMediaProps}>

--- a/assets/src/edit-story/output/page.js
+++ b/assets/src/edit-story/output/page.js
@@ -140,7 +140,7 @@ function OutputPage({ page, autoAdvance, defaultPageDuration }) {
 
 OutputPage.propTypes = {
   page: StoryPropTypes.page.isRequired,
-  autoAdvance: PropTypes.bool.isRequired,
+  autoAdvance: PropTypes.bool,
   defaultPageDuration: PropTypes.number,
 };
 

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -158,32 +158,36 @@ const StoryElementPropTypes = {
   opacity: PropTypes.number,
 };
 
+const StoryMediaPropTypes = {
+  scale: PropTypes.number.isRequired,
+  focalX: PropTypes.number,
+  focalY: PropTypes.number,
+};
+
 StoryPropTypes.element = PropTypes.shape(StoryElementPropTypes);
 
 StoryPropTypes.layer = PropTypes.shape(StoryLayerPropTypes);
 
 StoryPropTypes.elements = {};
 
-StoryPropTypes.elements.media = PropTypes.shape({
-  ...StoryElementPropTypes,
-  scale: PropTypes.number.isRequired,
-  focalX: PropTypes.number,
-  focalY: PropTypes.number,
-});
-
 StoryPropTypes.elements.image = PropTypes.shape({
   ...StoryElementPropTypes,
-  ...StoryPropTypes.elements.media,
+  ...StoryMediaPropTypes,
   resource: StoryPropTypes.imageResource,
 });
 
 StoryPropTypes.elements.video = PropTypes.shape({
   ...StoryElementPropTypes,
-  ...StoryPropTypes.elements.media,
+  ...StoryMediaPropTypes,
   resource: StoryPropTypes.videoResource,
   poster: PropTypes.string,
   loop: PropTypes.bool,
 });
+
+StoryPropTypes.elements.media = PropTypes.oneOfType([
+  StoryPropTypes.elements.image,
+  StoryPropTypes.elements.video,
+]);
 
 StoryPropTypes.elements.text = PropTypes.shape({
   ...StoryElementPropTypes,

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -65,7 +65,7 @@ StoryPropTypes.story = PropTypes.shape({
   excerpt: PropTypes.string.isRequired,
   featuredMedia: PropTypes.number.isRequired,
   password: PropTypes.string.isRequired,
-  autoAdvance: PropTypes.bool.isRequired,
+  autoAdvance: PropTypes.bool,
   defaultPageDuration: PropTypes.number,
 });
 


### PR DESCRIPTION
Closes #381 
Closes #807

### Changes
- Fixes multiple missing defaults (`scale`, `focalX`, `focalY`, `isFill`) and preserve them when using drop targets on an existing element
- Fixes PropType mismatch coming from #524 
- Fixes warning about `WithMasks` missing `children`