### PR TITLE
Fixes resizing of highlight text

### DIFF
--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -100,6 +100,7 @@ function TextDisplay({
   },
 }) {
   const ref = useRef(null);
+  const secondaryRef = useRef(null);
 
   const {
     state: {
@@ -133,6 +134,12 @@ function TextDisplay({
     target.style.fontSize = updatedFontSize
       ? `${dataToEditorY(updatedFontSize)}px`
       : '';
+    const secondaryTarget = secondaryRef.current;
+    if (secondaryTarget && secondaryTarget.ownerDocument) {
+      secondaryTarget.style.fontSize = updatedFontSize
+        ? `${dataToEditorY(updatedFontSize)}px`
+        : '';
+    }
   });
 
   if (backgroundTextMode === BACKGROUND_TEXT_MODE.HIGHLIGHT) {
@@ -148,7 +155,7 @@ function TextDisplay({
             />
           </MarginedElement>
         </HighlightElement>
-        <HighlightElement {...props}>
+        <HighlightElement ref={secondaryRef} {...props}>
           <MarginedElement {...props}>
             <ForegroundSpan
               {...props}

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -41,7 +41,7 @@ import {
   generateParagraphTextStyle,
 } from './util';
 
-const HighlightElement = styled.p`
+const HighlightWrapperElement = styled.div`
   ${elementFillContent}
   ${elementWithFont}
   ${elementWithFontColor}
@@ -50,6 +50,12 @@ const HighlightElement = styled.p`
     getHighlightLineheight(lineHeight, verticalPadding)};
   margin: 0;
   padding: 0;
+`;
+const HighlightElement = styled.p`
+  font-size: inherit;
+  line-height: inherit;
+  margin: 0;
+  position: absolute;
 `;
 
 const MarginedElement = styled.span`
@@ -100,7 +106,6 @@ function TextDisplay({
   },
 }) {
   const ref = useRef(null);
-  const secondaryRef = useRef(null);
 
   const {
     state: {
@@ -134,18 +139,12 @@ function TextDisplay({
     target.style.fontSize = updatedFontSize
       ? `${dataToEditorY(updatedFontSize)}px`
       : '';
-    const secondaryTarget = secondaryRef.current;
-    if (secondaryTarget && secondaryTarget.ownerDocument) {
-      secondaryTarget.style.fontSize = updatedFontSize
-        ? `${dataToEditorY(updatedFontSize)}px`
-        : '';
-    }
   });
 
   if (backgroundTextMode === BACKGROUND_TEXT_MODE.HIGHLIGHT) {
     return (
-      <>
-        <HighlightElement ref={ref} {...props}>
+      <HighlightWrapperElement ref={ref} {...props}>
+        <HighlightElement {...props}>
           <MarginedElement {...props}>
             <BackgroundSpan
               {...props}
@@ -155,7 +154,7 @@ function TextDisplay({
             />
           </MarginedElement>
         </HighlightElement>
-        <HighlightElement ref={secondaryRef} {...props}>
+        <HighlightElement {...props}>
           <MarginedElement {...props}>
             <ForegroundSpan
               {...props}
@@ -165,7 +164,7 @@ function TextDisplay({
             />
           </MarginedElement>
         </HighlightElement>
-      </>
+      </HighlightWrapperElement>
     );
   }
 


### PR DESCRIPTION
When a text field is resizing, it updates the font size of the reference element. However, in a highlight text element, only the background was the reference element - thus only the background changed font size, not the actual text.

This fixes it by introducing a wrapper element, that has all the common properties, that is then inherited by the two individual elements each displaying background and font respectively. Font size is then changed on this parent element and correctly inherited by both children.

Fixes #834.

| Before fix | After fix |
|--|--|
| ![resize-highlight-before](https://user-images.githubusercontent.com/637548/78925548-a1078200-7a69-11ea-9b98-1d4967b8386e.gif) | ![resize-highlight-after](https://user-images.githubusercontent.com/637548/78925558-a4027280-7a69-11ea-8def-d1121d1829d6.gif) |

