### PR TITLE
Fix dev/prod mode issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   "scripts": {
     "build": "npm-run-all build:*",
     "prebuild:js": "rm -rf assets/css/* assets/js/*",
-    "build:js": "webpack",
+    "build:js": "NODE_ENV=production webpack",
     "build:plugin": "wp dist-archive . $(pwd)/build/web-stories --create-target-dir",
     "build:storybook": "build-storybook -c .storybook -o build/storybook --quiet",
     "download-fonts": "curl -s \"https://www.googleapis.com/webfonts/v1/webfonts?fields=items&prettyPrint=false&key=$GOOGLE_FONTS_API_KEY\" | jq -c '[.items[] | { family: .family, variants: .variants, category: .category }]' > includes/data/fonts.json",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,7 @@ function requestToExternal(request) {
   return undefined;
 }
 
-process.env.NODE_ENV = process.env.NODE_ENV || 'production';
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 const isProduction = process.env.NODE_ENV === 'production';
 const mode = isProduction ? 'production' : 'development';
 


### PR DESCRIPTION
When using `npm run dev`, one shouldn't end up with a production build