### PR TITLE
Color picker styling improvements

### DIFF
--- a/assets/src/edit-story/components/colorPicker/colorPicker.js
+++ b/assets/src/edit-story/components/colorPicker/colorPicker.js
@@ -21,7 +21,6 @@ import { CSSTransition } from 'react-transition-group';
 import { useEffect, useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { rgba } from 'polished';
 
 /**
  * WordPress dependencies
@@ -39,11 +38,9 @@ import GradientPicker from './gradientPicker';
 import Header from './header';
 import useColor from './useColor';
 
-const CONTAINER_PADDING = 15;
-
 const Container = styled.div`
-  border-radius: 4px;
-  background: ${({ theme }) => theme.colors.bg.v7};
+  border-radius: 6px;
+  background: ${({ theme }) => theme.colors.bg.v8};
   color: ${({ theme }) => theme.colors.fg.v1};
   width: 240px;
   font-family: ${({ theme }) => theme.fonts.body1.family};
@@ -69,8 +66,7 @@ const Container = styled.div`
 `;
 
 const Body = styled.div`
-  border-top: 1px solid ${({ theme }) => rgba(theme.colors.fg.v2, 0.2)};
-  padding: ${CONTAINER_PADDING}px;
+  border-top: 1px solid ${({ theme }) => theme.colors.fg.v6};
 `;
 
 function ColorPicker({

--- a/assets/src/edit-story/components/colorPicker/currentColorPicker.js
+++ b/assets/src/edit-story/components/colorPicker/currentColorPicker.js
@@ -35,9 +35,9 @@ import { Eyedropper } from '../button';
 import Pointer from './pointer';
 import EditablePreview from './editablePreview';
 
-const CONTAINER_PADDING = 15;
+const CONTAINER_PADDING = 12;
 const EYEDROPPER_ICON_SIZE = 15;
-const HEADER_FOOTER_HEIGHT = 50;
+const HEADER_FOOTER_HEIGHT = 42;
 const BODY_HEIGHT = 140;
 const CONTROLS_WIDTH = 12;
 const CONTROLS_BORDER_RADIUS = 6;
@@ -48,18 +48,23 @@ const Container = styled.div`
   font-weight: normal;
   font-size: 12px;
   user-select: none;
+  padding: ${CONTAINER_PADDING}px;
+  padding-bottom: 0px;
 `;
 
 const Body = styled.div`
   padding-bottom: 0;
   display: grid;
-  grid: 'saturation hue alpha' ${BODY_HEIGHT}px / 1fr ${CONTROLS_WIDTH}px ${CONTROLS_WIDTH}px;
+  grid: ${({ showOpacity }) =>
+    showOpacity
+      ? `'saturation hue alpha' ${BODY_HEIGHT}px / 1fr ${CONTROLS_WIDTH}px ${CONTROLS_WIDTH}px`
+      : `'saturation hue' ${BODY_HEIGHT}px / 1fr ${CONTROLS_WIDTH}px`};
   grid-gap: 10px;
 `;
 
 const SaturationWrapper = styled.div`
   position: relative;
-  width: 167px;
+  width: 100%;
   height: ${BODY_HEIGHT}px;
   grid-area: saturation;
 `;
@@ -81,35 +86,22 @@ const AlphaWrapper = styled.div`
 `;
 
 const Footer = styled.div`
-  padding: ${CONTAINER_PADDING}px;
+  padding: ${CONTAINER_PADDING}px 0px;
   height: ${HEADER_FOOTER_HEIGHT}px;
   font-size: ${CONTROLS_WIDTH}px;
   line-height: 19px;
   position: relative;
-`;
-
-const EyedropperWrapper = styled.div`
-  position: absolute;
-  left: 0;
-  bottom: ${CONTAINER_PADDING}px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;
 
 const EyedropperButton = styled(Eyedropper)`
   line-height: ${EYEDROPPER_ICON_SIZE}px;
 `;
 
-const CurrentWrapper = styled.div`
-  position: absolute;
-  left: 0;
-  right: 0;
-  text-align: center;
-  bottom: ${CONTAINER_PADDING}px;
-`;
-
-const CurrentAlphaWrapper = styled.div`
-  position: absolute;
-  right: 0;
-  bottom: ${CONTAINER_PADDING}px;
+const OpacityPlaceholder = styled.div`
+  width: 32px;
 `;
 
 function CurrentColorPicker({ rgb, hsl, hsv, hex, onChange, showOpacity }) {
@@ -133,7 +125,7 @@ function CurrentColorPicker({ rgb, hsl, hsv, hex, onChange, showOpacity }) {
 
   return (
     <Container>
-      <Body>
+      <Body showOpacity={showOpacity}>
         <SaturationWrapper>
           <Saturation
             radius={`${CONTROLS_BORDER_RADIUS}px`}
@@ -173,33 +165,29 @@ function CurrentColorPicker({ rgb, hsl, hsv, hex, onChange, showOpacity }) {
       </Body>
       <Footer>
         {/* TODO: implement (see https://github.com/google/web-stories-wp/issues/262) */}
