### PR TITLE
Dashboard: Fixes popovers everywhere

### DIFF
--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -43,6 +43,10 @@ const StorySortDropdownContainer = styled.div`
 const SortDropdown = styled(Dropdown)`
   min-width: 210px;
   margin-right: 10px;
+
+  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
+    margin-right: 0px;
+  }
 `;
 
 const BodyViewOptions = ({

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -41,17 +41,8 @@ const StorySortDropdownContainer = styled.div`
 `;
 
 const SortDropdown = styled(Dropdown)`
-  min-width: 147px;
-  ul {
-    right: 20px;
-    max-width: 147px;
-  }
-
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    ul {
-      left: 20px;
-    }
-  }
+  min-width: 210px;
+  margin-right: 10px;
 `;
 
 const BodyViewOptions = ({

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -33,20 +33,11 @@ const DisplayFormatContainer = styled.div`
   display: flex;
   align-items: space-between;
   align-content: center;
-
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    flex-direction: column;
-    align-items: flex-start;
-  }
 `;
 
 const StorySortDropdownContainer = styled.div`
   margin: auto 0 auto auto;
   align-self: flex-end;
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    align-self: flex-start;
-    margin: 20px 0 0;
-  }
 `;
 
 const SortDropdown = styled(Dropdown)`

--- a/assets/src/dashboard/components/cardGridItem/cardItemMenu.js
+++ b/assets/src/dashboard/components/cardGridItem/cardItemMenu.js
@@ -28,7 +28,7 @@ import { STORY_CONTEXT_MENU_ITEMS } from '../../constants';
 import { StoryPropType } from '../../types';
 import { ReactComponent as MoreVerticalSvg } from '../../icons/moreVertical.svg';
 import useFocusOut from '../../utils/useFocusOut';
-import PopoverMenu, { PopoverRevealer } from '../popoverMenu';
+import { PopoverMenuCard } from '../popoverMenu';
 
 export const MoreVerticalButton = styled.button`
   border: none;
@@ -76,14 +76,12 @@ export default function CardItemMenu({
       >
         <MoreVerticalSvg width={4} height={20} />
       </MoreVerticalButton>
-      <PopoverRevealer isOpen={isPopoverMenuOpen}>
-        <PopoverMenu
-          isOpen={isPopoverMenuOpen}
-          framelessButton
-          onSelect={(menuItem) => onMenuItemSelected(menuItem, story)}
-          items={STORY_CONTEXT_MENU_ITEMS}
-        />
-      </PopoverRevealer>
+      <PopoverMenuCard
+        isOpen={isPopoverMenuOpen}
+        framelessButton
+        onSelect={(menuItem) => onMenuItemSelected(menuItem, story)}
+        items={STORY_CONTEXT_MENU_ITEMS}
+      />
     </MenuContainer>
   );
 }

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -32,8 +32,13 @@ import PopoverMenu from '../popoverMenu';
 import PopoverPanel from '../popoverPanel';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
 
+const StyledPopoverMenu = styled(PopoverMenu)`
+  left: 50%;
+  transform: translateX(-50%);
+`;
+
 export const DropdownContainer = styled.div`
-  position: static;
+  position: relative;
 `;
 
 const Label = styled.label`
