### PR TITLE
Dashboard: Story Grid Media Query/Resize Clean Up

### DIFF
--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -24,7 +24,7 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import {
-  StoryGrid,
+  CardGrid,
   CardGridItem,
   CardTitle,
   CardItemMenu,
@@ -37,6 +37,14 @@ export const DetailRow = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+`;
+
+const StoryGrid = styled(CardGrid)`
+  width: ${({ theme }) => `calc(100% - ${theme.pageGutter.desktop}px)`};
+
+  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
+    width: ${({ theme }) => `calc(100% - ${theme.pageGutter.min}px)`};
+  }
 `;
 
 const StoryGridView = ({ filteredStories }) => {

--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -30,12 +30,11 @@ const DashboardGrid = styled.div`
   width: 100%;
   align-content: space-between;
 
-  grid-template-columns: ${({ theme, columnWidth }) =>
-    `repeat(auto-fill, minmax(${columnWidth}px, ${theme.grid.desktop.fr}))`};
+  grid-template-columns: ${({ columnWidth }) =>
+    `repeat(auto-fill, minmax(${columnWidth}px, 1fr))`};
 
   @media ${({ theme }) => theme.breakpoint.min} {
-    grid-template-columns: ${({ theme }) =>
-      `repeat(2, ${theme.grid.smallDisplayPhone.fr})`};
+    grid-template-columns: repeat(2, 1fr);
   }
 `;
 

--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -20,49 +20,33 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-const CardGrid = styled.div`
+/**
+ * Internal dependencies
+ */
+import usePagePreviewSize from '../../utils/usePagePreviewSize';
+
+const DashboardGrid = styled.div`
   display: grid;
   width: 100%;
   align-content: space-between;
 
-  grid-template-columns: ${({ theme }) =>
-    `repeat(auto-fill, minmax(${theme.grid.desktop.itemWidth}px, ${theme.grid.desktop.fr}))`};
-  grid-gap: ${({ theme }) => theme.grid.desktop.gap};
-
-  @media ${({ theme }) => theme.breakpoint.tablet} {
-    grid-template-columns: ${({ theme }) =>
-      `repeat(auto-fill, minmax(${theme.grid.tablet.itemWidth}px, ${theme.grid.tablet.fr}))`};
-    grid-gap: ${({ theme }) => theme.grid.tablet.gap};
-  }
-  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
-    grid-template-columns: ${({ theme }) =>
-      `repeat(auto-fill, minmax(${theme.grid.largeDisplayPhone.itemWidth}px, ${theme.grid.largeDisplayPhone.fr}))`};
-    grid-gap: ${({ theme }) => theme.grid.largeDisplayPhone.gap};
-  }
-
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    grid-template-columns: ${({ theme }) =>
-      `repeat(auto-fill, minmax(${theme.grid.smallDisplayPhone.itemWidth}px, ${theme.grid.smallDisplayPhone.fr}))`};
-    grid-gap: ${({ theme }) => theme.grid.smallDisplayPhone.gap};
-  }
+  grid-template-columns: ${({ theme, columnWidth }) =>
+    `repeat(auto-fill, minmax(${columnWidth}px, ${theme.grid.desktop.fr}))`};
 
   @media ${({ theme }) => theme.breakpoint.min} {
     grid-template-columns: ${({ theme }) =>
       `repeat(2, ${theme.grid.smallDisplayPhone.fr})`};
-    grid-gap: ${({ theme }) => theme.grid.min.gap};
   }
 `;
+
+const CardGrid = ({ children }) => {
+  const { pageSize } = usePagePreviewSize();
+
+  return <DashboardGrid columnWidth={pageSize.width}>{children}</DashboardGrid>;
+};
 
 CardGrid.propTypes = {
   children: PropTypes.node.isRequired,
 };
-
-export const StoryGrid = styled(CardGrid)`
-  width: ${({ theme }) => `calc(100% - ${theme.pageGutter.desktop}px)`};
-
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    width: ${({ theme }) => `calc(100% - ${theme.pageGutter.min}px)`};
-  }
-`;
 
 export default CardGrid;

--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -29,7 +29,7 @@ const DashboardGrid = styled.div`
   display: grid;
   width: 100%;
   align-content: space-between;
-
+  grid-column-gap: 10px;
   grid-template-columns: ${({ columnWidth }) =>
     `repeat(auto-fill, minmax(${columnWidth}px, 1fr))`};
 

--- a/assets/src/dashboard/components/cardGridItem/cardItemMenu.js
+++ b/assets/src/dashboard/components/cardGridItem/cardItemMenu.js
@@ -46,10 +46,10 @@ MoreVerticalButton.propTypes = {
 
 const MenuContainer = styled.div`
   position: relative;
