### PR TITLE
Fix empty lines duplicating when editing text fields.

### DIFF
--- a/assets/src/edit-story/elements/text/edit.js
+++ b/assets/src/edit-story/elements/text/edit.js
@@ -145,6 +145,8 @@ function TextEdit({
   const { offset, clearContent, selectAll } = editingElementState || {};
   const initialState = useMemo(() => {
     const contentWithBreaks = (content || '')
+      // Re-insert manual line-breaks for empty lines
+      .replace(/\n(?=\n)/g, '\n<br />')
       .split('\n')
       .map((s) => {
         return `<p>${draftMarkupToContent(s, bold)}</p>`;
@@ -206,11 +208,13 @@ function TextEdit({
       const newHeight = editorHeightRef.current;
       wrapperRef.current.style.height = '';
       if (newState) {
-        // Remember to trim any trailing non-breaking space.
+        // Remove manual line breaks and remember to trim any trailing non-breaking space.
         const properties = {
           content: stateToHTML(lastKnownState.current, {
             defaultBlockTag: null,
-          }).replace(/&nbsp;$/, ''),
+          })
+            .replace(/<br ?\/?>/g, '')
+            .replace(/&nbsp;$/, ''),
         };
         // Recalculate the new height and offset.
         if (newHeight) {


### PR DESCRIPTION
This fixes a problem around empty lines in text field duplicating because not converting line breaks in and out of draftjs correctly.

This PR removes `<br />` when exiting text edit mode and reinserts them when entering.

It uses _look-ahead_ in the _RegExp_ to support consecutive empty lines - _look-behind_ is[ not supported in all browsers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Browser_compatibility), but I think _look-ahead_ is. Would be good to confirm, though.

Fixes #1108.

| Before fix | After fix |
|--|--|
| ![empty-line-before](https://user-images.githubusercontent.com/637548/78918365-53d1e300-7a5e-11ea-81d7-91c2541636a7.gif) | ![empty-line-after](https://user-images.githubusercontent.com/637548/78918499-8085fa80-7a5e-11ea-8c1b-5e061b30032e.gif) |