### PR TITLE
Dashboard: Delete and Duplicate Stories

### DIFF
--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -44,14 +44,16 @@ jest.mock('../wpAdapter', () => ({
           },
         ]),
     }),
-  post: (path, { data }) =>
-    Promise.resolve({
+  post: (path, { data }) => {
+    const title = typeof data.title === 'string' ? data.title : data.title.raw;
+    return Promise.resolve({
       id: data.id || 456,
       status: 'published',
-      title: { rendered: data.title, raw: data.title },
+      title: { rendered: title, raw: title },
       story_data: { pages: [{ id: 1, elements: [] }] },
       modified: '1970-01-01T00:00:00.000Z',
-    }),
+    });
+  },
   deleteRequest: (path, { data }) =>
     Promise.resolve({
       id: data.id,
@@ -217,15 +219,45 @@ describe('ApiProvider', () => {
           },
           title: {
             raw: 'Carlos',
-            rendered: 'Carlos',
           },
         },
       });
     });
 
     expect(result.current.state.stories.stories).toStrictEqual({
-      '456': {
+      '123': {
         bottomTargetAction: 'editStory&post=123',
+        centerTargetAction: '',
+        id: 123,
+        modified: moment('1970-01-01T00:00:00.000Z'),
+        originalStoryData: {
+          id: 123,
+          modified: '1970-01-01T00:00:00.000Z',
+          status: 'published',
+          story_data: {
+            pages: [
+              {
+                elements: [],
+                id: 1,
+              },
+            ],
+          },
+          title: {
+            raw: 'Carlos',
+            rendered: 'Carlos',
+          },
+        },
+        pages: [
+          {
+            elements: [],
+            id: 1,
+          },
+        ],
+        status: 'published',
+        title: 'Carlos',
+      },
+      '456': {
+        bottomTargetAction: 'editStory&post=456',
         centerTargetAction: '',
         id: 456,
         modified: moment('1970-01-01T00:00:00.000Z'),
@@ -253,7 +285,7 @@ describe('ApiProvider', () => {
           },
         ],
         status: 'published',
-        title: 'New Title',
+        title: 'Carlos (Copy)',
       },
     });
   });

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -154,12 +154,34 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
     [wpApi, dataAdapter, editStoryURL]
   );
 
