### PR TITLE
Dashboard infinite scroll implementation (My Stories)

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -113,10 +113,10 @@ export default function ApiProvider({ children }) {
       page = 1,
       perPage = ITEMS_PER_PAGE,
     }) => {
-      // dispatch({
-      //   type: STORY_ACTION_TYPES.LOADING_STORIES,
-      //   payload: true,
-      // });
+      dispatch({
+        type: STORY_ACTION_TYPES.LOADING_STORIES,
+        payload: true,
+      });
 
       if (!api.stories) {
         dispatch({
@@ -176,13 +176,12 @@ export default function ApiProvider({ children }) {
           payload: true,
         });
         return [];
+      } finally {
+        dispatch({
+          type: STORY_ACTION_TYPES.LOADING_STORIES,
+          payload: false,
+        });
       }
-      // finally {
-      //   dispatch({
-      //     type: STORY_ACTION_TYPES.LOADING_STORIES,
-      //     payload: false,
-      //   });
-      // }
     },
     [api.stories, editStoryURL]
   );

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -31,9 +31,11 @@ function storyReducer(state, action) {
       return {
         ...state,
         storiesOrderById: [],
+        stories: {},
       };
     }
     case ACTION_TYPES.UPDATE_STORIES:
+      // eslint-disable-next-line no-case-declarations
       let uniqueStoryIds = [
         ...state.storiesOrderById,
         ...action.payload.map(({ id }) => id),

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -33,6 +33,7 @@ function storyReducer(state, action) {
         storiesOrderById: [],
         stories: {},
         totalStories: 0,
+        totalPages: 0,
       };
     }
     case ACTION_TYPES.UPDATE_STORIES:

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -65,7 +65,7 @@ function storyReducer(state, action) {
         stories: { ...state.stories, ...groupBy(action.payload.stories, 'id') },
         totalPages: action.payload.totalPages,
         totalStories: action.payload.totalStories,
-        allPagesFetched: action.payload.page === action.payload.totalPages,
+        allPagesFetched: action.payload.page >= action.payload.totalPages,
       };
     }
 

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -20,20 +20,35 @@
 import groupBy from '../../utils/groupBy';
 
 export const ACTION_TYPES = {
+  LOADING_STORIES: 'loading_stories',
   UPDATE_STORIES: 'update_stories',
   UPDATE_TOTAL_STORIES_PAGES: 'update_total_stories_pages',
   UPDATE_TOTAL_STORIES_COUNT: 'update_total_stories_count',
 };
 
