### PR TITLE
Fix font variant tuple sorting and add test

### DIFF
--- a/assets/src/edit-story/utils/getGoogleFontURL.js
+++ b/assets/src/edit-story/utils/getGoogleFontURL.js
@@ -56,7 +56,15 @@ function getGoogleFontURL(fonts, display = 'swap') {
 
     const axisTuples = variants
       .sort((a, b) => {
-        return a[0] - b[0] + a[1] - b[1];
+        if (a[0] < b[0]) {
+          return -1;
+        }
+
+        if (a[0] > b[0]) {
+          return 1;
+        }
+
+        return a[1] - b[1];
       })
       .map(([fontStyle, fontWeight]) => {
         const tuple = [];

--- a/assets/src/edit-story/utils/test/getGoogleFontURL.js
+++ b/assets/src/edit-story/utils/test/getGoogleFontURL.js
@@ -53,6 +53,17 @@ describe('getGoogleFontURL', () => {
     const architects_daughter = {
       family: 'Architects Daughter',
     };
+    const roboto_condensed_all = {
+      family: 'Roboto Condensed',
+      variants: [
+        [0, 300],
+        [1, 300],
+        [0, 400],
+        [1, 400],
+        [0, 700],
+        [1, 700],
+      ],
+    };
 
     expect(getGoogleFontURL([roboto_400])).toStrictEqual(
       'https://fonts.googleapis.com/css2?display=swap&family=Roboto'
@@ -74,6 +85,9 @@ describe('getGoogleFontURL', () => {
     );
     expect(getGoogleFontURL([architects_daughter])).toStrictEqual(
       'https://fonts.googleapis.com/css2?display=swap&family=Architects+Daughter'
+    );
+    expect(getGoogleFontURL([roboto_condensed_all])).toStrictEqual(
+      'https://fonts.googleapis.com/css2?display=swap&family=Roboto+Condensed%3Aital%2Cwght%400%2C300%3B0%2C400%3B0%2C700%3B1%2C300%3B1%2C400%3B1%2C700'
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes 404s when requesting certain fonts.

## Relevant Technical Choices

Google Fonts requires the tuples in the URL to be sorted properly. This PR fixes that.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1382
