### PR TITLE
Dashboard: Clean up header styles and aligns them to the new designs

### DIFF
--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -35,7 +35,6 @@ import {
   ScrollToTop,
   Layout,
   ToggleButtonGroup,
-  ToggleButtonGroupContainer,
 } from '../../../components';
 import {
   VIEW_STYLE,
@@ -54,6 +53,7 @@ import {
   NoResults,
   StoryGridView,
   StoryListView,
+  HeaderToggleButtonContainer,
 } from '../shared';
 
 const DefaultBodyText = styled.p`
@@ -301,7 +301,7 @@ function MyStories() {
                 handleTypeaheadChange={handleTypeaheadChange}
                 typeaheadValue={typeaheadValue}
               >
-                <ToggleButtonGroupContainer>
+                <HeaderToggleButtonContainer>
                   <ToggleButtonGroup
                     buttons={STORY_STATUSES.map((storyStatus) => {
                       return {
@@ -313,7 +313,7 @@ function MyStories() {
                       };
                     })}
                   />
-                </ToggleButtonGroupContainer>
+                </HeaderToggleButtonContainer>
               </PageHeading>
               {storiesViewControls}
             </Layout.Squishable>

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -35,6 +35,7 @@ import {
   ScrollToTop,
   Layout,
   ToggleButtonGroup,
+  ToggleButtonGroupContainer,
 } from '../../../components';
 import {
   VIEW_STYLE,
@@ -300,17 +301,19 @@ function MyStories() {
                 handleTypeaheadChange={handleTypeaheadChange}
                 typeaheadValue={typeaheadValue}
               >
-                <ToggleButtonGroup
-                  buttons={STORY_STATUSES.map((storyStatus) => {
-                    return {
-                      handleClick: () =>
-                        handleFilterStatusUpdate(storyStatus.value),
-                      key: storyStatus.value,
-                      isActive: status === storyStatus.value,
-                      text: storyStatus.label,
-                    };
-                  })}
-                />
+                <ToggleButtonGroupContainer>
+                  <ToggleButtonGroup
+                    buttons={STORY_STATUSES.map((storyStatus) => {
+                      return {
+                        handleClick: () =>
+                          handleFilterStatusUpdate(storyStatus.value),
+                        key: storyStatus.value,
+                        isActive: status === storyStatus.value,
+                        text: storyStatus.label,
+                      };
+                    })}
+                  />
+                </ToggleButtonGroupContainer>
               </PageHeading>
               {storiesViewControls}
             </Layout.Squishable>

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -74,6 +74,7 @@ const BodyViewOptions = ({
         {layoutStyle === VIEW_STYLE.GRID && (
           <StorySortDropdownContainer>
             <SortDropdown
+              alignment="flex-end"
               ariaLabel={sortDropdownAriaLabel}
               items={STORY_SORT_MENU_ITEMS}
               type={DROPDOWN_TYPES.TRANSPARENT_MENU}

--- a/assets/src/dashboard/app/views/shared/index.js
+++ b/assets/src/dashboard/app/views/shared/index.js
@@ -17,7 +17,10 @@
 export { default as BodyWrapper } from './bodyWrapper';
 export { default as BodyViewOptions } from './bodyViewOptions';
 export { default as NoResults } from './noResults';
-export { default as PageHeading } from './pageHeading';
+export {
+  default as PageHeading,
+  HeaderToggleButtonContainer,
+} from './pageHeading';
 export { default as StoryGridView } from './storyGridView';
 export { default as StoryListView } from './storyListView';
 export { default as TypeaheadSearch } from './typeaheadSearch';

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -46,7 +46,9 @@ const StyledHeader = styled(ViewHeader)`
 `;
 
 const Content = styled.div`
-  display: block;
+  display: flex;
+  align-items: ${({ centerContent }) =>
+    centerContent ? 'center' : 'flex-end'};
   height: 100%;
 `;
 
@@ -68,12 +70,14 @@ const SearchInner = styled.div`
   top: 0;
   right: 0;
   width: min(190px, 100%);
+  display: flex;
+  justify-content: flex-end;
 `;
 
 const HeadingBodyWrapper = styled(BodyWrapper)`
   display: grid;
   grid-template-columns: 25% 50% 1fr;
-  align-items: start;
+  align-items: center;
   height: 75px;
   padding-bottom: 3px;
   border-bottom: ${({ theme }) => theme.subNavigationBar.border};
@@ -83,6 +87,7 @@ const PageHeading = ({
   children,
   defaultTitle,
   searchPlaceholder,
+  centerContent = false,
   filteredStories = [],
   handleTypeaheadChange,
   typeaheadValue = '',
@@ -94,7 +99,7 @@ const PageHeading = ({
           <NavMenuButton showOnlyOnSmallViewport />
           {defaultTitle}
         </StyledHeader>
-        <Content>{children}</Content>
+        <Content centerContent={centerContent}>{children}</Content>
         <SearchContainer>
           <SearchInner>
             <TypeaheadSearch
@@ -115,6 +120,7 @@ PageHeading.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
+  centerContent: PropTypes.bool,
   defaultTitle: PropTypes.string.isRequired,
   searchPlaceholder: PropTypes.string,
   filteredStories: StoriesPropType,

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -83,6 +83,12 @@ const HeadingBodyWrapper = styled(BodyWrapper)`
   border-bottom: ${({ theme }) => theme.subNavigationBar.border};
 `;
 
+export const HeaderToggleButtonContainer = styled.div`
+  display: block;
+  flex: 1;
+  height: 65%;
+`;
+
 const PageHeading = ({
   children,
   defaultTitle,

--- a/assets/src/dashboard/app/views/shared/stories/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/stories/pageHeading.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { boolean, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { PageHeading } from '../';
+
+export default {
+  title: 'Dashboard/Components/PageHeading',
+  component: PageHeading,
+};
+
+const InnerContent = styled.div`
+  background-color: red;
+  width: 100%;
+  height: 50%;
+`;
+
+export const _default = () => {
+  return (
+    <PageHeading
+      centerContent={boolean('Center Inner Content', false)}
+      filteredStories={[]}
+      handleTypeaheadChange={(value) => action('Search with value: ', value)}
+      defaultTitle={text('Page Heading', 'My Stories')}
+      searchPlaceholder={text('Search Placeholder', 'Find Stories')}
+    >
+      <InnerContent />
+    </PageHeading>
+  );
+};

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -181,6 +181,7 @@ function TemplatesGallery() {
           <Layout.Provider>
             <Layout.Squishable>
               <PageHeading
+                centerContent
                 defaultTitle={__('Templates', 'web-stories')}
                 searchPlaceholder={__('Template Stories', 'web-stories')}
                 filteredStories={orderedTemplates}

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -51,7 +51,7 @@ export const DropdownContainer = styled.div`
 const Label = styled.label`
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: ${({ alignment }) => alignment};
 `;
 
 export const InnerDropdown = styled.button`
@@ -123,6 +123,7 @@ const ClearButton = styled.div`
 `;
 
 const Dropdown = ({
+  alignment = 'center',
   ariaLabel,
   items,
   disabled,
@@ -179,7 +180,7 @@ const Dropdown = ({
 
   return (
     <DropdownContainer ref={dropdownRef} {...rest}>
-      <Label aria-label={ariaLabel}>
+      <Label aria-label={ariaLabel} alignment={alignment}>
         <InnerDropdown
           onClick={handleInnerDropdownClick}
           isOpen={showMenu}
@@ -242,6 +243,7 @@ const Dropdown = ({
 };
 
 Dropdown.propTypes = {
+  alignment: PropTypes.oneOf(['flex-start', 'center', 'flex-end']),
   ariaLabel: PropTypes.string.isRequired,
   items: PropTypes.arrayOf(DROPDOWN_ITEM_PROP_TYPE),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -62,10 +62,7 @@ export {
   TableTitleHeaderCell,
 } from './table';
 export { TemplateNavBar } from './templateNavBar';
-export {
-  default as ToggleButtonGroup,
-  ToggleButtonGroupContainer,
-} from './toggleButtonGroup';
+export { default as ToggleButtonGroup } from './toggleButtonGroup';
 export { default as TypeaheadInput } from './typeaheadInput';
 export { default as TypeaheadOptions } from './typeaheadOptions';
 export { ViewHeader } from './typography';

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -62,7 +62,10 @@ export {
   TableTitleHeaderCell,
 } from './table';
 export { TemplateNavBar } from './templateNavBar';
-export { default as ToggleButtonGroup } from './toggleButtonGroup';
+export {
+  default as ToggleButtonGroup,
+  ToggleButtonGroupContainer,
+} from './toggleButtonGroup';
 export { default as TypeaheadInput } from './typeaheadInput';
 export { default as TypeaheadOptions } from './typeaheadOptions';
 export { ViewHeader } from './typography';

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -82,12 +82,6 @@ ToggleButton.propTypes = {
   isActive: PropTypes.bool,
 };
 
-export const ToggleButtonGroupContainer = styled.div`
-  display: block;
-  flex: 1;
-  height: 65%;
-`;
-
 const ToggleButtonGroup = ({ buttons }) => {
   const [selectedButton, setSelectedButton] = useState(null);
   const [containerWidth, setContainerWidth] = useState(null);

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -47,7 +47,7 @@ const AnimationBar = styled.div`
     width: ${selectedButtonWidth}px;
     margin-left: ${selectedButtonLeft}%;
     background-color:  ${theme.colors.bluePrimary600};
-    transition: all 0.3s ${BEZIER.outSine}; 
+    transition: all 0.3s ${BEZIER.outSine};
   `}
 `;
 AnimationBar.propTypes = {
@@ -81,6 +81,12 @@ const ToggleButton = styled.button`
 ToggleButton.propTypes = {
   isActive: PropTypes.bool,
 };
+
+export const ToggleButtonGroupContainer = styled.div`
+  display: block;
+  flex: 1;
+  height: 65%;
+`;
 
 const ToggleButtonGroup = ({ buttons }) => {
   const [selectedButton, setSelectedButton] = useState(null);

--- a/assets/src/dashboard/components/typeaheadInput/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/index.js
@@ -36,6 +36,7 @@ import TypeaheadOptions from '../typeaheadOptions';
 
 const SearchContainer = styled.div`
   display: flex;
+  align-items: flex-end;
   flex-direction: column;
   border-radius: ${({ theme, isOpen }) =>
     isOpen ? `${theme.expandedTypeahead.borderRadius}px` : 'none'};
@@ -44,8 +45,8 @@ const SearchContainer = styled.div`
     isOpen ? theme.expandedTypeahead.boxShadow : 'none'};
 
   @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
-    width: ${({ isExpanded }) => (isExpanded ? '272px' : '48px')};
-    transition: width 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
+    flex: ${({ isExpanded }) => (isExpanded ? '1 0 100%' : '0 1 40px')};
+    transition: flex 0.2s cubic-bezier(0.39, 0.575, 0.565, 1);
   }
 `;
 SearchContainer.propTypes = {


### PR DESCRIPTION
## Summary

This PR makes sure everything in the header bar is correctly aligned by text. It also adjusts the filter dropdown to be right-aligned as shown in the new design videos.

## Relevant Technical Choices

- [x] Adds the ability to align the dropdown by start, center, or end
- [x] Adds `<PageHeader />` to storybook

<!-- Please describe your changes. -->

<img width="1030" alt="Screen Shot 2020-05-05 at 9 19 44 AM" src="https://user-images.githubusercontent.com/1738349/81081898-1ecb7b80-8eb8-11ea-8d85-adceb2262af0.png">
<img width="1002" alt="Screen Shot 2020-05-05 at 9 17 47 AM" src="https://user-images.githubusercontent.com/1738349/81081903-1f641200-8eb8-11ea-8f55-dcdd0ebcbc83.png">
<img width="289" alt="Screen Shot 2020-05-05 at 9 25 57 AM" src="https://user-images.githubusercontent.com/1738349/81081905-1ffca880-8eb8-11ea-8735-82ebb3276e28.png">
