### PR TITLE
Remove default background color from text.

### DIFF
--- a/assets/src/edit-story/components/colorPicker/useColor.js
+++ b/assets/src/edit-story/components/colorPicker/useColor.js
@@ -30,7 +30,7 @@ const initialState = {
     r: 0,
     g: 0,
     b: 0,
-    a: 0,
+    a: 1,
   },
   currentStopIndex: 0,
   rotation: 0.5,

--- a/assets/src/edit-story/components/library/panes/text/textPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textPane.js
@@ -94,7 +94,6 @@ function TextPane(props) {
                 ...getPresetById('subheading'),
                 content: __('Fill in some text', 'web-stories'),
                 color: createSolid(0, 0, 0),
-                backgroundColor: createSolid(196, 196, 196),
                 backgroundTextMode: BACKGROUND_TEXT_MODE.NONE,
                 width: DEFAULT_ELEMENT_WIDTH,
               })
@@ -112,7 +111,6 @@ function TextPane(props) {
               insertElement('text', {
                 ...preset,
                 color: createSolid(0, 0, 0),
-                backgroundColor: createSolid(196, 196, 196),
                 backgroundTextMode: BACKGROUND_TEXT_MODE.NONE,
                 width: DEFAULT_ELEMENT_WIDTH,
               })

--- a/assets/src/edit-story/components/library/panes/text/textTab.js
+++ b/assets/src/edit-story/components/library/panes/text/textTab.js
@@ -86,7 +86,6 @@ function TextTab(props) {
     insertElement('text', {
       content: __('Fill in some text', 'web-stories'),
       color: createSolid(0, 0, 0),
-      backgroundColor: createSolid(196, 196, 196),
       backgroundTextMode: BACKGROUND_TEXT_MODE.NONE,
       fontSize: DEFAULT_FONT_SIZE,
       width: DEFAULT_ELEMENT_WIDTH,


### PR DESCRIPTION
Fixes #960 

Uses non-transparent color as default in the color picker instead of transparent color.
Previously, the default was `(0,0,0,0)`, now it's `(0,0,0,1)`. 

This way, when the user chooses the color, it will actually be visible, there's no other difference for the user, the default color does not get assigned automatically.

WIP since confirming the behavior of switching between Fill-None with Sam.