### PR TITLE
Playground: add missing config

### DIFF
--- a/.storybook/stories/playground/index.js
+++ b/.storybook/stories/playground/index.js
@@ -30,6 +30,7 @@ const config = {
     audio: [],
     video: ['video/mp4'],
   },
+  allowedFileTypes: ['png', 'jpeg', 'jpg', 'gif', 'mp4'],
   storyId: 1234,
   api: {
     stories: '',


### PR DESCRIPTION
## Summary

Introduced in #1326 I believe.

<img width="985" alt="Screenshot 2020-04-30 at 13 30 03" src="https://user-images.githubusercontent.com/841956/80705428-b7dc4a00-8ae6-11ea-92f0-c7257d239ef4.png">

Test using `npm run storybook`. The editor should display properly again.

## Relevant Technical Choices

Add necessary mock to unbreak playground at least a little bit.

