### PR TITLE
Dashboard: Set up templates for infinite scroll

### DIFF
--- a/assets/src/dashboard/app/reducer/templates.js
+++ b/assets/src/dashboard/app/reducer/templates.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import groupBy from '../../utils/groupBy';
+
+export const ACTION_TYPES = {
+  LOADING_TEMPLATES: 'loading_templates',
+  FETCH_TEMPLATES_SUCCESS: 'fetch_templates_success',
+  FETCH_TEMPLATES_FAILURE: 'fetch_templates_failure',
+  PLACEHOLDER: 'placeholder',
+};
+
+export const defaultTemplatesState = {
+  allPagesFetched: false,
+  isError: false,
+  isLoading: false,
+  templates: {},
+  templatesOrderById: [],
+  totalTemplates: null,
+  totalPages: null,
+};
+
+function templateReducer(state, action) {
+  switch (action.type) {
+    case ACTION_TYPES.LOADING_TEMPLATES: {
+      return {
+        ...state,
+        isLoading: action.payload,
+      };
+    }
+    case ACTION_TYPES.FETCH_TEMPLATES_FAILURE:
+      return {
+        ...state,
+        isError: action.payload,
+      };
+
+    case ACTION_TYPES.FETCH_TEMPLATES_SUCCESS: {
+      const fetchedTemplatesById = action.payload.templates.map(({ id }) => id);
+
+      const combinedTemplateIds =
+        action.payload.page === 1
+          ? fetchedTemplatesById
+          : [...state.templatesOrderById, ...fetchedTemplatesById];
+
+      // we want to make sure that pagination is kept intact regardless of page number.
+      // we are using infinite scroll, not traditional pagination.
+      // this means we need to append our new templates to the bottom of our already existing templates.
+      // when we combine existing templates with the new ones we need to make sure we're not duplicating anything.
+      const uniqueTemplateIds = combinedTemplateIds.filter(
+        (templateId, index, templateIdsArray) => {
+          return templateIdsArray.indexOf(templateId) === index;
+        }
+      );
+
+      return {
+        ...state,
+        isError: false,
+        templatesOrderById: uniqueTemplateIds,
+        templates: {
+          ...state.templates,
+          ...groupBy(action.payload.templates, 'id'),
+        },
+        totalPages: action.payload.totalPages,
+        totalTemplates: action.payload.totalTemplates,
+        allPagesFetched: action.payload.page >= action.payload.totalPages,
+      };
+    }
+    case ACTION_TYPES.PLACEHOLDER:
+      return defaultTemplatesState;
+
+    default:
+      return state;
+  }
+}
+
+export default templateReducer;

