### PR TITLE
Dashboard: infinite scrolling messaging styled

### DIFF
--- a/assets/src/dashboard/components/infiniteScroller/index.js
+++ b/assets/src/dashboard/components/infiniteScroller/index.js
@@ -25,11 +25,15 @@ import { useEffect, useRef, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-// TODO
 const ScrollMessage = styled.div`
-  margin: 20px 0;
-  text-align: center;
   width: 100%;
+  margin: 40px auto;
+  font-family: ${({ theme }) => theme.fonts.body2.family};
+  font-size: ${({ theme }) => theme.fonts.body2.size};
+  font-weight: ${({ theme }) => theme.fonts.body2.weight};
+  line-height: ${({ theme }) => theme.fonts.body2.lineHeight};
+  text-align: center;
+  color: ${({ theme }) => theme.colors.gray500};
 `;
 
 const STATE = {

--- a/assets/src/dashboard/components/infiniteScroller/test/infiniteScroller.js
+++ b/assets/src/dashboard/components/infiniteScroller/test/infiniteScroller.js
@@ -18,18 +18,24 @@
  * External dependencies
  */
 import { render } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
 
 /**
  * Internal dependencies
  */
 import InfiniteScroller from '../index';
+import theme from '../../../theme';
+
+const wrapper = (children) => {
+  return render(<ThemeProvider theme={theme}>{children}</ThemeProvider>);
+};
 
 describe('InfiniteScroller', () => {
   const onGetDataMock = jest.fn();
 
   it('should render a loading component by default', () => {
-    const { getByTestId } = render(
-      <InfiniteScroller handleGetData={onGetDataMock} />
+    const { getByTestId } = wrapper(
+      <InfiniteScroller canLoadMore={true} onLoadMore={onGetDataMock} />
     );
 
     const loadingComponent = getByTestId('load-more-on-scroll');
@@ -38,11 +44,11 @@ describe('InfiniteScroller', () => {
   });
 
   it('should show all data loaded message when `allDataLoadedMessage` is true', () => {
-    const { getByText } = render(
+    const { getByText } = wrapper(
       <InfiniteScroller
-        handleGetData={onGetDataMock}
+        onLoadMore={onGetDataMock}
         allDataLoadedMessage="All data has been fetched"
-        isAllDataLoaded={true}
+        canLoadMore={false}
       />
     );
 


### PR DESCRIPTION
Updating the styling for the message displayed when you are 'loading' another page of stories or when there's no more stories to load. 

Based it off of this screenshot from one of the videos Sam took of the new UI: 
![Screen Shot 2020-04-22 at 11 06 26 AM](https://user-images.githubusercontent.com/10720454/80019336-35231180-848c-11ea-84c7-bd05dd58245d.png)
![Screen Shot 2020-04-22 at 11 07 27 AM](https://user-images.githubusercontent.com/10720454/80019383-49670e80-848c-11ea-9863-3967811b3ed3.png)

and it looks like this: 
![Screen Shot 2020-04-22 at 11 28 28 AM](https://user-images.githubusercontent.com/10720454/80019468-6bf92780-848c-11ea-96ef-0e14a44fa3a3.png)
