### PR TITLE
Dashboard: Move story and font actions to their own files

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -39,7 +39,6 @@ export default function ApiProvider({ children }) {
   });
 
   const { stories, api: storyApi } = useStoryApi(dataAdapter, {
-    pluginDir,
     editStoryURL,
     wpApi: api.stories,
   });

--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -18,200 +18,47 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { createContext, useCallback, useMemo, useReducer } from 'react';
-import moment from 'moment';
-import queryString from 'query-string';
+import { createContext, useMemo } from 'react';
 
 /**
  * Internal dependencies
  */
 import { useConfig } from '../config';
-import {
-  STORY_STATUSES,
-  STORY_SORT_OPTIONS,
-  ORDER_BY_SORT,
-  ITEMS_PER_PAGE,
-} from '../../constants';
-import storyReducer, {
-  defaultStoriesState,
-  ACTION_TYPES as STORY_ACTION_TYPES,
-} from '../reducer/stories';
+import useFontApi from './useFontApi';
+import useStoryApi from './useStoryApi';
 import useTemplateApi from './useTemplateApi';
 import dataAdapter from './wpAdapter';
 
 export const ApiContext = createContext({ state: {}, actions: {} });
 
-export function reshapeStoryObject(editStoryURL) {
-  return function ({ id, title, modified, status, story_data: storyData }) {
-    if (
-      !Array.isArray(storyData.pages) ||
-      !id ||
-      storyData.pages.length === 0
-    ) {
-      return null;
-    }
-    return {
-      id,
-      status,
-      title: title.rendered,
-      modified: moment(modified),
-      pages: storyData.pages,
-      centerTargetAction: '',
-      bottomTargetAction: `${editStoryURL}&post=${id}`,
-    };
-  };
-}
-
 export default function ApiProvider({ children }) {
   const { api, editStoryURL, pluginDir } = useConfig();
-  const [state, dispatch] = useReducer(storyReducer, defaultStoriesState);
 
   const { templates, api: templateApi } = useTemplateApi(dataAdapter, {
     pluginDir,
   });
 
-  const fetchStories = useCallback(
-    async ({
-      status = STORY_STATUSES[0].value,
-      sortOption = STORY_SORT_OPTIONS.LAST_MODIFIED,
-      sortDirection,
-      searchTerm,
-      page = 1,
-      perPage = ITEMS_PER_PAGE,
-    }) => {
-      dispatch({
-        type: STORY_ACTION_TYPES.LOADING_STORIES,
-        payload: true,
-      });
+  const { stories, api: storyApi } = useStoryApi(dataAdapter, {
+    pluginDir,
+    editStoryURL,
+    wpApi: api.stories,
+  });
 
-      if (!api.stories) {
-        dispatch({
-          type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
-          payload: true,
-        });
-        return [];
-      }
-
-      const query = {
-        context: 'edit',
-        search: searchTerm || undefined,
-        orderby: sortOption,
-        page,
-        per_page: perPage,
-        order: sortDirection || ORDER_BY_SORT[sortOption],
-        status,
-      };
-
-      try {
-        const path = queryString.stringifyUrl({
-          url: api.stories,
-          query,
-        });
-
-        const response = await dataAdapter.get(path, {
-          parse: false,
-        });
-
-        // TODO add headers for totals by status and have header reflect search
-        // only update totals when data is different
-        const totalStories = parseInt(response.headers.get('X-WP-Total'));
-        const totalPages = parseInt(response.headers.get('X-WP-TotalPages'));
-
-        const serverStoryResponse = await response.json();
-
-        const reshapedStories = serverStoryResponse
-          .map(reshapeStoryObject(editStoryURL))
-          .filter(Boolean);
-
-        dispatch({
-          type: STORY_ACTION_TYPES.FETCH_STORIES_SUCCESS,
-          payload: {
-            stories: reshapedStories,
-            totalPages,
-            totalStories,
-            page,
-          },
-        });
-
-        return reshapedStories;
-      } catch (err) {
-        dispatch({
-          type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
-          payload: true,
-        });
-        return [];
-      } finally {
-        dispatch({
-          type: STORY_ACTION_TYPES.LOADING_STORIES,
-          payload: false,
-        });
-      }
-    },
-    [api.stories, editStoryURL]
-  );
-
-  const updateStory = useCallback(
-    async (story) => {
-      try {
-        const response = await dataAdapter.post(`${api.stories}/${story.id}`, {
-          data: story,
-        });
-        dispatch({
-          type: STORY_ACTION_TYPES.UPDATE_STORY,
-          payload: reshapeStoryObject(editStoryURL)(response),
-        });
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e);
-      }
-    },
-    [api.stories, editStoryURL]
-  );
-
-  const getAllFonts = useCallback(() => {
-    if (!api.fonts) {
-      return Promise.resolve([]);
-    }
-
-    return dataAdapter.get(api.fonts).then((data) =>
-      data.map((font) => ({
-        value: font.name,
-        ...font,
-      }))
-    );
-  }, [api.fonts]);
+  const { api: fontApi } = useFontApi(dataAdapter, { wpApi: api.fonts });
 
   const value = useMemo(
     () => ({
       state: {
-        allPagesFetched: state.allPagesFetched,
-        isLoading: state.isLoading,
-        stories: state.stories,
-        storiesOrderById: state.storiesOrderById,
-        totalStories: state.totalStories,
-        totalPages: state.totalPages,
+        stories,
         templates,
       },
       actions: {
-        fetchStories,
+        storyApi,
         templateApi,
-        getAllFonts,
-        updateStory,
+        fontApi,
       },
     }),
-    [
-      state.allPagesFetched,
-      state.isLoading,
-      state.stories,
-      state.storiesOrderById,
-      state.totalStories,
-      state.totalPages,
-      templates,
-      fetchStories,
-      templateApi,
-      getAllFonts,
-      updateStory,
-    ]
+    [stories, templates, storyApi, templateApi, fontApi]
   );
 
   return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;

