### PR TITLE
Allow changing number values with up/down keys

### DIFF
--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -30,7 +30,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useFocusAndSelect from '../../utils/useFocusAndSelect';
-import { useIsKeyPressed, useKeyDownEffect } from '../keyboard';
+import { useKeyDownEffect } from '../keyboard';
 import Input from './input';
 import MULTIPLE_VALUE from './multipleValue';
 
@@ -83,26 +83,24 @@ function Numeric({
   const [dot, setDot] = useState(false);
   const ref = useRef();
 
-  const altPressed =
-    float && useIsKeyPressed(ref, { key: 'alt', editable: true });
-
   const handleUpDown = useCallback(
-    ({ key }) => {
+    ({ key, altKey }) => {
       if (isMultiple) {
         return;
       }
 
       let newValue;
+      const diff = Big(float && altKey ? 0.1 : 1);
       if (key === 'ArrowUp') {
         // Increment value
-        newValue = Big(value).plus(Big(altPressed ? 0.1 : 1));
+        newValue = Big(value).plus(diff);
       } else if (key === 'ArrowDown') {
         // Decrement value
-        newValue = Big(value).minus(Big(altPressed ? 0.1 : 1));
+        newValue = Big(value).minus(diff);
       }
       onChange(parseFloat(newValue.toString()));
     },
-    [onChange, value, isMultiple, altPressed]
+    [onChange, value, isMultiple, float]
   );
 
   useKeyDownEffect(

--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -20,7 +20,7 @@
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { rgba } from 'polished';
-import { useState, useRef } from 'react';
+import { useState, useRef, useCallback } from 'react';
 
 /**
  * WordPress dependencies
@@ -31,6 +31,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useFocusAndSelect from '../../utils/useFocusAndSelect';
+import { useKeyDownEffect } from '../keyboard';
 import Input from './input';
 import MULTIPLE_VALUE from './multipleValue';
 
@@ -82,6 +83,30 @@ function Numeric({
   const placeholder = isMultiple ? __('multiple', 'web-stories') : '';
   const [dot, setDot] = useState(false);
   const ref = useRef();
+
+  const handleUpDown = useCallback(
+    ({ key }) => {
+      if (isMultiple) {
+        return;
+      }
+      const isInt = Number.isInteger(value);
+      let newValue;
+
+      if (key === 'ArrowUp') {
+        // Increment value
+        newValue = isInt ? value + 1 : Math.ceil(value);
+      } else if (key === 'ArrowDown') {
+        // Decrement value
+        newValue = isInt ? value - 1 : Math.floor(value);
+      }
+      onChange(newValue);
+    },
+    [onChange, value, isMultiple]
+  );
+
+  useKeyDownEffect(ref, { key: ['up', 'down'], editable: true }, handleUpDown, [
+    handleUpDown,
+  ]);
 
   const { focused, handleFocus, handleBlur } = useFocusAndSelect(ref);
 

--- a/assets/src/edit-story/components/form/test/numeric.js
+++ b/assets/src/edit-story/components/form/test/numeric.js
@@ -26,10 +26,20 @@ import { Numeric } from '../';
 import { renderWithTheme } from '../../../testUtils';
 
 describe('Form/Numeric', () => {
+  const alt = (node) =>
+    fireEvent.keyDown(node, { key: 'Alt', which: 18, altKey: true });
   const arrowUp = (node) =>
     fireEvent.keyDown(node, { key: 'ArrowUp', which: 38 });
+  const altArrowUp = (node) => {
+    alt(node);
+    arrowUp(node);
+  };
   const arrowDown = (node) =>
     fireEvent.keyDown(node, { key: 'ArrowDown', which: 40 });
+  const altArrowDown = (node) => {
+    alt(node);
+    arrowDown(node);
+  };
 
   it('should render <Numeric /> form', () => {
     const onChangeMock = jest.fn();
@@ -49,7 +59,7 @@ describe('Form/Numeric', () => {
     expect(input).toBeDefined();
   });
 
-  it('should increment on key up', () => {
+  it('should increment int on key up', () => {
     const onChangeMock = jest.fn();
     const onBlurMock = jest.fn();
 
@@ -68,13 +78,13 @@ describe('Form/Numeric', () => {
     expect(onChangeMock).toHaveBeenCalledWith(1);
   });
 
-  it('should ceil float on key up', () => {
+  it('should increment non-float on alt + key up', () => {
     const onChangeMock = jest.fn();
     const onBlurMock = jest.fn();
 
     const { getByTestId } = renderWithTheme(
       <Numeric
-        value={1.3}
+        value={0}
         onChange={onChangeMock}
         onBlur={onBlurMock}
         data-testid="numeric"
@@ -82,12 +92,72 @@ describe('Form/Numeric', () => {
     );
 
     const input = getByTestId('numeric');
-    arrowUp(input);
+    altArrowUp(input);
 
-    expect(onChangeMock).toHaveBeenCalledWith(2);
+    expect(onChangeMock).toHaveBeenCalledWith(1);
   });
 
-  it('should decrement on key down', () => {
+  it('should increment to full int on alt + key up', () => {
+    const onChangeMock = jest.fn();
+    const onBlurMock = jest.fn();
+
+    const { getByTestId } = renderWithTheme(
+      <Numeric
+        value={0.9}
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        float={true}
+        data-testid="numeric"
+      />
+    );
+
+    const input = getByTestId('numeric');
+    altArrowUp(input);
+
+    expect(onChangeMock).toHaveBeenCalledWith(1);
+  });
+
+  it('should increment float point on alt + key up', () => {
+    const onChangeMock = jest.fn();
+    const onBlurMock = jest.fn();
+
+    const { getByTestId } = renderWithTheme(
+      <Numeric
+        value={0}
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        float={true}
+        data-testid="numeric"
+      />
+    );
+
+    const input = getByTestId('numeric');
+    altArrowUp(input);
+
+    expect(onChangeMock).toHaveBeenCalledWith(0.1);
+  });
+
+  it('should increment long float point on alt + key up', () => {
+    const onChangeMock = jest.fn();
+    const onBlurMock = jest.fn();
+
+    const { getByTestId } = renderWithTheme(
+      <Numeric
+        value={0.38934985}
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        float={true}
+        data-testid="numeric"
+      />
+    );
+
+    const input = getByTestId('numeric');
+    altArrowUp(input);
+
+    expect(onChangeMock).toHaveBeenCalledWith(0.48934985);
+  });
+
+  it('should decrement int on key down', () => {
     const onChangeMock = jest.fn();
     const onBlurMock = jest.fn();
 
@@ -106,13 +176,13 @@ describe('Form/Numeric', () => {
     expect(onChangeMock).toHaveBeenCalledWith(1);
   });
 
-  it('should floor float on key down', () => {
+  it('should decrement non-float on alt + key down', () => {
     const onChangeMock = jest.fn();
     const onBlurMock = jest.fn();
 
     const { getByTestId } = renderWithTheme(
       <Numeric
-        value={2.3}
+        value={2}
         onChange={onChangeMock}
         onBlur={onBlurMock}
         data-testid="numeric"
@@ -120,8 +190,48 @@ describe('Form/Numeric', () => {
     );
 
     const input = getByTestId('numeric');
-    arrowDown(input);
+    altArrowDown(input);
 
-    expect(onChangeMock).toHaveBeenCalledWith(2);
+    expect(onChangeMock).toHaveBeenCalledWith(1);
+  });
+
+  it('should decrement float point on alt + key down', () => {
+    const onChangeMock = jest.fn();
+    const onBlurMock = jest.fn();
+
+    const { getByTestId } = renderWithTheme(
+      <Numeric
+        value={2}
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        float={true}
+        data-testid="numeric"
+      />
+    );
+
+    const input = getByTestId('numeric');
+    altArrowDown(input);
+
+    expect(onChangeMock).toHaveBeenCalledWith(1.9);
+  });
+
+  it('should decrement long float point on alt + key down', () => {
+    const onChangeMock = jest.fn();
+    const onBlurMock = jest.fn();
+
+    const { getByTestId } = renderWithTheme(
+      <Numeric
+        value={2.34598345}
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        float={true}
+        data-testid="numeric"
+      />
+    );
+
+    const input = getByTestId('numeric');
+    altArrowDown(input);
+
+    expect(onChangeMock).toHaveBeenCalledWith(2.24598345);
   });
 });

--- a/assets/src/edit-story/components/form/test/numeric.js
+++ b/assets/src/edit-story/components/form/test/numeric.js
@@ -26,20 +26,14 @@ import { Numeric } from '../';
 import { renderWithTheme } from '../../../testUtils';
 
 describe('Form/Numeric', () => {
-  const alt = (node) =>
-    fireEvent.keyDown(node, { key: 'Alt', which: 18, altKey: true });
   const arrowUp = (node) =>
     fireEvent.keyDown(node, { key: 'ArrowUp', which: 38 });
-  const altArrowUp = (node) => {
-    alt(node);
-    arrowUp(node);
-  };
+  const altArrowUp = (node) =>
+    fireEvent.keyDown(node, { key: 'ArrowUp', which: 38, altKey: true });
   const arrowDown = (node) =>
     fireEvent.keyDown(node, { key: 'ArrowDown', which: 40 });
-  const altArrowDown = (node) => {
-    alt(node);
-    arrowDown(node);
-  };
+  const altArrowDown = (node) =>
+    fireEvent.keyDown(node, { key: 'ArrowDown', which: 40, altKey: true });
 
   it('should render <Numeric /> form', () => {
     const onChangeMock = jest.fn();

--- a/assets/src/edit-story/components/form/test/numeric.js
+++ b/assets/src/edit-story/components/form/test/numeric.js
@@ -15,12 +15,22 @@
  */
 
 /**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
 import { Numeric } from '../';
 import { renderWithTheme } from '../../../testUtils';
 
 describe('Form/Numeric', () => {
+  const arrowUp = (node) =>
+    fireEvent.keyDown(node, { key: 'ArrowUp', which: 38 });
+  const arrowDown = (node) =>
+    fireEvent.keyDown(node, { key: 'ArrowDown', which: 40 });
+
   it('should render <Numeric /> form', () => {
     const onChangeMock = jest.fn();
     const onBlurMock = jest.fn();
@@ -37,5 +47,81 @@ describe('Form/Numeric', () => {
     const input = getByTestId('numeric');
 
     expect(input).toBeDefined();
+  });
+
+  it('should increment on key up', () => {
+    const onChangeMock = jest.fn();
+    const onBlurMock = jest.fn();
+
+    const { getByTestId } = renderWithTheme(
+      <Numeric
+        value={0}
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        data-testid="numeric"
+      />
+    );
+
+    const input = getByTestId('numeric');
+    arrowUp(input);
+
+    expect(onChangeMock).toHaveBeenCalledWith(1);
+  });
+
+  it('should ceil float on key up', () => {
+    const onChangeMock = jest.fn();
+    const onBlurMock = jest.fn();
+
+    const { getByTestId } = renderWithTheme(
+      <Numeric
+        value={1.3}
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        data-testid="numeric"
+      />
+    );
+
+    const input = getByTestId('numeric');
+    arrowUp(input);
+
+    expect(onChangeMock).toHaveBeenCalledWith(2);
+  });
+
+  it('should decrement on key down', () => {
+    const onChangeMock = jest.fn();
+    const onBlurMock = jest.fn();
+
+    const { getByTestId } = renderWithTheme(
+      <Numeric
+        value={2}
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        data-testid="numeric"
+      />
+    );
+
+    const input = getByTestId('numeric');
+    arrowDown(input);
+
+    expect(onChangeMock).toHaveBeenCalledWith(1);
+  });
+
+  it('should floor float on key down', () => {
+    const onChangeMock = jest.fn();
+    const onBlurMock = jest.fn();
+
+    const { getByTestId } = renderWithTheme(
+      <Numeric
+        value={2.3}
+        onChange={onChangeMock}
+        onBlur={onBlurMock}
+        data-testid="numeric"
+      />
+    );
+
+    const input = getByTestId('numeric');
+    arrowDown(input);
+
+    expect(onChangeMock).toHaveBeenCalledWith(2);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9596,8 +9596,7 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
       "version": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@wordpress/api-fetch": "^3.14.0",
     "@wordpress/i18n": "^3.12.0",
+    "big.js": "^5.2.2",
     "colorthief": "^2.3.0",
     "draft-js": "^0.11.5",
     "draft-js-export-html": "^1.4.1",


### PR DESCRIPTION
## Summary

Allow arrow up/down to increment/decrement a value when focused on a numeric input field.

## Relevant Technical Choices

- Up/down on a float changes just the integer-part, so you go from 1.5 to 2.5 and so on
- Alt+up/down on a float increments the first fractional part, so you go from 1.5 to 1.6 and so on
- Use big.js to avoid floating point precision issues

Fixes #1027 