-  align-self: flex-end;
-  margin-top: 12px;
+  align-self: flex-start;
   text-align: right;
   flex-grow: 1;
+  margin-top: 12px;
 
   .grid-story-popover-menu {
     right: 0;

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -31,39 +31,20 @@ import styled from 'styled-components';
 import { Button } from '..';
 import { BUTTON_TYPES } from '../../constants';
 import { ReactComponent as PlayArrowSvg } from '../../icons/playArrow.svg';
+import usePagePreviewSize from '../../utils/usePagePreviewSize';
 
 const PreviewPane = styled.div`
   position: relative;
   border-radius: 8px;
-  height: ${({ theme }) => theme.grid.desktop.imageHeight}px;
-  width: ${({ theme }) => theme.grid.desktop.itemWidth}px;
+  height: ${({ cardSize }) => `${cardSize.height}px`};
+  width: ${({ cardSize }) => `${cardSize.width}px`};
   overflow: hidden;
   z-index: -1;
-
-  @media ${({ theme }) => theme.breakpoint.tablet} {
-    height: ${({ theme }) => theme.grid.tablet.imageHeight}px;
-    width: ${({ theme }) => theme.grid.tablet.itemWidth}px;
-  }
-
-  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
-    height: ${({ theme }) => theme.grid.largeDisplayPhone.imageHeight}px;
-    width: ${({ theme }) => theme.grid.largeDisplayPhone.itemWidth}px;
-  }
-
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    height: ${({ theme }) => theme.grid.smallDisplayPhone.imageHeight}px;
-    width: ${({ theme }) => theme.grid.smallDisplayPhone.itemWidth}px;
-  }
-
-  @media ${({ theme }) => theme.breakpoint.min} {
-    height: ${({ theme }) => theme.grid.min.imageHeight}px;
-    width: ${({ theme }) => theme.grid.min.itemWidth}px;
-  }
 `;
 
 const EditControls = styled.div`
-  width: ${({ theme }) => theme.grid.desktop.itemWidth}px;
-  height: ${({ theme }) => theme.grid.desktop.imageHeight}px;
+  height: ${({ cardSize }) => `${cardSize.height}px`};
+  width: ${({ cardSize }) => `${cardSize.width}px`};
   position: absolute;
   display: flex;
   flex-direction: column;
@@ -71,33 +52,15 @@ const EditControls = styled.div`
   justify-content: space-between;
   padding: 0;
 
-  @media ${({ theme }) => theme.breakpoint.tablet} {
-    height: ${({ theme }) => theme.grid.tablet.imageHeight}px;
-    width: ${({ theme }) => theme.grid.tablet.itemWidth}px;
-  }
-
-  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
-    height: ${({ theme }) => theme.grid.largeDisplayPhone.imageHeight}px;
-    width: ${({ theme }) => theme.grid.largeDisplayPhone.itemWidth}px;
-  }
-
   @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    height: ${({ theme }) => theme.grid.smallDisplayPhone.imageHeight}px;
-    width: ${({ theme }) => theme.grid.smallDisplayPhone.itemWidth}px;
-
     button,
     a {
-      min-width: 120px;
+      min-width: ${({ cardSize }) => cardSize.width};
       max-width: 90%;
       & > label {
         font-size: 12px;
       }
     }
-  }
-
-  @media ${({ theme }) => theme.breakpoint.min} {
-    height: ${({ theme }) => theme.grid.min.imageHeight}px;
-    width: ${({ theme }) => theme.grid.min.itemWidth}px;
   }
 `;
 
@@ -126,12 +89,12 @@ const EditButton = styled(Button).attrs({ onClick: () => {} })``;
 // TODO modify to handle other types of grid items, not just own stories
 const CardPreviewContainer = ({ editUrl, onPreviewClick, children }) => {
   const displayEditControls = onPreviewClick || editUrl;
-
+  const { pageSize } = usePagePreviewSize();
   return (
     <>
-      <PreviewPane>{children}</PreviewPane>
+      <PreviewPane cardSize={pageSize}>{children}</PreviewPane>
       {displayEditControls && (
-        <EditControls>
+        <EditControls cardSize={pageSize}>
           {onPreviewClick && (
             <PreviewContainer>
               <PreviewButton

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -25,6 +25,11 @@ import { __ } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
+/**
+ * Internal dependencies
+ */
+import { CARD_TITLE_AREA_HEIGHT } from '../../constants';
+
 const StyledCardTitle = styled.div`
   font-family: ${({ theme }) => theme.fonts.storyGridItem.family};
   font-size: ${({ theme }) => theme.fonts.storyGridItem.size};
