### PR TITLE
Template Detail: Added Card gallery widget

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -35,6 +35,7 @@ import {
   STORY_STATUSES,
   STORY_SORT_OPTIONS,
   ORDER_BY_SORT,
+  APP_ROUTES,
 } from '../../constants';
 import getAllTemplates from '../../templates';
 
@@ -68,7 +69,7 @@ export function reshapeTemplateObject({ id, title, pages }) {
     status: 'template',
     modified: moment('2020-04-07'),
     pages,
-    centerTargetAction: '',
+    centerTargetAction: `#${APP_ROUTES.TEMPLATE_DETAIL}?id=${id}`,
     bottomTargetAction: () => {},
   };
 }
@@ -76,11 +77,7 @@ export function reshapeTemplateObject({ id, title, pages }) {
 export default function ApiProvider({ children }) {
   const { api, editStoryURL, pluginDir } = useConfig();
   const [stories, setStories] = useState([]);
-
-  const templates = useMemo(
-    () => getAllTemplates({ pluginDir }).map(reshapeTemplateObject),
-    [pluginDir]
-  );
+  const [templates, setTemplates] = useState([]);
 
   const fetchStories = useCallback(
     async ({
@@ -122,6 +119,25 @@ export default function ApiProvider({ children }) {
     [api.stories, editStoryURL]
   );
 
+  const fetchTemplates = useCallback(() => {
+    const reshapedTemplates = getAllTemplates({ pluginDir }).map(
+      reshapeTemplateObject
+    );
+    setTemplates(reshapedTemplates);
+
+    return Promise.resolve(reshapedTemplates);
+  }, [pluginDir]);
+
+  const fetchTemplate = useCallback(
+    async (id) => {
+      const fetchedTemplates = await fetchTemplates();
+      return Promise.resolve(
+        fetchedTemplates.find((template) => template.id === id)
+      );
+    },
+    [fetchTemplates]
+  );
+
   const getAllFonts = useCallback(() => {
     if (!api.fonts) {
       return Promise.resolve([]);
@@ -138,9 +154,16 @@ export default function ApiProvider({ children }) {
   const value = useMemo(
     () => ({
       state: { stories, templates },
-      actions: { fetchStories, getAllFonts },
+      actions: { fetchStories, fetchTemplates, fetchTemplate, getAllFonts },
     }),
-    [stories, templates, fetchStories, getAllFonts]
+    [
+      stories,
+      templates,
+      fetchStories,
+      fetchTemplates,
+      fetchTemplate,
+      getAllFonts,
+    ]
   );
 
   return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -27,10 +27,16 @@ import PropTypes from 'prop-types';
 import theme, { GlobalStyle } from '../theme';
 import KeyboardOnlyOutline from '../utils/keyboardOnlyOutline';
 import { NavigationBar } from '../components';
+import { APP_ROUTES } from '../constants';
 import ApiProvider from './api/apiProvider';
 import { useRouteHistory, Route, RouterProvider } from './router';
 import { useConfig, ConfigProvider } from './config';
-import { MyStoriesView, TemplatesGalleryView, MyBookmarksView } from './views';
+import {
+  MyStoriesView,
+  TemplateDetail,
+  TemplatesGalleryView,
+  MyBookmarksView,
+} from './views';
 
 function App({ config }) {
   const { isRTL } = config;
@@ -43,12 +49,23 @@ function App({ config }) {
               <GlobalStyle />
               <KeyboardOnlyOutline />
               <NavigationBar />
-              <Route exact path="/" component={<MyStoriesView />} />
               <Route
-                path="/templates-gallery"
+                exact
+                path={APP_ROUTES.MY_STORIES}
+                component={<MyStoriesView />}
+              />
+              <Route
+                path={APP_ROUTES.TEMPLATE_DETAIL}
+                component={<TemplateDetail />}
+              />
+              <Route
+                path={APP_ROUTES.TEMPLATES_GALLERY}
                 component={<TemplatesGalleryView />}
               />
-              <Route path="/my-bookmarks" component={<MyBookmarksView />} />
+              <Route
+                path={APP_ROUTES.MY_BOOKMARKS}
+                component={<MyBookmarksView />}
+              />
             </RouterProvider>
           </ApiProvider>
         </ConfigProvider>

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useEffect, useState, useContext } from 'react';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import useRouteHistory from '../../router/useRouteHistory';
+import { ApiContext } from '../../api/apiProvider';
+import { TransformProvider } from '../../../../edit-story/components/transform';
+import FontProvider from '../../font/fontProvider';
+import { CardGallery, PreviewPage } from '../../../components';
+
+const PageContainer = styled.div`
+  display: flex;
+  padding: 20px;
+
+  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
+    display: block;
+  }
+`;
+
+const PageColumn = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 50%;
+
+  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
+    width: 100%;
+  }
+`;
+
+function TemplateDetail() {
+  const [template, setTemplate] = useState(null);
+  const {
+    state: {
+      queryParams: { id: templateId },
+    },
+  } = useRouteHistory();
+  const {
+    actions: { fetchTemplate },
+  } = useContext(ApiContext);
+
+  useEffect(() => {
+    async function getTemplateById(id) {
+      setTemplate(await fetchTemplate(parseInt(id)));
+    }
+
+    getTemplateById(templateId);
+  }, [fetchTemplate, templateId]);
+
+  return (
+    <PageContainer>
+      <PageColumn>
+        {template && (
+          <FontProvider>
+            <TransformProvider>
+              <CardGallery>
+                {template.pages.map((page) => (
+                  <PreviewPage key={page.id} page={page} />
+                ))}
+              </CardGallery>
+            </TransformProvider>
+          </FontProvider>
+        )}
+      </PageColumn>
+      <PageColumn />
+    </PageContainer>
+  );
+}
+
+export default TemplateDetail;

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -22,7 +22,7 @@ import { __, sprintf, _n } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useState, useContext, useMemo, useCallback } from 'react';
+import { useState, useContext, useMemo, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 
 /**
@@ -68,7 +68,12 @@ function TemplatesGallery() {
   const { pageSize } = usePagePreviewSize();
   const {
     state: { templates },
+    actions: { fetchTemplates },
   } = useContext(ApiContext);
+
+  useEffect(() => {
+    fetchTemplates();
+  }, [fetchTemplates]);
 
   const filteredTemplates = useMemo(() => {
     return templates.filter((template) => {

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types'; // import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**

--- a/assets/src/dashboard/components/cardGallery/components.js
+++ b/assets/src/dashboard/components/cardGallery/components.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+export const GalleryContainer = styled.div`
+  ${({ maxWidth }) => `
+    display: flex;
+    justify-content: space-around;
+    width: 100%;
+    max-width: ${maxWidth}px;
+  `}
+`;
+
+export const MiniCardsContainer = styled.div`
+  ${({ rowHeight, gap }) => `
+    display: grid;
+    grid-template-columns: auto auto auto;
+    grid-auto-rows: ${rowHeight}px;
+    column-gap: ${gap}px;
+    row-gap: ${gap}px;
+  `}
+`;
+
+export const MiniCardWrapper = styled.div`
+  ${({ width, height, theme, isSelected }) => `
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: ${width}px;
+    height: ${height}px;
+    overflow: hidden;
+    border-radius: 5px;
+    ${isSelected ? `border: 3px solid ${theme.colors.bluePrimary600}` : ``}
+  `}
+`;
+
+export const MiniCard = styled.div`
+  ${({ width, height }) => `
+    position: relative;
+    width: ${width}px;
+    height: ${height}px;
+    overflow: hidden;
+    border-radius: 4px;
+    cursor: pointer;
+  `}
+`;
+
+export const ActiveCard = styled.div`
+  ${({ theme, height, width }) => `
+    position: relative;
+    width: ${width}px;
+    height: ${height}px;
+    border-radius: ${theme.border.cardRadius};
+    box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.25);
+    overflow: hidden;
+  `}
+`;

--- a/assets/src/dashboard/components/cardGallery/components.js
+++ b/assets/src/dashboard/components/cardGallery/components.js
@@ -31,10 +31,9 @@ export const GalleryContainer = styled.div`
 export const MiniCardsContainer = styled.div`
   ${({ rowHeight, gap }) => `
     display: grid;
-    grid-template-columns: auto auto auto;
+    grid-template-columns: repeat(3, auto);
     grid-auto-rows: ${rowHeight}px;
-    column-gap: ${gap}px;
-    row-gap: ${gap}px;
+    grid-gap: ${gap}px;
   `}
 `;
 

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { useRef, useEffect, useState, useMemo, useCallback } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { PAGE_RATIO } from '../../constants';
+import { UnitsProvider } from '../../../edit-story/units';
+import {
+  ActiveCard,
+  GalleryContainer,
+  MiniCardsContainer,
+  MiniCardWrapper,
+  MiniCard,
+} from './components';
+
+const MAX_WIDTH = 680;
+const ACTIVE_CARD_WIDTH = 330;
+const MINI_CARD_WIDTH = 75;
+const CARD_GAP = 15;
+const CARD_WRAPPER_BUFFER = 10;
+
+function CardGallery({ children }) {
+  const [dimensionMultiplier, setDimensionMultiplier] = useState(1);
+  const [activeCardIndex, setActiveCardIndex] = useState(0);
+
+  const containerRef = useRef();
+
+  const cards = useMemo(
+    () => (Array.isArray(children) ? [...children] : [children]),
+    [children]
+  );
+
+  const { activeCardWidth, miniCardWidth, gap } = useMemo(
+    () => ({
+      activeCardWidth: ACTIVE_CARD_WIDTH * dimensionMultiplier,
+      miniCardWidth: MINI_CARD_WIDTH * dimensionMultiplier,
+      gap: CARD_GAP * dimensionMultiplier,
+    }),
+    [dimensionMultiplier]
+  );
+
+  const activeCardSize = useMemo(
+    () => ({
+      width: activeCardWidth,
+      height: activeCardWidth * PAGE_RATIO,
+    }),
+    [activeCardWidth]
+  );
+
+  const miniCardSize = useMemo(
+    () => ({
+      width: miniCardWidth,
+      height: miniCardWidth * PAGE_RATIO,
+    }),
+    [miniCardWidth]
+  );
+
+  const miniWrapperCardSize = useMemo(
+    () => ({
+      width: miniCardWidth + CARD_WRAPPER_BUFFER,
+      height: (miniCardWidth + CARD_WRAPPER_BUFFER / 2) * PAGE_RATIO,
+    }),
+    [miniCardWidth]
+  );
+
+  const handleMiniCardClick = useCallback((index) => {
+    setActiveCardIndex(index);
+  }, []);
+
+  const updateContainerSize = useCallback(() => {
+    const ratio = containerRef.current.offsetWidth / MAX_WIDTH;
+
+    if (ratio > 0.92) {
+      setDimensionMultiplier(1);
+    } else if (ratio > 0.75) {
+      setDimensionMultiplier(0.8);
+    } else if (ratio > 0.6) {
+      setDimensionMultiplier(0.6);
+    } else {
+      setDimensionMultiplier(0.5);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('resize', updateContainerSize);
+    updateContainerSize();
+    return () => {
+      window.removeEventListener('resize', updateContainerSize);
+    };
+  }, [updateContainerSize]);
+
+  return (
+    <GalleryContainer ref={containerRef} maxWidth={MAX_WIDTH}>
+      <UnitsProvider pageSize={miniCardSize}>
+        <MiniCardsContainer rowHeight={miniWrapperCardSize.height} gap={gap}>
+          {cards.map((card, index) => (
+            <MiniCardWrapper
+              key={index}
+              isSelected={index === activeCardIndex}
+              {...miniWrapperCardSize}
+              onClick={() => handleMiniCardClick(index)}
+            >
+              <MiniCard {...miniCardSize}>{card}</MiniCard>
+            </MiniCardWrapper>
+          ))}
+        </MiniCardsContainer>
+      </UnitsProvider>
+      <UnitsProvider pageSize={activeCardSize}>
+        <ActiveCard {...activeCardSize}>{cards[activeCardIndex]}</ActiveCard>
+      </UnitsProvider>
+    </GalleryContainer>
+  );
+}
+
+CardGallery.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.arrayOf(PropTypes.node),
+  ]).isRequired,
+};
+
+export default CardGallery;

--- a/assets/src/dashboard/components/cardGallery/stories/index.js
+++ b/assets/src/dashboard/components/cardGallery/stories/index.js
@@ -14,7 +14,36 @@
  * limitations under the License.
  */
 
-export { default as MyStoriesView } from './myStories';
-export { default as TemplatesGalleryView } from './templates/index';
-export { default as TemplateDetail } from './templates/detail';
-export { default as MyBookmarksView } from './my-bookmarks';
+/**
+ * Internal dependencies
+ */
+import CardGallery from '../index';
+
+export default {
+  title: 'Dashboard/Components/CardGallery',
+  component: CardGallery,
+};
+
+export const _default = () => {
+  const cards = [
+    'red',
+    'orange',
+    'green',
+    'blue',
+    'purple',
+    'aqua',
+    'yellow',
+    'grey',
+  ].map((color) => (
+    <div
+      key={color}
+      style={{ backgroundColor: color, width: '100%', height: '100%' }}
+    />
+  ));
+
+  return (
+    <div style={{ padding: '20px' }}>
+      <CardGallery>{cards}</CardGallery>
+    </div>
+  );
+};

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -25,6 +25,7 @@ export {
   MoreVerticalButton,
   ActionLabel,
 } from './cardGridItem';
+export { default as CardGallery } from './cardGallery';
 export { default as Dropdown } from './dropdown';
 export { default as NavigationBar } from './navigationBar';
 export { Pill, FloatingTab } from './pill';

--- a/assets/src/dashboard/constants.js
+++ b/assets/src/dashboard/constants.js
@@ -59,13 +59,20 @@ export const Z_INDEX = {
 export const PAGE_RATIO = PAGE_HEIGHT / PAGE_WIDTH;
 export const CARD_TITLE_AREA_HEIGHT = 80;
 
+export const APP_ROUTES = {
+  MY_STORIES: '/',
+  MY_BOOKMARKS: '/bookmarks',
+  TEMPLATES_GALLERY: '/templates-gallery',
+  TEMPLATE_DETAIL: '/template-detail',
+};
+
 export const paths = [
-  { value: '/', label: __('My Stories', 'web-stories') },
+  { value: APP_ROUTES.MY_STORIES, label: __('My Stories', 'web-stories') },
   // {
-  //   value: '/templates-gallery',
+  //   value: APP_ROUTES.TEMPLATES_GALLERY,
   //   label: __('Templates Gallery', 'web-stories'),
   // },
-  // { value: '/my-bookmarks', label: __('My Bookmarks', 'web-stories') },
+  // { value: APP_ROUTES.MY_BOOKMARKS, label: __('My Bookmarks', 'web-stories') },
 ];
 
 export const STORY_STATUSES = [

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -53,6 +53,7 @@ const colors = {
   gray25: '#F6F6F6',
   white: '#fff',
   bluePrimary: '#2979FF',
+  bluePrimary600: '#1A73E8',
   blueLight: '#EAF2FF',
   // taken from edit-stories
   action: '#47A0F4',


### PR DESCRIPTION
This PR does a couple things:
1.) I slightly restructured where the template pages exist.  I decided to use a rails type approach and moved the "Template Gallery" and "Template Details" page into a single folder called "templates".  `index.js` is the "Template Gallery", and `details.js` is the "Template Details" page.

2.) I created a `CardGallery` component that displays each page of a story using the layout shown in figma.  It's responsive, but not perfectly responsive, I'm going to continue to work on how it collapses for smaller screens when I add in the Template Details (follow up PR).

**TODO:** In a follow up PR I'm going to add in the template's information (i.e. title, description, etc...) and update the header to bring the Template Details page closer to completion (the final part will be the related templates).

![image](https://user-images.githubusercontent.com/40646372/79174928-16988880-7db1-11ea-9b0b-36dc9c421b14.png)

![travel_gallery](https://user-images.githubusercontent.com/40646372/79249488-2f954e00-7e32-11ea-8d1e-f280f811a2f7.gif)
