### PR TITLE
Dashboard: Add API hooks for categories, tags, users. Connected the data fetched to the story's list UI.

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -24,15 +24,26 @@ import { createContext, useMemo } from 'react';
  * Internal dependencies
  */
 import { useConfig } from '../config';
+import dataAdapter from './wpAdapter';
 import useFontApi from './useFontApi';
 import useStoryApi from './useStoryApi';
 import useTemplateApi from './useTemplateApi';
-import dataAdapter from './wpAdapter';
+import useTagsApi from './useTagsApi';
+import useCategoriesApi from './useCategoriesApi';
+import useUsersApi from './useUserApi';
 
 export const ApiContext = createContext({ state: {}, actions: {} });
 
 export default function ApiProvider({ children }) {
   const { api, editStoryURL, pluginDir } = useConfig();
+
+  const { users, api: usersApi } = useUsersApi(dataAdapter, {
+    wpApi: api.users,
+  });
+  const { tags, api: tagsApi } = useTagsApi(dataAdapter, { wpApi: api.tags });
+  const { categories, api: categoriesApi } = useCategoriesApi(dataAdapter, {
+    wpApi: api.categories,
+  });
 
   const { templates, api: templateApi } = useTemplateApi(dataAdapter, {
     pluginDir,
@@ -50,14 +61,32 @@ export default function ApiProvider({ children }) {
       state: {
         stories,
         templates,
+        tags,
+        categories,
+        users,
       },
       actions: {
         storyApi,
         templateApi,
         fontApi,
+        tagsApi,
+        categoriesApi,
+        usersApi,
       },
     }),
-    [stories, templates, storyApi, templateApi, fontApi]
+    [
+      users,
+      categories,
+      tags,
+      stories,
+      templates,
+      storyApi,
+      templateApi,
+      fontApi,
+      tagsApi,
+      categoriesApi,
+      usersApi,
+    ]
   );
 
   return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;

--- a/assets/src/dashboard/app/api/fetchAllFromPages.js
+++ b/assets/src/dashboard/app/api/fetchAllFromPages.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import queryString from 'query-string';
+
+/**
+ * This function takes a response from the WordPress fetch and will query
+ * for every entity for every possible page. This is used for tags, categories, and users
+ * on the Dashboard where individual requests for each story on each layout would not
+ * be ideal.
+ *
+ * @param response The response from the initial wpFetch call
+ * @param dataAdapter The WP Data Adapter that will make the additional page fetch requests
+ * @param wpApi The base url for the fetch calls
+ * @return Promise<any[]> A flattened array with all the entities
+ */
+
+export default async function fetchAllFromTotalPages(
+  response,
+  dataAdapter,
+  wpApi
+) {
+  const totalPages = parseInt(response.headers.get('X-WP-TotalPages'));
+  const additionalRequests = [];
+
+  if (totalPages > 1) {
+    for (let i = 2; i <= totalPages; i++) {
+      additionalRequests.push(
+        dataAdapter.get(
+          queryString.stringifyUrl({
+            url: wpApi,
+            query: { page: i },
+          })
+        )
+      );
+    }
+  }
+  try {
+    return (await Promise.all([response.json(), ...additionalRequests])).flat(
+      1
+    );
+  } catch (e) {
+    return [];
+  }
+}

--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -38,6 +38,9 @@ jest.mock('../wpAdapter', () => ({
           {
             id: 123,
             status: 'published',
+            tags: [1, 2, 3],
+            categories: [4, 5, 6],
+            author: 1,
             title: { rendered: 'Carlos', raw: 'Carlos' },
             story_data: { pages: [{ id: 1, elements: [] }] },
             modified: '1970-01-01T00:00:00.000Z',
@@ -50,6 +53,9 @@ jest.mock('../wpAdapter', () => ({
       id: data.id || 456,
       status: 'published',
       title: { rendered: title, raw: title },
+      tags: [1, 2, 3],
+      categories: [4, 5, 6],
+      author: 1,
       story_data: { pages: [{ id: 1, elements: [] }] },
       modified: '1970-01-01T00:00:00.000Z',
     });
@@ -87,10 +93,16 @@ describe('ApiProvider', () => {
         centerTargetAction: '',
         id: 123,
         modified: moment('1970-01-01T00:00:00.000Z'),
+        tags: [1, 2, 3],
+        categories: [4, 5, 6],
+        author: 1,
         originalStoryData: {
           id: 123,
           modified: '1970-01-01T00:00:00.000Z',
           status: 'published',
+          tags: [1, 2, 3],
+          categories: [4, 5, 6],
+          author: 1,
           story_data: {
             pages: [
               {
@@ -153,10 +165,16 @@ describe('ApiProvider', () => {
         centerTargetAction: '',
         id: 123,
         modified: moment('1970-01-01T00:00:00.000Z'),
+        tags: [1, 2, 3],
+        categories: [4, 5, 6],
+        author: 1,
         originalStoryData: {
           id: 123,
           modified: '1970-01-01T00:00:00.000Z',
           status: 'published',
+          tags: [1, 2, 3],
+          categories: [4, 5, 6],
+          author: 1,
           story_data: {
             pages: [
               {
@@ -208,8 +226,14 @@ describe('ApiProvider', () => {
         ],
         status: 'published',
         title: 'Carlos',
+        tags: [1, 2, 3],
+        categories: [4, 5, 6],
+        author: 1,
         originalStoryData: {
           story_data: {
+            tags: [1, 2, 3],
+            categories: [4, 5, 6],
+            author: 1,
             pages: [
               {
                 elements: [],
@@ -230,10 +254,16 @@ describe('ApiProvider', () => {
         centerTargetAction: '',
         id: 123,
         modified: moment('1970-01-01T00:00:00.000Z'),
+        tags: [1, 2, 3],
+        categories: [4, 5, 6],
+        author: 1,
         originalStoryData: {
           id: 123,
           modified: '1970-01-01T00:00:00.000Z',
           status: 'published',
+          tags: [1, 2, 3],
+          categories: [4, 5, 6],
+          author: 1,
           story_data: {
             pages: [
               {
@@ -261,10 +291,16 @@ describe('ApiProvider', () => {
         centerTargetAction: '',
         id: 456,
         modified: moment('1970-01-01T00:00:00.000Z'),
+        tags: [1, 2, 3],
+        categories: [4, 5, 6],
+        author: 1,
         originalStoryData: {
           id: 456,
           modified: '1970-01-01T00:00:00.000Z',
           status: 'published',
+          tags: [1, 2, 3],
+          categories: [4, 5, 6],
+          author: 1,
           story_data: {
             pages: [
               {

--- a/assets/src/dashboard/app/api/test/useCategoryApi.js
+++ b/assets/src/dashboard/app/api/test/useCategoryApi.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+import useCategoriesApi from '../useCategoriesApi';
+import wpAdapter from '../wpAdapter';
+
+jest.mock('../wpAdapter', () => ({
+  get: () =>
+    Promise.resolve({
+      headers: {
+        get: () => '1',
+      },
+      json: () =>
+        Promise.resolve([
+          {
+            id: 13,
+            name: 'Music',
+          },
+          {
+            id: 23,
+            name: 'Art',
+          },
+        ]),
+    }),
+}));
+
+describe('useCategoryApi', () => {
+  it('should return categories in state data when the API request is fired', async () => {
+    const { result } = renderHook(() =>
+      useCategoriesApi(wpAdapter, { wpApi: 'categories' })
+    );
+
+    await act(async () => {
+      await result.current.api.fetchCategories();
+    });
+
+    expect(result.current.categories).toStrictEqual({
+      13: {
+        id: 13,
+        name: 'Music',
+      },
+      23: {
+        id: 23,
+        name: 'Art',
+      },
+    });
+  });
+});

--- a/assets/src/dashboard/app/api/test/useCategoryApi.js
+++ b/assets/src/dashboard/app/api/test/useCategoryApi.js
@@ -26,16 +26,22 @@ import wpAdapter from '../wpAdapter';
 
 jest.mock('../wpAdapter', () => ({
   get: () =>
-    Promise.resolve([
-      {
-        id: 13,
-        name: 'Music',
+    Promise.resolve({
+      headers: {
+        get: () => '1',
       },
-      {
-        id: 23,
-        name: 'Art',
-      },
-    ]),
+      json: () =>
+        Promise.resolve([
+          {
+            id: 13,
+            name: 'Music',
+          },
+          {
+            id: 23,
+            name: 'Art',
+          },
+        ]),
+    }),
 }));
 
 describe('useCategoryApi', () => {

--- a/assets/src/dashboard/app/api/test/useCategoryApi.js
+++ b/assets/src/dashboard/app/api/test/useCategoryApi.js
@@ -26,22 +26,16 @@ import wpAdapter from '../wpAdapter';
 
 jest.mock('../wpAdapter', () => ({
   get: () =>
-    Promise.resolve({
-      headers: {
-        get: () => '1',
+    Promise.resolve([
+      {
+        id: 13,
+        name: 'Music',
       },
-      json: () =>
-        Promise.resolve([
-          {
-            id: 13,
-            name: 'Music',
-          },
-          {
-            id: 23,
-            name: 'Art',
-          },
-        ]),
-    }),
+      {
+        id: 23,
+        name: 'Art',
+      },
+    ]),
 }));
 
 describe('useCategoryApi', () => {

--- a/assets/src/dashboard/app/api/test/useTagsApi.js
+++ b/assets/src/dashboard/app/api/test/useTagsApi.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+import useTagsApi from '../useTagsApi';
+import wpAdapter from '../wpAdapter';
+
+jest.mock('../wpAdapter', () => ({
+  get: () =>
+    Promise.resolve({
+      headers: {
+        get: () => '1',
+      },
+      json: () =>
+        Promise.resolve([
+          {
+            id: 7,
+            name: 'Fun',
+            slug: 'fun',
+          },
+        ]),
+    }),
+}));
+
+describe('useTagsApi', () => {
+  it('should return tags in state data when the API request is fired', async () => {
+    const { result } = renderHook(() =>
+      useTagsApi(wpAdapter, { wpApi: 'tags' })
+    );
+
+    await act(async () => {
+      await result.current.api.fetchTags();
+    });
+
+    expect(result.current.tags).toStrictEqual({
+      7: {
+        id: 7,
+        name: 'Fun',
+        slug: 'fun',
+      },
+    });
+  });
+});

--- a/assets/src/dashboard/app/api/test/useTagsApi.js
+++ b/assets/src/dashboard/app/api/test/useTagsApi.js
@@ -26,19 +26,13 @@ import wpAdapter from '../wpAdapter';
 
 jest.mock('../wpAdapter', () => ({
   get: () =>
-    Promise.resolve({
-      headers: {
-        get: () => '1',
+    Promise.resolve([
+      {
+        id: 7,
+        name: 'Fun',
+        slug: 'fun',
       },
-      json: () =>
-        Promise.resolve([
-          {
-            id: 7,
-            name: 'Fun',
-            slug: 'fun',
-          },
-        ]),
-    }),
+    ]),
 }));
 
 describe('useTagsApi', () => {

--- a/assets/src/dashboard/app/api/test/useTagsApi.js
+++ b/assets/src/dashboard/app/api/test/useTagsApi.js
@@ -26,13 +26,19 @@ import wpAdapter from '../wpAdapter';
 
 jest.mock('../wpAdapter', () => ({
   get: () =>
-    Promise.resolve([
-      {
-        id: 7,
-        name: 'Fun',
-        slug: 'fun',
+    Promise.resolve({
+      headers: {
+        get: () => '1',
       },
-    ]),
+      json: () =>
+        Promise.resolve([
+          {
+            id: 7,
+            name: 'Fun',
+            slug: 'fun',
+          },
+        ]),
+    }),
 }));
 
 describe('useTagsApi', () => {

--- a/assets/src/dashboard/app/api/test/useUserApi.js
+++ b/assets/src/dashboard/app/api/test/useUserApi.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+import useUserApi from '../useUserApi';
+import wpAdapter from '../wpAdapter';
+
+jest.mock('../wpAdapter', () => ({
+  get: () =>
+    Promise.resolve({
+      headers: {
+        get: () => '1',
+      },
+      json: () =>
+        Promise.resolve([
+          {
+            id: 9,
+            name: 'admin',
+          },
+        ]),
+    }),
+}));
+
+describe('useUserApi', () => {
+  it('should return user in state data when the API request is fired', async () => {
+    const { result } = renderHook(() =>
+      useUserApi(wpAdapter, { wpApi: 'user' })
+    );
+
+    await act(async () => {
+      await result.current.api.fetchUsers();
+    });
+
+    expect(result.current.users).toStrictEqual({
+      9: {
+        id: 9,
+        name: 'admin',
+      },
+    });
+  });
+});

--- a/assets/src/dashboard/app/api/test/useUserApi.js
+++ b/assets/src/dashboard/app/api/test/useUserApi.js
@@ -26,18 +26,12 @@ import wpAdapter from '../wpAdapter';
 
 jest.mock('../wpAdapter', () => ({
   get: () =>
-    Promise.resolve({
-      headers: {
-        get: () => '1',
+    Promise.resolve([
+      {
+        id: 9,
+        name: 'admin',
       },
-      json: () =>
-        Promise.resolve([
-          {
-            id: 9,
-            name: 'admin',
-          },
-        ]),
-    }),
+    ]),
 }));
 
 describe('useUserApi', () => {

--- a/assets/src/dashboard/app/api/test/useUserApi.js
+++ b/assets/src/dashboard/app/api/test/useUserApi.js
@@ -26,12 +26,18 @@ import wpAdapter from '../wpAdapter';
 
 jest.mock('../wpAdapter', () => ({
   get: () =>
-    Promise.resolve([
-      {
-        id: 9,
-        name: 'admin',
+    Promise.resolve({
+      headers: {
+        get: () => '1',
       },
-    ]),
+      json: () =>
+        Promise.resolve([
+          {
+            id: 9,
+            name: 'admin',
+          },
+        ]),
+    }),
 }));
 
 describe('useUserApi', () => {

--- a/assets/src/dashboard/app/api/useCategoriesApi.js
+++ b/assets/src/dashboard/app/api/useCategoriesApi.js
@@ -22,13 +22,30 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
+import queryString from 'query-string';
 import groupBy from '../../utils/groupBy';
+import fetchAllFromTotalPages from './fetchAllFromPages';
 
 export default function useCategoriesApi(dataAdapter, { wpApi }) {
   const [categories, setCategories] = useState({});
   const fetchCategories = useCallback(async () => {
     try {
-      const categoriesJson = await dataAdapter.get(wpApi);
+      const response = await dataAdapter.get(
+        queryString.stringifyUrl({
+          url: wpApi,
+          query: { per_page: 100 },
+        }),
+        {
+          parse: false,
+        }
+      );
+
+      const categoriesJson = await fetchAllFromTotalPages(
+        response,
+        dataAdapter,
+        wpApi
+      );
+
       setCategories(
         groupBy(
           categoriesJson.map(({ _links, ...category }) => category),

--- a/assets/src/dashboard/app/api/useCategoriesApi.js
+++ b/assets/src/dashboard/app/api/useCategoriesApi.js
@@ -28,10 +28,7 @@ export default function useCategoriesApi(dataAdapter, { wpApi }) {
   const [categories, setCategories] = useState({});
   const fetchCategories = useCallback(async () => {
     try {
-      const response = await dataAdapter.get(wpApi, {
-        parse: false,
-      });
-      const categoriesJson = await response.json();
+      const categoriesJson = await dataAdapter.get(wpApi);
       setCategories(
         groupBy(
           categoriesJson.map(({ _links, ...category }) => category),

--- a/assets/src/dashboard/app/api/useCategoriesApi.js
+++ b/assets/src/dashboard/app/api/useCategoriesApi.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import groupBy from '../../utils/groupBy';
+
+export default function useCategoriesApi(dataAdapter, { wpApi }) {
+  const [categories, setCategories] = useState({});
+  const fetchCategories = useCallback(async () => {
+    try {
+      const response = await dataAdapter.get(wpApi, {
+        parse: false,
+      });
+      const categoriesJson = await response.json();
+      setCategories(
+        groupBy(
+          categoriesJson.map(({ _links, ...category }) => category),
+          'id'
+        )
+      );
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      setCategories({});
+    }
+  }, [dataAdapter, wpApi]);
+
+  useEffect(() => {
+    fetchCategories();
+  }, [fetchCategories]);
+
+  return useMemo(
+    () => ({
+      api: { fetchCategories },
+      categories,
+    }),
+    [fetchCategories, categories]
+  );
+}

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -48,6 +48,9 @@ export function reshapeStoryObject(editStoryURL) {
       title,
       modified,
       status,
+      tags,
+      categories,
+      author,
       story_data: storyData,
     } = originalStoryData;
     if (
@@ -63,6 +66,9 @@ export function reshapeStoryObject(editStoryURL) {
       title: title.rendered,
       modified: moment(modified),
       pages: storyData.pages,
+      tags,
+      categories,
+      author,
       centerTargetAction: '',
       bottomTargetAction: `${editStoryURL}&post=${id}`,
       originalStoryData,

--- a/assets/src/dashboard/app/api/useTagsApi.js
+++ b/assets/src/dashboard/app/api/useTagsApi.js
@@ -28,10 +28,7 @@ export default function useTagsApi(dataAdapter, { wpApi }) {
   const [tags, setTags] = useState({});
   const fetchTags = useCallback(async () => {
     try {
-      const response = await dataAdapter.get(wpApi, {
-        parse: false,
-      });
-      const tagsJson = await response.json();
+      const tagsJson = await dataAdapter.get(wpApi);
       setTags(
         groupBy(
           tagsJson.map(({ _links, ...tag }) => tag),

--- a/assets/src/dashboard/app/api/useTagsApi.js
+++ b/assets/src/dashboard/app/api/useTagsApi.js
@@ -22,13 +22,30 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
+import queryString from 'query-string';
 import groupBy from '../../utils/groupBy';
+import fetchAllFromTotalPages from './fetchAllFromPages';
 
 export default function useTagsApi(dataAdapter, { wpApi }) {
   const [tags, setTags] = useState({});
   const fetchTags = useCallback(async () => {
     try {
-      const tagsJson = await dataAdapter.get(wpApi);
+      const response = await dataAdapter.get(
+        queryString.stringifyUrl({
+          url: wpApi,
+          query: { per_page: 100 },
+        }),
+        {
+          parse: false,
+        }
+      );
+
+      const tagsJson = await fetchAllFromTotalPages(
+        response,
+        dataAdapter,
+        wpApi
+      );
+
       setTags(
         groupBy(
           tagsJson.map(({ _links, ...tag }) => tag),

--- a/assets/src/dashboard/app/api/useTagsApi.js
+++ b/assets/src/dashboard/app/api/useTagsApi.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import groupBy from '../../utils/groupBy';
+
+export default function useTagsApi(dataAdapter, { wpApi }) {
+  const [tags, setTags] = useState({});
+  const fetchTags = useCallback(async () => {
+    try {
+      const response = await dataAdapter.get(wpApi, {
+        parse: false,
+      });
+      const tagsJson = await response.json();
+      setTags(
+        groupBy(
+          tagsJson.map(({ _links, ...tag }) => tag),
+          'id'
+        )
+      );
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      setTags({});
+    }
+  }, [dataAdapter, wpApi]);
+
+  useEffect(() => {
+    fetchTags();
+  }, [fetchTags]);
+
+  return useMemo(
+    () => ({
+      api: { fetchTags },
+      tags,
+    }),
+    [fetchTags, tags]
+  );
+}

--- a/assets/src/dashboard/app/api/useUserApi.js
+++ b/assets/src/dashboard/app/api/useUserApi.js
@@ -28,10 +28,7 @@ export default function useUsersApi(dataAdapter, { wpApi }) {
   const [users, setUsers] = useState({});
   const fetchUsers = useCallback(async () => {
     try {
-      const response = await dataAdapter.get(wpApi, {
-        parse: false,
-      });
-      const usersJson = await response.json();
+      const usersJson = await dataAdapter.get(wpApi);
       setUsers(
         groupBy(
           usersJson.map(({ _links, ...user }) => user),

--- a/assets/src/dashboard/app/api/useUserApi.js
+++ b/assets/src/dashboard/app/api/useUserApi.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import groupBy from '../../utils/groupBy';
+
+export default function useUsersApi(dataAdapter, { wpApi }) {
+  const [users, setUsers] = useState({});
+  const fetchUsers = useCallback(async () => {
+    try {
+      const response = await dataAdapter.get(wpApi, {
+        parse: false,
+      });
+      const usersJson = await response.json();
+      setUsers(
+        groupBy(
+          usersJson.map(({ _links, ...user }) => user),
+          'id'
+        )
+      );
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+      setUsers({});
+    }
+  }, [dataAdapter, wpApi]);
+
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
+  return useMemo(
+    () => ({
+      api: { fetchUsers },
+      users,
+    }),
+    [fetchUsers, users]
+  );
+}

--- a/assets/src/dashboard/app/api/useUserApi.js
+++ b/assets/src/dashboard/app/api/useUserApi.js
@@ -22,13 +22,30 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
+import queryString from 'query-string';
 import groupBy from '../../utils/groupBy';
+import fetchAllFromTotalPages from './fetchAllFromPages';
 
 export default function useUsersApi(dataAdapter, { wpApi }) {
   const [users, setUsers] = useState({});
   const fetchUsers = useCallback(async () => {
     try {
-      const usersJson = await dataAdapter.get(wpApi);
+      const response = await dataAdapter.get(
+        queryString.stringifyUrl({
+          url: wpApi,
+          query: { per_page: 100 },
+        }),
+        {
+          parse: false,
+        }
+      );
+
+      const usersJson = await fetchAllFromTotalPages(
+        response,
+        dataAdapter,
+        wpApi
+      );
+
       setUsers(
         groupBy(
           usersJson.map(({ _links, ...user }) => user),

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -72,7 +72,7 @@ const PlayArrowIcon = styled(PlayArrowSvg).attrs({ width: 11, height: 14 })`
 function MyStories() {
   const [status, setStatus] = useState(STORY_STATUSES[0].value);
   const [typeaheadValue, setTypeaheadValue] = useState('');
-  const [viewStyle, setViewStyle] = useState(VIEW_STYLE.LIST);
+  const [viewStyle, setViewStyle] = useState(VIEW_STYLE.GRID);
   const [currentPage, setCurrentPage] = useState(1);
 
   const [currentStorySort, setCurrentStorySort] = useState(

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -72,7 +72,7 @@ const PlayArrowIcon = styled(PlayArrowSvg).attrs({ width: 11, height: 14 })`
 function MyStories() {
   const [status, setStatus] = useState(STORY_STATUSES[0].value);
   const [typeaheadValue, setTypeaheadValue] = useState('');
-  const [viewStyle, setViewStyle] = useState(VIEW_STYLE.GRID);
+  const [viewStyle, setViewStyle] = useState(VIEW_STYLE.LIST);
   const [currentPage, setCurrentPage] = useState(1);
 
   const [currentStorySort, setCurrentStorySort] = useState(
@@ -98,6 +98,9 @@ function MyStories() {
         totalStories,
         totalPages,
       },
+      tags,
+      categories,
+      users,
     },
   } = useContext(ApiContext);
 
@@ -205,6 +208,9 @@ function MyStories() {
             sortDirection={currentListSortDirection}
             handleSortChange={handleNewStorySort}
             handleSortDirectionChange={setListSortDirection}
+            tags={tags}
+            categories={categories}
+            users={users}
           />
         );
       default:
@@ -219,6 +225,9 @@ function MyStories() {
     currentStorySort,
     currentListSortDirection,
     handleNewStorySort,
+    tags,
+    categories,
+    users,
   ]);
 
   const storiesViewControls = useMemo(() => {

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -29,7 +29,12 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { useCallback } from 'react';
-import { StoriesPropType } from '../../../types';
+import {
+  CategoriesPropType,
+  StoriesPropType,
+  TagsPropType,
+  UsersPropType,
+} from '../../../types';
 import {
   PreviewPage,
   Table,
@@ -213,9 +218,9 @@ export default function StoryListView({
 
 StoryListView.propTypes = {
   filteredStories: StoriesPropType,
-  tags: PropTypes.object,
-  categories: PropTypes.object,
-  users: PropTypes.object,
+  tags: TagsPropType,
+  categories: CategoriesPropType,
+  users: UsersPropType,
   handleSortChange: PropTypes.func.isRequired,
   handleSortDirectionChange: PropTypes.func.isRequired,
   storySort: PropTypes.string.isRequired,

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -117,9 +117,8 @@ export default function StoryListView({
 }) {
   const metadataStringForIds = useCallback((metadata, ids) => {
     const metadataString = ids
-      .reduce((memo, current) => {
-        return [...memo, metadata[current].name];
-      }, [])
+      .reduce((memo, current) => [...memo, metadata[current]?.name], [])
+      .filter(Boolean)
       .join(', ');
     return metadataString === '' ? '—' : metadataString;
   }, []);

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -78,7 +78,12 @@ const ArrowIcon = styled.div`
 `;
 
 const ArrowIconWithTitle = styled(ArrowIcon)`
+  display: ${({ active }) => (active ? 'inline' : 'none')};
   margin-left: 15px;
+
+  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
+    margin-left: 5px;
+  }
 `;
 
 const SelectableTitle = styled.span.attrs({ tabIndex: 0 })`
@@ -92,13 +97,33 @@ const toggleSortLookup = {
   [SORT_DIRECTION.ASC]: SORT_DIRECTION.DESC,
 };
 
+const LastModifiedTableHeaderCell = styled(TableHeaderCell)`
+  min-width: 160px;
+`;
+
+const AuthorTableHeaderCell = styled(TableHeaderCell)`
+  min-width: 110px;
+`;
+
 export default function StoryListView({
   filteredStories,
   storySort,
   handleSortChange,
   handleSortDirectionChange,
   sortDirection,
+  tags,
+  categories,
+  users,
 }) {
+  const metadataStringForIds = useCallback((metadata, ids) => {
+    const metadataString = ids
+      .reduce((memo, current) => {
+        return [...memo, metadata[current].name];
+      }, [])
+      .join(', ');
+    return metadataString === '' ? '—' : metadataString;
+  }, []);
+
   const onSortTitleSelected = useCallback(
     (newStorySort) => {
       if (newStorySort !== storySort) {
@@ -128,7 +153,7 @@ export default function StoryListView({
                 <ArrowIconSvg {...ICON_METRICS.UP_DOWN_ARROW} />
               </ArrowIcon>
             </TableTitleHeaderCell>
-            <TableHeaderCell>
+            <AuthorTableHeaderCell>
               <SelectableTitle
                 onClick={() =>
                   onSortTitleSelected(STORY_SORT_OPTIONS.CREATED_BY)
@@ -142,25 +167,24 @@ export default function StoryListView({
               >
                 <ArrowIconSvg {...ICON_METRICS.UP_DOWN_ARROW} />
               </ArrowIconWithTitle>
-            </TableHeaderCell>
+            </AuthorTableHeaderCell>
             <TableHeaderCell>{__('Categories', 'web-stories')}</TableHeaderCell>
             <TableHeaderCell>{__('Tags', 'web-stories')}</TableHeaderCell>
-            <TableHeaderCell>
+            <LastModifiedTableHeaderCell>
               <SelectableTitle
                 onClick={() =>
                   onSortTitleSelected(STORY_SORT_OPTIONS.LAST_MODIFIED)
                 }
               >
                 {__('Last Modified', 'web-stories')}
+                <ArrowIconWithTitle
+                  active={storySort === STORY_SORT_OPTIONS.LAST_MODIFIED}
+                  asc={sortDirection === SORT_DIRECTION.ASC}
+                >
+                  <ArrowIconSvg {...ICON_METRICS.UP_DOWN_ARROW} />
+                </ArrowIconWithTitle>
               </SelectableTitle>
-
-              <ArrowIconWithTitle
-                active={storySort === STORY_SORT_OPTIONS.LAST_MODIFIED}
-                asc={sortDirection === SORT_DIRECTION.ASC}
-              >
-                <ArrowIconSvg {...ICON_METRICS.UP_DOWN_ARROW} />
-              </ArrowIconWithTitle>
-            </TableHeaderCell>
+            </LastModifiedTableHeaderCell>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -174,9 +198,11 @@ export default function StoryListView({
                 </PreviewContainer>
               </TablePreviewCell>
               <TableCell>{story.title}</TableCell>
-              <TableCell>{__('—', 'web-stories')}</TableCell>
-              <TableCell>{__('—', 'web-stories')}</TableCell>
-              <TableCell>{__('—', 'web-stories')}</TableCell>
+              <TableCell>{users[story.author].name}</TableCell>
+              <TableCell>
+                {metadataStringForIds(categories, story.categories)}
+              </TableCell>
+              <TableCell>{metadataStringForIds(tags, story.tags)}</TableCell>
               <TableCell>{story.modified.startOf('day').fromNow()}</TableCell>
             </TableRow>
           ))}
@@ -188,6 +214,9 @@ export default function StoryListView({
 
 StoryListView.propTypes = {
   filteredStories: StoriesPropType,
+  tags: PropTypes.object,
+  categories: PropTypes.object,
+  users: PropTypes.object,
   handleSortChange: PropTypes.func.isRequired,
   handleSortDirectionChange: PropTypes.func.isRequired,
   storySort: PropTypes.string.isRequired,

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -32,4 +32,30 @@ export const StoryPropType = PropTypes.shape({
   modified: PropTypes.object,
 });
 
+export const TagPropType = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  slug: PropTypes.string.isRequired,
+  count: PropTypes.number.isRequired,
+});
+
+export const CategoryPropType = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  parent: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  slug: PropTypes.string.isRequired,
+  count: PropTypes.number.isRequired,
+});
+
+export const UserPropType = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  slug: PropTypes.string.isRequired,
+  avatar_urls: PropTypes.object,
+});
+
 export const StoriesPropType = PropTypes.arrayOf(StoryPropType).isRequired;
+export const TagsPropType = PropTypes.objectOf(TagPropType).isRequired;
+export const CategoriesPropType = PropTypes.objectOf(CategoryPropType)
+  .isRequired;
+export const UsersPropType = PropTypes.objectOf(UserPropType).isRequired;

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -153,8 +153,11 @@ class Dashboard {
 					'pluginDir'    => WEBSTORIES_PLUGIN_DIR_URL,
 					'version'      => WEBSTORIES_VERSION,
 					'api'          => [
-						'stories' => sprintf( '/wp/v2/%s', $rest_base ),
-						'fonts'   => '/web-stories/v1/fonts',
+						'stories'    => sprintf( '/wp/v2/%s', $rest_base ),
+						'users'      => '/wp/v2/users',
+						'tags'       => '/wp/v2/tags',
+						'categories' => '/wp/v2/categories',
+						'fonts'      => '/web-stories/v1/fonts',
 					],
 				],
 			]


### PR DESCRIPTION
## Summary

Adds the ability to fetch the users, categories, and tags from the Wordpress API. Matches up the ids from the story to the user-facing strings from the data.

<img width="1032" alt="Screen Shot 2020-04-30 at 5 12 01 PM" src="https://user-images.githubusercontent.com/1738349/80764291-fa614f00-8b05-11ea-9a8a-8e43fd78ffbc.png">


## Relevant Technical Choices

- Follow the existing `useXApi` pattern to create smaller, testable modules for fetching and storing data
- Creating minimum width columns for author and last modified to ensure the header title doesn't crop

## To-do

- [x] Add in the two new columns from the new design videos in the next PR
Fixes #770 
