### PR TITLE
Dashboard: Bugfix - Conflicting Pill Styling

### DIFF
--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -48,6 +48,8 @@ import {
   StoryGridView,
 } from '../shared';
 
+// TODO once we know what we want this filter container to look like on small view ports (when we get designs) these should be updated
+
 const FilterContainer = styled.fieldset`
   padding: 0 20px 20px 0;
   margin: ${({ theme }) => `0 ${theme.pageGutter.desktop}px`};
@@ -55,7 +57,6 @@ const FilterContainer = styled.fieldset`
   border-bottom: ${({ theme: t }) => t.subNavigationBar.border};
 
   @media ${({ theme }) => theme.breakpoint.min} {
-    /* TODO once we know what we want this filter container to look like on small view ports (when we get designs) these should be updated */
     & > label span {
         border-radius: 0;
         box-shadow: none !important;

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -48,16 +48,20 @@ import {
   StoryGridView,
 } from '../shared';
 
-const FilterContainer = styled.div`
+const FilterContainer = styled.fieldset`
+  padding: 0 20px 20px 0;
   margin: ${({ theme }) => `0 ${theme.pageGutter.desktop}px`};
   padding-bottom: 20px;
   border-bottom: ${({ theme: t }) => t.subNavigationBar.border};
 
   @media ${({ theme }) => theme.breakpoint.min} {
-    & > label {
-      border-radius: 0;
-      box-shadow: none;
-      padding: 0 10px 0 0;
+    /* TODO once we know what we want this filter container to look like on small view ports (when we get designs) these should be updated */
+    & > label span {
+        border-radius: 0;
+        box-shadow: none !important;
+        padding: 0 10px 0 0;
+        background-color: transparent !important;
+      }
     }
   }
 `;
@@ -189,9 +193,10 @@ function MyStories() {
               <FloatingTab
                 key={storyStatus.value}
                 onClick={(_, value) => setStatus(value)}
-                name="all-stories"
+                name="my-stories-filter-selection"
                 value={storyStatus.value}
                 isSelected={status === storyStatus.value}
+                inputType="radio"
               >
                 {storyStatus.label}
               </FloatingTab>

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -61,7 +61,6 @@ const FilterContainer = styled.fieldset`
       border-radius: 0;
       box-shadow: none !important;
       padding: 0 10px 0 0;
-      background-color: transparent !important;
     }
   }
 `;

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -58,11 +58,10 @@ const FilterContainer = styled.fieldset`
 
   @media ${({ theme }) => theme.breakpoint.min} {
     & > label span {
-        border-radius: 0;
-        box-shadow: none !important;
-        padding: 0 10px 0 0;
-        background-color: transparent !important;
-      }
+      border-radius: 0;
+      box-shadow: none !important;
+      padding: 0 10px 0 0;
+      background-color: transparent !important;
     }
   }
 `;

--- a/assets/src/dashboard/components/pill/index.js
+++ b/assets/src/dashboard/components/pill/index.js
@@ -62,8 +62,7 @@ const PillLabel = styled.span`
   border: ${({ theme }) => `1px solid ${theme.colors.gray50}`};
   border-radius: ${({ theme }) => theme.border.buttonRadius};
 
-  ${PillInput}:checked + &,
-  ${PillInput}:enabled:hover + & {
+  ${PillInput}:checked + & {
     background-color: ${({ theme }) => theme.colors.blueLight};
     border-color: ${({ theme }) => theme.colors.action};
     color: ${({ theme }) => theme.colors.bluePrimary};

--- a/assets/src/dashboard/components/pill/index.js
+++ b/assets/src/dashboard/components/pill/index.js
@@ -64,7 +64,6 @@ const PillLabel = styled.span`
 
   ${PillInput}:checked + & {
     background-color: ${({ theme }) => theme.colors.blueLight};
-    border-color: ${({ theme }) => theme.colors.action};
     color: ${({ theme }) => theme.colors.bluePrimary};
     border: 1px solid transparent;
   }
@@ -86,6 +85,7 @@ const FloatingTabLabel = styled(PillLabel)`
 
   ${PillInput}:checked + & {
     box-shadow: ${({ theme }) => theme.floatingTab.shadow};
+    background-color: transparent;
   }
 `;
 


### PR DESCRIPTION
# Overview
When I updated the pill groups that open in the template dashboard view I neglected to notice the update throwing the my stories view out of sorts for the pills. What was happening is that the my stories pills needed to actually be radio inputs, after adding state styling to the pills it was turning everything active on my stories when it should have been switching ownership. 

This also pointed out that the transparent pills were no longer staying transparent! And that my 'temporary until we get designs' hover styling reusing the active styling is more annoying than helpful. 

Hopefully this will help pill components return to a good state across the board and be less confusing for what's active vs hovering. 

(thanks, @mariano-formidable  for pointing this out)

**The Bug:**
![branch_pills](https://user-images.githubusercontent.com/10720454/79147621-12e90f80-7d79-11ea-8537-b055a44c9122.gif)

**This update:** 
![fixed pill filters](https://user-images.githubusercontent.com/10720454/79147565-fcdb4f00-7d78-11ea-93e4-d6f1173c5ae0.gif)

## Testing
Check out the pill section of storybook (Dashboard/Components/Pill and Dashboard/Components/PopoverPanel) and see that the floating tabs don't turn background blue anymore and hover is no longer what active style it, there's no hover style anymore) 
See my-stories in dashboard and that you can only select one type of filter pill. 