@@ -171,7 +176,7 @@ const Dropdown = ({
           }}
         />
       ) : (
-        <PopoverMenu
+        <StyledPopoverMenu
           isOpen={showMenu}
           items={items}
           onSelect={handleMenuItemSelect}

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -44,27 +44,28 @@ export const DropdownContainer = styled.div`
 const Label = styled.label`
   display: flex;
   flex-direction: column;
+  align-items: center;
 `;
 
 export const InnerDropdown = styled.button`
+  display: inline-flex;
+  justify-content: center;
   align-items: center;
+  height: ${({ theme, type }) => theme.dropdown[type].height};
+  width: auto;
+  padding: 10px 16px;
+  margin: 0;
   background-color: ${({ theme, type, isOpen }) =>
     theme.dropdown[type][isOpen ? 'activeBackground' : 'background']};
   border-radius: ${({ theme, type }) => theme.dropdown[type].borderRadius};
   border: ${({ theme, type }) => theme.dropdown[type].border};
   color: ${({ theme }) => theme.colors.gray600};
   cursor: ${({ disabled }) => (disabled ? 'inherit' : 'pointer')};
-  display: flex;
   font-family: ${({ theme }) => theme.fonts.dropdown.family};
   font-size: ${({ theme }) => theme.fonts.dropdown.size};
   font-weight: ${({ theme }) => theme.fonts.dropdown.weight};
-  height: ${({ theme, type }) => theme.dropdown[type].height};
-  margin: 0;
-  justify-content: space-between;
   letter-spacing: ${({ theme }) => theme.fonts.dropdown.letterSpacing};
   line-height: ${({ theme }) => theme.fonts.dropdown.lineHeight};
-  padding: 10px 16px;
-  width: 100%;
 
   &:hover {
     background-color: ${({ theme, type }) =>

--- a/assets/src/dashboard/components/navigationBar.js
+++ b/assets/src/dashboard/components/navigationBar.js
@@ -54,7 +54,10 @@ const DropdownContainer = styled.div`
   display: none;
 
   @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
+    position: absolute;
     display: flex;
+    left: 50%;
+    transform: translateX(-50%);
   }
 
   @media ${({ theme }) => theme.breakpoint.min} {
@@ -63,6 +66,7 @@ const DropdownContainer = styled.div`
 `;
 
 const Nav = styled.nav`
+  position: relative;
   justify-content: space-between;
   align-items: center;
   border-bottom: 1px solid #eee;

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+/**
+ * Internal dependencies
+ */
+import { KEYS } from '../../constants';
+import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
+
+export const MenuContainer = styled.ul`
+  align-items: flex-start;
+  background-color: ${({ theme }) => theme.colors.white};
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  margin: ${({ framelessButton }) => (framelessButton ? '0' : '20px 0')};
+  min-width: 210px;
+  overflow: hidden;
+  padding: 0;
+`;
+MenuContainer.propTypes = {
+  isOpen: PropTypes.bool,
+};
+
+export const MenuItem = styled.li`
+  padding: 14px 16px;
+  background: ${({ isHovering, theme }) =>
+    isHovering ? theme.colors.gray50 : 'none'};
+  color: ${({ theme }) => theme.colors.gray700};
+  cursor: ${({ isDisabled }) => (isDisabled ? 'default' : 'pointer')};
+  display: flex;
+  font-family: ${({ theme }) => theme.fonts.popoverMenu.family};
+  font-size: ${({ theme }) => theme.fonts.popoverMenu.size};
+  line-height: ${({ theme }) => theme.fonts.popoverMenu.lineHeight};
+  font-weight: ${({ theme }) => theme.fonts.popoverMenu.weight};
+  letter-spacing: ${({ theme }) => theme.fonts.popoverMenu.letterSpacing};
+  width: 100%;
+`;
+
+MenuItem.propTypes = {
+  isDisabled: PropTypes.bool,
+  isHovering: PropTypes.bool,
+};
+
+const MenuItemContent = styled.span`
+  align-self: flex-start;
+  height: 100%;
+  margin: auto 0;
+`;
+
+const Separator = styled.li`
+  height: 1px;
+  background: ${({ theme }) => theme.colors.gray50};
+  width: 100%;
+`;
+
+const Menu = ({ isOpen, items, onSelect, framelessButton }) => {
+  const [hoveredIndex, setHoveredIndex] = useState(0);
+  const listRef = useRef(null);
+
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (isOpen) {
+      const handleKeyDown = (event) => {
+        switch (event.key) {
+          case KEYS.UP:
+            event.preventDefault();
+            if (hoveredIndex > 0) {
+              setHoveredIndex(hoveredIndex - 1);
+              if (listRef.current) {
+                listRef.current.scrollToItem(hoveredIndex - 1);
+              }
+            }
+            break;
+
+          case KEYS.DOWN:
+            event.preventDefault();
+            if (hoveredIndex < items.length - 1) {
+              setHoveredIndex(hoveredIndex + 1);
+              if (listRef.current) {
+                listRef.current.scrollToItem(hoveredIndex + 1);
+              }
+            }
+            break;
+
+          case KEYS.ENTER:
+            event.preventDefault();
+            if (onSelect) {
+              onSelect(items[hoveredIndex]);
+            }
+            break;
+
+          default:
+            break;
+        }
+      };
+
+      document.addEventListener('keydown', handleKeyDown);
+      return () => document.removeEventListener('keydown', handleKeyDown);
+    }
+  }, [hoveredIndex, items, onSelect, isOpen]);
+
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollToItem(0);
+    }
+    setHoveredIndex(0);
+  }, [items]);
+
+  const renderMenuItem = useCallback(
+    (item, index) => {
+      const itemIsDisabled = !item.value && item.value !== 0;
+      return (
+        <MenuItem
+          key={`${item.value}_${index}`}
+          isHovering={index === hoveredIndex}
+          onClick={() => !itemIsDisabled && onSelect && onSelect(item)}
+          onMouseEnter={() => setHoveredIndex(index)}
+          isDisabled={itemIsDisabled}
+        >
+          <MenuItemContent>{item.label}</MenuItemContent>
+        </MenuItem>
+      );
+    },
+    [hoveredIndex, onSelect]
+  );
+
+  const renderSeparator = useCallback((index) => {
+    return <Separator key={`separator-${index}`} />;
+  }, []);
+
+  return (
+    <MenuContainer framelessButton={framelessButton}>
+      {items.map((item, index) => {
+        if (item.separator) {
+          return renderSeparator(index);
+        }
+        return renderMenuItem(item, index);
+      })}
+    </MenuContainer>
+  );
+};
+
+export const MenuProps = {
+  items: PropTypes.arrayOf(DROPDOWN_ITEM_PROP_TYPE).isRequired,
+  isOpen: PropTypes.bool,
+  onSelect: PropTypes.func,
+  framelessButton: PropTypes.bool,
+};
+
+Menu.propTypes = MenuProps;
+
+export default Menu;

