### PR TITLE
Added next/previous controls to template detail view

### DIFF
--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { useContext } from 'react';
 import { StyleSheetManager, ThemeProvider } from 'styled-components';
 import stylisRTLPlugin from 'stylis-plugin-rtl';
 import PropTypes from 'prop-types';
@@ -29,7 +30,7 @@ import KeyboardOnlyOutline from '../utils/keyboardOnlyOutline';
 import { APP_ROUTES } from '../constants';
 import { AppFrame, LeftRail, PageContent } from '../components';
 import ApiProvider from './api/apiProvider';
-import { Route, RouterProvider } from './router';
+import { Route, RouterProvider, RouterContext, matchPath } from './router';
 import { ConfigProvider } from './config';
 import {
   MyStoriesView,
@@ -37,6 +38,39 @@ import {
   TemplatesGalleryView,
   SavedTemplatesView,
 } from './views';
+
+const AppContent = () => {
+  const {
+    state: { currentPath },
+  } = useContext(RouterContext);
+
+  const hideLeftRail = matchPath(currentPath, APP_ROUTES.TEMPLATE_DETAIL);
+
+  return (
+    <AppFrame>
+      {!hideLeftRail && <LeftRail />}
+      <PageContent fullWidth={hideLeftRail}>
+        <Route
+          exact
+          path={APP_ROUTES.MY_STORIES}
+          component={<MyStoriesView />}
+        />
+        <Route
+          path={APP_ROUTES.TEMPLATE_DETAIL}
+          component={<TemplateDetail />}
+        />
+        <Route
+          path={APP_ROUTES.TEMPLATES_GALLERY}
+          component={<TemplatesGalleryView />}
+        />
+        <Route
+          path={APP_ROUTES.SAVED_TEMPLATES}
+          component={<SavedTemplatesView />}
+        />
+      </PageContent>
+    </AppFrame>
+  );
+};
 
 function App({ config }) {
   const { isRTL } = config;
@@ -48,28 +82,7 @@ function App({ config }) {
             <RouterProvider>
               <GlobalStyle />
               <KeyboardOnlyOutline />
-              <AppFrame>
-                <LeftRail />
-                <PageContent>
-                  <Route
-                    exact
-                    path={APP_ROUTES.MY_STORIES}
-                    component={<MyStoriesView />}
-                  />
-                  <Route
-                    path={APP_ROUTES.TEMPLATE_DETAIL}
-                    component={<TemplateDetail />}
-                  />
-                  <Route
-                    path={APP_ROUTES.TEMPLATES_GALLERY}
-                    component={<TemplatesGalleryView />}
-                  />
-                  <Route
-                    path={APP_ROUTES.SAVED_TEMPLATES}
-                    component={<SavedTemplatesView />}
-                  />
-                </PageContent>
-              </AppFrame>
+              <AppContent />
             </RouterProvider>
           </ApiProvider>
         </ConfigProvider>

--- a/assets/src/dashboard/app/router/index.js
+++ b/assets/src/dashboard/app/router/index.js
@@ -20,4 +20,4 @@
 
 export { default as RouterProvider, RouterContext } from './routerProvider';
 export { default as useRouteHistory } from './useRouteHistory';
-export { default as Route } from './route';
+export { default as Route, matchPath } from './route';

--- a/assets/src/dashboard/app/router/route.js
+++ b/assets/src/dashboard/app/router/route.js
@@ -26,7 +26,7 @@ import PropTypes from 'prop-types';
  */
 import { RouterContext } from './routerProvider';
 
-function matchPath(currentPath, path, exact = false) {
+export function matchPath(currentPath, path, exact = false) {
   const match = new RegExp(`^${path}`).exec(currentPath);
   if (!match) {
     return null;

--- a/assets/src/dashboard/app/views/templates/components.js
+++ b/assets/src/dashboard/app/views/templates/components.js
@@ -19,6 +19,11 @@
  */
 import styled from 'styled-components';
 
+/**
+ * Internal dependencies
+ */
+import { Button } from '../../../components';
+
 export const ContentContainer = styled.div`
   ${({ theme }) => `
     padding: 0 ${theme.pageGutter.large.desktop}px;
@@ -45,11 +50,13 @@ export const ColumnContainer = styled.section`
 `;
 
 export const DetailContainer = styled.div`
+  width: 100%;
   padding: 40px 20px 0;
 `;
 
 export const Column = styled.div`
   ${({ theme }) => `
+    display: flex;
     width: 50%;
 
     & + & {
@@ -110,4 +117,19 @@ export const MetadataContainer = styled.fieldset`
       opacity: 1 !important;
     }
   }
+`;
+
+export const NavButton = styled(Button)`
+  ${({ theme }) => `
+    display: block;
+    align-self: center;
+    min-width: 0;
+    height: 40%;
+    color: ${theme.colors.gray900};
+    background-color: transparent;
+
+    &:hover, &:active, &:focus {
+      color: ${theme.colors.bluePrimary};
+    }
+  `}
 `;

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -61,10 +61,13 @@ function TemplateDetail() {
     state: {
       queryParams: { id: templateId, isLocal },
     },
+    actions,
   } = useRouteHistory();
   const {
     state: { templates },
-    actions: { templateApi },
+    actions: {
+      templateApi: { fetchMyTemplateById, fetchExternalTemplateById },
+    },
   } = useContext(ApiContext);
   const { isRTL } = useConfig();
 
@@ -77,15 +80,15 @@ function TemplateDetail() {
     const isLocalTemplate = isLocal && isLocal.toLowerCase() === 'true';
 
     if (isLocalTemplate) {
-      templateApi.fetchMyTemplateById(id).then((fetchedTemplate) => {
-        setTemplate(fetchedTemplate);
-      });
+      fetchMyTemplateById(id).then((fetchedTemplate) =>
+        setTemplate(fetchedTemplate)
+      );
     } else {
-      templateApi.fetchExternalTemplateById(id).then((fetchedTemplate) => {
-        setTemplate(fetchedTemplate);
-      });
+      fetchExternalTemplateById(id).then((fetchedTemplate) =>
+        setTemplate(fetchedTemplate)
+      );
     }
-  }, [templateApi, templateId, isLocal]);
+  }, [fetchMyTemplateById, fetchExternalTemplateById, templateId, isLocal]);
 
   const { byLine } = useMemo(() => {
     if (!template) {
@@ -119,9 +122,13 @@ function TemplateDetail() {
         0,
         templates.length - 1,
       ]);
-      setTemplate(templates[index]);
+      const selectedTemplate = templates[index];
+
+      actions.push(
+        `?id=${selectedTemplate.id}&isLocal=${selectedTemplate.isLocal}`
+      );
     },
-    [activeTemplateIndex, templates]
+    [activeTemplateIndex, templates, actions]
   );
 
   const { NextButton, PrevButton } = useMemo(() => {

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -124,6 +124,7 @@ function TemplatesGallery() {
             filteredStories={filteredTemplates}
             centerActionLabel={__('View details', 'web-stories')}
             bottomActionLabel={__('Use template', 'web-stories')}
+            updateStory={() => {}}
           />
         </BodyWrapper>
       );

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -109,6 +109,10 @@ function CardGallery({ children }) {
     };
   }, [updateContainerSize]);
 
+  useEffect(() => {
+    setActiveCardIndex(0);
+  }, [children]);
+
   return (
     <GalleryContainer ref={containerRef} maxWidth={MAX_WIDTH}>
       <UnitsProvider pageSize={miniCardSize}>

--- a/assets/src/dashboard/components/cardGallery/test/cardGallery.js
+++ b/assets/src/dashboard/components/cardGallery/test/cardGallery.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { renderWithTheme } from '../../../testUtils/';
+import CardGallery from '../';
+
+describe('CardGallery', () => {
+  it('should render CardGallery', () => {
+    const { getAllByTestId } = renderWithTheme(
+      <CardGallery>
+        <div data-testid={'test-child'}>{'Item 1'}</div>
+        <div data-testid={'test-child'}>{'Item 2'}</div>
+        <div data-testid={'test-child'}>{'Item 3'}</div>
+        <div data-testid={'test-child'}>{'Item 4'}</div>
+      </CardGallery>
+    );
+
+    // totalCards = childrenCount + activeCardCount (there is only 1 active card at a time)
+    const totalCards = 5;
+    expect(getAllByTestId('test-child')).toHaveLength(totalCards);
+  });
+
+  it('should set first child as active child', () => {
+    const { getAllByTestId } = renderWithTheme(
+      <CardGallery>
+        <div data-testid={'active-child'}>{'Item 1'}</div>
+        <div>{'Item 2'}</div>
+        <div>{'Item 3'}</div>
+        <div>{'Item 4'}</div>
+      </CardGallery>
+    );
+
+    // The active child should always appear twice
+    expect(getAllByTestId('active-child')).toHaveLength(2);
+  });
+
+  it('should change active child to the child that is clicked on', () => {
+    const { getAllByTestId } = renderWithTheme(
+      <CardGallery>
+        <div>{'Item 1'}</div>
+        <div>{'Item 2'}</div>
+        <div data-testid={'test-child'}>{'Item 3'}</div>
+        <div>{'Item 4'}</div>
+      </CardGallery>
+    );
+
+    // When the child is not active, it should only appear once
+    const testIds = getAllByTestId('test-child');
+    expect(testIds).toHaveLength(1);
+
+    // Simulate clicking on Item 3
+    fireEvent.click(testIds[0]);
+
+    // When active, it should appear twice
+    expect(getAllByTestId('test-child')).toHaveLength(2);
+  });
+});

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -50,7 +50,7 @@ export const AppFrame = styled.div`
 export const PageContent = styled.div`
   position: relative;
   width: 100%;
-  padding-left: max(15%, 190px);
+  padding-left: ${({ fullWidth }) => (fullWidth ? '0' : 'max(15%, 190px)')};
   height: inherit;
 `;
 

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -71,12 +71,12 @@ export const APP_ROUTES = {
 export const primaryPaths = [
   { value: APP_ROUTES.MY_STORIES, label: __('My Stories', 'web-stories') },
   {
-    value: APP_ROUTES.TEMPLATES_GALLERY,
-    label: __('Explore Templates', 'web-stories'),
-  },
-  {
     value: APP_ROUTES.SAVED_TEMPLATES,
     label: __('Saved Templates', 'web-stories'),
+  },
+  {
+    value: APP_ROUTES.TEMPLATES_GALLERY,
+    label: __('Explore Templates', 'web-stories'),
   },
 ];
 
@@ -106,6 +106,7 @@ export const VIEW_STYLE = {
 export const ICON_METRICS = {
   VIEW_STYLE: { width: 17, height: 14 },
   UP_DOWN_ARROW: { width: 16, height: 16 },
+  LEFT_RIGHT_ARROW: { width: 16, height: 16 },
 };
 
 export const STORY_CONTEXT_MENU_ACTIONS = {


### PR DESCRIPTION
Fixes #1280.

This PR does a couple things:
- Lets the left railsnav hide itself based on route.
- Adds next/prev buttons to navigate through the pool of templates based off the templates stored in context (which I think... might actually be the correct way to handle this in the long run too 🤔)

NOTE:  The left/right arrows I'm using are the old ones, until we get some updated figma goodness I figured it'd do just to use the old svgs so we can focus on the code and functionality. 

All the pages for each template is the same which is why the pages aren't changing, but the title and description changing means it's properly jump from template to template:
![next_prev_templates](https://user-images.githubusercontent.com/40646372/80045274-bba31780-84bb-11ea-8b6d-7a9ab211601d.gif)

Left arrow disabled on first template:
![image](https://user-images.githubusercontent.com/40646372/80045119-5a7b4400-84bb-11ea-98a7-197e10dbfe29.png)

Both arrows enabled in the middle:
![image](https://user-images.githubusercontent.com/40646372/80045136-623ae880-84bb-11ea-902d-05968f978065.png)

Right arrow disabled on last template:
![image](https://user-images.githubusercontent.com/40646372/80045155-6a932380-84bb-11ea-980b-2b930a4184cc.png)
