### PR TITLE
(Temporarily) Re-add templates assets to bundle

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -3,7 +3,6 @@
 .idea
 .storybook
 __mocks__
-assets/images/templates
 assets/src
 bin
 build

--- a/assets/src/dashboard/templates/data/cooking.js
+++ b/assets/src/dashboard/templates/data/cooking.js
@@ -78,7 +78,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_page1_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_page1_bg.jpg`,
               width: 220,
               height: 330,
               posterId: 0,
@@ -169,7 +169,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_logo.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_logo.png`,
               width: 56,
               height: 12,
               posterId: 0,
@@ -377,7 +377,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_radish.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_radish.png`,
               width: 220,
               height: 309,
               posterId: 0,
@@ -706,7 +706,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_page3_image1.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_page3_image1.jpg`,
               width: 220,
               height: 147,
               posterId: 0,
@@ -940,7 +940,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_persimmon.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_persimmon.png`,
               width: 220,
               height: 228,
               posterId: 0,
@@ -1179,7 +1179,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_arrow.png`,
               width: 100,
               height: 47,
               posterId: 0,
@@ -1252,7 +1252,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_radish.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_radish.png`,
               width: 220,
               height: 309,
               posterId: 0,
@@ -1290,7 +1290,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_carrot.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_carrot.png`,
               width: 220,
               height: 237,
               posterId: 0,
@@ -1328,7 +1328,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_persimmon.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_persimmon.png`,
               width: 220,
               height: 228,
               posterId: 0,
@@ -1366,7 +1366,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_artichoke.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_artichoke.png`,
               width: 220,
               height: 223,
               posterId: 0,
@@ -1981,7 +1981,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_page5_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_page5_bg.jpg`,
               width: 220,
               height: 391,
               posterId: 0,
@@ -2183,7 +2183,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_up_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_up_arrow.png`,
               width: 150,
               height: 69,
               posterId: 0,
@@ -2487,7 +2487,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_page5_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_page5_bg.jpg`,
               width: 220,
               height: 391,
               posterId: 0,
@@ -2732,7 +2732,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_arrow.png`,
               width: 100,
               height: 47,
               posterId: 0,
@@ -4112,7 +4112,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_page7_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_page7_bg.jpg`,
               width: 220,
               height: 330,
               posterId: 0,
@@ -4362,7 +4362,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_arrow.png`,
               width: 100,
               height: 47,
               posterId: 0,
@@ -5148,7 +5148,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_page8_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_page8_bg.jpg`,
               width: 220,
               height: 147,
               posterId: 0,
@@ -5607,7 +5607,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_page9_image1.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_page9_image1.jpg`,
               width: 220,
               height: 294,
               posterId: 0,
@@ -5646,7 +5646,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_page9_image2.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_page9_image2.jpg`,
               width: 220,
               height: 330,
               posterId: 0,
@@ -5689,7 +5689,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_page9_image3.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_page9_image3.jpg`,
               width: 220,
               height: 275,
               posterId: 0,
@@ -5732,7 +5732,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_page9_image4.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_page9_image4.jpg`,
               width: 220,
               height: 284,
               posterId: 0,
@@ -5762,7 +5762,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_facebook.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_facebook.png`,
               width: 50,
               height: 100,
               posterId: 0,
@@ -5800,7 +5800,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_instagram.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_instagram.png`,
               width: 150,
               height: 150,
               posterId: 0,
@@ -5838,7 +5838,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_youtube.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_youtube.png`,
               width: 100,
               height: 68,
               posterId: 0,
@@ -5876,7 +5876,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/cooking/cooking_icon_twitter.png`,
+              src: `${imageBaseUrl}assets/images/templates/cooking/cooking_icon_twitter.png`,
               width: 100,
               height: 79,
               posterId: 0,

--- a/assets/src/dashboard/templates/data/diy.js
+++ b/assets/src/dashboard/templates/data/diy.js
@@ -78,7 +78,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page1_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page1_bg.jpg`,
               width: 220,
               height: 330,
               posterId: 0,
@@ -379,7 +379,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_icon_org_cross.png`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_icon_org_cross.png`,
               width: 150,
               height: 150,
               posterId: 0,
@@ -467,7 +467,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page2_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page2_bg.jpg`,
               width: 220,
               height: 330,
               posterId: 0,
@@ -654,7 +654,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page3_image1.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page3_image1.jpg`,
               width: 220,
               height: 147,
               posterId: 0,
@@ -956,7 +956,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page4_page5_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page4_page5_bg.jpg`,
               width: 220,
               height: 275,
               posterId: 0,
@@ -1101,7 +1101,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page4_page5_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page4_page5_bg.jpg`,
               width: 220,
               height: 275,
               posterId: 0,
@@ -1364,7 +1364,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_icon_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_icon_arrow.png`,
               width: 128,
               height: 128,
               posterId: 0,
@@ -1410,7 +1410,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page6_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page6_bg.jpg`,
               width: 220,
               height: 147,
               posterId: 0,
@@ -1673,7 +1673,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_icon_wh_cross.png`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_icon_wh_cross.png`,
               width: 150,
               height: 158,
               posterId: 0,
