### PR TITLE
Fixes a couple of bugs surrounding text edit component and colors.

### DIFF
--- a/assets/src/edit-story/elements/text/edit.js
+++ b/assets/src/edit-story/elements/text/edit.js
@@ -118,7 +118,11 @@ function TextEdit({
         rest.lineHeight,
         dataToEditorX(rest.padding?.vertical || 0)
       ),
+      color: createSolid(0, 0, 0),
       backgroundColor: createSolid(255, 255, 255),
+    }),
+    ...(backgroundTextMode === BACKGROUND_TEXT_MODE.NONE && {
+      backgroundColor: null,
     }),
   };
   const wrapperRef = useRef(null);


### PR DESCRIPTION
Fixes #944 by defaulting color to be white-on-black when editing a highlight-text node.

Fixes #945 by always removing the background when text fill mode is set to `NONE`.