### PR TITLE
POC: Improve render / state update performance when loading media gallery images

### DIFF
--- a/assets/src/edit-story/app/media/useMediaReducer/reducer.js
+++ b/assets/src/edit-story/app/media/useMediaReducer/reducer.js
@@ -21,6 +21,11 @@
  */
 import * as types from './types';
 
+/**
+ * External dependencies
+ */
+import deepEqual from 'deep-equal';
+
 export const INITIAL_STATE = {
   media: [],
   processing: [],
@@ -37,6 +42,12 @@ export const INITIAL_STATE = {
 function reducer(state, { type, payload }) {
   switch (type) {
     case types.FETCH_MEDIA_START: {
+      // TODO: Find a better way to return the same state reference from
+      // reducers when the state doesn't change, perhaps by using immutable
+      // libraries (such as icepick, seamless-immutable etc).
+      if (!state.isMediaLoaded && state.isMediaLoading) {
+        return state;
+      }
       return {
         ...state,
         isMediaLoaded: false,
@@ -48,7 +59,7 @@ function reducer(state, { type, payload }) {
       const { media, mediaType, searchTerm, pagingNum, totalPages } = payload;
       if (mediaType === state.mediaType && searchTerm === state.searchTerm) {
         const hasMore = pagingNum < totalPages;
-        return {
+        const newState = {
           ...state,
           media: [...state.media, ...media],
           pagingNum,
@@ -57,6 +68,9 @@ function reducer(state, { type, payload }) {
           isMediaLoaded: true,
           isMediaLoading: false,
         };
+        if (!deepEqual(state, newState, { strict: true })) {
+          state = newState;
+        }
       }
       return state;
     }
@@ -116,6 +130,9 @@ function reducer(state, { type, payload }) {
     case types.SET_MEDIA: {
       const { media } = payload;
 
+      if (media === state.media) {
+        return state;
+      }
       return {
         ...state,
         media,

--- a/assets/src/edit-story/components/canvas/canvasElementDropzone.js
+++ b/assets/src/edit-story/components/canvas/canvasElementDropzone.js
@@ -87,8 +87,9 @@ function CanvasElementDropzone({ children }) {
     [activeDropTargetId]
   );
 
+  // TODO: Find out why [onDropHandler] causes unnecessary re-renders.
   return (
-    <Container onDrop={onDropHandler} onDragOver={onDragOverHandler}>
+    <Container onDrop={null} onDragOver={onDragOverHandler}>
       {children}
     </Container>
   );

--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -62,4 +62,4 @@ function CanvasLayout() {
   );
 }
 
-export default CanvasLayout;
+export default React.memo(CanvasLayout);

--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 /**
  * Internal dependencies
@@ -133,28 +133,46 @@ function CanvasProvider({ children }) {
 
   useCanvasSelectionCopyPaste(pageContainer);
 
-  const state = {
-    state: {
+  const state = useMemo(
+    () => ({
+      state: {
+        pageContainer,
+        nodesById,
+        editingElement,
+        editingElementState,
+        isEditing: Boolean(editingElement),
+        lastSelectionEvent,
+        pageSize,
+      },
+      actions: {
+        setPageContainer,
+        setNodeForElement,
+        setEditingElement: setEditingElementWithoutState,
+        setEditingElementWithState,
+        clearEditing,
+        handleSelectElement,
+        selectIntersection,
+        setPageSize,
+      },
+    }),
+    [
       pageContainer,
       nodesById,
       editingElement,
       editingElementState,
-      isEditing: Boolean(editingElement),
+      editingElement,
       lastSelectionEvent,
       pageSize,
-    },
-    actions: {
       setPageContainer,
       setNodeForElement,
-      setEditingElement: setEditingElementWithoutState,
+      setEditingElementWithoutState,
       setEditingElementWithState,
       clearEditing,
       handleSelectElement,
       selectIntersection,
       setPageSize,
-    },
-  };
-
+    ]
+  );
   return (
     <Context.Provider value={state}>
       <UnitsProvider pageSize={pageSize}>{children}</UnitsProvider>

--- a/assets/src/edit-story/components/canvas/canvasUploadDropTarget.js
+++ b/assets/src/edit-story/components/canvas/canvasUploadDropTarget.js
@@ -37,22 +37,24 @@ import { Layer as CanvasLayer, PageArea } from './layout';
 import useUploadWithPreview from './useUploadWithPreview';
 
 const MESSAGE_ID = 'edit-story-canvas-upload-message';
+const message = __(
+  'Upload to media library and add to the page.',
+  'web-stories'
+);
 
 function CanvasUploadDropTarget({ children }) {
-  const uploadWithPreview = useUploadWithPreview();
+  // TODO: Find out why [uploadWithPreview] causes unnecessary re-renders.
+  //const uploadWithPreview = useUploadWithPreview();
 
   return (
-    <UploadDropTarget onDrop={uploadWithPreview} labelledBy={MESSAGE_ID}>
+    <UploadDropTarget onDrop={null} labelledBy={MESSAGE_ID}>
       {children}
       <UploadDropTargetOverlay>
         <CanvasLayer>
           <PageArea>
             <UploadDropTargetMessage
               id={MESSAGE_ID}
-              message={__(
-                'Upload to media library and add to the page.',
-                'web-stories'
-              )}
+              message={message}
             />
           </PageArea>
         </CanvasLayer>

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -72,4 +72,4 @@ function DisplayLayer() {
   );
 }
 
-export default DisplayLayer;
+export default React.memo(DisplayLayer);

--- a/assets/src/edit-story/components/canvas/editLayer.js
+++ b/assets/src/edit-story/components/canvas/editLayer.js
@@ -109,4 +109,4 @@ EditLayerForElement.propTypes = {
   element: StoryPropTypes.element.isRequired,
 };
 
-export default EditLayer;
+export default React.memo(EditLayer);

--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -106,4 +106,4 @@ function FramesLayer() {
   );
 }
 
-export default FramesLayer;
+export default React.memo(FramesLayer);

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -201,19 +201,25 @@ function useLayoutParamsCssVars() {
   };
 }
 
+// TODO: Find out why [PageAreaFullbleedContainer] etc cause unnecessary
+// re-renders.
 const PageArea = forwardRef(({ children, showDangerZone }, ref) => {
-  return (
-    <PageAreaFullbleedContainer>
-      <PageAreaSafeZone ref={ref}>{children}</PageAreaSafeZone>
-      {showDangerZone && (
-        <>
-          <PageAreaDangerZoneTop />
-          <PageAreaDangerZoneBottom />
-        </>
-      )}
-    </PageAreaFullbleedContainer>
-  );
+  return <PageAreaSafeZone ref={ref}>{children}</PageAreaSafeZone>;
 });
+// cause unnecessary re-renders.
+// const PageArea = forwardRef(({ children, showDangerZone }, ref) => {
+//   return (
+//   <PageAreaFullbleedContainer>
+//     <PageAreaSafeZone ref={ref}>{children}</PageAreaSafeZone>
+//     {showDangerZone && (
+//       <>
+//         <PageAreaDangerZoneTop />
+//         <PageAreaDangerZoneBottom />
+//       </>
+//     )}
+//   </PageAreaFullbleedContainer>
+// );
+// });
 
 PageArea.propTypes = {
   children: PropTypes.node,

--- a/assets/src/edit-story/components/canvas/navLayer.js
+++ b/assets/src/edit-story/components/canvas/navLayer.js
@@ -57,4 +57,4 @@ function NavLayer() {
   );
 }
 
-export default NavLayer;
+export default React.memo(NavLayer);

--- a/assets/src/edit-story/components/canvas/useEditingElement.js
+++ b/assets/src/edit-story/components/canvas/useEditingElement.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useReducer, useCallback, useState } from 'react';
+import { useReducer, useCallback, useState, useMemo } from 'react';
 
 function useEditingElement() {
   const [state, dispatch] = useReducer(reducer, {
@@ -28,7 +28,7 @@ function useEditingElement() {
 
   const clearEditing = useCallback(() => {
     dispatch({ editingElement: null });
-  }, []);
+  }, [dispatch]);
 
   const setEditingElementWithoutState = useCallback((id) => {
     dispatch({ editingElement: id });
@@ -44,15 +44,26 @@ function useEditingElement() {
   );
 
   const { editingElement, editingElementState } = state;
-  return {
-    nodesById,
-    editingElement,
-    editingElementState,
-    setEditingElementWithState,
-    setEditingElementWithoutState,
-    clearEditing,
-    setNodeForElement,
-  };
+  return useMemo(
+    () => ({
+      nodesById,
+      editingElement,
+      editingElementState,
+      setEditingElementWithState,
+      setEditingElementWithoutState,
+      clearEditing,
+      setNodeForElement,
+    }),
+    [
+      nodesById,
+      editingElement,
+      editingElementState,
+      setEditingElementWithState,
+      setEditingElementWithoutState,
+      clearEditing,
+      setNodeForElement
+    ]
+  );
 }
 
 function reducer(state, { editingElement, editingElementState = {} }) {

--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -82,7 +82,8 @@ function useInsertElement() {
       focusCanvas();
       return element;
     },
-    [addElement, backfillResource, focusCanvas]
+    // TODO: Find out why these cause unnecessary re-renders.
+    [],//addElement, backfillResource, focusCanvas]
   );
 
   return insertElement;

--- a/assets/src/edit-story/components/dropTargets/provider.js
+++ b/assets/src/edit-story/components/dropTargets/provider.js
@@ -69,13 +69,13 @@ function DropTargetsProvider({ children }) {
     });
   }, []);
 
-  const isDropSource = (type) => {
+  const isDropSource = useCallback((type) => {
     return DROP_SOURCE_ALLOWED_TYPES.includes(type);
-  };
+  }, []);
 
-  const isDropTarget = (type) => {
+  const isDropTarget = useCallback((type) => {
     return DROP_TARGET_ALLOWED_TYPES.includes(type);
-  };
+  }, []);
 
   const activeDropTarget = useMemo(
     () => currentPage?.elements.find((el) => el.id === activeDropTargetId),

--- a/assets/src/edit-story/components/library/libraryProvider.js
+++ b/assets/src/edit-story/components/library/libraryProvider.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import {useMemo, useState} from 'react';
 
 /**
  * Internal dependencies
@@ -44,18 +44,21 @@ function LibraryProvider({ children }) {
   const [tab, setTab] = useState(MEDIA);
   const insertElement = useInsertElement();
 
-  const state = {
-    state: {
-      tab,
-    },
-    actions: {
-      setTab,
-      insertElement,
-    },
-    data: {
-      tabs: TABS,
-    },
-  };
+  const state = useMemo(
+    () => ({
+      state: {
+        tab,
+      },
+      actions: {
+        setTab,
+        insertElement,
+      },
+      data: {
+        tabs: TABS,
+      },
+    }),
+    [tab, setTab, insertElement]
+  );
 
   return <Context.Provider value={state}>{children}</Context.Provider>;
 }

--- a/assets/src/edit-story/components/library/libraryUploadDropTarget.js
+++ b/assets/src/edit-story/components/library/libraryUploadDropTarget.js
@@ -32,23 +32,25 @@ import { UploadDropTarget, UploadDropTargetMessage } from '../uploadDropTarget';
 import { useMedia } from '../../app/media';
 
 const MESSAGE_ID = 'edit-story-library-upload-message';
+const message = __('Upload to media library', 'web-stories');
 
 function LibraryUploadDropTarget({ children }) {
-  const {
-    actions: { uploadMedia },
-  } = useMedia();
-  const onDropHandler = useCallback(
-    (files) => {
-      uploadMedia(files);
-    },
-    [uploadMedia]
-  );
+  // TODO: Find out why [uploadMedia] causes unnecessary re-renders.
+  // const {
+  //   actions: { uploadMedia },
+  // } = useMedia();
+  // const onDropHandler = useCallback(
+  //   (files) => {
+  //     uploadMedia(files);
+  //   },
+  //   [uploadMedia]
+  // );
   return (
-    <UploadDropTarget onDrop={onDropHandler} labelledBy={MESSAGE_ID}>
+    <UploadDropTarget onDrop={null} labelledBy={MESSAGE_ID}>
       {children}
       <UploadDropTargetMessage
         id={MESSAGE_ID}
-        message={__('Upload to media library', 'web-stories')}
+        message={message}
       />
     </UploadDropTarget>
   );

--- a/assets/src/edit-story/components/library/panes/media/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaElement.js
@@ -268,4 +268,4 @@ MediaElement.propTypes = {
   onInsert: PropTypes.func,
 };
 
-export default MediaElement;
+export default React.memo(MediaElement);

--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -196,10 +196,16 @@ function MediaPane(props) {
    * @param {Object} resource Resource object
    * @return {null|*} Return onInsert or null.
    */
-  const insertMediaElement = (resource) => {
-    const width = Math.min(resource.width * DEFAULT_DPR, DEFAULT_ELEMENT_WIDTH);
-    return insertElement(resource.type, { resource, width });
-  };
+  const insertMediaElement = useCallback(
+    (resource) => {
+      const width = Math.min(
+        resource.width * DEFAULT_DPR,
+        DEFAULT_ELEMENT_WIDTH
+      );
+      return insertElement(resource.type, { resource, width });
+    },
+    [insertElement]
+  );
 
   /**
    * Check if number is odd or even.

--- a/assets/src/edit-story/components/uploadDropTarget/message.js
+++ b/assets/src/edit-story/components/uploadDropTarget/message.js
@@ -91,4 +91,4 @@ UploadDropTargetMessage.propTypes = {
   message: PropTypes.string.isRequired,
 };
 
-export default UploadDropTargetMessage;
+export default React.memo(UploadDropTargetMessage);

--- a/assets/src/edit-story/components/uploadDropTarget/overlay.js
+++ b/assets/src/edit-story/components/uploadDropTarget/overlay.js
@@ -36,14 +36,17 @@ const Overlay = styled.div`
   background-color: ${({ theme }) => rgba(theme.colors.bg.v11, 0.6)};
 `;
 
-function UploadDropTargetOverlayWithRef(props, ref) {
-  const { isDragging } = useUploadDropTarget();
-  if (!isDragging) {
-    return null;
-  }
-  return <Overlay ref={ref} {...props} />;
+// TODO: Find out why [useUploadDropTarget] causes unnecessary re-renders.
+function UploadDropTargetOverlayWithRef(props) {
+  return null;
+  // const { isDragging } = useUploadDropTarget();
+  // if (!isDragging) {
+  //   return null;
+  // }
+  // return <Overlay ref={ref} {...props} />;
 }
 
-const UploadDropTargetOverlay = forwardRef(UploadDropTargetOverlayWithRef);
+//const UploadDropTargetOverlay = forwardRef(UploadDropTargetOverlayWithRef);
+const UploadDropTargetOverlay = UploadDropTargetOverlayWithRef;
 
 export default UploadDropTargetOverlay;

--- a/assets/src/edit-story/index.js
+++ b/assets/src/edit-story/index.js
@@ -38,6 +38,11 @@ const initialize = (id, config) => {
   // see http://reactcommunity.org/react-modal/accessibility/
   Modal.setAppElement(appElement);
 
+  const whyDidYouRender = require('@welldone-software/why-did-you-render');
+  whyDidYouRender(React, {
+    trackAllPureComponents: true,
+  });
+
   render(<App config={config} />, appElement);
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7582,6 +7582,14 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@welldone-software/why-did-you-render": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@welldone-software/why-did-you-render/-/why-did-you-render-4.1.3.tgz",
+      "integrity": "sha512-xUlrJfG6zyqAqJ9M3uI/Wa88EF99fgeT3tb7VhztnVxWG/k6nn1kRuddlCIZSqrvDTen52seLLvLaqw/VEbWag==",
+      "requires": {
+        "lodash": "^4"
+      }
+    },
     "@wordpress/api-fetch": {
       "version": "3.14.0",
       "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.14.0.tgz",
@@ -8332,6 +8340,11 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -8547,6 +8560,14 @@
           "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
           "dev": true
         }
+      }
+    },
+    "available-typed-arrays": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
+      "requires": {
+        "array-filter": "^1.0.0"
       }
     },
     "aws-sign2": {
@@ -11528,6 +11549,61 @@
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
+    "deep-equal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.0.3.tgz",
+      "integrity": "sha512-Spqdl4H+ky45I9ByyJtXteOm9CaIrPmnIPmOhrkKGNYWeDgCvJ8jNYVCTjChxW4FqGuZnLHADc8EKRMX6+CgvA==",
+      "requires": {
+        "es-abstract": "^1.17.5",
+        "es-get-iterator": "^1.1.0",
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.2",
+        "is-regex": "^1.0.5",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "regexp.prototype.flags": "^1.3.0",
+        "side-channel": "^1.0.2",
+        "which-boxed-primitive": "^1.0.1",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.2"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        },
+        "object-is": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+          "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5"
+          }
+        }
+      }
+    },
     "deep-extend": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
@@ -12190,7 +12266,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
       "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
-      "dev": true,
       "requires": {
         "es-abstract": "^1.17.4",
         "has-symbols": "^1.0.1",
@@ -12204,8 +12279,7 @@
         "isarray": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         }
       }
     },
@@ -14011,6 +14085,11 @@
       "requires": {
         "for-in": "^1.0.1"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -16041,14 +16120,18 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
+    },
+    "is-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.0.tgz",
+      "integrity": "sha512-t5mGUXC/xRheCK431ylNiSkGGpBp8bHENBcENTkDT6ppwPzEVxNGZRvgvmOEfbWkFhA7D2GEuE2mmQTr78sl2g=="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -16058,6 +16141,11 @@
       "requires": {
         "binary-extensions": "^1.0.0"
       }
+    },
+    "is-boolean-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
+      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ=="
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -16227,8 +16315,7 @@
     "is-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
-      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
-      "dev": true
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
     },
     "is-number": {
       "version": "3.0.0",
@@ -16247,6 +16334,11 @@
           }
         }
       }
+    },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
     },
     "is-obj": {
       "version": "2.0.0",
@@ -16309,8 +16401,7 @@
     "is-set": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
-      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
-      "dev": true
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -16320,8 +16411,7 @@
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "dev": true
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-svg": {
       "version": "3.0.0",
@@ -16345,10 +16435,31 @@
       "resolved": "https://registry.npmjs.org/is-touch-device/-/is-touch-device-1.0.1.tgz",
       "integrity": "sha512-LAYzo9kMT1b2p19L/1ATGt2XcSilnzNlyvq6c0pbPRVisLbAPpLqr53tIJS00kvrTkj0HtR8U7+u8X0yR8lPSw=="
     },
+    "is-typed-array": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
+      "requires": {
+        "available-typed-arrays": "^1.0.0",
+        "es-abstract": "^1.17.4",
+        "foreach": "^2.0.5",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA=="
+    },
+    "is-weakset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.1.tgz",
+      "integrity": "sha512-pi4vhbhVHGLxohUw7PhGsueT4vRGFoXhP7+RGN0jKIv9+8PWYCQTqtADngrxOm2g46hoH0+g8uZZBzMrvVGDmw=="
     },
     "is-whitespace-character": {
       "version": "1.0.4",
@@ -25831,7 +25942,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
@@ -26898,7 +27008,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
       "integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
-      "dev": true,
       "requires": {
         "es-abstract": "^1.17.0-next.1",
         "object-inspect": "^1.7.0"
@@ -30227,6 +30336,29 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.1.tgz",
+      "integrity": "sha512-7BT4TwISdDGBgaemWU0N0OU7FeAEJ9Oo2P1PHRm/FCWoEi2VLWC9b6xvxAA3C/NMpxg3HXVgi0sMmGbNUbNepQ==",
+      "requires": {
+        "is-bigint": "^1.0.0",
+        "is-boolean-object": "^1.0.0",
+        "is-number-object": "^1.0.3",
+        "is-string": "^1.0.4",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -30238,6 +30370,39 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
+    },
+    "which-typed-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+      "requires": {
+        "available-typed-arrays": "^1.0.2",
+        "es-abstract": "^1.17.5",
+        "foreach": "^2.0.5",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-typed-array": "^1.1.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        }
+      }
     },
     "wide-align": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "url": "https://github.com/google/web-stories-wp/issues"
   },
   "dependencies": {
+    "@welldone-software/why-did-you-render": "^4.1.3",
     "@wordpress/api-fetch": "^3.14.0",
     "@wordpress/i18n": "^3.12.0",
     "colorthief": "^2.3.0",
+    "deep-equal": "^2.0.3",
     "draft-js": "^0.11.5",
     "draft-js-export-html": "^1.4.1",
     "draft-js-import-html": "^1.4.1",


### PR DESCRIPTION
## Summary

This PR demonstrates changes for improving render / state update performance of loading a page of images, following some suggestions from Dima.

(This is a proof of concept, do not merge)

## Relevant Technical Choices

There are two problems:

1. Existing image components (&lt;MediaElement/&gt;) are re-rendered when loading a new page, not only newly loaded images.

This will be addressed by the images virtual list work.

In the meantime, MediaElement can be a Pure Component using React.memo(), which re-renders only when props have changed (even if only measure performance without the re-renders).

To demonstrate, below is a React profiler screenshot when rendering the last page of images:
Before: https://share.getcloudapp.com/v1uDjmw2
After: https://share.getcloudapp.com/RBuvEXGp

In the 'after' screenshot, <MediaElement/> components of the first few pages are not re-rendered (ie. are grey in color).

2. Other components are re-rendered unnecessarily.

This is addressed by:
- Using Pure Components with React.memo for simple components in the render path.
- Use useMemo / useCallback to memoize state / callback instances in the render path, which eventually results in less component re-renders.
- Return the same 'state' reference from reducers when no changes are made, to avoid component re-renders.

React profiler results can be found below (total time saving 170ms -> 48ms).
Before: https://share.getcloudapp.com/DOuQ6vYz
After: https://share.getcloudapp.com/nOu85mOK

## To-do

* Consider memoizing each context state in a generalized way.
* Find a better way to return the same state reference from reducers when the state doesn't change, perhaps by using immutable libraries (such as icepick, seamless-immutable etc).
* Consider how to test memoize performance regressions longer term.
* Uncomment commented code (and fix).

---

Issue #1466
