### PR TITLE
Fix missing createInterpolateElement import

### DIFF
--- a/assets/src/edit-story/app/media/useUploadMedia/useUploadMedia.js
+++ b/assets/src/edit-story/app/media/useUploadMedia/useUploadMedia.js
@@ -23,7 +23,7 @@ import { useCallback, useState } from 'react';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/app/uploader/useUploader.js
+++ b/assets/src/edit-story/app/uploader/useUploader.js
@@ -23,7 +23,7 @@ import { useCallback } from 'react';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/components/panels/backgroundDisplay/dialogContent.js
+++ b/assets/src/edit-story/components/panels/backgroundDisplay/dialogContent.js
@@ -24,7 +24,7 @@ import { rgba } from 'polished';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/components/panels/link/dialogContent.js
+++ b/assets/src/edit-story/components/panels/link/dialogContent.js
@@ -23,7 +23,7 @@ import styled from 'styled-components';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { __experimentalCreateInterpolateElement as createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
I think this solves part of the bug reported in #981.

Didn't realize `createInterpolateElement` is not considered unstable anymore. Wasn't really flagged anywhere