### PR TITLE
Fix duplicate element ids when duplicating page

### DIFF
--- a/assets/src/edit-story/elements/index.js
+++ b/assets/src/edit-story/elements/index.js
@@ -44,9 +44,19 @@ export const createNewElement = (type, attributes = {}) => {
 };
 
 export const createPage = (attributes = {}) => {
-  const { elements, backgroundElementId } = attributes;
+  const { elements: oldElements, ...rest } = attributes;
+
+  // Ensure all existing elements get new ids
+  const elements = (oldElements || []).map(({ type, ...attrs }) =>
+    createNewElement(type, attrs)
+  );
+  const newAttributes = {
+    elements,
+    ...rest,
+  };
+
   // Enforce having background element for each Page.
-  if (!backgroundElementId) {
+  if (!newAttributes.backgroundElementId) {
     // The values of x, y, width, height are irrelevant here, however, need to be set.
     const props = {
       x: 1,
@@ -59,12 +69,11 @@ export const createPage = (attributes = {}) => {
       isBackground: true,
     };
     const backgroundElement = createNewElement('shape', props);
-    attributes.elements = elements
-      ? [backgroundElement, ...elements]
-      : [backgroundElement];
-    attributes.backgroundElementId = backgroundElement.id;
+    newAttributes.elements = [backgroundElement, ...elements];
+    newAttributes.backgroundElementId = backgroundElement.id;
   }
-  return createNewElement('page', attributes);
+
+  return createNewElement('page', newAttributes);
 };
 
 export const elementTypes = [

--- a/assets/src/edit-story/elements/index.js
+++ b/assets/src/edit-story/elements/index.js
@@ -34,7 +34,10 @@ import * as videoElement from './video';
 
 export const createNewElement = (type, attributes = {}) => {
   const element = elementTypes.find((el) => el.type === type);
-  const defaultAttributes = element ? element.defaultAttributes : {};
+  if (!element) {
+    throw new Error(`Unknown element type: ${type}`);
+  }
+  const { defaultAttributes } = element;
   return {
     ...defaultAttributes,
     ...attributes,

--- a/assets/src/edit-story/elements/index.js
+++ b/assets/src/edit-story/elements/index.js
@@ -71,6 +71,10 @@ export const createPage = (attributes = {}) => {
     const backgroundElement = createNewElement('shape', props);
     newAttributes.elements = [backgroundElement, ...elements];
     newAttributes.backgroundElementId = backgroundElement.id;
+  } else {
+    // Update reference background element, as we just changed the id
+    // Background element is guaranteed to be first element
+    newAttributes.backgroundElementId = elements[0].id;
   }
 
   return createNewElement('page', newAttributes);

--- a/assets/src/edit-story/elements/test/index.js
+++ b/assets/src/edit-story/elements/test/index.js
@@ -20,6 +20,16 @@
 import { createNewElement, createPage } from '../';
 describe('Element', () => {
   describe('createNewElement', () => {
+    it('should create an element with just default attributes', () => {
+      const imageElement = createNewElement('image');
+      expect(imageElement).toStrictEqual(
+        expect.objectContaining({
+          opacity: 100, // a default shared attribute
+          scale: 100, // a default media attribute
+        })
+      );
+    });
+
     it('should create an element with correct attributes', () => {
       const atts = {
         x: 10,
@@ -35,6 +45,11 @@ describe('Element', () => {
         'Helvetica',
         'sans-serif',
       ]);
+    });
+
+    it('should throw if trying to create unknown element type', () => {
+      const unknownElementCreator = () => createNewElement('puppy');
+      expect(unknownElementCreator).toThrow(/unknown element type: puppy/i);
     });
   });
 

--- a/assets/src/edit-story/elements/test/index.js
+++ b/assets/src/edit-story/elements/test/index.js
@@ -45,5 +45,54 @@ describe('Element', () => {
       expect(page.elements).toHaveLength(1);
       expect(page.elements[0].id).toStrictEqual(page.backgroundElementId);
     });
+
+    it('should generate new ids when duplicating a page (including bg)', () => {
+      const oldElements = [
+        { id: 'abc001', isBackground: true, x: 10, y: 20, type: 'shape' },
+        { id: 'abc002', x: 110, y: 120, type: 'text' },
+        { id: 'abc003', x: 210, y: 220, type: 'image' },
+      ];
+      const oldPage = {
+        id: 'abc000',
+        type: 'page',
+        backgroundElementId: oldElements[0].id,
+        elements: oldElements,
+        otherProperty: '45',
+      };
+      const newPage = createPage(oldPage);
+
+      // Expect same structure but new id's!
+      expect(newPage).toStrictEqual({
+        id: expect.not.stringMatching(oldPage.id),
+        type: 'page',
+        otherProperty: '45',
+        backgroundElementId: expect.not.stringMatching(
+          oldPage.backgroundElementId
+        ),
+        elements: [
+          expect.objectContaining({
+            id: expect.not.stringMatching(oldElements[0].id),
+            isBackground: true,
+            x: 10,
+            y: 20,
+            type: 'shape',
+          }),
+          expect.objectContaining({
+            id: expect.not.stringMatching(oldElements[1].id),
+            x: 110,
+            y: 120,
+            type: 'text',
+          }),
+          expect.objectContaining({
+            id: expect.not.stringMatching(oldElements[2].id),
+            x: 210,
+            y: 220,
+            type: 'image',
+          }),
+        ],
+      });
+      // And bg ids to match
+      expect(newPage.elements[0].id).toStrictEqual(newPage.backgroundElementId);
+    });
   });
 });


### PR DESCRIPTION
Ensure unique ids by recreating elements when duplicating a page.

Fully fixes #1131 (the other half not covered by #1139 as [mentioned](https://github.com/google/web-stories-wp/issues/1131#issuecomment-611766617).