--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -24,7 +24,7 @@ import moment from 'moment';
  */
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useContext } from 'react';
-import ApiProvider, { ApiContext, reshapeStoryObject } from '../apiProvider';
+import ApiProvider, { ApiContext } from '../apiProvider';
 import { ConfigProvider } from '../../config';
 
 jest.mock('../wpAdapter', () => ({
@@ -54,121 +54,6 @@ jest.mock('../wpAdapter', () => ({
     }),
 }));
 
-describe('reshapeStoryObject', () => {
-  it('should reshape the response object with a Moment date', () => {
-    const responseObj = {
-      id: 27,
-      date: '2020-03-26T20:57:24',
-      date_gmt: '2020-03-26T20:57:24',
-      guid: {
-        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=27',
-      },
-      modified: '2020-03-26T21:42:14',
-      modified_gmt: '2020-03-26T21:42:14',
-      slug: '',
-      status: 'draft',
-      type: 'web-story',
-      link: 'http://localhost:8899/?post_type=web-story&p=27',
-      title: { rendered: 'Carlos Draft' },
-      content: {
-        rendered: `<p><html amp="" lang="en"><head><meta charSet="utf…></amp-story-page></amp-story></body></html></p>`,
-        protected: false,
-      },
-      excerpt: { rendered: '', protected: false },
-      author: 1,
-      featured_media: 0,
-      template: '',
-      categories: [],
-      tags: [],
-      featured_media_url: '',
-      story_data: { pages: [{ id: 0, elements: [] }] },
-    };
-
-    const reshapedObj = reshapeStoryObject('http://editstory.com?action=edit')(
-      responseObj
-    );
-
-    expect(reshapedObj).toMatchObject({
-      id: 27,
-      title: 'Carlos Draft',
-      status: 'draft',
-      modified: moment('2020-03-26T21:42:14'),
-      pages: [{ id: 0, elements: [] }],
-      centerTargetAction: '',
-      bottomTargetAction: 'http://editstory.com?action=edit&post=27',
-    });
-  });
-
-  it('should return null if the ID is missing', () => {
-    const responseObj = {
-      date: '2020-03-26T20:57:24',
-      date_gmt: '2020-03-26T20:57:24',
-      guid: {
-        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=27',
-      },
-      modified: '2020-03-26T21:42:14',
-      modified_gmt: '2020-03-26T21:42:14',
-      slug: '',
-      status: 'draft',
-      type: 'web-story',
-      link: 'http://localhost:8899/?post_type=web-story&p=27',
-      title: { rendered: 'Carlos Draft' },
-      content: {
-        rendered: `<p><html amp="" lang="en"><head><meta charSet="utf…></amp-story-page></amp-story></body></html></p>`,
-        protected: false,
-      },
-      excerpt: { rendered: '', protected: false },
-      author: 1,
-      featured_media: 0,
-      template: '',
-      categories: [],
-      tags: [],
-      featured_media_url: '',
-      story_data: { pages: [{ id: 0, elements: [] }] },
-    };
-
-    const reshapedObj = reshapeStoryObject('http://editstory.com?action=edit')(
-      responseObj
-    );
-    expect(reshapedObj).toBeNull();
-  });
-
-  it('should return null if the story has no pages', () => {
-    const responseObj = {
-      id: 27,
-      date: '2020-03-26T20:57:24',
-      date_gmt: '2020-03-26T20:57:24',
-      guid: {
-        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=27',
-      },
-      modified: '2020-03-26T21:42:14',
-      modified_gmt: '2020-03-26T21:42:14',
-      slug: '',
-      status: 'draft',
-      type: 'web-story',
-      link: 'http://localhost:8899/?post_type=web-story&p=27',
-      title: { rendered: 'Carlos Draft' },
-      content: {
-        rendered: `<p><html amp="" lang="en"><head><meta charSet="utf…></amp-story-page></amp-story></body></html></p>`,
-        protected: false,
-      },
-      excerpt: { rendered: '', protected: false },
-      author: 1,
-      featured_media: 0,
-      template: '',
-      categories: [],
-      tags: [],
-      featured_media_url: '',
-      story_data: { pages: [] },
-    };
-
-    const reshapedObj = reshapeStoryObject('http://editstory.com?action=edit')(
-      responseObj
-    );
-    expect(reshapedObj).toBeNull();
-  });
-});
-
 describe('ApiProvider', () => {
   it('should return a story in state data when the API request is fired', async () => {
     const { result } = renderHook(() => useContext(ApiContext), {
@@ -183,10 +68,10 @@ describe('ApiProvider', () => {
     });
 
     await act(async () => {
-      await result.current.actions.fetchStories({});
+      await result.current.actions.storyApi.fetchStories({});
     });
 
-    expect(result.current.state.stories).toStrictEqual({
+    expect(result.current.state.stories.stories).toStrictEqual({
       '123': {
         bottomTargetAction: 'editStory&post=123',
         centerTargetAction: '',
@@ -217,11 +102,11 @@ describe('ApiProvider', () => {
     });
 
     await act(async () => {
-      await result.current.actions.fetchStories({});
+      await result.current.actions.storyApi.fetchStories({});
     });
 
     await act(async () => {
-      await result.current.actions.updateStory({
+      await result.current.actions.storyApi.updateStory({
         id: 123,
         modified: moment('1970-01-01T00:00:00.000Z'),
         pages: [
@@ -235,7 +120,7 @@ describe('ApiProvider', () => {
       });
     });
 
-    expect(result.current.state.stories).toStrictEqual({
+    expect(result.current.state.stories.stories).toStrictEqual({
       '123': {
         bottomTargetAction: 'editStory&post=123',
         centerTargetAction: '',

--- a/assets/src/dashboard/app/api/test/useStoryApi.js
+++ b/assets/src/dashboard/app/api/test/useStoryApi.js
@@ -24,33 +24,6 @@ import moment from 'moment';
  */
 import { reshapeStoryObject } from '../useStoryApi';
 
-jest.mock('../wpAdapter', () => ({
-  get: () =>
-    Promise.resolve({
-      headers: {
-        get: () => '1',
-      },
-      json: () =>
-        Promise.resolve([
-          {
-            id: 123,
-            status: 'published',
-            title: { rendered: 'Carlos', raw: 'Carlos' },
-            story_data: { pages: [{ id: 1, elements: [] }] },
-            modified: '1970-01-01T00:00:00.000Z',
-          },
-        ]),
-    }),
-  post: (path, { data }) =>
-    Promise.resolve({
-      id: data.id,
-      status: 'published',
-      title: { rendered: data.title, raw: data.title },
-      story_data: { pages: [{ id: 1, elements: [] }] },
-      modified: '1970-01-01T00:00:00.000Z',
-    }),
-}));
-
 describe('reshapeStoryObject', () => {
   it('should reshape the response object with a Moment date', () => {
     const responseObj = {

--- a/assets/src/dashboard/app/api/test/useStoryApi.js
+++ b/assets/src/dashboard/app/api/test/useStoryApi.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { reshapeStoryObject } from '../useStoryApi';
+
+jest.mock('../wpAdapter', () => ({
+  get: () =>
+    Promise.resolve({
+      headers: {
+        get: () => '1',
+      },
+      json: () =>
+        Promise.resolve([
+          {
+            id: 123,
+            status: 'published',
+            title: { rendered: 'Carlos', raw: 'Carlos' },
+            story_data: { pages: [{ id: 1, elements: [] }] },
+            modified: '1970-01-01T00:00:00.000Z',
+          },
+        ]),
+    }),
+  post: (path, { data }) =>
+    Promise.resolve({
+      id: data.id,
+      status: 'published',
+      title: { rendered: data.title, raw: data.title },
+      story_data: { pages: [{ id: 1, elements: [] }] },
+      modified: '1970-01-01T00:00:00.000Z',
+    }),
+}));
+
+describe('reshapeStoryObject', () => {
+  it('should reshape the response object with a Moment date', () => {
+    const responseObj = {
+      id: 27,
+      date: '2020-03-26T20:57:24',
+      date_gmt: '2020-03-26T20:57:24',
+      guid: {
+        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=27',
+      },
+      modified: '2020-03-26T21:42:14',
+      modified_gmt: '2020-03-26T21:42:14',
+      slug: '',
+      status: 'draft',
+      type: 'web-story',
+      link: 'http://localhost:8899/?post_type=web-story&p=27',
+      title: { rendered: 'Carlos Draft' },
+      content: {
+        rendered: `<p><html amp="" lang="en"><head><meta charSet="utf…></amp-story-page></amp-story></body></html></p>`,
+        protected: false,
+      },
+      excerpt: { rendered: '', protected: false },
+      author: 1,
+      featured_media: 0,
+      template: '',
+      categories: [],
+      tags: [],
+      featured_media_url: '',
+      story_data: { pages: [{ id: 0, elements: [] }] },
+    };
+
+    const reshapedObj = reshapeStoryObject('http://editstory.com?action=edit')(
+      responseObj
+    );
+
+    expect(reshapedObj).toMatchObject({
+      id: 27,
+      title: 'Carlos Draft',
+      status: 'draft',
+      modified: moment('2020-03-26T21:42:14'),
+      pages: [{ id: 0, elements: [] }],
+      centerTargetAction: '',
+      bottomTargetAction: 'http://editstory.com?action=edit&post=27',
+    });
+  });
+
+  it('should return null if the ID is missing', () => {
+    const responseObj = {
+      date: '2020-03-26T20:57:24',
+      date_gmt: '2020-03-26T20:57:24',
+      guid: {
+        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=27',
+      },
+      modified: '2020-03-26T21:42:14',
+      modified_gmt: '2020-03-26T21:42:14',
+      slug: '',
+      status: 'draft',
+      type: 'web-story',
+      link: 'http://localhost:8899/?post_type=web-story&p=27',
+      title: { rendered: 'Carlos Draft' },
+      content: {
+        rendered: `<p><html amp="" lang="en"><head><meta charSet="utf…></amp-story-page></amp-story></body></html></p>`,
+        protected: false,
+      },
+      excerpt: { rendered: '', protected: false },
+      author: 1,
+      featured_media: 0,
+      template: '',
+      categories: [],
+      tags: [],
+      featured_media_url: '',
+      story_data: { pages: [{ id: 0, elements: [] }] },
+    };
+
+    const reshapedObj = reshapeStoryObject('http://editstory.com?action=edit')(
+      responseObj
+    );
+    expect(reshapedObj).toBeNull();
+  });
+
+  it('should return null if the story has no pages', () => {
+    const responseObj = {
+      id: 27,
+      date: '2020-03-26T20:57:24',
+      date_gmt: '2020-03-26T20:57:24',
+      guid: {
+        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=27',
+      },
+      modified: '2020-03-26T21:42:14',
+      modified_gmt: '2020-03-26T21:42:14',
+      slug: '',
+      status: 'draft',
+      type: 'web-story',
+      link: 'http://localhost:8899/?post_type=web-story&p=27',
+      title: { rendered: 'Carlos Draft' },
+      content: {
+        rendered: `<p><html amp="" lang="en"><head><meta charSet="utf…></amp-story-page></amp-story></body></html></p>`,
+        protected: false,
+      },
+      excerpt: { rendered: '', protected: false },
+      author: 1,
+      featured_media: 0,
+      template: '',
+      categories: [],
+      tags: [],
+      featured_media_url: '',
+      story_data: { pages: [] },
+    };
+
+    const reshapedObj = reshapeStoryObject('http://editstory.com?action=edit')(
+      responseObj
+    );
+    expect(reshapedObj).toBeNull();
+  });
+});

--- a/assets/src/dashboard/app/api/useFontApi.js
+++ b/assets/src/dashboard/app/api/useFontApi.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo } from 'react';
+
+const useFontApi = (dataAdapter, { wpApi }) => {
+  const getAllFonts = useCallback(() => {
+    if (!wpApi) {
+      return Promise.resolve([]);
+    }
+
+    return dataAdapter.get(wpApi).then((data) =>
+      data.map((font) => ({
+        value: font.name,
+        ...font,
+      }))
+    );
+  }, [dataAdapter, wpApi]);
+
+  const api = useMemo(
+    () => ({
+      getAllFonts,
+    }),
+    [getAllFonts]
+  );
+
+  return { api };
+};
+
+export default useFontApi;

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -121,13 +121,11 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
             page,
           },
         });
-        return;
       } catch (err) {
         dispatch({
           type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
           payload: true,
         });
-        return;
       } finally {
         dispatch({
           type: STORY_ACTION_TYPES.LOADING_STORIES,

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -78,7 +78,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
           type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
           payload: true,
         });
-        return [];
+        return;
       }
 
       const query = {
@@ -121,14 +121,13 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
             page,
           },
         });
-
-        return reshapedStories;
+        return;
       } catch (err) {
         dispatch({
           type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
           payload: true,
         });
-        return [];
+        return;
       } finally {
         dispatch({
           type: STORY_ACTION_TYPES.LOADING_STORIES,

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo, useReducer } from 'react';
+import moment from 'moment';
+import queryString from 'query-string';
+
+/**
+ * Internal dependencies
+ */
+import {
+  STORY_STATUSES,
+  STORY_SORT_OPTIONS,
+  ORDER_BY_SORT,
+  ITEMS_PER_PAGE,
+} from '../../constants';
+import storyReducer, {
+  defaultStoriesState,
+  ACTION_TYPES as STORY_ACTION_TYPES,
+} from '../reducer/stories';
+
+export function reshapeStoryObject(editStoryURL) {
+  return function ({ id, title, modified, status, story_data: storyData }) {
+    if (
+      !Array.isArray(storyData.pages) ||
+      !id ||
+      storyData.pages.length === 0
+    ) {
+      return null;
+    }
+    return {
+      id,
+      status,
+      title: title.rendered,
+      modified: moment(modified),
+      pages: storyData.pages,
+      centerTargetAction: '',
+      bottomTargetAction: `${editStoryURL}&post=${id}`,
+    };
+  };
+}
+
+const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
+  const [state, dispatch] = useReducer(storyReducer, defaultStoriesState);
+
+  const fetchStories = useCallback(
+    async ({
+      status = STORY_STATUSES[0].value,
+      sortOption = STORY_SORT_OPTIONS.LAST_MODIFIED,
+      sortDirection,
+      searchTerm,
+      page = 1,
+      perPage = ITEMS_PER_PAGE,
+    }) => {
+      dispatch({
+        type: STORY_ACTION_TYPES.LOADING_STORIES,
+        payload: true,
+      });
+
+      if (!wpApi) {
+        dispatch({
+          type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
+          payload: true,
+        });
+        return [];
+      }
+
+      const query = {
+        context: 'edit',
+        search: searchTerm || undefined,
+        orderby: sortOption,
+        page,
+        per_page: perPage,
+        order: sortDirection || ORDER_BY_SORT[sortOption],
+        status,
+      };
+
+      try {
+        const path = queryString.stringifyUrl({
+          url: wpApi,
+          query,
+        });
+
+        const response = await dataAdapter.get(path, {
+          parse: false,
+        });
+
+        // TODO add headers for totals by status and have header reflect search
+        // only update totals when data is different
+        const totalStories = parseInt(response.headers.get('X-WP-Total'));
+        const totalPages = parseInt(response.headers.get('X-WP-TotalPages'));
+
+        const serverStoryResponse = await response.json();
+
+        const reshapedStories = serverStoryResponse
+          .map(reshapeStoryObject(editStoryURL))
+          .filter(Boolean);
+
+        dispatch({
+          type: STORY_ACTION_TYPES.FETCH_STORIES_SUCCESS,
+          payload: {
+            stories: reshapedStories,
+            totalPages,
+            totalStories,
+            page,
+          },
+        });
+
+        return reshapedStories;
+      } catch (err) {
+        dispatch({
+          type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
+          payload: true,
+        });
+        return [];
+      } finally {
+        dispatch({
+          type: STORY_ACTION_TYPES.LOADING_STORIES,
+          payload: false,
+        });
+      }
+    },
+    [wpApi, dataAdapter, editStoryURL]
+  );
+
+  const updateStory = useCallback(
+    async (story) => {
+      try {
+        const response = await dataAdapter.post(`${wpApi}/${story.id}`, {
+          data: story,
+        });
+        dispatch({
+          type: STORY_ACTION_TYPES.UPDATE_STORY,
+          payload: reshapeStoryObject(editStoryURL)(response),
+        });
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
+    },
+    [wpApi, dataAdapter, editStoryURL]
+  );
+
+  const api = useMemo(
+    () => ({
+      updateStory,
+      fetchStories,
+    }),
+    [updateStory, fetchStories]
+  );
+
+  return { stories: state, api };
+};
+
+export default useStoryApi;

--- a/assets/src/dashboard/app/font/fontProvider.js
+++ b/assets/src/dashboard/app/font/fontProvider.js
@@ -30,7 +30,9 @@ import useLoadFontFiles from '../../../edit-story/app/font/actions/useLoadFontFi
 function FontProvider({ children }) {
   const [fonts, setFonts] = useState([]);
   const {
-    actions: { getAllFonts },
+    actions: {
+      fontApi: { getAllFonts },
+    },
   } = useContext(ApiContext);
 
   const getFontBy = useCallback(

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -102,14 +102,18 @@ function MyStories() {
     thumbnailMode: viewStyle === VIEW_STYLE.LIST,
   });
   const {
-    actions: { fetchStories, updateStory },
+    actions: {
+      storyApi: { updateStory, fetchStories },
+    },
     state: {
-      allPagesFetched,
-      stories,
-      storiesOrderById,
-      totalStories,
-      totalPages,
-      isLoading,
+      stories: {
+        allPagesFetched,
+        stories,
+        storiesOrderById,
+        totalStories,
+        totalPages,
+        isLoading,
+      },
     },
   } = useContext(ApiContext);
 
@@ -126,9 +130,9 @@ function MyStories() {
     currentListSortDirection,
     currentPage,
     currentStorySort,
-    fetchStories,
     status,
     typeaheadValue,
+    fetchStories,
   ]);
 
   const setCurrentPageClamped = useCallback(
@@ -256,9 +260,7 @@ function MyStories() {
             canLoadMore={!allPagesFetched}
             isLoading={isLoading}
             allDataLoadedMessage={__('No more stories', 'web-stories')}
-            onLoadMore={() => {
-              handleNewPageRequest();
-            }}
+            onLoadMore={handleNewPageRequest}
           />
           <ScrollToTop />
         </BodyWrapper>


### PR DESCRIPTION
# Overview 
- Moving story related actions to their own useStoryApi file in provider to clean up apiProvider file, doing the same for fonts. 
- (better test coverage on new files will come later - I want this structure update before I implement scrolling on templates so we have consistent patterns) 

## Testing 
- updating story names and scrolling should both still work as expected. 