### PR TITLE
Center Page Carousel

### DIFF
--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -64,7 +64,7 @@ const CAROUSEL_BOTTOM_SCROLL_MARGIN = 8;
 const Wrapper = styled.div`
   position: relative;
   display: grid;
-  grid: 'prev-navigation carousel next-navigation menu' auto / 53px 1fr 53px 53px;
+  grid: 'space prev-navigation carousel next-navigation menu' auto / 53px 53px 1fr 53px 53px;
   background-color: ${({ theme }) => theme.colors.bg.v1};
   color: ${({ theme }) => theme.colors.fg.v1};
   width: 100%;
@@ -320,6 +320,7 @@ function Carousel() {
   return (
     <>
       <Wrapper>
+        <NavArea area="space" />
         <NavArea area="prev-navigation" marginBottom={arrowsBottomMargin}>
           <PrevButton
             isHidden={!hasHorizontalOverflow || isAtBeginningOfList}


### PR DESCRIPTION
## Summary

| **Few items** | **Many items** |
| --- | --- |
| <img width="620" alt="Screen Shot 2020-05-04 at 2 16 45 pm" src="https://user-images.githubusercontent.com/1552225/80935882-00ab4000-8e12-11ea-8ab5-ff2fe8a0d31a.png"> | <img width="615" alt="Screen Shot 2020-05-04 at 2 04 39 pm" src="https://user-images.githubusercontent.com/1552225/80935873-f5581480-8e11-11ea-9909-531372f6a608.png"> |

## Relevant Technical Choices

I added a left spacing of the size of the right menu to fully center align the page list even if it has a lot of items and needs to scroll. Looked somewhat weird otherwise.

Fixes #1178
