### PR TITLE
Added template api to consolidate all template endpoints

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -37,7 +37,7 @@ import storyReducer, {
   ACTION_TYPES as STORY_ACTION_TYPES,
 } from '../reducer/stories';
 import useTemplateApi from './useTemplateApi';
-import wpAdapter from './wpAdapter';
+import dataAdapter from './wpAdapter';
 
 export const ApiContext = createContext({ state: {}, actions: {} });
 
@@ -66,7 +66,7 @@ export default function ApiProvider({ children }) {
   const { api, editStoryURL, pluginDir } = useConfig();
   const [state, dispatch] = useReducer(storyReducer, defaultStoriesState);
 
-  const { templates, api: templateApi } = useTemplateApi(wpAdapter, {
+  const { templates, api: templateApi } = useTemplateApi(dataAdapter, {
     pluginDir,
   });
 
@@ -108,14 +108,13 @@ export default function ApiProvider({ children }) {
           query,
         });
 
-        const response = await wpAdapter.get(path, {
+        const response = await dataAdapter.get(path, {
           parse: false,
         });
 
         // TODO add headers for totals by status and have header reflect search
         // only update totals when data is different
         const totalStories = parseInt(response.headers.get('X-WP-Total'));
-
         const totalPages = parseInt(response.headers.get('X-WP-TotalPages'));
 
         const serverStoryResponse = await response.json();
@@ -156,7 +155,7 @@ export default function ApiProvider({ children }) {
       return Promise.resolve([]);
     }
 
-    return wpAdapter.get(api.fonts).then((data) =>
+    return dataAdapter.get(api.fonts).then((data) =>
       data.map((font) => ({
         value: font.name,
         ...font,

--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -18,20 +18,9 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import {
-  createContext,
-  useCallback,
-  useMemo,
-  useState,
-  useReducer,
-} from 'react';
+import { createContext, useCallback, useMemo, useReducer } from 'react';
 import moment from 'moment';
 import queryString from 'query-string';
-
-/**
- * WordPress dependencies
- */
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -41,14 +30,14 @@ import {
   STORY_STATUSES,
   STORY_SORT_OPTIONS,
   ORDER_BY_SORT,
-  APP_ROUTES,
   ITEMS_PER_PAGE,
 } from '../../constants';
-import getAllTemplates from '../../templates';
 import storyReducer, {
   defaultStoriesState,
   ACTION_TYPES as STORY_ACTION_TYPES,
 } from '../reducer/stories';
+import useTemplateApi from './useTemplateApi';
+import wpAdapter from './wpAdapter';
 
 export const ApiContext = createContext({ state: {}, actions: {} });
 
@@ -73,36 +62,13 @@ export function reshapeStoryObject(editStoryURL) {
   };
 }
 
-export function reshapeTemplateObject({
-  id,
-  title,
-  tags,
-  colors,
-  createdBy,
-  description,
-  pages,
-}) {
-  return {
-    id,
-    title,
-    createdBy,
-    description,
-    status: 'template',
-    modified: moment('2020-04-07'),
-    metadata: [...tags, ...colors].map((value) =>
-      typeof value === 'object' ? { ...value } : { label: value }
-    ),
-    pages,
-    centerTargetAction: `#${APP_ROUTES.TEMPLATE_DETAIL}?id=${id}`,
-    bottomTargetAction: () => {},
-  };
-}
-
 export default function ApiProvider({ children }) {
   const { api, editStoryURL, pluginDir } = useConfig();
   const [state, dispatch] = useReducer(storyReducer, defaultStoriesState);
 
-  const [templates, setTemplates] = useState([]);
+  const { templates, api: templateApi } = useTemplateApi(wpAdapter, {
+    pluginDir,
+  });
 
   const fetchStories = useCallback(
     async ({
@@ -142,8 +108,7 @@ export default function ApiProvider({ children }) {
           query,
         });
 
-        const response = await apiFetch({
-          path,
+        const response = await wpAdapter.get(path, {
           parse: false,
         });
 
@@ -186,31 +151,12 @@ export default function ApiProvider({ children }) {
     [api.stories, editStoryURL]
   );
 
-  const fetchTemplates = useCallback(() => {
-    const reshapedTemplates = getAllTemplates({ pluginDir }).map(
-      reshapeTemplateObject
-    );
-    setTemplates(reshapedTemplates);
-
-    return Promise.resolve(reshapedTemplates);
-  }, [pluginDir]);
-
-  const fetchTemplate = useCallback(
-    async (id) => {
-      const fetchedTemplates = await fetchTemplates();
-      return Promise.resolve(
-        fetchedTemplates.find((template) => template.id === id)
-      );
-    },
-    [fetchTemplates]
-  );
-
   const getAllFonts = useCallback(() => {
     if (!api.fonts) {
       return Promise.resolve([]);
     }
 
-    return apiFetch({ path: api.fonts }).then((data) =>
+    return wpAdapter.get(api.fonts).then((data) =>
       data.map((font) => ({
         value: font.name,
         ...font,
@@ -231,16 +177,14 @@ export default function ApiProvider({ children }) {
       },
       actions: {
         fetchStories,
-        fetchTemplates,
-        fetchTemplate,
+        templateApi,
         getAllFonts,
       },
     }),
     [
-      templates,
       fetchStories,
-      fetchTemplates,
-      fetchTemplate,
+      templates,
+      templateApi,
       getAllFonts,
       state.allPagesFetched,
       state.isLoading,

--- a/assets/src/dashboard/app/api/test/__snapshots__/useTemplateApi.js.snap
+++ b/assets/src/dashboard/app/api/test/__snapshots__/useTemplateApi.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reshapeTemplateObject should reshape object to match snapshot 1`] = `
+Object {
+  "bottomTargetAction": [Function],
+  "centerTargetAction": "#/template-detail?id=1&isLocal=true",
+  "createdBy": "Google AMP",
+  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+  "id": 1,
+  "isLocal": true,
+  "metadata": Array [
+    Object {
+      "label": "Health",
+    },
+    Object {
+      "label": "Bold",
+    },
+    Object {
+      "label": "Joy",
+    },
+    Object {
+      "color": "#f3d9e1",
+      "label": "Pink",
+    },
+    Object {
+      "color": "#d8ddcc",
+      "label": "Green",
+    },
+    Object {
+      "color": "#28292b",
+      "label": "Black",
+    },
+  ],
+  "modified": "2020-04-21T07:00:00.000Z",
+  "pages": Array [
+    Object {
+      "elements": Array [],
+      "id": 0,
+    },
+  ],
+  "status": "template",
+  "title": "Beauty",
+}
+`;

--- a/assets/src/dashboard/app/api/test/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/test/useTemplateApi.js
@@ -29,7 +29,7 @@ describe('reshapeTemplateObject', () => {
     id: 1,
     title: 'Beauty',
     createdBy: 'Google AMP',
-    modified: '2020-04-21',
+    modified: '2020-04-21T07:00:00.000Z',
     tags: ['Health', 'Bold', 'Joy'],
     colors: [
       { label: 'Pink', color: '#f3d9e1' },
@@ -47,7 +47,9 @@ describe('reshapeTemplateObject', () => {
 
   it('should reshape template object with Moment date', () => {
     const reshapedObject = reshapeTemplateObject(true)(templateData);
-    expect(reshapedObject.modified).toMatchObject(moment('2020-04-21'));
+    expect(reshapedObject.modified).toMatchObject(
+      moment('2020-04-21T07:00:00.000Z')
+    );
   });
 
   it('should combine template tags and colors into metadata', () => {

--- a/assets/src/dashboard/app/api/test/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/test/useTemplateApi.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { reshapeTemplateObject } from '../useTemplateApi';
+
+describe('reshapeTemplateObject', () => {
+  const templateData = {
+    id: 1,
+    title: 'Beauty',
+    createdBy: 'Google AMP',
+    modified: '2020-04-21',
+    tags: ['Health', 'Bold', 'Joy'],
+    colors: [
+      { label: 'Pink', color: '#f3d9e1' },
+      { label: 'Green', color: '#d8ddcc' },
+      { label: 'Black', color: '#28292b' },
+    ],
+    description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    pages: [{ id: 0, elements: [] }],
+  };
+
+  it('should reshape object to match snapshot', () => {
+    const reshapedObject = reshapeTemplateObject(true)(templateData);
+    expect(reshapedObject).toMatchSnapshot();
+  });
+
+  it('should reshape template object with Moment date', () => {
+    const reshapedObject = reshapeTemplateObject(true)(templateData);
+    expect(reshapedObject.modified).toMatchObject(moment('2020-04-21'));
+  });
+
+  it('should combine template tags and colors into metadata', () => {
+    const reshapedObject = reshapeTemplateObject(true)(templateData);
+    expect(reshapedObject.metadata).toMatchObject([
+      { label: 'Health' },
+      { label: 'Bold' },
+      { label: 'Joy' },
+      { label: 'Pink', color: '#f3d9e1' },
+      { label: 'Green', color: '#d8ddcc' },
+      { label: 'Black', color: '#28292b' },
+    ]);
+  });
+
+  it('should apply isLocal to the reshaped object', () => {
+    const localReshapedObject = reshapeTemplateObject(true)(templateData);
+    expect(localReshapedObject.isLocal).toBe(true);
+
+    const notlocalReshapedObject = reshapeTemplateObject(false)(templateData);
+    expect(notlocalReshapedObject.isLocal).toBe(false);
+  });
+});

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -26,15 +26,24 @@ import moment from 'moment';
 import getAllTemplates from '../../templates';
 import { APP_ROUTES } from '../../constants';
 
-function reshapeTemplateObject(isLocal) {
-  return ({ id, title, tags, colors, createdBy, description, pages }) => ({
+export function reshapeTemplateObject(isLocal) {
+  return ({
+    id,
+    title,
+    modified,
+    tags,
+    colors,
+    createdBy,
+    description,
+    pages,
+  }) => ({
     isLocal,
     id,
     title,
     createdBy,
     description,
     status: 'template',
-    modified: moment('2020-04-07'),
+    modified: moment(modified),
     metadata: [...tags, ...colors].map((value) =>
       typeof value === 'object' ? { ...value } : { label: value }
     ),

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -50,9 +50,9 @@ const useTemplateApi = (dataAdapter, config) => {
   const [templates, setTemplates] = useState([]);
   const { pluginDir } = config;
 
-  const createStoryFromTemplatePages = (pages) => {
+  const createStoryFromTemplatePages = useCallback((pages) => {
     return Promise.resolve({ success: true, storyId: -1 });
-  };
+  }, []);
 
   const fetchSavedTemplates = useCallback((filters) => {
     // Saved Templates = Bookmarked Templates + My Templates
@@ -96,8 +96,19 @@ const useTemplateApi = (dataAdapter, config) => {
     [fetchExternalTemplates]
   );
 
+  const bookmarkTemplate = useCallback((templateId, shouldBookmark) => {
+    if (shouldBookmark) {
+      // api call to bookmark template
+      return Promise.resolve({ success: true });
+    } else {
+      // api call to remove bookmark from template
+      return Promise.resolve({ success: true });
+    }
+  }, []);
+
   const api = useMemo(
     () => ({
+      bookmarkTemplate,
       createStoryFromTemplatePages,
       fetchBookmarkedTemplates,
       fetchSavedTemplates,
@@ -107,6 +118,8 @@ const useTemplateApi = (dataAdapter, config) => {
       fetchExternalTemplateById,
     }),
     [
+      bookmarkTemplate,
+      createStoryFromTemplatePages,
       fetchBookmarkedTemplates,
       fetchExternalTemplateById,
       fetchExternalTemplates,

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -55,6 +55,7 @@ const useTemplateApi = (dataAdapter, config) => {
   };
 
   const fetchSavedTemplates = useCallback((filters) => {
+    // Saved Templates = Bookmarked Templates + My Templates
     setTemplates([]);
     return Promise.resolve([]);
   }, []);

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -96,7 +96,7 @@ const useTemplateApi = (dataAdapter, config) => {
     [fetchExternalTemplates]
   );
 
-  const bookmarkTemplate = useCallback((templateId, shouldBookmark) => {
+  const bookmarkTemplateById = useCallback((templateId, shouldBookmark) => {
     if (shouldBookmark) {
       // api call to bookmark template
       return Promise.resolve({ success: true });
@@ -108,7 +108,7 @@ const useTemplateApi = (dataAdapter, config) => {
 
   const api = useMemo(
     () => ({
-      bookmarkTemplate,
+      bookmarkTemplateById,
       createStoryFromTemplatePages,
       fetchBookmarkedTemplates,
       fetchSavedTemplates,
@@ -118,7 +118,7 @@ const useTemplateApi = (dataAdapter, config) => {
       fetchExternalTemplateById,
     }),
     [
-      bookmarkTemplate,
+      bookmarkTemplateById,
       createStoryFromTemplatePages,
       fetchBookmarkedTemplates,
       fetchExternalTemplateById,

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useState, useMemo, useCallback } from 'react';
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import getAllTemplates from '../../templates';
+import { APP_ROUTES } from '../../constants';
+
+function reshapeTemplateObject(isLocal) {
+  return ({ id, title, tags, colors, createdBy, description, pages }) => ({
+    isLocal,
+    id,
+    title,
+    createdBy,
+    description,
+    status: 'template',
+    modified: moment('2020-04-07'),
+    metadata: [...tags, ...colors].map((value) =>
+      typeof value === 'object' ? { ...value } : { label: value }
+    ),
+    pages,
+    centerTargetAction: `#${APP_ROUTES.TEMPLATE_DETAIL}?id=${id}&isLocal=${isLocal}`,
+    bottomTargetAction: () => {},
+  });
+}
+
+// TODO: Remove this eslint rule once endpoints are working
+/* eslint-disable no-unused-vars */
+const useTemplateApi = (dataAdapter, config) => {
+  const [templates, setTemplates] = useState([]);
+  const { pluginDir } = config;
+
+  const createStoryFromTemplatePages = (pages) => {
+    return Promise.resolve({ success: true, storyId: -1 });
+  };
+
+  const fetchSavedTemplates = useCallback((filters) => {
+    setTemplates([]);
+    return Promise.resolve([]);
+  }, []);
+
+  const fetchBookmarkedTemplates = useCallback((filters) => {
+    setTemplates([]);
+    return Promise.resolve([]);
+  }, []);
+
+  const fetchMyTemplates = useCallback((filters) => {
+    setTemplates([]);
+    return Promise.resolve([]);
+  }, []);
+
+  const fetchMyTemplateById = useCallback((templateId) => {
+    return Promise.resolve({});
+  }, []);
+
+  const fetchExternalTemplates = useCallback(
+    (filters) => {
+      const reshapedTemplates = getAllTemplates({ pluginDir }).map(
+        reshapeTemplateObject(false)
+      );
+      setTemplates(reshapedTemplates);
+      return Promise.resolve(reshapedTemplates);
+    },
+    [pluginDir]
+  );
+
+  const fetchExternalTemplateById = useCallback(
+    async (templateId) => {
+      const fetchedTemplates = await fetchExternalTemplates();
+
+      return Promise.resolve(
+        fetchedTemplates.find((template) => template.id === templateId)
+      );
+    },
+    [fetchExternalTemplates]
+  );
+
+  const api = useMemo(
+    () => ({
+      createStoryFromTemplatePages,
+      fetchBookmarkedTemplates,
+      fetchSavedTemplates,
+      fetchMyTemplates,
+      fetchMyTemplateById,
+      fetchExternalTemplates,
+      fetchExternalTemplateById,
+    }),
+    [
+      fetchBookmarkedTemplates,
+      fetchExternalTemplateById,
+      fetchExternalTemplates,
+      fetchMyTemplateById,
+      fetchMyTemplates,
+      fetchSavedTemplates,
+    ]
+  );
+
+  return { templates, api };
+};
+/* eslint-enable no-unused-vars */
+
+export default useTemplateApi;

--- a/assets/src/dashboard/app/api/wpAdapter.js
+++ b/assets/src/dashboard/app/api/wpAdapter.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+const get = (path, options = {}) => apiFetch({ path, ...options });
+
+const post = (path, options = {}) =>
+  apiFetch({
+    path,
+    ...options,
+    method: 'POST',
+  });
+
+const deleteRequest = (path, options = {}) =>
+  apiFetch({
+    path,
+    ...options,
+    method: 'DELETE',
+  });
+
+export default {
+  get,
+  post,
+  deleteRequest,
+};

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -53,11 +53,11 @@ function TemplateDetail() {
   const [template, setTemplate] = useState(null);
   const {
     state: {
-      queryParams: { id: templateId },
+      queryParams: { id: templateId, isLocal },
     },
   } = useRouteHistory();
   const {
-    actions: { fetchTemplate },
+    actions: { templateApi },
   } = useContext(ApiContext);
 
   useEffect(() => {
@@ -65,12 +65,19 @@ function TemplateDetail() {
       return;
     }
 
-    async function getTemplateById(id) {
-      setTemplate(await fetchTemplate(parseInt(id)));
-    }
+    const id = parseInt(templateId);
+    const isLocalTemplate = isLocal && isLocal.toLowerCase() === 'true';
 
-    getTemplateById(templateId);
-  }, [fetchTemplate, templateId]);
+    if (isLocalTemplate) {
+      templateApi.fetchMyTemplateById(id).then((fetchedTemplate) => {
+        setTemplate(fetchedTemplate);
+      });
+    } else {
+      templateApi.fetchExternalTemplateById(id).then((fetchedTemplate) => {
+        setTemplate(fetchedTemplate);
+      });
+    }
+  }, [templateApi, templateId, isLocal]);
 
   const { title, byLine } = useMemo(() => {
     if (!template) {

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -70,12 +70,12 @@ function TemplatesGallery() {
   });
   const {
     state: { templates },
-    actions: { fetchTemplates },
+    actions: { templateApi },
   } = useContext(ApiContext);
 
   useEffect(() => {
-    fetchTemplates();
-  }, [fetchTemplates]);
+    templateApi.fetchExternalTemplates();
+  }, [templateApi]);
 
   const filteredTemplates = useMemo(() => {
     return templates.filter((template) => {

--- a/assets/src/dashboard/templates/index.js
+++ b/assets/src/dashboard/templates/index.js
@@ -23,11 +23,16 @@ export default function (config) {
   const { pluginDir } = config;
   const travelStoryData = getTravelStoryData(pluginDir);
 
+  const globalConfig = {
+    createdBy: 'Google AMP',
+    modified: '2020-04-21',
+  };
+
   return [
     {
       id: 1,
       title: 'Beauty',
-      createdBy: 'Google AMP',
+      ...globalConfig,
       tags: ['Health', 'Bold', 'Joy'],
       colors: [
         { label: 'Pink', color: '#f3d9e1' },
@@ -43,7 +48,7 @@ export default function (config) {
     {
       id: 2,
       title: 'Cooking',
-      createdBy: 'Google AMP',
+      ...globalConfig,
       tags: ['Delicious', 'Baker', 'Cook'],
       colors: [
         { label: 'Cream', color: '#fff933' },
@@ -59,7 +64,7 @@ export default function (config) {
     {
       id: 3,
       title: 'DIY',
-      createdBy: 'Google AMP',
+      ...globalConfig,
       tags: ['Doers', 'Expand', 'Start'],
       colors: [
         { label: 'Black', color: '#211f1e' },
@@ -76,7 +81,7 @@ export default function (config) {
     {
       id: 4,
       title: 'Entertainment',
-      createdBy: 'Google AMP',
+      ...globalConfig,
       tags: ['Funny', 'Action', 'Hip'],
       colors: [
         { label: 'Black', color: '#000' },
@@ -91,7 +96,7 @@ export default function (config) {
     {
       id: 5,
       title: 'Fashion',
-      createdBy: 'Google AMP',
+      ...globalConfig,
       tags: ['Clothing', 'Sparkle'],
       colors: [
         { label: 'Cream', color: '#ffece3' },
@@ -107,7 +112,7 @@ export default function (config) {
     {
       id: 6,
       title: 'Fitness',
-      createdBy: 'Google AMP',
+      ...globalConfig,
       tags: ['Exercise', 'Fitness', 'Health', 'Workout', 'Bold'],
       colors: [
         { label: 'Black', color: '#1a1a1a' },
@@ -121,7 +126,7 @@ export default function (config) {
     {
       id: 7,
       title: 'Travel',
-      createdBy: 'Google AMP',
+      ...globalConfig,
       tags: ['Explore', 'Adventure', 'Taste'],
       colors: [
         { label: 'Green', color: '#094228' },
@@ -136,7 +141,7 @@ export default function (config) {
     {
       id: 8,
       title: 'Wellbeing',
-      createdBy: 'Google AMP',
+      ...globalConfig,
       tags: ['Health', 'Happiness', 'Joy', 'Mindfulness'],
       colors: [
         { label: 'Blue', color: '#1f2a2e' },


### PR DESCRIPTION
Fixes #1281.

This PR refactors and stubs out the template api so we can flesh out the rest of the template UI while we get access to the real endpoints at a later date.

The following endpoints are stubbed out:
`bookmarkTemplateById`:  Bookmarks or un-bookmarks a template by a template's id.

`createStoryFromTemplatePages`:  This is what we should call when the "Use this template" button is clicked.

`fetchBookmarkedTemplates`:  Used to return all the templates bookmarked by the current user.

`fetchSavedTemplates`:  This returns a combination of bookmarked templates and templates generated by the current user.

`fetchMyTemplates`:  Returns all the templates generated by the current user.

`fetchMyTemplateById`:  Gets the specified template from the user generated templates.

`fetchExternalTemplates`:  Returns all the external templates hosted elsewhere which can be seen when the user navigates to "Explore Templates".

`fetchExternalTemplateById`:  Gets the specified template from the external template source.
