### PR TITLE
(closed) POC: Improve rendering performance of media gallery

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -72,7 +72,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: /build/web-stories.zip
+          asset_path: build/web-stories.zip
           asset_name: web-stories.zip
           asset_content_type: application/zip
 
@@ -82,6 +82,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: /build/web-stories-composer.zip
+          asset_path: build/web-stories-composer.zip
           asset_name: web-stories-composer.zip
           asset_content_type: application/zip

--- a/assets/src/edit-story/app/history/useHistoryReducer.js
+++ b/assets/src/edit-story/app/history/useHistoryReducer.js
@@ -63,6 +63,7 @@ const reducer = (size) => (state, { type, payload }) => {
     case REPLAY:
       return {
         ...state,
+        versionNumber: state.versionNumber + (state.offset - payload),
         replayState: state.entries[payload],
       };
 

--- a/assets/src/edit-story/app/index.js
+++ b/assets/src/edit-story/app/index.js
@@ -35,6 +35,7 @@ import { GlobalStyle as ModalGlobalStyle } from '../components/modal';
 import { GlobalStyle as CalendarGlobalStyle } from '../components/form/dateTime/calendarStyle';
 import { useDropTargets, DropTargetsProvider } from '../components/dropTargets';
 import { useTransform, TransformProvider } from '../components/transform';
+import AutoSaveHandler from '../components/autoSaveHandler';
 import { useHistory, HistoryProvider } from './history';
 import { useAPI, APIProvider } from './api';
 import { useConfig, ConfigProvider } from './config';
@@ -54,6 +55,7 @@ function App({ config }) {
             <HistoryProvider size={50}>
               <SnackbarProvider>
                 <StoryProvider storyId={storyId}>
+                  <AutoSaveHandler />
                   <FontProvider>
                     <MediaProvider>
                       <TransformProvider>

--- a/assets/src/edit-story/app/story/actions/useSaveStory.js
+++ b/assets/src/edit-story/app/story/actions/useSaveStory.js
@@ -32,8 +32,8 @@ import { useAPI } from '../../api';
 import { useConfig } from '../../config';
 import useRefreshPostEditURL from '../../../utils/useRefreshPostEditURL';
 import { useSnackbar } from '../../snackbar';
-import usePreventWindowUnload from '../../../utils/usePreventWindowUnload';
 import getStoryPropsToSave from '../utils/getStoryPropsToSave';
+import { useHistory } from '../../history';
 
 /**
  * Custom hook to save story.
@@ -48,10 +48,12 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
   const {
     actions: { saveStoryById },
   } = useAPI();
+  const {
+    actions: { resetNewChanges },
+  } = useHistory();
   const { metadata } = useConfig();
   const { showSnackbar } = useSnackbar();
   const [isSaving, setIsSaving] = useState(false);
-  const setPreventUnload = usePreventWindowUnload();
 
   const refreshPostEditURL = useRefreshPostEditURL(storyId);
 
@@ -79,7 +81,7 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
         })
         .finally(() => {
           setIsSaving(false);
-          setPreventUnload('history', false);
+          resetNewChanges();
         });
     },
     [
@@ -91,7 +93,7 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
       updateStory,
       refreshPostEditURL,
       showSnackbar,
-      setPreventUnload,
+      resetNewChanges,
     ]
   );
 

--- a/assets/src/edit-story/components/autoSaveHandler/index.js
+++ b/assets/src/edit-story/components/autoSaveHandler/index.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useConfig, useHistory, useStory } from '../../app';
+
+function AutoSaveHandler() {
+  const { autoSaveInterval } = useConfig();
+  const {
+    state: { hasNewChanges },
+  } = useHistory();
+  const {
+    state: {
+      story: { status },
+    },
+    actions: { saveStory },
+  } = useStory();
+
+  const isDraft = 'draft' === status;
+
+  // If autoSaveInterval is set to 0 or not defined, don't.
+  if (!autoSaveInterval) {
+    return null;
+  }
+
+  useEffect(() => {
+    // @todo The isDraft check is temporary to ensure only draft gets auto-saved,
+    // until the logic for other statuses has been decided.
+    if (!isDraft || !hasNewChanges) {
+      return undefined;
+    }
+    let timeout = setTimeout(() => {
+      saveStory();
+      timeout = null;
+    }, autoSaveInterval * 1000);
+
+    return () => {
+      timeout && clearTimeout(timeout);
+    };
+  }, [autoSaveInterval, isDraft, saveStory, status, hasNewChanges]);
+
+  return null;
+}
+
+export default AutoSaveHandler;

--- a/assets/src/edit-story/components/autoSaveHandler/test/autoSaveHandler.js
+++ b/assets/src/edit-story/components/autoSaveHandler/test/autoSaveHandler.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import HistoryContext from '../../../app/history/context';
+import StoryContext from '../../../app/story/context';
+import ConfigContext from '../../../app/config/context';
+import AutoSaveHandler from '../index';
+
+function setup({
+  hasNewChanges = true,
+  status = 'draft',
+  autoSaveInterval = 0.1,
+}) {
+  const saveStory = jest.fn();
+  const historyContextValue = { state: { hasNewChanges } };
+  const configValue = {
+    autoSaveInterval,
+  };
+  const storyContextValue = {
+    state: {
+      story: { status },
+    },
+    actions: { saveStory },
+  };
+  render(
+    <ConfigContext.Provider value={configValue}>
+      <HistoryContext.Provider value={historyContextValue}>
+        <StoryContext.Provider value={storyContextValue}>
+          <AutoSaveHandler />
+        </StoryContext.Provider>
+      </HistoryContext.Provider>
+    </ConfigContext.Provider>
+  );
+  return {
+    saveStory,
+  };
+}
+
+jest.useFakeTimers();
+
+describe('AutoSaveHandler', () => {
+  it('should trigger saving in case of a draft', () => {
+    const { saveStory } = setup({});
+    jest.runAllTimers();
+    expect(saveStory).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not trigger saving in case of not having new changes', () => {
+    const { saveStory } = setup({ hasNewChanges: false });
+    jest.runAllTimers();
+    expect(saveStory).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not trigger saving in case of a non-draft post', () => {
+    const { saveStory } = setup({ hasNewChanges: true, status: 'publish' });
+    jest.runAllTimers();
+    expect(saveStory).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not trigger saving when interval is 0', () => {
+    const { saveStory } = setup({
+      autoSaveInterval: 0,
+    });
+    jest.runAllTimers();
+    expect(saveStory).toHaveBeenCalledTimes(0);
+  });
+});

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -64,7 +64,7 @@ const CAROUSEL_BOTTOM_SCROLL_MARGIN = 8;
 const Wrapper = styled.div`
   position: relative;
   display: grid;
-  grid: 'prev-navigation carousel next-navigation menu' auto / 53px 1fr 53px 53px;
+  grid: 'space prev-navigation carousel next-navigation menu' auto / 53px 53px 1fr 53px 53px;
   background-color: ${({ theme }) => theme.colors.bg.v1};
   color: ${({ theme }) => theme.colors.fg.v1};
   width: 100%;
@@ -320,6 +320,7 @@ function Carousel() {
   return (
     <>
       <Wrapper>
+        <NavArea area="space" />
         <NavArea area="prev-navigation" marginBottom={arrowsBottomMargin}>
           <PrevButton
             isHidden={!hasHorizontalOverflow || isAtBeginningOfList}

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -29,7 +29,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import addQueryArgs from '../../utils/addQueryArgs';
-import { useStory, useMedia, useConfig } from '../../app';
+import { useStory, useMedia, useConfig, useHistory } from '../../app';
 import useRefreshPostEditURL from '../../utils/useRefreshPostEditURL';
 import { Outline, Plain, Primary } from '../button';
 import CircularProgress from '../circularProgress';
@@ -223,6 +223,9 @@ function Update() {
   const {
     state: { isUploading },
   } = useMedia();
+  const {
+    state: { hasNewChanges },
+  } = useHistory();
 
   let text;
   switch (status) {
@@ -238,7 +241,7 @@ function Update() {
       return (
         <Outline
           onClick={() => saveStory({ status: 'draft' })}
-          isDisabled={isSaving || isUploading}
+          isDisabled={isSaving || isUploading || !hasNewChanges}
         >
           {text}
         </Outline>

--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { rgba } from 'polished';
 import { useCallback, useRef } from 'react';
 import styled from 'styled-components';
 
@@ -102,6 +103,19 @@ const Inner = styled.div`
     'header   ' auto
     'infinitescroll' 1fr
     / 1fr;
+`;
+
+const Loading = styled.div`
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 80px;
+  background-color: ${({ theme }) => rgba(theme.colors.bg.v0, 0.4)};
+  border-radius: 100px;
+  font-size: ${({ theme }) => theme.fonts.label.size};
+  line-height: ${({ theme }) => theme.fonts.label.lineHeight};
+  font-weight: 500;
 `;
 
 const FILTERS = [
@@ -296,7 +310,11 @@ function MediaPane(props) {
                   />
                 ))}
             </Column>
-            {hasMore && <div ref={refContainerFooter}>{'Loading...'}</div>}
+            {hasMore && (
+              <Loading ref={refContainerFooter}>
+                {__('Loading…', 'web-stories')}
+              </Loading>
+            )}
           </Container>
         )}
       </Inner>

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -166,7 +166,7 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Retrieves the attachment's schema, conforming to JSON Schema.
+	 * Retrieves the story's schema, conforming to JSON Schema.
 	 *
 	 * @return array Item schema as an array.
 	 */
@@ -210,5 +210,4 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 
 		return $this->add_additional_fields_schema( $this->schema );
 	}
-
 }

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -185,6 +185,22 @@ class Story_Post_Type {
 			PHP_INT_MAX,
 			2
 		);
