### PR TITLE
Don't steal focus from the design panel when the edit mode exits

### DIFF
--- a/assets/src/edit-story/components/canvas/editLayer.js
+++ b/assets/src/edit-story/components/canvas/editLayer.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 /**
  * Internal dependencies
@@ -31,6 +31,7 @@ import withOverlay from '../overlay/withOverlay';
 import EditElement from './editElement';
 import { Layer, PageArea, Z_INDEX } from './layout';
 import useCanvas from './useCanvas';
+import useFocusCanvas from './useFocusCanvas';
 
 const LayerWithGrayout = styled(Layer)`
   background-color: ${({ grayout, theme }) =>
@@ -73,9 +74,18 @@ function EditLayerForElement({ element }) {
   const {
     actions: { clearEditing },
   } = useCanvas();
+
+  const focusCanvas = useFocusCanvas();
+
   useKeyDownEffect(ref, { key: 'esc', editable: true }, () => clearEditing(), [
     clearEditing,
   ]);
+
+  // Unmount effect to restore focus, but do not force it, in case the
+  // design panel is active.
+  useEffect(() => {
+    return () => focusCanvas(/* force */ false);
+  }, [focusCanvas]);
 
   return (
     <LayerWithGrayout

--- a/assets/src/edit-story/components/canvas/useEditingElement.js
+++ b/assets/src/edit-story/components/canvas/useEditingElement.js
@@ -19,11 +19,6 @@
  */
 import { useReducer, useCallback, useState } from 'react';
 
-/**
- * Internal dependencies
- */
-import useFocusCanvas from './useFocusCanvas';
-
 function useEditingElement() {
   const [state, dispatch] = useReducer(reducer, {
     editingElement: null,
@@ -31,12 +26,9 @@ function useEditingElement() {
   });
   const [nodesById, setNodesById] = useState({});
 
-  const focusCanvas = useFocusCanvas();
-
   const clearEditing = useCallback(() => {
     dispatch({ editingElement: null });
-    focusCanvas();
-  }, [focusCanvas]);
+  }, []);
 
   const setEditingElementWithoutState = useCallback((id) => {
     dispatch({ editingElement: id });

--- a/assets/src/edit-story/components/canvas/useFocusCanvas.js
+++ b/assets/src/edit-story/components/canvas/useFocusCanvas.js
@@ -21,18 +21,14 @@ import { useCallback } from 'react';
 
 function useFocusCanvas() {
   /**
-   * @param {boolean} forceCanvasFocus When true, the focus will always be
+   * @param {boolean} force When true, the focus will always be
    * transfered to the canvas. Otherwise, the focus will only be transfered
    * when no other editor input is holding it.
    */
-  const focusCanvas = useCallback((forceCanvasFocus = true) => {
+  const focusCanvas = useCallback((force = true) => {
     setTimeout(() => {
       const doc = window.document;
-      if (
-        forceCanvasFocus &&
-        doc.activeElement &&
-        doc.activeElement !== doc.body
-      ) {
+      if (force && doc.activeElement && doc.activeElement !== doc.body) {
         doc.activeElement.blur();
       }
       const evt = new window.FocusEvent('focusout');

--- a/assets/src/edit-story/components/canvas/useFocusCanvas.js
+++ b/assets/src/edit-story/components/canvas/useFocusCanvas.js
@@ -20,10 +20,19 @@
 import { useCallback } from 'react';
 
 function useFocusCanvas() {
-  const focusCanvas = useCallback(() => {
+  /**
+   * @param {boolean} forceCanvasFocus When true, the focus will always be
+   * transfered to the canvas. Otherwise, the focus will only be transfered
+   * when no other editor input is holding it.
+   */
+  const focusCanvas = useCallback((forceCanvasFocus = true) => {
     setTimeout(() => {
       const doc = window.document;
-      if (doc.activeElement && doc.activeElement !== doc.body) {
+      if (
+        forceCanvasFocus &&
+        doc.activeElement &&
+        doc.activeElement !== doc.body
+      ) {
         doc.activeElement.blur();
       }
       const evt = new window.FocusEvent('focusout');


### PR DESCRIPTION
Closes https://github.com/google/web-stories-wp/pull/1185.