### PR TITLE
Content style toggling

### DIFF
--- a/assets/src/edit-story/elements/text/test/useContentHelper.test.js
+++ b/assets/src/edit-story/elements/text/test/useContentHelper.test.js
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useContentHelper from '../useContentHelper';
+
+describe('useContentHelper', () => {
+  let setFlag;
+  let isFlagSet;
+  let toggleFlag;
+  let setCustomStyle;
+
+  beforeEach(() => {
+    setFlag = null;
+    render(<StubElement />);
+  });
+
+  function StubElement() {
+    const contentHelper = useContentHelper();
+    ({ setFlag, isFlagSet, toggleFlag, setCustomStyle } = contentHelper);
+    return <div />;
+  }
+
+  describe('set a flag', () => {
+    it('should set a flag', () => {
+      expect(setFlag('hello &amp; world', 'b', true)).toBe(
+        '<b>hello &amp; world</b>'
+      );
+    });
+
+    it('should set a flag on empty content', () => {
+      expect(setFlag('', 'b', true)).toBe('<b></b>');
+    });
+
+    it('should set a flag when already set', () => {
+      expect(setFlag('<b>hello world</b>', 'b', true)).toBe(
+        '<b>hello world</b>'
+      );
+    });
+
+    it('should set a flag when already set nested', () => {
+      expect(setFlag('<b>hello <b>world</b></b>', 'b', true)).toBe(
+        '<b>hello world</b>'
+      );
+    });
+
+    it('should set a flag when already partially set', () => {
+      expect(
+        setFlag('hello <b>world</b> <i>A <b>even deeper</b> B</i> C', 'b', true)
+      ).toBe('<b>hello world <i>A even deeper B</i> C</b>');
+    });
+  });
+
+  describe('unset a flag', () => {
+    it('should unset a flag', () => {
+      expect(setFlag('<b>hello &amp; world</b>', 'b', false)).toBe(
+        'hello &amp; world'
+      );
+    });
+
+    it('should unset a flag on empty content', () => {
+      expect(setFlag('', 'b', false)).toBe('');
+      expect(setFlag('<b></b>', 'b', false)).toBe('');
+    });
+
+    it('should unset a flag when set nested', () => {
+      expect(setFlag('<b>hello <b>world</b></b>', 'b', false)).toBe(
+        'hello world'
+      );
+      expect(setFlag('hello <b>world</b>', 'b', false)).toBe('hello world');
+    });
+
+    it('should unset a flag when already partially set', () => {
+      expect(
+        setFlag(
+          'hello <b>world</b> <i>A <b>even deeper</b> B</i> C',
+          'b',
+          false
+        )
+      ).toBe('hello world <i>A even deeper B</i> C');
+    });
+  });
+
+  describe('isFlagSet', () => {
+    it('should determine that a flag is set', () => {
+      expect(isFlagSet('<b>hello &amp; world</b>', 'b')).toBe(true);
+    });
+
+    it('should determine that a flag is not set', () => {
+      expect(isFlagSet('hello &amp; world', 'b')).toBe(false);
+    });
+
+    it('should determine that a flag is not set on partial', () => {
+      expect(isFlagSet('<b>hello</b> &amp; <b>world</b>', 'b')).toBe(false);
+    });
+
+    it('should determine that a flag is set/not set on empty content', () => {
+      expect(isFlagSet('', 'b')).toBe(false);
+      expect(isFlagSet('<b></b>', 'b')).toBe(true);
+    });
+  });
+
+  describe('toggleFlag', () => {
+    it('should toggle flag on empty', () => {
+      expect(toggleFlag('', 'b')).toBe('<b></b>');
+      expect(toggleFlag('<b></b>', 'b')).toBe('');
+    });
+
+    it('should toggle flag', () => {
+      expect(toggleFlag('hello world', 'b')).toBe('<b>hello world</b>');
+      expect(toggleFlag('<b>hello world</b>', 'b')).toBe('hello world');
+    });
+  });
+
+  describe('setCustomStyle', () => {
+    it('should set a custom bold style', () => {
+      expect(
+        setCustomStyle('<b>hello <b>nested</b></b>', 'b', { fontWeight: 900 })
+      ).toBe(
+        '<b style="font-weight: 900;">hello <b style="font-weight: 900;">nested</b></b>'
+      );
+    });
+  });
+});

