### PR TITLE
Dashboard: Color and Categories Filters UI for Templates Gallery

### DIFF
--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -53,6 +53,7 @@ import {
   StoryGridView,
   BodyViewOptions,
 } from '../shared';
+import useTemplateFilters from './templateFilters';
 
 const ExploreFiltersContainer = styled.div`
   padding: 0 20px 20px;
@@ -132,6 +133,15 @@ function TemplatesGallery() {
     totalTemplates
   );
 
+  const {
+    selectedCategories,
+    selectedColors,
+    onNewCategorySelected,
+    onNewColorSelected,
+    clearAllCategories,
+    clearAllColors,
+  } = useTemplateFilters();
+
   const BodyContent = useMemo(() => {
     if (totalTemplates > 0) {
       return (
@@ -180,8 +190,9 @@ function TemplatesGallery() {
                   ariaLabel={__('Category Dropdown', 'web-stories')}
                   type={DROPDOWN_TYPES.PANEL}
                   placeholder={__('Category', 'web-stories')}
-                  items={[]}
-                  onChange={() => {}}
+                  items={selectedCategories}
+                  onClear={clearAllCategories}
+                  onChange={onNewCategorySelected}
                 />
                 <Dropdown
                   ariaLabel={__('Style Dropdown', 'web-stories')}
@@ -194,8 +205,9 @@ function TemplatesGallery() {
                   ariaLabel={__('Color Dropdown', 'web-stories')}
                   type={DROPDOWN_TYPES.PANEL}
                   placeholder={__('Color', 'web-stories')}
-                  items={[]}
-                  onChange={() => {}}
+                  items={selectedColors}
+                  onClear={clearAllColors}
+                  onChange={onNewColorSelected}
                 />
                 <Dropdown
                   ariaLabel={__('Layout Type Dropdown', 'web-stories')}

--- a/assets/src/dashboard/app/views/templates/templateFilters.js
+++ b/assets/src/dashboard/app/views/templates/templateFilters.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useMemo, useState } from 'react';
+/**
+ * Internal dependencies
+ */
+import {
+  TEMPLATE_CATEGORY_ITEMS,
+  TEMPLATE_COLOR_ITEMS,
+} from '../../../constants';
+
+export function updateSelectedItems(items, setter) {
+  return function (sender) {
+    const newSelectedItems = items.map((item) => {
+      if (item.value === sender) {
+        return { ...item, selected: !item.selected };
+      }
+      return item;
+    });
+
+    setter(newSelectedItems);
+  };
+}
+
+export function clearAllSelectedItems(items, setter) {
+  return function () {
+    const newSelectedItems = items.map((item) => {
+      return { ...item, selected: false };
+    });
+
+    setter(newSelectedItems);
+  };
+}
+
+export default function useTemplateFilters() {
+  const [selectedCategories, setSelectedCategories] = useState(
+    TEMPLATE_CATEGORY_ITEMS
+  );
+
+  const [selectedColors, setSelectedColors] = useState(TEMPLATE_COLOR_ITEMS);
+
+  return useMemo(
+    () => ({
+      selectedCategories,
+      selectedColors,
+      onNewCategorySelected: updateSelectedItems(
+        selectedCategories,
+        setSelectedCategories
+      ),
+      onNewColorSelected: updateSelectedItems(
+        selectedColors,
+        setSelectedColors
+      ),
+      clearAllCategories: clearAllSelectedItems(
+        selectedCategories,
+        setSelectedCategories
+      ),
+      clearAllColors: clearAllSelectedItems(selectedColors, setSelectedColors),
+    }),
+    [selectedColors, selectedCategories]
+  );
+}

--- a/assets/src/dashboard/app/views/templates/test/templateFilters.js
+++ b/assets/src/dashboard/app/views/templates/test/templateFilters.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useTemplateFilters from '../templateFilters';
+import { TEMPLATE_CATEGORIES, TEMPLATE_COLORS } from '../../../../constants';
+
+describe('templateFilters', () => {
+  it('should select a color when the value is passed to the color selected method', () => {
+    const { result } = renderHook(() => useTemplateFilters());
+
+    act(() => {
+      result.current.onNewColorSelected(TEMPLATE_COLORS.YELLOW);
+    });
+
+    const yellow = result.current.selectedColors.find(
+      (color) => color.value === TEMPLATE_COLORS.YELLOW
+    );
+
+    expect(yellow.selected).toBe(true);
+  });
+
+  it('should select a category when the value is passed to the category selected method', () => {
+    const { result } = renderHook(() => useTemplateFilters());
+
+    act(() => {
+      result.current.onNewCategorySelected(TEMPLATE_CATEGORIES.SPORTS);
+    });
+
+    const sports = result.current.selectedCategories.find(
+      (category) => category.value === TEMPLATE_CATEGORIES.SPORTS
+    );
+
+    expect(sports.selected).toBe(true);
+  });
+
+  it('should clear the category selection when the clear method is called', () => {
+    const { result } = renderHook(() => useTemplateFilters());
+
+    act(() => {
+      result.current.onNewCategorySelected(TEMPLATE_CATEGORIES.SPORTS);
+    });
+
+    expect(
+      result.current.selectedCategories.find(
+        (category) => category.value === TEMPLATE_CATEGORIES.SPORTS
+      ).selected
+    ).toBe(true);
+
+    act(() => {
+      result.current.clearAllCategories();
+    });
+
+    expect(
+      result.current.selectedCategories.find(
+        (category) => category.value === TEMPLATE_CATEGORIES.SPORTS
+      ).selected
+    ).toBe(false);
+  });
+
+  it('should clear the color selection when the clear method is called', () => {
+    const { result } = renderHook(() => useTemplateFilters());
+
+    act(() => {
+      result.current.onNewColorSelected(TEMPLATE_COLORS.BLUE);
+    });
+
+    expect(
+      result.current.selectedColors.find(
+        (color) => color.value === TEMPLATE_COLORS.BLUE
+      ).selected
+    ).toBe(true);
+
+    act(() => {
+      result.current.clearAllColors();
+    });
+
+    expect(
+      result.current.selectedColors.find(
+        (color) => color.value === TEMPLATE_COLORS.BLUE
+      ).selected
+    ).toBe(false);
+  });
+});

--- a/assets/src/dashboard/components/colorDot.js
+++ b/assets/src/dashboard/components/colorDot.js
@@ -20,10 +20,10 @@ import styled from 'styled-components';
 
 export const ColorDot = styled.div`
   display: inline-block;