--- a/assets/src/dashboard/app/reducer/test/templates.js
+++ b/assets/src/dashboard/app/reducer/test/templates.js
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import templateReducer, {
+  ACTION_TYPES,
+  defaultTemplatesState as initialState,
+} from '../templates';
+
+describe('templateReducer', () => {
+  it(`should update stories state when ${ACTION_TYPES.FETCH_TEMPLATES_SUCCESS} is called`, () => {
+    const result = templateReducer(initialState, {
+      type: ACTION_TYPES.FETCH_TEMPLATES_SUCCESS,
+      payload: {
+        page: 1,
+        templates: [
+          {
+            id: 1,
+            title: 'Beauty',
+          },
+          {
+            id: 2,
+            title: 'Cooking',
+          },
+          {
+            id: 3,
+            title: 'DIY',
+          },
+          {
+            id: 4,
+            title: 'Cooking',
+          },
+          {
+            id: 5,
+            title: 'Entertainment',
+          },
+        ],
+        totalTemplates: 33,
+        totalPages: 4,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ...initialState,
+      isError: false,
+      templatesOrderById: [1, 2, 3, 4, 5],
+      templates: {
+        1: {
+          id: 1,
+          title: 'Beauty',
+        },
+        2: {
+          id: 2,
+          title: 'Cooking',
+        },
+        3: {
+          id: 3,
+          title: 'DIY',
+        },
+        4: {
+          id: 4,
+          title: 'Cooking',
+        },
+        5: {
+          id: 5,
+          title: 'Entertainment',
+        },
+      },
+      totalTemplates: 33,
+      totalPages: 4,
+      allPagesFetched: false,
+    });
+  });
+
+  it(`should update stories state when ${ACTION_TYPES.FETCH_TEMPLATES_SUCCESS} is called and maintain order from existing state`, () => {
+    const result = templateReducer(
+      { ...initialState, templatesOrderById: [1, 2, 3, 8, 9] },
+      {
+        type: ACTION_TYPES.FETCH_TEMPLATES_SUCCESS,
+        payload: {
+          page: 2,
+          templates: [
+            {
+              id: 7,
+              title: 'Beauty',
+            },
+            {
+              id: 2,
+              title: 'Cooking',
+            },
+            {
+              id: 3,
+              title: 'DIY',
+            },
+            {
+              id: 4,
+              title: 'Cooking',
+            },
+            {
+              id: 5,
+              title: 'Entertainment',
+            },
+          ],
+          totalTemplates: 8,
+          totalPages: 2,
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      templatesOrderById: [1, 2, 3, 8, 9, 7, 4, 5],
+      templates: {
+        7: {
+          id: 7,
+          title: 'Beauty',
+        },
+        2: {
+          id: 2,
+          title: 'Cooking',
+        },
+        3: {
+          id: 3,
+          title: 'DIY',
+        },
+        4: {
+          id: 4,
+          title: 'Cooking',
+        },
+        5: {
+          id: 5,
+          title: 'Entertainment',
+        },
+      },
+      totalTemplates: 8,
+      totalPages: 2,
+      allPagesFetched: true,
+    });
+  });
+
+  it(`should update isLoading when ${ACTION_TYPES.LOADING_TEMPLATES} is called`, () => {
+    const result = templateReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.LOADING_TEMPLATES,
+        payload: true,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      isLoading: true,
+    });
+  });
+
+  it(`should update isError when ${ACTION_TYPES.FETCH_TEMPLATES_FAILURE} is called`, () => {
+    const result = templateReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.FETCH_TEMPLATES_FAILURE,
+        payload: true,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      isError: true,
+    });
+  });
+});

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -28,6 +28,8 @@ import { useCallback, useContext, useEffect, useState, useMemo } from 'react';
 /**
  * Internal dependencies
  */
+import { UnitsProvider } from '../../../../edit-story/units';
+import { TransformProvider } from '../../../../edit-story/components/transform';
 import {
   FloatingTab,
   InfiniteScroller,
@@ -40,13 +42,10 @@ import {
   STORY_SORT_OPTIONS,
   SORT_DIRECTION,
 } from '../../../constants';
-import { ApiContext } from '../../api/apiProvider';
-import { UnitsProvider } from '../../../../edit-story/units';
-import { TransformProvider } from '../../../../edit-story/components/transform';
-import FontProvider from '../../font/fontProvider';
-import clamp from '../../../utils/clamp';
-import usePagePreviewSize from '../../../utils/usePagePreviewSize';
 import { ReactComponent as PlayArrowSvg } from '../../../icons/playArrow.svg';
+import { ApiContext } from '../../api/apiProvider';
+import FontProvider from '../../font/fontProvider';
+import { clamp, usePagePreviewSize } from '../../../utils/';
 import {
   BodyWrapper,
   BodyViewOptions,
@@ -113,11 +112,11 @@ function MyStories() {
     state: {
       stories: {
         allPagesFetched,
+        isLoading,
         stories,
         storiesOrderById,
         totalStories,
         totalPages,
-        isLoading,
       },
     },
   } = useContext(ApiContext);

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -128,7 +128,7 @@ StoryGridView.propTypes = {
   filteredStories: StoriesPropType,
   centerActionLabel: ActionLabel,
   bottomActionLabel: ActionLabel,
-  updateStory: PropTypes.func.isRequired,
+  updateStory: PropTypes.func,
 };
 
 export default StoryGridView;

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -113,10 +113,13 @@ function TemplateDetail() {
     };
   }, [template]);
 
