### PR TITLE
Exclude template assets from plugin bundle for now

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -3,6 +3,7 @@
 .idea
 .storybook
 __mocks__
+assets/images/templates
 assets/src
 bin
 build


### PR DESCRIPTION
The [images](https://github.com/google/web-stories-wp/tree/1b755a46a8bea35778d4917a5fe91e8d0c1a47c5/assets/images/templates/travel) for the travel template are quite large, even after compression. The plugin bundle is currently over 11MB.

Since templates aren't fully implemented yet, let's omit them from the plugin bundle for now to avoid issues with the ZIP file being too large to upload.