### PR TITLE
Save story before showing the preview

### DIFF
--- a/assets/src/edit-story/app/story/actions/useSaveStory.js
+++ b/assets/src/edit-story/app/story/actions/useSaveStory.js
@@ -87,7 +87,7 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
         'defaultPageDuration',
       ]);
       const content = getStoryMarkup(story, pages, metadata);
-      saveStoryById({
+      return saveStoryById({
         storyId,
         content,
         pages,

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -81,9 +81,7 @@ function PreviewButton() {
         popup.document.write('<!DOCTYPE html><html><head>');
         popup.document.write('<title>');
         popup.document.write(
-          escapeHTML(
-            __('Generating the preview...', 'web-stories')
-          )
+          escapeHTML(__('Generating the preview...', 'web-stories'))
         );
         popup.document.write('</title>');
         popup.document.write('</head><body>');

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -100,8 +100,9 @@ function PreviewButton() {
       // will be resolved after the story is saved.
     }
 
-    // DO NOT SUBMIT: what if the status is no longer draft?
-    saveStory({ status: 'draft' }).then(() => {
+    // @todo: See https://github.com/google/web-stories-wp/issues/1149. This
+    // has the effect of pushing the changes to a published story.
+    saveStory().then(() => {
       let previewOpened = false;
       if (popup && !popup.closed) {
         try {

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -105,8 +105,12 @@ function PreviewButton() {
       let previewOpened = false;
       if (popup && !popup.closed) {
         try {
-          popup.location.replace(previewLink);
-          previewOpened = true;
+          // The `popup.location.href` will fail if the expected window has
+          // been naviagted to a different origin.
+          if (popup.location.href) {
+            popup.location.replace(previewLink);
+            previewOpened = true;
+          }
         } catch (e) {
           // Ignore the errors. They will simply trigger the "try again"
           // dialog.
@@ -120,7 +124,9 @@ function PreviewButton() {
 
   const openPreviewLinkSync = (evt) => {
     setPreviewLinkToOpenViaDialog(null);
-    window.open(previewLinkToOpenViaDialog, PREVIEW_TARGET);
+    // Ensure that this method is as safe as possible and pass the random
+    // target in case the normal target is not openable.
+    window.open(previewLinkToOpenViaDialog, PREVIEW_TARGET + Math.random());
     evt.preventDefault();
   };
 

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 /**
  * WordPress dependencies
@@ -31,8 +31,12 @@ import { __ } from '@wordpress/i18n';
 import addQueryArgs from '../../utils/addQueryArgs';
 import { useStory, useMedia } from '../../app';
 import useRefreshPostEditURL from '../../utils/useRefreshPostEditURL';
-import { Outline, Primary } from '../button';
+import { Outline, Plain, Primary } from '../button';
 import CircularProgress from '../circularProgress';
+import Dialog from '../dialog';
+import escapeHTML from '../../utils/escapeHTML';
+
+const PREVIEW_TARGET = 'story-preview';
 
 const ButtonList = styled.nav`
   display: flex;
@@ -55,19 +59,94 @@ function PreviewButton() {
       meta: { isSaving },
       story: { link },
     },
+    actions: { saveStory },
   } = useStory();
+
+  const [previewLinkToOpenViaDialog, setPreviewLinkToOpenViaDialog] = useState(
+    null
+  );
 
   /**
    * Open a preview of the story in current window.
    */
   const openPreviewLink = () => {
     const previewLink = addQueryArgs(link, { preview: 'true' });
-    window.open(previewLink, 'story-preview');
+
+    // Start a about:blank popup with waiting message until we complete
+    // the saving operation. That way we will not bust the popup timeout.
+    let popup;
+    try {
+      popup = window.open('about:blank', PREVIEW_TARGET);
+      if (popup) {
+        popup.document.write('<!DOCTYPE html><html><body>');
+        // Output "waiting" message.
+        popup.document.write(
+          escapeHTML(
+            __('Please wait. Generating the preview...', 'web-stories')
+          )
+        );
+        // Force redirect to the preview URL after 5 seconds. The saving tab
+        // might get frozen by the browser.
+        popup.document.write(
+          `<script>
+            setTimeout(function() {
+              location.replace(${JSON.stringify(previewLink)});
+            }, 5000);
+          </script>`
+        );
+      }
+    } catch (e) {
+      // Ignore errors. Anything can happen with a popup. The errors
+      // will be resolved after the story is saved.
+    }
+
+    // DO NOT SUBMIT: what if the status is no longer draft?
+    saveStory({ status: 'draft' }).then(() => {
+      let previewOpened = false;
+      if (popup) {
+        try {
+          popup.location.replace(previewLink);
+          previewOpened = true;
+        } catch (e) {
+          // Ignore the errors. They will simply trigger the "try again"
+          // dialog.
+        }
+      }
+      if (!previewOpened) {
+        setPreviewLinkToOpenViaDialog(previewLink);
+      }
+    });
   };
+
+  const openPreviewLinkSync = (evt) => {
+    setPreviewLinkToOpenViaDialog(null);
+    window.open(previewLinkToOpenViaDialog, PREVIEW_TARGET);
+    evt.preventDefault();
+  };
+
   return (
-    <Outline onClick={openPreviewLink} isDisabled={isSaving}>
-      {__('Preview', 'web-stories')}
-    </Outline>
+    <>
+      <Outline onClick={openPreviewLink} isDisabled={isSaving}>
+        {__('Preview', 'web-stories')}
+      </Outline>
+      <Dialog
+        open={Boolean(previewLinkToOpenViaDialog)}
+        onClose={() => setPreviewLinkToOpenViaDialog(null)}
+        title={__('Open preview', 'web-stories')}
+        actions={
+          <>
+            <Primary onClick={openPreviewLinkSync}>
+              {__('Try again', 'web-stories')}
+            </Primary>
+            <Plain onClick={() => setPreviewLinkToOpenViaDialog(null)}>
+              {__('Cancel', 'web-stories')}
+            </Plain>
+          </>
+        }
+      >
+        {__('The preview window failed to open.', 'web-stories')}
+      </Dialog>
+    </>
   );
 }
 

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -140,7 +140,7 @@ function PreviewButton() {
   return (
     <>
       <Outline onClick={openPreviewLink} isDisabled={isSaving}>
-        {__('Preview', 'web-stories')}
+        {__('Save & Preview', 'web-stories')}
       </Outline>
       <Dialog
         open={Boolean(previewLinkToOpenViaDialog)}

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -103,7 +103,7 @@ function PreviewButton() {
     // DO NOT SUBMIT: what if the status is no longer draft?
     saveStory({ status: 'draft' }).then(() => {
       let previewOpened = false;
-      if (popup) {
+      if (popup && !popup.closed) {
         try {
           popup.location.replace(previewLink);
           previewOpened = true;

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -78,7 +78,15 @@ function PreviewButton() {
     try {
       popup = window.open('about:blank', PREVIEW_TARGET);
       if (popup) {
-        popup.document.write('<!DOCTYPE html><html><body>');
+        popup.document.write('<!DOCTYPE html><html><head>');
+        popup.document.write('<title>');
+        popup.document.write(
+          escapeHTML(
+            __('Generating the preview...', 'web-stories')
+          )
+        );
+        popup.document.write('</title>');
+        popup.document.write('</head><body>');
         // Output "waiting" message.
         popup.document.write(
           escapeHTML(

--- a/assets/src/edit-story/components/header/test/buttons.js
+++ b/assets/src/edit-story/components/header/test/buttons.js
@@ -109,7 +109,7 @@ describe('buttons', () => {
     const { getByText, saveStory } = setupButtons({
       link: 'https://example.com',
     });
-    const previewButton = getByText('Preview');
+    const previewButton = getByText('Save & Preview');
 
     expect(previewButton).toBeDefined();
 

--- a/assets/src/edit-story/components/header/test/buttons.js
+++ b/assets/src/edit-story/components/header/test/buttons.js
@@ -105,11 +105,19 @@ describe('buttons', () => {
     expect(getByRole(container, 'progressbar')).toBeInTheDocument();
   });
 
-  it('should open preview when clicking on Preview', () => {
-    const { getByText } = setupButtons({ link: 'https://example.com' });
+  it('should open preview when clicking on Preview via about:blank', () => {
+    const { getByText, saveStory } = setupButtons({
+      link: 'https://example.com',
+    });
     const previewButton = getByText('Preview');
 
     expect(previewButton).toBeDefined();
+
+    saveStory.mockImplementation(() => ({
+      then(callback) {
+        callback();
+      },
+    }));
 
     const mockedOpen = jest.fn();
     const originalWindow = { ...window };
@@ -119,11 +127,23 @@ describe('buttons', () => {
       open: mockedOpen,
     }));
 
+    const popup = {
+      document: {
+        write: jest.fn(),
+      },
+      location: {
+        href: 'about:blank',
+        replace: jest.fn(),
+      },
+    };
+    mockedOpen.mockImplementation(() => popup);
+
     fireEvent.click(previewButton);
 
-    expect(mockedOpen).toHaveBeenCalledWith(
-      'https://example.com/?preview=true',
-      'story-preview'
+    expect(saveStory).toHaveBeenCalledWith();
+    expect(mockedOpen).toHaveBeenCalledWith('about:blank', 'story-preview');
+    expect(popup.location.replace).toHaveBeenCalledWith(
+      'https://example.com/?preview=true'
     );
 
     windowSpy.mockRestore();

--- a/assets/src/edit-story/utils/escapeHTML.js
+++ b/assets/src/edit-story/utils/escapeHTML.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const buffer = document.createElement('div');
+
+export default function escapeHTML(string) {
+  // @todo: implement a cheaper way to escape HTML characters.
+  buffer.textContent = string;
+  return buffer.innerHTML;
+}


### PR DESCRIPTION
Fixes: #1072.

This is a rather strange approach, but usually works ok. We open the popup with "about:blank", wait for the async operation to finish and then re-navigate the popup to the final URL. This way we do not bust the `window.open` timeout.

TODO:

- [x] What to do with a published story?
- [x] Tests