+
+		add_filter( '_wp_post_revision_fields', [ __CLASS__, 'filter_revision_fields' ], 10, 2 );
+	}
+
+	/**
+	 * Filters the revision fields to ensure that JSON representation gets saved to Story revisions.
+	 *
+	 * @param array $fields Array of allowed revision fields.
+	 * @param array $story Story post array.
+	 * @return array Array of allowed fields.
+	 */
+	public static function filter_revision_fields( $fields, $story ) {
+		if ( self::POST_TYPE_SLUG === $story['post_type'] ) {
+			$fields['post_content_filtered'] = __( 'Story data', 'web-stories' );
+		}
+		return $fields;
 	}
 
 	/**
@@ -291,6 +307,7 @@ class Story_Post_Type {
 			[
 				'id'     => 'edit-story',
 				'config' => [
+					'autoSaveInterval' => defined( 'AUTOSAVE_INTERVAL' ) ? AUTOSAVE_INTERVAL : null,
 					'isRTL'            => is_rtl(),
 					'timeFormat'       => get_option( 'time_format' ),
 					'allowedMimeTypes' => self::get_allowed_mime_types(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1513,17 +1513,17 @@
       }
     },
     "@daybrush/drag": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@daybrush/drag/-/drag-0.13.1.tgz",
-      "integrity": "sha512-wUciS4IAwHQ2zGGjBwp67YVB4jd3jReG/Ol8Ib9k5etmMSrLlBh8h6L5diZuzT09NUKRWPfEuYkhKs9A1lykng==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@daybrush/drag/-/drag-0.14.0.tgz",
+      "integrity": "sha512-AVVFLfGOosSR2LrgxyRKg8FRSATaa5sDFZlTQ9YgKy/F5etg2v/IO8kdcpIKD6FDZ74kT5hdjG0JJf+9YcIWfQ==",
       "requires": {
-        "@daybrush/utils": "^0.10.0"
+        "@daybrush/utils": "^0.10.3"
       }
     },
     "@daybrush/utils": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@daybrush/utils/-/utils-0.10.1.tgz",
-      "integrity": "sha512-pKnlI3C+u/qgkhypQQT9G7YwEmBp+6XD5ZHzVCKtA0avuku//KGdLoIT6QL78aXI7ZPlJwY31t24+6xkxqdoJg=="
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@daybrush/utils/-/utils-0.10.3.tgz",
+      "integrity": "sha512-CwbGNct2loskTaSJ/OSmapOhdNfDHI71cApPQSPs5MXbfUb33u2JHNkL6sUJpv0VVpsO+s+3UPpGDS2KCAyEKQ=="
     },
     "@egjs/agent": {
       "version": "2.1.5",
@@ -24791,12 +24791,12 @@
       }
     },
     "react-moveable": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.19.2.tgz",
-      "integrity": "sha512-11N8ucq8Q+U0Nrv6/qcq0/ayOqDr2Km5zhy5wtBodHa4uRqMCyx+AhYS02//EY5RD7lh8k3fG+m36s3vmegp0A==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.20.3.tgz",
+      "integrity": "sha512-j5ct2tvPh4LbplrlKsqM9yCBMhNv4Ehv0E6RbehMv2fObIUR57OZDcIqwm9k4Fkn8vkRO3SPMmAyoLarvDOBog==",
       "requires": {
-        "@daybrush/drag": "^0.13.1",
-        "@daybrush/utils": "^0.10.1",
+        "@daybrush/drag": "^0.14.0",
+        "@daybrush/utils": "^0.10.3",
         "@egjs/agent": "^2.1.5",
         "@egjs/children-differ": "^1.0.0",
         "@moveable/matrix": "^0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24323,9 +24323,9 @@
       }
     },
     "react-color": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.18.0.tgz",
-      "integrity": "sha512-FyVeU1kQiSokWc8NPz22azl1ezLpJdUyTbWL0LPUpcuuYDrZ/Y1veOk9rRK5B3pMlyDGvTk4f4KJhlkIQNRjEA==",
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.18.1.tgz",
+      "integrity": "sha512-X5XpyJS6ncplZs74ak0JJoqPi+33Nzpv5RYWWxn17bslih+X7OlgmfpmGC1fNvdkK7/SGWYf1JJdn7D2n5gSuQ==",
       "requires": {
         "@icons/material": "^0.2.4",
         "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-dates": "^21.8.0",
     "react-dom": "^16.13.1",
     "react-modal": "^3.11.2",
-    "react-moveable": "^0.19.2",
+    "react-moveable": "^0.20.3",
     "react-transition-group": "^4.3.0",
     "resize-observer-polyfill": "^1.5.1",
     "styled-components": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "prop-types": "^15.7.2",
     "query-string": "^6.12.1",
     "react": "^16.13.1",
-    "react-color": "^2.18.0",
+    "react-color": "^2.18.1",
     "react-dates": "^21.8.0",
     "react-dom": "^16.13.1",
     "react-modal": "^3.11.2",


### PR DESCRIPTION
## Summary

This PR demonstrates changes that can improve rendering performance of the media gallery.

(This is a proof of concept, do not merge)

## Relevant Technical Choices

There are two problems:

1. All <MediaElement/> image components are re-rendered when scrolling, not only newly loaded images.

This is addressed by making MediaElement a Pure Component using React.memo(), which re-renders only when props have changed.

To demonstrate, below is a React profiler screenshot when rendering the last page of images:
Before: https://share.getcloudapp.com/v1uDjmw2
After: https://share.getcloudapp.com/RBuvEXGp

In the 'after' screenshot, <MediaElement/> components of the first few pages are not re-rendered (ie. are grey in color).

2. Other components are re-rendered unnecessarily.

This is addressed by:
- Using Pure Components with React.memo for simple components in the render path.
- Use useMemo / useCallback to memoize state / callback instances in the render path, which eventually results in less component re-renders.
- Return the same 'state' reference from reducers when no changes are made, to avoid component re-renders.

React profiler results can be found below.
Before: https://share.getcloudapp.com/DOuQ6vYz
After: https://share.getcloudapp.com/nOu85mOK

## To-do

1 Consider memoizing each context state in a generalized way.
2. Find a better way to return the same state reference from reducers when the state doesn't change, perhaps by using immutable libraries (such as icepick, seamless-immutable etc).
3. Consider how to test memoize performance regressions longer term.
4. Uncomment commented code (and fix).

---

Issue #1466