+export const defaultStoriesState = {
+  isLoading: false,
+  stories: {},
+  storiesOrderById: [],
+  totalStories: null,
+  totalPages: null,
+};
+
 function storyReducer(state, action) {
   switch (action.type) {
+    case ACTION_TYPES.LOADING_STORIES: {
+      return {
+        ...state,
+        isLoading: action.payload,
+      };
+    }
     case ACTION_TYPES.CLEAR_STORIES_ORDER: {
       return {
         ...state,
         storiesOrderById: [],
         stories: {},
-        totalStories: 0,
         totalPages: 0,
+        totalStories: 0,
       };
     }
     case ACTION_TYPES.UPDATE_STORIES:

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -50,14 +50,22 @@ function storyReducer(state, action) {
 
     case ACTION_TYPES.FETCH_STORIES_SUCCESS: {
       const fetchedStoriesById = action.payload.stories.map(({ id }) => id);
+
       const combinedStoryIds =
         action.payload.page === 1
           ? fetchedStoriesById
           : [...state.storiesOrderById, ...fetchedStoriesById];
 
-      const uniqueStoryIds = combinedStoryIds.filter((value, index, self) => {
-        return self.indexOf(value) === index;
-      });
+      // we want to make sure that pagination is kept intact regardless of page number.
+      // we are using infinite scroll, not traditional pagination.
+      // this means we need to append our new stories to the bottom of our already existing stories.
+      // when we combine existing stories with the new ones we need to make sure we're not duplicating anything.
+      const uniqueStoryIds = combinedStoryIds.filter(
+        (storyId, index, storyIdsArray) => {
+          return storyIdsArray.indexOf(storyId) === index;
+        }
+      );
+
       return {
         ...state,
         isError: false,

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -32,6 +32,7 @@ function storyReducer(state, action) {
         ...state,
         storiesOrderById: [],
         stories: {},
+        totalStories: 0,
       };
     }
     case ACTION_TYPES.UPDATE_STORIES:

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import groupBy from '../../utils/groupBy';
+
+export const ACTION_TYPES = {
+  UPDATE_STORIES: 'update_stories',
+  UPDATE_TOTAL_STORIES_PAGES: 'update_total_stories_pages',
+  UPDATE_TOTAL_STORIES_COUNT: 'update_total_stories_count',
+};
+
+function storyReducer(state, action) {
+  switch (action.type) {
+    case ACTION_TYPES.CLEAR_STORIES_ORDER: {
+      return {
+        ...state,
+        storiesOrderById: [],
+      };
+    }
+    case ACTION_TYPES.UPDATE_STORIES:
+      let uniqueStoryIds = [
+        ...state.storiesOrderById,
+        ...action.payload.map(({ id }) => id),
+      ];
+      uniqueStoryIds = uniqueStoryIds.filter((value, index, self) => {
+        return self.indexOf(value) === index;
+      });
+
+      return {
+        ...state,
+        storiesOrderById: uniqueStoryIds,
+        stories: { ...state.stories, ...groupBy(action.payload, 'id') },
+      };
+    case ACTION_TYPES.UPDATE_TOTAL_STORIES_COUNT:
+      return {
+        ...state,
+        totalStories: action.payload,
+      };
+    case ACTION_TYPES.UPDATE_TOTAL_STORIES_PAGES:
+      return {
+        ...state,
+        totalPages: action.payload,
+      };
+
+    default:
+      return state;
+  }
+}
+
+export default storyReducer;

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -21,9 +21,11 @@ import storyReducer, { ACTION_TYPES } from '../stories';
 
 describe('storyReducer', () => {
   const initialState = {
+    isLoading: false,
     stories: {},
-    totalPages: 0,
-    totalStories: 0,
+    storiesOrderById: [],
+    totalStories: null,
+    totalPages: null,
   };
   it(`should update stories state when ${ACTION_TYPES.UPDATE_STORIES} is called`, () => {
     const result = storyReducer(initialState, {
@@ -38,6 +40,33 @@ describe('storyReducer', () => {
 
     expect(result).toMatchObject({
       ...initialState,
+      storiesOrderById: [94, 65, 78, 12],
+      stories: {
+        94: { id: 94, status: 'draft', title: 'my test story 1' },
+        65: { id: 65, status: 'published', title: 'my test story 2' },
+        78: { id: 78, status: 'draft', title: 'my test story 3' },
+        12: { id: 12, status: 'draft', title: 'my test story 4' },
+      },
+    });
+  });
+
+  it(`should update stories state when ${ACTION_TYPES.UPDATE_STORIES} is called and maintain order from existing state`, () => {
+    const result = storyReducer(
+      { ...initialState, storiesOrderById: [55, 99, 10, 3] },
+      {
+        type: ACTION_TYPES.UPDATE_STORIES,
+        payload: [
+          { id: 94, status: 'draft', title: 'my test story 1' },
+          { id: 65, status: 'published', title: 'my test story 2' },
+          { id: 78, status: 'draft', title: 'my test story 3' },
+          { id: 12, status: 'draft', title: 'my test story 4' },
+        ],
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      storiesOrderById: [55, 99, 10, 3, 94, 65, 78, 12],
       stories: {
         94: { id: 94, status: 'draft', title: 'my test story 1' },
         65: { id: 65, status: 'published', title: 'my test story 2' },
@@ -68,6 +97,33 @@ describe('storyReducer', () => {
     expect(result).toMatchObject({
       ...initialState,
       totalPages: 3,
+    });
+  });
+
+  it(`should update isLoading state to true when ${ACTION_TYPES.LOADING_STORIES} is called with true payload`, () => {
+    const result = storyReducer(initialState, {
+      type: ACTION_TYPES.LOADING_STORIES,
+      payload: true,
+    });
+
+    expect(result).toMatchObject({
+      ...initialState,
+      isLoading: true,
+    });
+  });
+
+  it(`should update isLoading state to false when ${ACTION_TYPES.LOADING_STORIES} is called with false payload`, () => {
+    const result = storyReducer(
+      { ...initialState, isLoading: true },
+      {
+        type: ACTION_TYPES.LOADING_STORIES,
+        payload: false,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      isLoading: false,
     });
   });
 });

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -27,19 +27,25 @@ describe('storyReducer', () => {
     totalStories: null,
     totalPages: null,
   };
-  it(`should update stories state when ${ACTION_TYPES.UPDATE_STORIES} is called`, () => {
+  it(`should update stories state when ${ACTION_TYPES.FETCH_STORIES_SUCCESS} is called`, () => {
     const result = storyReducer(initialState, {
-      type: ACTION_TYPES.UPDATE_STORIES,
-      payload: [
-        { id: 94, status: 'draft', title: 'my test story 1' },
-        { id: 65, status: 'published', title: 'my test story 2' },
-        { id: 78, status: 'draft', title: 'my test story 3' },
-        { id: 12, status: 'draft', title: 'my test story 4' },
-      ],
+      type: ACTION_TYPES.FETCH_STORIES_SUCCESS,
+      payload: {
+        page: 1,
+        stories: [
+          { id: 94, status: 'draft', title: 'my test story 1' },
+          { id: 65, status: 'published', title: 'my test story 2' },
+          { id: 78, status: 'draft', title: 'my test story 3' },
+          { id: 12, status: 'draft', title: 'my test story 4' },
+        ],
+        totalStories: 33,
+        totalPages: 4,
+      },
     });
 
     expect(result).toMatchObject({
       ...initialState,
+      isError: false,
       storiesOrderById: [94, 65, 78, 12],
       stories: {
         94: { id: 94, status: 'draft', title: 'my test story 1' },
@@ -47,20 +53,28 @@ describe('storyReducer', () => {
         78: { id: 78, status: 'draft', title: 'my test story 3' },
         12: { id: 12, status: 'draft', title: 'my test story 4' },
       },
+      totalStories: 33,
+      totalPages: 4,
+      allPagesFetched: false,
     });
   });
 
-  it(`should update stories state when ${ACTION_TYPES.UPDATE_STORIES} is called and maintain order from existing state`, () => {
+  it(`should update stories state when ${ACTION_TYPES.FETCH_STORIES_SUCCESS} is called and maintain order from existing state`, () => {
     const result = storyReducer(
       { ...initialState, storiesOrderById: [55, 99, 10, 3] },
       {
-        type: ACTION_TYPES.UPDATE_STORIES,
-        payload: [
-          { id: 94, status: 'draft', title: 'my test story 1' },
-          { id: 65, status: 'published', title: 'my test story 2' },
-          { id: 78, status: 'draft', title: 'my test story 3' },
-          { id: 12, status: 'draft', title: 'my test story 4' },
-        ],
+        type: ACTION_TYPES.FETCH_STORIES_SUCCESS,
+        payload: {
+          page: 2,
+          stories: [
+            { id: 94, status: 'draft', title: 'my test story 1' },
+            { id: 65, status: 'published', title: 'my test story 2' },
+            { id: 78, status: 'draft', title: 'my test story 3' },
+            { id: 12, status: 'draft', title: 'my test story 4' },
+          ],
+          totalStories: 8,
+          totalPages: 2,
+        },
       }
     );
 
@@ -73,57 +87,9 @@ describe('storyReducer', () => {
         78: { id: 78, status: 'draft', title: 'my test story 3' },
         12: { id: 12, status: 'draft', title: 'my test story 4' },
       },
-    });
-  });
-
-  it(`should update totalStories state when ${ACTION_TYPES.UPDATE_TOTAL_STORIES_COUNT} is called`, () => {
-    const result = storyReducer(initialState, {
-      type: ACTION_TYPES.UPDATE_TOTAL_STORIES_COUNT,
-      payload: 10,
-    });
-
-    expect(result).toMatchObject({
-      ...initialState,
-      totalStories: 10,
-    });
-  });
-
-  it(`should update totalPages state when ${ACTION_TYPES.UPDATE_TOTAL_STORIES_PAGES} is called`, () => {
-    const result = storyReducer(initialState, {
-      type: ACTION_TYPES.UPDATE_TOTAL_STORIES_PAGES,
-      payload: 3,
-    });
-
-    expect(result).toMatchObject({
-      ...initialState,
-      totalPages: 3,
-    });
-  });
-
-  it(`should update isLoading state to true when ${ACTION_TYPES.LOADING_STORIES} is called with true payload`, () => {
-    const result = storyReducer(initialState, {
-      type: ACTION_TYPES.LOADING_STORIES,
-      payload: true,
-    });
-
-    expect(result).toMatchObject({
-      ...initialState,
-      isLoading: true,
-    });
-  });
-
-  it(`should update isLoading state to false when ${ACTION_TYPES.LOADING_STORIES} is called with false payload`, () => {
-    const result = storyReducer(
-      { ...initialState, isLoading: true },
-      {
-        type: ACTION_TYPES.LOADING_STORIES,
-        payload: false,
-      }
-    );
-
-    expect(result).toMatchObject({
-      ...initialState,
-      isLoading: false,
+      totalStories: 8,
+      totalPages: 2,
+      allPagesFetched: true,
     });
   });
 });

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import storyReducer, { ACTION_TYPES } from '../stories';
+
+describe('storyReducer', () => {
+  const initialState = {
+    stories: {},
+    totalPages: 0,
+    totalStories: 0,
+  };
+  it(`should update stories state when ${ACTION_TYPES.UPDATE_STORIES} is called`, () => {
+    const result = storyReducer(initialState, {
+      type: ACTION_TYPES.UPDATE_STORIES,
+      payload: [
+        { id: 94, status: 'draft', title: 'my test story 1' },
+        { id: 65, status: 'published', title: 'my test story 2' },
+        { id: 78, status: 'draft', title: 'my test story 3' },
+        { id: 12, status: 'draft', title: 'my test story 4' },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      ...initialState,
+      stories: {
+        94: { id: 94, status: 'draft', title: 'my test story 1' },
+        65: { id: 65, status: 'published', title: 'my test story 2' },
+        78: { id: 78, status: 'draft', title: 'my test story 3' },
+        12: { id: 12, status: 'draft', title: 'my test story 4' },
+      },
+    });
+  });
+
+  it(`should update totalStories state when ${ACTION_TYPES.UPDATE_TOTAL_STORIES_COUNT} is called`, () => {
+    const result = storyReducer(initialState, {
+      type: ACTION_TYPES.UPDATE_TOTAL_STORIES_COUNT,
+      payload: 10,
+    });
+
+    expect(result).toMatchObject({
+      ...initialState,
+      totalStories: 10,
+    });
+  });
+
+  it(`should update totalPages state when ${ACTION_TYPES.UPDATE_TOTAL_STORIES_PAGES} is called`, () => {
+    const result = storyReducer(initialState, {
+      type: ACTION_TYPES.UPDATE_TOTAL_STORIES_PAGES,
+      payload: 3,
+    });
+
+    expect(result).toMatchObject({
+      ...initialState,
+      totalPages: 3,
+    });
+  });
+});

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -21,6 +21,7 @@ import storyReducer, { ACTION_TYPES } from '../stories';
 
 describe('storyReducer', () => {
   const initialState = {
+    isError: false,
     isLoading: false,
     stories: {},
     storiesOrderById: [],
@@ -90,6 +91,36 @@ describe('storyReducer', () => {
       totalStories: 8,
       totalPages: 2,
       allPagesFetched: true,
+    });
+  });
+
+  it(`should update isLoading when ${ACTION_TYPES.LOADING_STORIES} is called`, () => {
+    const result = storyReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.LOADING_STORIES,
+        payload: true,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      isLoading: true,
+    });
+  });
+
+  it(`should update isError when ${ACTION_TYPES.FETCH_STORIES_FAILURE} is called`, () => {
+    const result = storyReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.FETCH_STORIES_FAILURE,
+        payload: true,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      isError: true,
     });
   });
 });

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -128,13 +128,9 @@ function MyStories() {
   ]);
 
   const setCurrentPageClamped = useCallback(
-    (v) => {
+    (newPage) => {
       const pageRange = [1, totalPages];
-      setCurrentPage(
-        typeof v === 'function'
-          ? (current) => clamp(v(current), pageRange)
-          : clamp(v, pageRange)
-      );
+      setCurrentPage(clamp(newPage, pageRange));
     },
     [totalPages]
   );

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -161,7 +161,7 @@ function MyStories() {
 
   const storiesView = useMemo(() => {
     switch (viewStyle) {
-      case VIEW_STYLE.GRID: {
+      case VIEW_STYLE.GRID:
         return (
           orderedStories.length > 0 && (
             <InfiniteScroller
@@ -186,7 +186,6 @@ function MyStories() {
             </InfiniteScroller>
           )
         );
-      }
       case VIEW_STYLE.LIST:
         return (
           <StoryListView

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -188,13 +188,25 @@ function MyStories() {
         );
       case VIEW_STYLE.LIST:
         return (
-          <StoryListView
-            filteredStories={orderedStories}
-            storySort={currentStorySort}
-            sortDirection={currentListSortDirection}
-            handleSortChange={setCurrentStorySort}
-            handleSortDirectionChange={setListSortDirection}
-          />
+          orderedStories.length > 0 && (
+            <InfiniteScroller
+              isAllDataLoaded={allPagesLoaded}
+              allDataLoadedMessage={__('No more stories', 'web-stories')}
+              handleGetData={() => {
+                if (!isLoading) {
+                  setCurrentPageToFetch(currentPageToFetch + 1);
+                }
+              }}
+            >
+              <StoryListView
+                filteredStories={orderedStories}
+                storySort={currentStorySort}
+                sortDirection={currentListSortDirection}
+                handleSortChange={setCurrentStorySort}
+                handleSortDirectionChange={setListSortDirection}
+              />
+            </InfiniteScroller>
+          )
         );
       default:
         return null;

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -105,6 +105,7 @@ function MyStories() {
       storiesOrderById,
       totalStories,
       totalPages,
+      isLoading,
     },
   } = useContext(ApiContext);
 
@@ -182,42 +183,26 @@ function MyStories() {
     switch (viewStyle) {
       case VIEW_STYLE.GRID:
         return (
-          orderedStories.length > 0 && (
-            <InfiniteScroller
-              isAllDataLoaded={allPagesFetched}
-              allDataLoadedMessage={__('No more stories', 'web-stories')}
-              handleGetData={handleNewPageRequest}
-            >
-              <StoryGridView
-                filteredStories={orderedStories}
-                centerActionLabel={
-                  <>
-                    <PlayArrowIcon />
-                    {__('Preview', 'web-stories')}
-                  </>
-                }
-                bottomActionLabel={__('Open in editor', 'web-stories')}
-              />
-            </InfiniteScroller>
-          )
+          <StoryGridView
+            filteredStories={orderedStories}
+            centerActionLabel={
+              <>
+                <PlayArrowIcon />
+                {__('Preview', 'web-stories')}
+              </>
+            }
+            bottomActionLabel={__('Open in editor', 'web-stories')}
+          />
         );
       case VIEW_STYLE.LIST:
         return (
-          orderedStories.length > 0 && (
-            <InfiniteScroller
-              isAllDataLoaded={allPagesFetched}
-              allDataLoadedMessage={__('No more stories', 'web-stories')}
-              handleGetData={handleNewPageRequest}
-            >
-              <StoryListView
-                filteredStories={orderedStories}
-                storySort={currentStorySort}
-                sortDirection={currentListSortDirection}
-                handleSortChange={handleNewStorySort}
-                handleSortDirectionChange={setListSortDirection}
-              />
-            </InfiniteScroller>
-          )
+          <StoryListView
+            filteredStories={orderedStories}
+            storySort={currentStorySort}
+            sortDirection={currentListSortDirection}
+            handleSortChange={handleNewStorySort}
+            handleSortDirectionChange={setListSortDirection}
+          />
         );
       default:
         return null;
@@ -225,8 +210,6 @@ function MyStories() {
   }, [
     currentStorySort,
     currentListSortDirection,
-    allPagesFetched,
-    handleNewPageRequest,
     handleNewStorySort,
     orderedStories,
     viewStyle,
@@ -255,11 +238,19 @@ function MyStories() {
   ]);
 
   const BodyContent = useMemo(() => {
-    if (totalStories > 0) {
+    if (orderedStories.length > 0) {
       return (
         <BodyWrapper>
           {storiesViewControls}
           {storiesView}
+          <InfiniteScroller
+            canLoadMore={!allPagesFetched}
+            isLoading={isLoading}
+            allDataLoadedMessage={__('No more stories', 'web-stories')}
+            onLoadMore={() => {
+              handleNewPageRequest();
+            }}
+          />
         </BodyWrapper>
       );
     } else if (typeaheadValue.length > 0) {
@@ -271,7 +262,15 @@ function MyStories() {
         {__('Create a story to get started!', 'web-stories')}
       </DefaultBodyText>
     );
-  }, [totalStories, typeaheadValue, storiesViewControls, storiesView]);
+  }, [
+    orderedStories.length,
+    isLoading,
+    allPagesFetched,
+    handleNewPageRequest,
+    typeaheadValue,
+    storiesViewControls,
+    storiesView,
+  ]);
 
   return (
     <FontProvider>

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -152,6 +152,13 @@ function MyStories() {
     },
     [setCurrentStorySort, setCurrentPageClamped]
   );
+  const handleFilterStatusUpdate = useCallback(
+    (_, value) => {
+      setCurrentPageClamped(1);
+      setStatus(value);
+    },
+    [setCurrentPageClamped]
+  );
 
   const handleNewPageRequest = useCallback(() => {
     setCurrentPageClamped(currentPage + 1);
@@ -288,7 +295,7 @@ function MyStories() {
             {STORY_STATUSES.map((storyStatus) => (
               <FloatingTab
                 key={storyStatus.value}
-                onClick={(_, value) => setStatus(value)}
+                onClick={handleFilterStatusUpdate}
                 name="my-stories-filter-selection"
                 value={storyStatus.value}
                 isSelected={status === storyStatus.value}

--- a/assets/src/dashboard/components/infiniteScroller/index.js
+++ b/assets/src/dashboard/components/infiniteScroller/index.js
@@ -25,12 +25,11 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
+// TODO
 const ScrollMessage = styled.div`
   margin: 20px 0;
   text-align: center;
   width: 100%;
-  border: 1px solid green;
-  background-color: yellow;
 `;
 const InfiniteScroller = ({
   allDataLoadedMessage = __('No More Stories', 'web-stories'),

--- a/assets/src/dashboard/components/infiniteScroller/index.js
+++ b/assets/src/dashboard/components/infiniteScroller/index.js
@@ -44,6 +44,7 @@ const ACTION = {
   ON_EXTERNAL_LOAD: 'external on load',
   ON_ALL_LOADED: 'all loaded',
   ON_LOAD_SUCCESS: 'load success',
+  ON_CAN_LOAD_MORE: 'can load more',
 };
 
 const machine = {
@@ -60,7 +61,7 @@ const machine = {
     [ACTION.ON_LOAD_SUCCESS]: STATE.loadable,
   },
   [STATE.complete]: {
-    [ACTION.ON_LOAD_SUCCESS]: STATE.loadable,
+    [ACTION.ON_CAN_LOAD_MORE]: STATE.loadable,
   },
 };
 
@@ -100,8 +101,8 @@ const InfiniteScroller = ({
   }, [isLoading, canLoadMore]);
 
   useEffect(() => {
-    if (loadState === STATE.complete && canLoadMore) {
-      dispatch(ACTION.ON_LOAD_SUCCESS);
+    if (canLoadMore) {
+      dispatch(ACTION.ON_CAN_LOAD_MORE);
     }
   }, [canLoadMore, loadState]);
 

--- a/assets/src/dashboard/components/infiniteScroller/stories/index.js
+++ b/assets/src/dashboard/components/infiniteScroller/stories/index.js
@@ -81,7 +81,10 @@ export const _default = () => {
           }}
           isLoading={isLoading}
           canLoadMore={!isAllDataLoaded}
-          loadingMessage={text('loadingMessage', 'Data is loading')}
+          loadingMessage={text(
+            'loadingMessage',
+            'Data is loading - please note, interesection observers and storybook do not play nicely in firefox.'
+          )}
           allDataLoadedMessage={text(
             'allDataLoadedMessage',
             'all data is loaded'

--- a/assets/src/dashboard/components/infiniteScroller/stories/index.js
+++ b/assets/src/dashboard/components/infiniteScroller/stories/index.js
@@ -55,6 +55,7 @@ const generateArray = (n) => new Array(n).fill(<span>{'Demo Item'}</span>);
 export const _default = () => {
   const [currentCount, setCurrentCount] = useState(5);
   const [isAllDataLoaded, setIsAllDataLoaded] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [dummyData, setDummyData] = useState(generateArray(currentCount));
 
   useEffect(() => {
@@ -62,24 +63,32 @@ export const _default = () => {
     if (currentCount === 30) {
       setIsAllDataLoaded(true);
     }
+    setIsLoading(false);
   }, [currentCount]);
 
-  return (
-    <InfiniteScroller
-      handleGetData={() => {
-        if (!isAllDataLoaded) {
-          setCurrentCount(currentCount + 5);
-        }
-      }}
-      isAllDataLoaded={isAllDataLoaded}
-      loadingMessage={text('loadingMessage', 'Data is loading')}
-      allDataLoadedMessage={text('allDataLoadedMessage', 'all data is loaded')}
-    >
-      {dummyData.map((data, index) => (
-        <Item key={index}>
-          {data} {index}
-        </Item>
-      ))}
-    </InfiniteScroller>
-  );
+  if (dummyData.length > 0) {
+    return (
+      <>
+        {dummyData.map((data, index) => (
+          <Item key={index}>
+            {data} {index}
+          </Item>
+        ))}
+        <InfiniteScroller
+          onLoadMore={() => {
+            setIsLoading(true);
+            setCurrentCount(currentCount + 5);
+          }}
+          isLoading={isLoading}
+          canLoadMore={!isAllDataLoaded}
+          loadingMessage={text('loadingMessage', 'Data is loading')}
+          allDataLoadedMessage={text(
+            'allDataLoadedMessage',
+            'all data is loaded'
+          )}
+        />
+      </>
+    );
+  }
+  return null;
 };

--- a/assets/src/dashboard/components/infiniteScroller/test/infiniteScroller.js
+++ b/assets/src/dashboard/components/infiniteScroller/test/infiniteScroller.js
@@ -24,28 +24,17 @@ import { render } from '@testing-library/react';
  */
 import InfiniteScroller from '../index';
 
-const generateArray = (n) => new Array(n).fill(<span>{'Demo Item'}</span>);
-
 describe('InfiniteScroller', () => {
   const onGetDataMock = jest.fn();
-  const dummyData = generateArray(5);
 
-  it('should render children and a loading component by default', () => {
-    const { getByTestId, getAllByTestId } = render(
-      <InfiniteScroller handleGetData={onGetDataMock}>
-        {dummyData.map((data, index) => (
-          <div data-testid="child-item" key={index}>
-            {data} {index}
-          </div>
-        ))}
-      </InfiniteScroller>
+  it('should render a loading component by default', () => {
+    const { getByTestId } = render(
+      <InfiniteScroller handleGetData={onGetDataMock} />
     );
 
     const loadingComponent = getByTestId('load-more-on-scroll');
-    const scrollingChildren = getAllByTestId('child-item');
 
     expect(loadingComponent).toBeDefined();
-    expect(scrollingChildren).toHaveLength(5);
   });
 
   it('should show all data loaded message when `allDataLoadedMessage` is true', () => {
@@ -54,13 +43,7 @@ describe('InfiniteScroller', () => {
         handleGetData={onGetDataMock}
         allDataLoadedMessage="All data has been fetched"
         isAllDataLoaded={true}
-      >
-        {dummyData.map((data, index) => (
-          <div key={index}>
-            {data} {index}
-          </div>
-        ))}
-      </InfiniteScroller>
+      />
     );
 
     const allDataLoaded = getByText('All data has been fetched');

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -130,6 +130,8 @@ export const STORY_CONTEXT_MENU_ITEMS = [
   },
 ];
 
+export const ITEMS_PER_PAGE = 10;
+
 export const STORY_SORT_OPTIONS = {
   NAME: 'title',
   DATE_CREATED: 'date',

--- a/assets/src/dashboard/utils/clamp.js
+++ b/assets/src/dashboard/utils/clamp.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const clamp = (v, range) => {
+  const lowerBound = Math.min(range[0], range[1]);
+  const upperBound = Math.max(range[0], range[1]);
+
+  return Math.min(Math.max(lowerBound, v), upperBound);
+};
+
+export default clamp;

--- a/assets/src/dashboard/utils/groupBy.js
+++ b/assets/src/dashboard/utils/groupBy.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const groupBy = (arr, key) => {
+  return arr.reduce((prev, curr) => {
+    if (!curr[key]) {
+      return prev;
+    }
+    if (prev[curr[key]]) {
+      prev[curr[key]] = curr;
+    } else {
+      prev[curr[key]] = curr;
+    }
+    return prev;
+  }, {});
+};
+
+export default groupBy;

--- a/assets/src/dashboard/utils/test/clamp.js
+++ b/assets/src/dashboard/utils/test/clamp.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import clamp from '../clamp';
+
+describe('clamp', () => {
+  it('should return 2 when range is [1, 6] and value is 2', () => {
+    const range = [1, 6];
+    const clampedNumber = clamp(2, range);
+
+    expect(clampedNumber).toBe(2);
+  });
+
+  it('should return 1 when range is [1, 6] and value is 8', () => {
+    const range = [1, 6];
+    const clampedNumber = clamp(8, range);
+
+    expect(clampedNumber).toBe(6);
+  });
+
+  it('should return 6 when range is [1, 6] and value is 0', () => {
+    const range = [1, 6];
+    const clampedNumber = clamp(0, range);
+
+    expect(clampedNumber).toBe(1);
+  });
+
+  it('should return 1 when range is [1, 6] and value is -1', () => {
+    const range = [1, 6];
+    const clampedNumber = clamp(-1, range);
+
+    expect(clampedNumber).toBe(1);
+  });
+
+  it('should return 5.4 when range is [1, 6] and value is 5.4', () => {
+    const range = [1, 6];
+    const clampedNumber = clamp(5.4, range);
+
+    expect(clampedNumber).toBe(5.4);
+  });
+
+  it('should return 6 when range is [1, 6] and value is 6.4', () => {
+    const range = [1, 6];
+    const clampedNumber = clamp(6.4, range);
+
+    expect(clampedNumber).toBe(6);
+  });
+});

--- a/assets/src/dashboard/utils/test/groupBy.js
+++ b/assets/src/dashboard/utils/test/groupBy.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import groupBy from '../groupBy';
+
+describe('groupBy', () => {
+  it('should shape an array of objects by a given key', () => {
+    const initialArray = [
+      { id: 94, status: 'draft', title: 'my test story 1' },
+      { id: 65, status: 'published', title: 'my test story 2' },
+      { id: 78, status: 'draft', title: 'my test story 3' },
+      { id: 12, status: 'draft', title: 'my test story 4' },
+    ];
+
+    const groupedById = groupBy(initialArray, 'id');
+
+    expect(groupedById).toMatchObject({
+      94: { id: 94, status: 'draft', title: 'my test story 1' },
+      65: { id: 65, status: 'published', title: 'my test story 2' },
+      78: { id: 78, status: 'draft', title: 'my test story 3' },
+      12: { id: 12, status: 'draft', title: 'my test story 4' },
+    });
+  });
+});


### PR DESCRIPTION
# Overview
Gets my stories dashboard view hooked up to infinite scroll. The biggie here is that it converts the story state in the context provider to a reducer so that we can story pages of stories and track the order they are supposed to be presented. 

## Updates to context 
- we now have reducer/stories, where stories related state can be tracked. 
- I separated out a stories object and an array of ids that correspond to stories returned. the array will track the order of what we want displayed since order is tied to the results. The stories are re-sorted by the view with the array of ids and then used in the same format we're used to. This is important! 
- we need to update the array of items for what comes back to only be unique ids so that stories don't display more than once. This is also why you'll see that the stories and the order (and totals) get cleared out when filtering/searching happen. 
- Added a loading state. isLoading is true as soon as `fetchStories` gets called, then added a `.finally` to put `isLoading` back to false. 

## views/myStories/index.js 
- Few things I want to call out here - sorting and searching 
- we have to keep clearing out the existing order and stories object with search because the results might be different. i debounced it, but if you have other ideas i'm all ears. 
- something similar with sort really, we start from the top when new order is selected so that pagination has a chance to reset. 
- ~There is a bug here that i am still figuring out**: when you page down after a fresh reload, then search something, then clear your search and scroll all the way down to see all the results - one page will be missing. Now re-sort the view and scroll back down, all pages are present. There's a rogue paint to the grid that shouldn't be happening that I've yet to trace.~ 

## components/infiniteScroller/index
- Also here I want to call out the changes I made. Turns out I was only about half way there with my firefox + iframe + intersection observer. The layout effect hook was getting called repeatedly because the refs were updating with the callback from what I can see. So checking for the `currentIntersectingRef` before observing fixes it. The other thing here is that we're ONLY looking at .observe and .unobserve to trigger the effect - if you switch this to just `observer` it will break. So I disabled the exhaustive deps rule. 
- Simplified the surrounding message logic 

Todo
- [x] fix that bug I mentioned above 
- [ ] UI for infinite scroll messaging and scroll to top (will be separate) 
- [ ] I want opinions on separating out the API related constants but also that might be good to do separately 

## Testing 
- Pull the branch and run locally. Scroll through your stories. For this to work you should have more than a page's worth, which is 10 right now. If you want to you can update `ITEMS_PER_PAGE` to something smaller, but it's still easier to test this if you have at least 3 pages to go through. 
- So scroll through stuff
- Re-sort, see that the stories re arrange and are still scrolling the right amount so that you can see all of them 
- click on a filter and see that it updates 
- search for something 

![smalldemo](https://user-images.githubusercontent.com/10720454/79807270-40a4fa00-831f-11ea-9171-e6b69dd41bd8.gif)
