### PR TITLE
#769 Dashboard: Create template from story context menu (needs API) 

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -222,14 +222,25 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
     [wpApi, dataAdapter, editStoryURL]
   );
 
+  const createTemplateFromStory = useCallback(async (story) => {
+    await story;
+  }, []);
+
   const api = useMemo(
     () => ({
       updateStory,
       fetchStories,
       trashStory,
       duplicateStory,
+      createTemplateFromStory,
     }),
-    [duplicateStory, trashStory, updateStory, fetchStories]
+    [
+      duplicateStory,
+      trashStory,
+      updateStory,
+      fetchStories,
+      createTemplateFromStory,
+    ]
   );
 
   return { stories: state, api };

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -222,25 +222,14 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
     [wpApi, dataAdapter, editStoryURL]
   );
 
-  const createTemplateFromStory = useCallback(async (story) => {
-    await story;
-  }, []);
-
   const api = useMemo(
     () => ({
       updateStory,
       fetchStories,
       trashStory,
       duplicateStory,
-      createTemplateFromStory,
     }),
-    [
-      duplicateStory,
-      trashStory,
-      updateStory,
-      fetchStories,
-      createTemplateFromStory,
-    ]
+    [duplicateStory, trashStory, updateStory, fetchStories]
   );
 
   return { stories: state, api };

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -159,10 +159,18 @@ const useTemplateApi = (dataAdapter, config) => {
     }
   }, []);
 
+  const createTemplateFromStory = useCallback(async (story) => {
+    // api call to create a template from a story
+    await dispatch({
+      type: TEMPLATE_ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY,
+    });
+  }, []);
+
   const api = useMemo(
     () => ({
       bookmarkTemplateById,
       createStoryFromTemplatePages,
+      createTemplateFromStory,
       fetchBookmarkedTemplates,
       fetchSavedTemplates,
       fetchMyTemplates,
@@ -173,6 +181,7 @@ const useTemplateApi = (dataAdapter, config) => {
     [
       bookmarkTemplateById,
       createStoryFromTemplatePages,
+      createTemplateFromStory,
       fetchBookmarkedTemplates,
       fetchExternalTemplateById,
       fetchExternalTemplates,

--- a/assets/src/dashboard/app/reducer/templates.js
+++ b/assets/src/dashboard/app/reducer/templates.js
@@ -20,6 +20,7 @@
 import groupBy from '../../utils/groupBy';
 
 export const ACTION_TYPES = {
+  CREATE_TEMPLATE_FROM_STORY: 'create_template_from_story',
   LOADING_TEMPLATES: 'loading_templates',
   FETCH_TEMPLATES_SUCCESS: 'fetch_templates_success',
   FETCH_TEMPLATES_FAILURE: 'fetch_templates_failure',
@@ -38,6 +39,9 @@ export const defaultTemplatesState = {
 
 function templateReducer(state, action) {
   switch (action.type) {
+    case ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY: {
+      return state;
+    }
     case ACTION_TYPES.LOADING_TEMPLATES: {
       return {
         ...state,

--- a/assets/src/dashboard/app/reducer/test/templates.js
+++ b/assets/src/dashboard/app/reducer/test/templates.js
@@ -182,4 +182,13 @@ describe('templateReducer', () => {
       isError: true,
     });
   });
+
+  it(`should return the existing state when ${ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY} is called`, () => {
+    const result = templateReducer(
+      { ...initialState },
+      { type: ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY }
+    );
+
+    expect(result).toMatchObject(initialState);
+  });
 });

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -87,13 +87,8 @@ function MyStories() {
   });
   const {
     actions: {
-      storyApi: {
-        updateStory,
-        createTemplateFromStory,
-        fetchStories,
-        trashStory,
-        duplicateStory,
-      },
+      storyApi: { updateStory, fetchStories, trashStory, duplicateStory },
+      templateApi: { createTemplateFromStory },
     },
     state: {
       stories: {

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -87,7 +87,13 @@ function MyStories() {
   });
   const {
     actions: {
-      storyApi: { updateStory, fetchStories, trashStory, duplicateStory },
+      storyApi: {
+        updateStory,
+        createTemplateFromStory,
+        fetchStories,
+        trashStory,
+        duplicateStory,
+      },
     },
     state: {
       stories: {
@@ -186,6 +192,7 @@ function MyStories() {
           <StoryGridView
             trashStory={trashStory}
             updateStory={updateStory}
+            createTemplateFromStory={createTemplateFromStory}
             duplicateStory={duplicateStory}
             filteredStories={orderedStories}
             centerActionLabel={
@@ -212,6 +219,7 @@ function MyStories() {
     }
   }, [
     duplicateStory,
+    createTemplateFromStory,
     trashStory,
     viewStyle,
     updateStory,

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -58,6 +58,7 @@ const StoryGridView = ({
   filteredStories,
   centerActionLabel,
   bottomActionLabel,
+  createTemplateFromStory,
   updateStory,
   trashStory,
   duplicateStory,
@@ -81,6 +82,10 @@ const StoryGridView = ({
           duplicateStory(story);
           break;
 
+        case STORY_CONTEXT_MENU_ACTIONS.CREATE_TEMPLATE:
+          createTemplateFromStory(story);
+          break;
+
         case STORY_CONTEXT_MENU_ACTIONS.DELETE:
           if (
             window.confirm(
@@ -99,7 +104,7 @@ const StoryGridView = ({
           break;
       }
     },
-    [trashStory, duplicateStory]
+    [createTemplateFromStory, duplicateStory, trashStory]
   );
 
   const handleOnRenameStory = useCallback(
@@ -158,6 +163,7 @@ StoryGridView.propTypes = {
   filteredStories: StoriesPropType,
   centerActionLabel: ActionLabel,
   bottomActionLabel: ActionLabel,
+  createTemplateFromStory: PropTypes.func,
   updateStory: PropTypes.func,
   trashStory: PropTypes.func,
   duplicateStory: PropTypes.func,


### PR DESCRIPTION
## Summary
Adds in groundwork to create a template from a story

## Relevant Technical Choices
Follows same conventions as other actions in the context menu, new action in template context getting passed to story menu. Empty reducer action for handling a created template from a story. 


## To-do
Wire up API once it exists
Write relevant tests once the api is there and we know what data we are returning in the reducer or how we are displaying success/failure

