### PR TITLE
Ignore background color when text mode is set to transparent bg

### DIFF
--- a/assets/src/edit-story/elements/shared/index.js
+++ b/assets/src/edit-story/elements/shared/index.js
@@ -22,7 +22,6 @@ import { css } from 'styled-components';
 /**
  * Internal dependencies
  */
-import { BACKGROUND_TEXT_MODE } from '../../constants';
 import generatePatternStyles from '../../utils/generatePatternStyles';
 import convertToCSS from '../../utils/convertToCSS';
 
@@ -51,10 +50,8 @@ export const elementWithRotation = css`
 `;
 
 export const elementWithBackgroundColor = css`
-  ${({ backgroundColor, backgroundTextMode }) =>
-    backgroundTextMode === BACKGROUND_TEXT_MODE.NONE
-      ? ''
-      : convertToCSS(generatePatternStyles(backgroundColor))};
+  ${({ backgroundColor }) =>
+    convertToCSS(generatePatternStyles(backgroundColor))};
 `;
 
 export const elementWithFontColor = css`

--- a/assets/src/edit-story/elements/shared/index.js
+++ b/assets/src/edit-story/elements/shared/index.js
@@ -22,6 +22,7 @@ import { css } from 'styled-components';
 /**
  * Internal dependencies
  */
+import { BACKGROUND_TEXT_MODE } from '../../constants';
 import generatePatternStyles from '../../utils/generatePatternStyles';
 import convertToCSS from '../../utils/convertToCSS';
 
@@ -50,8 +51,10 @@ export const elementWithRotation = css`
 `;
 
 export const elementWithBackgroundColor = css`
-  ${({ backgroundColor }) =>
-    convertToCSS(generatePatternStyles(backgroundColor))};
+  ${({ backgroundColor, backgroundTextMode }) =>
+    backgroundTextMode === BACKGROUND_TEXT_MODE.NONE
+      ? ''
+      : convertToCSS(generatePatternStyles(backgroundColor))};
 `;
 
 export const elementWithFontColor = css`

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -111,6 +111,7 @@ function TextDisplay({
   const props = {
     color,
     backgroundColor,
+    backgroundTextMode,
     ...generateParagraphTextStyle(rest, dataToEditorX, dataToEditorY),
     horizontalBuffer: 0.01 * pageWidth,
     horizontalPadding: dataToEditorX(rest.padding?.horizontal || 0),

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -110,8 +110,9 @@ function TextDisplay({
 
   const props = {
     color,
-    backgroundColor,
-    backgroundTextMode,
+    ...(backgroundTextMode === BACKGROUND_TEXT_MODE.NONE
+      ? {}
+      : { backgroundColor }),
     ...generateParagraphTextStyle(rest, dataToEditorX, dataToEditorY),
     horizontalBuffer: 0.01 * pageWidth,
     horizontalPadding: dataToEditorX(rest.padding?.horizontal || 0),

--- a/assets/src/edit-story/elements/text/output.js
+++ b/assets/src/edit-story/elements/text/output.js
@@ -65,7 +65,9 @@ export function TextOutputWithUnits({
       dataToStyleY,
       dataToFontSizeY
     ),
-    ...generatePatternStyles(backgroundColor),
+    ...(backgroundTextMode === BACKGROUND_TEXT_MODE.NONE
+      ? {}
+      : generatePatternStyles(backgroundColor)),
     ...generatePatternStyles(color, 'color'),
     padding: `${paddingStyles.vertical} ${paddingStyles.horizontal}`,
   };

--- a/assets/src/edit-story/elements/text/output.js
+++ b/assets/src/edit-story/elements/text/output.js
@@ -58,6 +58,12 @@ export function TextOutputWithUnits({
     vertical: `${(padding.vertical / width) * 100}%`,
     horizontal: `${(padding.horizontal / width) * 100}%`,
   };
+
+  const bgColor =
+    backgroundTextMode !== BACKGROUND_TEXT_MODE.NONE
+      ? generatePatternStyles(backgroundColor)
+      : undefined;
+
   const fillStyle = {
     ...generateParagraphTextStyle(
       rest,
@@ -65,17 +71,10 @@ export function TextOutputWithUnits({
       dataToStyleY,
       dataToFontSizeY
     ),
-    ...(backgroundTextMode === BACKGROUND_TEXT_MODE.NONE
-      ? {}
-      : generatePatternStyles(backgroundColor)),
     ...generatePatternStyles(color, 'color'),
+    ...bgColor,
     padding: `${paddingStyles.vertical} ${paddingStyles.horizontal}`,
   };
-
-  const bgColor =
-    backgroundTextMode !== BACKGROUND_TEXT_MODE.NONE
-      ? generatePatternStyles(backgroundColor)
-      : undefined;
 
   const unitlessPaddingVertical = parseFloat(dataToStyleY(padding.vertical));
   const unitlessFontSize = parseFloat(dataToStyleY(rest.fontSize));


### PR DESCRIPTION
Fixes #959 by rendering no background when fill mode is `NONE`