### PR TITLE
Dashboard: Link option on 'Button' Component 

### DIFF
--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -41,6 +41,7 @@ const StyledButton = styled.button`
   opacity: 0.75;
   padding: 0 10px;
   text-decoration: none;
+  background-color: ${({ isLink }) => (isLink ? 'salmon' : 'lime')};
 
   &:focus,
   &:active,
@@ -91,7 +92,7 @@ const StyledChildren = styled.span`
 const Button = ({
   children,
   isDisabled,
-  onClick,
+  isLink,
   type = BUTTON_TYPES.PRIMARY,
   ...rest
 }) => {
@@ -104,7 +105,11 @@ const Button = ({
   const StyledButtonByType = ButtonOptions[type];
 
   return (
-    <StyledButtonByType disabled={isDisabled} onClick={onClick} {...rest}>
+    <StyledButtonByType
+      as={isLink ? 'a' : 'button'}
+      disabled={isDisabled}
+      {...rest}
+    >
       <StyledChildren>{children}</StyledChildren>
     </StyledButtonByType>
   );
@@ -112,9 +117,9 @@ const Button = ({
 
 Button.propTypes = {
   children: PropTypes.node.isRequired,
-  onClick: PropTypes.func.isRequired,
   isCta: PropTypes.bool,
   isDisabled: PropTypes.bool,
+  isLink: PropTypes.bool,
   type: PropTypes.oneOf(Object.values(BUTTON_TYPES)),
 };
 

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -41,7 +41,6 @@ const StyledButton = styled.button`
   opacity: 0.75;
   padding: 0 10px;
   text-decoration: none;
-  background-color: ${({ isLink }) => (isLink ? 'salmon' : 'lime')};
 
   &:focus,
   &:active,

--- a/assets/src/dashboard/components/button/stories/index.js
+++ b/assets/src/dashboard/components/button/stories/index.js
@@ -32,23 +32,31 @@ export default {
   component: Button,
 };
 
+const ButtonContainer = styled.div`
+  width: 60vw;
+`;
+
 export const _default = () => {
   return (
-    <Button
-      isDisabled={boolean('isDisabled')}
-      onClick={action('clicked')}
-      type={select(
-        'type',
-        {
-          cta: BUTTON_TYPES.CTA,
-          primary: BUTTON_TYPES.PRIMARY,
-          secondary: BUTTON_TYPES.SECONDARY,
-        },
-        BUTTON_TYPES.PRIMARY
-      )}
-    >
-      {text('children', 'Default Button Demo')}
-    </Button>
+    <ButtonContainer>
+      <Button
+        isLink={boolean('isLink')}
+        href={text('href', '')}
+        isDisabled={boolean('isDisabled')}
+        onClick={action('clicked')}
+        type={select(
+          'type',
+          {
+            cta: BUTTON_TYPES.CTA,
+            primary: BUTTON_TYPES.PRIMARY,
+            secondary: BUTTON_TYPES.SECONDARY,
+          },
+          BUTTON_TYPES.PRIMARY
+        )}
+      >
+        {text('children', 'Default Button Demo')}
+      </Button>
+    </ButtonContainer>
   );
 };
 
@@ -62,6 +70,8 @@ export const _LongButton = () => {
   return (
     <LongContainer>
       <LongButton
+        isLink={boolean('isLink')}
+        href={text('href', '')}
         isDisabled={boolean('isDisabled')}
         onClick={action('clicked')}
         type={select(
@@ -97,6 +107,8 @@ export const SecondaryButton = () => {
   return (
     <SecondaryButtonContainer>
       <Button
+        isLink={boolean('isLink')}
+        href={text('href', '')}
         isDisabled={boolean('isDisabled')}
         onClick={action('clicked')}
         type={select(

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -85,7 +85,7 @@ const BottomActionButton = styled(Button)`
 
 const getActionAttributes = (targetAction) =>
   typeof targetAction === 'string'
-    ? { forwardedAs: 'a', href: targetAction, onClick: () => {} }
+    ? { href: targetAction, isLink: true }
     : { onClick: targetAction };
 
 const CardPreviewContainer = ({ centerAction, bottomAction, children }) => {

--- a/assets/src/dashboard/components/navigationBar.js
+++ b/assets/src/dashboard/components/navigationBar.js
@@ -106,8 +106,6 @@ PageLinks.propTypes = {
   pathCount: PropTypes.number,
 };
 
-const NewStoryLink = styled(Button).attrs({ onClick: () => {} })``;
-
 function NavigationBar() {
   const { state, actions } = useRouteHistory();
   const { newStoryURL } = useConfig();
@@ -135,9 +133,9 @@ function NavigationBar() {
         ))}
       </PageLinks>
 
-      <NewStoryLink forwardedAs="a" type={BUTTON_TYPES.CTA} href={newStoryURL}>
+      <Button type={BUTTON_TYPES.CTA} href={newStoryURL} isLink={true}>
         {__('Create Story', 'web-stories')}
-      </NewStoryLink>
+      </Button>
     </Nav>
   );
 }


### PR DESCRIPTION
# Overview 
Adding `isLink` as a prop to the `Button` component to avoid having to set forwardAs on each instance where we want a CTA link that stylistically looks like a button. Now using ...rest to decide onClick vs href.

## Testing 
See that the 'create new story' "button" (it's a link, it just looks like a button) still sends you to the proper url. 
See Dashboard/Components/Button on storybook, toggle 'isLink' to see the button become an anchor element. href and onClick are now both just forwarded as is to the component. 