### PR TITLE
Fix useLoadStory to load the publish date in UTC time

### DIFF
--- a/assets/src/edit-story/app/api/test/_utils.js
+++ b/assets/src/edit-story/app/api/test/_utils.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const TEST_COLOR = {
+  color: { r: 1, g: 1, b: 1 },
+};
+
+export function createStory(properties = {}) {
+  return {
+    title: { raw: 'title' },
+    excerpt: { raw: 'excerpt' },
+    permalink_template: 'http://localhost:8899/stories/%pagename%',
+    style_presets: { fillColors: [TEST_COLOR] },
+    ...properties,
+  };
+}

--- a/assets/src/edit-story/app/story/effects/test/useLoadStory.js
+++ b/assets/src/edit-story/app/story/effects/test/useLoadStory.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { createStory } from '../../../api/test/_utils';
+import useLoadStory from '../useLoadStory';
+import APIContext from '../../../api/context';
+import HistoryContext from '../../../history/context';
+
+const getStoryById = jest.fn();
+const clearHistory = jest.fn();
+
+const apiContextValue = { actions: { getStoryById } };
+const historyContextValue = { actions: { clearHistory } };
+
+function ContextWrapper({ children }) {
+  return (
+    <APIContext.Provider value={apiContextValue}>
+      <HistoryContext.Provider value={historyContextValue}>
+        {children}
+      </HistoryContext.Provider>
+    </APIContext.Provider>
+  );
+}
+
+ContextWrapper.propTypes = {
+  children: PropTypes.any.isRequired,
+};
+
+describe('useLoadStory', () => {
+  beforeEach(() => {
+    getStoryById.mockReset();
+    clearHistory.mockReset();
+  });
+
+  it('should load publish date with correct utc timezone', async () => {
+    getStoryById.mockReturnValue(
+      Promise.resolve(
+        createStory({
+          date: '2020-01-01T19:20:20',
+          date_gmt: '2020-01-01T20:20:20',
+        })
+      )
+    );
+
+    const restore = jest.fn();
+    await renderHook(
+      () => useLoadStory({ storyId: 11, shouldLoad: true, restore }),
+      { wrapper: ContextWrapper }
+    );
+    expect(restore.mock.calls[0][0].story).toStrictEqual(
+      expect.objectContaining({ date: '2020-01-01T20:20:20Z' })
+    );
+  });
+});

--- a/assets/src/edit-story/app/story/effects/useLoadStory.js
+++ b/assets/src/edit-story/app/story/effects/useLoadStory.js
@@ -55,7 +55,7 @@ function useLoadStory({ storyId, shouldLoad, restore }) {
           status,
           author,
           slug,
-          date,
+          date_gmt,
           modified,
           excerpt: { raw: excerpt },
           link,
@@ -67,6 +67,7 @@ function useLoadStory({ storyId, shouldLoad, restore }) {
           style_presets: stylePresets,
           password,
         } = post;
+        const date = `${date_gmt}Z`;
 
         const [prefix, suffix] = permalinkTemplate.split(
           /%(?:postname|pagename)%/


### PR DESCRIPTION
When a new story is created, getStoryById is called to return the story using a wordpress API, which uses the server time for the publish 'date' field (usually expressed in UTC) without a timezone qualifier.

This change instead uses the 'date_gmt' field with a timezone qualifier.

See also:
https://developer.wordpress.org/rest-api/reference/posts#schema-date
