### PR TITLE
Added template json for Travel template

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -54,6 +54,10 @@ export default function ApiProvider({ children }) {
 
   const fetchStories = useCallback(
     async ({ status = STORY_STATUSES[0].value }) => {
+      if (!api.stories) {
+        return [];
+      }
+
       try {
         const path = queryString.stringifyUrl({
           url: api.stories,
@@ -75,6 +79,10 @@ export default function ApiProvider({ children }) {
   );
 
   const getAllFonts = useCallback(() => {
+    if (!api.fonts) {
+      return Promise.resolve([]);
+    }
+
     return apiFetch({ path: api.fonts }).then((data) =>
       data.map((font) => ({
         value: font.name,

--- a/assets/src/dashboard/app/font/fontProvider.js
+++ b/assets/src/dashboard/app/font/fontProvider.js
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import { useCallback, useContext, useEffect, useState } from 'react';
+
 /**
  * Internal dependencies
  */
-import PropTypes from 'prop-types';
 import { ApiContext } from '../api/apiProvider';
 import Context from '../../../edit-story/app/font/context';
 import useLoadFontFiles from '../../../edit-story/app/font/actions/useLoadFontFiles';

--- a/assets/src/dashboard/templates/data/travel.json
+++ b/assets/src/dashboard/templates/data/travel.json
@@ -1,0 +1,4144 @@
+{
+  "version": 12,
+  "pages": [
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "scale": 130,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/lauren-kay-MoAbTalDlD8-unsplash-2.jpg",
+            "width": 220,
+            "height": 147,
+            "videoId": 128,
+            "alt": "",
+            "sizes": {
+              "thumbnail": {
+                "height": 150,
+                "width": 150,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/lauren-kay-MoAbTalDlD8-unsplash-2-150x150.jpg",
+                "orientation": "landscape"
+              },
+              "medium": {
+                "height": 200,
+                "width": 300,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/lauren-kay-MoAbTalDlD8-unsplash-2-300x200.jpg",
+                "orientation": "landscape"
+              },
+              "large": {
+                "height": 387,
+                "width": 580,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/lauren-kay-MoAbTalDlD8-unsplash-2-1024x683.jpg",
+                "orientation": "landscape"
+              },
+              "full": {
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/lauren-kay-MoAbTalDlD8-unsplash-2.jpg",
+                "height": 1600,
+                "width": 2400,
+                "orientation": "landscape"
+              }
+            }
+          },
+          "x": 22,
+          "y": 12,
+          "width": 220,
+          "height": 147,
+          "mask": {
+            "type": "rectangle",
+            "name": "Rectangle",
+            "path": "M 0,0 1,0 1,1 0,1 0,0",
+            "ratio": 1
+          },
+          "type": "image",
+          "id": "bba76c46-4e06-4f4c-871c-202e2d187ef2",
+          "isBackground": true
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Playfair Display",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 38,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "center",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "EXPERIENCE",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 80,
+          "y": 281,
+          "width": 304,
+          "height": 38,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "d5ca2488-668b-4e21-a7d8-05c17084742b"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 500,
+          "fontSize": 90,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "center",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "THAILAND",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 32,
+          "y": 330,
+          "width": 375,
+          "height": 90,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "3c00f665-e2ff-4393-aef4-6ca790f599fd"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "isFill": false,
+          "x": 0,
+          "y": 579,
+          "width": 152,
+          "height": 82,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "id": "7de325ef-2490-4e19-9c9c-7031bffa4b05"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/png",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/tl-logo-2-1.png",
+            "width": 47,
+            "height": 15,
+            "videoId": 131,
+            "alt": "",
+            "sizes": {
+              "full": {
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/tl-logo-2-1.png",
+                "height": 29,
+                "width": 94,
+                "orientation": "landscape"
+              }
+            }
+          },
+          "x": 32,
+          "y": 603,
+          "width": 94,
+          "height": 30,
+          "mask": {
+            "type": "rectangle",
+            "name": "Rectangle",
+            "path": "M 0,0 1,0 1,1 0,1 0,0",
+            "ratio": 1
+          },
+          "type": "image",
+          "id": "a4cb7d99-e379-4dec-8463-06b3bd6dafbb"
+        }
+      ],
+      "type": "page",
+      "id": "fca5c47a-e26f-4feb-b2a3-f6d8b6c68996",
+      "backgroundElementId": "bba76c46-4e06-4f4c-871c-202e2d187ef2",
+      "backgroundOverlay": "none"
+    },
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "isFill": false,
+          "x": 45.40724475706104,
+          "y": 0.3275797182305329,
+          "width": 146.66666666666666,
+          "height": 146.66666666666666,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "type": "shape",
+          "id": "143182cf-804b-4d71-93d8-d4a53c9e6ed6"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "isFill": false,
+          "x": -11,
+          "y": 0,
+          "width": 465,
+          "height": 435,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "id": "a81f2dcc-b5a3-4be6-8a06-bb42ac828ed0"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 500,
+          "fontSize": 48,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "YOUR BODY IS\nNOT A TEMPLE,\nIT'S AN\nAMUSEMENT\nPARK.\"",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 80,
+          "y": 78,
+          "width": 280,
+          "height": 236,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "bfd53cf2-f8e8-41f0-8449-48772b5194bb"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 500,
+          "fontSize": 48,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "\"",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 59,
+          "y": 78,
+          "width": 20,
+          "height": 48,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "90e3970e-a7be-4ecb-91a6-4f6065f28de1"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "– Anthony Bordain",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 78,
+          "y": 383,
+          "width": 220,
+          "height": 20,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "88df74ed-7334-4e91-957c-c48b8da344e4"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": true,
+            "horizontal": false
+          },
+          "rotationAngle": 90,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "x": 103,
+          "y": 319,
+          "width": 234,
+          "height": 450,
+          "scale": 120,
+          "focalX": 49.958297992927974,
+          "focalY": 47.911921059829645,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "id": "8a21c4e7-4e9b-4811-9b8b-f36d0297a9e4",
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/alex-block-9Zw3SLS-YS4-unsplash-scaled.jpg",
+            "width": 220,
+            "height": 331,
+            "videoId": 134,
+            "alt": "",
+            "sizes": {
+              "thumbnail": {
+                "height": 150,
+                "width": 150,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/alex-block-9Zw3SLS-YS4-unsplash-150x150.jpg",
+                "orientation": "landscape"
+              },
+              "medium": {
+                "height": 300,
+                "width": 199,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/alex-block-9Zw3SLS-YS4-unsplash-199x300.jpg",
+                "orientation": "portrait"
+              },
+              "large": {
+                "height": 873,
+                "width": 580,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/alex-block-9Zw3SLS-YS4-unsplash-680x1024.jpg",
+                "orientation": "portrait"
+              },
+              "full": {
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/alex-block-9Zw3SLS-YS4-unsplash-scaled.jpg",
+                "height": 2560,
+                "width": 1701,
+                "orientation": "portrait"
+              }
+            }
+          }
+        }
+      ],
+      "backgroundElementId": "143182cf-804b-4d71-93d8-d4a53c9e6ed6",
+      "backgroundOverlay": "none",
+      "type": "page",
+      "id": "3cdf0fde-f515-477d-8688-472c4cc5a8b3"
+    },
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "isFill": false,
+          "x": 96.59535123281229,
+          "y": 92.15172881763873,
+          "width": 146.66666666666666,
+          "height": 146.66666666666666,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "type": "shape",
+          "id": "b39e1373-e1d4-40ee-bd0c-298924b61a3e"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 254,
+              "g": 200,
+              "b": 90
+            }
+          },
+          "isFill": false,
+          "x": 307,
+          "y": 527,
+          "width": 134,
+          "height": 134,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "id": "6e549d8a-d851-45c5-b168-f3e681261bab"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 31,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "LEARN\nMORE",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 337,
+          "y": 563,
+          "width": 74,
+          "height": 62,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "3cf17fb8-a5ae-4f32-8e5f-d3a0513215de"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "The cheapest and most authentic way to experience Thai life. Prepare yourself, some like it hot!",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 44,
+          "y": 162,
+          "width": 234,
+          "height": 80,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "883808f1-b87b-4b35-b0f1-0945e0faef2e"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 48,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "STREET\nFOOD",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 44,
+          "y": 50,
+          "width": 208,
+          "height": 96,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "6258d646-a291-498f-81ab-3095f352bb26"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "x": -1,
+          "y": 314,
+          "width": 314,
+          "height": 347,
+          "scale": 100,
+          "focalX": 49.81801455703381,
+          "focalY": 44.55730329866608,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "id": "4c694857-df14-4ba9-8791-9b13935dbbbe",
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash.jpg",
+            "width": 237,
+            "height": 295,
+            "poster": "",
+            "posterId": 0,
+            "videoId": 141,
+            "title": "artyom-pj-lmnQJk5mumo-unsplash",
+            "alt": "",
+            "local": false,
+            "sizes": {
+              "medium": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-240x300.jpg",
+                "width": 240,
+                "height": 300,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-240x300.jpg"
+              },
+              "large": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-819x1024.jpg",
+                "width": 819,
+                "height": 1024,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-819x1024.jpg"
+              },
+              "thumbnail": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-150x150.jpg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-150x150.jpg"
+              },
+              "medium_large": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-768x960.jpg",
+                "width": 768,
+                "height": 960,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-768x960.jpg"
+              },
+              "1536x1536": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-1229x1536.jpg",
+                "width": 1229,
+                "height": 1536,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-1229x1536.jpg"
+              },
+              "2048x2048": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-1638x2048.jpg",
+                "width": 1638,
+                "height": 2048,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-1638x2048.jpg"
+              },
+              "post-thumbnail": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-1200x1500.jpg",
+                "width": 1200,
+                "height": 1500,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-1200x1500.jpg"
+              },
+              "web-stories-poster-portrait": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-696x928.jpg",
+                "width": 696,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-696x928.jpg"
+              },
+              "web-stories-poster-square": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-928x928.jpg",
+                "width": 928,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-928x928.jpg"
+              },
+              "web-stories-poster-landscape": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-928x696.jpg",
+                "width": 928,
+                "height": 696,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-928x696.jpg"
+              },
+              "web_stories_thumbnail": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash-150x188.jpg",
+                "width": 150,
+                "height": 188,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash-150x188.jpg"
+              },
+              "full": {
+                "file": "artyom-pj-lmnQJk5mumo-unsplash.jpg",
+                "width": 1920,
+                "height": 2400,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/artyom-pj-lmnQJk5mumo-unsplash.jpg"
+              }
+            }
+          }
+        }
+      ],
+      "backgroundElementId": "b39e1373-e1d4-40ee-bd0c-298924b61a3e",
+      "backgroundOverlay": "none",
+      "type": "page",
+      "id": "80b4f7b3-c54a-4e40-9a75-c937cedfed4b"
+    },
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "scale": 100,
+          "focalX": 47.34848484848485,
+          "focalY": 51.388888888888886,
+          "isFill": false,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/andrew-ly-4fkJZ4Txrbw-unsplash.jpg",
+            "width": 220,
+            "height": 147,
+            "videoId": 147,
+            "alt": "",
+            "sizes": {
+              "thumbnail": {
+                "height": 150,
+                "width": 150,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/andrew-ly-4fkJZ4Txrbw-unsplash-150x150.jpg",
+                "orientation": "landscape"
+              },
+              "medium": {
+                "height": 200,
+                "width": 300,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/andrew-ly-4fkJZ4Txrbw-unsplash-300x200.jpg",
+                "orientation": "landscape"
+              },
+              "large": {
+                "height": 387,
+                "width": 580,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/andrew-ly-4fkJZ4Txrbw-unsplash-1024x683.jpg",
+                "orientation": "landscape"
+              },
+              "full": {
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/andrew-ly-4fkJZ4Txrbw-unsplash.jpg",
+                "height": 1600,
+                "width": 2400,
+                "orientation": "landscape"
+              }
+            }
+          },
+          "x": 109,
+          "y": 132,
+          "width": 220,
+          "height": 147,
+          "mask": {
+            "type": "rectangle",
+            "name": "Rectangle",
+            "path": "M 0,0 1,0 1,1 0,1 0,0",
+            "ratio": 1
+          },
+          "type": "image",
+          "id": "568dd141-9c07-44b3-aed0-4ff56c2089d6",
+          "isBackground": true
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "isFill": false,
+          "x": 68,
+          "y": 72,
+          "width": 304,
+          "height": 153,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "id": "3d3b38a3-d8db-4a86-a4e2-0be30e92b177"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 18,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "FLOATING MARKET",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 88,
+          "y": 106,
+          "width": 148,
+          "height": 23,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "1b892512-7510-4c09-a750-7dfd21ece74a"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "Experience the unique floating market, where all goods are sold from boats.",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 88,
+          "y": 139,
+          "width": 262,
+          "height": 60,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "d773e2ce-05a7-4195-a815-cfd66e93f66a"
+        }
+      ],
+      "backgroundElementId": "568dd141-9c07-44b3-aed0-4ff56c2089d6",
+      "backgroundOverlay": "none",
+      "type": "page",
+      "id": "6302fb0d-8f99-4498-91eb-bca15d67ae84"
+    },
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-DQPP9rVLYGQ-unsplash.jpg",
+            "width": 220,
+            "height": 149,
+            "videoId": 151,
+            "alt": "",
+            "sizes": {
+              "thumbnail": {
+                "height": 150,
+                "width": 150,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-DQPP9rVLYGQ-unsplash-150x150.jpg",
+                "orientation": "landscape"
+              },
+              "medium": {
+                "height": 203,
+                "width": 300,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-DQPP9rVLYGQ-unsplash-300x203.jpg",
+                "orientation": "landscape"
+              },
+              "large": {
+                "height": 393,
+                "width": 580,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-DQPP9rVLYGQ-unsplash-1024x693.jpg",
+                "orientation": "landscape"
+              },
+              "full": {
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-DQPP9rVLYGQ-unsplash.jpg",
+                "height": 1624,
+                "width": 2400,
+                "orientation": "landscape"
+              }
+            }
+          },
+          "x": 47,
+          "y": 85,
+          "width": 220,
+          "height": 149,
+          "mask": {
+            "type": "rectangle",
+            "name": "Rectangle",
+            "path": "M 0,0 1,0 1,1 0,1 0,0",
+            "ratio": 1
+          },
+          "type": "image",
+          "id": "e2b5cfae-e50a-407b-a326-772f3ee70199",
+          "isBackground": true
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Playfair Display",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 38,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "center",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "CAPTURE",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 110,
+          "y": 46,
+          "width": 220,
+          "height": 49,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "65283dae-40f2-4ace-8b0a-0d9f2066a38a"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 90,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "center",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "BANGKOK",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 36,
+          "y": 86,
+          "width": 368,
+          "height": 117,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "95c08a42-48cd-4112-b0e2-f24362adc7bc"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "center",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "Tips and tricks for caturing this iconic city in a day.",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 111,
+          "y": 507,
+          "width": 220,
+          "height": 40,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "7dae1bd9-9f88-4ae8-93eb-f3d908cace09"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/png",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/Masked-image.png",
+            "width": 137,
+            "height": 52,
+            "videoId": 153,
+            "alt": "",
+            "sizes": {
+              "thumbnail": {
+                "height": 104,
+                "width": 150,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/Masked-image-150x104.png",
+                "orientation": "landscape"
+              },
+              "full": {
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/Masked-image.png",
+                "height": 104,
+                "width": 273,
+                "orientation": "landscape"
+              }
+            }
+          },
+          "x": 137,
+          "y": 159,
+          "width": 106,
+          "height": 47,
+          "mask": {
+            "type": "rectangle",
+            "name": "Rectangle",
+            "path": "M 0,0 1,0 1,1 0,1 0,0",
+            "ratio": 1
+          },
+          "type": "image",
+          "id": "c3f29fd0-8b39-4739-a7a9-494a1d1708b8"
+        }
+      ],
+      "backgroundElementId": "e2b5cfae-e50a-407b-a326-772f3ee70199",
+      "backgroundOverlay": "none",
+      "type": "page",
+      "id": "22081c00-a02f-4085-84de-0f4a31253222"
+    },
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "scale": 140,
+          "focalX": 29.758297258297254,
+          "focalY": 50,
+          "isFill": false,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1.jpg",
+            "width": 220,
+            "height": 124,
+            "poster": "",
+            "posterId": 0,
+            "videoId": 161,
+            "title": "bharath-mohan-2CjOnwJCMJM-unsplash",
+            "alt": "",
+            "local": false,
+            "sizes": {
+              "medium": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-300x169.jpg",
+                "width": 300,
+                "height": 169,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-300x169.jpg"
+              },
+              "large": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-1024x576.jpg",
+                "width": 1024,
+                "height": 576,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-1024x576.jpg"
+              },
+              "thumbnail": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-150x150.jpg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-150x150.jpg"
+              },
+              "medium_large": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-768x432.jpg",
+                "width": 768,
+                "height": 432,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-768x432.jpg"
+              },
+              "1536x1536": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-1536x864.jpg",
+                "width": 1536,
+                "height": 864,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-1536x864.jpg"
+              },
+              "2048x2048": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-2048x1152.jpg",
+                "width": 2048,
+                "height": 1152,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-2048x1152.jpg"
+              },
+              "post-thumbnail": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-1200x675.jpg",
+                "width": 1200,
+                "height": 675,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-1200x675.jpg"
+              },
+              "twentytwenty-fullscreen": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-1980x1114.jpg",
+                "width": 1980,
+                "height": 1114,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-1980x1114.jpg"
+              },
+              "web-stories-poster-portrait": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-696x928.jpg",
+                "width": 696,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-696x928.jpg"
+              },
+              "web-stories-poster-square": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-928x928.jpg",
+                "width": 928,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-928x928.jpg"
+              },
+              "web-stories-poster-landscape": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-928x696.jpg",
+                "width": 928,
+                "height": 696,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-928x696.jpg"
+              },
+              "web_stories_thumbnail": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1-150x84.jpg",
+                "width": 150,
+                "height": 84,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1-150x84.jpg"
+              },
+              "full": {
+                "file": "bharath-mohan-2CjOnwJCMJM-unsplash-1.jpg",
+                "width": 2400,
+                "height": 1350,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/bharath-mohan-2CjOnwJCMJM-unsplash-1.jpg"
+              }
+            }
+          },
+          "x": 89,
+          "y": 141,
+          "width": 220,
+          "height": 124,
+          "mask": {
+            "type": "rectangle",
+            "name": "Rectangle",
+            "path": "M 0,0 1,0 1,1 0,1 0,0",
+            "ratio": 1
+          },
+          "type": "image",
+          "id": "252c3d99-9025-453f-9194-c863a9783bd1",
+          "isBackground": true
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 48,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "TOP 5\nCHIANG MAI",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 48,
+          "y": 397,
+          "width": 220,
+          "height": 123,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "c40c8eae-e683-4fa6-a632-e1d652279a37"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Arial",
+          "fontFallback": [
+            "Helvetica Neue",
+            "Helvetica",
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.2,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "If you only have one day to see as many sights as you can, we’ve compiled a list of walkable must-see destinations.",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "x": 48,
+          "y": 538,
+          "width": 280,
+          "height": 76,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "id": "ca20176a-3245-4735-9b1c-66017aa9e528"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/png",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/chiang_mai.png",
+            "width": 220,
+            "height": 371,
+            "videoId": 158,
+            "alt": "",
+            "sizes": {
+              "thumbnail": {
+                "height": 150,
+                "width": 150,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/chiang_mai-150x150.png",
+                "orientation": "landscape"
+              },
+              "medium": {
+                "height": 300,
+                "width": 178,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/chiang_mai-178x300.png",
+                "orientation": "portrait"
+              },
+              "full": {
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/chiang_mai.png",
+                "height": 782,
+                "width": 464,
+                "orientation": "portrait"
+              }
+            }
+          },
+          "x": 186,
+          "y": 0,
+          "width": 245,
+          "height": 413,
+          "mask": {
+            "type": "rectangle",
+            "name": "Rectangle",
+            "path": "M 0,0 1,0 1,1 0,1 0,0",
+            "ratio": 1
+          },
+          "type": "image",
+          "id": "49a53e0a-eb49-4d9b-b5fc-a087171e28b9"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "isFill": false,
+          "x": 233,
+          "y": 15,
+          "width": 18,
+          "height": 18,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "circle"
+          },
+          "type": "shape",
+          "id": "4393667f-c2ab-417b-a901-81c9aa4e3bb3"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 254,
+              "g": 200,
+              "b": 90
+            }
+          },
+          "isFill": false,
+          "x": 236,
+          "y": 18,
+          "width": 12,
+          "height": 12,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "circle"
+          },
+          "type": "shape",
+          "id": "e024d5d3-7398-454a-b28c-52e111e33f1b"
+        }
+      ],
+      "backgroundElementId": "252c3d99-9025-453f-9194-c863a9783bd1",
+      "backgroundOverlay": "none",
+      "type": "page",
+      "id": "c2d56aca-cb1a-41eb-bbdc-41dc2c4f597c"
+    },
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "isFill": false,
+          "x": 7.085362677981848,
+          "y": 66.1806632027532,
+          "width": 146.66666666666666,
+          "height": 146.66666666666666,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "type": "shape",
+          "id": "9012bef0-e5e3-4910-8412-a10ce18e23a6"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "isFill": false,
+          "x": 307,
+          "y": 0,
+          "width": 134,
+          "height": 134,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "id": "7c4a2686-3bcc-4e41-92ed-f12b899b615b"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 31,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "NO. 3",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 70,
+          "height": 31,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "3cf17fb8-a5ae-4f32-8e5f-d3a0513215de",
+          "id": "4f71e74f-fd3f-4840-9ea4-8c0f59363952",
+          "x": 339,
+          "y": 51.5
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 48,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "TEMPLE\nNAME",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 208,
+          "height": 94,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "6258d646-a291-498f-81ab-3095f352bb26",
+          "id": "3932eb5c-e456-43d8-988d-4aa01dd4a8bd",
+          "x": 45,
+          "y": 440
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "The courtyard around the 3 Kings Monument is the best place to give early morning Alms to the Monks in Central Chiang Mai.",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 260,
+          "height": 82,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "883808f1-b87b-4b35-b0f1-0945e0faef2e",
+          "id": "bc7d8800-b421-4a19-9db0-f594e9b0bd8d",
+          "x": 45,
+          "y": 545
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "x": 0,
+          "y": 0,
+          "width": 307,
+          "height": 392,
+          "scale": 100,
+          "focalX": 50.000000000000014,
+          "focalY": 57.36776812717045,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "id": "37a09535-568f-4dc6-a07d-57f3ac1c9d39",
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/markus-winkler-YD62W4hcWbM-unsplash-scaled.jpg",
+            "width": 220,
+            "height": 330,
+            "videoId": 166,
+            "alt": "",
+            "sizes": {
+              "thumbnail": {
+                "height": 150,
+                "width": 150,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/markus-winkler-YD62W4hcWbM-unsplash-150x150.jpg",
+                "orientation": "landscape"
+              },
+              "medium": {
+                "height": 300,
+                "width": 200,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/markus-winkler-YD62W4hcWbM-unsplash-200x300.jpg",
+                "orientation": "portrait"
+              },
+              "large": {
+                "height": 870,
+                "width": 580,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/markus-winkler-YD62W4hcWbM-unsplash-683x1024.jpg",
+                "orientation": "portrait"
+              },
+              "full": {
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/markus-winkler-YD62W4hcWbM-unsplash-scaled.jpg",
+                "height": 2560,
+                "width": 1707,
+                "orientation": "portrait"
+              }
+            }
+          }
+        }
+      ],
+      "backgroundElementId": "9012bef0-e5e3-4910-8412-a10ce18e23a6",
+      "backgroundOverlay": "none",
+      "type": "page",
+      "id": "7b7d7662-fb1f-46b5-94e0-b01029a666a5"
+    },
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/robin-noguier-sydwCr54rf0-unsplash.jpg",
+            "width": 220,
+            "height": 147,
+            "videoId": 168,
+            "alt": "",
+            "sizes": {
+              "thumbnail": {
+                "height": 150,
+                "width": 150,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/robin-noguier-sydwCr54rf0-unsplash-150x150.jpg",
+                "orientation": "landscape"
+              },
+              "medium": {
+                "height": 200,
+                "width": 300,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/robin-noguier-sydwCr54rf0-unsplash-300x200.jpg",
+                "orientation": "landscape"
+              },
+              "large": {
+                "height": 387,
+                "width": 580,
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/robin-noguier-sydwCr54rf0-unsplash-1024x683.jpg",
+                "orientation": "landscape"
+              },
+              "full": {
+                "url": "http://localhost:8899/wp-content/uploads/2020/04/robin-noguier-sydwCr54rf0-unsplash.jpg",
+                "height": 1600,
+                "width": 2400,
+                "orientation": "landscape"
+              }
+            }
+          },
+          "x": 4,
+          "y": 21,
+          "width": 220,
+          "height": 147,
+          "mask": {
+            "type": "rectangle",
+            "name": "Rectangle",
+            "path": "M 0,0 1,0 1,1 0,1 0,0",
+            "ratio": 1
+          },
+          "type": "image",
+          "id": "0318dc71-fb48-4814-8552-2f88d71d53b9",
+          "isBackground": true
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 254,
+              "g": 200,
+              "b": 90
+            }
+          },
+          "isFill": false,
+          "width": 134,
+          "height": 134,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "basedOn": "7c4a2686-3bcc-4e41-92ed-f12b899b615b",
+          "id": "5f598141-8e1c-4486-8d73-9fd9e8934c48",
+          "x": 307,
+          "y": 0
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 31,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "LEARN\nMORE",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 77,
+          "height": 62,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "3cf17fb8-a5ae-4f32-8e5f-d3a0513215de",
+          "id": "28b135fd-63b8-456c-985d-3dfe542fffd7",
+          "x": 335.5,
+          "y": 36
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 159,
+              "g": 208,
+              "b": 255,
+              "a": 0.5
+            }
+          },
+          "isFill": false,
+          "x": 0,
+          "y": 1,
+          "width": 306,
+          "height": 380,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "id": "f60ae332-db13-481f-ace7-107885b1c202"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 48,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "ISLAND\nHOPPING",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 208,
+          "height": 94,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "6258d646-a291-498f-81ab-3095f352bb26",
+          "id": "30716193-c4ff-4619-b485-8108d250c8b8",
+          "x": 42,
+          "y": 51
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "The main island hopping hubs are Phuket, Krabi, Koh Phi Phi, and Koh Lipe. Other favorites include Ko Tao, Ko Pha-Ngan, Ko Samui and Surat Thani.",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 222,
+          "height": 120,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "883808f1-b87b-4b35-b0f1-0945e0faef2e",
+          "id": "41d3069f-61de-4998-8487-036ea86917a6",
+          "x": 42,
+          "y": 171
+        }
+      ],
+      "backgroundElementId": "0318dc71-fb48-4814-8552-2f88d71d53b9",
+      "backgroundOverlay": "none",
+      "type": "page",
+      "id": "1659f169-eb29-498a-bd00-6aea80d7ace7"
+    },
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "isFill": false,
+          "x": 35.02560418743476,
+          "y": 104.1066042748157,
+          "width": 146.66666666666666,
+          "height": 146.66666666666666,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "type": "shape",
+          "id": "55fcd4fb-1af4-4540-ac57-a783f94f6864"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 18,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "1. PHUKET",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 220,
+          "height": 18,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "3932eb5c-e456-43d8-988d-4aa01dd4a8bd",
+          "id": "5cb07f8c-750f-437b-981f-cc3228cdeffd",
+          "x": 183,
+          "y": 47
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 18,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "2. KOH PHI PHI",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 220,
+          "height": 18,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "5cb07f8c-750f-437b-981f-cc3228cdeffd",
+          "id": "840cd415-bf08-4186-9649-932beb2e6778",
+          "x": 183,
+          "y": 180
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 18,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "3. KOH YAO YAI",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 220,
+          "height": 18,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "5cb07f8c-750f-437b-981f-cc3228cdeffd",
+          "id": "2192d51d-a5e1-437e-a6a1-c7c2a1d7a7c4",
+          "x": 184,
+          "y": 306
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 18,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "4. KOH LIPE",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 220,
+          "height": 18,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "5cb07f8c-750f-437b-981f-cc3228cdeffd",
+          "id": "bbe6302e-87c0-49d2-b16b-ff787059c187",
+          "x": 183,
+          "y": 441
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 18,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "5. KO SAMUI",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 208,
+          "height": 18,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "5cb07f8c-750f-437b-981f-cc3228cdeffd",
+          "id": "44db08e2-0900-40a6-9e52-3ab2325aeab2",
+          "x": 183,
+          "y": 576
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "Start your journey here",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 200,
+          "height": 20,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "d773e2ce-05a7-4195-a815-cfd66e93f66a",
+          "id": "adc642e3-a739-4349-9646-cb06d88f51a4",
+          "x": 184,
+          "y": 76
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "Scoot around the island",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 200,
+          "height": 20,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "adc642e3-a739-4349-9646-cb06d88f51a4",
+          "id": "919e9a80-e851-49fe-9660-c67937a14e13",
+          "x": 182,
+          "y": 206
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "Snorkle with the fish",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 200,
+          "height": 20,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "adc642e3-a739-4349-9646-cb06d88f51a4",
+          "id": "0ac04592-1df3-4d5a-896b-18c821c93c4a",
+          "x": 182,
+          "y": 333
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "Best red curry",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 200,
+          "height": 20,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "adc642e3-a739-4349-9646-cb06d88f51a4",
+          "id": "63b0bbbf-6ef4-42c1-b017-d7db0db07039",
+          "x": 185,
+          "y": 467
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Lora",
+          "fontFallback": [
+            "serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 16,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "Semi-secluded island",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 200,
+          "height": 20,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "adc642e3-a739-4349-9646-cb06d88f51a4",
+          "id": "300c43cc-b0b0-45de-97ba-1775028d50bb",
+          "x": 183,
+          "y": 599
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 241,
+              "g": 241,
+              "b": 241
+            }
+          },
+          "isFill": false,
+          "x": -5,
+          "y": 128,
+          "width": 445,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "id": "d90985a8-8ba6-45b1-8e8a-ef2fa073dac9"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 241,
+              "g": 241,
+              "b": 241
+            }
+          },
+          "isFill": false,
+          "width": 445,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "basedOn": "d90985a8-8ba6-45b1-8e8a-ef2fa073dac9",
+          "id": "3a1f5ae5-8bc5-418f-8178-8dfc4427f719",
+          "x": -2,
+          "y": 262
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 241,
+              "g": 241,
+              "b": 241
+            }
+          },
+          "isFill": false,
+          "width": 445,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "basedOn": "d90985a8-8ba6-45b1-8e8a-ef2fa073dac9",
+          "id": "359fca2c-a5ab-448c-b9e6-11dd47517650",
+          "x": 0,
+          "y": 390
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 241,
+              "g": 241,
+              "b": 241
+            }
+          },
+          "isFill": false,
+          "width": 445,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "basedOn": "359fca2c-a5ab-448c-b9e6-11dd47517650",
+          "id": "2a391259-057a-4976-b90d-2c6140e2a222",
+          "x": 1,
+          "y": 524
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "x": -3,
+          "y": 0,
+          "width": 133,
+          "height": 133,
+          "scale": 210,
+          "focalX": 71.09866593641652,
+          "focalY": 42.12316471707116,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "id": "43b28f35-fdc3-4b59-b3da-ad9581cbeb8c",
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2.jpg",
+            "width": 220,
+            "height": 165,
+            "poster": "",
+            "posterId": 0,
+            "videoId": 203,
+            "title": "deepain-jindal-z6-wQHB6p2Y-unsplash (2)",
+            "alt": "",
+            "local": false,
+            "sizes": {
+              "medium": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2-300x225.jpg",
+                "width": 300,
+                "height": 225,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2-300x225.jpg"
+              },
+              "large": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2-1024x768.jpg",
+                "width": 1024,
+                "height": 768,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2-1024x768.jpg"
+              },
+              "thumbnail": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2-150x150.jpg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2-150x150.jpg"
+              },
+              "medium_large": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2-768x576.jpg",
+                "width": 768,
+                "height": 576,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2-768x576.jpg"
+              },
+              "1536x1536": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2-1536x1152.jpg",
+                "width": 1536,
+                "height": 1152,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2-1536x1152.jpg"
+              },
+              "post-thumbnail": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2-1200x900.jpg",
+                "width": 1200,
+                "height": 900,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2-1200x900.jpg"
+              },
+              "web-stories-poster-portrait": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2-696x928.jpg",
+                "width": 696,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2-696x928.jpg"
+              },
+              "web-stories-poster-square": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2-928x928.jpg",
+                "width": 928,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2-928x928.jpg"
+              },
+              "web-stories-poster-landscape": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2-928x696.jpg",
+                "width": 928,
+                "height": 696,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2-928x696.jpg"
+              },
+              "web_stories_thumbnail": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2-150x113.jpg",
+                "width": 150,
+                "height": 113,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2-150x113.jpg"
+              },
+              "full": {
+                "file": "deepain-jindal-z6-wQHB6p2Y-unsplash-2.jpg",
+                "width": 1920,
+                "height": 1440,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/deepain-jindal-z6-wQHB6p2Y-unsplash-2.jpg"
+              }
+            }
+          }
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "width": 133,
+          "height": 133,
+          "scale": 130,
+          "focalX": 38.57638552918454,
+          "focalY": 50.00000000000002,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "basedOn": "43b28f35-fdc3-4b59-b3da-ad9581cbeb8c",
+          "id": "d16ef169-d80c-4e70-817a-9e3bf66d1428",
+          "x": -3,
+          "y": 132,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1.jpg",
+            "width": 220,
+            "height": 124,
+            "poster": "",
+            "posterId": 0,
+            "videoId": 202,
+            "title": "colton-duke-C2D8g0qDOmU-unsplash (1)",
+            "alt": "",
+            "local": false,
+            "sizes": {
+              "medium": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1-300x169.jpg",
+                "width": 300,
+                "height": 169,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1-300x169.jpg"
+              },
+              "large": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1-1024x576.jpg",
+                "width": 1024,
+                "height": 576,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1-1024x576.jpg"
+              },
+              "thumbnail": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1-150x150.jpg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1-150x150.jpg"
+              },
+              "medium_large": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1-768x432.jpg",
+                "width": 768,
+                "height": 432,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1-768x432.jpg"
+              },
+              "1536x1536": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1-1536x864.jpg",
+                "width": 1536,
+                "height": 864,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1-1536x864.jpg"
+              },
+              "post-thumbnail": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1-1200x675.jpg",
+                "width": 1200,
+                "height": 675,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1-1200x675.jpg"
+              },
+              "web-stories-poster-portrait": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1-696x928.jpg",
+                "width": 696,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1-696x928.jpg"
+              },
+              "web-stories-poster-square": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1-928x928.jpg",
+                "width": 928,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1-928x928.jpg"
+              },
+              "web-stories-poster-landscape": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1-928x696.jpg",
+                "width": 928,
+                "height": 696,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1-928x696.jpg"
+              },
+              "web_stories_thumbnail": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1-150x84.jpg",
+                "width": 150,
+                "height": 84,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1-150x84.jpg"
+              },
+              "full": {
+                "file": "colton-duke-C2D8g0qDOmU-unsplash-1-1.jpg",
+                "width": 1920,
+                "height": 1080,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-C2D8g0qDOmU-unsplash-1-1.jpg"
+              }
+            }
+          }
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "width": 133,
+          "height": 133,
+          "scale": 120,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "basedOn": "43b28f35-fdc3-4b59-b3da-ad9581cbeb8c",
+          "id": "cc687c94-be82-4e6c-8700-610ef40d6f5e",
+          "x": -2,
+          "y": 264,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2.jpg",
+            "width": 220,
+            "height": 151,
+            "poster": "",
+            "posterId": 0,
+            "videoId": 201,
+            "title": "jakob-owens-GakQTH4frng-unsplash (2)",
+            "alt": "",
+            "local": false,
+            "sizes": {
+              "medium": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2-300x206.jpg",
+                "width": 300,
+                "height": 206,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2-300x206.jpg"
+              },
+              "large": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2-1024x703.jpg",
+                "width": 1024,
+                "height": 703,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2-1024x703.jpg"
+              },
+              "thumbnail": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2-150x150.jpg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2-150x150.jpg"
+              },
+              "medium_large": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2-768x527.jpg",
+                "width": 768,
+                "height": 527,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2-768x527.jpg"
+              },
+              "1536x1536": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2-1536x1054.jpg",
+                "width": 1536,
+                "height": 1054,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2-1536x1054.jpg"
+              },
+              "post-thumbnail": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2-1200x824.jpg",
+                "width": 1200,
+                "height": 824,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2-1200x824.jpg"
+              },
+              "web-stories-poster-portrait": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2-696x928.jpg",
+                "width": 696,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2-696x928.jpg"
+              },
+              "web-stories-poster-square": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2-928x928.jpg",
+                "width": 928,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2-928x928.jpg"
+              },
+              "web-stories-poster-landscape": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2-928x696.jpg",
+                "width": 928,
+                "height": 696,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2-928x696.jpg"
+              },
+              "web_stories_thumbnail": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2-150x103.jpg",
+                "width": 150,
+                "height": 103,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2-150x103.jpg"
+              },
+              "full": {
+                "file": "jakob-owens-GakQTH4frng-unsplash-2.jpg",
+                "width": 1920,
+                "height": 1318,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/jakob-owens-GakQTH4frng-unsplash-2.jpg"
+              }
+            }
+          }
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "width": 133,
+          "height": 133,
+          "scale": 110,
+          "focalX": 37.799042537992264,
+          "focalY": 54.72610116975728,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "basedOn": "43b28f35-fdc3-4b59-b3da-ad9581cbeb8c",
+          "id": "a7ca1ee4-5f88-45e3-aa3d-ea3cfda6b027",
+          "x": -3,
+          "y": 396,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2.jpg",
+            "width": 220,
+            "height": 147,
+            "poster": "",
+            "posterId": 0,
+            "videoId": 200,
+            "title": "8-low-ural-_6bfVnELZXE-unsplash (2)",
+            "alt": "",
+            "local": false,
+            "sizes": {
+              "medium": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2-300x200.jpg",
+                "width": 300,
+                "height": 200,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2-300x200.jpg"
+              },
+              "large": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2-1024x683.jpg",
+                "width": 1024,
+                "height": 683,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2-1024x683.jpg"
+              },
+              "thumbnail": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2-150x150.jpg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2-150x150.jpg"
+              },
+              "medium_large": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2-768x512.jpg",
+                "width": 768,
+                "height": 512,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2-768x512.jpg"
+              },
+              "1536x1536": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2-1536x1024.jpg",
+                "width": 1536,
+                "height": 1024,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2-1536x1024.jpg"
+              },
+              "post-thumbnail": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2-1200x800.jpg",
+                "width": 1200,
+                "height": 800,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2-1200x800.jpg"
+              },
+              "web-stories-poster-portrait": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2-696x928.jpg",
+                "width": 696,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2-696x928.jpg"
+              },
+              "web-stories-poster-square": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2-928x928.jpg",
+                "width": 928,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2-928x928.jpg"
+              },
+              "web-stories-poster-landscape": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2-928x696.jpg",
+                "width": 928,
+                "height": 696,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2-928x696.jpg"
+              },
+              "web_stories_thumbnail": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2-150x100.jpg",
+                "width": 150,
+                "height": 100,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2-150x100.jpg"
+              },
+              "full": {
+                "file": "8-low-ural-_6bfVnELZXE-unsplash-2.jpg",
+                "width": 1920,
+                "height": 1280,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/8-low-ural-_6bfVnELZXE-unsplash-2.jpg"
+              }
+            }
+          }
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "width": 133,
+          "height": 133,
+          "scale": 160,
+          "focalX": 68.9811217492273,
+          "focalY": 60.54933296820826,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "basedOn": "43b28f35-fdc3-4b59-b3da-ad9581cbeb8c",
+          "id": "07155f07-19d8-4eca-8817-9b512fd3303f",
+          "x": -3,
+          "y": 527,
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1.jpg",
+            "width": 220,
+            "height": 330,
+            "poster": "",
+            "posterId": 0,
+            "videoId": 199,
+            "title": "joshua-fuller-T_G3XglC8nw-unsplash (1)",
+            "alt": "",
+            "local": false,
+            "sizes": {
+              "medium": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-200x300.jpg",
+                "width": 200,
+                "height": 300,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-200x300.jpg"
+              },
+              "large": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-683x1024.jpg",
+                "width": 683,
+                "height": 1024,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-683x1024.jpg"
+              },
+              "thumbnail": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-150x150.jpg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-150x150.jpg"
+              },
+              "medium_large": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-768x1152.jpg",
+                "width": 768,
+                "height": 1152,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-768x1152.jpg"
+              },
+              "1536x1536": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-1024x1536.jpg",
+                "width": 1024,
+                "height": 1536,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-1024x1536.jpg"
+              },
+              "2048x2048": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-1365x2048.jpg",
+                "width": 1365,
+                "height": 2048,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-1365x2048.jpg"
+              },
+              "post-thumbnail": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-1200x1800.jpg",
+                "width": 1200,
+                "height": 1800,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-1200x1800.jpg"
+              },
+              "web-stories-poster-portrait": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-696x928.jpg",
+                "width": 696,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-696x928.jpg"
+              },
+              "web-stories-poster-square": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-928x928.jpg",
+                "width": 928,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-928x928.jpg"
+              },
+              "web-stories-poster-landscape": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-928x696.jpg",
+                "width": 928,
+                "height": 696,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-928x696.jpg"
+              },
+              "web_stories_thumbnail": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-150x225.jpg",
+                "width": 150,
+                "height": 225,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-150x225.jpg"
+              },
+              "full": {
+                "file": "joshua-fuller-T_G3XglC8nw-unsplash-1-1-scaled.jpg",
+                "width": 1707,
+                "height": 2560,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/joshua-fuller-T_G3XglC8nw-unsplash-1-1-scaled.jpg"
+              }
+            }
+          }
+        }
+      ],
+      "backgroundElementId": "55fcd4fb-1af4-4540-ac57-a783f94f6864",
+      "backgroundOverlay": "none",
+      "type": "page",
+      "id": "78da0e6c-6bc7-4680-90a8-2b6bf6e98aaa"
+    },
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "isFill": false,
+          "x": 87.55367762615079,
+          "y": 67.20277600599519,
+          "width": 146.66666666666666,
+          "height": 146.66666666666666,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "type": "shape",
+          "id": "282588c3-fbc2-4b63-8260-2e58d0e63294"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 254,
+              "g": 200,
+              "b": 90
+            }
+          },
+          "isFill": false,
+          "x": 240,
+          "y": 201,
+          "width": 213,
+          "height": 134,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "id": "b542beff-39c1-4787-a8ad-a2a061c51a60"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 236,
+              "g": 236,
+              "b": 236
+            }
+          },
+          "isFill": false,
+          "width": 213,
+          "height": 134,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "shape",
+          "basedOn": "b542beff-39c1-4787-a8ad-a2a061c51a60",
+          "id": "12b82d84-167c-49b1-8efd-afae77b857f0",
+          "x": 239,
+          "y": 469
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 18,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "5 SPICIEST\nDISHES",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 87,
+          "height": 36,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "840cd415-bf08-4186-9649-932beb2e6778",
+          "id": "7ea7ab1b-9bcd-45d6-941d-2c1143cadf0f",
+          "x": 279,
+          "y": 230
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 18,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "HIKES OFF THE BEATEN\nTRAIL",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 87,
+          "height": 52,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "7ea7ab1b-9bcd-45d6-941d-2c1143cadf0f",
+          "id": "cb201d61-faec-476e-9d72-14caf813197b",
+          "x": 279,
+          "y": 361
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 18,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "CATCH THE SWIMMING MONKEYS",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 87,
+          "height": 52,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "cb201d61-faec-476e-9d72-14caf813197b",
+          "id": "fcdc8182-cfb1-4010-82cd-91b5f235f0fc",
+          "x": 279,
+          "y": 494
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "bold": false,
+          "fontFamily": "Oswald",
+          "fontFallback": [
+            "sans-serif"
+          ],
+          "fontWeight": 400,
+          "fontSize": 48,
+          "fontStyle": "normal",
+          "color": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "letterSpacing": 0,
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "textDecoration": "none",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0
+          },
+          "content": "MORE\nSTORIES",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "width": 208,
+          "height": 94,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "isFill": false,
+          "type": "text",
+          "basedOn": "3932eb5c-e456-43d8-988d-4aa01dd4a8bd",
+          "id": "e5272870-2b37-4bba-abcf-eab0ffc222a4",
+          "x": 40,
+          "y": 53
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "x": 0,
+          "y": 201,
+          "width": 241,
+          "height": 134,
+          "scale": 230,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "id": "85439d79-2100-4dc8-9b20-e6e51d2064af",
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash.jpg",
+            "width": 220,
+            "height": 112,
+            "poster": "",
+            "posterId": 0,
+            "videoId": 187,
+            "title": "v2osk-gY-WgPBe5vQ-unsplash",
+            "alt": "",
+            "local": false,
+            "sizes": {
+              "medium": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash-300x153.jpg",
+                "width": 300,
+                "height": 153,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash-300x153.jpg"
+              },
+              "large": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash-1024x521.jpg",
+                "width": 1024,
+                "height": 521,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash-1024x521.jpg"
+              },
+              "thumbnail": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash-150x150.jpg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash-150x150.jpg"
+              },
+              "medium_large": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash-768x391.jpg",
+                "width": 768,
+                "height": 391,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash-768x391.jpg"
+              },
+              "1536x1536": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash-1536x782.jpg",
+                "width": 1536,
+                "height": 782,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash-1536x782.jpg"
+              },
+              "post-thumbnail": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash-1200x611.jpg",
+                "width": 1200,
+                "height": 611,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash-1200x611.jpg"
+              },
+              "web-stories-poster-portrait": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash-696x928.jpg",
+                "width": 696,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash-696x928.jpg"
+              },
+              "web-stories-poster-square": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash-928x928.jpg",
+                "width": 928,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash-928x928.jpg"
+              },
+              "web-stories-poster-landscape": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash-928x696.jpg",
+                "width": 928,
+                "height": 696,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash-928x696.jpg"
+              },
+              "web_stories_thumbnail": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash-150x76.jpg",
+                "width": 150,
+                "height": 76,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash-150x76.jpg"
+              },
+              "full": {
+                "file": "v2osk-gY-WgPBe5vQ-unsplash.jpg",
+                "width": 1920,
+                "height": 977,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/v2osk-gY-WgPBe5vQ-unsplash.jpg"
+              }
+            }
+          }
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "width": 241,
+          "height": 134,
+          "scale": 170,
+          "focalX": 49.82857225203227,
+          "focalY": 66.89928999986729,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash.jpg",
+            "width": 220,
+            "height": 83,
+            "poster": "",
+            "posterId": 0,
+            "videoId": 189,
+            "title": "colton-duke-QRU0i5AqEJA-unsplash",
+            "alt": "",
+            "local": false,
+            "sizes": {
+              "medium": {
+                "file": "colton-duke-QRU0i5AqEJA-unsplash-300x113.jpg",
+                "width": 300,
+                "height": 113,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash-300x113.jpg"
+              },
+              "large": {
+                "file": "colton-duke-QRU0i5AqEJA-unsplash-1024x386.jpg",
+                "width": 1024,
+                "height": 386,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash-1024x386.jpg"
+              },
+              "thumbnail": {
+                "file": "colton-duke-QRU0i5AqEJA-unsplash-150x150.jpg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash-150x150.jpg"
+              },
+              "medium_large": {
+                "file": "colton-duke-QRU0i5AqEJA-unsplash-768x289.jpg",
+                "width": 768,
+                "height": 289,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash-768x289.jpg"
+              },
+              "post-thumbnail": {
+                "file": "colton-duke-QRU0i5AqEJA-unsplash-1200x452.jpg",
+                "width": 1200,
+                "height": 452,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash-1200x452.jpg"
+              },
+              "web-stories-poster-portrait": {
+                "file": "colton-duke-QRU0i5AqEJA-unsplash-696x565.jpg",
+                "width": 696,
+                "height": 565,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash-696x565.jpg"
+              },
+              "web-stories-poster-square": {
+                "file": "colton-duke-QRU0i5AqEJA-unsplash-928x565.jpg",
+                "width": 928,
+                "height": 565,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash-928x565.jpg"
+              },
+              "web-stories-poster-landscape": {
+                "file": "colton-duke-QRU0i5AqEJA-unsplash-928x565.jpg",
+                "width": 928,
+                "height": 565,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash-928x565.jpg"
+              },
+              "web_stories_thumbnail": {
+                "file": "colton-duke-QRU0i5AqEJA-unsplash-150x57.jpg",
+                "width": 150,
+                "height": 57,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash-150x57.jpg"
+              },
+              "full": {
+                "file": "colton-duke-QRU0i5AqEJA-unsplash.jpg",
+                "width": 1499,
+                "height": 565,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/colton-duke-QRU0i5AqEJA-unsplash.jpg"
+              }
+            }
+          },
+          "basedOn": "85439d79-2100-4dc8-9b20-e6e51d2064af",
+          "id": "19fd443d-f580-436b-82b4-ef2938c55e89",
+          "x": -1,
+          "y": 335
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 51,
+              "g": 51,
+              "b": 51
+            }
+          },
+          "isFill": false,
+          "width": 241,
+          "height": 134,
+          "scale": 110,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "type": "image",
+          "resource": {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "src": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash.jpg",
+            "width": 220,
+            "height": 138,
+            "poster": "",
+            "posterId": 0,
+            "videoId": 188,
+            "title": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash",
+            "alt": "",
+            "local": false,
+            "sizes": {
+              "medium": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash-300x188.jpg",
+                "width": 300,
+                "height": 188,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash-300x188.jpg"
+              },
+              "large": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash-1024x641.jpg",
+                "width": 1024,
+                "height": 641,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash-1024x641.jpg"
+              },
+              "thumbnail": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash-150x150.jpg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash-150x150.jpg"
+              },
+              "medium_large": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash-768x481.jpg",
+                "width": 768,
+                "height": 481,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash-768x481.jpg"
+              },
+              "1536x1536": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash-1536x962.jpg",
+                "width": 1536,
+                "height": 962,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash-1536x962.jpg"
+              },
+              "post-thumbnail": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash-1200x751.jpg",
+                "width": 1200,
+                "height": 751,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash-1200x751.jpg"
+              },
+              "web-stories-poster-portrait": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash-696x928.jpg",
+                "width": 696,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash-696x928.jpg"
+              },
+              "web-stories-poster-square": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash-928x928.jpg",
+                "width": 928,
+                "height": 928,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash-928x928.jpg"
+              },
+              "web-stories-poster-landscape": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash-928x696.jpg",
+                "width": 928,
+                "height": 696,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash-928x696.jpg"
+              },
+              "web_stories_thumbnail": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash-150x94.jpg",
+                "width": 150,
+                "height": 94,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash-150x94.jpg"
+              },
+              "full": {
+                "file": "ciprian-boiciuc-SkQo_ZPFvOc-unsplash.jpg",
+                "width": 1920,
+                "height": 1202,
+                "mime_type": "image/jpeg",
+                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/ciprian-boiciuc-SkQo_ZPFvOc-unsplash.jpg"
+              }
+            }
+          },
+          "basedOn": "19fd443d-f580-436b-82b4-ef2938c55e89",
+          "id": "098c9143-7ca0-4b04-866f-02c5c48339d2",
+          "x": -2,
+          "y": 469
+        }
+      ],
+      "backgroundElementId": "282588c3-fbc2-4b63-8260-2e58d0e63294",
+      "backgroundOverlay": "none",
+      "type": "page",
+      "id": "9a45a0b2-0261-4298-aef7-c08b99771787"
+    }
+  ]
+}

