### PR TITLE
Dashboard: Add support for opening story in editor

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -35,24 +35,21 @@ import { STORY_STATUSES } from '../../constants';
 
 export const ApiContext = createContext({ state: {}, actions: {} });
 
-export function reshapeStoryObject({
-  id,
-  title,
-  modified,
-  status,
-  story_data: storyData,
-}) {
-  return {
-    id,
-    status,
-    title: title.rendered,
-    modified: moment(modified),
-    pages: storyData.pages,
+export function reshapeStoryObject(editStoryURL) {
+  return function ({ id, title, modified, status, story_data: storyData }) {
+    return {
+      id,
+      status,
+      title: title.rendered,
+      modified: moment(modified),
+      pages: storyData.pages,
+      editStoryUrl: `${editStoryURL}&post=${id}`,
+    };
   };
 }
 
 export default function ApiProvider({ children }) {
-  const { api } = useConfig();
+  const { api, editStoryURL } = useConfig();
   const [stories, setStories] = useState([]);
 
   const fetchStories = useCallback(
@@ -65,14 +62,16 @@ export default function ApiProvider({ children }) {
         const serverStoryResponse = await apiFetch({
           path,
         });
-        const reshapedStories = serverStoryResponse.map(reshapeStoryObject);
+        const reshapedStories = serverStoryResponse.map(
+          reshapeStoryObject(editStoryURL)
+        );
         setStories(reshapedStories);
         return reshapedStories;
       } catch (err) {
         return [];
       }
     },
-    [api.stories]
+    [api.stories, editStoryURL]
   );
 
   const getAllFonts = useCallback(() => {

--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -54,13 +54,16 @@ describe('reshapeStoryObject', () => {
       story_data: { pages: [{ id: 0, elements: [] }] },
     };
 
-    const reshapedObj = reshapeStoryObject(responseObj);
+    const reshapedObj = reshapeStoryObject('http://editstory.com?action=edit')(
+      responseObj
+    );
     expect(reshapedObj).toMatchObject({
       id: 27,
       title: 'Carlos Draft',
       status: 'draft',
       modified: moment('2020-03-26T21:42:14'),
       pages: [{ id: 0, elements: [] }],
+      editStoryUrl: 'http://editstory.com?action=edit&post=27',
     });
   });
 });

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -150,7 +150,6 @@ function MyStories() {
               </FloatingTab>
             ))}
           </FilterContainer>
-
           {BodyContent}
         </UnitsProvider>
       </TransformProvider>

--- a/assets/src/dashboard/app/views/myStories/storyGridView.js
+++ b/assets/src/dashboard/app/views/myStories/storyGridView.js
@@ -31,7 +31,7 @@ const StoryGridView = ({ filteredStories }) => (
     {filteredStories.map((story) => (
       <CardGridItem key={story.id}>
         <CardPreviewContainer
-          onOpenInEditorClick={() => {}}
+          editUrl={story.editStoryUrl}
           onPreviewClick={() => {}}
           previewSource={'http://placeimg.com/225/400/nature'}
         >

--- a/assets/src/dashboard/components/cardGridItem/card-preview.js
+++ b/assets/src/dashboard/components/cardGridItem/card-preview.js
@@ -102,13 +102,11 @@ const PlayArrowIcon = styled(PlayArrowSvg).attrs({ width: 11, height: 14 })`
   margin-right: 9px;
 `;
 
+const EditButton = styled(Button).attrs({ onClick: () => {} })``;
+
 // TODO modify to handle other types of grid items, not just own stories
-const CardPreviewContainer = ({
-  onOpenInEditorClick,
-  onPreviewClick,
-  children,
-}) => {
-  const displayEditControls = onPreviewClick || onOpenInEditorClick;
+const CardPreviewContainer = ({ editUrl, onPreviewClick, children }) => {
+  const displayEditControls = onPreviewClick || editUrl;
 
   return (
     <>
@@ -126,11 +124,11 @@ const CardPreviewContainer = ({
               </PreviewButton>
             </PreviewContainer>
           )}
-          {onOpenInEditorClick && (
+          {editUrl && (
             <CtaContainer>
-              <Button type={BUTTON_TYPES.PRIMARY} onClick={onOpenInEditorClick}>
+              <EditButton forwardedAs="a" href={editUrl}>
                 {__('Open in editor', 'web-stories')}
-              </Button>
+              </EditButton>
             </CtaContainer>
           )}
         </EditControls>
@@ -141,7 +139,7 @@ const CardPreviewContainer = ({
 
 CardPreviewContainer.propTypes = {
   children: PropTypes.node.isRequired,
-  onOpenInEditorClick: PropTypes.func,
+  editUrl: PropTypes.string.isRequired,
   onPreviewClick: PropTypes.func,
 };
 

--- a/assets/src/dashboard/components/cardGridItem/card-preview.js
+++ b/assets/src/dashboard/components/cardGridItem/card-preview.js
@@ -124,13 +124,11 @@ const CardPreviewContainer = ({ editUrl, onPreviewClick, children }) => {
               </PreviewButton>
             </PreviewContainer>
           )}
-          {editUrl && (
-            <CtaContainer>
-              <EditButton forwardedAs="a" href={editUrl}>
-                {__('Open in editor', 'web-stories')}
-              </EditButton>
-            </CtaContainer>
-          )}
+          <CtaContainer>
+            <EditButton forwardedAs="a" href={editUrl}>
+              {__('Open in editor', 'web-stories')}
+            </EditButton>
+          </CtaContainer>
         </EditControls>
       )}
     </>

--- a/assets/src/dashboard/components/cardGridItem/stories/index.js
+++ b/assets/src/dashboard/components/cardGridItem/stories/index.js
@@ -28,7 +28,7 @@ export const _default = () => {
   return (
     <CardGridItem>
       <CardPreviewContainer
-        onOpenInEditorClick={() => {}}
+        editUrl={'https://www.google.com'}
         onPreviewClick={() => {}}
         previewSource={'http://placeimg.com/225/400/nature'}
       />

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -132,15 +132,25 @@ class Dashboard {
 			)
 		);
 
+		$edit_story_url = admin_url(
+			add_query_arg(
+				[
+					'action' => 'edit',
+				],
+				'post.php'
+			)
+		);
+
 		wp_localize_script(
 			self::SCRIPT_HANDLE,
 			'webStoriesDashboardSettings',
 			[
 				'id'     => 'web-stories-dashboard',
 				'config' => [
-					'isRTL'       => is_rtl(),
-					'newStoryURL' => $new_story_url,
-					'api'         => [
+					'isRTL'        => is_rtl(),
+					'newStoryURL'  => $new_story_url,
+					'editStoryURL' => $edit_story_url,
+					'api'          => [
 						'stories' => sprintf( '/wp/v2/%s', $rest_base ),
 						'fonts'   => '/web-stories/v1/fonts',
 					],


### PR DESCRIPTION
- Adds edit story URL to config
- Forwards edit story button as `a` tag since it is a hyperlink
- Lets user edit the story from the dashboard 