### PR TITLE
Disable functionality that has not been implemented yet.

### DIFF
--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -319,6 +319,7 @@ function Carousel() {
               <KeyboardShortcutsButton
                 width="24"
                 height="24"
+                isDisabled={true}
                 aria-label={__('Keyboard Shortcuts', 'web-stories')}
               />
             </OverflowButtons>

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -319,7 +319,7 @@ function Carousel() {
               <KeyboardShortcutsButton
                 width="24"
                 height="24"
-                isDisabled={true}
+                isDisabled
                 aria-label={__('Keyboard Shortcuts', 'web-stories')}
               />
             </OverflowButtons>

--- a/assets/src/edit-story/components/library/common/searchInput.js
+++ b/assets/src/edit-story/components/library/common/searchInput.js
@@ -44,10 +44,20 @@ const Search = styled.input.attrs({ type: 'text' })`
   }
 `;
 
-export default function SearchInput({ value, placeholder, onChange }) {
+export default function SearchInput({
+  value,
+  placeholder,
+  onChange,
+  disabled,
+}) {
   return (
     <SearchField>
-      <Search value={value} placeholder={placeholder} onChange={onChange} />
+      <Search
+        value={value}
+        placeholder={placeholder}
+        onChange={onChange}
+        disabled={disabled}
+      />
     </SearchField>
   );
 }
@@ -56,4 +66,9 @@ SearchInput.propTypes = {
   value: PropTypes.string.isRequired,
   placeholder: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+SearchInput.defaultProps = {
+  disabled: false,
 };

--- a/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
+++ b/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
@@ -68,7 +68,7 @@ function ShapesPane(props) {
         value={''}
         placeholder={__('Search', 'web-stories')}
         onChange={() => {}}
-        disabled={true}
+        disabled
       />
       <Section title={__('Basic shapes', 'web-stories')}>
         <SectionContent>

--- a/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
+++ b/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
@@ -68,6 +68,7 @@ function ShapesPane(props) {
         value={''}
         placeholder={__('Search', 'web-stories')}
         onChange={() => {}}
+        disabled={true}
       />
       <Section title={__('Basic shapes', 'web-stories')}>
         <SectionContent>

--- a/assets/src/edit-story/components/library/panes/text/textPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textPane.js
@@ -20,6 +20,11 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
  * Internal dependencies
  */
 import { PAGE_WIDTH } from '../../../../constants';
@@ -67,6 +72,8 @@ function getPresetById(id) {
   return null;
 }
 
+const SectionContent = styled.p``;
+
 function TextPane(props) {
   const {
     actions: { insertElement },
@@ -77,7 +84,7 @@ function TextPane(props) {
         value={''}
         placeholder={__('Search', 'web-stories')}
         onChange={() => {}}
-        disabled={true}
+        disabled
       />
 
       <Section
@@ -112,8 +119,9 @@ function TextPane(props) {
           />
         ))}
       </Section>
-      <Section title={__('Text Sets', 'web-stories')} />
-      {__('Coming soon.', 'web-stories')}
+      <Section title={__('Text Sets', 'web-stories')}>
+        <SectionContent>{__('Coming soon.', 'web-stories')}</SectionContent>
+      </Section>
     </Pane>
   );
 }

--- a/assets/src/edit-story/components/library/panes/text/textPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textPane.js
@@ -77,6 +77,7 @@ function TextPane(props) {
         value={''}
         placeholder={__('Search', 'web-stories')}
         onChange={() => {}}
+        disabled={true}
       />
 
       <Section
@@ -112,6 +113,7 @@ function TextPane(props) {
         ))}
       </Section>
       <Section title={__('Text Sets', 'web-stories')} />
+      {__('Coming soon.', 'web-stories')}
     </Pane>
   );
 }


### PR DESCRIPTION
Follow up from #520

Removed to more functionality that is not implemented. 

This includes.

- Keyboard shortcut icon ( does nothing when clicked ). 
- Search field in Text tab of library ( does nothing text entered ). 
- Text sets ( nothing displayed ).
- Search field in Shape tab of library ( does nothing text entered ). 
