### PR TITLE
Dashboard: New toggle button group

### DIFF
--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -50,7 +50,7 @@ export {
   TableRow,
   TableTitleHeaderCell,
 } from './table';
-export { ToggleButton, ToggleButtonGroup } from './toggleButtonGroup';
+export { default as ToggleButtonGroup } from './toggleButtonGroup';
 export { default as TypeaheadInput } from './typeaheadInput';
 export { default as TypeaheadOptions } from './typeaheadOptions';
 export { ViewHeader } from './typography';

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -50,6 +50,7 @@ export {
   TableRow,
   TableTitleHeaderCell,
 } from './table';
+export { ToggleButton, ToggleButtonGroup } from './toggleButtonGroup';
 export { default as TypeaheadInput } from './typeaheadInput';
 export { default as TypeaheadOptions } from './typeaheadOptions';
 export { ViewHeader } from './typography';

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -24,7 +24,7 @@ import { useState, useCallback, useLayoutEffect, useRef } from 'react';
 /**
  * Internal dependencies
  */
-import { KEYBOARD_USER_SELECTOR } from '../../constants';
+import { KEYBOARD_USER_SELECTOR, BEZIER } from '../../constants';
 
 const ToggleButtonContainer = styled.div`
   display: flex;
@@ -40,7 +40,7 @@ const AnimationBar = styled.div`
     width: ${selectedButtonWidth}px;
     left: ${selectedButtonLeft}px;
     background-color:  ${theme.colors.bluePrimary600};