@@ -1761,7 +1761,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page7_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page7_bg.jpg`,
               width: 220,
               height: 124,
               posterId: 0,
@@ -2012,7 +2012,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_icon_up_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_icon_up_arrow.png`,
               width: 150,
               height: 69,
               posterId: 0,
@@ -2239,7 +2239,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page8_image1.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page8_image1.jpg`,
               width: 220,
               height: 131,
               posterId: 0,
@@ -2278,7 +2278,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page8_image2.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page8_image2.jpg`,
               width: 220,
               height: 147,
               posterId: 0,
@@ -2324,7 +2324,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page8_image3.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page8_image3.jpg`,
               width: 220,
               height: 147,
               posterId: 0,
@@ -2736,7 +2736,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_icon_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_icon_arrow.png`,
               width: 128,
               height: 128,
               posterId: 0,
@@ -2782,7 +2782,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page7_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page7_bg.jpg`,
               width: 220,
               height: 124,
               posterId: 0,
@@ -3375,7 +3375,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page7_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page7_bg.jpg`,
               width: 220,
               height: 124,
               posterId: 0,
@@ -3414,7 +3414,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page7_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page7_bg.jpg`,
               width: 220,
               height: 124,
               posterId: 0,
@@ -3457,7 +3457,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page7_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page7_bg.jpg`,
               width: 220,
               height: 124,
               posterId: 0,
@@ -3500,7 +3500,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_page7_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_page7_bg.jpg`,
               width: 220,
               height: 124,
               posterId: 0,
@@ -4026,7 +4026,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_icon_fb.png`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_icon_fb.png`,
               width: 150,
               height: 300,
               posterId: 0,
@@ -4064,7 +4064,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_icon_insta.png`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_icon_insta.png`,
               width: 150,
               height: 150,
               posterId: 0,
@@ -4102,7 +4102,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_icon_yt.png`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_icon_yt.png`,
               width: 150,
               height: 102,
               posterId: 0,
@@ -4140,7 +4140,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/diy/diy_icon_tw.png`,
+              src: `${imageBaseUrl}assets/images/templates/diy/diy_icon_tw.png`,
               width: 151,
               height: 119,
               posterId: 0,

--- a/assets/src/dashboard/templates/data/fashion.js
+++ b/assets/src/dashboard/templates/data/fashion.js
@@ -78,7 +78,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page1_hero.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page1_hero.jpg`,
               width: 220,
               height: 297,
               posterId: 0,
@@ -158,7 +158,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page1_logotype.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page1_logotype.png`,
               width: 46,
               height: 12,
               posterId: 0,
@@ -337,7 +337,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page2_pinwheel_full.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page2_pinwheel_full.png`,
               width: 220,
               height: 220,
               posterId: 0,
@@ -375,7 +375,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page2_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page2_arrow.png`,
               width: 31,
               height: 24,
               posterId: 0,
@@ -464,7 +464,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page3_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page3_bg.jpg`,
               width: 220,
               height: 261,
               posterId: 0,
@@ -740,7 +740,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page3_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page3_arrow.png`,
               width: 7,
               height: 3,
               posterId: 0,
@@ -1704,7 +1704,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page5_handbag.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page5_handbag.png`,
               width: 220,
               height: 194,
               posterId: 0,
@@ -1952,7 +1952,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page5_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page5_arrow.png`,
               width: 8,
               height: 4,
               posterId: 0,
@@ -2428,7 +2428,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page6_pinwheel-outline.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page6_pinwheel-outline.png`,
               width: 28,
               height: 28,
               posterId: 0,
@@ -2520,7 +2520,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page6_pinwheel-outline.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page6_pinwheel-outline.png`,
               width: 28,
               height: 28,
               posterId: 0,
@@ -2613,7 +2613,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page6_pinwheel-outline.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page6_pinwheel-outline.png`,
               width: 28,
               height: 28,
               posterId: 0,
@@ -2706,7 +2706,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page6_pinwheel-outline.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page6_pinwheel-outline.png`,
               width: 28,
               height: 28,
               posterId: 0,
@@ -2799,7 +2799,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page6_pinwheel-outline.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page6_pinwheel-outline.png`,
               width: 28,
               height: 28,
               posterId: 0,
@@ -2943,7 +2943,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page7_hero.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page7_hero.jpg`,
               width: 220,
               height: 274,
               posterId: 0,
@@ -3039,7 +3039,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page7_pinwheel.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page7_pinwheel.png`,
               width: 123,
               height: 123,
               posterId: 0,
@@ -3259,7 +3259,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page7_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page7_arrow.png`,
               width: 8,
               height: 4,
               posterId: 0,
@@ -3319,7 +3319,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page8_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page8_bg.jpg`,
               width: 220,
               height: 291,
               posterId: 0,
@@ -3867,7 +3867,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page8_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page8_arrow.png`,
               width: 5,
               height: 5,
               posterId: 0,
