### PR TITLE
AMP Validation: Fix `font-fallback` inline style appearing for text elements

### DIFF
--- a/assets/src/edit-story/elements/text/util.js
+++ b/assets/src/edit-story/elements/text/util.js
@@ -50,7 +50,6 @@ export function generateParagraphTextStyle(
     whiteSpace: 'pre-wrap',
     margin: 0,
     fontFamily: generateFontFamily(fontFamily, fontFallback),
-    fontFallback,
     fontSize: dataToFontSizeY(fontSize),
     fontStyle,
     fontWeight,


### PR DESCRIPTION
Right now I get frontend output like this:

```html
<p class="fill" style="white-space:pre-wrap;margin:0;font-family:Arial,Helvetica Neue,Helvetica,sans-serif;font-fallback:Helvetica Neue,Helvetica,sans-serif;font-size:0.606061em;font-style:normal;font-weight:400;line-height:calc(
    1.3em
    -
    0em
  );letter-spacing:0em;text-align:center;text-decoration:none;padding:0;color:#e3e9eb;background-color:#187b9e;background:none"><span style="display:inline-block;position:relative;margin:0 calc(2.3255813953488373% + 2%);left:calc(-2.3255813953488373% - 2%);top:0"><span style="background-color:#187b9e;-webkit-box-decoration-break:clone;box-decoration-break:clone;border-radius:3px;position:relative;padding:0% 2.3255813953488373%;color:transparent">Chicago
The Windy City</span></span></p>
```

A bunch of things not ideal here, but this PR addresses the `font-fallback` property. Not valid CSS, not valid AMP.

AMP validator flags this immediately.

See #989