### PR TITLE
Dashboard: Use empty i18n helper to make storybook work

### DIFF
--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -60,7 +60,7 @@ export default function StoryListView({ filteredStories }) {
         <TableHeader>
           <TableRow>
             <TableHeaderCell>{__('Title', 'web-stories')}</TableHeaderCell>
-            <TableHeaderCell />
+            <TableHeaderCell>{__('', 'web-stories')}</TableHeaderCell>
             <TableHeaderCell>{__('Author', 'web-stories')}</TableHeaderCell>
             <TableHeaderCell>{__('Categories', 'web-stories')}</TableHeaderCell>
             <TableHeaderCell>{__('Tags', 'web-stories')}</TableHeaderCell>


### PR DESCRIPTION
Apparently production storybook does not like empty table headers. Prettier does not allow us to use `{' '}` since it will wipe it out. **This cell will get replaced with a sorting arrow icon in a future PR hopefully today** so this is only a placeholder to get static storybook compiling. 