@@ -4265,7 +4265,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page9_item1-cropped.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page9_item1-cropped.png`,
               width: 43,
               height: 43,
               posterId: 0,
@@ -4308,7 +4308,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page9_item2.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page9_item2.jpg`,
               width: 220,
               height: 331,
               posterId: 0,
@@ -4351,7 +4351,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page9_item3.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page9_item3.jpg`,
               width: 229,
               height: 157,
               posterId: 0,
@@ -4447,7 +4447,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page9_facebook.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page9_facebook.png`,
               width: 24,
               height: 24,
               posterId: 0,
@@ -4485,7 +4485,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page9_instagram.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page9_instagram.png`,
               width: 24,
               height: 24,
               posterId: 0,
@@ -4523,7 +4523,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page9_youtube.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page9_youtube.png`,
               width: 24,
               height: 24,
               posterId: 0,
@@ -4561,7 +4561,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/fashion/fashion_page9_twitter.png`,
+              src: `${imageBaseUrl}assets/images/templates/fashion/fashion_page9_twitter.png`,
               width: 24,
               height: 24,
               posterId: 0,

--- a/assets/src/dashboard/templates/data/travel.js
+++ b/assets/src/dashboard/templates/data/travel.js
@@ -35,7 +35,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page1_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page1_bg.jpg`,
               width: 220,
               height: 147,
               poster: '',
@@ -204,7 +204,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page1_logo.png`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page1_logo.png`,
               width: 47,
               height: 15,
               poster: '',
@@ -472,7 +472,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page2_image1.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page2_image1.jpg`,
               width: 220,
               height: 331,
               poster: '',
@@ -730,7 +730,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page3_image1.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page3_image1.jpg`,
               width: 220,
               height: 275,
               poster: '',
@@ -765,7 +765,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page4_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page4_bg.jpg`,
               width: 220,
               height: 147,
               poster: '',
@@ -1017,7 +1017,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_icon_up_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_icon_up_arrow.png`,
               width: 150,
               height: 69,
               posterId: 0,
@@ -1062,7 +1062,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page5_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page5_bg.jpg`,
               width: 220,
               height: 149,
               poster: '',
@@ -1254,7 +1254,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page5_image1.png`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page5_image1.png`,
               width: 137,
               height: 52,
               poster: '',
@@ -1375,7 +1375,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_icon_up_arrow.png`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_icon_up_arrow.png`,
               width: 150,
               height: 69,
               posterId: 0,
@@ -1421,7 +1421,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page6_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page6_bg.jpg`,
               width: 220,
               height: 124,
               poster: '',
@@ -1619,7 +1619,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page6_image1.png`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page6_image1.png`,
               width: 220,
               height: 371,
               poster: '',
@@ -1891,7 +1891,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page7_image1.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page7_image1.jpg`,
               width: 220,
               height: 330,
               poster: '',
@@ -1926,7 +1926,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page8_bg.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page8_bg.jpg`,
               width: 220,
               height: 147,
               poster: '',
@@ -2864,7 +2864,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page9_image1.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page9_image1.jpg`,
               width: 220,
               height: 165,
               poster: '',
@@ -2907,7 +2907,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page9_image2.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page9_image2.jpg`,
               width: 220,
               height: 124,
               poster: '',
@@ -2950,7 +2950,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page9_image3.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page9_image3.jpg`,
               width: 220,
               height: 151,
               poster: '',
@@ -2993,7 +2993,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page9_image4.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page9_image4.jpg`,
               width: 220,
               height: 147,
               poster: '',
@@ -3036,7 +3036,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page9_image5.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page9_image5.jpg`,
               width: 220,
               height: 330,
               poster: '',
@@ -3377,7 +3377,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page10_image1.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page10_image1.jpg`,
               width: 220,
               height: 112,
               poster: '',
@@ -3416,7 +3416,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page10_image2.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page10_image2.jpg`,
               width: 220,
               height: 83,
               poster: '',
@@ -3459,7 +3459,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_page10_image3.jpg`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_page10_image3.jpg`,
               width: 220,
               height: 124,
               poster: '',
@@ -3491,7 +3491,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_icon_fb.png`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_icon_fb.png`,
               width: 150,
               height: 300,
               posterId: 0,
@@ -3529,7 +3529,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_icon_insta.png`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_icon_insta.png`,
               width: 150,
               height: 156,
               posterId: 0,
@@ -3567,7 +3567,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_icon_yt.png`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_icon_yt.png`,
               width: 150,
               height: 106,
               posterId: 0,
@@ -3605,7 +3605,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/png',
-              src: `${imageBaseUrl}/assets/images/templates/travel/travel_icon_tw.png`,
+              src: `${imageBaseUrl}assets/images/templates/travel/travel_icon_tw.png`,
               width: 150,
               height: 121,
               posterId: 0,


### PR DESCRIPTION
## Summary

This reverts #1267.

Hopefully temporarily, as it increases the bundle size from **1.8MB** to over **53MB**.

## Relevant Technical Choices

Also removes double-slashes from assets URLs. `WEBSTORIES_PLUGIN_DIR_URL` / `pluginDir` / `imageBaseUrl` already has a trailing slash.

---

See #1268.