-  width: 14px;
-  height: 14px;
-  margin-right: 8px;
+  width: 26px;
+  height: 26px;
+  margin: 0 4px;
   box-shadow: inset 0 0 0 1px hsla(0, 0%, 0%, 0.25);
-  border-radius: 7px;
+  border-radius: 13px;
   background-color: ${({ color }) => color};
 `;

--- a/assets/src/dashboard/components/colorDot.js
+++ b/assets/src/dashboard/components/colorDot.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+export const ColorDot = styled.div`
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  margin-right: 8px;
+  box-shadow: inset 0 0 0 1px hsla(0, 0%, 0%, 0.25);
+  border-radius: 7px;
+  background-color: ${({ color }) => color};
+`;

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -31,6 +31,8 @@ import { DROPDOWN_TYPES } from '../../constants';
 import PopoverMenu from '../popoverMenu';
 import PopoverPanel from '../popoverPanel';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
+import { ColorDot } from '../colorDot';
+import { ReactComponent as CloseIcon } from '../../icons/close.svg';
 
 const StyledPopoverMenu = styled(PopoverMenu)`
   left: 50%;
@@ -82,6 +84,9 @@ InnerDropdown.propTypes = {
 };
 
 const InnerDropdownText = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -101,6 +106,17 @@ const DropdownIcon = styled.span`
   }
 `;
 
