### PR TITLE
Update code coverage configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,6 @@ jobs:
       php: nightly
       env: PHP=1 WP_VERSION=trunk
     - name: PHP and JavaScript unit tests (7.4, WordPress latest, with code coverage)
-      if: branch = master AND type = push
       php: 7.4
       env: JS=1 PHP=1 COVERAGE=1 WP_VERSION=latest
     - name: E2E tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,16 +1,48 @@
+# Overall settings for PR integration via codecov.io
+# See https://docs.codecov.io/docs/codecovyml-reference
+
+# Separate PR statuses for project-level and patch-level coverage
+# See https://docs.codecov.io/docs/commit-status
 coverage:
   status:
+    # Project-level coverage
     project:
       default:
-        threshold: 1%
-        branches:
-          - master
-        if_not_found: success
-        if_ci_failed: error
+        base: auto
         # Disable once code base is more mature.
         informational: true
         only_pulls: true
+        target: 60%
+        threshold: 10%
+        if_not_found: success
+        if_ci_failed: error
 
+      php:
+        paths:
+          - includes
+
+      dashboard:
+        paths:
+          - assets/src/dashboard
+
+      editor:
+        paths:
+          - assets/src/edit-story
+
+    # Patch-level coverage (how well is the PR tested)
+    patch:
+      default:
+        base: auto
+        # Disable once code base is more mature.
+        informational: true
+        only_pulls: true
+        target: 80%
+        threshold: 10%
+        if_not_found: success
+        if_ci_failed: error
+
+# Pull request comments
+# See https://docs.codecov.io/docs/pull-request-comments
 comment:
   layout: 'reach, diff, flags, files'
   behavior: default


### PR DESCRIPTION
This way, test coverage is run for PRs; which makes Codecov show a status accordingly.

<img width="700" alt="Screenshot 2020-04-23 at 12 52 29" src="https://user-images.githubusercontent.com/841956/80091391-530e7600-8561-11ea-9153-77ab91ba987f.png">