-  const activeTemplateIndex = useMemo(
-    () => orderedTemplates?.findIndex((t) => t.id === template?.id),
-    [template, orderedTemplates]
-  );
+  const activeTemplateIndex = useMemo(() => {
+    if (orderedTemplates.length <= 0) {
+      return 0;
+    }
+
+    return orderedTemplates.findIndex((t) => t.id === template?.id);
+  }, [template, orderedTemplates]);
 
   const previewPages = useMemo(
     () =>

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -28,18 +28,24 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { Layout, Dropdown } from '../../../components';
+import { UnitsProvider } from '../../../../edit-story/units';
+import { TransformProvider } from '../../../../edit-story/components/transform';
+
+import {
+  Layout,
+  Dropdown,
+  InfiniteScroller,
+  ScrollToTop,
+} from '../../../components';
 import { DropdownContainer } from '../../../components/dropdown';
 import {
   VIEW_STYLE,
   DROPDOWN_TYPES,
   STORY_SORT_OPTIONS,
 } from '../../../constants';
+import { clamp, usePagePreviewSize } from '../../../utils/';
 import { ApiContext } from '../../api/apiProvider';
-import { UnitsProvider } from '../../../../edit-story/units';
-import { TransformProvider } from '../../../../edit-story/components/transform';
 import FontProvider from '../../font/fontProvider';
-import usePagePreviewSize from '../../../utils/usePagePreviewSize';
 import {
   BodyWrapper,
   PageHeading,
@@ -62,6 +68,7 @@ const ExploreFiltersContainer = styled.div`
 function TemplatesGallery() {
   const [typeaheadValue, setTypeaheadValue] = useState('');
   const [viewStyle, setViewStyle] = useState(VIEW_STYLE.GRID);
+  const [currentPage, setCurrentPage] = useState(1);
   const [currentTemplateSort, setCurrentTemplateSort] = useState(
     STORY_SORT_OPTIONS.LAST_MODIFIED
   );
@@ -69,20 +76,30 @@ function TemplatesGallery() {
     thumbnailMode: viewStyle === VIEW_STYLE.LIST,
   });
   const {
-    state: { templates },
-    actions: { templateApi },
+    state: {
+      templates: {
+        allPagesFetched,
+        isLoading,
+        templates,
+        templatesOrderById,
+        totalPages,
+        totalTemplates,
+      },
+    },
+    actions: {
+      templateApi: { fetchExternalTemplates },
+    },
   } = useContext(ApiContext);
 
   useEffect(() => {
-    templateApi.fetchExternalTemplates();
-  }, [templateApi]);
+    fetchExternalTemplates();
+  }, [fetchExternalTemplates]);
 
-  const filteredTemplates = useMemo(() => {
-    return templates.filter((template) => {
-      const lowerTypeaheadValue = typeaheadValue.toLowerCase();
-      return template.title.toLowerCase().includes(lowerTypeaheadValue);
+  const orderedTemplates = useMemo(() => {
+    return templatesOrderById.map((templateId) => {
+      return templates[templateId];
     });
-  }, [templates, typeaheadValue]);
+  }, [templatesOrderById, templates]);
 
   const handleViewStyleBarButtonSelected = useCallback(() => {
     if (viewStyle === VIEW_STYLE.LIST) {
@@ -92,35 +109,59 @@ function TemplatesGallery() {
     }
   }, [viewStyle]);
 
-  const filteredTemplatesCount = filteredTemplates.length;
+  const setCurrentPageClamped = useCallback(
+    (newPage) => {
+      const pageRange = [1, totalPages];
+      setCurrentPage(clamp(newPage, pageRange));
+    },
+    [totalPages]
+  );
+
+  const handleNewPageRequest = useCallback(() => {
+    setCurrentPageClamped(currentPage + 1);
+  }, [currentPage, setCurrentPageClamped]);
 
   const listBarLabel = sprintf(
     /* translators: %s: number of stories */
     _n(
       '%s total template',
       '%s total templates',
-      filteredTemplatesCount,
+      totalTemplates,
       'web-stories'
     ),
-    filteredTemplatesCount
+    totalTemplates
   );
 
   const BodyContent = useMemo(() => {
-    if (filteredTemplatesCount > 0) {
+    if (totalTemplates > 0) {
       return (
         <BodyWrapper>
           <StoryGridView
-            filteredStories={filteredTemplates}
+            filteredStories={orderedTemplates}
             centerActionLabel={__('View details', 'web-stories')}
             bottomActionLabel={__('Use template', 'web-stories')}
             updateStory={() => {}}
           />
+          <InfiniteScroller
+            canLoadMore={!allPagesFetched}
+            isLoading={isLoading}
+            allDataLoadedMessage={__('No more templates', 'web-stories')}
+            onLoadMore={handleNewPageRequest}
+          />
+          <ScrollToTop />
         </BodyWrapper>
       );
     }
 
     return <NoResults typeaheadValue={typeaheadValue} />;
-  }, [filteredTemplates, filteredTemplatesCount, typeaheadValue]);
+  }, [
+    allPagesFetched,
+    handleNewPageRequest,
+    isLoading,
+    orderedTemplates,
+    totalTemplates,
+    typeaheadValue,
+  ]);
 
   return (
     <FontProvider>

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -172,7 +172,7 @@ function TemplatesGallery() {
               <PageHeading
                 defaultTitle={__('Explore Templates', 'web-stories')}
                 searchPlaceholder={__('Template Stories', 'web-stories')}
-                filteredStories={filteredTemplates}
+                filteredStories={orderedTemplates}
                 handleTypeaheadChange={setTypeaheadValue}
                 typeaheadValue={typeaheadValue}
               />

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -148,7 +148,6 @@ function TemplatesGallery() {
             allDataLoadedMessage={__('No more templates', 'web-stories')}
             onLoadMore={handleNewPageRequest}
           />
-          <ScrollToTop />
         </BodyWrapper>
       );
     }
@@ -219,6 +218,9 @@ function TemplatesGallery() {
               />
             </Layout.Squishable>
             <Layout.Scrollable>{BodyContent}</Layout.Scrollable>
+            <Layout.Fixed>
+              <ScrollToTop />
+            </Layout.Fixed>
           </Layout.Provider>
         </UnitsProvider>
       </TransformProvider>

--- a/assets/src/dashboard/utils/index.js
+++ b/assets/src/dashboard/utils/index.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as clamp } from './clamp';
+export { default as getCurrentYAxis } from './getCurrentYAxis';
+export { default as groupBy } from './groupBy';
+export { default as keyboardOnlyOutline } from './keyboardOnlyOutline';
+export { default as useFocusOut } from './useFocusOut';
+export { default as usePagePreviewSize } from './usePagePreviewSize';


### PR DESCRIPTION
# Overview 
Even though templates API isn't available yet and everything is local, still a good time to get the infrastructure ready for when we have the APIs working. 
- Giving templates the same treatment we just gave myStories with infinite scroll and the backToTop button. 
- Setting up a reducer for templates and using that as the source of truth for templates instead of useState in useTemplateApi
 - Placeholder action for places that were setting templates to [] (`setTemplates([])` 
- Updating how template is retrieved on detail view by first looking at state and then if id isn't there fetching templates and pulling from state. I know that this functionality isn't fleshed out yet so I didn't update the reducer to grab the template, it's overkill for now. 
- While I was at it, gave the /utils directory an index to reduce the lines of import code for util usage. Swapped out util imports in views, figure the rest can come incrementally. 

## Testing 
- See that there's now a 'No more templates' message when you scroll past the 8 templates available.
- See that there's a scroll to top button and clicking it scrolls to the top. 
- Confirm that template pages (index, details) still render
<img width="1205" alt="Screen Shot 2020-04-24 at 2 24 18 PM" src="https://user-images.githubusercontent.com/10720454/80258120-4f4d2300-8637-11ea-86e3-a547084ee555.png">
