### PR TITLE
Ensure valid HTML in text

### DIFF
--- a/assets/src/edit-story/elements/text/test/util.js
+++ b/assets/src/edit-story/elements/text/test/util.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { generateFontFamily } from '../util';
+import { draftMarkupToContent, generateFontFamily } from '../util';
 
 describe('Text/util', () => {
   describe('Text/util/generateFontFamily', () => {
@@ -31,6 +31,27 @@ describe('Text/util', () => {
       const expected = '"Baloo Bhaina 2","foo","bar",sans-serif';
       expect(generateFontFamily('Baloo Bhaina 2', fallbackArray)).toStrictEqual(
         expected
+      );
+    });
+  });
+
+  describe('Text/util/draftMarkupToContent', () => {
+    it('should return valid HTML for content', () => {
+      const input = '<em>Hello World!';
+      expect(draftMarkupToContent(input, false)).toStrictEqual(
+        '<em>Hello World!</em>'
+      );
+
+      const nestedInput = '<em>Hello <strong>World, again!';
+      expect(draftMarkupToContent(nestedInput, false)).toStrictEqual(
+        '<em>Hello <strong>World, again!</strong></em>'
+      );
+    });
+
+    it('should add <strong> wrapper when bold', () => {
+      const input = 'Hello World!';
+      expect(draftMarkupToContent(input, true)).toStrictEqual(
+        '<strong>Hello World!</strong>'
       );
     });
   });

--- a/assets/src/edit-story/elements/text/test/util.js
+++ b/assets/src/edit-story/elements/text/test/util.js
@@ -46,6 +46,11 @@ describe('Text/util', () => {
       expect(draftMarkupToContent(nestedInput, false)).toStrictEqual(
         '<em>Hello <strong>World, again!</strong></em>'
       );
+
+      const invalidInput = '<em>Hello</strong> world<u font="> not';
+      expect(draftMarkupToContent(invalidInput, false)).toStrictEqual(
+        '<em>Hello world</em>'
+      );
     });
 
     it('should add <strong> wrapper when bold', () => {

--- a/assets/src/edit-story/elements/text/util.js
+++ b/assets/src/edit-story/elements/text/util.js
@@ -158,7 +158,7 @@ let contentBuffer = null;
 export const draftMarkupToContent = (content, bold) => {
   // @todo This logic is temporary and will change with selecting part + marking bold/italic/underline.
   if (bold) {
-    content = `<strong>${content}`;
+    content = `<strong>${content}</strong>`;
   }
   if (!contentBuffer) {
     contentBuffer = document.createElement('template');

--- a/assets/src/edit-story/elements/text/util.js
+++ b/assets/src/edit-story/elements/text/util.js
@@ -154,12 +154,18 @@ export const generateFontFamily = (fontFamily, fontFallback) => {
   return fontFamilyDisplay;
 };
 
+let contentBuffer = null;
 export const draftMarkupToContent = (content, bold) => {
   // @todo This logic is temporary and will change with selecting part + marking bold/italic/underline.
   if (bold) {
-    return `<strong>${content}</strong>`;
+    content = `<strong>${content}`;
   }
-  return content;
+  if (!contentBuffer) {
+    contentBuffer = document.createElement('template');
+  }
+  // Ensures the content is valid HTML.
+  contentBuffer.innerHTML = content;
+  return contentBuffer.innerHTML;
 };
 
 export const getHighlightLineheight = function (


### PR DESCRIPTION
Fixes #1121 

Ensures valid HTML from text edit by setting the content as `innerHTML` to a template element.