+const ClearButton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background-color: transparent;
+  color: ${({ theme }) => theme.colors.bluePrimary600};
+  margin: 0 8px 0 0;
+  padding: 0;
+`;
+
 const Dropdown = ({
   ariaLabel,
   items,
@@ -108,6 +124,7 @@ const Dropdown = ({
   onChange,
   value,
   placeholder,
+  onClear,
   type = DROPDOWN_TYPES.MENU,
   children,
   ...rest
@@ -142,14 +159,18 @@ const Dropdown = ({
     setShowMenu(false);
   };
 
+  const selectedItems = useMemo(
+    () => items.filter((item) => item.value !== 'all' && item.selected),
+    [items]
+  );
+
   const currentLabel = useMemo(() => {
     const getCurrentLabel = () => {
       const grouping = [items.find((item) => item.value === value)];
       return grouping[0]?.label;
     };
-
-    return value ? getCurrentLabel() : placeholder;
-  }, [value, placeholder, items]);
+    return value && getCurrentLabel();
+  }, [value, items]);
 
   return (
     <DropdownContainer ref={dropdownRef} {...rest}>
@@ -160,7 +181,26 @@ const Dropdown = ({
           disabled={disabled}
           type={type}
         >
-          <InnerDropdownText>{currentLabel}</InnerDropdownText>
+          <InnerDropdownText>
+            {currentLabel || (
+              <>
+                {selectedItems.length > 0 && (
+                  <ClearButton
+                    tab-index={0}
+                    data-testid="dropdown-clear-btn"
+                    aria-label="Clear Button"
+                    onClick={onClear}
+                  >
+                    <CloseIcon width={13} height={13} />
+                  </ClearButton>
+                )}
+                {selectedItems[0]?.hex && (
+                  <ColorDot color={selectedItems[0].hex} />
+                )}
+                {selectedItems[0]?.label || placeholder}
+              </>
+            )}
+          </InnerDropdownText>
           <DropdownIcon type={type}>
             {showMenu ? <DropUpArrow /> : <DropDownArrow />}
           </DropdownIcon>
@@ -170,7 +210,7 @@ const Dropdown = ({
       {type === DROPDOWN_TYPES.PANEL ? (
         <PopoverPanel
           isOpen={showMenu}
-          title={currentLabel}
+          title={placeholder}
           onClose={() => setShowMenu(false)}
           items={items}
           onSelect={(__, selectedValue) => {
@@ -195,6 +235,7 @@ Dropdown.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
+  onClear: PropTypes.func,
   placeholder: PropTypes.string,
   type: PropTypes.oneOf(Object.values(DROPDOWN_TYPES)),
   children: PropTypes.node,

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * External dependencies
  */
 import PropTypes from 'prop-types';
@@ -194,10 +199,17 @@ const Dropdown = ({
                     <CloseIcon width={13} height={13} />
                   </ClearButton>
                 )}
-                {selectedItems[0]?.hex && (
+                {selectedItems[0]?.hex ? (
                   <ColorDot color={selectedItems[0].hex} />
+                ) : (
+                  selectedItems[0]?.label || placeholder
                 )}
-                {selectedItems[0]?.label || placeholder}
+                {selectedItems.length > 1 &&
+                  sprintf(
+                    /* translators: %s: number selected */
+                    __(' + %s', 'web-stories'),
+                    (selectedItems.length - 1).toString(10)
+                  )}
               </>
             )}
           </InnerDropdownText>
@@ -213,7 +225,7 @@ const Dropdown = ({
           title={placeholder}
           onClose={() => setShowMenu(false)}
           items={items}
-          onSelect={(__, selectedValue) => {
+          onSelect={(_, selectedValue) => {
             handleMenuItemSelect(selectedValue);
           }}
         />

--- a/assets/src/dashboard/components/pill/index.js
+++ b/assets/src/dashboard/components/pill/index.js
@@ -55,8 +55,10 @@ const PillLabel = styled.span`
   cursor: pointer;
   margin: auto;
   width: 100%;
-  display: block;
+  display: flex;
   padding: 6px 16px;
+  align-items: center;
+  justify-content: center;
   background-color: ${({ theme }) => theme.colors.white};
   color: ${({ theme }) => theme.colors.gray600};
   border: ${({ theme }) => theme.borders.gray50};
@@ -92,7 +94,7 @@ const FloatingTabLabel = styled(PillLabel)`
 const Pill = ({
   children,
   inputType = PILL_TYPES.CHECKBOX,
-  isSelected,
+  isSelected = false,
   name,
   onClick,
   floatingTab,
@@ -100,7 +102,6 @@ const Pill = ({
   ...rest
 }) => {
   const Label = floatingTab ? FloatingTabLabel : PillLabel;
-
   return (
     <PillContainer>
       <PillInput

--- a/assets/src/dashboard/components/popoverPanel/index.js
+++ b/assets/src/dashboard/components/popoverPanel/index.js
@@ -27,6 +27,7 @@ import { ReactComponent as CloseIcon } from '../../icons/close.svg';
 import { Z_INDEX } from '../../constants';
 import { Pill } from '../pill';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
+import { ColorDot } from '../colorDot';
 
 export const Panel = styled.div`
   align-items: flex-start;
