### PR TITLE
Move Calendar to floating sidebar

### DIFF
--- a/assets/src/edit-story/components/form/color/colorPreview.js
+++ b/assets/src/edit-story/components/form/color/colorPreview.js
@@ -33,6 +33,7 @@ import { __, _x } from '@wordpress/i18n';
 import { PatternPropType } from '../../../types';
 import { useSidebar } from '../../sidebar';
 import MULTIPLE_VALUE from '../multipleValue';
+import ColorPicker from '../../colorPicker';
 import getPreviewText from './getPreviewText';
 import getPreviewStyle from './getPreviewStyle';
 import ColorBox from './colorBox';
@@ -79,28 +80,25 @@ function ColorPreview({ onChange, hasGradient, hasOpacity, value, label }) {
   const previewText = getPreviewText(value);
 
   const {
-    actions: { showColorPickerAt, hideSidebar },
+    actions: { showSidebarAt, hideSidebar },
   } = useSidebar();
 
   const ref = useRef();
 
-  const handleOpenEditing = useCallback(() => {
-    showColorPickerAt(ref.current, {
+  const displayColorPicker = useCallback(() => {
+    const props = {
       color: isMultiple ? null : value,
       onChange,
       hasGradient,
       hasOpacity,
       onClose: hideSidebar,
-    });
-  }, [
-    showColorPickerAt,
-    hideSidebar,
-    isMultiple,
-    value,
-    onChange,
-    hasGradient,
-    hasOpacity,
-  ]);
+    };
+    return <ColorPicker {...props} />;
+  }, [hasGradient, hasOpacity, hideSidebar, isMultiple, onChange, value]);
+
+  const handleOpenEditing = useCallback(() => {
+    showSidebarAt(ref.current, displayColorPicker);
+  }, [showSidebarAt, displayColorPicker]);
 
   const [hexInputValue, setHexInputValue] = useState('');
 

--- a/assets/src/edit-story/components/form/color/test/colorPreview.js
+++ b/assets/src/edit-story/components/form/color/test/colorPreview.js
@@ -37,7 +37,7 @@ jest.mock('../getPreviewText', () => jest.fn());
 function arrange(children = null) {
   const sidebarContextValue = {
     actions: {
-      showColorPickerAt: jest.fn(),
+      showSidebarAt: jest.fn(),
       hideSidebar: jest.fn(),
     },
   };
@@ -141,7 +141,7 @@ describe('<ColorPreview />', () => {
     const onChange = jest.fn();
     const onClose = jest.fn();
     const value = { a: 1 };
-    const { button, showColorPickerAt, hideSidebar } = arrange(
+    const { button, showSidebarAt } = arrange(
       <ColorPreview
         onChange={onChange}
         value={value}
@@ -154,37 +154,10 @@ describe('<ColorPreview />', () => {
 
     fireEvent.click(button);
 
-    expect(showColorPickerAt).toHaveBeenCalledWith(expect.any(Object), {
-      color: value,
-      onChange,
-      hasGradient: true,
-      hasOpacity: false,
-      onClose: hideSidebar,
-    });
-  });
-
-  it('should invoke callback correctly if multiple', () => {
-    const onChange = jest.fn();
-    const onClose = jest.fn();
-    const { button, showColorPickerAt, hideSidebar } = arrange(
-      <ColorPreview
-        onChange={onChange}
-        value={MULTIPLE_VALUE}
-        hasGradient
-        onClose={onClose}
-        label="Color"
-      />
+    expect(showSidebarAt).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Function)
     );
-
-    fireEvent.click(button);
-
-    expect(showColorPickerAt).toHaveBeenCalledWith(expect.any(Object), {
-      color: null,
-      onChange,
-      hasGradient: true,
-      hasOpacity: true,
-      onClose: hideSidebar,
-    });
   });
 
   it('should invoke onChange when inputting valid hex', () => {

--- a/assets/src/edit-story/components/form/dateTime/index.js
+++ b/assets/src/edit-story/components/form/dateTime/index.js
@@ -8,28 +8,26 @@
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { rgba } from 'polished';
+import { useRef } from 'react';
 
 /**
  * Internal dependencies
  */
+import useFocusOut from '../../../utils/useFocusOut';
 import DateTimePicker from './dateTimePicker';
 import DatePicker from './datePicker';
 
 const DateTimeWrapper = styled.div`
-  position: absolute;
-  top: 0;
-  left: -15px;
   box-shadow: 0 3px 30px rgba(25, 30, 35, 0.1);
   border: 1px solid ${({ theme }) => rgba(theme.colors.bg.v0, 0.2)};
   background-color: ${({ theme }) => theme.colors.fg.v1};
-  z-index: 1;
-  width: 270px;
-  padding: 4px;
 `;
 
-function DateTime({ value, onChange, is12Hour = true, forwardedRef }) {
+function DateTime({ value, onChange, is12Hour = true, onClose }) {
+  const containerRef = useRef();
+  useFocusOut(containerRef, onClose);
   return (
-    <DateTimeWrapper ref={forwardedRef}>
+    <DateTimeWrapper ref={containerRef}>
       <DateTimePicker
         currentTime={value}
         onChange={onChange}
@@ -44,7 +42,7 @@ DateTime.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string,
   is12Hour: PropTypes.bool,
-  forwardedRef: PropTypes.object,
+  onClose: PropTypes.func,
 };
 
 export default DateTime;

--- a/assets/src/edit-story/components/inspector/document/publish/index.js
+++ b/assets/src/edit-story/components/inspector/document/publish/index.js
@@ -29,7 +29,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Row, DropDown, Label, Media, Required } from '../../../form';
+import { Row, DropDown, Label, Media, Required, DateTime } from '../../../form';
 import { SimplePanel } from '../../../panels/panel';
 import useInspector from '../../../inspector/useInspector';
 import { useStory } from '../../../../app/story';
@@ -101,7 +101,7 @@ function PublishPanel() {
   } = useStory();
 
   const {
-    actions: { showCalendarAt, hideSidebar },
+    actions: { showSidebarAt, hideSidebar },
     state: { hasSidebar },
   } = useSidebar();
 
@@ -133,14 +133,20 @@ function PublishPanel() {
   );
 
   const use12HourFormat = is12Hour(timeFormat);
-  const handleOpenCalendar = useCallback(() => {
-    showCalendarAt(dateFieldNode.current, {
+
+  const displayCalendar = useCallback(() => {
+    const props = {
       value: date,
       onChange: handleDateChange,
       is12Hour: use12HourFormat,
       onClose: hideSidebar,
-    });
-  }, [showCalendarAt, date, handleDateChange, use12HourFormat, hideSidebar]);
+    };
+    return <DateTime {...props} />;
+  }, [date, handleDateChange, hideSidebar, use12HourFormat]);
+
+  const handleOpenCalendar = useCallback(() => {
+    showSidebarAt(dateFieldNode.current, displayCalendar);
+  }, [showSidebarAt, displayCalendar]);
 
   const handleChangeCover = useCallback(
     (image) =>

--- a/assets/src/edit-story/components/inspector/document/test/publish.js
+++ b/assets/src/edit-story/components/inspector/document/test/publish.js
@@ -27,6 +27,7 @@ import StoryContext from '../../../../app/story/context';
 import InspectorContext from '../../../inspector/context';
 import theme from '../../../../theme';
 import PublishPanel from '../publish';
+import SidebarContext from '../../../sidebar/context';
 
 function setupPanel(
   capabilities = {
@@ -52,19 +53,32 @@ function setupPanel(
       users: [{ value: 'foo' }, { value: 'bar' }],
     },
   };
-  const { getByText, getByRole, queryByText } = render(
+
+  const showSidebarAt = jest.fn();
+  const sidebarContextValue = {
+    state: {
+      hasSidebar: false,
+    },
+    actions: {
+      showSidebarAt,
+      hideSidebar: jest.fn(),
+    },
+  };
+  const { getByText, queryByText } = render(
     <ThemeProvider theme={theme}>
       <StoryContext.Provider value={storyContextValue}>
         <InspectorContext.Provider value={inspectorContextValue}>
-          <PublishPanel />
+          <SidebarContext.Provider value={sidebarContextValue}>
+            <PublishPanel />
+          </SidebarContext.Provider>
         </InspectorContext.Provider>
       </StoryContext.Provider>
     </ThemeProvider>
   );
   return {
     getByText,
-    getByRole,
     queryByText,
+    showSidebarAt,
   };
 }
 
@@ -92,12 +106,14 @@ describe('PublishPanel', () => {
     expect(element).toBeNull();
   });
 
-  it('should open Date picker when clicking on date', () => {
-    const { getByText, getByRole } = setupPanel();
+  it('should open sidebar when clicking on the date field', () => {
+    const { getByText, showSidebarAt } = setupPanel();
     const element = getByText('01/01/2020');
 
     fireEvent.click(element);
-    const calendar = getByRole('application');
-    expect(calendar).toBeDefined();
+    expect(showSidebarAt).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.any(Function)
+    );
   });
 });

--- a/assets/src/edit-story/components/reorderable/useScroll.js
+++ b/assets/src/edit-story/components/reorderable/useScroll.js
@@ -33,7 +33,7 @@ function useScroll(isReordering) {
   const scrollTarget = useRef(null);
 
   const setScrollTarget = useCallback(
-    (node) => (scrollTarget.current = node.parentElement),
+    (node) => node && (scrollTarget.current = node.parentElement),
     []
   );
 

--- a/assets/src/edit-story/components/sidebar/provider.js
+++ b/assets/src/edit-story/components/sidebar/provider.js
@@ -24,8 +24,6 @@ import { useState, useCallback, useRef } from 'react';
 /**
  * Internal dependencies
  */
-import ColorPicker from '../../components/colorPicker';
-import DateTime from '../form/dateTime';
 import { WorkspaceLayout, CanvasArea } from '../workspace/layout';
 import Context from './context';
 
@@ -48,36 +46,22 @@ const SidebarContent = styled.div`
   top: ${({ top }) => `${top}px`};
 `;
 
-const TYPE_COLORPICKER = 'colorpicker';
-const TYPE_CALENDAR = 'calendar';
-
 function SidebarProvider({ children }) {
   const [sidebarState, setSidebarState] = useState(null);
 
   const hasSidebar = sidebarState !== null;
   const offset = hasSidebar && sidebarState.offset;
-  const type = hasSidebar && sidebarState.type;
-  const props = hasSidebar && sidebarState.props;
 
   const ref = useRef();
 
-  const showSidebarAt = useCallback((sidebarType, node, sidebarProps) => {
+  const showSidebarAt = useCallback((node, displayContent) => {
     const sidebarOffset =
       node.getBoundingClientRect().y - ref.current.getBoundingClientRect().y;
     setSidebarState({
-      type: sidebarType,
       offset: sidebarOffset,
-      props: sidebarProps,
+      displayContent,
     });
   }, []);
-
-  const showColorPickerAt = (node, colorProps) => {
-    showSidebarAt(TYPE_COLORPICKER, node, colorProps);
-  };
-
-  const showCalendarAt = (node, calendarProps) => {
-    showSidebarAt(TYPE_CALENDAR, node, calendarProps);
-  };
 
   const hideSidebar = useCallback(() => {
     setSidebarState(null);
@@ -88,8 +72,7 @@ function SidebarProvider({ children }) {
       hasSidebar,
     },
     actions: {
-      showColorPickerAt,
-      showCalendarAt,
+      showSidebarAt,
       hideSidebar,
     },
   };
@@ -100,8 +83,7 @@ function SidebarProvider({ children }) {
         <Sidebar ref={ref}>
           {hasSidebar && (
             <SidebarContent top={offset}>
-              {type === TYPE_COLORPICKER && <ColorPicker {...props} />}
-              {type === TYPE_CALENDAR && <DateTime {...props} />}
+              {sidebarState.displayContent && sidebarState.displayContent()}
             </SidebarContent>
           )}
         </Sidebar>

--- a/assets/src/edit-story/components/sidebar/provider.js
+++ b/assets/src/edit-story/components/sidebar/provider.js
@@ -25,6 +25,7 @@ import { useState, useCallback, useRef } from 'react';
  * Internal dependencies
  */
 import ColorPicker from '../../components/colorPicker';
+import DateTime from '../form/dateTime';
 import { WorkspaceLayout, CanvasArea } from '../workspace/layout';
 import Context from './context';
 
@@ -48,6 +49,7 @@ const SidebarContent = styled.div`
 `;
 
 const TYPE_COLORPICKER = 'colorpicker';
+const TYPE_CALENDAR = 'calendar';
 
 function SidebarProvider({ children }) {
   const [sidebarState, setSidebarState] = useState(null);
@@ -59,15 +61,23 @@ function SidebarProvider({ children }) {
 
   const ref = useRef();
 
-  const showColorPickerAt = useCallback((node, colorProps) => {
-    const colorOffset =
+  const showSidebarAt = useCallback((sidebarType, node, sidebarProps) => {
+    const sidebarOffset =
       node.getBoundingClientRect().y - ref.current.getBoundingClientRect().y;
     setSidebarState({
-      type: TYPE_COLORPICKER,
-      offset: colorOffset,
-      props: colorProps,
+      type: sidebarType,
+      offset: sidebarOffset,
+      props: sidebarProps,
     });
   }, []);
+
+  const showColorPickerAt = (node, colorProps) => {
+    showSidebarAt(TYPE_COLORPICKER, node, colorProps);
+  };
+
+  const showCalendarAt = (node, calendarProps) => {
+    showSidebarAt(TYPE_CALENDAR, node, calendarProps);
+  };
 
   const hideSidebar = useCallback(() => {
     setSidebarState(null);
@@ -79,6 +89,7 @@ function SidebarProvider({ children }) {
     },
     actions: {
       showColorPickerAt,
+      showCalendarAt,
       hideSidebar,
     },
   };
@@ -90,6 +101,7 @@ function SidebarProvider({ children }) {
           {hasSidebar && (
             <SidebarContent top={offset}>
               {type === TYPE_COLORPICKER && <ColorPicker {...props} />}
+              {type === TYPE_CALENDAR && <DateTime {...props} />}
             </SidebarContent>
           )}
         </Sidebar>


### PR DESCRIPTION

Moves calendar to the floating sidebar and reworks `useSidebar` to not depend on the components that are rendered in the content.