### PR TITLE
Remove Story Flash

### DIFF
--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -28,13 +28,21 @@ const sizeFromWidth = (width) => ({
   height: PAGE_RATIO * width,
 });
 
-const ascendingBreakpointKeys = Object.keys(theme.breakpoint.raw).sort(
-  (a, b) => theme.breakpoint.raw[a] - theme.breakpoint.raw[b]
+const descendingBreakpointKeys = Object.keys(theme.breakpoint.raw).sort(
+  (a, b) => theme.breakpoint.raw[b] - theme.breakpoint.raw[a]
 );
+const defaultBp = descendingBreakpointKeys[0];
+const getCurrentBp = () =>
+  descendingBreakpointKeys.reduce((current, mq) => {
+    if (window.innerWidth <= theme.breakpoint.raw[mq]) {
+      current = mq;
+    }
+    return current;
+  }, defaultBp);
 
 export default function usePagePreviewSize(options = {}) {
-  const [bp, setBp] = useState('desktop');
   const { thumbnailMode = false } = options;
+  const [bp, setBp] = useState(getCurrentBp());
 
   useEffect(() => {
     if (thumbnailMode) {
@@ -42,10 +50,8 @@ export default function usePagePreviewSize(options = {}) {
     }
 
     const handleResize = () => {
-      setBp('desktop');
+      setBp(getCurrentBp);
     };
-
-    handleResize();
     window.addEventListener('resize', handleResize);
     return () => {
       window.removeEventListener('resize', handleResize);
@@ -53,8 +59,7 @@ export default function usePagePreviewSize(options = {}) {
   }, [thumbnailMode]);
 
   return useMemo(() => {
-    const pageWidth =
-      thumbnailMode && !bp && ascendingBreakpointKeys ? 33 : 100;
+    const pageWidth = thumbnailMode ? 33 : theme.previewWidth[bp];
     return {
       pageSize: sizeFromWidth(pageWidth),
     };

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -23,8 +23,6 @@ import { useEffect, useMemo, useState } from 'react';
 import { PAGE_RATIO } from '../constants';
 import theme from '../theme';
 
-const THUMBNAIL_WIDTH = 33;
-
 const descendingBreakpointKeys = Object.keys(theme.breakpoint.raw).sort(
   (a, b) => theme.breakpoint.raw[b] - theme.breakpoint.raw[a]
 );
@@ -59,7 +57,7 @@ export default function usePagePreviewSize(options = {}) {
   return useMemo(
     () => ({
       pageSize: sizeFromWidth(
-        thumbnailMode ? THUMBNAIL_WIDTH : theme.previewWidth[bp]
+        theme.previewWidth[thumbnailMode ? 'thumbnail' : bp]
       ),
     }),
     [bp, thumbnailMode]

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -23,11 +23,6 @@ import { useEffect, useState, useMemo } from 'react';
 import theme from '../theme';
 import { PAGE_RATIO } from '../constants';
 
-const sizeFromWidth = (width) => ({
-  width,
-  height: PAGE_RATIO * width,
-});
-
 const descendingBreakpointKeys = Object.keys(theme.breakpoint.raw).sort(
   (a, b) => theme.breakpoint.raw[b] - theme.breakpoint.raw[a]
 );
@@ -39,6 +34,11 @@ const getCurrentBp = () =>
     }
     return current;
   }, defaultBp);
+
+const sizeFromWidth = (width) => ({
+  width,
+  height: PAGE_RATIO * width,
+});
 
 export default function usePagePreviewSize(options = {}) {
   const { thumbnailMode = false } = options;
@@ -58,10 +58,10 @@ export default function usePagePreviewSize(options = {}) {
     };
   }, [thumbnailMode]);
 
-  return useMemo(() => {
-    const pageWidth = thumbnailMode ? 33 : theme.previewWidth[bp];
-    return {
-      pageSize: sizeFromWidth(pageWidth),
-    };
-  }, [bp, thumbnailMode]);
+  return useMemo(
+    () => ({
+      pageSize: sizeFromWidth(thumbnailMode ? 33 : theme.previewWidth[bp]),
+    }),
+    [bp, thumbnailMode]
+  );
 }

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -16,24 +16,24 @@
 /**
  * External dependencies
  */
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
-import theme from '../theme';
 import { PAGE_RATIO } from '../constants';
+import theme from '../theme';
+
+const THUMBNAIL_WIDTH = 33;
 
 const descendingBreakpointKeys = Object.keys(theme.breakpoint.raw).sort(
   (a, b) => theme.breakpoint.raw[b] - theme.breakpoint.raw[a]
 );
-const defaultBp = descendingBreakpointKeys[0];
 const getCurrentBp = () =>
-  descendingBreakpointKeys.reduce((current, mq) => {
-    if (window.innerWidth <= theme.breakpoint.raw[mq]) {
-      current = mq;
-    }
-    return current;
-  }, defaultBp);
+  descendingBreakpointKeys.reduce(
+    (current, bp) =>
+      window.innerWidth <= theme.breakpoint.raw[bp] ? bp : current,
+    descendingBreakpointKeys[0]
+  );
 
 const sizeFromWidth = (width) => ({
   width,
@@ -49,9 +49,7 @@ export default function usePagePreviewSize(options = {}) {
       return () => {};
     }
 
-    const handleResize = () => {
-      setBp(getCurrentBp);
-    };
+    const handleResize = () => setBp(getCurrentBp());
     window.addEventListener('resize', handleResize);
     return () => {
       window.removeEventListener('resize', handleResize);
@@ -60,7 +58,9 @@ export default function usePagePreviewSize(options = {}) {
 
   return useMemo(
     () => ({
-      pageSize: sizeFromWidth(thumbnailMode ? 33 : theme.previewWidth[bp]),
+      pageSize: sizeFromWidth(
+        thumbnailMode ? THUMBNAIL_WIDTH : theme.previewWidth[bp]
+      ),
     }),
     [bp, thumbnailMode]
   );


### PR DESCRIPTION
## Summary
This task eliminates a render from `usePagePreviewSize` when calculating size from its initial args.

Now the only time it will cause a re-render is if either `thumbnailMode` changes or there's an update to the current breakpoint and it's not in `thumbnailMode`