### PR TITLE
Custom scrollbars to match with rest of editor

### DIFF
--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -38,6 +38,32 @@ const Editor = styled.div`
   letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing};
   background-color: ${({ theme }) => theme.colors.bg.v1};
 
+  /*
+   * Custom dark scrollbars for Chromium & Firefox.
+   * Scoped to <Editor> to make sure we don't mess with WP dialogs
+   * like the Backbone Media Gallery dialog.
+   */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: ${({ theme }) => theme.colors.bg.v10}
+      ${({ theme }) => theme.colors.bg.v3};
+  }
+
+  *::-webkit-scrollbar {
+    width: 11px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: ${({ theme }) => theme.colors.bg.v3};
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background-color: ${({ theme }) => theme.colors.bg.v10};
+    border: 2px solid ${({ theme }) => theme.colors.bg.v3};
+    border-left-width: 3px;
+    border-radius: 6px;
+  }
+
   position: relative;
   height: 100%;
   width: 100%;

--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -29,6 +29,7 @@ import {
   LIBRARY_MIN_WIDTH,
   LIBRARY_MAX_WIDTH,
   INSPECTOR_MIN_WIDTH,
+  SCROLLBAR_WIDTH,
 } from '../../constants';
 
 const Editor = styled.div`
@@ -50,7 +51,8 @@ const Editor = styled.div`
   }
 
   *::-webkit-scrollbar {
-    width: 11px;
+    width: ${SCROLLBAR_WIDTH}px;
+    height: ${SCROLLBAR_WIDTH}px;
   }
 
   *::-webkit-scrollbar-track {
@@ -61,6 +63,7 @@ const Editor = styled.div`
     background-color: ${({ theme }) => theme.colors.bg.v10};
     border: 2px solid ${({ theme }) => theme.colors.bg.v3};
     border-left-width: 3px;
+    border-top-width: 3px;
     border-radius: 6px;
   }
 

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -46,12 +46,11 @@ import {
   CAROUSEL_VERTICAL_PADDING,
 } from '../layout';
 import DropZoneProvider from '../../dropzone/dropZoneProvider';
-import { PAGE_WIDTH, PAGE_HEIGHT } from '../../../constants';
+import { PAGE_WIDTH, PAGE_HEIGHT, SCROLLBAR_WIDTH } from '../../../constants';
 import { THUMB_FRAME_HEIGHT, THUMB_FRAME_WIDTH } from '../pagepreview';
 import CompactIndicator from './compactIndicator';
 
 const CAROUSEL_BOTTOM_SCROLL_MARGIN = 8;
-const SCROLLBAR_HEIGHT = 8;
 
 const Wrapper = styled.div`
   position: relative;
@@ -117,18 +116,21 @@ const List = styled(Area).attrs({
   overflow-x: scroll;
   overflow-y: hidden;
   margin: 0 0 ${CAROUSEL_BOTTOM_SCROLL_MARGIN}px 0;
-  scrollbar-color: rgba(255, 255, 255, 0.54) transparent;
-  scrollbar-width: auto;
-  &::-webkit-scrollbar {
-    width: ${SCROLLBAR_HEIGHT}px;
-    height: ${SCROLLBAR_HEIGHT}px;
-  }
+
+  /*
+   * These overrides are an exception - generally scrollbars should all
+   * look the same. We do this only here because this scrollbar is always visible.
+   * /
+  scrollbar-color: ${({ theme }) => theme.colors.bg.v10}
+    ${({ theme }) => theme.colors.bg.v1} !important;
+
   &::-webkit-scrollbar-track {
-    background-color: transparent;
+    background: ${({ theme }) => theme.colors.bg.v1} !important;
   }
+
   &::-webkit-scrollbar-thumb {
-    background-color: rgba(255, 255, 255, 0.54);
-    border-radius: ${SCROLLBAR_HEIGHT * 2}px;
+    border: 2px solid ${({ theme }) => theme.colors.bg.v1} !important;
+    border-top-width: 3px !important;
   }
 `;
 
@@ -255,7 +257,7 @@ function Carousel() {
     [carouselSize]
   );
   const arrowsBottomMargin = isCompact
-    ? CAROUSEL_BOTTOM_SCROLL_MARGIN + SCROLLBAR_HEIGHT
+    ? CAROUSEL_BOTTOM_SCROLL_MARGIN + SCROLLBAR_WIDTH
     : CAROUSEL_BOTTOM_SCROLL_MARGIN;
 
   return (

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -120,7 +120,7 @@ const List = styled(Area).attrs({
   /*
    * These overrides are an exception - generally scrollbars should all
    * look the same. We do this only here because this scrollbar is always visible.
-   * /
+   */
   scrollbar-color: ${({ theme }) => theme.colors.bg.v10}
     ${({ theme }) => theme.colors.bg.v1} !important;
 

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -16,6 +16,7 @@
 
 export const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
 
+export const SCROLLBAR_WIDTH = 11;
 export const ADMIN_TOOLBAR_HEIGHT = 32;
 export const HEADER_HEIGHT = 48;
 export const CANVAS_MIN_WIDTH = 480;


### PR DESCRIPTION
Turns out I was able to make scrollbars dramatically nicer for browsers that support it, after all (Chromium, Firefox for now):

![image](https://user-images.githubusercontent.com/43004/78175402-a6345380-740f-11ea-8119-140c7ea4cb47.png)

/cc @samitron7, let me know if you would style them differently (can be a follow up to this PR though).