### PR TITLE
Handle paste processing only when not dealing with files.

### DIFF
--- a/assets/src/edit-story/components/canvas/useCanvasSelectionCopyPaste.js
+++ b/assets/src/edit-story/components/canvas/useCanvasSelectionCopyPaste.js
@@ -168,9 +168,11 @@ function useCanvasSelectionCopyPaste(container) {
       const { clipboardData } = evt;
 
       try {
+        // Get the html text and plain text but only if it's not a file being copied.
         const content =
-          clipboardData.getData('text/html') ||
-          clipboardData.getData('text/plain');
+          !clipboardData.files?.length &&
+          (clipboardData.getData('text/html') ||
+            clipboardData.getData('text/plain'));
         if (content) {
           const template = document.createElement('template');
           // Remove meta tag.


### PR DESCRIPTION
Fixes #1242 

Proceeds with text paste only if no files are found from pasting.