### PR TITLE
Fix text element not registering the first keystroke

### DIFF
--- a/assets/src/edit-story/elements/text/util.js
+++ b/assets/src/edit-story/elements/text/util.js
@@ -84,6 +84,8 @@ export function getSelectionForOffset(content, offset) {
       const selection = new SelectionState({
         anchorKey: block.getKey(),
         anchorOffset: countdown,
+        focusKey: block.getKey(),
+        focusOffset: countdown,
       });
       return selection;
     }


### PR DESCRIPTION
Fixes https://github.com/google/web-stories-wp/issues/1222

It just took those 2 lines to fix the bug, don't ask about time spent on this 😫 
At least I know DraftJS better now.