--- a/assets/src/dashboard/templates/stories/travel.js
+++ b/assets/src/dashboard/templates/stories/travel.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { PreviewPage } from '../../components';
+import ApiProvider from '../../app/api/apiProvider';
+import FontProvider from '../../app/font/fontProvider';
+import { UnitsProvider } from '../../../edit-story/units';
+import { TransformProvider } from '../../../edit-story/components/transform';
+import travelData from '../data/travel.json';
+
+export default {
+  title: 'Dashboard/Templates/Travel',
+};
+
+const PageContainer = styled.div`
+  position: relative;
+  width: 280px;
+  height: 420px;
+  border-radius: 8px;
+  margin: 20px;
+  overflow: hidden;
+`;
+
+const StoryProviders = ({ width, height, children }) => (
+  <ApiProvider>
+    <FontProvider>
+      <TransformProvider>
+        <UnitsProvider pageSize={{ width, height }}>{children}</UnitsProvider>
+      </TransformProvider>
+    </FontProvider>
+  </ApiProvider>
+);
+
+StoryProviders.propTypes = {
+  width: PropTypes.number,
+  height: PropTypes.number,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+};
+
+const TemplateFonts = () => (
+  <link
+    rel="stylesheet"
+    id="google-sans-font-css"
+    href="https://fonts.googleapis.com/css2?family=Lora&family=Oswald:wght@500&family=Playfair+Display&display=swap"
+    media="all"
+  />
+);
+
+export const _default = () => {
+  const { pages } = travelData;
+
+  return (
+    <>
+      <TemplateFonts />
+      <StoryProviders width={280} height={420}>
+        {pages.map((page, index) => (
+          <PageContainer key={index}>
+            <PreviewPage page={page} />
+          </PageContainer>
+        ))}
+      </StoryProviders>
+    </>
+  );
+};


### PR DESCRIPTION
This PR adds a json file that describes a static (no animations) version of the Travel template.  Using our `PreviewPage` component I was able to get the template to render inside storybook.

The static Travel template is about 95% complete, a few small details are still missing but I figure this is a good start to test out creating a template using our editor data structure, and it unblocks us so we can start creating the Template Dashboard pages.  It also gives us a data structure to add in animations.  

![image](https://user-images.githubusercontent.com/40646372/78701238-898a9680-78bb-11ea-894e-df9f9c132b33.png)
(Travel template in storybook, scroll down in storybook to see the rest if the pages)
