### PR TITLE
Fix video controls on drop targets

### DIFF
--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -98,10 +98,10 @@ function DisplayElement({ element, previewMode, page }) {
         target.style.width = `${resize[0]}px`;
         target.style.height = `${resize[1]}px`;
       }
-      if (typeof dropTargets?.hover !== 'undefined') {
+      if (dropTargets?.hover !== undefined) {
         target.style.opacity = dropTargets.hover ? 0 : 1;
       }
-      if (typeof dropTargets?.replacement !== 'undefined') {
+      if (dropTargets?.replacement !== undefined) {
         setReplacement(dropTargets.replacement || null);
       }
     }

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -34,6 +34,7 @@ import {
 import { useUnits } from '../../units';
 import WithMask from '../../masks/frame';
 import WithLink from '../link/frame';
+import { useTransformHandler } from '../transform';
 import useCanvas from './useCanvas';
 
 // @todo: should the frame borders follow clip lines?
@@ -84,6 +85,13 @@ function FrameElement({ element }) {
   const isSelected = selectedElementIds.includes(id);
   const box = getBox(element);
   const isBackground = currentPage?.backgroundElementId === id;
+
+  useTransformHandler(id, (transform) => {
+    const target = elementRef.current;
+    if (transform?.dropTargets?.hover !== undefined) {
+      target.style.opacity = transform.dropTargets.hover ? 0 : 1;
+    }
+  });
 
   return (
     <Wrapper


### PR DESCRIPTION
Close #1026 

### Changes
- Fixes an issue that caused the play/pause button to show up while dragging an element onto a drop target