### PR TITLE
Use Error Boundary around preview

### DIFF
--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -34,6 +34,7 @@ import {
 } from '../../../components';
 import { StoriesPropType } from '../../../types';
 import { STORY_CONTEXT_MENU_ACTIONS } from '../../../constants';
+import PreviewErrorBoundary from '../../../components/previewErrorBoundary';
 
 export const DetailRow = styled.div`
   display: flex;
@@ -82,7 +83,9 @@ const StoryGridView = ({
               label: bottomActionLabel,
             }}
           >
-            <PreviewPage page={story.pages[0]} />
+            <PreviewErrorBoundary>
+              <PreviewPage page={{}} />
+            </PreviewErrorBoundary>
           </CardPreviewContainer>
           <DetailRow>
             <CardTitle

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -84,7 +84,7 @@ const StoryGridView = ({
             }}
           >
             <PreviewErrorBoundary>
-              <PreviewPage page={{}} />
+              <PreviewPage page={story.pages[0]} />
             </PreviewErrorBoundary>
           </CardPreviewContainer>
           <DetailRow>

--- a/assets/src/dashboard/components/previewErrorBoundary.js
+++ b/assets/src/dashboard/components/previewErrorBoundary.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+
+export default class PreviewErrorBoundary extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+  };
+
+  state = {
+    hasError: false,
+  };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // eslint-disable-next-line no-console
+    console.error(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div />;
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
This is to prevent malformed story data from breaking the preview renderer thus the dashboard page.

As shown below the page still renders even when the preview component is fed malformed data.

<img width="1333" alt="Screen Shot 2020-04-14 at 4 40 20 PM" src="https://user-images.githubusercontent.com/1738349/79277133-d697db00-7e6e-11ea-92c3-660a44a86308.png">
