### PR TITLE
Minimum element sizes

### DIFF
--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -63,7 +63,7 @@ const EmptyFrame = styled.div`
 
 function FrameElement({ element }) {
   const { id, type } = element;
-  const { Frame, isMaskable } = getDefinitionForType(type);
+  const { Frame, isMaskable, Controls } = getDefinitionForType(type);
   const elementRef = useRef();
 
   const {
@@ -76,7 +76,7 @@ function FrameElement({ element }) {
     actions: { getBox },
   } = useUnits();
   const {
-    state: { activeDropTargetId },
+    state: { activeDropTargetId, draggingResource },
   } = useDropTargets();
 
   useLayoutEffect(() => {
@@ -100,6 +100,15 @@ function FrameElement({ element }) {
       dragging={Boolean(activeDropTargetId)}
       anchorRef={elementRef}
     >
+      {Controls && (
+        <Controls
+          isDragged={Boolean(draggingResource)}
+          isSelected={isSelected}
+          box={box}
+          elementRef={elementRef}
+          element={element}
+        />
+      )}
       <Wrapper
         ref={elementRef}
         data-element-id={id}

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -169,9 +169,8 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
     !snapDisabled && (!isDragging || (isDragging && !activeDropTargetId));
   const hideHandles = (isDragging && isMaskable) || Boolean(draggingResource);
 
-  // Will be moved to element definition, resizeRules.minWidth/minHeight?
-  const minWidth = dataToEditorY(20);
-  const minHeight = dataToEditorY(20);
+  const minWidth = dataToEditorY(resizeRules.minWidth);
+  const minHeight = dataToEditorY(resizeRules.minHeight);
   const aspectRatio = selectedElement.width / selectedElement.height;
 
   return (

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -237,17 +237,6 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
         let newWidth = width;
         let newHeight = height;
         let updates = null;
-        if (updateForResizeEvent) {
-          updates = updateForResizeEvent(
-            selectedElement,
-            direction,
-            editorToDataX(newWidth),
-            editorToDataY(newHeight)
-          );
-        }
-        if (updates && updates.height) {
-          newHeight = dataToEditorY(updates.height);
-        }
 
         if (isResizingFromCorner) {
           if (newWidth < minWidth) {
@@ -261,6 +250,18 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
         } else {
           newHeight = Math.max(newHeight, minHeight);
           newWidth = Math.max(newWidth, minWidth);
+        }
+
+        if (updateForResizeEvent) {
+          updates = updateForResizeEvent(
+            selectedElement,
+            direction,
+            editorToDataX(newWidth),
+            editorToDataY(newHeight)
+          );
+        }
+        if (updates && updates.height) {
+          newHeight = dataToEditorY(updates.height);
         }
 
         target.style.width = `${newWidth}px`;

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -169,6 +169,11 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
     !snapDisabled && (!isDragging || (isDragging && !activeDropTargetId));
   const hideHandles = (isDragging && isMaskable) || Boolean(draggingResource);
 
+  // Will be moved to element definition, resizeRules.minWidth/minHeight?
+  const minWidth = dataToEditorY(20);
+  const minHeight = dataToEditorY(20);
+  const aspectRatio = selectedElement.width / selectedElement.height;
+
   return (
     <Movable
       className={`default-movable ${hideHandles ? 'hide-handles' : ''} ${
@@ -230,7 +235,7 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
         }
       }}
       onResize={({ target, direction, width, height, drag }) => {
-        const newWidth = width;
+        let newWidth = width;
         let newHeight = height;
         let updates = null;
         if (updateForResizeEvent) {
@@ -244,6 +249,21 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
         if (updates && updates.height) {
           newHeight = dataToEditorY(updates.height);
         }
+
+        if (isResizingFromCorner) {
+          if (newWidth < minWidth) {
+            newWidth = minWidth;
+            newHeight = newWidth / aspectRatio;
+          }
+          if (newHeight < minHeight) {
+            newHeight = minHeight;
+            newWidth = minHeight * aspectRatio;
+          }
+        } else {
+          newHeight = Math.max(newHeight, minHeight);
+          newWidth = Math.max(newWidth, minWidth);
+        }
+
         target.style.width = `${newWidth}px`;
         target.style.height = `${newHeight}px`;
         frame.direction = direction;

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -53,7 +53,13 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
     },
   } = useCanvas();
   const {
-    actions: { getBox, editorToDataX, editorToDataY, dataToEditorY },
+    actions: {
+      getBox,
+      editorToDataX,
+      editorToDataY,
+      dataToEditorY,
+      dataToEditorX,
+    },
   } = useUnits();
   const {
     actions: { pushTransform },
@@ -169,12 +175,13 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
     !snapDisabled && (!isDragging || (isDragging && !activeDropTargetId));
   const hideHandles = (isDragging && isMaskable) || Boolean(draggingResource);
 
-  const minWidth = dataToEditorY(resizeRules.minWidth);
+  const minWidth = dataToEditorX(resizeRules.minWidth);
   const minHeight = dataToEditorY(resizeRules.minHeight);
   const aspectRatio = selectedElement.width / selectedElement.height;
 
   const visuallyHideHandles =
-    selectedElement.width <= minWidth || selectedElement.height <= minHeight;
+    selectedElement.width <= resizeRules.minWidth ||
+    selectedElement.height <= resizeRules.minHeight;
 
   return (
     <Movable

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -173,11 +173,14 @@ function SingleSelectionMovable({ selectedElement, targetEl, pushEvent }) {
   const minHeight = dataToEditorY(resizeRules.minHeight);
   const aspectRatio = selectedElement.width / selectedElement.height;
 
+  const visuallyHideHandles =
+    selectedElement.width <= minWidth || selectedElement.height <= minHeight;
+
   return (
     <Movable
       className={`default-movable ${hideHandles ? 'hide-handles' : ''} ${
-        selectedElement.type === 'text' ? 'type-text' : ''
-      }`}
+        visuallyHideHandles ? 'visually-hide-handles' : ''
+      } ${selectedElement.type === 'text' ? 'type-text' : ''}`}
       zIndex={0}
       ref={moveable}
       target={targetEl}

--- a/assets/src/edit-story/components/movable/moveStyle.js
+++ b/assets/src/edit-story/components/movable/moveStyle.js
@@ -76,4 +76,13 @@ export const GlobalStyle = createGlobalStyle`
 	.default-movable.hide-handles .moveable-line.moveable-direction {
 		display: none;
 	}
+
+  .default-movable.visually-hide-handles .moveable-control.moveable-e,
+  .default-movable.visually-hide-handles .moveable-control.moveable-w,
+  .default-movable.visually-hide-handles .moveable-control.moveable-s,
+  .default-movable.visually-hide-handles .moveable-control.moveable-ne,
+  .default-movable.visually-hide-handles .moveable-control.moveable-nw,
+  .default-movable.visually-hide-handles .moveable-control.moveable-sw {
+	  opacity: 0;
+	}
 `;

--- a/assets/src/edit-story/elements/media/index.js
+++ b/assets/src/edit-story/elements/media/index.js
@@ -76,6 +76,8 @@ export const resizeRules = {
   vertical: true,
   horizontal: true,
   diagonal: true,
+  minWidth: 20,
+  minHeight: 20,
 };
 
 export const MEDIA_PANELS = [

--- a/assets/src/edit-story/elements/shape/index.js
+++ b/assets/src/edit-story/elements/shape/index.js
@@ -45,6 +45,8 @@ export const resizeRules = {
   vertical: true,
   horizontal: true,
   diagonal: true,
+  minWidth: 20,
+  minHeight: 20,
 };
 
 export const panels = [

--- a/assets/src/edit-story/elements/text/index.js
+++ b/assets/src/edit-story/elements/text/index.js
@@ -58,6 +58,8 @@ export const resizeRules = {
   vertical: false,
   horizontal: true,
   diagonal: true,
+  minWidth: 20,
+  minHeight: 20,
 };
 
 export const panels = [

--- a/assets/src/edit-story/elements/video/controls.js
+++ b/assets/src/edit-story/elements/video/controls.js
@@ -37,6 +37,8 @@ import { useStory } from '../../app/story';
 import StoryPropTypes from '../../types';
 
 const PLAY_BUTTON_SIZE = 48;
+const PLAY_ABOVE_BREAKPOINT_WIDTH = 108;
+const PLAY_ABOVE_BREAKPOINT_HEIGHT = 120;
 
 const Controls = styled.div`
   position: absolute;
@@ -49,7 +51,7 @@ const Controls = styled.div`
 
 const ButtonWrapper = styled.div.attrs({ role: 'button', tabIndex: -1 })`
   position: absolute;
-  top: 50%;
+  top: ${({ isAbove }) => (isAbove ? `-52px` : `50%`)};
   left: 50%;
   transform: translate(-50%, -50%);
   cursor: pointer;
@@ -57,7 +59,7 @@ const ButtonWrapper = styled.div.attrs({ role: 'button', tabIndex: -1 })`
   width: ${PLAY_BUTTON_SIZE}px;
   height: ${PLAY_BUTTON_SIZE}px;
 
-  opacity: 0;
+  opacity: ${({ isAbove }) => (isAbove ? 1 : 0)};
   &.button-enter {
     opacity: 0;
   }
@@ -79,13 +81,20 @@ const ButtonWrapper = styled.div.attrs({ role: 'button', tabIndex: -1 })`
 const Play = styled(PlayIcon)`
   width: 100%;
   height: 100%;
+  opacity: 0.84;
+  filter: drop-shadow(0px 0px 10px rgba(0, 0, 0, 0.2));
 `;
 const Pause = styled(PauseIcon)`
   width: 100%;
   height: 100%;
+  opacity: 0.84;
+  filter: drop-shadow(0px 0px 10px rgba(0, 0, 0, 0.2));
 `;
 
 function VideoControls({ box, isSelected, isDragged, elementRef, element }) {
+  const isPlayAbove =
+    element.width < PLAY_ABOVE_BREAKPOINT_WIDTH ||
+    element.height < PLAY_ABOVE_BREAKPOINT_HEIGHT;
   const [hovering, setHovering] = useState(false);
   const [showControls, setShowControls] = useState(true);
   const [isPlaying, setIsPlaying] = useState(false);
@@ -131,13 +140,14 @@ function VideoControls({ box, isSelected, isDragged, elementRef, element }) {
   }, [getVideoNode, id]);
 
   const [checkShowControls] = useDebouncedCallback(() => {
-    setShowControls(!isPlaying);
+    if (!isPlayAbove) {
+      setShowControls(!isPlaying);
+    }
   }, 2000);
-  // eslint-disable-next-line consistent-return
   const [checkMouseInBBox] = useDebouncedCallback((evt) => {
     const node = elementRef.current;
     if (!node) {
-      return null;
+      return;
     }
     const elementBBox = node.getBoundingClientRect();
     const isHovering =
@@ -180,20 +190,27 @@ function VideoControls({ box, isSelected, isDragged, elementRef, element }) {
   const buttonTitle = isPlaying
     ? __('Click to pause', 'web-stories')
     : __('Click to play', 'web-stories');
+  const TransitionWrapper = isPlayAbove ? 'div' : CSSTransition;
 
   return (
     <Controls {...box}>
       {showControls && (
-        <CSSTransition in={hovering} appear classNames="button" timeout={100}>
+        <TransitionWrapper
+          in={hovering}
+          appear
+          classNames="button"
+          timeout={100}
+        >
           <ButtonWrapper
             title={buttonTitle}
             aria-pressed={isPlaying}
             key="wrapper"
             onMouseDown={handlePlayPause}
+            isAbove={isPlayAbove}
           >
             {isPlaying ? <Pause /> : <Play />}
           </ButtonWrapper>
-        </CSSTransition>
+        </TransitionWrapper>
       )}
     </Controls>
   );

--- a/assets/src/edit-story/elements/video/controls.js
+++ b/assets/src/edit-story/elements/video/controls.js
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { useCallback, useEffect, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+import { CSSTransition } from 'react-transition-group';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ReactComponent as PlayIcon } from '../../icons/play.svg';
+import { ReactComponent as PauseIcon } from '../../icons/pause.svg';
+import { useStory } from '../../app/story';
+import StoryPropTypes from '../../types';
+
+const PLAY_BUTTON_SIZE = 48;
+
+const Controls = styled.div`
+  position: absolute;
+  z-index: 2;
+  left: ${({ x }) => `${x}px`};
+  top: ${({ y }) => `${y}px`};
+  width: ${({ width }) => `${width}px`};
+  height: ${({ height }) => `${height}px`};
+`;
+
+const ButtonWrapper = styled.div.attrs({ role: 'button', tabIndex: -1 })`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  pointer-events: initial;
+  width: ${PLAY_BUTTON_SIZE}px;
+  height: ${PLAY_BUTTON_SIZE}px;
+
+  opacity: 0;
+  &.button-enter {
+    opacity: 0;
+  }
+  &.button-enter-active,
+  &.button-enter-done {
+    opacity: 1;
+    transition: opacity 100ms;
+  }
+  &.button-exit {
+    opacity: 1;
+  }
+  &.button-exit-active,
+  &.button-exit-done {
+    opacity: 0;
+    transition: opacity 100ms;
+  }
+`;
+
+const Play = styled(PlayIcon)`
+  width: 100%;
+  height: 100%;
+`;
+const Pause = styled(PauseIcon)`
+  width: 100%;
+  height: 100%;
+`;
+
+function VideoControls({ box, isSelected, isDragged, elementRef, element }) {
+  const [hovering, setHovering] = useState(false);
+  const [showControls, setShowControls] = useState(true);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const { id } = element;
+  const {
+    state: { selectedElementIds },
+  } = useStory();
+  const isElementSelected = selectedElementIds.includes(id);
+  const getVideoNode = useCallback(
+    () => document.getElementById(`video-${id}`),
+    [id]
+  );
+
+  useEffect(() => {
+    const videoNode = getVideoNode();
+    if (!isElementSelected && videoNode) {
+      videoNode.pause();
+      videoNode.currentTime = 0;
+      setIsPlaying(false);
+      setShowControls(true);
+    }
+    const syncTimer = setTimeout(() => {
+      if (isElementSelected && videoNode && !videoNode.paused) {
+        setIsPlaying(true);
+      }
+    }, 0);
+    return () => clearTimeout(syncTimer);
+  }, [getVideoNode, id, isElementSelected]);
+
+  useEffect(() => {
+    const videoNode = getVideoNode();
+    if (!videoNode) {
+      return undefined;
+    }
+
+    const onVideoEnd = () => {
+      videoNode.currentTime = 0;
+      setIsPlaying(false);
+      setShowControls(true);
+    };
+    videoNode.addEventListener('ended', onVideoEnd);
+    return () => videoNode.removeEventListener('ended', onVideoEnd);
+  }, [getVideoNode, id]);
+
+  const [checkShowControls] = useDebouncedCallback(() => {
+    setShowControls(!isPlaying);
+  }, 2000);
+  // eslint-disable-next-line consistent-return
+  const [checkMouseInBBox] = useDebouncedCallback((evt) => {
+    const node = elementRef.current;
+    if (!node) {
+      return null;
+    }
+    const elementBBox = node.getBoundingClientRect();
+    const isHovering =
+      evt.clientX >= elementBBox.left &&
+      evt.clientX <= elementBBox.right &&
+      evt.clientY >= elementBBox.top &&
+      evt.clientY <= elementBBox.bottom;
+    setHovering(isHovering);
+    setShowControls(true);
+    checkShowControls();
+  }, 10);
+
+  useEffect(() => {
+    document.addEventListener('pointermove', checkMouseInBBox);
+    return () => {
+      document.removeEventListener('pointermove', checkMouseInBBox);
+    };
+  }, [checkMouseInBBox]);
+
+  if (!isSelected || isDragged) {
+    return null;
+  }
+
+  const handlePlayPause = (evt) => {
+    evt.stopPropagation();
+    const videoNode = getVideoNode();
+    if (!videoNode) {
+      return;
+    }
+
+    if (isPlaying) {
+      videoNode.pause();
+      setIsPlaying(false);
+      setShowControls(true);
+    } else {
+      videoNode.play().then(() => setIsPlaying(true));
+    }
+  };
+
+  const buttonTitle = isPlaying
+    ? __('Click to pause', 'web-stories')
+    : __('Click to play', 'web-stories');
+
+  return (
+    <Controls {...box}>
+      {showControls && (
+        <CSSTransition in={hovering} appear classNames="button" timeout={100}>
+          <ButtonWrapper
+            title={buttonTitle}
+            aria-pressed={isPlaying}
+            key="wrapper"
+            onMouseDown={handlePlayPause}
+          >
+            {isPlaying ? <Pause /> : <Play />}
+          </ButtonWrapper>
+        </CSSTransition>
+      )}
+    </Controls>
+  );
+}
+
+VideoControls.propTypes = {
+  box: StoryPropTypes.box.isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  isDragged: PropTypes.bool.isRequired,
+  elementRef: PropTypes.object.isRequired,
+  element: StoryPropTypes.element.isRequired,
+};
+
+export default VideoControls;

--- a/assets/src/edit-story/elements/video/frame.js
+++ b/assets/src/edit-story/elements/video/frame.js
@@ -149,7 +149,10 @@ function VideoFrame({ element, box }) {
     : __('Click to play', 'web-stories');
 
   const smallestDimension = Math.min(box.width, box.height);
-  const buttonSize = Math.max(Math.ceil(smallestDimension * 0.2), PLAY_BUTTON_MIN_SIZE);
+  const buttonSize = Math.max(
+    Math.ceil(smallestDimension * 0.2),
+    PLAY_BUTTON_MIN_SIZE
+  );
 
   return (
     <Wrapper

--- a/assets/src/edit-story/elements/video/frame.js
+++ b/assets/src/edit-story/elements/video/frame.js
@@ -15,169 +15,17 @@
  */
 
 /**
- * External dependencies
- */
-import { useEffect, useState, useCallback } from 'react';
-import styled from 'styled-components';
-import { CSSTransition } from 'react-transition-group';
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import StoryPropTypes from '../../types';
 import MediaFrame from '../media/frame';
-import { elementFillContent } from '../shared';
-import { useStory } from '../../app/story';
-import { ReactComponent as PlayIcon } from '../../icons/play.svg';
-import { ReactComponent as PauseIcon } from '../../icons/pause.svg';
 
-export const PLAY_BUTTON_MIN_SIZE = 24;
-
-const Play = styled(PlayIcon)`
-  width: 100%;
-  height: 100%;
-`;
-const Pause = styled(PauseIcon)`
-  width: 100%;
-  height: 100%;
-`;
-
-const Wrapper = styled.div`
-  ${elementFillContent}
-`;
-
-const ButtonWrapper = styled.div.attrs({ role: 'button', tabIndex: -1 })`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  cursor: pointer;
-  width: ${({ size }) => size}px;
-  height: ${({ size }) => size}px;
-
-  opacity: 0;
-  &.button-enter {
-    opacity: 0;
-  }
-  &.button-enter-active,
-  &.button-enter-done {
-    opacity: 1;
-    transition: opacity 200ms;
-  }
-  &.button-exit {
-    opacity: 1;
-  }
-  &.button-exit-active,
-  &.button-exit-done {
-    opacity: 0;
-    transition: opacity 200ms;
-  }
-`;
-
-function VideoFrame({ element, box }) {
-  const { id } = element;
-  const [hovering, setHovering] = useState(false);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const {
-    state: { selectedElementIds },
-  } = useStory();
-  const isElementSelected = selectedElementIds.includes(id);
-  const getVideoNode = useCallback(
-    () => document.getElementById(`video-${id}`),
-    [id]
-  );
-
-  const onPointerEnter = () => {
-    // Sync UI for auto-play on insert.
-    const videoNode = getVideoNode();
-    const currentlyPlaying = videoNode && !videoNode.paused;
-    if (currentlyPlaying && !isPlaying) {
-      setIsPlaying(true);
-    }
-    setHovering(true);
-  };
-
-  useEffect(() => {
-    const videoNode = getVideoNode();
-    if (!isElementSelected && videoNode) {
-      videoNode.pause();
-      videoNode.currentTime = 0;
-      setIsPlaying(false);
-    }
-    const syncTimer = setTimeout(() => {
-      if (isElementSelected && videoNode && !videoNode.paused) {
-        setIsPlaying(true);
-      }
-    }, 0);
-    return () => clearTimeout(syncTimer);
-  }, [getVideoNode, id, isElementSelected]);
-
-  const handlePlayPause = () => {
-    const videoNode = getVideoNode();
-    if (!videoNode) {
-      return;
-    }
-
-    if (isPlaying) {
-      videoNode.pause();
-      setIsPlaying(false);
-    } else {
-      videoNode.play().then(() => setIsPlaying(true));
-    }
-  };
-
-  useEffect(() => {
-    const videoNode = getVideoNode();
-    if (!videoNode) {
-      return undefined;
-    }
-
-    const onVideoEnd = () => {
-      videoNode.currentTime = 0;
-      setIsPlaying(false);
-    };
-    videoNode.addEventListener('ended', onVideoEnd);
-    return () => videoNode.removeEventListener('ended', onVideoEnd);
-  }, [getVideoNode, id]);
-
-  const buttonTitle = isPlaying
-    ? __('Click to pause', 'web-stories')
-    : __('Click to play', 'web-stories');
-
-  const smallestDimension = Math.min(box.width, box.height);
-  const buttonSize = Math.max(
-    Math.ceil(smallestDimension * 0.2),
-    PLAY_BUTTON_MIN_SIZE
-  );
-
-  return (
-    <Wrapper
-      onPointerEnter={onPointerEnter}
-      onPointerLeave={() => setHovering(false)}
-    >
-      <MediaFrame element={element} />
-      <CSSTransition in={hovering} classNames="button" timeout={200}>
-        <ButtonWrapper
-          title={buttonTitle}
-          aria-pressed={isPlaying}
-          key="wrapper"
-          onClick={handlePlayPause}
-          size={buttonSize}
-        >
-          {isPlaying ? <Pause /> : <Play />}
-        </ButtonWrapper>
-      </CSSTransition>
-    </Wrapper>
-  );
+function VideoFrame({ element }) {
+  return <MediaFrame element={element} />;
 }
 
 VideoFrame.propTypes = {
   element: StoryPropTypes.elements.video.isRequired,
-  box: StoryPropTypes.box.isRequired,
 };
 
 export default VideoFrame;

--- a/assets/src/edit-story/elements/video/frame.js
+++ b/assets/src/edit-story/elements/video/frame.js
@@ -35,6 +35,8 @@ import { useStory } from '../../app/story';
 import { ReactComponent as PlayIcon } from '../../icons/play.svg';
 import { ReactComponent as PauseIcon } from '../../icons/pause.svg';
 
+export const PLAY_BUTTON_MIN_SIZE = 24;
+
 const Play = styled(PlayIcon)`
   width: 100%;
   height: 100%;
@@ -147,7 +149,7 @@ function VideoFrame({ element, box }) {
     : __('Click to play', 'web-stories');
 
   const smallestDimension = Math.min(box.width, box.height);
-  const buttonSize = Math.max(Math.ceil(smallestDimension * 0.2), 24);
+  const buttonSize = Math.max(Math.ceil(smallestDimension * 0.2), PLAY_BUTTON_MIN_SIZE);
 
   return (
     <Wrapper

--- a/assets/src/edit-story/elements/video/index.js
+++ b/assets/src/edit-story/elements/video/index.js
@@ -19,7 +19,12 @@
  */
 import { PanelTypes } from '../../components/panels';
 import { SHARED_DEFAULT_ATTRIBUTES } from '../shared';
-import { MEDIA_DEFAULT_ATTRIBUTES, MEDIA_PANELS } from '../media';
+import {
+  MEDIA_DEFAULT_ATTRIBUTES,
+  MEDIA_PANELS,
+  resizeRules as mediaResizeRules,
+} from '../media';
+import { PLAY_BUTTON_MIN_SIZE } from './frame';
 export { default as Display } from './display';
 export { default as Edit } from './edit';
 export { default as Frame } from './frame';
@@ -33,8 +38,13 @@ export {
   isMedia,
   hasEditMode,
   editModeGrayout,
-  resizeRules,
 } from '../media';
+
+export const resizeRules = {
+  ...mediaResizeRules,
+  minWidth: PLAY_BUTTON_MIN_SIZE,
+  minHeight: PLAY_BUTTON_MIN_SIZE,
+};
 
 export const defaultAttributes = {
   ...SHARED_DEFAULT_ATTRIBUTES,

--- a/assets/src/edit-story/elements/video/index.js
+++ b/assets/src/edit-story/elements/video/index.js
@@ -24,10 +24,10 @@ import {
   MEDIA_PANELS,
   resizeRules as mediaResizeRules,
 } from '../media';
-import { PLAY_BUTTON_MIN_SIZE } from './frame';
 export { default as Display } from './display';
 export { default as Edit } from './edit';
 export { default as Frame } from './frame';
+export { default as Controls } from './controls';
 export { default as Output } from './output';
 export { default as LayerContent } from './layer';
 export { default as LayerIcon } from './icon';
@@ -42,8 +42,6 @@ export {
 
 export const resizeRules = {
   ...mediaResizeRules,
-  minWidth: PLAY_BUTTON_MIN_SIZE,
-  minHeight: PLAY_BUTTON_MIN_SIZE,
 };
 
 export const defaultAttributes = {


### PR DESCRIPTION
Issue #917

![resize](https://user-images.githubusercontent.com/21036224/78303432-eb09d880-753c-11ea-9b29-78e5feaf9d13.gif)

What should happen for multi-selection? I guess we should stop the resize as soon as any of the elements reaches their minimum?

Minimum for Video will be bigger - to make the play button large enough.
Some special rules for Text, because it will impact min. font size.

About resizing via inputs: I looked at Gutenberg and I'm not sure whatever it's a bug or a feature to resize it like this:
![gt](https://user-images.githubusercontent.com/21036224/78302880-fdcfdd80-753b-11ea-96f3-c305fce3b1e6.gif)

Pasting what we have in Figma:
![image](https://user-images.githubusercontent.com/21036224/78303750-99ae1900-753d-11ea-895f-f817dd1a327a.png)
Should we hide the handles at min size, but still, allow resizing by an edge? (Right now)