@@ -33,34 +38,7 @@ const StyledCardTitle = styled.div`
   line-height: ${({ theme }) => theme.fonts.storyGridItem.lineHeight};
   padding-top: 12px;
   max-width: 80%;
-  height: ${({ theme }) =>
-    `${theme.grid.desktop.itemHeight - theme.grid.desktop.imageHeight}px`};
-
-  @media ${({ theme }) => theme.breakpoint.tablet} {
-    height: ${({ theme }) =>
-      `${theme.grid.tablet.itemHeight - theme.grid.tablet.imageHeight}px`};
-  }
-
-  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
-    height: ${({ theme }) =>
-      `${
-        theme.grid.largeDisplayPhone.itemHeight -
-        theme.grid.largeDisplayPhone.imageHeight
-      }px`};
-  }
-
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    height: ${({ theme }) =>
-      `${
-        theme.grid.smallDisplayPhone.itemHeight -
-        theme.grid.smallDisplayPhone.imageHeight
-      }px`};
-  }
-
-  @media ${({ theme }) => theme.breakpoint.min} {
-    height: ${({ theme }) =>
-      `${theme.grid.min.itemHeight - theme.grid.min.imageHeight}px`};
-  }
+  height: ${CARD_TITLE_AREA_HEIGHT}px;
 `;
 
 const StyledTitle = styled.p`

--- a/assets/src/dashboard/components/cardGridItem/index.js
+++ b/assets/src/dashboard/components/cardGridItem/index.js
@@ -28,7 +28,7 @@ import usePagePreviewSize from '../../utils/usePagePreviewSize';
 import { MoreVerticalButton } from './cardItemMenu';
 
 const StyledCard = styled.div`
-  margin: auto 10px;
+  margin: auto 0;
   height: ${({ cardSize }) => `${cardSize.height + CARD_TITLE_AREA_HEIGHT}px`};
   width: ${({ cardSize }) => `${cardSize.width}px`};
   display: flex;

--- a/assets/src/dashboard/components/cardGridItem/index.js
+++ b/assets/src/dashboard/components/cardGridItem/index.js
@@ -18,44 +18,36 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
+import { CARD_TITLE_AREA_HEIGHT } from '../../constants';
+import usePagePreviewSize from '../../utils/usePagePreviewSize';
 import { MoreVerticalButton } from './cardItemMenu';
 
-const CardGridItem = styled.div`
-  margin: auto 0;
-  height: ${({ theme }) => `${theme.grid.desktop.itemHeight}px`};
-  width: ${({ theme }) => `${theme.grid.desktop.itemWidth}px`};
+const StyledCard = styled.div`
+  margin: auto 10px;
+  height: ${({ cardSize }) => `${cardSize.height + CARD_TITLE_AREA_HEIGHT}px`};
+  width: ${({ cardSize }) => `${cardSize.width}px`};
   display: flex;
   flex-direction: column;
