### PR TITLE
Dashboard 1286: Implementin Toggle Button Group (my stories)

### DIFF
--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -31,7 +31,6 @@ import { useCallback, useContext, useEffect, useState, useMemo } from 'react';
 import { UnitsProvider } from '../../../../edit-story/units';
 import { TransformProvider } from '../../../../edit-story/components/transform';
 import {
-  FloatingTab,
   InfiniteScroller,
   ScrollToTop,
   Layout,

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -35,6 +35,7 @@ import {
   InfiniteScroller,
   ScrollToTop,
   Layout,
+  ToggleButtonGroup,
 } from '../../../components';
 import {
   VIEW_STYLE,
@@ -141,7 +142,7 @@ function MyStories() {
     [setCurrentStorySort, setCurrentPageClamped]
   );
   const handleFilterStatusUpdate = useCallback(
-    (_, value) => {
+    (value) => {
       setCurrentPageClamped(1);
       setStatus(value);
     },
@@ -288,18 +289,17 @@ function MyStories() {
                 handleTypeaheadChange={handleTypeaheadChange}
                 typeaheadValue={typeaheadValue}
               >
-                {STORY_STATUSES.map((storyStatus) => (
-                  <FloatingTab
-                    key={storyStatus.value}
-                    onClick={handleFilterStatusUpdate}
-                    name="my-stories-filter-selection"
-                    value={storyStatus.value}
-                    isSelected={status === storyStatus.value}
-                    inputType="radio"
-                  >
-                    {storyStatus.label}
-                  </FloatingTab>
-                ))}
+                <ToggleButtonGroup
+                  buttons={STORY_STATUSES.map((storyStatus) => {
+                    return {
+                      handleClick: () =>
+                        handleFilterStatusUpdate(storyStatus.value),
+                      key: storyStatus.value,
+                      isActive: status === storyStatus.value,
+                      text: storyStatus.label,
+                    };
+                  })}
+                />
               </PageHeading>
               {storiesViewControls}
             </Layout.Squishable>

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -34,8 +34,7 @@ const Container = styled.div`
 `;
 
 const StyledHeader = styled(ViewHeader)`
-  display: inline-flex;
-  width: 25%;
+  display: flex;
   justify-content: flex-start;
   align-items: center;
   line-height: 1;
@@ -48,25 +47,17 @@ const StyledHeader = styled(ViewHeader)`
 `;
 
 const Content = styled.div`
-  display: inline-flex;
+  display: block;
   align-items: center;
   justify-content: center;
-  width: 50%;
-
-  ${DropdownContainer} {
-    margin-right: 10px;
-
-    &:last-child {
-      margin-right: 0;
-    }
-  }
+  height: 100%;
 `;
 
 const SearchContainer = styled.div`
   display: inline-block;
   vertical-align: baseline;
   position: relative;
-  width: 25%;
+  width: 100%;
   height: 29px;
   @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
     left: ${({ theme }) => `${theme.pageGutter.small.min}px`};
@@ -83,10 +74,11 @@ const SearchInner = styled.div`
 `;
 
 const HeadingBodyWrapper = styled(BodyWrapper)`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding-bottom: 10px;
+  display: grid;
+  grid-template-columns: 25% 50% 1fr;
+  align-items: start;
+  height: 75px;
+  padding-bottom: 3px;
   border-bottom: ${({ theme }) => theme.subNavigationBar.border};
 `;
 

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -47,8 +47,6 @@ const StyledHeader = styled(ViewHeader)`
 
 const Content = styled.div`
   display: block;
-  align-items: center;
-  justify-content: center;
   height: 100%;
 `;
 

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -25,7 +25,6 @@ import PropTypes from 'prop-types';
 import cssLerp from '../../../utils/cssLerp';
 import { StoriesPropType } from '../../../types';
 import { ViewHeader, NavMenuButton } from '../../../components';
-import { DropdownContainer } from '../../../components/dropdown';
 import BodyWrapper from './bodyWrapper';
 import TypeaheadSearch from './typeaheadSearch';
 

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -23,6 +23,7 @@ import { __, sprintf, _n } from '@wordpress/i18n';
  * External dependencies
  */
 import { useState, useContext, useMemo, useCallback, useEffect } from 'react';
+import styled from 'styled-components';
 
 /**
  * Internal dependencies
@@ -36,6 +37,8 @@ import {
   InfiniteScroller,
   ScrollToTop,
 } from '../../../components';
+import { DropdownContainer } from '../../../components/dropdown';
+
 import {
   VIEW_STYLE,
   DROPDOWN_TYPES,
@@ -53,6 +56,18 @@ import {
 } from '../shared';
 import useTemplateFilters from './templateFilters';
 
+const HeadingDropdownsContainer = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-evenly;
+
+  ${DropdownContainer} {
+    margin-right: 10px;
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+`;
 function TemplatesGallery() {
   const [typeaheadValue, setTypeaheadValue] = useState('');
   const [viewStyle, setViewStyle] = useState(VIEW_STYLE.GRID);
@@ -171,36 +186,38 @@ function TemplatesGallery() {
                 handleTypeaheadChange={setTypeaheadValue}
                 typeaheadValue={typeaheadValue}
               >
-                <Dropdown
-                  ariaLabel={__('Category Dropdown', 'web-stories')}
-                  type={DROPDOWN_TYPES.PANEL}
-                  placeholder={__('Category', 'web-stories')}
-                  items={selectedCategories}
-                  onClear={clearAllCategories}
-                  onChange={onNewCategorySelected}
-                />
-                <Dropdown
-                  ariaLabel={__('Style Dropdown', 'web-stories')}
-                  type={DROPDOWN_TYPES.PANEL}
-                  placeholder={__('Style', 'web-stories')}
-                  items={[]}
-                  onChange={() => {}}
-                />
-                <Dropdown
-                  ariaLabel={__('Color Dropdown', 'web-stories')}
-                  type={DROPDOWN_TYPES.PANEL}
-                  placeholder={__('Color', 'web-stories')}
-                  items={selectedColors}
-                  onClear={clearAllColors}
-                  onChange={onNewColorSelected}
-                />
-                <Dropdown
-                  ariaLabel={__('Layout Type Dropdown', 'web-stories')}
-                  type={DROPDOWN_TYPES.PANEL}
-                  placeholder={__('Layout Type', 'web-stories')}
-                  items={[]}
-                  onChange={() => {}}
-                />
+                <HeadingDropdownsContainer>
+                  <Dropdown
+                    ariaLabel={__('Category Dropdown', 'web-stories')}
+                    type={DROPDOWN_TYPES.PANEL}
+                    placeholder={__('Category', 'web-stories')}
+                    items={selectedCategories}
+                    onClear={clearAllCategories}
+                    onChange={onNewCategorySelected}
+                  />
+                  <Dropdown
+                    ariaLabel={__('Style Dropdown', 'web-stories')}
+                    type={DROPDOWN_TYPES.PANEL}
+                    placeholder={__('Style', 'web-stories')}
+                    items={[]}
+                    onChange={() => {}}
+                  />
+                  <Dropdown
+                    ariaLabel={__('Color Dropdown', 'web-stories')}
+                    type={DROPDOWN_TYPES.PANEL}
+                    placeholder={__('Color', 'web-stories')}
+                    items={selectedColors}
+                    onClear={clearAllColors}
+                    onChange={onNewColorSelected}
+                  />
+                  <Dropdown
+                    ariaLabel={__('Layout Type Dropdown', 'web-stories')}
+                    type={DROPDOWN_TYPES.PANEL}
+                    placeholder={__('Layout Type', 'web-stories')}
+                    items={[]}
+                    onChange={() => {}}
+                  />
+                </HeadingDropdownsContainer>
               </PageHeading>
               <BodyViewOptions
                 listBarLabel={listBarLabel}

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -119,7 +119,7 @@ const ToggleButtonGroup = ({ buttons }) => {
       <ToggleButtonContainer ref={containerRef}>
         {buttons.map(({ isActive, handleClick, key, text }, idx) => (
           <ToggleButton
-            ref={isActive ? activeRef : null}
+            {...(isActive ? { ref: activeRef } : {})}
             type="button"
             onClick={(e) => handleButtonClick(e, handleClick)}
             key={key || `toggle_button_${idx}`}

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -38,7 +38,6 @@ const ToggleButtonContainer = styled.div`
   height: 100%;
   flex-direction: row;
   justify-content: space-evenly;
-  border: 1px solid red;
 `;
 
 const AnimationBar = styled.div`
@@ -113,7 +112,6 @@ const ToggleButtonGroup = ({ buttons }) => {
     if (!activeRef.current) {
       return;
     }
-
     updateBarDimensions(activeRef.current);
   }, [updateBarDimensions]);
 


### PR DESCRIPTION
## Summary
Uses the new `ToggleButtonGroup` component for the group of filters on My Stories in the page header 

## Relevant Technical Choices
- swap out flexbox for grid on `PageHeader` to make boundaries sturdy for the three distinct parts we now have in the header layout. 
- Make the `Content` in `PageHeader` block, the contents can set a wrapper (like in both my stories and templates) to do what it wants with the space, but this way nothing wonky is forced into the children. We were having to grab components and add margin if they existed and if the pageHeader is truly shared we want it to be agnostic of the contents. 
- the toggleButtonGroup needs a height set for the spacing to work and be elastic to its situation, so I added an estimated 75px to the headerHeight, this seems like it might be what's set in the video we're going off of but I anticipate it changes a bit. 
- I also noticed in said design video that the toggle button active blue line sits _right on top_ of the header bottom border, so I adjusted the padding a bit on that container. 
- Found out when I dropped the new button group in wordpress that using `getBoundingClientRect` becomes a little more complicated and we need to grab the container x position and then subtract the active ref from the container. To make this a little more straightforward I swapped to using x instead of left and am now using left margin to set the location of our active animated div. 
- Also decided to go ahead and handle resizing browsers so that doesn't come up later, added a calculation for the percentage from the container left for the active animation element and added in a resizeObserver to track the container width. Not sure if we need to worry about debouncing this so I didn't for the time being. 

![updated page header filters](https://user-images.githubusercontent.com/10720454/80752930-42ba4600-8ae1-11ea-9e0a-7fc72ec0ecf0.gif)

