### PR TITLE
Dashboard: Remove circular imports from dashboard app

### DIFF
--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -79,5 +79,3 @@ App.propTypes = {
 };
 
 export default App;
-
-export { useConfig, useRouteHistory };

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -29,8 +29,8 @@ import KeyboardOnlyOutline from '../utils/keyboardOnlyOutline';
 import { NavigationBar } from '../components';
 import { APP_ROUTES } from '../constants';
 import ApiProvider from './api/apiProvider';
-import { useRouteHistory, Route, RouterProvider } from './router';
-import { useConfig, ConfigProvider } from './config';
+import { Route, RouterProvider } from './router';
+import { ConfigProvider } from './config';
 import {
   MyStoriesView,
   TemplateDetail,

--- a/assets/src/dashboard/components/navigationBar.js
+++ b/assets/src/dashboard/components/navigationBar.js
@@ -28,9 +28,10 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { useConfig, useRouteHistory } from '../app';
 import { ReactComponent as WebStoriesLogoSVG } from '../images/logo.svg';
 import { BUTTON_TYPES, DROPDOWN_TYPES, paths } from '../constants';
+import { useConfig } from '../app/config';
+import { useRouteHistory } from '../app/router';
 import Button from './button';
 import Dropdown from './dropdown';
 


### PR DESCRIPTION
Huge props to @merapi for finding this circular import which also had unexpected results for the timing of imports. 

- [x] I double checked the routing of secondary pages and those still work
- [x] Checked production build of storybook

<img width="630" alt="Screen Shot 2020-04-17 at 9 20 51 AM" src="https://user-images.githubusercontent.com/1738349/79579122-ca896480-808c-11ea-81d5-a7a6091bbd88.png">
 