### PR TITLE
Fix `prebuild:fonts` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "build:js": "NODE_ENV=production webpack",
     "build:plugin": "./bin/commander.js build",
     "build:storybook": "build-storybook -c .storybook -o build/storybook --quiet",
-    "prebuild:fonts": "[[ ! -z $GOOGLE_FONTS_API_KEY ]] && curl -s \"https://www.googleapis.com/webfonts/v1/webfonts?fields=items&prettyPrint=false&key=$GOOGLE_FONTS_API_KEY\" | jq -c '[.items[] | { family: .family, variants: .variants, category: .category }]' > includes/data/fonts.json",
+    "prebuild:fonts": "curl -s \"https://www.googleapis.com/webfonts/v1/webfonts?fields=items&prettyPrint=false&key=$GOOGLE_FONTS_API_KEY\" | jq -c '[.items[] | { family: .family, variants: .variants, category: .category }]' > includes/data/fonts.json",
     "build:fonts": "./bin/build-fonts.js",
     "bundle-plugin": "./bin/commander.js bundle",
     "predev": "rm -rf assets/css/* assets/js/*",


### PR DESCRIPTION
Causes the GH action to fail:

https://github.com/google/web-stories-wp/runs/642684494?check_suite_focus=true