-
-  @media ${({ theme }) => theme.breakpoint.tablet} {
-    height: ${({ theme }) => `${theme.grid.tablet.itemHeight}px`};
-    width: ${({ theme }) => `${theme.grid.tablet.itemWidth}px`};
-  }
-
-  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
-    height: ${({ theme }) => `${theme.grid.largeDisplayPhone.itemHeight}px`};
-    width: ${({ theme }) => `${theme.grid.largeDisplayPhone.itemWidth}px`};
-  }
-
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    height: ${({ theme }) => `${theme.grid.smallDisplayPhone.itemHeight}px`};
-    width: ${({ theme }) => `${theme.grid.smallDisplayPhone.itemWidth}px`};
-    margin: auto;
-  }
-
-  @media ${({ theme }) => theme.breakpoint.min} {
-    height: ${({ theme }) => `${theme.grid.min.itemHeight}px`};
-    width: ${({ theme }) => `${theme.grid.min.itemWidth}px`};
-  }
 
   &:hover ${MoreVerticalButton}, &:active ${MoreVerticalButton} {
     opacity: 1;
   }
 `;
+
+const CardGridItem = ({ children }) => {
+  const { pageSize } = usePagePreviewSize();
+
+  return <StyledCard cardSize={pageSize}>{children}</StyledCard>;
+};
+
+CardGridItem.propTypes = {
+  children: PropTypes.node,
+};
 
 export default CardGridItem;
 export { default as CardPreviewContainer } from './cardPreview';

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -16,7 +16,7 @@
 
 export { default as BookmarkChip } from './bookmark-chip';
 export { default as Button } from './button';
-export { default as CardGrid, StoryGrid } from './cardGrid';
+export { default as CardGrid } from './cardGrid';
 export {
   default as CardGridItem,
   CardPreviewContainer,

--- a/assets/src/dashboard/constants.js
+++ b/assets/src/dashboard/constants.js
@@ -57,6 +57,7 @@ export const Z_INDEX = {
 };
 
 export const PAGE_RATIO = PAGE_HEIGHT / PAGE_WIDTH;
+export const CARD_TITLE_AREA_HEIGHT = 80;
 
 export const paths = [
   { value: '/', label: __('My Stories', 'web-stories') },

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -212,42 +212,12 @@ const theme = {
     desktop: 20,
     min: 10,
   },
-  grid: {
-    desktop: {
-      gap: '25px',
-      itemWidth: 221,
-      itemHeight: 391,
-      imageHeight: 331,
-      fr: '1fr',
-    },
-    tablet: {
-      gap: '22px',
-      itemWidth: 189,
-      itemHeight: 324,
-      imageHeight: 284,
-      fr: '1fr',
-    },
-    largeDisplayPhone: {
-      gap: '20px',
-      itemWidth: 162,
-      itemHeight: 303,
-      imageHeight: 243,
-      fr: '1fr',
-    },
-    smallDisplayPhone: {
-      gap: '24px',
-      itemWidth: 185,
-      itemHeight: 338,
-      imageHeight: 278,
-      fr: '1fr',
-    },
-    min: {
-      gap: '16px',
-      itemWidth: 139,
-      itemHeight: 256,
-      imageHeight: 209,
-      fr: '1fr',
-    },
+  previewWidth: {
+    desktop: 221,
+    tablet: 189,
+    largeDisplayPhone: 162,
+    smallDisplayPhone: 185,
+    min: 139,
   },
   breakpoint: {
     desktop: 'screen and (max-width: 1280px)',

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -32,7 +32,9 @@ export default function usePagePreviewSize() {
     const { innerWidth } = window;
     let itemWidth = 0;
 
-    if (innerWidth <= theme.breakpoint.raw.smallDisplayPhone) {
+    if (innerWidth <= theme.breakpoint.raw.min) {
+      itemWidth = theme.grid.min.itemWidth;
+    } else if (innerWidth <= theme.breakpoint.raw.smallDisplayPhone) {
       itemWidth = theme.grid.smallDisplayPhone.itemWidth;
     } else if (innerWidth <= theme.breakpoint.raw.largeDisplayPhone) {
       itemWidth = theme.grid.largeDisplayPhone.itemWidth;

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -33,17 +33,16 @@ export default function usePagePreviewSize() {
     let itemWidth = 0;
 
     if (innerWidth <= theme.breakpoint.raw.min) {
-      itemWidth = theme.grid.min.itemWidth;
+      itemWidth = theme.previewWidth.min;
     } else if (innerWidth <= theme.breakpoint.raw.smallDisplayPhone) {
-      itemWidth = theme.grid.smallDisplayPhone.itemWidth;
+      itemWidth = theme.previewWidth.smallDisplayPhone;
     } else if (innerWidth <= theme.breakpoint.raw.largeDisplayPhone) {
-      itemWidth = theme.grid.largeDisplayPhone.itemWidth;
+      itemWidth = theme.previewWidth.largeDisplayPhone;
     } else if (innerWidth <= theme.breakpoint.raw.tablet) {
-      itemWidth = theme.grid.tablet.itemWidth;
+      itemWidth = theme.previewWidth.tablet;
     } else {
-      itemWidth = theme.grid.desktop.itemWidth;
+      itemWidth = theme.previewWidth.desktop;
     }
-
     setPageSize({
       width: itemWidth,
       height: itemWidth * PAGE_RATIO,


### PR DESCRIPTION
# Overview
@mariano-formidable pointed out in my prior PR (https://github.com/google/web-stories-wp/pull/1091) that: 
> we're setting width and height in a lot of places using similar (or the same) breakpoints, and that we have the usePagePreviewSize which also calculates the appropriate width and height of a card based on the window size... I'm curious if there's a way to use usePagePreviewSize to set the width and height for all the things that need it, and then we can remove a bunch of the media queries we have that implement the same restriction.

> I only ask because right now it's possible for our breakpoints and usePagePreviewSize to get out of sync. In fact, I think I found an out-of-sync bug in the current code, in the gif below I'm highlighting the PreviewPane container and the DisplayElement container and notice how the PreviewPane container's width & height (set by media queries) is smaller than the DisplayElement container (set by usePagePreviewSize).

And this PR should resolve that discrepancy. 


I was able to shrink the theme to just desired width based on breakpoint, the `usePagePreviewSize` util is doing the work of creating the ratio to display story previews on. This ratio is what we should be basing the parent grid on to ensure consistent display. This also means we can ditch a bunch of media queries. 🎉  

## Testing 
- Play with my stories and make sure it's still collapsing gracefully. 
- Hover over a card and see the new context menu displaying right. 

![samesize](https://user-images.githubusercontent.com/10720454/78821577-91ffd180-798e-11ea-9ca1-e34573b20fdb.gif)
