### PR TITLE
Dashboard: Rename Story

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -150,6 +150,24 @@ export default function ApiProvider({ children }) {
     [api.stories, editStoryURL]
   );
 
+  const updateStory = useCallback(
+    async (story) => {
+      try {
+        const response = await dataAdapter.post(`${api.stories}/${story.id}`, {
+          data: story,
+        });
+        dispatch({
+          type: STORY_ACTION_TYPES.UPDATE_STORY,
+          payload: reshapeStoryObject(editStoryURL)(response),
+        });
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
+    },
+    [api.stories, editStoryURL]
+  );
+
   const getAllFonts = useCallback(() => {
     if (!api.fonts) {
       return Promise.resolve([]);
@@ -178,19 +196,21 @@ export default function ApiProvider({ children }) {
         fetchStories,
         templateApi,
         getAllFonts,
+        updateStory,
       },
     }),
     [
-      fetchStories,
-      templates,
-      templateApi,
-      getAllFonts,
       state.allPagesFetched,
       state.isLoading,
       state.stories,
       state.storiesOrderById,
       state.totalStories,
       state.totalPages,
+      templates,
+      fetchStories,
+      templateApi,
+      getAllFonts,
+      updateStory,
     ]
   );
 

--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -22,7 +22,37 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import { reshapeStoryObject } from '../apiProvider';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useContext } from 'react';
+import ApiProvider, { ApiContext, reshapeStoryObject } from '../apiProvider';
+import { ConfigProvider } from '../../config';
+
+jest.mock('../wpAdapter', () => ({
+  get: () =>
+    Promise.resolve({
+      headers: {
+        get: () => '1',
+      },
+      json: () =>
+        Promise.resolve([
+          {
+            id: 123,
+            status: 'published',
+            title: { rendered: 'Carlos', raw: 'Carlos' },
+            story_data: { pages: [{ id: 1, elements: [] }] },
+            modified: '1970-01-01T00:00:00.000Z',
+          },
+        ]),
+    }),
+  post: (path, { data }) =>
+    Promise.resolve({
+      id: data.id,
+      status: 'published',
+      title: { rendered: data.title, raw: data.title },
+      story_data: { pages: [{ id: 1, elements: [] }] },
+      modified: '1970-01-01T00:00:00.000Z',
+    }),
+}));
 
 describe('reshapeStoryObject', () => {
   it('should reshape the response object with a Moment date', () => {
@@ -136,5 +166,90 @@ describe('reshapeStoryObject', () => {
       responseObj
     );
     expect(reshapedObj).toBeNull();
+  });
+});
+
+describe('ApiProvider', () => {
+  it('should return a story in state data when the API request is fired', async () => {
+    const { result } = renderHook(() => useContext(ApiContext), {
+      // eslint-disable-next-line react/display-name
+      wrapper: (props) => (
+        <ConfigProvider
+          config={{ api: { stories: 'stories' }, editStoryURL: 'editStory' }}
+        >
+          <ApiProvider {...props} />
+        </ConfigProvider>
+      ),
+    });
+
+    await act(async () => {
+      await result.current.actions.fetchStories({});
+    });
+
+    expect(result.current.state.stories).toStrictEqual({
+      '123': {
+        bottomTargetAction: 'editStory&post=123',
+        centerTargetAction: '',
+        id: 123,
+        modified: moment('1970-01-01T00:00:00.000Z'),
+        pages: [
+          {
+            elements: [],
+            id: 1,
+          },
+        ],
+        status: 'published',
+        title: 'Carlos',
+      },
+    });
+  });
+
+  it('should return an updated story in state data when the API request is fired', async () => {
+    const { result } = renderHook(() => useContext(ApiContext), {
+      // eslint-disable-next-line react/display-name
+      wrapper: (props) => (
+        <ConfigProvider
+          config={{ api: { stories: 'stories' }, editStoryURL: 'editStory' }}
+        >
+          <ApiProvider {...props} />
+        </ConfigProvider>
+      ),
+    });
+
+    await act(async () => {
+      await result.current.actions.fetchStories({});
+    });
+
+    await act(async () => {
+      await result.current.actions.updateStory({
+        id: 123,
+        modified: moment('1970-01-01T00:00:00.000Z'),
+        pages: [
+          {
+            elements: [],
+            id: 1,
+          },
+        ],
+        status: 'published',
+        title: 'New Title',
+      });
+    });
+
+    expect(result.current.state.stories).toStrictEqual({
+      '123': {
+        bottomTargetAction: 'editStory&post=123',
+        centerTargetAction: '',
+        id: 123,
+        modified: moment('1970-01-01T00:00:00.000Z'),
+        pages: [
+          {
+            elements: [],
+            id: 1,
+          },
+        ],
+        status: 'published',
+        title: 'New Title',
+      },
+    });
   });
 });

--- a/assets/src/dashboard/app/api/test/wpAdapter.js
+++ b/assets/src/dashboard/app/api/test/wpAdapter.js
@@ -31,7 +31,7 @@ describe('wpAdapter', () => {
 
     jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
 
-    wpAdapter.get('https://stories.google.com');
+    wpAdapter.get('https://stories.google.com').catch(() => {});
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
@@ -50,7 +50,9 @@ describe('wpAdapter', () => {
 
     jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
 
-    wpAdapter.post('https://stories.google.com', { data: 'Carlos' });
+    wpAdapter
+      .post('https://stories.google.com', { data: 'Carlos' })
+      .catch(() => {});
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
@@ -74,7 +76,7 @@ describe('wpAdapter', () => {
 
     jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
 
-    wpAdapter.deleteRequest('https://stories.google.com');
+    wpAdapter.deleteRequest('https://stories.google.com').catch(() => {});
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(

--- a/assets/src/dashboard/app/api/test/wpAdapter.js
+++ b/assets/src/dashboard/app/api/test/wpAdapter.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import wpAdapter from '../wpAdapter';
+
+describe('wpAdapter', () => {
+  afterEach(() => {
+    global.fetch.mockClear();
+  });
+
+  it('calls fetch with options for GET request', () => {
+    const mockFetchPromise = Promise.resolve({
+      json: () => Promise.resolve({}),
+    });
+
+    jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
+
+    wpAdapter.get('https://stories.google.com');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://stories.google.com?_locale=user',
+      {
+        credentials: 'include',
+        headers: { Accept: 'application/json, */*;q=0.1' },
+      }
+    );
+  });
+
+  it('calls fetch with options for POST request', () => {
+    const mockFetchPromise = Promise.resolve({
+      json: () => Promise.resolve({}),
+    });
+
+    jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
+
+    wpAdapter.post('https://stories.google.com', { data: 'Carlos' });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://stories.google.com?_locale=user',
+      {
+        body: JSON.stringify('Carlos'),
+        credentials: 'include',
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, */*;q=0.1',
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  });
+
+  it('calls fetch with options for DELETE request', () => {
+    const mockFetchPromise = Promise.resolve({
+      json: () => Promise.resolve({}),
+    });
+
+    jest.spyOn(global, 'fetch').mockImplementation(() => mockFetchPromise);
+
+    wpAdapter.deleteRequest('https://stories.google.com');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://stories.google.com?_locale=user',
+      {
+        credentials: 'include',
+        method: 'POST',
+        headers: {
+          Accept: 'application/json, */*;q=0.1',
+          'Content-Type': 'application/json',
+          'X-HTTP-Method-Override': 'DELETE',
+        },
+      }
+    );
+  });
+});

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -23,6 +23,7 @@ export const ACTION_TYPES = {
   LOADING_STORIES: 'loading_stories',
   FETCH_STORIES_SUCCESS: 'fetch_stories_success',
   FETCH_STORIES_FAILURE: 'fetch_stories_failure',
+  UPDATE_STORY: 'update_story',
 };
 
 export const defaultStoriesState = {
@@ -46,6 +47,15 @@ function storyReducer(state, action) {
       return {
         ...state,
         isError: action.payload,
+      };
+
+    case ACTION_TYPES.UPDATE_STORY:
+      return {
+        ...state,
+        stories: {
+          ...state.stories,
+          [action.payload.id]: action.payload,
+        },
       };
 
     case ACTION_TYPES.FETCH_STORIES_SUCCESS: {

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -123,4 +123,32 @@ describe('storyReducer', () => {
       isError: true,
     });
   });
+
+  it(`should update stories state when ${ACTION_TYPES.UPDATE_STORY} is called`, () => {
+    const result = storyReducer(
+      {
+        ...initialState,
+        stories: {
+          94: { id: 94, status: 'draft', title: 'my test story 1' },
+          65: { id: 65, status: 'published', title: 'my test story 2' },
+          78: { id: 78, status: 'draft', title: 'my test story 3' },
+          12: { id: 12, status: 'draft', title: 'my test story 4' },
+        },
+      },
+      {
+        type: ACTION_TYPES.UPDATE_STORY,
+        payload: { id: 65, status: 'published', title: 'new title for story' },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      stories: {
+        94: { id: 94, status: 'draft', title: 'my test story 1' },
+        65: { id: 65, status: 'published', title: 'new title for story' },
+        78: { id: 78, status: 'draft', title: 'my test story 3' },
+        12: { id: 12, status: 'draft', title: 'my test story 4' },
+      },
+    });
+  });
 });

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -98,7 +98,7 @@ function MyStories() {
     thumbnailMode: viewStyle === VIEW_STYLE.LIST,
   });
   const {
-    actions: { fetchStories },
+    actions: { fetchStories, updateStory },
     state: {
       allPagesFetched,
       stories,
@@ -187,6 +187,7 @@ function MyStories() {
       case VIEW_STYLE.GRID:
         return (
           <StoryGridView
+            updateStory={updateStory}
             filteredStories={orderedStories}
             centerActionLabel={
               <>
@@ -211,11 +212,12 @@ function MyStories() {
         return null;
     }
   }, [
+    viewStyle,
+    updateStory,
+    orderedStories,
     currentStorySort,
     currentListSortDirection,
     handleNewStorySort,
-    orderedStories,
-    viewStyle,
   ]);
 
   const storiesViewControls = useMemo(() => {

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -54,8 +55,10 @@ const StoryGridView = ({
   filteredStories,
   centerActionLabel,
   bottomActionLabel,
+  updateStory,
 }) => {
   const [contextMenuId, setContextMenuId] = useState(-1);
+  const [titleRenameId, setTitleRenameId] = useState(-1);
 
   const handleMenuItemSelected = useCallback((sender, story) => {
     setContextMenuId(-1);
@@ -63,11 +66,22 @@ const StoryGridView = ({
       case STORY_CONTEXT_MENU_ACTIONS.OPEN_IN_EDITOR:
         window.location.href = story.bottomTargetAction;
         break;
+      case STORY_CONTEXT_MENU_ACTIONS.RENAME:
+        setTitleRenameId(story.id);
+        break;
 
       default:
         break;
     }
   }, []);
+
+  const handleOnRenameStory = useCallback(
+    (story, newTitle) => {
+      setTitleRenameId(-1);
+      updateStory({ ...story, title: { raw: newTitle } });
+    },
+    [updateStory]
+  );
 
   return (
     <StoryGrid>
@@ -91,6 +105,11 @@ const StoryGridView = ({
             <CardTitle
               title={story.title}
               modifiedDate={story.modified.startOf('day').fromNow()}
+              onEditComplete={(newTitle) =>
+                handleOnRenameStory(story, newTitle)
+              }
+              onEditCancel={() => setTitleRenameId(-1)}
+              editMode={titleRenameId === story.id}
             />
             <CardItemMenu
               onMoreButtonSelected={setContextMenuId}
@@ -109,6 +128,7 @@ StoryGridView.propTypes = {
   filteredStories: StoriesPropType,
   centerActionLabel: ActionLabel,
   bottomActionLabel: ActionLabel,
+  updateStory: PropTypes.func.isRequired,
 };
 
 export default StoryGridView;

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -28,9 +28,10 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { CARD_TITLE_AREA_HEIGHT } from '../../constants';
 import { TextInput } from '../input';
+import useFocusOut from '../../utils/useFocusOut';
 
 const StyledCardTitle = styled.div`
   font-family: ${({ theme }) => theme.fonts.storyGridItem.family};
@@ -65,7 +66,18 @@ const CardTitle = ({
   onEditComplete,
   onEditCancel,
 }) => {
+  const inputContainerRef = useRef(null);
   const [newTitle, setNewTitle] = useState(title);
+
+  useFocusOut(
+    inputContainerRef,
+    () => {
+      if (editMode) {
+        onEditCancel();
+      }
+    },
+    [editMode]
+  );
 
   const handleChange = useCallback(({ target }) => {
     setNewTitle(target.value);
@@ -85,12 +97,14 @@ const CardTitle = ({
   return (
     <StyledCardTitle>
       {editMode ? (
-        <TextInput
-          data-testid={'title-rename-input'}
-          value={newTitle}
-          onKeyDown={handleKeyPress}
-          onChange={handleChange}
-        />
+        <div ref={inputContainerRef}>
+          <TextInput
+            data-testid={'title-rename-input'}
+            value={newTitle}
+            onKeyDown={handleKeyPress}
+            onChange={handleChange}
+          />
+        </div>
       ) : (
         <StyledTitle>{title}</StyledTitle>
       )}

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -22,13 +22,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
+import { useCallback, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
  * Internal dependencies
  */
-import { useCallback, useRef, useState } from 'react';
 import { CARD_TITLE_AREA_HEIGHT } from '../../constants';
 import { TextInput } from '../input';
 import useFocusOut from '../../utils/useFocusOut';

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -28,7 +28,9 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
+import { useCallback, useState } from 'react';
 import { CARD_TITLE_AREA_HEIGHT } from '../../constants';
+import { TextInput } from '../input';
 
 const StyledCardTitle = styled.div`
   font-family: ${({ theme }) => theme.fonts.storyGridItem.family};
@@ -56,19 +58,54 @@ const StyledDate = styled.p`
   font-family: ${({ theme }) => theme.fonts.storyGridItemSub.family};
 `;
 
-// TODO this needs date handling
-// TODO modify to handle other types of card titles - not just own stories
-const CardTitle = ({ title, modifiedDate }) => (
-  <StyledCardTitle>
-    <StyledTitle>{title}</StyledTitle>
-    <StyledDate>{`
+const CardTitle = ({
+  title,
+  modifiedDate,
+  editMode,
+  onEditComplete,
+  onEditCancel,
+}) => {
+  const [newTitle, setNewTitle] = useState(title);
+
+  const handleChange = useCallback(({ target }) => {
+    setNewTitle(target.value);
+  }, []);
+
+  const handleKeyPress = useCallback(
+    ({ nativeEvent }) => {
+      if (nativeEvent.keyCode === 13) {
+        onEditComplete(newTitle);
+      } else if (nativeEvent.keyCode === 27) {
+        onEditCancel();
+      }
+    },
+    [newTitle, onEditComplete, onEditCancel]
+  );
+
+  return (
+    <StyledCardTitle>
+      {editMode ? (
+        <TextInput
+          data-testid={'title-rename-input'}
+          value={newTitle}
+          onKeyDown={handleKeyPress}
+          onChange={handleChange}
+        />
+      ) : (
+        <StyledTitle>{title}</StyledTitle>
+      )}
+      <StyledDate>{`
       ${__('Modified', 'web-stories')} ${modifiedDate} `}</StyledDate>
-  </StyledCardTitle>
-);
+    </StyledCardTitle>
+  );
+};
 
 CardTitle.propTypes = {
   title: PropTypes.string.isRequired,
+  editMode: PropTypes.bool,
   modifiedDate: PropTypes.string.isRequired,
+  onEditComplete: PropTypes.func.isRequired,
+  onEditCancel: PropTypes.func.isRequired,
 };
 
 export default CardTitle;

--- a/assets/src/dashboard/components/cardGridItem/test/cartTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/test/cartTitle.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { ThemeProvider } from 'styled-components';
+import CardTitle from '../cardTitle';
+import theme from '../../../theme';
+
+const wrapper = (children) => {
+  return render(<ThemeProvider theme={theme}>{children}</ThemeProvider>);
+};
+
+describe('CardTitle', () => {
+  it('should render Card Title with static text when edit mode is false', () => {
+    const { getByText, queryByTestId } = wrapper(
+      <CardTitle
+        title="Sample Story"
+        modifiedDate="July 13"
+        onEditCancel={jest.fn()}
+        onEditComplete={jest.fn}
+        editMode={false}
+      />
+    );
+
+    expect(queryByTestId('title-rename-input')).toBeNull();
+    expect(getByText('Sample Story')).toBeDefined();
+  });
+
+  it('should render Card Title with an input field when edit mode is true', () => {
+    const { getByTestId } = wrapper(
+      <CardTitle
+        title="Sample Story"
+        modifiedDate="July 13"
+        onEditCancel={jest.fn()}
+        onEditComplete={jest.fn}
+        editMode={true}
+      />
+    );
+
+    expect(getByTestId('title-rename-input')).toBeDefined();
+  });
+});

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -51,3 +51,4 @@ export {
 } from './table';
 export { default as MultiPartPill } from './multiPartPill';
 export { LeftRail, PageContent, AppFrame } from './pageStructure';
+export { TextInput } from './input';

--- a/assets/src/dashboard/components/input/index.js
+++ b/assets/src/dashboard/components/input/index.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+export const TextInput = styled.input`
+  margin: 0;
+  padding: ${({ theme }) => theme.fonts.textInput.padding};
+  border-radius: 6px;
+  border: ${({ theme }) => theme.fonts.textInput.border};
+  font-family: ${({ theme }) => theme.fonts.textInput.family};
+  font-size: ${({ theme }) => theme.fonts.textInput.size}px;
+  letter-spacing: ${({ theme }) => theme.fonts.textInput.letterSpacing};
+`;

--- a/assets/src/dashboard/components/input/stories/index.js
+++ b/assets/src/dashboard/components/input/stories/index.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import { TextInput } from '../index';
+
+export default {
+  title: 'Dashboard/Components/TextInput',
+  component: TextInput,
+};
+
+export const _default = () => {
+  return <TextInput value={text('Text', 'Hello Storybook')} />;
+};

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -218,6 +218,15 @@ const theme = {
       weight: '500',
       letterSpacing: '0.01em',
     },
+    textInput: {
+      family: "'Google Sans', sans-serif",
+      size: 13,
+      border: `1px solid ${colors.gray100}`,
+      activeBorder: `1px solid ${colors.bluePrimary}`,
+      weight: '400',
+      letterSpacing: '0.01em',
+      padding: '1px 8px',
+    },
     storyGridItem: {
       family: "'Google Sans', sans-serif",
       size: '14px',


### PR DESCRIPTION
The first half of https://github.com/google/web-stories-wp/issues/768

**Description**
Adds the ability to rename a story from the contextual menu on the dashboard. This also adds a simple styled input field that mirrors the Material Design input from Google Docs. This can be updated when designs are more fleshed out. Also included are reducer actions and the POST request for updating the story in the database.

To close the box without saving the user would hit `Esc` to save they would hit `Enter`.

![Kapture 2020-04-23 at 14 24 52](https://user-images.githubusercontent.com/1738349/80140878-3b89ba00-856e-11ea-825f-fdcf57ec00e0.gif)



