### PR TITLE
Changed exit to be on pointerdown, not click

### DIFF
--- a/assets/src/edit-story/components/canvas/editLayer.js
+++ b/assets/src/edit-story/components/canvas/editLayer.js
@@ -82,7 +82,7 @@ function EditLayerForElement({ element }) {
       ref={ref}
       grayout={editModeGrayout}
       zIndex={Z_INDEX.EDIT}
-      onClick={(evt) => {
+      onPointerDown={(evt) => {
         if (evt.target === ref.current || evt.target === pageAreaRef.current) {
           clearEditing();
         }

--- a/assets/src/edit-story/components/colorPicker/colorPicker.js
+++ b/assets/src/edit-story/components/colorPicker/colorPicker.js
@@ -107,7 +107,7 @@ function ColorPicker({
 
   // Detect focus out of color picker (clicks or focuses outside)
   const containerRef = useRef();
-  useFocusOut(containerRef, onClose, [], 'pointerdown');
+  useFocusOut(containerRef, onClose);
 
   // Re-establish focus when actively exiting by button or key press
   const previousFocus = useRef(document.activeElement);

--- a/assets/src/edit-story/components/colorPicker/colorPicker.js
+++ b/assets/src/edit-story/components/colorPicker/colorPicker.js
@@ -107,7 +107,7 @@ function ColorPicker({
 
   // Detect focus out of color picker (clicks or focuses outside)
   const containerRef = useRef();
-  useFocusOut(containerRef, onClose);
+  useFocusOut(containerRef, onClose, [], 'pointerdown');
 
   // Re-establish focus when actively exiting by button or key press
   const previousFocus = useRef(document.activeElement);

--- a/assets/src/edit-story/utils/useFocusOut.js
+++ b/assets/src/edit-story/utils/useFocusOut.js
@@ -19,7 +19,7 @@
  */
 import { useLayoutEffect } from 'react';
 
-function useFocusOut(ref, callback, deps, clickEvent = 'click') {
+function useFocusOut(ref, callback, deps) {
   useLayoutEffect(() => {
     const node = ref.current;
     if (!node) {
@@ -43,11 +43,11 @@ function useFocusOut(ref, callback, deps, clickEvent = 'click') {
     };
 
     node.addEventListener('focusout', onFocusOut);
-    node.ownerDocument.addEventListener(clickEvent, onDocumentClick);
+    node.ownerDocument.addEventListener('pointerdown', onDocumentClick);
 
     return () => {
       node.removeEventListener('focusout', onFocusOut);
-      node.ownerDocument.removeEventListener(clickEvent, onDocumentClick);
+      node.ownerDocument.removeEventListener('pointerdown', onDocumentClick);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps || []);

--- a/assets/src/edit-story/utils/useFocusOut.js
+++ b/assets/src/edit-story/utils/useFocusOut.js
@@ -19,7 +19,7 @@
  */
 import { useLayoutEffect } from 'react';
 
-function useFocusOut(ref, callback, deps) {
+function useFocusOut(ref, callback, deps, clickEvent = 'click') {
   useLayoutEffect(() => {
     const node = ref.current;
     if (!node) {
@@ -43,11 +43,11 @@ function useFocusOut(ref, callback, deps) {
     };
 
     node.addEventListener('focusout', onFocusOut);
-    node.ownerDocument.addEventListener('click', onDocumentClick);
+    node.ownerDocument.addEventListener(clickEvent, onDocumentClick);
 
     return () => {
       node.removeEventListener('focusout', onFocusOut);
-      node.ownerDocument.removeEventListener('click', onDocumentClick);
+      node.ownerDocument.removeEventListener(clickEvent, onDocumentClick);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps || []);


### PR DESCRIPTION
This changes how the mouse-based exit detection works for both edit mode and color picker.

If you _mouse-down_ inside the component, but subsequently _mouse-up_ outside the component, the component should not treat this as an exit signal.

This is done by changed the listener to be a `pointerdown` listener rather than a `click` listener in both instances (and nothing else actually).

This might have unexpected consequences, so heavy testing is required.

Fixes #1186.

### Demo

#### Text edit

| Before | After |
|-|-|
| ![drag-exits-editmode](https://user-images.githubusercontent.com/637548/79167370-49dd1680-7db5-11ea-857e-2b67adc26acc.gif) | ![drag-editmode-fixed](https://user-images.githubusercontent.com/637548/79167400-582b3280-7db5-11ea-88ef-d18187ec4ec5.gif) |

#### Color picker

| Before | After |
|-|-|
| ![drag-exits-colorpicker](https://user-images.githubusercontent.com/637548/79167438-6b3e0280-7db5-11ea-80dd-0ec1e970d662.gif) |  ![drag-colorpicker-fixed](https://user-images.githubusercontent.com/637548/79167452-709b4d00-7db5-11ea-8aba-ff14699415c1.gif) |
