### PR TITLE
Revert latest Moveable update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25031,9 +25031,9 @@
       }
     },
     "react-moveable": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.20.4.tgz",
-      "integrity": "sha512-LqAxXuu4woK//h7zKXk7+lL1sX9t+Aj9jIf8BMP5PA7KN7sP3C/RU8wLqP0+PYhADaum9dB66l3MUvNf/zJZMw==",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/react-moveable/-/react-moveable-0.20.3.tgz",
+      "integrity": "sha512-j5ct2tvPh4LbplrlKsqM9yCBMhNv4Ehv0E6RbehMv2fObIUR57OZDcIqwm9k4Fkn8vkRO3SPMmAyoLarvDOBog==",
       "requires": {
         "@daybrush/drag": "^0.14.0",
         "@daybrush/utils": "^0.10.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-dates": "^21.8.0",
     "react-dom": "^16.13.1",
     "react-modal": "^3.11.2",
-    "react-moveable": "^0.20.4",
+    "react-moveable": "0.20.3",
     "react-transition-group": "^4.3.0",
     "resize-observer-polyfill": "^1.5.1",
     "styled-components": "^5.1.0",


### PR DESCRIPTION
The update in 3286ae63c7127b99b8699a228c355595364b591c (#1533) causes issues.

Pinning the last working version until the issue is resolved.
