### PR TITLE
Fix travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,12 +60,7 @@ deploy:
       branch: master
   - provider: script
     edge: true
-    # This script also runs `npm run build`.
-    script:
-      - npm run build:js --silent
-      - npm run build:plugin --silent -- --prerelease
-      - npm run bundle-plugin --silent -- --copy
-      - bin/deploy-to-test-environment.sh
+    script: bin/deploy-to-test-environment.sh
     on:
       branch: master
 

--- a/bin/deploy-to-test-environment.sh
+++ b/bin/deploy-to-test-environment.sh
@@ -81,6 +81,13 @@ fi
 # Install and build.
 cd "$project_dir"
 
+echo "Building plugin"
+npm run build:js --silent
+npm run build:plugin --silent -- --prerelease
+
+echo "Bundling plugin"
+npm run bundle-plugin --silent -- --copy
+
 echo "Moving files to repository"
 rsync -avz --delete ./build/web-stories/ "$repo_dir/wp-content/plugins/web-stories/"
 git --no-pager log -1 --format="Build Web Stories plugin at %h: %s" > /tmp/commit-message.txt


### PR DESCRIPTION
The argument to `script:` in the script deployment provider needs to be a single command.

Introduced in #1399.