### PR TITLE
Dashboard: minor grid clean up

### DIFF
--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -28,21 +28,22 @@ import usePagePreviewSize from '../../utils/usePagePreviewSize';
 const DashboardGrid = styled.div`
   display: grid;
   width: 100%;
-  align-content: space-between;
-  grid-column-gap: 10px;
+  grid-column-gap: 1vw;
   grid-row-gap: 20px;
   grid-template-columns: ${({ columnWidth }) =>
     `repeat(auto-fill, minmax(${columnWidth}px, 1fr))`};
 
-  @media ${({ theme }) => theme.breakpoint.min} {
-    grid-template-columns: repeat(2, 1fr);
-  }
+  grid-template-rows: ${({ columnHeight }) =>
+    `minmax(${columnHeight}px, auto)`};
 `;
 
 const CardGrid = ({ children }) => {
   const { pageSize } = usePagePreviewSize();
-
-  return <DashboardGrid columnWidth={pageSize.width}>{children}</DashboardGrid>;
+  return (
+    <DashboardGrid columnWidth={pageSize.width} columnHeight={pageSize.height}>
+      {children}
+    </DashboardGrid>
+  );
 };
 
 CardGrid.propTypes = {

--- a/assets/src/dashboard/components/cardGridItem/index.js
+++ b/assets/src/dashboard/components/cardGridItem/index.js
@@ -23,15 +23,12 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { CARD_TITLE_AREA_HEIGHT } from '../../constants';
 import usePagePreviewSize from '../../utils/usePagePreviewSize';
 import { MoreVerticalButton } from './cardItemMenu';
 import { ActionLabel } from './types';
 
 const StyledCard = styled.div`
-  margin: auto 0;
-  height: ${({ cardSize, isTemplate }) =>
-    cardSize.height + (isTemplate ? 0 : CARD_TITLE_AREA_HEIGHT)}px;
+  margin: 0;
   width: ${({ cardSize }) => `${cardSize.width}px`};
   display: flex;
   flex-direction: column;


### PR DESCRIPTION

## Summary
Minor clean up of existing grid for stories. My goal here was just to clean up dead code / fix the current grid implementation so that when we update it it's more straightforward and we've got a cleaner starting point. 

## Relevant Technical Choices
- set height of grid rows flexible with `minmax` to avoid having to set it with a const internally by each item. 
- align-content was not doing anything for the grid style
- change grid column gap to 1vw. 
- Eliminate min breakpoint, grid does it for us.

## To-do
The grid could be a lot more dynamic but doing so now without more detail design direction isn't really worth the time. We need to know more about the sizing of grid items + the intended gutter around the items in order to update responsively.  

