### PR TITLE
Use relative paths for lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged --relative"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Fixes an issue with markdownlint which expects relative paths.