@@ -44,7 +45,15 @@ export const Panel = styled.div`
   transform: ${({ isOpen }) =>
     isOpen ? 'translate3d(0, 0, 0)' : 'translate3d(0, -1rem, 0)'};
   z-index: ${Z_INDEX.POPOVER_PANEL};
-  max-width: 595px;
+  max-width: ${({ theme }) => theme.popoverPanel.desktopWidth}px;
+
+  @media ${({ theme }) => theme.breakpoint.tablet} {
+    width: ${({ theme }) => theme.popoverPanel.tabletWidth}px;
+  }
+
+  @media ${({ theme }) => theme.breakpoint.desktop} {
+    width: ${({ theme }) => theme.popoverPanel.desktopWidth}px;
+  }
 `;
 
 Panel.propTypes = {
@@ -102,21 +111,24 @@ const PopoverPanel = ({ isOpen, onClose, title, items, onSelect }) => {
       </TitleBar>
       {isOpen && (
         <PillFieldset data-testid={'pill-fieldset'}>
-          {items.map(({ label, selected, value, disabled = false }, index) => {
-            return (
-              <Pill
-                key={`${value}_${index}`}
-                inputType="checkbox"
-                name={`${title}_pillGroup_${value}`}
-                onClick={onSelect}
-                value={value}
-                isSelected={selected}
-                disabled={disabled}
-              >
-                {label}
-              </Pill>
-            );
-          })}
+          {items.map(
+            ({ label, selected, value, hex, disabled = false }, index) => {
+              return (
+                <Pill
+                  key={`${value}_${index}`}
+                  inputType="checkbox"
+                  name={`${title}_pillGroup_${value}`}
+                  onClick={onSelect}
+                  value={value}
+                  isSelected={selected}
+                  disabled={disabled}
+                >
+                  {hex && <ColorDot color={hex} />}
+                  {label}
+                </Pill>
+              );
+            }
+          )}
         </PillFieldset>
       )}
     </Panel>

--- a/assets/src/dashboard/components/popoverPanel/index.js
+++ b/assets/src/dashboard/components/popoverPanel/index.js
@@ -123,8 +123,7 @@ const PopoverPanel = ({ isOpen, onClose, title, items, onSelect }) => {
                   isSelected={selected}
                   disabled={disabled}
                 >
-                  {hex && <ColorDot color={hex} />}
-                  {label}
+                  {hex ? <ColorDot color={hex} /> : label}
                 </Pill>
               );
             }

--- a/assets/src/dashboard/components/popoverPanel/index.js
+++ b/assets/src/dashboard/components/popoverPanel/index.js
@@ -45,7 +45,7 @@ export const Panel = styled.div`
   transform: ${({ isOpen }) =>
     isOpen ? 'translate3d(0, 0, 0)' : 'translate3d(0, -1rem, 0)'};
   z-index: ${Z_INDEX.POPOVER_PANEL};
-  max-width: ${({ theme }) => theme.popoverPanel.desktopWidth}px;
+  width: ${({ theme }) => theme.popoverPanel.desktopWidth}px;
 
   @media ${({ theme }) => theme.breakpoint.tablet} {
     width: ${({ theme }) => theme.popoverPanel.tabletWidth}px;

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -197,3 +197,4 @@ export const STORY_SORT_MENU_ITEMS = [
 
 export * from './animation';
 export * from './direction';
+export * from './templates';

--- a/assets/src/dashboard/constants/templates.js
+++ b/assets/src/dashboard/constants/templates.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const TEMPLATE_CATEGORIES = {
+  DIY_CRAFTS: 'diy_crafts',
+  MOVIES_TV: 'movies_tv',
+  BEAUTY_STYLE: 'beauty_style',
+  FITNESS_WELLBEING: 'fitness_wellbeing',
+  FOOD: 'food',
+  TRAVEL: 'travel',
+  MUSIC: 'music',
+  SPORTS: 'sports',
+};
+
+export const TEMPLATE_CATEGORY_ITEMS = [
+  {
+    label: __('DIY & Crafts', 'web-stories'),
+    value: TEMPLATE_CATEGORIES.DIY_CRAFTS,
+  },
+  {
+    label: __('Movies & TV', 'web-stories'),
+    value: TEMPLATE_CATEGORIES.MOVIES_TV,
+  },
+  {
+    label: __('Beauty & Style', 'web-stories'),
+    value: TEMPLATE_CATEGORIES.BEAUTY_STYLE,
+  },
+  {
+    label: __('Fitness & Wellbeing', 'web-stories'),
+    value: TEMPLATE_CATEGORIES.FITNESS_WELLBEING,
+  },
+  {
+    label: __('Food', 'web-stories'),
+    value: TEMPLATE_CATEGORIES.FOOD,
+  },
+  {
+    label: __('Travel', 'web-stories'),
+    value: TEMPLATE_CATEGORIES.TRAVEL,
+  },
+  {
+    label: __('Music', 'web-stories'),
+    value: TEMPLATE_CATEGORIES.MUSIC,
+  },
+  {
+    label: __('Sports', 'web-stories'),
+    value: TEMPLATE_CATEGORIES.SPORTS,
+  },
+];
+
+export const TEMPLATE_COLORS = {
+  WHITE: 'white',
+  BLACK: 'black',
+  GRAY: 'gray',
+  BROWN: 'brown',
+  RED: 'red',
+  ORANGE: 'orange',
+  YELLOW: 'yellow',
+  GREEN: 'green',
+  BLUE: 'blue',
+  PINK: 'pink',
+  PURPLE: 'purple',
+};
+
+export const TEMPLATE_COLOR_ITEMS = [
+  {
+    label: __('White', 'web-stories'),
+    hex: '#FFFFFF',
+    value: TEMPLATE_COLORS.WHITE,
+  },
+  {
+    label: __('Black', 'web-stories'),
+    hex: '#1A1D1F',
+    value: TEMPLATE_COLORS.BLACK,
+  },
+  {
+    label: __('Gray', 'web-stories'),
+    hex: '#9AA1A9',
+    value: TEMPLATE_COLORS.GRAY,
+  },
+  {
+    label: __('Brown', 'web-stories'),
+    hex: '#974A04',
+    value: TEMPLATE_COLORS.BROWN,
+  },
+  {
+    label: __('Red', 'web-stories'),
+    hex: '#EB5757',
+    value: TEMPLATE_COLORS.RED,
+  },
+  {
+    label: __('Orange', 'web-stories'),
+    hex: '#FA902E',
+    value: TEMPLATE_COLORS.ORANGE,
+  },
+  {
+    label: __('Yellow', 'web-stories'),
+    hex: '#FAE84C',
+    value: TEMPLATE_COLORS.YELLOW,
+  },
+  {
+    label: __('Green', 'web-stories'),
+    hex: '#6AE86F',
+    value: TEMPLATE_COLORS.GREEN,
+  },
+  {
+    label: __('Blue', 'web-stories'),
+    hex: '#1374FA',
+    value: TEMPLATE_COLORS.BLUE,
+  },
+  {
+    label: __('Pink', 'web-stories'),
+    hex: '#F078F2',
+    value: TEMPLATE_COLORS.PINK,
+  },
+  {
+    label: __('Purple', 'web-stories'),
+    hex: '#AA6FE1',
+    value: TEMPLATE_COLORS.PURPLE,
+  },
+];

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -146,6 +146,10 @@ const theme = {
     previewOverlay:
       'linear-gradient(360deg, rgba(26, 29, 31, 0.8) 11.58%, rgba(26, 29, 31, 0) 124.43%)',
   },
+  popoverPanel: {
+    desktopWidth: 595,
+    tabletWidth: 395,
+  },
   fonts: {
     heading1: {
       family: themeFonts.primary,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8823,15 +8823,6 @@
         "test-exclude": "^5.2.3"
       }
     },
-    "babel-plugin-jest-hoist": {
-      "version": "25.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-25.4.0.tgz",
-      "integrity": "sha512-M3a10JCtTyKevb0MjuH6tU+cP/NVQZ82QPADqI1RQYY1OphztsCeIeQmTsHmF/NS6m0E51Zl4QNsI3odXSQF5w==",
-      "dev": true,
-      "requires": {
-        "@types/babel__traverse": "^7.0.6"
-      }
-    },
     "babel-plugin-macros": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
@@ -9090,16 +9081,6 @@
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
-      }
-    },
-    "babel-preset-jest": {
-      "version": "25.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-25.4.0.tgz",
-      "integrity": "sha512-PwFiEWflHdu3JCeTr0Pb9NcHHE34qWFnPQRVPvqQITx4CsDCzs6o05923I10XvLvn9nNsRHuiVgB72wG/90ZHQ==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-jest-hoist": "^25.4.0",
-        "babel-preset-current-node-syntax": "^0.1.2"
       }
     },
     "babel-preset-minify": {


### PR DESCRIPTION
## Summary

- Adds the ability to filter and sort colors and categories
- Adds support to clear multiple-selected choices and show a color dot for colors
- Adds constants for currently-defined template filter choices

## Relevant Technical Choices

- Create a hook to separate out the set, update, and clear logic so the main template page does not get cluttered and it can be reused. 

Addresses #776 

<img width="630" alt="Screen Shot 2020-04-28 at 11 24 32 AM" src="https://user-images.githubusercontent.com/1738349/80515925-54b4b100-8948-11ea-9983-0370d3ae37b2.png">
<img width="566" alt="Screen Shot 2020-04-28 at 11 24 39 AM" src="https://user-images.githubusercontent.com/1738349/80515932-57170b00-8948-11ea-99af-c1f8ef1a4de1.png">