--- a/assets/src/edit-story/elements/text/useContentHelper.js
+++ b/assets/src/edit-story/elements/text/useContentHelper.js
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+
+function useContentHelper() {
+  const helper = useMemo(() => {
+    let buffer = null;
+
+    /**
+     * @param {string} content
+     * @return {DocumentFragment}
+     */
+    function parse(content) {
+      if (!buffer) {
+        buffer = document.createElement('template');
+      }
+      buffer.innerHTML = content;
+      return buffer.content;
+    }
+
+    /**
+     * @return {string}
+     * @private
+     */
+    function stringify() {
+      return (buffer && buffer.innerHTML) || '';
+    }
+
+    /**
+     * @param {string} content
+     * @param {function(DocumentFragment)} callback
+     * @return {string}
+     */
+    function transform(content, callback) {
+      const dom = parse(content);
+      callback(dom);
+      return stringify();
+    }
+
+    function purgeAll(nodeList) {
+      for (let i = nodeList.length - 1; i >= 0; i--) {
+        const node = nodeList[i];
+        if (node.parentNode) {
+          node.replaceWith(...node.childNodes);
+        }
+      }
+    }
+
+    function setStyles(nodeList, styles) {
+      const entries = Object.entries(styles);
+      for (let i = 0; i < nodeList.length; i++) {
+        const node = nodeList[i];
+        entries.forEach(([k, v]) => (node.style[k] = v));
+      }
+    }
+
+    /**
+     * @param {string} content
+     * @param {string} flag
+     * @return {boolean}
+     */
+    function isFlagSet(content, flag) {
+      const tagName = flag.toUpperCase();
+      const dom = parse(content);
+      return (
+        dom.childNodes.length === 1 && dom.childNodes[0].tagName === tagName
+      );
+    }
+
+    /**
+     * @param {string} content
+     * @param {string} flag
+     * @return {string} content
+     */
+    function setFlagOn(content, flag) {
+      const tagName = flag.toUpperCase();
+      return transform(content, (dom) => {
+        let top;
+        if (
+          dom.childNodes.length === 1 &&
+          dom.childNodes[0].tagName === tagName
+        ) {
+          top = dom.childNodes[0];
+        } else {
+          top = document.createElement(tagName);
+          top.append(...dom.childNodes);
+          dom.appendChild(top);
+        }
+        purgeAll(top.querySelectorAll(tagName));
+      });
+    }
+
+    /**
+     * @param {string} content
+     * @param {string} flag
+     * @return {string} content
+     */
+    function setFlagOff(content, flag) {
+      const tagName = flag.toUpperCase();
+      return transform(content, (dom) => {
+        purgeAll(dom.querySelectorAll(tagName));
+      });
+    }
+
+    /**
+     * @param {string} content
+     * @param {string} flag
+     * @param {boolean} value
+     * @return {string} content
+     */
+    function setFlag(content, flag, value) {
+      return value ? setFlagOn(content, flag) : setFlagOff(content, flag);
+    }
+
+    /**
+     * @param {string} content
+     * @param {string} flag
+     * @return {string} content
+     */
+    function toggleFlag(content, flag) {
+      return setFlag(content, flag, !isFlagSet(content, flag));
+    }
+
+    /**
+     * @param {string} content
+     * @param {string} flag
+     * @param {Object} styles
+     * @return {string} content
+     */
+    function setCustomStyle(content, flag, styles) {
+      const tagName = flag.toUpperCase();
+      return transform(content, (dom) => {
+        setStyles(dom.querySelectorAll(tagName), styles);
+      });
+    }
+
+    return { isFlagSet, setCustomStyle, setFlag, toggleFlag };
+  }, []);
+  return helper;
+}
+
+export default useContentHelper;


### PR DESCRIPTION
Partial for #1007.

The proposal here is to toggle B/I/U styles on the content and not on the attributes of the element. The reason for this is because element styles cannot be changed by the text editor, which would make styles inconsistent between text selection and the complete text element. From the user point of view, toggling Bold on the side panel for the frame, or cmd+B in the text editor are completely interchangeable.

With this tool, toggling styles becomes:

```
const {toggleFlag} = useContentHelper();
const updateContentStyleToggle = useCallback((flag, value) => {
  pushUpdates(({content}) => {content: setFlag(content, flag, value));
});
...
<BoldButton onClick={(value) => updateContentStyleToggle('b', value)}>
<ItalicButton onClick={(value) => updateContentStyleToggle('i', value)}>
...
```

And I propose we solve the "bold" problem this way:

```
const {content, fontWeight} = props;  // e.g. 100, 400, 700, etc.
const {setCustomStyles} = useContentHelper();
const boldWeight = Math.min(Math.max(fontWeight + 100, 700), 900);
if boldWeight > 700) {
  contentMarkup = setCustomStyles(content, 'b', {fontWeight: boldWeight});
}
```

Basically this will work simply like this:
 1. A 100-600 fonts will get bold of weight 700. That's the default anyhow.
 2. A 700 font will get bold of 800, a 800 font will get bold of 900.
 3. A 900 font will always just get 900. I.e. bold toggle has no effect.
