### PR TITLE
Do not include `@wordpress/element` script in bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,12 +36,7 @@ const DependencyExtractionWebpackPlugin = require('@wordpress/dependency-extract
  * @return {(string|undefined|boolean)} Script global
  */
 function requestToExternal(request) {
-  const packages = [
-    'react',
-    'react-dom',
-    'react-dom/server',
-    '@wordpress/element',
-  ];
+  const packages = ['react', 'react-dom', 'react-dom/server'];
   if (packages.includes(request)) {
     return false;
   }


### PR DESCRIPTION
Previously done to save some bytes, but we don't want this to be in the bundle due to licenses.
