### PR TITLE
Dashboard: Popover Menu Dynamic Alignment

### DIFF
--- a/assets/src/dashboard/components/cardGridItem/cardItemMenu.js
+++ b/assets/src/dashboard/components/cardGridItem/cardItemMenu.js
@@ -28,7 +28,7 @@ import { STORY_CONTEXT_MENU_ITEMS } from '../../constants';
 import { StoryPropType } from '../../types';
 import { ReactComponent as MoreVerticalSvg } from '../../icons/moreVertical.svg';
 import useFocusOut from '../../utils/useFocusOut';
-import PopoverMenu from '../popoverMenu';
+import PopoverMenu, { PopeverRevealer } from '../popoverMenu';
 
 export const MoreVerticalButton = styled.button`
   border: none;
@@ -65,21 +65,25 @@ export default function CardItemMenu({
   }, [contextMenuId, onMoreButtonSelected, story.id]);
   useFocusOut(containerRef, handleFocusOut, [contextMenuId]);
 
+  const isPopoverMenuOpen = contextMenuId === story.id;
+
   return (
     <MenuContainer ref={containerRef}>
       <MoreVerticalButton
-        menuOpen={contextMenuId === story.id}
+        menuOpen={isPopoverMenuOpen}
         aria-label="More Options"
-        onClick={() => onMoreButtonSelected(story.id)}
+        onClick={() => onMoreButtonSelected(isPopoverMenuOpen ? -1 : story.id)}
       >
         <MoreVerticalSvg width={4} height={20} />
       </MoreVerticalButton>
-      <PopoverMenu
-        isOpen={contextMenuId === story.id}
-        framelessButton
-        onSelect={(menuItem) => onMenuItemSelected(menuItem, story)}
-        items={STORY_CONTEXT_MENU_ITEMS}
-      />
+      <PopeverRevealer isOpen={isPopoverMenuOpen}>
+        <PopoverMenu
+          isOpen={isPopoverMenuOpen}
+          framelessButton
+          onSelect={(menuItem) => onMenuItemSelected(menuItem, story)}
+          items={STORY_CONTEXT_MENU_ITEMS}
+        />
+      </PopeverRevealer>
     </MenuContainer>
   );
 }

--- a/assets/src/dashboard/components/cardGridItem/cardItemMenu.js
+++ b/assets/src/dashboard/components/cardGridItem/cardItemMenu.js
@@ -28,7 +28,7 @@ import { STORY_CONTEXT_MENU_ITEMS } from '../../constants';
 import { StoryPropType } from '../../types';
 import { ReactComponent as MoreVerticalSvg } from '../../icons/moreVertical.svg';
 import useFocusOut from '../../utils/useFocusOut';
-import PopoverMenu, { PopeverRevealer } from '../popoverMenu';
+import PopoverMenu, { PopoverRevealer } from '../popoverMenu';
 
 export const MoreVerticalButton = styled.button`
   border: none;
@@ -76,14 +76,14 @@ export default function CardItemMenu({
       >
         <MoreVerticalSvg width={4} height={20} />
       </MoreVerticalButton>
-      <PopeverRevealer isOpen={isPopoverMenuOpen}>
+      <PopoverRevealer isOpen={isPopoverMenuOpen}>
         <PopoverMenu
           isOpen={isPopoverMenuOpen}
           framelessButton
           onSelect={(menuItem) => onMenuItemSelected(menuItem, story)}
           items={STORY_CONTEXT_MENU_ITEMS}
         />
-      </PopeverRevealer>
+      </PopoverRevealer>
     </MenuContainer>
   );
 }