-    transition: all 0.3s ease-out; 
+    transition: all 0.3s ${BEZIER.outSine}; 
   `}
 `;
 AnimationBar.propTypes = {

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -35,12 +35,12 @@ const ToggleButtonContainer = styled.div`
 
 const AnimationBar = styled.div`
   ${({ theme, selectedButtonWidth = 0, selectedButtonLeft = 0 }) => `
+    position: absolute;
     height: 3px;
-    background-color:  ${theme.colors.bluePrimary600};
     width: ${selectedButtonWidth}px;
     left: ${selectedButtonLeft}px;
+    background-color:  ${theme.colors.bluePrimary600};
     transition: all 0.3s ease-out; 
-    position: absolute;
   `}
 `;
 AnimationBar.propTypes = {
@@ -50,24 +50,24 @@ AnimationBar.propTypes = {
 
 const ToggleButton = styled.button`
   ${({ theme, isActive }) => `
-  display: flex;
-  background-color: transparent;
-  flex-direction: column;
-  justify-content: space-between;
-  outline: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  font-size: ${theme.fonts.body1.size}px;
-  font-family: ${theme.fonts.body1.family};
-  font-weight: ${theme.fonts.body1.weight}};
-  line-height: ${theme.fonts.body1.lineHeight}px;
-  letter-spacing: ${theme.fonts.body1.letterSpacing}em;
-  color: ${isActive ? theme.colors.gray900 : theme.colors.gray600};
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    outline: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font-size: ${theme.fonts.body1.size}px;
+    font-family: ${theme.fonts.body1.family};
+    font-weight: ${theme.fonts.body1.weight}};
+    line-height: ${theme.fonts.body1.lineHeight}px;
+    letter-spacing: ${theme.fonts.body1.letterSpacing}em;
+    color: ${isActive ? theme.colors.gray900 : theme.colors.gray600};
+    background-color: transparent;
 
-  ${KEYBOARD_USER_SELECTOR} &:focus {
-    border: 1px solid ${theme.colors.action};
-  }
+    ${KEYBOARD_USER_SELECTOR} &:focus {
+        border: 1px solid ${theme.colors.action};
+    }
   `}
 `;
 

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -76,9 +76,10 @@ ToggleButton.propTypes = {
 };
 
 const ToggleButtonGroup = ({ buttons }) => {
-  const [selectedButton, setSelectedButton] = useState();
+  const [selectedButton, setSelectedButton] = useState(null);
   const activeRef = useRef(null);
 
+  // this layout effect hook will take care of setting the initial selectedButton state with left/width property of active button after first paint
   useLayoutEffect(() => {
     if (!activeRef || !activeRef.current) {
       return;
@@ -87,6 +88,10 @@ const ToggleButtonGroup = ({ buttons }) => {
     setSelectedButton({ left, width });
   }, []);
 
+  // if buttons is not present we do not want to render the component
+  if (!buttons || buttons.length <= 0) {
+    return null;
+  }
   return (
     <>
       <ToggleButtonContainer>

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { KEYBOARD_USER_SELECTOR } from '../../constants';
+
+const ToggleButtonGroup = styled.div`
+  display: flex;
+  height: 100%;
+  flex-direction: row;
+  justify-content: space-around;
+`;
+
+ToggleButtonGroup.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+const ToggleButton = styled.button`
+  ${({ theme, isActive }) => `
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  outline: none;
+  border: none;
+  padding-bottom: 0;
+  font-size: ${theme.fonts.body1.size}px;
+  font-family: ${theme.fonts.body1.family};
+  font-weight: ${isActive ? 600 : theme.fonts.body1.weight}};
+  line-height: ${theme.fonts.body1.lineHeight}px;
+  letter-spacing: ${theme.fonts.body1.letterSpacing}em;
+  color: ${isActive ? theme.colors.gray900 : theme.colors.gray600};
+
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    border: 1px solid ${theme.colors.action};
+  }
+
+  &:after {
+    content: '';
+    width: 100%;
+    display: inline-block;
+    border-bottom: 3px solid
+        ${isActive ? theme.colors.bluePrimary600 : 'transparent'};
+  }
+  `}
+`;
+
+ToggleButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  isActive: PropTypes.bool,
+};
+
+export { ToggleButtonGroup, ToggleButton };

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -78,12 +78,14 @@ ToggleButton.propTypes = {
 const ToggleButtonGroup = ({ buttons }) => {
   const [selectedButton, setSelectedButton] = useState();
   const activeRef = useRef(null);
-  activeRef.current = activeRef;
 
   useLayoutEffect(() => {
-    const { left, width } = activeRef?.current?.getBoundingClientRect();
+    if (!activeRef || !activeRef.current) {
+      return;
+    }
+    const { left, width } = activeRef.current.getBoundingClientRect();
     setSelectedButton({ left, width });
-  }, [activeRef]);
+  }, []);
 
   return (
     <>

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -81,12 +81,21 @@ const ToggleButtonGroup = ({ buttons }) => {
 
   // this layout effect hook will take care of setting the initial selectedButton state with left/width property of active button after first paint
   useLayoutEffect(() => {
-    if (!activeRef || !activeRef.current) {
+    if (!activeRef.current) {
       return;
     }
     const { left, width } = activeRef.current.getBoundingClientRect();
     setSelectedButton({ left, width });
   }, []);
+
+  const handleButtonClick = useCallback(
+    (e, handleClick) => {
+      const { left, width } = e.currentTarget.getBoundingClientRect();
+      setSelectedButton({ left, width });
+      handleClick && handleClick();
+    },
+    [setSelectedButton]
+  );
 
   // if buttons is not present we do not want to render the component
   if (!buttons || buttons.length <= 0) {
@@ -99,14 +108,7 @@ const ToggleButtonGroup = ({ buttons }) => {
           <ToggleButton
             ref={isActive ? activeRef : null}
             type="button"
-            onClick={useCallback(
-              (e) => {
-                const { left, width } = e.currentTarget.getBoundingClientRect();
-                handleClick();
-                setSelectedButton({ left, width });
-              },
-              [handleClick]
-            )}
+            onClick={(e) => handleButtonClick(e, handleClick)}
             key={key || `toggle_button_${idx}`}
             isActive={isActive}
           >

--- a/assets/src/dashboard/components/toggleButtonGroup/stories/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/stories/index.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { ToggleButton, ToggleButtonGroup } from '../';
+import { STORY_STATUSES } from '../../../constants';
+
+export default {
+  title: 'Dashboard/Components/ToggleButtonGroup',
+  component: ToggleButtonGroup,
+};
+
+const Container = styled.div`
+  height: 60px;
+`;
+
+export const _default = () => {
+  const [status, setStatus] = useState(STORY_STATUSES[0].value);
+  return (
+    <Container>
+      <ToggleButtonGroup>
+        {STORY_STATUSES.map((storyStatus) => (
+          <ToggleButton
+            key={storyStatus.value}
+            onClick={() => {
+              setStatus(storyStatus.value);
+              action('button clicked ', storyStatus.value);
+            }}
+            isActive={status === storyStatus.value}
+          >
+            {storyStatus.label}
+          </ToggleButton>
+        ))}
+      </ToggleButtonGroup>
+    </Container>
+  );
+};

--- a/assets/src/dashboard/components/toggleButtonGroup/stories/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/stories/index.js
@@ -24,7 +24,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { ToggleButton, ToggleButtonGroup } from '../';
+import ToggleButtonGroup from '../';
 import { STORY_STATUSES } from '../../../constants';
 
 export default {
@@ -40,20 +40,19 @@ export const _default = () => {
   const [status, setStatus] = useState(STORY_STATUSES[0].value);
   return (
     <Container>
-      <ToggleButtonGroup>
-        {STORY_STATUSES.map((storyStatus) => (
-          <ToggleButton
-            key={storyStatus.value}
-            onClick={() => {
+      <ToggleButtonGroup
+        buttons={STORY_STATUSES.map((storyStatus) => {
+          return {
+            handleClick: () => {
               setStatus(storyStatus.value);
               action('button clicked ', storyStatus.value);
-            }}
-            isActive={status === storyStatus.value}
-          >
-            {storyStatus.label}
-          </ToggleButton>
-        ))}
-      </ToggleButtonGroup>
+            },
+            key: storyStatus.value,
+            isActive: status === storyStatus.value,
+            text: storyStatus.label,
+          };
+        })}
+      />
     </Container>
   );
 };

--- a/assets/src/dashboard/components/toggleButtonGroup/test/toggleButtonGroup.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/test/toggleButtonGroup.js
@@ -35,7 +35,7 @@ describe('ToggleButton', () => {
   const onClickMock = jest.fn();
 
   it('should render a button group with three items', () => {
-    const { debug, getAllByRole } = renderWithTheme(
+    const { getAllByRole } = renderWithTheme(
       <ToggleButtonGroup
         buttons={TEST_BUTTON_GROUP.map((storyStatus) => {
           return {
@@ -47,14 +47,12 @@ describe('ToggleButton', () => {
         })}
       />
     );
-    debug();
 
     const buttons = getAllByRole('button');
-    // expect(getAllByRole('button')).toHaveLength(3);
-    expect(buttons).toBeDefined();
+    expect(buttons).toHaveLength(3);
   });
 
-  xit('should simulate a click on a button in <ToggleButtonGroup />', () => {
+  it('should simulate a click on a button in <ToggleButtonGroup />', () => {
     const { getByText } = renderWithTheme(
       <ToggleButtonGroup
         buttons={TEST_BUTTON_GROUP.map((storyStatus) => {

--- a/assets/src/dashboard/components/toggleButtonGroup/test/toggleButtonGroup.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/test/toggleButtonGroup.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+
+import { fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { ToggleButton } from '../';
+import { renderWithTheme } from '../../../testUtils/';
+
+describe('ToggleButton', () => {
+  const buttonText = 'Some button text';
+  const onClickMock = jest.fn();
+
+  it('should render the default non cta button', () => {
+    const { getByText } = renderWithTheme(
+      <ToggleButton onClick={onClickMock}>{buttonText}</ToggleButton>
+    );
+
+    expect(getByText(buttonText)).toBeDefined();
+  });
+
+  it('should simulate a click on <ToggleButton />', () => {
+    const { getByText } = renderWithTheme(
+      <ToggleButton onClick={onClickMock}>{buttonText}</ToggleButton>
+    );
+
+    const button = getByText(buttonText);
+
+    fireEvent.click(button);
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assets/src/dashboard/components/toggleButtonGroup/test/toggleButtonGroup.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/test/toggleButtonGroup.js
@@ -17,33 +17,58 @@
 /**
  * External dependencies
  */
-
 import { fireEvent } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
-import { ToggleButton } from '../';
+import ToggleButtonGroup from '../';
 import { renderWithTheme } from '../../../testUtils/';
 
+const TEST_BUTTON_GROUP = [
+  { label: 'label one', value: 'label_one' },
+  { label: 'label two', value: 'label_two' },
+  { label: 'label three', value: 'label_three' },
+];
+
 describe('ToggleButton', () => {
-  const buttonText = 'Some button text';
   const onClickMock = jest.fn();
 
-  it('should render the default non cta button', () => {
-    const { getByText } = renderWithTheme(
-      <ToggleButton onClick={onClickMock}>{buttonText}</ToggleButton>
+  it('should render a button group with three items', () => {
+    const { debug, getAllByRole } = renderWithTheme(
+      <ToggleButtonGroup
+        buttons={TEST_BUTTON_GROUP.map((storyStatus) => {
+          return {
+            handleClick: onClickMock,
+            key: storyStatus.value,
+            isActive: status === storyStatus.value,
+            text: storyStatus.label,
+          };
+        })}
+      />
     );
+    debug();
 
-    expect(getByText(buttonText)).toBeDefined();
+    const buttons = getAllByRole('button');
+    // expect(getAllByRole('button')).toHaveLength(3);
+    expect(buttons).toBeDefined();
   });
 
-  it('should simulate a click on <ToggleButton />', () => {
+  xit('should simulate a click on a button in <ToggleButtonGroup />', () => {
     const { getByText } = renderWithTheme(
-      <ToggleButton onClick={onClickMock}>{buttonText}</ToggleButton>
+      <ToggleButtonGroup
+        buttons={TEST_BUTTON_GROUP.map((storyStatus) => {
+          return {
+            handleClick: onClickMock,
+            key: storyStatus.value,
+            isActive: status === storyStatus.value,
+            text: storyStatus.label,
+          };
+        })}
+      />
     );
 
-    const button = getByText(buttonText);
+    const button = getByText('label two');
 
     fireEvent.click(button);
 


### PR DESCRIPTION
## Summary

Adds a new toggle button group component to the dashboard to update the header area filter UI with.  Currently only lives in Storybook (Dashboard/Components/ToggleButtonGroup)

## Relevant Technical Choices

- Using flexbox to have the `ToggleButtonGroup` respond to whatever the height is of the parent to make it flexible 

**Reference from Sam's video recording of new designs:** 
![my stories heading](https://user-images.githubusercontent.com/10720454/80639436-dd9a1e00-8a16-11ea-9c7e-857089e81cc2.png)

**Gif of storybook**
![animated filters](https://user-images.githubusercontent.com/10720454/80659614-4d6fcf00-8a3e-11ea-98b0-fc96d744525b.gif)


---

<!-- Please reference the issue(s) this PR addresses. -->

Updates #1286 