+  const trashStory = useCallback(
+    async (story) => {
+      try {
+        const response = await dataAdapter.deleteRequest(
+          `${wpApi}/${story.id}`,
+          {
+            data: story,
+          }
+        );
+        dispatch({
+          type: STORY_ACTION_TYPES.TRASH_STORY,
+          payload: reshapeStoryObject(editStoryURL)(response),
+        });
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error(e);
+      }
+    },
+    [wpApi, dataAdapter, editStoryURL]
+  );
+
   const api = useMemo(
     () => ({
       updateStory,
       fetchStories,
+      trashStory,
     }),
-    [updateStory, fetchStories]
+    [trashStory, updateStory, fetchStories]
   );
 
   return { stories: state, api };

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -171,22 +171,19 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
   const trashStory = useCallback(
     async (story) => {
       try {
-        const response = await dataAdapter.deleteRequest(
-          `${wpApi}/${story.id}`,
-          {
-            data: story,
-          }
-        );
+        await dataAdapter.deleteRequest(`${wpApi}/${story.id}`, {
+          data: story,
+        });
         dispatch({
           type: STORY_ACTION_TYPES.TRASH_STORY,
-          payload: reshapeStoryObject(editStoryURL)(response),
+          payload: { id: story.id },
         });
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error(e);
       }
     },
-    [wpApi, dataAdapter, editStoryURL]
+    [wpApi, dataAdapter]
   );
 
   const duplicateStory = useCallback(

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -24,6 +24,7 @@ export const ACTION_TYPES = {
   FETCH_STORIES_SUCCESS: 'fetch_stories_success',
   FETCH_STORIES_FAILURE: 'fetch_stories_failure',
   UPDATE_STORY: 'update_story',
+  TRASH_STORY: 'trash_story',
 };
 
 export const defaultStoriesState = {
@@ -56,6 +57,21 @@ function storyReducer(state, action) {
           ...state.stories,
           [action.payload.id]: action.payload,
         },
+      };
+
+    case ACTION_TYPES.TRASH_STORY:
+      return {
+        ...state,
+        storiesOrderById: state.storiesOrderById.filter(
+          (id) => id !== action.payload.id
+        ),
+        totalStories: state.totalStories - 1,
+        stories: Object.keys(state.stories).reduce((memo, storyId) => {
+          if (storyId !== action.payload.id) {
+            memo[storyId] = state.stories[storyId];
+          }
+          return memo;
+        }, {}),
       };
 
     case ACTION_TYPES.FETCH_STORIES_SUCCESS: {

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -25,6 +25,7 @@ export const ACTION_TYPES = {
   FETCH_STORIES_FAILURE: 'fetch_stories_failure',
   UPDATE_STORY: 'update_story',
   TRASH_STORY: 'trash_story',
+  DUPLICATE_STORY: 'duplicate_story',
 };
 
 export const defaultStoriesState = {
@@ -67,11 +68,22 @@ function storyReducer(state, action) {
         ),
         totalStories: state.totalStories - 1,
         stories: Object.keys(state.stories).reduce((memo, storyId) => {
-          if (storyId !== action.payload.id) {
+          if (parseInt(storyId) !== action.payload.id) {
             memo[storyId] = state.stories[storyId];
           }
           return memo;
         }, {}),
+      };
+
+    case ACTION_TYPES.DUPLICATE_STORY:
+      return {
+        ...state,
+        storiesOrderById: [...state.storiesOrderById, action.payload.id],
+        totalStories: state.totalStories + 1,
+        stories: {
+          ...state.stories,
+          [action.payload.id]: action.payload,
+        },
       };
 
     case ACTION_TYPES.FETCH_STORIES_SUCCESS: {

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -78,7 +78,7 @@ function storyReducer(state, action) {
     case ACTION_TYPES.DUPLICATE_STORY:
       return {
         ...state,
-        storiesOrderById: [...state.storiesOrderById, action.payload.id],
+        storiesOrderById: [action.payload.id, ...state.storiesOrderById],
         totalStories: state.totalStories + 1,
         stories: {
           ...state.stories,

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -107,7 +107,7 @@ function MyStories() {
   });
   const {
     actions: {
-      storyApi: { updateStory, fetchStories, trashStory },
+      storyApi: { updateStory, fetchStories, trashStory, duplicateStory },
     },
     state: {
       stories: {
@@ -201,6 +201,7 @@ function MyStories() {
           <StoryGridView
             trashStory={trashStory}
             updateStory={updateStory}
+            duplicateStory={duplicateStory}
             filteredStories={orderedStories}
             centerActionLabel={
               <>
@@ -225,6 +226,7 @@ function MyStories() {
         return null;
     }
   }, [
+    duplicateStory,
     trashStory,
     viewStyle,
     updateStory,

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -107,7 +107,7 @@ function MyStories() {
   });
   const {
     actions: {
-      storyApi: { updateStory, fetchStories },
+      storyApi: { updateStory, fetchStories, trashStory },
     },
     state: {
       stories: {
@@ -199,6 +199,7 @@ function MyStories() {
       case VIEW_STYLE.GRID:
         return (
           <StoryGridView
+            trashStory={trashStory}
             updateStory={updateStory}
             filteredStories={orderedStories}
             centerActionLabel={
@@ -224,6 +225,7 @@ function MyStories() {
         return null;
     }
   }, [
+    trashStory,
     viewStyle,
     updateStory,
     orderedStories,

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
 /**
  * External dependencies
  */
@@ -57,6 +60,7 @@ const StoryGridView = ({
   bottomActionLabel,
   updateStory,
   trashStory,
+  duplicateStory,
 }) => {
   const [contextMenuId, setContextMenuId] = useState(-1);
   const [titleRenameId, setTitleRenameId] = useState(-1);
@@ -72,15 +76,29 @@ const StoryGridView = ({
           setTitleRenameId(story.id);
           break;
 
+        case STORY_CONTEXT_MENU_ACTIONS.DUPLICATE:
+          duplicateStory(story);
+          break;
+
         case STORY_CONTEXT_MENU_ACTIONS.DELETE:
-          trashStory(story);
+          if (
+            window.confirm(
+              sprintf(
+                /* translators: %s: story title. */
+                __('Are you sure you want to delete "%s"?', 'web-stories'),
+                story.title
+              )
+            )
+          ) {
+            trashStory(story);
+          }
           break;
 
         default:
           break;
       }
     },
-    [trashStory]
+    [trashStory, duplicateStory]
   );
 
   const handleOnRenameStory = useCallback(
@@ -136,8 +154,9 @@ StoryGridView.propTypes = {
   filteredStories: StoriesPropType,
   centerActionLabel: ActionLabel,
   bottomActionLabel: ActionLabel,
-  updateStory: PropTypes.func,
-  trashStory: PropTypes.func,
+  updateStory: PropTypes.func.isRequired,
+  trashStory: PropTypes.func.isRequired,
+  duplicateStory: PropTypes.func.isRequired,
 };
 
 export default StoryGridView;

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -56,24 +56,32 @@ const StoryGridView = ({
   centerActionLabel,
   bottomActionLabel,
   updateStory,
+  trashStory,
 }) => {
   const [contextMenuId, setContextMenuId] = useState(-1);
   const [titleRenameId, setTitleRenameId] = useState(-1);
 
-  const handleMenuItemSelected = useCallback((sender, story) => {
-    setContextMenuId(-1);
-    switch (sender.value) {
-      case STORY_CONTEXT_MENU_ACTIONS.OPEN_IN_EDITOR:
-        window.location.href = story.bottomTargetAction;
-        break;
-      case STORY_CONTEXT_MENU_ACTIONS.RENAME:
-        setTitleRenameId(story.id);
-        break;
+  const handleMenuItemSelected = useCallback(
+    (sender, story) => {
+      setContextMenuId(-1);
+      switch (sender.value) {
+        case STORY_CONTEXT_MENU_ACTIONS.OPEN_IN_EDITOR:
+          window.location.href = story.bottomTargetAction;
+          break;
+        case STORY_CONTEXT_MENU_ACTIONS.RENAME:
+          setTitleRenameId(story.id);
+          break;
 
-      default:
-        break;
-    }
-  }, []);
+        case STORY_CONTEXT_MENU_ACTIONS.DELETE:
+          trashStory(story);
+          break;
+
+        default:
+          break;
+      }
+    },
+    [trashStory]
+  );
 
   const handleOnRenameStory = useCallback(
     (story, newTitle) => {
@@ -129,6 +137,7 @@ StoryGridView.propTypes = {
   centerActionLabel: ActionLabel,
   bottomActionLabel: ActionLabel,
   updateStory: PropTypes.func,
+  trashStory: PropTypes.func,
 };
 
 export default StoryGridView;


### PR DESCRIPTION
This PR adds the ability to delete and duplicate stories from the grid view on the dashboard.

Deleting a story will fire off a `DELETE` request and then dispatch a `TRASH` action to the reducer. We then decrement the story count by 1 and remove the story from both the IDs array and the stories object.

Duplicating a story will fire off a `POST` request with `story_data` and other properties used to save a story from the editor portion. This will dispatch a `DUPLICATE` action to the reducer which adds the story to the IDs array, story object, and increments the story count. Finally all duplicated stories are listed as `draft` status.

Adds tests for both the duplicate and delete actions with state updates.

## Relevant Technical Choices

- Delete story uses `window.confirm` as the UX. This will get replaced in a future PR with a custom MD dialog.
- Duplicate story adds "(Copy)" to the title and sets the status as `draft`

Closes #768 
