### PR TITLE
Fix console error on hover play

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaElement.js
@@ -237,6 +237,7 @@ const MediaElement = ({
         width={width}
         height={height}
         preload="metadata"
+        muted
         {...dropTargetsBindings}
       >
         <source src={src} type={mimeType} />


### PR DESCRIPTION
![Screenshot from 2020-04-03 13-39-23](https://user-images.githubusercontent.com/237508/78361678-b46da580-75b0-11ea-911f-62548f6ddb3a.png)

This notice appears when video play when hovered. 

As of Chrome 66, the policy on video playing changed. See [google developer docs](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes#developer-switches) and [stack overflow](https://stackoverflow.com/questions/49930680/how-to-handle-uncaught-in-promise-domexception-play-failed-because-the-use).

Made the video muted for now.