### PR TITLE
Allow disabling warning on exit in development

### DIFF
--- a/assets/src/edit-story/utils/usePreventWindowUnload.js
+++ b/assets/src/edit-story/utils/usePreventWindowUnload.js
@@ -50,7 +50,10 @@ function usePreventWindowUnload() {
     },
     [context]
   );
-
+  const isDevelopment = process.env.NODE_ENV === 'development';
+  if (isDevelopment) {
+    return () => {};
+  }
   return setPreventUnload;
 }
 

--- a/assets/src/edit-story/utils/usePreventWindowUnload.js
+++ b/assets/src/edit-story/utils/usePreventWindowUnload.js
@@ -50,11 +50,9 @@ function usePreventWindowUnload() {
     },
     [context]
   );
-  const isDevelopment = process.env.NODE_ENV === 'development';
-  if (isDevelopment) {
-    return () => {};
-  }
   return setPreventUnload;
 }
 
-export default usePreventWindowUnload;
+const isDevelopment = process.env.NODE_ENV === 'development';
+
+export default isDevelopment ? () => {} : usePreventWindowUnload;

--- a/assets/src/edit-story/utils/usePreventWindowUnload.js
+++ b/assets/src/edit-story/utils/usePreventWindowUnload.js
@@ -53,6 +53,5 @@ function usePreventWindowUnload() {
   return setPreventUnload;
 }
 
-const isDevelopment = process.env.NODE_ENV === 'development';
-
-export default isDevelopment ? () => {} : usePreventWindowUnload;
+const shouldDisablePrevent = Boolean(process.env.DISABLE_PREVENT);
+export default shouldDisablePrevent ? () => {} : usePreventWindowUnload;

--- a/assets/src/edit-story/utils/useWhyDidYouUpdate.js
+++ b/assets/src/edit-story/utils/useWhyDidYouUpdate.js
@@ -56,6 +56,6 @@ function useWhyDidYouUpdate(name, props) {
   });
 }
 
-const isDevelopment = process.env.NODE_ENV !== 'production';
+const isDevelopment = process.env.NODE_ENV === 'development';
 
 export default isDevelopment ? useWhyDidYouUpdate : () => {};

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,6 +83,10 @@ To get a production build, run:
 npm run build:js
 ```
 
+### Live reload
+
+We don't provide it OOTB. You can setup your own solution and `DISABLE_PREVENT=1 npm run dev` will help you with unwanted `beforeunload` alert.
+
 ### Testing
 
 #### PHP Unit Tests


### PR DESCRIPTION
Don't warn on exit in development because It is a bit annoying (especially when you use auto-reload).

+`isDevelopment` variable narrow down to development only (we have production/test/development?).