### PR TITLE
Align flip buttons next to each other

### DIFF
--- a/assets/src/edit-story/components/panels/backgroundSizePosition.js
+++ b/assets/src/edit-story/components/panels/backgroundSizePosition.js
@@ -68,6 +68,7 @@ function BackgroundSizePositionPanel({ selectedElements, pushUpdate }) {
         <FlipControls
           onChange={(value) => pushUpdate({ flip: value }, true)}
           value={flip}
+          margin={'36px'}
         />
       </Row>
     </SimplePanel>

--- a/assets/src/edit-story/components/panels/backgroundSizePosition.js
+++ b/assets/src/edit-story/components/panels/backgroundSizePosition.js
@@ -68,7 +68,7 @@ function BackgroundSizePositionPanel({ selectedElements, pushUpdate }) {
         <FlipControls
           onChange={(value) => pushUpdate({ flip: value }, true)}
           value={flip}
-          margin={'36px'}
+          elementSpacing={36}
         />
       </Row>
     </SimplePanel>

--- a/assets/src/edit-story/components/panels/shared/flipControls.js
+++ b/assets/src/edit-story/components/panels/shared/flipControls.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 
 /**
@@ -31,30 +32,61 @@ import { ReactComponent as FlipHorizontal } from '../../../icons/flip_horizontal
 import { ReactComponent as FlipVertical } from '../../../icons/flip_vertical.svg';
 import Toggle from '../../form/toggle';
 
-function FlipControls({ value, onChange }) {
+const styledToggle = css`
+  width: 36px;
+  height: 36px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  float: left;
+`;
+
+const ToggleContainer = styled.div`
+  ${styledToggle}
+  margin-right: ${({ margin }) => (margin ? margin : '0px')};
+`;
+
+const ControlsContainer = styled.div`
+  width: fit-content;
+`;
+
+/**
+ * Get flip controls for flipping elements horizontally and vertically.
+ *
+ * @param {Object} value Element's flip object.
+ * @param {Object} onChange Callback to flip element.
+ * @param {number} margin Space between the two flip toggles (defaults to '8px').
+ * @return {*} Element or null if does not map to video/image.
+ */
+function FlipControls({ value, onChange, margin = '8px' }) {
   return (
-    <>
-      <Toggle
-        title={__('Flip horizontally', 'web-stories')}
-        aria-label={__('Flip horizontally', 'web-stories')}
-        icon={<FlipHorizontal />}
-        value={value.horizontal === true}
-        onChange={(horizontal) => onChange({ ...value, horizontal })}
-      />
-      <Toggle
-        title={__('Flip vertically', 'web-stories')}
-        aria-label={__('Flip vertically', 'web-stories')}
-        icon={<FlipVertical />}
-        value={value.vertical === true}
-        onChange={(vertical) => onChange({ ...value, vertical })}
-      />
-    </>
+    <ControlsContainer>
+      <ToggleContainer margin={margin}>
+        <Toggle
+          title={__('Flip horizontally', 'web-stories')}
+          aria-label={__('Flip horizontally', 'web-stories')}
+          icon={<FlipHorizontal />}
+          value={value.horizontal === true}
+          onChange={(horizontal) => onChange({ ...value, horizontal })}
+        />
+      </ToggleContainer>
+      <ToggleContainer>
+        <Toggle
+          title={__('Flip vertically', 'web-stories')}
+          aria-label={__('Flip vertically', 'web-stories')}
+          icon={<FlipVertical />}
+          value={value.vertical === true}
+          onChange={(vertical) => onChange({ ...value, vertical })}
+        />
+      </ToggleContainer>
+    </ControlsContainer>
   );
 }
 
 FlipControls.propTypes = {
   value: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
+  margin: PropTypes.string,
 };
 
 export default FlipControls;

--- a/assets/src/edit-story/components/panels/shared/flipControls.js
+++ b/assets/src/edit-story/components/panels/shared/flipControls.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 /**
@@ -32,36 +32,34 @@ import { ReactComponent as FlipHorizontal } from '../../../icons/flip_horizontal
 import { ReactComponent as FlipVertical } from '../../../icons/flip_vertical.svg';
 import Toggle from '../../form/toggle';
 
-const styledToggle = css`
+const ToggleContainer = styled.div`
   width: 36px;
   height: 36px;
   display: flex;
   justify-content: center;
   align-items: center;
-  float: left;
-`;
-
-const ToggleContainer = styled.div`
-  ${styledToggle}
-  margin-right: ${({ margin }) => (margin ? margin : '0px')};
+  margin-right: ${({ margin }) => (margin ? margin : 0)}px;
 `;
 
 const ControlsContainer = styled.div`
-  width: fit-content;
+  display: flex;
+  justify-content: left;
+  align-items: flex-start;
 `;
 
 /**
  * Get flip controls for flipping elements horizontally and vertically.
  *
- * @param {Object} value Element's flip object.
- * @param {Object} onChange Callback to flip element.
- * @param {number} margin Space between the two flip toggles (defaults to '8px').
- * @return {*} Element or null if does not map to video/image.
+ * @param {Object} props Component props.
+ * @param {Object} props.value Element's flip object.
+ * @param {function(boolean)} props.onChange Callback to flip element.
+ * @param {number} props.elementSpacing Space between the two flip toggles (defaults to 8).
+ * @return {*} Rendered component.
  */
-function FlipControls({ value, onChange, margin = '8px' }) {
+function FlipControls({ value, onChange, elementSpacing = 8 }) {
   return (
     <ControlsContainer>
-      <ToggleContainer margin={margin}>
+      <ToggleContainer margin={elementSpacing}>
         <Toggle
           title={__('Flip horizontally', 'web-stories')}
           aria-label={__('Flip horizontally', 'web-stories')}
@@ -86,7 +84,7 @@ function FlipControls({ value, onChange, margin = '8px' }) {
 FlipControls.propTypes = {
   value: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
-  margin: PropTypes.string,
+  elementSpacing: PropTypes.number,
 };
 
 export default FlipControls;

--- a/assets/src/edit-story/components/panels/shared/flipControls.js
+++ b/assets/src/edit-story/components/panels/shared/flipControls.js
@@ -56,7 +56,7 @@ const ControlsContainer = styled.div`
  * @param {number} props.elementSpacing Space between the two flip toggles (defaults to 8).
  * @return {*} Rendered component.
  */
-function FlipControls({ value, onChange, elementSpacing = 8 }) {
+function FlipControls({ value, onChange, elementSpacing }) {
   return (
     <ControlsContainer>
       <ToggleContainer margin={elementSpacing}>
@@ -85,6 +85,10 @@ FlipControls.propTypes = {
   value: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
   elementSpacing: PropTypes.number,
+};
+
+FlipControls.defaultProps = {
+  elementSpacing: 8,
 };
 
 export default FlipControls;


### PR DESCRIPTION
Buttons float to the left with a set margin between them.

## Summary

Fixes incorrect flip button placement when image is set as background.

(For background images)
![Screen Shot 2020-05-04 at 5 54 00 PM](https://user-images.githubusercontent.com/15134432/80945994-69a1b080-8e30-11ea-9ed0-3a7cd54d06a2.png)

(For non-background images - no change from before)
![Screen Shot 2020-05-04 at 5 54 07 PM](https://user-images.githubusercontent.com/15134432/80946003-71f9eb80-8e30-11ea-8d18-44d06c34e422.png)

Fixes #1212
