### PR TITLE
Dashboard: My Stories Search (part 3, apiProvider update)

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -58,13 +58,12 @@ export default function ApiProvider({ children }) {
         return [];
       }
       const perPage = '100'; // TODO set up pagination
-      const query = searchTerm
-        ? {
-            status,
-            search: `${searchTerm}`,
-            per_page: perPage,
-          }
-        : { status, per_page: perPage, context: 'edit' };
+      const query = {
+        status,
+        per_page: perPage,
+        context: 'edit',
+        search: searchTerm || undefined,
+      };
 
       try {
         const path = queryString.stringifyUrl({

--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -53,16 +53,25 @@ export default function ApiProvider({ children }) {
   const [stories, setStories] = useState([]);
 
   const fetchStories = useCallback(
-    async ({ status = STORY_STATUSES[0].value }) => {
+    async ({ status = STORY_STATUSES[0].value, searchTerm }) => {
       if (!api.stories) {
         return [];
       }
+      const perPage = '100'; // TODO set up pagination
+      const query = searchTerm
+        ? {
+            status,
+            search: `${searchTerm}`,
+            per_page: perPage,
+          }
+        : { status, per_page: perPage, context: 'edit' };
 
       try {
         const path = queryString.stringifyUrl({
           url: api.stories,
-          query: { status, context: 'edit' },
+          query,
         });
+
         const serverStoryResponse = await apiFetch({
           path,
         });

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -70,8 +70,8 @@ function MyStories() {
   } = useContext(ApiContext);
 
   useEffect(() => {
-    fetchStories({ status });
-  }, [fetchStories, status]);
+    fetchStories({ status, searchTerm: typeaheadValue });
+  }, [fetchStories, status, typeaheadValue]);
 
   const filteredStories = useMemo(() => {
     return stories.filter((story) => {


### PR DESCRIPTION
Please note: this PR will follow #954 (https://github.com/google/web-stories-wp/pull/954/files) 

# Overview 
- update apiProvider to pass optional `searchTerm` to fetch stories. 
- Adding queries for better immediate usage (ie, default page limit is 10, which gets weird when you're testing things and not seeing results). 

## TODO  
- pagination set up
- error handling (templates come back as an error)
- Configuring to get counts of type (right now our current set up is too minimal to get the total number of stories by status) 

## Testing 
- See that stories are still coming into my stories appropriately 
- Filter and see that your stories are coming in accurately 