### PR TITLE
Updated template detail UI to new designs

### DIFF
--- a/assets/src/dashboard/app/api/test/__snapshots__/useTemplateApi.js.snap
+++ b/assets/src/dashboard/app/api/test/__snapshots__/useTemplateApi.js.snap
@@ -4,20 +4,7 @@ exports[`reshapeTemplateObject should reshape object to match snapshot 1`] = `
 Object {
   "bottomTargetAction": [Function],
   "centerTargetAction": "#/template-detail?id=1&isLocal=true",
-  "createdBy": "Google AMP",
-  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-  "id": 1,
-  "isLocal": true,
-  "metadata": Array [
-    Object {
-      "label": "Health",
-    },
-    Object {
-      "label": "Bold",
-    },
-    Object {
-      "label": "Joy",
-    },
+  "colors": Array [
     Object {
       "color": "#f3d9e1",
       "label": "Pink",
@@ -31,6 +18,10 @@ Object {
       "label": "Black",
     },
   ],
+  "createdBy": "Google AMP",
+  "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+  "id": 1,
+  "isLocal": true,
   "modified": "2020-04-21T07:00:00.000Z",
   "pages": Array [
     Object {
@@ -39,6 +30,11 @@ Object {
     },
   ],
   "status": "template",
+  "tags": Array [
+    "Health",
+    "Bold",
+    "Joy",
+  ],
   "title": "Beauty",
 }
 `;

--- a/assets/src/dashboard/app/api/test/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/test/useTemplateApi.js
@@ -52,12 +52,11 @@ describe('reshapeTemplateObject', () => {
     );
   });
 