-        <EyedropperWrapper>
-          <EyedropperButton
-            width={EYEDROPPER_ICON_SIZE}
-            height={EYEDROPPER_ICON_SIZE}
-            aria-label={__('Select color', 'web-stories')}
-            isDisabled
-          />
-        </EyedropperWrapper>
-        <CurrentWrapper>
+        <EyedropperButton
+          width={EYEDROPPER_ICON_SIZE}
+          height={EYEDROPPER_ICON_SIZE}
+          aria-label={__('Select color', 'web-stories')}
+          isDisabled
+        />
+        <EditablePreview
+          label={__('Edit hex value', 'web-stories')}
+          value={hexValue}
+          onChange={handleHexInputChange}
+          width={56}
+          format={handleFormatHex}
+        />
+        {showOpacity ? (
           <EditablePreview
-            label={__('Edit hex value', 'web-stories')}
-            value={hexValue}
-            onChange={handleHexInputChange}
-            width={65}
-            format={handleFormatHex}
+            label={__('Edit opacity', 'web-stories')}
+            value={alphaPercentage}
+            width={32}
+            format={handleFormatPercentage}
+            onChange={handleOpacityInputChange}
           />
-        </CurrentWrapper>
-        {showOpacity && (
-          <CurrentAlphaWrapper>
-            <EditablePreview
-              label={__('Edit opacity', 'web-stories')}
-              value={alphaPercentage}
-              width={35}
-              format={handleFormatPercentage}
-              onChange={handleOpacityInputChange}
-            />
-          </CurrentAlphaWrapper>
+        ) : (
+          <OpacityPlaceholder />
         )}
       </Footer>
     </Container>

--- a/assets/src/edit-story/components/colorPicker/editablePreview.js
+++ b/assets/src/edit-story/components/colorPicker/editablePreview.js
@@ -20,7 +20,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { EditableInput } from 'react-color/lib/components/common';
-import { useCallback, useRef, useLayoutEffect, useState } from 'react';
+import { useCallback, useMemo, useRef, useLayoutEffect, useState } from 'react';
 
 /**
  * Internal dependencies
@@ -31,7 +31,7 @@ const Preview = styled.button`
   padding: 0;
   margin: 0;
   border: none;
-  background: ${({ theme }) => theme.colors.bg.v7};
+  background: ${({ theme }) => theme.colors.bg.v8};
   color: ${({ theme }) => theme.colors.fg.v1};
 `;
 
@@ -41,13 +41,23 @@ function EditablePreview({ label, value, width, format, onChange }) {
   const disableEditing = useCallback(() => setIsEditing(false), []);
   const wrapperRef = useRef(null);
   const editableRef = useRef();
-  const inputStyles = {
-    input: {
-      fontFamily: 'monospace',
-      width: `${width}px`,
-      textAlign: 'center',
-    },
-  };
+  const inputStyles = useMemo(
+    () => ({
+      input: {
+        textAlign: 'center',
+        border: 'none',
+        textTransform: 'lowercase',
+        width: '100%',
+        padding: '4px',
+        borderRadius: '2px',
+      },
+      wrap: {
+        lineHeight: 0,
+        maxWidth: `${width}px`,
+      },
+    }),
+    [width]
+  );
 
   // Handle ESC keypress to toggle input field.
   useKeyDownEffect(wrapperRef, { key: 'esc', editable: true }, disableEditing, [

--- a/assets/src/edit-story/components/colorPicker/gradientPicker.js
+++ b/assets/src/edit-story/components/colorPicker/gradientPicker.js
@@ -37,6 +37,7 @@ const Wrapper = styled.div`
   justify-content: space-between;
   align-items: center;
   margin-right: -3px;
+  padding: 12px;
 `;
 
 const Button = styled.button`

--- a/assets/src/edit-story/components/colorPicker/header.js
+++ b/assets/src/edit-story/components/colorPicker/header.js
@@ -31,7 +31,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { Close } from '../button';
 
-const CONTAINER_PADDING = 15;
+const CONTAINER_PADDING = 12;
 const HEADER_FOOTER_HEIGHT = 50;
 
 const Wrapper = styled.div`

--- a/assets/src/edit-story/components/panels/stylePreset/colorPresetActions.js
+++ b/assets/src/edit-story/components/panels/stylePreset/colorPresetActions.js
@@ -35,20 +35,16 @@ import { useKeyDownEffect } from '../../keyboard';
 import { findMatchingColor } from './utils';
 
 const ActionsWrapper = styled.div`
-  position: absolute;
-  right: 0;
-  left: 0;
-  bottom: 0;
   text-align: center;
-  border-top: 1px solid ${({ theme }) => rgba(theme.colors.fg.v8, 0.2)};
+  border-top: 1px solid ${({ theme }) => theme.colors.fg.v6};
 `;
 
 const AddColorPreset = styled.button`
   background: transparent;
   border: none;
-  color: ${({ theme }) => rgba(theme.colors.fg.v7, 0.84)};
+  color: ${({ theme }) => rgba(theme.colors.fg.v1, 0.84)};
   cursor: pointer;
-  padding: 0;
+  padding: 12px 0px;
   line-height: 18px;
   font-size: 13px;
 `;

--- a/assets/src/edit-story/components/sidebar/provider.js
+++ b/assets/src/edit-story/components/sidebar/provider.js
@@ -43,7 +43,7 @@ const Sidebar = styled(CanvasArea)`
 
 const SidebarContent = styled.div`
   position: absolute;
-  right: 0px;
+  right: 20px;
   top: ${({ top }) => `${top}px`};
 `;
 


### PR DESCRIPTION
Closes #751 

### Changes
- Fixes a gap that was shown when the color picker had no opacity controls
- Uses the right colors for the picker and its internal elements
- Fixes a styling issue that prevented blurring the text input when manually editing the color's hex value
- Removes usages of `position: absolute` in favor of `flex-box`
- Clean up unnecessary wrappers

### Screenshots

#### After
![After](https://user-images.githubusercontent.com/591655/78464735-cc712200-76a1-11ea-918b-459b417ee117.gif)


#### Before
![Before](https://user-images.githubusercontent.com/591655/78464727-b9f6e880-76a1-11ea-9b62-026005babbeb.gif)