--- a/assets/src/dashboard/components/popoverMenu/popover.js
+++ b/assets/src/dashboard/components/popoverMenu/popover.js
@@ -17,28 +17,22 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import Menu, { MenuProps } from './menu';
-import PopoverCard from './popoverCard';
-import PopoverStandard from './popoverStandard';
+import { Z_INDEX } from '../../constants';
 
-const PopoverMenu = ({ className, ...props }) => (
-  <PopoverStandard isOpen={props.isOpen} className={className}>
-    <Menu {...props} />
-  </PopoverStandard>
-);
-PopoverMenu.propTypes = {
+const Popover = styled.div`
+  position: absolute;
+  z-index: ${Z_INDEX.POPOVER_MENU};
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
+`;
+
+Popover.propTypes = {
   className: PropTypes.string,
-  ...MenuProps,
+  isOpen: PropTypes.bool.isRequired,
 };
 
-export const PopoverMenuCard = (props) => (
-  <PopoverCard isOpen={props.isOpen}>
-    <Menu {...props} />
-  </PopoverCard>
-);
-PopoverMenuCard.propTypes = MenuProps;
-
-export default PopoverMenu;
+export default Popover;

--- a/assets/src/dashboard/components/popoverMenu/popoverCard.js
+++ b/assets/src/dashboard/components/popoverMenu/popoverCard.js
@@ -18,18 +18,14 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
-import { useEffect, useLayoutEffect, useState, useRef } from 'react';
-
 /**
  * Internal dependencies
  */
-import {
-  BEZIER,
-  CORNER_DIRECTIONS,
-  DIRECTIONS,
-  Z_INDEX,
-} from '../../constants';
+import { BEZIER, CORNER_DIRECTIONS, DIRECTIONS } from '../../constants';
+import Popover from './popover';
+import Shadow from './shadow';
 
 const PERCENTAGE_OFFSET = {
   [DIRECTIONS.TOP]: 100,
@@ -51,13 +47,6 @@ const MenuWrapper = styled.div`
   position: absolute;
 `;
 
-const MenuShadow = styled.div`
-  position: absolute;
-  border-radius: 8px;
-  box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
-  ${fullSize}
-`;
-
 const MenuRevealer = styled.div`
   overflow: hidden;
   border-radius: 8px;
@@ -68,27 +57,23 @@ const MenuCounterRevealer = styled.div`
   border-radius: 8px;
 `;
 
-const ButtonInner = styled.div`
+const ButtonInner = styled(Popover)`
   ${fullSize}
-  position: absolute;
-  z-index: ${Z_INDEX.POPOVER_MENU};
-  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
-  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
   transform: ${(props) => {
     switch (props.align) {
-      case CORNER_DIRECTIONS.TOP_LEFT:
+      case CORNER_DIRECTIONS.top_left:
         return `translate(${PERCENTAGE_OFFSET[DIRECTIONS.LEFT]}%, ${
           PERCENTAGE_OFFSET[DIRECTIONS.TOP]
         }%)`;
-      case CORNER_DIRECTIONS.TOP_RIGHT:
+      case CORNER_DIRECTIONS.top_right:
         return `translate(${PERCENTAGE_OFFSET[DIRECTIONS.RIGHT]}%, ${
           PERCENTAGE_OFFSET[DIRECTIONS.TOP]
         }%)`;
-      case CORNER_DIRECTIONS.BOTTOM_RIGHT:
+      case CORNER_DIRECTIONS.bottom_right:
         return `translate(${PERCENTAGE_OFFSET[DIRECTIONS.RIGHT]}%, ${
           PERCENTAGE_OFFSET[DIRECTIONS.BOTTOM]
         }%)`;
-      case CORNER_DIRECTIONS.BOTTOM_LEFT:
+      case CORNER_DIRECTIONS.bottom_left:
       default:
         return `translate(${PERCENTAGE_OFFSET[DIRECTIONS.LEFT]}%, ${
           PERCENTAGE_OFFSET[DIRECTIONS.BOTTOM]
@@ -99,22 +84,22 @@ const ButtonInner = styled.div`
   ${MenuWrapper} {
     ${(props) => {
       switch (props.align) {
-        case CORNER_DIRECTIONS.TOP_RIGHT:
+        case CORNER_DIRECTIONS.top_right:
           return css`
             top: 0;
             right: 0;
           `;
-        case CORNER_DIRECTIONS.TOP_LEFT:
+        case CORNER_DIRECTIONS.top_left:
           return css`
             top: 0;
             left: 0;
           `;
-        case CORNER_DIRECTIONS.BOTTOM_RIGHT:
+        case CORNER_DIRECTIONS.bottom_right:
           return css`
             right: 0;
             bottom: 0;
           `;
-        case CORNER_DIRECTIONS.BOTTOM_LEFT:
+        case CORNER_DIRECTIONS.bottom_left:
         default:
           return css`
             left: 0;
@@ -129,25 +114,25 @@ const ButtonInner = styled.div`
     ${(props) => {
       const translateFromScale = 100 * (1 - initialScale);
       switch (props.align) {
-        case CORNER_DIRECTIONS.TOP_RIGHT:
+        case CORNER_DIRECTIONS.top_right:
           return css`
             transform: ${props.isOpen
               ? 'none'
               : `translate(${translateFromScale}%, -${translateFromScale}%)`};
           `;
-        case CORNER_DIRECTIONS.TOP_LEFT:
+        case CORNER_DIRECTIONS.top_left:
           return css`
             transform: ${props.isOpen
               ? 'none'
               : `translate(-${translateFromScale}%, -${translateFromScale}%)`};
           `;
-        case CORNER_DIRECTIONS.BOTTOM_RIGHT:
+        case CORNER_DIRECTIONS.bottom_right:
           return css`
             transform: ${props.isOpen
               ? 'none'
               : `translate(${translateFromScale}%, ${translateFromScale}%)`};
           `;
-        case CORNER_DIRECTIONS.BOTTOM_LEFT:
+        case CORNER_DIRECTIONS.bottom_left:
         default:
           return css`
             transform: ${props.isOpen
@@ -163,25 +148,25 @@ const ButtonInner = styled.div`
     ${(props) => {
       const translateFromScale = 100 * (1 - initialScale);
       switch (props.align) {
-        case CORNER_DIRECTIONS.TOP_RIGHT:
+        case CORNER_DIRECTIONS.top_right:
           return css`
             transform: ${props.isOpen
               ? 'none'
               : `translate(-${translateFromScale}%, ${translateFromScale}%)`};
           `;
-        case CORNER_DIRECTIONS.TOP_LEFT:
+        case CORNER_DIRECTIONS.top_left:
           return css`
             transform: ${props.isOpen
               ? 'none'
               : `translate(${translateFromScale}%, ${translateFromScale}%)`};
           `;
-        case CORNER_DIRECTIONS.BOTTOM_RIGHT:
+        case CORNER_DIRECTIONS.bottom_right:
           return css`
             transform: ${props.isOpen
               ? 'none'
               : `translate(-${translateFromScale}%, -${translateFromScale}%)`};
           `;
-        case CORNER_DIRECTIONS.BOTTOM_LEFT:
+        case CORNER_DIRECTIONS.bottom_left:
         default:
           return css`
             transform: ${props.isOpen
@@ -192,18 +177,18 @@ const ButtonInner = styled.div`
     }}
   }
 
-  ${MenuShadow} {
+  ${Shadow} {
     transition: ${(props) => (props.isOpen ? transition : 'none')};
     transform: ${(props) => (props.isOpen ? 'none' : `scale(${initialScale})`)};
     transform-origin: ${(props) => {
       switch (props.align) {
-        case CORNER_DIRECTIONS.TOP_RIGHT:
+        case CORNER_DIRECTIONS.top_right:
           return 'right top';
-        case CORNER_DIRECTIONS.TOP_LEFT:
+        case CORNER_DIRECTIONS.top_left:
           return 'left top';
-        case CORNER_DIRECTIONS.BOTTOM_RIGHT:
+        case CORNER_DIRECTIONS.bottom_right:
           return 'right bottom';
-        case CORNER_DIRECTIONS.BOTTOM_LEFT:
+        case CORNER_DIRECTIONS.bottom_left:
         default:
           return 'left bottom';
       }
@@ -215,7 +200,7 @@ ButtonInner.propTypes = {
   isOpen: PropTypes.bool,
 };
 
-const PopoverRevealer = ({ children, isOpen }) => {
+const popoverCard = ({ children, isOpen }) => {
   const [align, setAlign] = useState(null);
   const [isReady, setIsReady] = useState(false);
   const menuPositionRef = useRef(null);
@@ -276,15 +261,18 @@ const PopoverRevealer = ({ children, isOpen }) => {
             {children}
           </MenuCounterRevealer>
         </MenuRevealer>
-        <MenuShadow />
+        <Shadow />
       </MenuWrapper>
     </ButtonInner>
   );
 };
 
-PopoverRevealer.propTypes = {
-  children: PropTypes.children,
+popoverCard.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
   isOpen: PropTypes.bool.isRequired,
 };
 
-export default PopoverRevealer;
+export default popoverCard;

--- a/assets/src/dashboard/components/popoverMenu/popoverStandard.js
+++ b/assets/src/dashboard/components/popoverMenu/popoverStandard.js
@@ -20,25 +20,24 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import Menu, { MenuProps } from './menu';
-import PopoverCard from './popoverCard';
-import PopoverStandard from './popoverStandard';
+import Popover from './popover';
+import Shadow from './shadow';
 
-const PopoverMenu = ({ className, ...props }) => (
-  <PopoverStandard isOpen={props.isOpen} className={className}>
-    <Menu {...props} />
-  </PopoverStandard>
-);
-PopoverMenu.propTypes = {
+const PopoverStandard = ({ className, children, isOpen }) => {
+  return (
+    <Popover isOpen={isOpen} className={className}>
+      <Shadow />
+      {children}
+    </Popover>
+  );
+};
+PopoverStandard.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
   className: PropTypes.string,
-  ...MenuProps,
+  isOpen: PropTypes.boolean.isRequired,
 };
 
-export const PopoverMenuCard = (props) => (
-  <PopoverCard isOpen={props.isOpen}>
-    <Menu {...props} />
-  </PopoverCard>
-);
-PopoverMenuCard.propTypes = MenuProps;
-
-export default PopoverMenu;
+export default PopoverStandard;

--- a/assets/src/dashboard/components/popoverMenu/popoverStandard.js
+++ b/assets/src/dashboard/components/popoverMenu/popoverStandard.js
@@ -37,7 +37,7 @@ PopoverStandard.propTypes = {
     PropTypes.node,
   ]).isRequired,
   className: PropTypes.string,
-  isOpen: PropTypes.boolean.isRequired,
+  isOpen: PropTypes.bool.isRequired,
 };
 
 export default PopoverStandard;

--- a/assets/src/dashboard/components/popoverMenu/shadow.js
+++ b/assets/src/dashboard/components/popoverMenu/shadow.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+const Shadow = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  border-radius: 8px;
+  box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
+`;
+
+export default Shadow;

--- a/assets/src/dashboard/components/popoverMenu/shadow.js
+++ b/assets/src/dashboard/components/popoverMenu/shadow.js
@@ -26,6 +26,7 @@ const Shadow = styled.div`
   left: 0;
   border-radius: 8px;
   box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
 `;
 
 export default Shadow;

--- a/assets/src/dashboard/style.css
+++ b/assets/src/dashboard/style.css
@@ -35,7 +35,8 @@ body.web-story_page_stories-dashboard #wpbody-content {
   padding: 0;
 }
 
-body.web-story_page_dashboard #web-stories-dashboard {
+body.web-story_page_stories-dashboard #web-stories-dashboard {
+  position: relative;
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
**Fixes**

- Filter dropdown always open
- Remove horizontal overflow from hidden menus
- Dynamic card popovers corner alignment wasn't working

**Technical updates**

- Ties the reveal portion of the component into all exported components
- Adds for base and variations pattern with popover reveals to allow for multiple reveal animations
- Separates out card popover from a standard popover so we can have different reveal and logic on the cards, but not bloat the components interface
- Centers all standard popovers
- Remove overflow from Dashboard area

****
