### PR TITLE
Dashboard: Added slide-navigation with responsive support for Dashboard

### DIFF
--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -27,7 +27,7 @@ import PropTypes from 'prop-types';
 import theme, { GlobalStyle } from '../theme';
 import KeyboardOnlyOutline from '../utils/keyboardOnlyOutline';
 import { APP_ROUTES } from '../constants';
-import { AppFrame, LeftRail, PageContent } from '../components';
+import { AppFrame, LeftRail, PageContent, NavProvider } from '../components';
 import ApiProvider from './api/apiProvider';
 import { Route, RouterProvider } from './router';
 import { ConfigProvider } from './config';
@@ -46,30 +46,32 @@ function App({ config }) {
         <ConfigProvider config={config}>
           <ApiProvider>
             <RouterProvider>
-              <GlobalStyle />
-              <KeyboardOnlyOutline />
-              <AppFrame>
-                <LeftRail />
-                <PageContent>
-                  <Route
-                    exact
-                    path={APP_ROUTES.MY_STORIES}
-                    component={<MyStoriesView />}
-                  />
-                  <Route
-                    path={APP_ROUTES.TEMPLATE_DETAIL}
-                    component={<TemplateDetail />}
-                  />
-                  <Route
-                    path={APP_ROUTES.TEMPLATES_GALLERY}
-                    component={<TemplatesGalleryView />}
-                  />
-                  <Route
-                    path={APP_ROUTES.SAVED_TEMPLATES}
-                    component={<SavedTemplatesView />}
-                  />
-                </PageContent>
-              </AppFrame>
+              <NavProvider>
+                <GlobalStyle />
+                <KeyboardOnlyOutline />
+                <AppFrame>
+                  <LeftRail />
+                  <PageContent>
+                    <Route
+                      exact
+                      path={APP_ROUTES.MY_STORIES}
+                      component={<MyStoriesView />}
+                    />
+                    <Route
+                      path={APP_ROUTES.TEMPLATE_DETAIL}
+                      component={<TemplateDetail />}
+                    />
+                    <Route
+                      path={APP_ROUTES.TEMPLATES_GALLERY}
+                      component={<TemplatesGalleryView />}
+                    />
+                    <Route
+                      path={APP_ROUTES.SAVED_TEMPLATES}
+                      component={<SavedTemplatesView />}
+                    />
+                  </PageContent>
+                </AppFrame>
+              </NavProvider>
             </RouterProvider>
           </ApiProvider>
         </ConfigProvider>

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -32,6 +32,9 @@ import {
   FloatingTab,
   InfiniteScroller,
   ScrollToTop,
+  LayoutProvider,
+  LayoutScrollable,
+  LayoutSquishable,
 } from '../../../components';
 import {
   VIEW_STYLE,
@@ -288,28 +291,32 @@ function MyStories() {
     <FontProvider>
       <TransformProvider>
         <UnitsProvider pageSize={pageSize}>
-          <PageHeading
-            defaultTitle={__('My Stories', 'web-stories')}
-            searchPlaceholder={__('Search Stories', 'web-stories')}
-            filteredStories={orderedStories}
-            handleTypeaheadChange={handleTypeaheadChange}
-            typeaheadValue={typeaheadValue}
-          />
-          <FilterContainer>
-            {STORY_STATUSES.map((storyStatus) => (
-              <FloatingTab
-                key={storyStatus.value}
-                onClick={handleFilterStatusUpdate}
-                name="my-stories-filter-selection"
-                value={storyStatus.value}
-                isSelected={status === storyStatus.value}
-                inputType="radio"
-              >
-                {storyStatus.label}
-              </FloatingTab>
-            ))}
-          </FilterContainer>
-          {BodyContent}
+          <LayoutProvider>
+            <LayoutSquishable>
+              <PageHeading
+                defaultTitle={__('My Stories', 'web-stories')}
+                searchPlaceholder={__('Search Stories', 'web-stories')}
+                filteredStories={orderedStories}
+                handleTypeaheadChange={handleTypeaheadChange}
+                typeaheadValue={typeaheadValue}
+              />
+              <FilterContainer>
+                {STORY_STATUSES.map((storyStatus) => (
+                  <FloatingTab
+                    key={storyStatus.value}
+                    onClick={handleFilterStatusUpdate}
+                    name="my-stories-filter-selection"
+                    value={storyStatus.value}
+                    isSelected={status === storyStatus.value}
+                    inputType="radio"
+                  >
+                    {storyStatus.label}
+                  </FloatingTab>
+                ))}
+              </FilterContainer>
+            </LayoutSquishable>
+            <LayoutScrollable>{BodyContent}</LayoutScrollable>
+          </LayoutProvider>
         </UnitsProvider>
       </TransformProvider>
     </FontProvider>

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -32,9 +32,7 @@ import {
   FloatingTab,
   InfiniteScroller,
   ScrollToTop,
-  LayoutProvider,
-  LayoutScrollable,
-  LayoutSquishable,
+  Layout,
 } from '../../../components';
 import {
   VIEW_STYLE,
@@ -86,6 +84,10 @@ const DefaultBodyText = styled.p`
 
 const PlayArrowIcon = styled(PlayArrowSvg).attrs({ width: 11, height: 14 })`
   margin-right: 9px;
+`;
+
+const CardPanel = styled.div`
+  padding-top: 60px;
 `;
 
 function MyStories() {
@@ -256,17 +258,17 @@ function MyStories() {
   const BodyContent = useMemo(() => {
     if (orderedStories.length > 0) {
       return (
-        <BodyWrapper>
-          {storiesViewControls}
-          {storiesView}
-          <InfiniteScroller
-            canLoadMore={!allPagesFetched}
-            isLoading={isLoading}
-            allDataLoadedMessage={__('No more stories', 'web-stories')}
-            onLoadMore={handleNewPageRequest}
-          />
-          <ScrollToTop />
-        </BodyWrapper>
+        <CardPanel>
+          <BodyWrapper>
+            {storiesView}
+            <InfiniteScroller
+              canLoadMore={!allPagesFetched}
+              isLoading={isLoading}
+              allDataLoadedMessage={__('No more stories', 'web-stories')}
+              onLoadMore={handleNewPageRequest}
+            />
+          </BodyWrapper>
+        </CardPanel>
       );
     } else if (typeaheadValue.length > 0) {
       return <NoResults typeaheadValue={typeaheadValue} />;
@@ -283,7 +285,6 @@ function MyStories() {
     allPagesFetched,
     handleNewPageRequest,
     typeaheadValue,
-    storiesViewControls,
     storiesView,
   ]);
 
@@ -291,8 +292,8 @@ function MyStories() {
     <FontProvider>
       <TransformProvider>
         <UnitsProvider pageSize={pageSize}>
-          <LayoutProvider>
-            <LayoutSquishable>
+          <Layout.Provider>
+            <Layout.Squishable>
               <PageHeading
                 defaultTitle={__('My Stories', 'web-stories')}
                 searchPlaceholder={__('Search Stories', 'web-stories')}
@@ -314,9 +315,13 @@ function MyStories() {
                   </FloatingTab>
                 ))}
               </FilterContainer>
-            </LayoutSquishable>
-            <LayoutScrollable>{BodyContent}</LayoutScrollable>
-          </LayoutProvider>
+              {storiesViewControls}
+            </Layout.Squishable>
+            <Layout.Scrollable>{BodyContent}</Layout.Scrollable>
+            <Layout.Fixed>
+              <ScrollToTop />
+            </Layout.Fixed>
+          </Layout.Provider>
         </UnitsProvider>
       </TransformProvider>
     </FontProvider>

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -29,11 +29,9 @@ import {
   DROPDOWN_TYPES,
   VIEW_STYLE,
 } from '../../../constants';
+import BodyWrapper from './bodyWrapper';
 
 const DisplayFormatContainer = styled.div`
-  margin: ${({ theme }) => `${theme.pageGutter.small.desktop}px 0`};
-  padding-bottom: 20px;
-  padding-left: 15px;
   display: flex;
   align-items: space-between;
   align-content: center;
@@ -46,11 +44,6 @@ const StorySortDropdownContainer = styled.div`
 
 const SortDropdown = styled(Dropdown)`
   min-width: 210px;
-  margin-right: 10px;
-
-  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
-    margin-right: 0px;
-  }
 `;
 
 const BodyViewOptions = ({
@@ -61,24 +54,26 @@ const BodyViewOptions = ({
   layoutStyle,
   sortDropdownAriaLabel,
 }) => (
-  <DisplayFormatContainer>
-    <ListBar
-      label={listBarLabel}
-      layoutStyle={layoutStyle}
-      onPress={handleLayoutSelect}
-    />
-    {layoutStyle === VIEW_STYLE.GRID && (
-      <StorySortDropdownContainer>
-        <SortDropdown
-          ariaLabel={sortDropdownAriaLabel}
-          items={STORY_SORT_MENU_ITEMS}
-          type={DROPDOWN_TYPES.TRANSPARENT_MENU}
-          value={currentSort}
-          onChange={(newSort) => handleSortChange(newSort.value)}
-        />
-      </StorySortDropdownContainer>
-    )}
-  </DisplayFormatContainer>
+  <BodyWrapper>
+    <DisplayFormatContainer>
+      <ListBar
+        label={listBarLabel}
+        layoutStyle={layoutStyle}
+        onPress={handleLayoutSelect}
+      />
+      {layoutStyle === VIEW_STYLE.GRID && (
+        <StorySortDropdownContainer>
+          <SortDropdown
+            ariaLabel={sortDropdownAriaLabel}
+            items={STORY_SORT_MENU_ITEMS}
+            type={DROPDOWN_TYPES.TRANSPARENT_MENU}
+            value={currentSort}
+            onChange={(newSort) => handleSortChange(newSort.value)}
+          />
+        </StorySortDropdownContainer>
+      )}
+    </DisplayFormatContainer>
+  </BodyWrapper>
 );
 
 BodyViewOptions.propTypes = {

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -13,12 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * WordPress dependencies
- */
-import { __, sprintf } from '@wordpress/i18n';
-
 /**
  * External dependencies
  */
@@ -30,85 +24,101 @@ import PropTypes from 'prop-types';
  */
 import { StoriesPropType } from '../../../types';
 import { ViewHeader } from '../../../components';
+import BodyWrapper from './bodyWrapper';
 import TypeaheadSearch from './typeaheadSearch';
 
-const Container = styled.div`
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  margin: ${({ theme }) => `20px ${theme.pageGutter.small.desktop}px 40px`};
-  max-width: 100%;
+const lerp = (start, end, progress) => {
+  return `calc(calc(calc(1 - var(${progress}, 0)) * ${start}) + calc(var(${progress}, 0) * ${end}))`;
+};
 
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    display: block;
-    margin: ${({ theme }) => `20px ${theme.pageGutter.small.min}px 60px`};
-  }
+const Container = styled.div`
+  padding: 10px 0;
 `;
 
-const ViewHeaderContainer = styled.div`
-  width: 60%;
-  margin: auto 0;
-  overflow-wrap: break-word;
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    width: 100%;
-    padding-bottom: 5px;
-  }
+const StyledHeader = styled(ViewHeader)`
+  display: inline-block;
+  width: 25%;
+  justify-content: baseline;
+  line-height: 1;
+  font-size: ${lerp('38px', '24px', '--progress')};
+`;
+
+const Content = styled.div`
+  display: inline-block;
+  justify-content: baseline;
+  width: 50%;
 `;
 
 const SearchContainer = styled.div`
-  position: absolute;
-  max-width: 35%;
-  margin: auto 0;
-  right: ${({ theme }) => `${theme.pageGutter.small.desktop}px`};
-  display: flex;
-  justify-content: flex-end;
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
+  display: inline-block;
+  vertical-align: baseline;
+  position: relative;
+  width: 25%;
+  overflow: hidden; 
+  /* needed to break display flow and align bottom to text */
+  /* margin: auto 0; */
+  /* right: ${({ theme }) => `${theme.pageGutter.small.desktop}px`}; */
+  /* display: flex;
+  justify-content: flex-end; */
+  /* @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
     left: ${({ theme }) => `${theme.pageGutter.small.min}px`};
     max-width: 100%;
     justify-content: flex-start;
-  }
+  } */
+`;
+
+const SearchInner = styled.div`
+  position: relative;
+  width: min(190px, 100%);
+  margin-left: auto;
 `;
 
 const PageHeading = ({
+  children,
   defaultTitle,
   searchPlaceholder,
   filteredStories = [],
   handleTypeaheadChange,
   typeaheadValue = '',
 }) => {
-  const resultsText =
-    filteredStories.length > 0
-      ? sprintf(
-          /* translators: %s: search term. */
-          __('Results for "%s"', 'web-stories'),
-          typeaheadValue
-        )
-      : sprintf(
-          /* translators: %s: search term. */
-          __('No results for "%s"', 'web-stories'),
-          typeaheadValue
-        );
-
-  const viewHeaderText = typeaheadValue.length ? resultsText : defaultTitle;
+  // const resultsText =
+  //   filteredStories.length > 0
+  //     ? sprintf(
+  //         /* translators: %s: search term. */
+  //         __('Results for "%s"', 'web-stories'),
+  //         typeaheadValue
+  //       )
+  //     : sprintf(
+  //         /* translators: %s: search term. */
+  //         __('No results for "%s"', 'web-stories'),
+  //         typeaheadValue
+  //       );
 
   return (
     <Container>
-      <ViewHeaderContainer>
-        <ViewHeader>{viewHeaderText}</ViewHeader>
-      </ViewHeaderContainer>
-      <SearchContainer>
-        <TypeaheadSearch
-          placeholder={searchPlaceholder}
-          currentValue={typeaheadValue}
-          filteredStories={filteredStories}
-          handleChange={handleTypeaheadChange}
-        />
-      </SearchContainer>
+      <BodyWrapper>
+        <StyledHeader>{defaultTitle}</StyledHeader>
+        <Content>{children}</Content>
+        <SearchContainer>
+          <SearchInner>
+            <TypeaheadSearch
+              placeholder={searchPlaceholder}
+              currentValue={typeaheadValue}
+              filteredStories={filteredStories}
+              handleChange={handleTypeaheadChange}
+            />
+          </SearchInner>
+        </SearchContainer>
+      </BodyWrapper>
     </Container>
   );
 };
 
 PageHeading.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   defaultTitle: PropTypes.string.isRequired,
   searchPlaceholder: PropTypes.string,
   filteredStories: StoriesPropType,

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -22,14 +22,11 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import cssLerp from '../../../utils/cssLerp';
 import { StoriesPropType } from '../../../types';
 import { ViewHeader } from '../../../components';
 import BodyWrapper from './bodyWrapper';
 import TypeaheadSearch from './typeaheadSearch';
-
-const lerp = (start, end, progress) => {
-  return `calc(calc(calc(1 - var(${progress}, 0)) * ${start}) + calc(var(${progress}, 0) * ${end}))`;
-};
 
 const Container = styled.div`
   padding: 10px 0;
@@ -40,7 +37,8 @@ const StyledHeader = styled(ViewHeader)`
   width: 25%;
   justify-content: baseline;
   line-height: 1;
-  font-size: ${lerp('38px', '24px', '--progress')};
+  font-size: ${cssLerp('38px', '24px', '--squish-progress')};
+  white-space: nowrap;
 `;
 
 const Content = styled.div`
@@ -54,23 +52,19 @@ const SearchContainer = styled.div`
   vertical-align: baseline;
   position: relative;
   width: 25%;
-  overflow: hidden; 
-  /* needed to break display flow and align bottom to text */
-  /* margin: auto 0; */
-  /* right: ${({ theme }) => `${theme.pageGutter.small.desktop}px`}; */
-  /* display: flex;
-  justify-content: flex-end; */
-  /* @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
+  height: 29px;
+  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
     left: ${({ theme }) => `${theme.pageGutter.small.min}px`};
     max-width: 100%;
     justify-content: flex-start;
-  } */
+  }
 `;
 
 const SearchInner = styled.div`
-  position: relative;
+  position: absolute;
+  top: 0;
+  right: 0;
   width: min(190px, 100%);
-  margin-left: auto;
 `;
 
 const PageHeading = ({
@@ -81,19 +75,6 @@ const PageHeading = ({
   handleTypeaheadChange,
   typeaheadValue = '',
 }) => {
-  // const resultsText =
-  //   filteredStories.length > 0
-  //     ? sprintf(
-  //         /* translators: %s: search term. */
-  //         __('Results for "%s"', 'web-stories'),
-  //         typeaheadValue
-  //       )
-  //     : sprintf(
-  //         /* translators: %s: search term. */
-  //         __('No results for "%s"', 'web-stories'),
-  //         typeaheadValue
-  //       );
-
   return (
     <Container>
       <BodyWrapper>

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -34,13 +34,14 @@ import {
   PreviewPage,
   Table,
   TableBody,
-  TableCell,
   TableHeader,
-  TableHeaderCell,
   TablePreviewCell,
   TablePreviewHeaderCell,
   TableRow,
   TableTitleHeaderCell,
+  TableTitleCell,
+  TableContentCell,
+  TableContentHeaderCell,
 } from '../../../components';
 import {
   ICON_METRICS,
@@ -62,6 +63,7 @@ const PreviewContainer = styled.div`
   height: ${({ theme }) => theme.previewWidth.thumbnail * PAGE_RATIO}px;
   vertical-align: middle;
   display: inline-block;
+  overflow: hidden;
 `;
 
 const ArrowIcon = styled.div`
@@ -128,7 +130,7 @@ export default function StoryListView({
                 <ArrowIconSvg {...ICON_METRICS.UP_DOWN_ARROW} />
               </ArrowIcon>
             </TableTitleHeaderCell>
-            <TableHeaderCell>
+            <TableContentHeaderCell>
               <SelectableTitle
                 onClick={() =>
                   onSortTitleSelected(STORY_SORT_OPTIONS.CREATED_BY)
@@ -142,10 +144,14 @@ export default function StoryListView({
               >
                 <ArrowIconSvg {...ICON_METRICS.UP_DOWN_ARROW} />
               </ArrowIconWithTitle>
-            </TableHeaderCell>
-            <TableHeaderCell>{__('Categories', 'web-stories')}</TableHeaderCell>
-            <TableHeaderCell>{__('Tags', 'web-stories')}</TableHeaderCell>
-            <TableHeaderCell>
+            </TableContentHeaderCell>
+            <TableContentHeaderCell>
+              {__('Categories', 'web-stories')}
+            </TableContentHeaderCell>
+            <TableContentHeaderCell>
+              {__('Tags', 'web-stories')}
+            </TableContentHeaderCell>
+            <TableContentHeaderCell>
               <SelectableTitle
                 onClick={() =>
                   onSortTitleSelected(STORY_SORT_OPTIONS.LAST_MODIFIED)
@@ -160,7 +166,7 @@ export default function StoryListView({
               >
                 <ArrowIconSvg {...ICON_METRICS.UP_DOWN_ARROW} />
               </ArrowIconWithTitle>
-            </TableHeaderCell>
+            </TableContentHeaderCell>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -173,11 +179,13 @@ export default function StoryListView({
                   </PreviewErrorBoundary>
                 </PreviewContainer>
               </TablePreviewCell>
-              <TableCell>{story.title}</TableCell>
-              <TableCell>{__('—', 'web-stories')}</TableCell>
-              <TableCell>{__('—', 'web-stories')}</TableCell>
-              <TableCell>{__('—', 'web-stories')}</TableCell>
-              <TableCell>{story.modified.startOf('day').fromNow()}</TableCell>
+              <TableTitleCell>{story.title}</TableTitleCell>
+              <TableContentCell>{__('—', 'web-stories')}</TableContentCell>
+              <TableContentCell>{__('—', 'web-stories')}</TableContentCell>
+              <TableContentCell>{__('—', 'web-stories')}</TableContentCell>
+              <TableContentCell>
+                {story.modified.startOf('day').fromNow()}
+              </TableContentCell>
             </TableRow>
           ))}
         </TableBody>

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -28,7 +28,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { Dropdown } from '../../../components';
+import { Layout, Dropdown } from '../../../components';
 import { DropdownContainer } from '../../../components/dropdown';
 import {
   VIEW_STYLE,
@@ -109,17 +109,6 @@ function TemplatesGallery() {
     if (filteredTemplatesCount > 0) {
       return (
         <BodyWrapper>
-          <BodyViewOptions
-            listBarLabel={listBarLabel}
-            layoutStyle={viewStyle}
-            handleLayoutSelect={handleViewStyleBarButtonSelected}
-            currentSort={currentTemplateSort}
-            handleSortChange={setCurrentTemplateSort}
-            sortDropdownAriaLabel={__(
-              'Choose sort option for display',
-              'web-stories'
-            )}
-          />
           <StoryGridView
             filteredStories={filteredTemplates}
             centerActionLabel={__('View details', 'web-stories')}
@@ -130,58 +119,65 @@ function TemplatesGallery() {
     }
 
     return <NoResults typeaheadValue={typeaheadValue} />;
-  }, [
-    filteredTemplates,
-    filteredTemplatesCount,
-    handleViewStyleBarButtonSelected,
-    listBarLabel,
-    typeaheadValue,
-    viewStyle,
-    currentTemplateSort,
-  ]);
+  }, [filteredTemplates, filteredTemplatesCount, typeaheadValue]);
 
   return (
     <FontProvider>
       <TransformProvider>
         <UnitsProvider pageSize={pageSize}>
-          <PageHeading
-            defaultTitle={__('Explore Templates', 'web-stories')}
-            searchPlaceholder={__('Template Stories', 'web-stories')}
-            filteredStories={filteredTemplates}
-            handleTypeaheadChange={setTypeaheadValue}
-            typeaheadValue={typeaheadValue}
-          />
-          <ExploreFiltersContainer>
-            <Dropdown
-              ariaLabel={__('Category Dropdown', 'web-stories')}
-              type={DROPDOWN_TYPES.PANEL}
-              placeholder={__('Category', 'web-stories')}
-              items={[]}
-              onChange={() => {}}
-            />
-            <Dropdown
-              ariaLabel={__('Style Dropdown', 'web-stories')}
-              type={DROPDOWN_TYPES.PANEL}
-              placeholder={__('Style', 'web-stories')}
-              items={[]}
-              onChange={() => {}}
-            />
-            <Dropdown
-              ariaLabel={__('Color Dropdown', 'web-stories')}
-              type={DROPDOWN_TYPES.PANEL}
-              placeholder={__('Color', 'web-stories')}
-              items={[]}
-              onChange={() => {}}
-            />
-            <Dropdown
-              ariaLabel={__('Layout Type Dropdown', 'web-stories')}
-              type={DROPDOWN_TYPES.PANEL}
-              placeholder={__('Layout Type', 'web-stories')}
-              items={[]}
-              onChange={() => {}}
-            />
-          </ExploreFiltersContainer>
-          {BodyContent}
+          <Layout.Provider>
+            <Layout.Squishable>
+              <PageHeading
+                defaultTitle={__('Explore Templates', 'web-stories')}
+                searchPlaceholder={__('Template Stories', 'web-stories')}
+                filteredStories={filteredTemplates}
+                handleTypeaheadChange={setTypeaheadValue}
+                typeaheadValue={typeaheadValue}
+              />
+              <ExploreFiltersContainer>
+                <Dropdown
+                  ariaLabel={__('Category Dropdown', 'web-stories')}
+                  type={DROPDOWN_TYPES.PANEL}
+                  placeholder={__('Category', 'web-stories')}
+                  items={[]}
+                  onChange={() => {}}
+                />
+                <Dropdown
+                  ariaLabel={__('Style Dropdown', 'web-stories')}
+                  type={DROPDOWN_TYPES.PANEL}
+                  placeholder={__('Style', 'web-stories')}
+                  items={[]}
+                  onChange={() => {}}
+                />
+                <Dropdown
+                  ariaLabel={__('Color Dropdown', 'web-stories')}
+                  type={DROPDOWN_TYPES.PANEL}
+                  placeholder={__('Color', 'web-stories')}
+                  items={[]}
+                  onChange={() => {}}
+                />
+                <Dropdown
+                  ariaLabel={__('Layout Type Dropdown', 'web-stories')}
+                  type={DROPDOWN_TYPES.PANEL}
+                  placeholder={__('Layout Type', 'web-stories')}
+                  items={[]}
+                  onChange={() => {}}
+                />
+              </ExploreFiltersContainer>{' '}
+              <BodyViewOptions
+                listBarLabel={listBarLabel}
+                layoutStyle={viewStyle}
+                handleLayoutSelect={handleViewStyleBarButtonSelected}
+                currentSort={currentTemplateSort}
+                handleSortChange={setCurrentTemplateSort}
+                sortDropdownAriaLabel={__(
+                  'Choose sort option for display',
+                  'web-stories'
+                )}
+              />
+            </Layout.Squishable>
+            <Layout.Scrollable>{BodyContent}</Layout.Scrollable>
+          </Layout.Provider>
         </UnitsProvider>
       </TransformProvider>
     </FontProvider>

--- a/assets/src/dashboard/components/bookmark-chip/index.js
+++ b/assets/src/dashboard/components/bookmark-chip/index.js
@@ -44,10 +44,10 @@ const chipSize = {
   },
 };
 
-const ChipContainer = styled.button`
+export const ChipContainer = styled.button`
   align-items: center;
   background-color: ${({ theme }) => theme.colors.white};
-  border: 1px solid none;
+  border: none;
   border-radius: ${({ theme }) => theme.border.buttonRadius};
   box-shadow: ${({ theme }) => theme.chip.shadow};
   color: ${({ theme }) => theme.colors.gray500};

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -16,40 +16,47 @@
 
 export { default as BookmarkChip } from './bookmark-chip';
 export { default as Button } from './button';
+export { default as CardGallery } from './cardGallery';
 export { default as CardGrid } from './cardGrid';
 export {
-  default as CardGridItem,
+  ActionLabel,
+  CardItemMenu,
   CardPreviewContainer,
   CardTitle,
-  CardItemMenu,
+  default as CardGridItem,
   MoreVerticalButton,
-  ActionLabel,
 } from './cardGridItem';
-export { default as CardGallery } from './cardGallery';
 export { default as ColorList } from './colorList';
 export { default as Dropdown } from './dropdown';
 export { default as InfiniteScroller } from './infiniteScroller';
+export { TextInput } from './input';
+export {
+  LayoutFixed,
+  LayoutProvider,
+  LayoutScrollable,
+  LayoutSquishable,
+  useLayoutContext,
+} from './layout';
+export { default as MultiPartPill } from './multiPartPill';
 export { TemplateNavBar } from './navigationBar';
-export { Pill, FloatingTab } from './pill';
+export { AppFrame, LeftRail, PageContent } from './pageStructure';
+export { FloatingTab, Pill } from './pill';
 export { default as PopoverMenu } from './popoverMenu';
 export { default as PopoverPanel } from './popoverPanel';
 export { default as PreviewPage } from './previewPage';
 export { default as ScrollToTop } from './scrollToTop';
+export {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TablePreviewCell,
+  TablePreviewHeaderCell,
+  TableRow,
+  TableTitleHeaderCell,
+} from './table';
 export { default as TypeaheadInput } from './typeaheadInput';
 export { default as TypeaheadOptions } from './typeaheadOptions';
 export { ViewHeader } from './typography';
 export { default as ListBar } from './viewStyleBar';
-export {
-  Table,
-  TableBody,
-  TableHeaderCell,
-  TableCell,
-  TablePreviewCell,
-  TableHeader,
-  TablePreviewHeaderCell,
-  TableTitleHeaderCell,
-  TableRow,
-} from './table';
-export { default as MultiPartPill } from './multiPartPill';
-export { LeftRail, PageContent, AppFrame } from './pageStructure';
-export { TextInput } from './input';

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -34,6 +34,10 @@ export { default as Layout, useLayoutContext } from './layout';
 export { default as MultiPartPill } from './multiPartPill';
 export { TemplateNavBar } from './navigationBar';
 export { AppFrame, LeftRail, PageContent } from './pageStructure';
+export {
+  default as NavProvider,
+  useNavContext,
+} from '../components/pageStructure/navProvider';
 export { FloatingTab, Pill } from './pill';
 export { default as PopoverMenu } from './popoverMenu';
 export { default as PopoverPanel } from './popoverPanel';

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -30,13 +30,7 @@ export { default as ColorList } from './colorList';
 export { default as Dropdown } from './dropdown';
 export { default as InfiniteScroller } from './infiniteScroller';
 export { TextInput } from './input';
-export {
-  LayoutFixed,
-  LayoutProvider,
-  LayoutScrollable,
-  LayoutSquishable,
-  useLayoutContext,
-} from './layout';
+export { default as Layout, useLayoutContext } from './layout';
 export { default as MultiPartPill } from './multiPartPill';
 export { TemplateNavBar } from './navigationBar';
 export { AppFrame, LeftRail, PageContent } from './pageStructure';

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -47,6 +47,9 @@ export {
   TableHeaderCell,
   TablePreviewCell,
   TablePreviewHeaderCell,
+  TableTitleCell,
+  TableContentCell,
+  TableContentHeaderCell,
   TableRow,
   TableTitleHeaderCell,
 } from './table';

--- a/assets/src/dashboard/components/layout/fixed.js
+++ b/assets/src/dashboard/components/layout/fixed.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const FixedContent = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  pointer-events: none;
+
+  /**
+   * Not sure how much I like this because 
+   * it will be a higher specifity than a 
+   * styled declaration, but I don't want
+   * devs to have to declare this on every
+   * component in this view.
+   */
+  & > * {
+    pointer-events: auto;
+  }
+`;
+
+const Fixed = ({ children }) => {
+  return <FixedContent>{children}</FixedContent>;
+};
+
+Fixed.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+};
+
+export default Fixed;

--- a/assets/src/dashboard/components/layout/fixed.js
+++ b/assets/src/dashboard/components/layout/fixed.js
@@ -16,8 +16,13 @@
 /**
  * External dependencies
  */
+import { useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+/**
+ * Internal dependencies
+ */
+import useAddSquishVar from './useAddSquishVar';
 
 const FixedContent = styled.div`
   position: absolute;
@@ -41,7 +46,10 @@ const FixedContent = styled.div`
 `;
 
 const Fixed = ({ children }) => {
-  return <FixedContent>{children}</FixedContent>;
+  const rootRef = useRef(null);
+  useAddSquishVar(rootRef);
+
+  return <FixedContent ref={rootRef}>{children}</FixedContent>;
 };
 
 Fixed.propTypes = {

--- a/assets/src/dashboard/components/layout/index.js
+++ b/assets/src/dashboard/components/layout/index.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+export { default as LayoutProvider } from './provider';
+export { default as LayoutScrollable } from './scrollable';
+export { default as LayoutSquishable } from './squishable';
+export { default as LayoutFixed } from './fixed';
+export { default as useLayoutContext } from './useLayoutContext';

--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import React, {
+  createContext,
+  useMemo,
+  useRef,
+  useLayoutEffect,
+  useCallback,
+  useState,
+} from 'react';
+import PropTypes from 'prop-types';
+
+export const SQUISH_LENGTH = 90;
+
+const generateThreshold = (steps) => {
+  return Array.from({ length: steps + 1 }, (_, i) => i / steps);
+};
+
+export const LayoutContext = createContext(null);
+
+const Provider = ({ children }) => {
+  const [squishContentHeight, setSquishContentHeight] = useState(0);
+  const scrollFrameRef = useRef(null);
+  const squishDriverRef = useRef(null);
+
+  useLayoutEffect(() => {
+    const squishDriverEl = squishDriverRef.current;
+    const scrollFrameEl = scrollFrameRef.current;
+    if (!(squishDriverEl || scrollFrameEl)) {
+      return () => {};
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.intersectionRatio) {
+            const event = new CustomEvent('squish');
+            event.data = {
+              progress: 1 - entry.intersectionRatio,
+            };
+            squishDriverEl.dispatchEvent(event);
+          }
+        });
+      },
+      {
+        root: scrollFrameEl,
+        threshold: generateThreshold(1000),
+      }
+    );
+
+    observer.observe(squishDriverEl);
+    return () => {
+      observer.unobserve(squishDriverEl);
+    };
+  }, []);
+
+  const addSquishListener = useCallback((listener) => {
+    if (!squishDriverRef.current) {
+      return;
+    }
+    squishDriverRef.current.addEventListener('squish', listener);
+  }, []);
+
+  const removeSquishListener = useCallback((listener) => {
+    if (!squishDriverRef.current) {
+      return;
+    }
+    squishDriverRef.current.removeEventListener('squish', listener);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      state: {
+        scrollFrameRef,
+        squishDriverRef,
+        squishContentHeight,
+      },
+      actions: {
+        /**
+         * @typedef {{progress: number}} SquishEvent
+         * @typedef {(event: SquishEvent) => void} SquishListener
+         *
+         * @param {SquishListener} listener - Takes `squish` event which contains a progress value in range `[0, 1]`
+         * @return {void}
+         */
+        addSquishListener,
+        /**
+         * @param {SquishListener} listener - Takes `squish` event which contains a progress value in range `[0, 1]`
+         * @return {void}
+         */
+        removeSquishListener,
+        setSquishContentHeight,
+      },
+    }),
+    [addSquishListener, removeSquishListener, squishContentHeight]
+  );
+
+  return (
+    <LayoutContext.Provider value={value}>{children}</LayoutContext.Provider>
+  );
+};
+
+Provider.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+};
+
+export default Provider;

--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -27,6 +27,7 @@ import React, {
 import PropTypes from 'prop-types';
 
 export const SQUISH_LENGTH = 90;
+export const SQUISH_CSS_VAR = '--squish-progress';
 
 const generateThreshold = (steps) => {
   return Array.from({ length: steps + 1 }, (_, i) => i / steps);
@@ -84,6 +85,17 @@ const Provider = ({ children }) => {
     squishDriverRef.current.removeEventListener('squish', listener);
   }, []);
 
+  const scrollToTop = useCallback(() => {
+    const scrollFrameEl = scrollFrameRef.current;
+    if (!scrollFrameEl) {
+      return;
+    }
+    scrollFrameEl.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  }, []);
+
   const value = useMemo(
     () => ({
       state: {
@@ -106,9 +118,10 @@ const Provider = ({ children }) => {
          */
         removeSquishListener,
         setSquishContentHeight,
+        scrollToTop,
       },
     }),
-    [addSquishListener, removeSquishListener, squishContentHeight]
+    [addSquishListener, removeSquishListener, squishContentHeight, scrollToTop]
   );
 
   return (

--- a/assets/src/dashboard/components/layout/scrollable.js
+++ b/assets/src/dashboard/components/layout/scrollable.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+/**
+ * Internal dependencies
+ */
+import useLayoutContext from './useLayoutContext';
+import { SQUISH_LENGTH } from './provider';
+
+const ScrollContent = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+`;
+
+const Inner = styled.div`
+  position: relative;
+  padding-top: 200px;
+`;
+
+const SquishRange = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: ${SQUISH_LENGTH}px;
+  pointer-events: none;
+`;
+
+SquishRange.propTypes = {
+  height: PropTypes.number,
+};
+
+const Scrollable = ({ children }) => {
+  const {
+    state: { scrollFrameRef, squishDriverRef },
+  } = useLayoutContext();
+
+  return (
+    <ScrollContent ref={scrollFrameRef}>
+      <SquishRange ref={squishDriverRef} />
+      <Inner>{children}</Inner>
+    </ScrollContent>
+  );
+};
+
+Scrollable.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+};
+
+export default Scrollable;

--- a/assets/src/dashboard/components/layout/scrollable.js
+++ b/assets/src/dashboard/components/layout/scrollable.js
@@ -37,8 +37,12 @@ const ScrollContent = styled.div`
 
 const Inner = styled.div`
   position: relative;
-  padding-top: 200px;
+  padding-top: ${(props) => props.paddingTop || 0}px;
 `;
+
+Inner.propTypes = {
+  paddingTop: PropTypes.number,
+};
 
 const SquishRange = styled.div`
   position: absolute;
@@ -55,13 +59,13 @@ SquishRange.propTypes = {
 
 const Scrollable = ({ children }) => {
   const {
-    state: { scrollFrameRef, squishDriverRef },
+    state: { scrollFrameRef, squishDriverRef, squishContentHeight },
   } = useLayoutContext();
 
   return (
     <ScrollContent ref={scrollFrameRef}>
       <SquishRange ref={squishDriverRef} />
-      <Inner>{children}</Inner>
+      <Inner paddingTop={squishContentHeight}>{children}</Inner>
     </ScrollContent>
   );
 };

--- a/assets/src/dashboard/components/layout/squishable.js
+++ b/assets/src/dashboard/components/layout/squishable.js
@@ -16,29 +16,23 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
-import { SQUISH_LENGTH } from './provider';
+import cssLerp from '../../utils/cssLerp';
+import { SQUISH_LENGTH, SQUISH_CSS_VAR } from './provider';
 import useLayoutContext from './useLayoutContext';
-
-const lerp = (start, end, progress) => {
-  return `calc(calc(calc(1 - var(${progress}, 0)) * ${start}) + calc(var(${progress}, 0) * ${end}))`;
-};
+import useAddSquishVar from './useAddSquishVar';
 
 const Squish = styled.div`
-  contain: content;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  padding-top: ${lerp(`${SQUISH_LENGTH}px`, '0px', '--progress')};
+  padding-top: ${cssLerp(`${SQUISH_LENGTH}px`, '0px', SQUISH_CSS_VAR)};
   background-color: ${({ theme }) => theme.colors.white};
   z-index: 2;
 `;
@@ -49,29 +43,23 @@ const Content = styled.div`
 
 const Squishable = ({ children }) => {
   const contentRef = useRef(null);
-  const cssVarScope = useRef(null);
+  const rootRef = useRef(null);
+  useAddSquishVar(rootRef);
+
   const {
-    actions: { addSquishListener, removeSquishListener },
+    actions: { setSquishContentHeight },
   } = useLayoutContext();
 
-  useEffect(() => {
-    const cssVarEl = cssVarScope.current;
-    if (!cssVarEl) {
-      return () => {};
+  useLayoutEffect(() => {
+    const contentEl = contentRef.current;
+    if (!contentEl) {
+      return;
     }
-
-    const handleSquish = (event) => {
-      cssVarEl.style.setProperty('--progress', event.data.progress);
-    };
-
-    addSquishListener(handleSquish);
-    return () => {
-      removeSquishListener(handleSquish);
-    };
-  }, [addSquishListener, removeSquishListener]);
+    setSquishContentHeight(contentEl.offsetHeight + SQUISH_LENGTH);
+  }, [setSquishContentHeight]);
 
   return (
-    <Squish ref={cssVarScope}>
+    <Squish ref={rootRef}>
       <Content ref={contentRef}>{children}</Content>
     </Squish>
   );

--- a/assets/src/dashboard/components/layout/squishable.js
+++ b/assets/src/dashboard/components/layout/squishable.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+/**
+ * Internal dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import { SQUISH_LENGTH } from './provider';
+import useLayoutContext from './useLayoutContext';
+
+const lerp = (start, end, progress) => {
+  return `calc(calc(calc(1 - var(${progress}, 0)) * ${start}) + calc(var(${progress}, 0) * ${end}))`;
+};
+
+const Squish = styled.div`
+  contain: content;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding-top: ${lerp(`${SQUISH_LENGTH}px`, '0px', '--progress')};
+  background-color: ${({ theme }) => theme.colors.white};
+  z-index: 2;
+`;
+
+const Content = styled.div`
+  position: relative;
+`;
+
+const Squishable = ({ children }) => {
+  const contentRef = useRef(null);
+  const cssVarScope = useRef(null);
+  const {
+    actions: { addSquishListener, removeSquishListener },
+  } = useLayoutContext();
+
+  useEffect(() => {
+    const cssVarEl = cssVarScope.current;
+    if (!cssVarEl) {
+      return () => {};
+    }
+
+    const handleSquish = (event) => {
+      cssVarEl.style.setProperty('--progress', event.data.progress);
+    };
+
+    addSquishListener(handleSquish);
+    return () => {
+      removeSquishListener(handleSquish);
+    };
+  }, [addSquishListener, removeSquishListener]);
+
+  return (
+    <Squish ref={cssVarScope}>
+      <Content ref={contentRef}>{children}</Content>
+    </Squish>
+  );
+};
+
+Squishable.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+};
+
+export default Squishable;

--- a/assets/src/dashboard/components/layout/test/useLayoutContext.js
+++ b/assets/src/dashboard/components/layout/test/useLayoutContext.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import LayoutProvider from '../provider';
+import useLayoutContext from '../useLayoutContext';
+
+describe('useLayoutContext()', () => {
+  it('should throw an error if used oustide LayoutProvider', () => {
+    expect(renderHook(() => useLayoutContext())).toThrow(Error);
+  });
+
+  it('should not throw an error if used inside LayoutProvider', () => {
+    expect(
+      renderHook({
+        callback: () => useLayoutContext(),
+        options: {
+          wrapper: LayoutProvider,
+        },
+      })
+    ).not.toThrow(Error);
+  });
+
+  it.todo('has a setable squish height');
+
+  it.todo('is subscribable to squish events', () => {
+    const { result } = renderHook({
+      callback: () => useLayoutContext(),
+      options: {
+        wrapper: LayoutProvider,
+      },
+    });
+
+    const listener = jest.fn();
+    result.addSquishListener(listener);
+
+    /**
+     * @todo find way to get SquishDriver DOM node and fire event below:
+     * const event = new CustomEvent('squish', {
+     * progress: 1,
+     * });
+     * squishDriverEl.dispatchEvent(event);
+     */
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it.todo('can unsubscribe from squish events', () => {
+    const { result } = renderHook({
+      callback: () => useLayoutContext(),
+      options: {
+        wrapper: LayoutProvider,
+      },
+    });
+
+    const listener = jest.fn();
+    result.addSquishListener(listener);
+    result.removeSquishListener(listener);
+
+    /**
+     * @todo find way to get SquishDriver DOM node and fire event below:
+     * const event = new CustomEvent('squish', {
+     * progress: 1,
+     * });
+     * squishDriverEl.dispatchEvent(event);
+     */
+
+    expect(listener).toHaveBeenCalledTimes(0);
+  });
+});

--- a/assets/src/dashboard/components/layout/useAddSquishVar.js
+++ b/assets/src/dashboard/components/layout/useAddSquishVar.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { SQUISH_CSS_VAR } from './provider';
+import useLayoutContext from './useLayoutContext';
+
+const useAddSquishVar = (rootRef) => {
+  const {
+    actions: { addSquishListener, removeSquishListener },
+  } = useLayoutContext();
+
+  useEffect(() => {
+    const rootEl = rootRef.current;
+    if (!rootEl) {
+      return () => {};
+    }
+
+    const handleSquish = (event) => {
+      rootEl.style.setProperty(SQUISH_CSS_VAR, event.data.progress);
+    };
+
+    addSquishListener(handleSquish);
+    return () => {
+      removeSquishListener(handleSquish);
+    };
+  }, [addSquishListener, removeSquishListener, rootRef]);
+};
+
+export default useAddSquishVar;

--- a/assets/src/dashboard/components/layout/useLayoutContext.js
+++ b/assets/src/dashboard/components/layout/useLayoutContext.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useContext } from 'react';
+/**
+ * Internal dependencies
+ */
+import { LayoutContext } from './provider';
+
+const useLayoutContext = () => {
+  const context = useContext(LayoutContext);
+  if (!context) {
+    throw new Error(
+      'useLayoutContext() must be used within a <Layout.Provider />'
+    );
+  }
+  return context;
+};
+
+export default useLayoutContext;

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -57,6 +57,10 @@ export const PageContent = styled.div`
   right: 0;
   bottom: 0;
   left: max(15%, 190px);
+
+  @media ${({ theme }) => theme.breakpoint.tablet} {
+    left: 0;
+  }
 `;
 
 export const LeftRailContainer = styled.nav`
@@ -74,7 +78,6 @@ export const LeftRailContainer = styled.nav`
     visibility 0.25s linear;
 
   @media ${({ theme }) => theme.breakpoint.tablet} {
-    padding-left: 0;
     visibility: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
     transform: translateX(${({ isOpen }) => (isOpen ? 'none' : `-100%`)});
   }

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -35,23 +35,38 @@ import { BUTTON_TYPES, primaryPaths, secondaryPaths } from '../../constants';
 import {
   AppInfo,
   Content,
-  LeftRailContainer,
   LogoPlaceholder,
   NavLink,
   Rule,
 } from './navigationComponents';
 
 export const AppFrame = styled.div`
-  display: flex;
-  flex-direction: row;
-  height: inherit;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 `;
 
 export const PageContent = styled.div`
-  position: relative;
-  width: 100%;
-  padding-left: max(15%, 190px);
-  height: inherit;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: max(15%, 190px);
+`;
+
+export const LeftRailContainer = styled.nav`
+  position: absolute;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  top: 0;
+  bottom: 0;
+  width: max(15%, 190px);
+  background: ${({ theme }) => theme.colors.white};
+  border-right: ${({ theme }) => theme.leftRail.border};
+  z-index: 2;
 `;
 
 export function LeftRail() {

--- a/assets/src/dashboard/components/pageStructure/menuButton.js
+++ b/assets/src/dashboard/components/pageStructure/menuButton.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled, { css } from 'styled-components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { CHIP_TYPES } from '../../constants';
+import { ReactComponent as MenuSvg } from '../../icons/menu.svg';
+import { ChipContainer } from '../bookmark-chip';
+import { useNavContext } from './navProvider';
+
+const MenuIcon = styled(MenuSvg)`
+  color: ${({ theme }) => theme.colors.gray900};
+`;
+
+const Container = styled.div`
+  display: inline-block;
+  ${({ showOnlyOnSmallViewport }) =>
+    showOnlyOnSmallViewport &&
+    css`
+      display: none;
+      @media ${({ theme }) => theme.breakpoint.tablet} {
+        display: inline-block;
+      }
+    `}
+`;
+
+export default function NavMenuButton({ showOnlyOnSmallViewport }) {
+  const { actions } = useNavContext();
+  return (
+    <Container showOnlyOnSmallViewport={showOnlyOnSmallViewport}>
+      <ChipContainer
+        chipType={CHIP_TYPES.STANDARD}
+        onClick={actions.toggleSideBar}
+      >
+        <MenuIcon />
+      </ChipContainer>
+    </Container>
+  );
+}
+
+NavMenuButton.propTypes = {
+  showOnlyOnSmallViewport: PropTypes.bool,
+};

--- a/assets/src/dashboard/components/pageStructure/navProvider.js
+++ b/assets/src/dashboard/components/pageStructure/navProvider.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import PropTypes from 'prop-types';
+
+const NavContext = createContext({ actions: {}, state: {} });
+
+export function useNavContext() {
+  return useContext(NavContext);
+}
+
+export default function NavProvider({ children }) {
+  const [sideBarVisible, setSideBarVisible] = useState(false);
+  const toggleSideBar = useCallback(() => {
+    setSideBarVisible(!sideBarVisible);
+  }, [sideBarVisible]);
+
+  const value = useMemo(
+    () => ({
+      actions: { toggleSideBar },
+      state: { sideBarVisible },
+    }),
+    [sideBarVisible, toggleSideBar]
+  );
+
+  return <NavContext.Provider value={value}>{children}</NavContext.Provider>;
+}
+
+NavProvider.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+};

--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -19,18 +19,6 @@
  */
 import styled from 'styled-components';
 
-export const LeftRailContainer = styled.nav`
-  position: fixed;
-  display: flex;
-  justify-content: space-between;
-  flex-direction: column;
-  z-index: 1;
-  height: calc(100vh - 32px); /* ADMIN_TOOLBAR_HEIGHT = 32 */
-  width: max(15%, 190px);
-  background: ${({ theme }) => theme.colors.white};
-  border-right: ${({ theme }) => theme.leftRail.border};
-`;
-
 export const Content = styled.div`
   display: flex;
   flex-direction: column;

--- a/assets/src/dashboard/components/pageStructure/stories/menuButton.js
+++ b/assets/src/dashboard/components/pageStructure/stories/menuButton.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { boolean } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import NavProvider, { useNavContext } from '../navProvider';
+import NavMenuButton from '../menuButton';
+
+export default {
+  title: 'Dashboard/Components/NavMenuButton',
+};
+
+const Status = () => {
+  const { state } = useNavContext();
+  return <span>{String(state.sideBarVisible)}</span>;
+};
+
+export const _default = () => {
+  return (
+    <NavProvider>
+      <NavMenuButton
+        showOnlyOnSmallViewport={boolean('showOnlyOnSmallViewport')}
+      />
+      <br />
+      <Status />
+    </NavProvider>
+  );
+};

--- a/assets/src/dashboard/components/scrollToTop/index.js
+++ b/assets/src/dashboard/components/scrollToTop/index.js
@@ -21,30 +21,29 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useRef, useState, useLayoutEffect } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { useDebouncedCallback } from 'use-debounce';
 /**
  * Internal dependencies
  */
 import { ReactComponent as DropUpArrowSvg } from '../../icons/dropUpArrow.svg';
-import getCurrentYAxis from '../../utils/getCurrentYAxis';
+import cssLerp from '../../utils/cssLerp';
+import { useLayoutContext, SQUISH_CSS_VAR } from '../layout';
 
 const ScrollButton = styled.button`
-  position: fixed;
+  position: absolute;
   right: 40px;
   bottom: 40px;
   height: 50px;
   width: 50px;
-  visibility: ${({ isVisible }) => (isVisible ? 'visible' : 'hidden')};
+  pointer-events: ${({ isVisible }) => (isVisible ? 'auto' : 'none')};
   cursor: pointer;
   border-radius: 50%;
   border: 1px solid transparent;
   box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
   color: ${({ theme }) => theme.colors.gray900};
   background-color: ${({ theme }) => theme.colors.white};
-  opacity: ${({ isVisible }) => (isVisible ? 1.0 : 0)};
-  transition: opacity 0.5s linear;
+  opacity: ${cssLerp(0, 1, SQUISH_CSS_VAR)};
 `;
 
 // TODO needs actual SVG
@@ -54,32 +53,26 @@ const DropUpArrowIcon = styled(DropUpArrowSvg).attrs({ width: 30, height: 40 })`
 
 const ScrollToTop = () => {
   const [isVisible, setIsVisible] = useState(false);
-  const targetRef = useRef(null);
+  const {
+    actions: { scrollToTop, addSquishListener, removeSquishListener },
+  } = useLayoutContext();
 
-  const [handleScroll] = useDebouncedCallback(() => {
-    const hasScrolledDown = getCurrentYAxis();
-    setIsVisible(hasScrolledDown > 0);
-  }, 100);
+  useEffect(() => {
+    const isVisibleFromProgress = (event) => {
+      setIsVisible(event.data.progress > 0);
+    };
 
-  useLayoutEffect(() => {
-    window.addEventListener('scroll', handleScroll);
-
-    return () => window.removeEventListener('scroll', handleScroll);
-  });
-
-  const handleScrollBackToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    });
-  };
+    addSquishListener(isVisibleFromProgress);
+    return () => {
+      removeSquishListener(isVisibleFromProgress);
+    };
+  }, [addSquishListener, removeSquishListener]);
 
   return (
     <ScrollButton
       data-testid="scroll-to-top-button"
-      ref={targetRef}
       isVisible={isVisible}
-      onClick={handleScrollBackToTop}
+      onClick={scrollToTop}
       title={__('scroll back to top', 'web-stories')}
     >
       <DropUpArrowIcon aria-hidden={true} />

--- a/assets/src/dashboard/components/table/index.js
+++ b/assets/src/dashboard/components/table/index.js
@@ -48,17 +48,36 @@ export const TablePreviewHeaderCell = styled(TableHeaderCell)`
 
 export const TableTitleHeaderCell = styled(TableHeaderCell)`
   padding-left: 0;
+  width: 30%;
+  min-width: 220px;
+`;
+
+export const TableContentHeaderCell = styled(TableHeaderCell)`
+  width: 17.5%;
+  min-width: 160px;
 `;
 
 export const TableRow = styled.tr``;
 
 export const TableCell = styled.td`
-  padding: 0 ${({ theme }) => theme.table.cellPadding}px;
+  padding: ${({ theme }) => theme.table.cellPadding}px;
   font-weight: ${({ theme }) => theme.fonts.table.weight};
   color: ${({ theme }) => theme.colors.gray900};
   height: ${({ theme }) => theme.table.cellPadding * 2 + 50}px;
   vertical-align: middle;
   line-height: ${({ theme }) => theme.table.headerContentSize}px;
+`;
+
+export const TableTitleCell = styled(TableCell)`
+  width: 30%;
+  min-width: 220px;
+  word-wrap: break-word;
+`;
+
+export const TableContentCell = styled(TableCell)`
+  width: 17.5%;
+  min-width: 160px;
+  word-wrap: break-word;
 `;
 
 export const TablePreviewCell = styled(TableCell)`

--- a/assets/src/dashboard/components/typeaheadInput/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/index.js
@@ -56,10 +56,8 @@ SearchContainer.propTypes = {
 const InputContainer = styled.div`
   position: relative;
   display: flex;
-  flex-direction: row;
   width: 100%;
   padding: 5px 8px;
-  align-items: center;
   border-radius: ${({ theme, isOpen }) =>
     isOpen ? 'none' : theme.border.typeaheadRadius};
   border: none;
@@ -73,9 +71,9 @@ InputContainer.propTypes = {
 };
 
 const ControlVisibilityContainer = styled.div`
-  flex-grow: 1;
+  position: relative;
   display: flex;
-  justify-content: flex-start;
+  flex-grow: 1;
 
   @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
     opacity: ${({ isExpanded }) => (isExpanded ? '1' : '0')};
@@ -87,19 +85,19 @@ ControlVisibilityContainer.propTypes = {
 };
 
 const StyledInput = styled.input`
-  align-self: center;
-  border: none;
-  background-color: transparent;
-  text-overflow: ellipsis;
-  padding: 0 7.5px;
+  position: relative;
   height: 100%;
-  flex-grow: 1;
+  width: 100%;
+  padding: 0 0 0 7.5px;
   font-family: ${({ theme }) => theme.fonts.typeaheadInput.family};
   font-size: ${({ theme }) => theme.fonts.typeaheadInput.size};
   line-height: ${({ theme }) => theme.fonts.typeaheadInput.lineHeight};
   letter-spacing: ${({ theme }) => theme.fonts.typeaheadInput.letterSpacing};
   font-weight: ${({ theme }) => theme.fonts.typeaheadInput.weight};
+  text-overflow: ellipsis;
   color: ${({ theme }) => theme.colors.gray};
+  background-color: transparent;
+  border: none;
 
   &:disabled {
     cursor: default;
@@ -130,15 +128,17 @@ const SearchButton = styled.button`
 `;
 
 const ClearInputButton = styled.button`
-  align-self: flex-end;
   border: none;
   background-color: transparent;
   margin: auto 0;
-  width: 14px;
-  height: 14px;
   padding: 0;
   color: ${({ theme }) => theme.colors.gray600};
   cursor: pointer;
+  height: 14px;
+
+  & > svg {
+    height: 100%;
+  }
 `;
 
 const TypeaheadInput = ({
@@ -253,16 +253,16 @@ const TypeaheadInput = ({
             }}
             placeholder={placeholder}
           />
-          {inputValue.length > 0 && !isMenuOpen && (
-            <ClearInputButton
-              data-testid="clear-search"
-              onClick={handleInputClear}
-              aria-label={__('Clear Input', 'web-stories')}
-            >
-              <CloseIcon />
-            </ClearInputButton>
-          )}
         </ControlVisibilityContainer>
+        {inputValue.length > 0 && !isMenuOpen && (
+          <ClearInputButton
+            data-testid="clear-search"
+            onClick={handleInputClear}
+            aria-label={__('Clear Input', 'web-stories')}
+          >
+            <CloseIcon />
+          </ClearInputButton>
+        )}
       </InputContainer>
 
       {isMenuOpen && (

--- a/assets/src/dashboard/components/typeaheadInput/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/index.js
@@ -35,8 +35,6 @@ import useFocusOut from '../../utils/useFocusOut';
 import TypeaheadOptions from '../typeaheadOptions';
 
 const SearchContainer = styled.div`
-  width: 272px;
-  position: static;
   display: flex;
   flex-direction: column;
   border-radius: ${({ theme, isOpen }) =>
@@ -60,8 +58,7 @@ const InputContainer = styled.div`
   display: flex;
   flex-direction: row;
   width: 100%;
-  height: 48px;
-  padding: 16px;
+  padding: 5px 8px;
   align-items: center;
   border-radius: ${({ theme, isOpen }) =>
     isOpen ? 'none' : theme.border.typeaheadRadius};
@@ -69,8 +66,7 @@ const InputContainer = styled.div`
   border-bottom: ${({ theme, isOpen }) =>
     isOpen && `1px solid ${theme.colors.gray50}`};
   color: ${({ theme }) => theme.colors.gray500};
-  background-color: ${({ theme, isOpen }) =>
-    isOpen ? theme.colors.white : theme.colors.gray25};
+  background-color: ${({ theme }) => theme.colors.gray50};
 `;
 InputContainer.propTypes = {
   isOpen: PropTypes.bool,
@@ -95,8 +91,7 @@ const StyledInput = styled.input`
   border: none;
   background-color: transparent;
   text-overflow: ellipsis;
-  padding: 0 12px;
-  margin: auto 0;
+  padding: 0 7.5px;
   height: 100%;
   flex-grow: 1;
   font-family: ${({ theme }) => theme.fonts.typeaheadInput.family};
@@ -104,7 +99,7 @@ const StyledInput = styled.input`
   line-height: ${({ theme }) => theme.fonts.typeaheadInput.lineHeight};
   letter-spacing: ${({ theme }) => theme.fonts.typeaheadInput.letterSpacing};
   font-weight: ${({ theme }) => theme.fonts.typeaheadInput.weight};
-  color: ${({ theme }) => theme.colors.gray500};
+  color: ${({ theme }) => theme.colors.gray};
 
   &:disabled {
     cursor: default;
@@ -124,9 +119,9 @@ const SearchButton = styled.button`
   border: none;
   background-color: transparent;
   color: ${({ theme }) => theme.colors.gray300};
+  height: 18px;
   & > svg {
-    width: 16px;
-    height: 16px;
+    height: 100%;
   }
 
   @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {

--- a/assets/src/dashboard/icons/menu.svg
+++ b/assets/src/dashboard/icons/menu.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" fill="currentColor" />
+</svg>

--- a/assets/src/dashboard/style.css
+++ b/assets/src/dashboard/style.css
@@ -30,14 +30,31 @@ body {
   display: none;
 }
 
+body.web-story_page_stories-dashboard {
+  position: relative;
+}
+
+body.web-story_page_stories-dashboard #wpwrap,
+body.web-story_page_stories-dashboard #wpbody-content {
+  position: absolute;
+  overflow: hidden;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: 0;
+  padding: 0;
+}
+
 body.web-story_page_stories-dashboard #wpcontent,
 body.web-story_page_stories-dashboard #wpbody-content {
   padding: 0;
 }
 
-body.web-story_page_stories-dashboard #web-stories-dashboard {
+body.web-story_page_stories-dashboard #wpbody {
   position: relative;
-  overflow-x: hidden;
+  width: 100%;
+  height: 100%;
 }
 
 body.web-story_page_stories-dashboard #web-stories-dashboard .loading-message {

--- a/assets/src/dashboard/utils/cssLerp.js
+++ b/assets/src/dashboard/utils/cssLerp.js
@@ -13,21 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Internal dependencies
- */
-import Provider from './provider';
-import Scrollable from './scrollable';
-import Squishable from './squishable';
-import Fixed from './fixed';
-
-const Layout = {
-  Provider,
-  Scrollable,
-  Squishable,
-  Fixed,
+const cssLerp = (start, end, progress) => {
+  return `calc(calc(calc(1 - var(${progress}, 0)) * ${start}) + calc(var(${progress}, 0) * ${end}))`;
 };
 
-export default Layout;
-export { default as useLayoutContext } from './useLayoutContext';
-export { SQUISH_CSS_VAR } from './provider';
+export default cssLerp;


### PR DESCRIPTION
This PR adds slide-out navigation for the left rail on dashboard. It also fixes responsive styles for the table layout on dashboard. Finally it adds a menu button that launches the menu when the viewport is small enough.

![Kapture 2020-04-27 at 13 59 46](https://user-images.githubusercontent.com/1738349/80414074-1068d880-8896-11ea-9546-4ad9f7fb0fd9.gif)


## Relevant Technical Choices

- Adds a Provider that manages the state of the left rail navigation
- Sets minimum widths to the table columns to prevent data from crunching and to preserve the list sorting

Addresses a new responsive menu feature that builds on top of #1258 