--- a/assets/src/dashboard/components/cardGridItem/cardItemMenu.js
+++ b/assets/src/dashboard/components/cardGridItem/cardItemMenu.js
@@ -48,13 +48,7 @@ const MenuContainer = styled.div`
   position: relative;
   align-self: flex-start;
   text-align: right;
-  flex-grow: 1;
   margin-top: 12px;
-
-  .grid-story-popover-menu {
-    right: 0;
-    top: 0;
-  }
 `;
 
 export default function CardItemMenu({
@@ -81,7 +75,6 @@ export default function CardItemMenu({
         <MoreVerticalSvg width={4} height={20} />
       </MoreVerticalButton>
       <PopoverMenu
-        className="grid-story-popover-menu"
         isOpen={contextMenuId === story.id}
         framelessButton
         onSelect={(menuItem) => onMenuItemSelected(menuItem, story)}

--- a/assets/src/dashboard/components/popoverMenu/index.js
+++ b/assets/src/dashboard/components/popoverMenu/index.js
@@ -18,27 +18,25 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { useCallback, useEffect, useState, useRef } from 'react';
 
 /**
  * Internal dependencies
  */
-import { CORNER_DIRECTIONS, KEYS, Z_INDEX } from '../../constants';
+import { KEYS } from '../../constants';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
 
 export const Menu = styled.ul`
   align-items: flex-start;
   background-color: ${({ theme }) => theme.colors.white};
   border-radius: 8px;
-  box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
   display: flex;
   flex-direction: column;
   margin: ${({ framelessButton }) => (framelessButton ? '0' : '20px 0')};
   min-width: 210px;
   overflow: hidden;
   padding: 0;
-  position: absolute;
 `;
 Menu.propTypes = {
   isOpen: PropTypes.bool,
@@ -76,66 +74,6 @@ const Separator = styled.li`
   width: 100%;
 `;
 
-const PopoverMenuWrapper = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
-  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
-  z-index: ${Z_INDEX.POPOVER_MENU};
-  transform: ${(props) => {
-    switch (props.align) {
-      case CORNER_DIRECTIONS.TOP_LEFT:
-        return 'translate(-100%, -100%)';
-      case CORNER_DIRECTIONS.TOP_RIGHT:
-        return 'transformranslate(100%, -100%)';
-      case CORNER_DIRECTIONS.BOTTOM_RIGHT:
-        return 'translate(100%, 20%)';
-      case CORNER_DIRECTIONS.BOTTOM_LEFT:
-      default:
-        return 'translate(-100%, 20%)';
-    }
-  }};
-
-  ${Menu} {
-    ${(props) => {
-      switch (props.align) {
-        case CORNER_DIRECTIONS.TOP_RIGHT:
-          return css`
-            top: 0;
-            right: 0;
-            transform: translate(0%, 0%);
-          `;
-        case CORNER_DIRECTIONS.TOP_LEFT:
-          return css`
-            top: 0;
-            left: 0;
-            transform: translate(0%, 0%);
-          `;
-        case CORNER_DIRECTIONS.BOTTOM_RIGHT:
-          return css`
-            right: 0;
-            bottom: 0;
-            transform: translate(0%, 0%);
-          `;
-        case CORNER_DIRECTIONS.BOTTOM_LEFT:
-        default:
-          return css`
-            left: 0;
-            bottom: 0;
-            transform: translate(0%, 0%);
-          `;
-      }
-    }}
-  }
-`;
-PopoverMenuWrapper.propTypes = {
-  align: PropTypes.oneOf(Object.values(CORNER_DIRECTIONS)),
-  isOpen: PropTypes.bool,
-};
-
 const PopoverMenu = ({
   className,
   isOpen,
@@ -143,11 +81,8 @@ const PopoverMenu = ({
   onSelect,
   framelessButton,
 }) => {
-  const [align, setAlign] = useState(null);
   const [hoveredIndex, setHoveredIndex] = useState(0);
   const listRef = useRef(null);
-  const menuRef = useRef(null);
-  const menuTogglePositionRef = useRef(null);
 
   // eslint-disable-next-line consistent-return
   useEffect(() => {
@@ -220,47 +155,15 @@ const PopoverMenu = ({
     return <Separator key={`separator-${index}`} />;
   }, []);
 
-  useEffect(() => {
-    if (!isOpen) {
-      setAlign(null);
-      return;
-    }
-    if (!(menuTogglePositionRef.current && menuRef.current)) return;
-
-    const toggleBoundingBox = menuTogglePositionRef.current.getBoundingClientRect();
-    const menuBoundingBox = menuRef.current.getBoundingClientRect();
-
-    const alignHorizontal =
-      toggleBoundingBox.left + menuBoundingBox.width > window.innerWidth
-        ? 'RIGHT'
-        : 'LEFT';
-    const alignVertical =
-      0 > toggleBoundingBox.bottom - menuBoundingBox.height ? 'TOP' : 'BOTTOM';
-
-    setAlign(CORNER_DIRECTIONS[`${alignVertical}_${alignHorizontal}`]);
-  }, [isOpen]);
-
-  const isOpenAndAlignmentSet = isOpen && Boolean(align);
-
   return (
-    <PopoverMenuWrapper
-      ref={menuTogglePositionRef}
-      isOpen={isOpenAndAlignmentSet}
-      align={align}
-    >
-      <Menu
-        ref={menuRef}
-        className={className}
-        framelessButton={framelessButton}
-      >
-        {items.map((item, index) => {
-          if (item.separator) {
-            return renderSeparator(index);
-          }
-          return renderMenuItem(item, index);
-        })}
-      </Menu>
-    </PopoverMenuWrapper>
+    <Menu className={className} framelessButton={framelessButton}>
+      {items.map((item, index) => {
+        if (item.separator) {
+          return renderSeparator(index);
+        }
+        return renderMenuItem(item, index);
+      })}
+    </Menu>
   );
 };
 
@@ -273,3 +176,4 @@ PopoverMenu.propTypes = {
 };
 
 export default PopoverMenu;
+export { default as PopeverRevealer } from './popoverRevealer';

--- a/assets/src/dashboard/components/popoverMenu/index.js
+++ b/assets/src/dashboard/components/popoverMenu/index.js
@@ -176,4 +176,4 @@ PopoverMenu.propTypes = {
 };
 
 export default PopoverMenu;
-export { default as PopeverRevealer } from './popoverRevealer';
+export { default as PopoverRevealer } from './popoverRevealer';

--- a/assets/src/dashboard/components/popoverMenu/popoverRevealer.js
+++ b/assets/src/dashboard/components/popoverMenu/popoverRevealer.js
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { useEffect, useLayoutEffect, useState, useRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { CORNER_DIRECTIONS, Z_INDEX, BEZIER } from '../../constants';
+
+const PERCENTAGE_OFFSET = {
+  TOP: 100,
+  RIGHT: 0,
+  BOTTOM: -100,
+  LEFT: -50,
+};
+
+const transition = `transform 0.2s ${BEZIER.outSine}`;
+const initialScale = 0.5;
+const fullSize = css`
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+`;
+
+const MenuWrapper = styled.div`
+  position: absolute;
+`;
+
+const MenuShadow = styled.div`
+  position: absolute;
+  border-radius: 8px;
+  box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
+  ${fullSize}
+`;
+
+const MenuRevealer = styled.div`
+  overflow: hidden;
+  border-radius: 8px;
+  ${fullSize}
+`;
+
+const MenuCounterRevealer = styled.div`
+  border-radius: 8px;
+`;
+
+const ButtonInner = styled.div`
+  ${fullSize}
+  position: absolute;
+  z-index: ${Z_INDEX.POPOVER_MENU};
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
+  transform: ${(props) => {
+    switch (props.align) {
+      case CORNER_DIRECTIONS.TOP_LEFT:
+        return `translate(${PERCENTAGE_OFFSET.LEFT}%, ${PERCENTAGE_OFFSET.TOP}%)`;
+      case CORNER_DIRECTIONS.TOP_RIGHT:
+        return `translate(${PERCENTAGE_OFFSET.RIGHT}%, ${PERCENTAGE_OFFSET.TOP}%)`;
+      case CORNER_DIRECTIONS.BOTTOM_RIGHT:
+        return `translate(${PERCENTAGE_OFFSET.RIGHT}%, ${PERCENTAGE_OFFSET.BOTTOM}%)`;
+      case CORNER_DIRECTIONS.BOTTOM_LEFT:
+      default:
+        return `translate(${PERCENTAGE_OFFSET.LEFT}%, ${PERCENTAGE_OFFSET.BOTTOM}%)`;
+    }
+  }};
+
+  ${MenuWrapper} {
+    ${(props) => {
+      switch (props.align) {
+        case CORNER_DIRECTIONS.TOP_RIGHT:
+          return css`
+            top: 0;
+            right: 0;
+          `;
+        case CORNER_DIRECTIONS.TOP_LEFT:
+          return css`
+            top: 0;
+            left: 0;
+          `;
+        case CORNER_DIRECTIONS.BOTTOM_RIGHT:
+          return css`
+            right: 0;
+            bottom: 0;
+          `;
+        case CORNER_DIRECTIONS.BOTTOM_LEFT:
+        default:
+          return css`
+            left: 0;
+            bottom: 0;
+          `;
+      }
+    }}
+  }
+
+  ${MenuRevealer} {
+    transition: ${(props) => (props.isOpen ? transition : 'none')};
+    ${(props) => {
+      const translateFromScale = 100 * (1 - initialScale);
+      switch (props.align) {
+        case CORNER_DIRECTIONS.TOP_RIGHT:
+          return css`
+            transform: ${props.isOpen
+              ? 'none'
+              : `translate(${translateFromScale}%, -${translateFromScale}%)`};
+          `;
+        case CORNER_DIRECTIONS.TOP_LEFT:
+          return css`
+            transform: ${props.isOpen
+              ? 'none'
+              : `translate(-${translateFromScale}%, -${translateFromScale}%)`};
+          `;
+        case CORNER_DIRECTIONS.BOTTOM_RIGHT:
+          return css`
+            transform: ${props.isOpen
+              ? 'none'
+              : `translate(${translateFromScale}%, ${translateFromScale}%)`};
+          `;
+        case CORNER_DIRECTIONS.BOTTOM_LEFT:
+        default:
+          return css`
+            transform: ${props.isOpen
+              ? 'none'
+              : `translate(-${translateFromScale}%, ${translateFromScale}%)`};
+          `;
+      }
+    }}
+  }
+
+  ${MenuCounterRevealer} {
+    transition: ${(props) => (props.isOpen ? transition : 'none')};
+    ${(props) => {
+      const translateFromScale = 100 * (1 - initialScale);
+      switch (props.align) {
+        case CORNER_DIRECTIONS.TOP_RIGHT:
+          return css`
+            transform: ${props.isOpen
+              ? 'none'
+              : `translate(-${translateFromScale}%, ${translateFromScale}%)`};
+          `;
+        case CORNER_DIRECTIONS.TOP_LEFT:
+          return css`
+            transform: ${props.isOpen
+              ? 'none'
+              : `translate(${translateFromScale}%, ${translateFromScale}%)`};
+          `;
+        case CORNER_DIRECTIONS.BOTTOM_RIGHT:
+          return css`
+            transform: ${props.isOpen
+              ? 'none'
+              : `translate(-${translateFromScale}%, -${translateFromScale}%)`};
+          `;
+        case CORNER_DIRECTIONS.BOTTOM_LEFT:
+        default:
+          return css`
+            transform: ${props.isOpen
+              ? 'none'
+              : `translate(${translateFromScale}%, -${translateFromScale}%)`};
+          `;
+      }
+    }}
+  }
+
+  ${MenuShadow} {
+    transition: ${(props) => (props.isOpen ? transition : 'none')};
+    transform: ${(props) => (props.isOpen ? 'none' : `scale(${initialScale})`)};
+    transform-origin: ${(props) => {
+      switch (props.align) {
+        case CORNER_DIRECTIONS.TOP_RIGHT:
+          return 'right top';
+        case CORNER_DIRECTIONS.TOP_LEFT:
+          return 'left top';
+        case CORNER_DIRECTIONS.BOTTOM_RIGHT:
+          return 'right bottom';
+        case CORNER_DIRECTIONS.BOTTOM_LEFT:
+        default:
+          return 'left bottom';
+      }
+    }};
+  }
+`;
+ButtonInner.propTypes = {
+  align: PropTypes.oneOf(Object.values(CORNER_DIRECTIONS)),
+  isOpen: PropTypes.bool,
+};
+
+const PopoverRevealer = ({ children, isOpen }) => {
+  const [align, setAlign] = useState(null);
+  const [isReady, setIsReady] = useState(false);
+  const menuPositionRef = useRef(null);
+  const menuTogglePositionRef = useRef(null);
+
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setAlign(null);
+      return;
+    }
+    if (!(menuTogglePositionRef.current && menuPositionRef.current)) return;
+
+    const toggleBoundingBox = menuTogglePositionRef.current.getBoundingClientRect();
+    const menuWrapperBoundingBox = menuPositionRef.current.getBoundingClientRect();
+
+    const menuLeft =
+      toggleBoundingBox.left +
+      toggleBoundingBox.width * (PERCENTAGE_OFFSET.LEFT / 100);
+    const menuBottom =
+      toggleBoundingBox.bottom +
+      toggleBoundingBox.height * (PERCENTAGE_OFFSET.BOTTOM / 100);
+
+    const alignHorizontal =
+      menuLeft + menuWrapperBoundingBox.width > window.innerWidth
+        ? 'RIGHT'
+        : 'LEFT';
+    const alignVertical =
+      0 > menuBottom - menuWrapperBoundingBox.height ? 'TOP' : 'BOTTOM';
+
+    setAlign(CORNER_DIRECTIONS[`${alignVertical}_${alignHorizontal}`]);
+  }, [isOpen]);
+
+  /**
+   * Seems funky, but we need 1 full render where the proper
+   * alignment is set before we animate in. This prevents react
+   * from batching those renders and animating from wrong alignemnt.
+   *
+   * Other options include scheduling with something like rAF
+   * if we think it's a more robust solution.
+   */
+  useEffect(() => {
+    setIsReady(Boolean(align));
+  }, [align]);
+
+  return (
+    <ButtonInner
+      ref={menuTogglePositionRef}
+      isOpen={isOpen && isReady}
+      align={align}
+    >
+      <MenuWrapper>
+        <MenuRevealer>
+          <MenuCounterRevealer ref={menuPositionRef}>
+            {children}
+          </MenuCounterRevealer>
+        </MenuRevealer>
+        <MenuShadow />
+      </MenuWrapper>
+    </ButtonInner>
+  );
+};
+
+PopoverRevealer.propTypes = {
+  children: PropTypes.children,
+  isOpen: PropTypes.bool.isRequired,
+};
+
+export default PopoverRevealer;

--- a/assets/src/dashboard/components/popoverMenu/popoverRevealer.js
+++ b/assets/src/dashboard/components/popoverMenu/popoverRevealer.js
@@ -213,7 +213,9 @@ const PopoverRevealer = ({ children, isOpen }) => {
       setAlign(null);
       return;
     }
-    if (!(menuTogglePositionRef.current && menuPositionRef.current)) return;
+    if (!(menuTogglePositionRef.current && menuPositionRef.current)) {
+      return;
+    }
 
     const toggleBoundingBox = menuTogglePositionRef.current.getBoundingClientRect();
     const menuWrapperBoundingBox = menuPositionRef.current.getBoundingClientRect();

--- a/assets/src/dashboard/components/popoverMenu/popoverRevealer.js
+++ b/assets/src/dashboard/components/popoverMenu/popoverRevealer.js
@@ -24,16 +24,21 @@ import { useEffect, useLayoutEffect, useState, useRef } from 'react';
 /**
  * Internal dependencies
  */
-import { CORNER_DIRECTIONS, Z_INDEX, BEZIER } from '../../constants';
+import {
+  BEZIER,
+  CORNER_DIRECTIONS,
+  DIRECTIONS,
+  Z_INDEX,
+} from '../../constants';
 
 const PERCENTAGE_OFFSET = {
-  TOP: 100,
-  RIGHT: 0,
-  BOTTOM: -100,
-  LEFT: -50,
+  [DIRECTIONS.TOP]: 100,
+  [DIRECTIONS.RIGHT]: 0,
+  [DIRECTIONS.BOTTOM]: -100,
+  [DIRECTIONS.LEFT]: -50,
 };
 
-const transition = `transform 0.2s ${BEZIER.outSine}`;
+const transition = `transform 0.175s ${BEZIER.outSine}`;
 const initialScale = 0.5;
 const fullSize = css`
   top: 0;
@@ -72,14 +77,22 @@ const ButtonInner = styled.div`
   transform: ${(props) => {
     switch (props.align) {
       case CORNER_DIRECTIONS.TOP_LEFT:
-        return `translate(${PERCENTAGE_OFFSET.LEFT}%, ${PERCENTAGE_OFFSET.TOP}%)`;
+        return `translate(${PERCENTAGE_OFFSET[DIRECTIONS.LEFT]}%, ${
+          PERCENTAGE_OFFSET[DIRECTIONS.TOP]
+        }%)`;
       case CORNER_DIRECTIONS.TOP_RIGHT:
-        return `translate(${PERCENTAGE_OFFSET.RIGHT}%, ${PERCENTAGE_OFFSET.TOP}%)`;
+        return `translate(${PERCENTAGE_OFFSET[DIRECTIONS.RIGHT]}%, ${
+          PERCENTAGE_OFFSET[DIRECTIONS.TOP]
+        }%)`;
       case CORNER_DIRECTIONS.BOTTOM_RIGHT:
-        return `translate(${PERCENTAGE_OFFSET.RIGHT}%, ${PERCENTAGE_OFFSET.BOTTOM}%)`;
+        return `translate(${PERCENTAGE_OFFSET[DIRECTIONS.RIGHT]}%, ${
+          PERCENTAGE_OFFSET[DIRECTIONS.BOTTOM]
+        }%)`;
       case CORNER_DIRECTIONS.BOTTOM_LEFT:
       default:
-        return `translate(${PERCENTAGE_OFFSET.LEFT}%, ${PERCENTAGE_OFFSET.BOTTOM}%)`;
+        return `translate(${PERCENTAGE_OFFSET[DIRECTIONS.LEFT]}%, ${
+          PERCENTAGE_OFFSET[DIRECTIONS.BOTTOM]
+        }%)`;
     }
   }};
 
@@ -222,17 +235,19 @@ const PopoverRevealer = ({ children, isOpen }) => {
 
     const menuLeft =
       toggleBoundingBox.left +
-      toggleBoundingBox.width * (PERCENTAGE_OFFSET.LEFT / 100);
+      toggleBoundingBox.width * (PERCENTAGE_OFFSET[DIRECTIONS.LEFT] / 100);
     const menuBottom =
       toggleBoundingBox.bottom +
-      toggleBoundingBox.height * (PERCENTAGE_OFFSET.BOTTOM / 100);
+      toggleBoundingBox.height * (PERCENTAGE_OFFSET[DIRECTIONS.BOTTOM] / 100);
 
     const alignHorizontal =
       menuLeft + menuWrapperBoundingBox.width > window.innerWidth
-        ? 'RIGHT'
-        : 'LEFT';
+        ? DIRECTIONS.RIGHT
+        : DIRECTIONS.LEFT;
     const alignVertical =
-      0 > menuBottom - menuWrapperBoundingBox.height ? 'TOP' : 'BOTTOM';
+      0 > menuBottom - menuWrapperBoundingBox.height
+        ? DIRECTIONS.TOP
+        : DIRECTIONS.BOTTOM;
 
     setAlign(CORNER_DIRECTIONS[`${alignVertical}_${alignHorizontal}`]);
   }, [isOpen]);

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -27,13 +27,6 @@ import { useEffect, useState, useRef } from 'react';
 import { KEYS, Z_INDEX } from '../../constants';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
 
-export const DROPDOWN_MENU_DIRECTIONS = {
-  UP: 'up',
-  DOWN: 'down',
-  LEFT: 'left',
-  RIGHT: 'right',
-};
-
 export const Menu = styled.ul`
   width: 100%;
   align-items: flex-start;

--- a/assets/src/dashboard/constants.js
+++ b/assets/src/dashboard/constants.js
@@ -50,6 +50,13 @@ export const KEYS = {
 export const KEYBOARD_USER_CLASS = `useskeyboard`;
 export const KEYBOARD_USER_SELECTOR = `.${KEYBOARD_USER_CLASS}`;
 
+export const CORNER_DIRECTIONS = {
+  TOP_LEFT: 'top_left',
+  TOP_RIGHT: 'top_right',
+  BOTTOM_RIGHT: 'bottom_right',
+  BOTTOM_LEFT: 'bottom_left',
+};
+
 export const Z_INDEX = {
   POPOVER_MENU: 10,
   TYPEAHEAD_OPTIONS: 10,

--- a/assets/src/dashboard/constants.js
+++ b/assets/src/dashboard/constants.js
@@ -24,6 +24,31 @@ import { __ } from '@wordpress/i18n';
  */
 import { PAGE_HEIGHT, PAGE_WIDTH } from '../edit-story/constants';
 
+export const BEZIER = {
+  linear: 'linear',
+  inQuad: 'cubic-bezier(0.55, 0.085, 0.68, 0.53)',
+  outQuad: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+  inOutQuad: 'cubic-bezier(0.455, 0.03, 0.515, 0.955)',
+  inCubic: 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
+  outCubic: 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  inOutCubic: 'cubic-bezier(0.645, 0.045, 0.355, 1)',
+  inQuart: 'cubic-bezier(0.895, 0.03, 0.685, 0.22)',
+  outQuart: 'cubic-bezier(0.165, 0.84, 0.44, 1)',
+  inOutQuart: 'cubic-bezier(0.77, 0, 0.175, 1)',
+  inQuint: 'cubic-bezier(0.755, 0.05, 0.855, 0.06)',
+  outQuint: 'cubic-bezier(0.23, 1, 0.32, 1)',
+  inOutQuint: 'cubic-bezier(0.86, 0, 0.07, 1)',
+  inSine: 'cubic-bezier(0.47, 0, 0.745, 0.715)',
+  outSine: 'cubic-bezier(0.39, 0.575, 0.565, 1)',
+  inOutSine: 'cubic-bezier(0.445, 0.05, 0.55, 0.95)',
+  inExpo: 'cubic-bezier(0.95, 0.05, 0.795, 0.035)',
+  outExpo: 'cubic-bezier(0.19, 1, 0.22, 1)',
+  inOutExpo: 'cubic-bezier(1, 0, 0, 1)',
+  inCirc: 'cubic-bezier(0.6, 0.04, 0.98, 0.335)',
+  outCirc: 'cubic-bezier(0.075, 0.82, 0.165, 1)',
+  inOutCirc: 'cubic-bezier(0.785, 0.135, 0.15, 0.86)',
+};
+
 export const BUTTON_TYPES = {
   CTA: 'cta',
   PRIMARY: 'primary',

--- a/assets/src/dashboard/constants/animation.js
+++ b/assets/src/dashboard/constants/animation.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const BEZIER = {
+  outQuad: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+  outCubic: 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  outQuart: 'cubic-bezier(0.165, 0.84, 0.44, 1)',
+  outQuint: 'cubic-bezier(0.23, 1, 0.32, 1)',
+  outSine: 'cubic-bezier(0.39, 0.575, 0.565, 1)',
+  outCirc: 'cubic-bezier(0.075, 0.82, 0.165, 1)',
+};

--- a/assets/src/dashboard/constants/direction.js
+++ b/assets/src/dashboard/constants/direction.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const DIRECTIONS = {
+  TOP: 'top',
+  RIGHT: 'right',
+  BOTTOM: 'bottom',
+  LEFT: 'left',
+};
+
+export const CORNER_DIRECTIONS = {
+  [`${DIRECTIONS.TOP}_${DIRECTIONS.LEFT}`]: `${DIRECTIONS.TOP}_${DIRECTIONS.LEFT}`,
+  [`${DIRECTIONS.TOP}_${DIRECTIONS.RIGHT}`]: `${DIRECTIONS.TOP}_${DIRECTIONS.RIGHT}`,
+  [`${DIRECTIONS.BOTTOM}_${DIRECTIONS.RIGHT}`]: `${DIRECTIONS.BOTTOM}_${DIRECTIONS.RIGHT}`,
+  [`${DIRECTIONS.BOTTOM}_${DIRECTIONS.LEFT}`]: `${DIRECTIONS.BOTTOM}_${DIRECTIONS.LEFT}`,
+};

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -22,32 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { PAGE_HEIGHT, PAGE_WIDTH } from '../edit-story/constants';
-
-export const BEZIER = {
-  linear: 'linear',
-  inQuad: 'cubic-bezier(0.55, 0.085, 0.68, 0.53)',
-  outQuad: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)',
-  inOutQuad: 'cubic-bezier(0.455, 0.03, 0.515, 0.955)',
-  inCubic: 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
-  outCubic: 'cubic-bezier(0.215, 0.61, 0.355, 1)',
-  inOutCubic: 'cubic-bezier(0.645, 0.045, 0.355, 1)',
-  inQuart: 'cubic-bezier(0.895, 0.03, 0.685, 0.22)',
-  outQuart: 'cubic-bezier(0.165, 0.84, 0.44, 1)',
-  inOutQuart: 'cubic-bezier(0.77, 0, 0.175, 1)',
-  inQuint: 'cubic-bezier(0.755, 0.05, 0.855, 0.06)',
-  outQuint: 'cubic-bezier(0.23, 1, 0.32, 1)',
-  inOutQuint: 'cubic-bezier(0.86, 0, 0.07, 1)',
-  inSine: 'cubic-bezier(0.47, 0, 0.745, 0.715)',
-  outSine: 'cubic-bezier(0.39, 0.575, 0.565, 1)',
-  inOutSine: 'cubic-bezier(0.445, 0.05, 0.55, 0.95)',
-  inExpo: 'cubic-bezier(0.95, 0.05, 0.795, 0.035)',
-  outExpo: 'cubic-bezier(0.19, 1, 0.22, 1)',
-  inOutExpo: 'cubic-bezier(1, 0, 0, 1)',
-  inCirc: 'cubic-bezier(0.6, 0.04, 0.98, 0.335)',
-  outCirc: 'cubic-bezier(0.075, 0.82, 0.165, 1)',
-  inOutCirc: 'cubic-bezier(0.785, 0.135, 0.15, 0.86)',
-};
+import { PAGE_HEIGHT, PAGE_WIDTH } from '../../edit-story/constants';
 
 export const BUTTON_TYPES = {
   CTA: 'cta',
@@ -74,13 +49,6 @@ export const KEYS = {
 
 export const KEYBOARD_USER_CLASS = `useskeyboard`;
 export const KEYBOARD_USER_SELECTOR = `.${KEYBOARD_USER_CLASS}`;
-
-export const CORNER_DIRECTIONS = {
-  TOP_LEFT: 'top_left',
-  TOP_RIGHT: 'top_right',
-  BOTTOM_RIGHT: 'bottom_right',
-  BOTTOM_LEFT: 'bottom_left',
-};
 
 export const Z_INDEX = {
   POPOVER_MENU: 10,
@@ -197,3 +165,6 @@ export const STORY_SORT_MENU_ITEMS = [
     value: STORY_SORT_OPTIONS.CREATED_BY,
   },
 ];
+
+export * from './animation';
+export * from './direction';


### PR DESCRIPTION
## Summary
Dynamically aligns story context menu to menu toggle in the dashboard depending on viewport space. Adds a subtle reveal animation as well.

Tried to make most of these changes in a revealer that wrap around the popover menu and take into account the popover menu's dynamic size.

Also note that I had to separate the shadow layer to nail the animation, so it no longer appears with the menu in storybook.

**Note**
the entering downward if there's not enough space at the top of the viewport seems like it could be refined a bit. lemme know if we should alter this at all

#### Issues
#767 
https://github.com/google/web-stories-wp/issues/767#issuecomment-613438267


#### Screenshots
![Kapture 2020-04-15 at 14 38 00](https://user-images.githubusercontent.com/35983235/79386030-c04d5600-7f26-11ea-89db-2a5b0b15955e.gif)
