### PR TITLE
Add back curly eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,7 @@
     "block-scoped-var": "error",
     "complexity": ["error", {"max": 20}],
     "consistent-return": "error",
+    "curly": ["error", "all"],
     "default-case": "error",
     "guard-for-in": "error",
     "no-await-in-loop": "error",

--- a/assets/src/edit-story/app/media/useMediaReducer/reducer.js
+++ b/assets/src/edit-story/app/media/useMediaReducer/reducer.js
@@ -79,7 +79,9 @@ function reducer(state, { type, payload }) {
 
     case types.SET_SEARCH_TERM: {
       const { searchTerm } = payload;
-      if (searchTerm === state.searchTerm) return state;
+      if (searchTerm === state.searchTerm) {
+        return state;
+      }
       return {
         ...INITIAL_STATE,
         processing: [...state.processing],
@@ -91,7 +93,9 @@ function reducer(state, { type, payload }) {
 
     case types.SET_MEDIA_TYPE: {
       const { mediaType } = payload;
-      if (mediaType === state.mediaType) return state;
+      if (mediaType === state.mediaType) {
+        return state;
+      }
       return {
         ...INITIAL_STATE,
         media: state.media.filter(({ local }) => local), // This filter allows remove temporary file returned on upload

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/updateElementsByResourceId.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/updateElementsByResourceId.js
@@ -41,7 +41,9 @@ function updateElementsByResourceId(
   state,
   { id, properties: propertiesOrUpdater }
 ) {
-  if (id === null) return state;
+  if (id === null) {
+    return state;
+  }
   const updatedPages = state.pages.map((page, pageIndex) => {
     const updatedElements = page.elements.map((element) => {
       if (element.resource?.id === id) {

--- a/assets/src/edit-story/components/form/dropDown/list.js
+++ b/assets/src/edit-story/components/form/dropDown/list.js
@@ -170,7 +170,9 @@ function DropDownList({
 
   useEffect(() => {
     if (!isNullOrUndefined(focusedValue)) {
-      if (focusedIndex < 0) return;
+      if (focusedIndex < 0) {
+        return;
+      }
       listRef.current.children[focusedIndex].focus();
     }
   }, [focusedValue, options, focusedIndex, listRef]);

--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -226,9 +226,15 @@ function MediaPane(props) {
       rootMargin: '0px 0px 300px 0px',
     },
     (entry) => {
-      if (!isMediaLoaded || isMediaLoading) return;
-      if (!hasMore) return;
-      if (!entry.isIntersecting) return;
+      if (!isMediaLoaded || isMediaLoading) {
+        return;
+      }
+      if (!hasMore) {
+        return;
+      }
+      if (!entry.isIntersecting) {
+        return;
+      }
 
       setNextPage();
     },

--- a/assets/src/edit-story/components/panels/utils/getBoundRect.js
+++ b/assets/src/edit-story/components/panels/utils/getBoundRect.js
@@ -67,7 +67,9 @@ function getBoundRect(list) {
 }
 
 export function calcRotatedObjectPositionAndSize(angle, x, y, width, height) {
-  if (!angle || angle === 0) return { x, y, width, height };
+  if (!angle || angle === 0) {
+    return { x, y, width, height };
+  }
   /// variables
   const centerX = x + width * 0.5;
   const centerY = y + height * 0.5;

--- a/assets/src/edit-story/elements/video/frame.js
+++ b/assets/src/edit-story/elements/video/frame.js
@@ -116,7 +116,9 @@ function VideoFrame({ element, box }) {
 
   const handlePlayPause = () => {
     const videoNode = getVideoNode();
-    if (!videoNode) return;
+    if (!videoNode) {
+      return;
+    }
 
     if (isPlaying) {
       videoNode.pause();


### PR DESCRIPTION
Turns out it was inadvertently disabled when we switched to Prettier as `eslint-config-prettier` requires it to be set explicitly to avoid formatting conflicts.