-  it('should combine template tags and colors into metadata', () => {
+  it('should pass through tags and colors into reshaped object', () => {
     const reshapedObject = reshapeTemplateObject(true)(templateData);
-    expect(reshapedObject.metadata).toMatchObject([
-      { label: 'Health' },
-      { label: 'Bold' },
-      { label: 'Joy' },
+
+    expect(reshapedObject.tags).toMatchObject(['Health', 'Bold', 'Joy']);
+    expect(reshapedObject.colors).toMatchObject([
       { label: 'Pink', color: '#f3d9e1' },
       { label: 'Green', color: '#d8ddcc' },
       { label: 'Black', color: '#28292b' },

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -44,9 +44,8 @@ export function reshapeTemplateObject(isLocal) {
     description,
     status: 'template',
     modified: moment(modified),
-    metadata: [...tags, ...colors].map((value) =>
-      typeof value === 'object' ? { ...value } : { label: value }
-    ),
+    tags,
+    colors,
     pages,
     centerTargetAction: `#${APP_ROUTES.TEMPLATE_DETAIL}?id=${id}&isLocal=${isLocal}`,
     bottomTargetAction: () => {},

--- a/assets/src/dashboard/app/views/templates/components.js
+++ b/assets/src/dashboard/app/views/templates/components.js
@@ -70,11 +70,11 @@ export const Column = styled.div`
 
 export const Title = styled.h2`
   ${({ theme }) => `
-    margin: 0 0 5px;
-    font-family: ${theme.fonts.heading2.family};
-    font-size: ${theme.fonts.heading2.size};
-    font-weight: ${theme.fonts.heading2.weight};
-    line-height: ${theme.fonts.heading2.lineHeight};
+    margin: 0;
+    font-family: ${theme.fonts.heading4.family};
+    font-size: ${theme.fonts.heading4.size};
+    font-weight: ${theme.fonts.heading4.weight};
+    line-height: ${theme.fonts.heading4.lineHeight};
     color: ${theme.colors.gray900};
   `}
 `;
@@ -82,10 +82,9 @@ export const Title = styled.h2`
 export const ByLine = styled.p`
   ${({ theme }) => `
     margin: 0 0 20px;
-    font-family: ${theme.fonts.body1.family};
-    font-size: ${theme.fonts.body1.size};
-    font-weight: ${theme.fonts.body1.weight};
-    line-height: ${theme.fonts.body1.lineHeight};
+    font-family: ${theme.fonts.body2.family};
+    font-size: ${theme.fonts.body2.size};
+    line-height: ${theme.fonts.body2.lineHeight};
     color: ${theme.colors.gray400};
   `}
 `;
@@ -97,7 +96,7 @@ export const Text = styled.p`
     font-size: ${theme.fonts.body2.size};
     line-height: ${theme.fonts.body2.lineHeight};
     letter-spacing: 0.015em;
-    color: ${theme.colors.gray600};
+    color: ${theme.colors.gray900};
   `}
 `;
 
@@ -111,22 +110,4 @@ export const MetadataContainer = styled.fieldset`
       opacity: 1 !important;
     }
   }
-`;
-
-const borderLookup = (color) => ({
-  '#fff': `border: solid 1px ${color}`,
-  '#ffffff': `border: solid 1px ${color}`,
-  white: `border: solid 1px ${color}`,
-});
-
-export const ColorBadge = styled.span`
-  ${({ theme, color }) => `
-    display: inline-block;
-    width: 14px;
-    height: 14px;
-    border-radius: 14px;
-    margin-right: 8px;
-    background-color: ${color};
-    ${borderLookup(theme.colors.gray50)[color] || ''}
-  `}
 `;

--- a/assets/src/dashboard/app/views/templates/components.js
+++ b/assets/src/dashboard/app/views/templates/components.js
@@ -53,12 +53,12 @@ export const Column = styled.div`
     width: 50%;
 
     & + & {
-      padding-left: ${theme.pageGutter.large.desktop}px;
+      padding-left: ${theme.pageGutter.small.desktop}px;
     }
 
     @media ${theme.breakpoint.tablet} {
       & + & {
-        padding-left: ${theme.pageGutter.large.tablet}px;
+        padding-left: ${theme.pageGutter.small.min}px;
       }
     }
 

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -33,6 +33,7 @@ import { TransformProvider } from '../../../../edit-story/components/transform';
 import FontProvider from '../../font/fontProvider';
 import {
   CardGallery,
+  ColorList,
   PreviewPage,
   Pill,
   TemplateNavBar,
@@ -40,7 +41,6 @@ import {
 import {
   ByLine,
   ContentContainer,
-  ColorBadge,
   ColumnContainer,
   Column,
   DetailContainer,
@@ -79,17 +79,12 @@ function TemplateDetail() {
     }
   }, [templateApi, templateId, isLocal]);
 
-  const { title, byLine } = useMemo(() => {
+  const { byLine } = useMemo(() => {
     if (!template) {
       return {};
     }
 
     return {
-      title: sprintf(
-        /* translators: %s: template title  */
-        __('%s Template', 'web-stories'),
-        template.title
-      ),
       byLine: sprintf(
         /* translators: %s: template author  */
         __('by %s', 'web-stories'),
@@ -102,7 +97,7 @@ function TemplateDetail() {
     template && (
       <FontProvider>
         <TransformProvider>
-          <TemplateNavBar title={template.title} />
+          <TemplateNavBar />
           <ContentContainer>
             <ColumnContainer>
               <Column>
@@ -114,22 +109,24 @@ function TemplateDetail() {
               </Column>
               <Column>
                 <DetailContainer>
-                  <Title>{title}</Title>
+                  <Title>{template.title}</Title>
                   <ByLine>{byLine}</ByLine>
                   <Text>{template.description}</Text>
                   <MetadataContainer>
-                    {template.metadata.map(({ label, color }) => (
+                    {template.tags.map((tag) => (
                       <Pill
-                        name={label}
-                        key={label}
+                        name={tag}
+                        key={tag}
                         disabled
                         onClick={() => {}}
-                        value={label}
+                        value={tag}
                       >
-                        {color && <ColorBadge color={color} />}
-                        {label}
+                        {tag}
                       </Pill>
                     ))}
+                  </MetadataContainer>
+                  <MetadataContainer>
+                    <ColorList colors={template.colors} size={30} />
                   </MetadataContainer>
                 </DetailContainer>
               </Column>

--- a/assets/src/dashboard/components/cardGallery/components.js
+++ b/assets/src/dashboard/components/cardGallery/components.js
@@ -45,7 +45,6 @@ export const MiniCardWrapper = styled.div`
     width: ${width}px;
     height: ${height}px;
     overflow: hidden;
-    border-radius: 5px;
     ${isSelected ? `border: 3px solid ${theme.colors.bluePrimary600}` : ``}
   `}
 `;
@@ -56,18 +55,15 @@ export const MiniCard = styled.div`
     width: ${width}px;
     height: ${height}px;
     overflow: hidden;
-    border-radius: 4px;
     cursor: pointer;
   `}
 `;
 
 export const ActiveCard = styled.div`
-  ${({ theme, height, width }) => `
+  ${({ height, width }) => `
     position: relative;
     width: ${width}px;
     height: ${height}px;
-    border-radius: ${theme.border.cardRadius};
-    box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.25);
     overflow: hidden;
   `}
 `;

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -37,7 +37,7 @@ const MAX_WIDTH = 680;
 const ACTIVE_CARD_WIDTH = 330;
 const MINI_CARD_WIDTH = 75;
 const CARD_GAP = 15;
-const CARD_WRAPPER_BUFFER = 10;
+const CARD_WRAPPER_BUFFER = 12;
 
 function CardGallery({ children }) {
   const [dimensionMultiplier, setDimensionMultiplier] = useState(1);
@@ -78,7 +78,7 @@ function CardGallery({ children }) {
   const miniWrapperCardSize = useMemo(
     () => ({
       width: miniCardWidth + CARD_WRAPPER_BUFFER,
-      height: (miniCardWidth + CARD_WRAPPER_BUFFER / 2) * PAGE_RATIO,
+      height: miniCardWidth * PAGE_RATIO + CARD_WRAPPER_BUFFER,
     }),
     [miniCardWidth]
   );

--- a/assets/src/dashboard/components/colorList/index.js
+++ b/assets/src/dashboard/components/colorList/index.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { ColorType } from '../types';
+
+const borderLookup = (color) => ({
+  '#fff': `border: solid 1px ${color}`,
+  '#ffffff': `border: solid 1px ${color}`,
+  white: `border: solid 1px ${color}`,
+});
+
+const ColorContainer = styled.div`
+  display: flex;
+`;
+
+const Color = styled.div`
+  ${({ theme, color, size, spacing }) => `
+    width: ${size}px;
+    height: ${size}px;
+    border-radius: 50%;
+    background-color: ${color};
+    ${borderLookup(theme.colors.gray50)[color] || ''};
+
+    & + & {
+      margin-left: ${spacing || 10}px;
+    }
+  `}
+`;
+
+function ColorList({ colors, size, spacing }) {
+  return (
+    <ColorContainer>
+      {colors.map(({ label, color }, index) => (
+        <Color
+          key={index}
+          size={size}
+          spacing={spacing}
+          color={color}
+          title={label}
+          ariaLabel={label}
+        />
+      ))}
+    </ColorContainer>
+  );
+}
+
+ColorList.propTypes = {
+  colors: PropTypes.arrayOf(ColorType).isRequired,
+  size: PropTypes.number.isRequired,
+  spacing: PropTypes.number,
+};
+
+export default ColorList;

--- a/assets/src/dashboard/components/colorList/stories/index.js
+++ b/assets/src/dashboard/components/colorList/stories/index.js
@@ -17,17 +17,31 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
+import { number } from '@storybook/addon-knobs';
 
-export const DROPDOWN_ITEM_PROP_TYPE = PropTypes.shape({
-  label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
-  selected: PropTypes.bool,
-  separator: PropTypes.bool,
-  disabled: PropTypes.bool,
-});
+/**
+ * Internal dependencies
+ */
+import ColorList from '../';
 
-export const ColorType = PropTypes.shape({
-  label: PropTypes.string.isRequired,
-  color: PropTypes.string.isRequired,
-});
+export default {
+  title: 'Dashboard/Components/ColorList',
+  component: ColorList,
+};
+
+export const _default = () => {
+  const colors = [
+    { label: 'Red', color: 'red' },
+    { label: 'Blue', color: 'blue' },
+    { label: 'Green', color: 'green' },
+    { label: 'White', color: 'white' },
+  ];
+
+  return (
+    <ColorList
+      colors={colors}
+      size={number('Size', 50) || 0}
+      spacing={number('Spacing', 10) || 10}
+    />
+  );
+};

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -26,6 +26,7 @@ export {
   ActionLabel,
 } from './cardGridItem';
 export { default as CardGallery } from './cardGallery';
+export { default as ColorList } from './colorList';
 export { default as Dropdown } from './dropdown';
 export { default as InfiniteScroller } from './infiniteScroller';
 export { TemplateNavBar } from './navigationBar';

--- a/assets/src/dashboard/components/navigationBar/templateNavBar.js
+++ b/assets/src/dashboard/components/navigationBar/templateNavBar.js
@@ -17,19 +17,17 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
  * Internal dependencies
  */
 import { BUTTON_TYPES, APP_ROUTES } from '../../constants';
-import { ReactComponent as Close } from '../../icons/close.svg';
 import BookmarkChip from '../../components/bookmark-chip';
 import { Nav, ActionLink } from './components';
 
@@ -43,55 +41,30 @@ const BookmarkToggle = styled(BookmarkChip)`
 `;
 
 const CloseLink = styled.a`
-  display: inline-block;
-  color: ${({ theme }) => theme.colors.gray200};
-  width: 14px;
-  height: 14px;
-  margin-right: 20px;
-  cursor: pointer;
-`;
-
-const Title = styled.h1`
   ${({ theme }) => `
-  margin: 0;
-  font-family: ${theme.fonts.body1.family};
-  font-size: ${theme.fonts.body1.size};
-  font-weight: ${theme.fonts.body1.weight};
-  line-height: ${theme.fonts.body1.lineHeight};
-  color: ${theme.colors.gray700};
+    font-family: ${theme.fonts.body1.family};
+    font-size: ${theme.fonts.body1.size};
+    font-weight: ${theme.fonts.body1.weight};
+    line-height: ${theme.fonts.body1.lineHeight};
+    text-decoration: none;
+    color: ${theme.colors.gray700};
   `}
 `;
 
-export function TemplateNavBar({ title }) {
-  const translatedTitle = sprintf(
-    /* translators: %s: template title */
-    __('%s Template', 'web-stories'),
-    title
-  );
-  const closeLabel = __('Go back to template gallery', 'web-stories');
-
+export function TemplateNavBar() {
   return (
     <Nav>
       <Container>
-        <CloseLink
-          title={closeLabel}
-          aria-label={closeLabel}
-          href={`#${APP_ROUTES.TEMPLATES_GALLERY}`}
-        >
-          <Close />
+        <CloseLink href={`#${APP_ROUTES.TEMPLATES_GALLERY}`}>
+          {__('Close', 'web-stories')}
         </CloseLink>
-        <Title>{translatedTitle}</Title>
       </Container>
       <Container>
         <BookmarkToggle />
         <ActionLink type={BUTTON_TYPES.CTA} href={'#'} isLink={true}>
-          {__('Use this template', 'web-stories')}
+          {__('USE TEMPLATE', 'web-stories')}
         </ActionLink>
       </Container>
     </Nav>
   );
 }
-
-TemplateNavBar.propTypes = {
-  title: PropTypes.string.isRequired,
-};

--- a/assets/src/dashboard/templates/index.js
+++ b/assets/src/dashboard/templates/index.js
@@ -24,7 +24,7 @@ export default function (config) {
   const travelStoryData = getTravelStoryData(pluginDir);
 
   const globalConfig = {
-    createdBy: 'Google AMP',
+    createdBy: 'Google Web Stories',
     modified: '2020-04-21',
   };
 

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -152,6 +152,12 @@ const theme = {
       letterSpacing: '-.01em',
       weight: 500,
     },
+    heading4: {
+      family: 'Google Sans',
+      size: '28px',
+      lineHeight: '35px',
+      weight: 500,
+    },
     body1: {
       family: "'Google Sans', sans-serif",
       size: '16px',


### PR DESCRIPTION
Fixes #1279.

This PR updates our existing Template Detail UI to look closer to the new designs (we don't have figma mocks for the new design, so just eyeing it off the video):

This is our site:
![image](https://user-images.githubusercontent.com/40646372/79927428-94354780-83f4-11ea-8a1e-af89f7d2f9c4.png)

This is a screenshot from the mock video:
![image](https://user-images.githubusercontent.com/40646372/79926594-30118400-83f2-11ea-9431-f5bca3555357.png)

Also, I wrote a new component called the `ColorList` and created a storybook page for it:
![image](https://user-images.githubusercontent.com/40646372/79927488-c181f580-83f4-11ea-8c0f-cf416080f878.png)
