### PR TITLE
[Task] Smoother more deterministic squish

### DIFF
--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -28,7 +28,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { clamp } from '../../utils';
+import { clamp, throttleToAnimationFrame } from '../../utils';
 
 export const SQUISH_LENGTH = 90;
 export const SQUISH_CSS_VAR = '--squish-progress';
@@ -56,13 +56,13 @@ const Provider = ({ children }) => {
     }
 
     let prevProgress;
-    const handleScroll = (e) => {
+    const handleScroll = throttleToAnimationFrame((e) => {
       const progress = clamp(e.target.scrollTop / SQUISH_LENGTH, [0, 1]);
       if (!(progress === 1 && prevProgress === 1)) {
-        dispatchSquishEvent(scrollFrameRef, progress);
+        dispatchSquishEvent(scrollFrameEl, progress);
       }
       prevProgress = progress;
-    };
+    });
 
     scrollFrameEl.addEventListener('scroll', handleScroll, { passive: true });
     return () => {

--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -58,6 +58,10 @@ const Provider = ({ children }) => {
     let prevProgress;
     const handleScroll = throttleToAnimationFrame((e) => {
       const progress = clamp(e.target.scrollTop / SQUISH_LENGTH, [0, 1]);
+      /**
+       * Only dispatch squish event if we're within
+       * the squish range.
+       */
       if (!(progress === 1 && prevProgress === 1)) {
         dispatchSquishEvent(scrollFrameEl, progress);
       }

--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -25,13 +25,13 @@ import React, {
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
+/**
+ * Internal dependencies
+ */
+import { clamp } from '../../utils';
 
 export const SQUISH_LENGTH = 90;
 export const SQUISH_CSS_VAR = '--squish-progress';
-
-const generateThreshold = (steps) => {
-  return Array.from({ length: steps + 1 }, (_, i) => i / steps);
-};
 
 export const dispatchSquishEvent = (el, progress) => {
   /**
@@ -48,47 +48,42 @@ export const LayoutContext = createContext(null);
 const Provider = ({ children }) => {
   const [squishContentHeight, setSquishContentHeight] = useState(0);
   const scrollFrameRef = useRef(null);
-  const squishDriverRef = useRef(null);
 
   useLayoutEffect(() => {
-    const squishDriverEl = squishDriverRef.current;
     const scrollFrameEl = scrollFrameRef.current;
-    if (!(squishDriverEl || scrollFrameEl)) {
+    if (!scrollFrameEl) {
       return () => {};
     }
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.intersectionRatio) {
-            dispatchSquishEvent(squishDriverEl, 1 - entry.intersectionRatio);
-          }
-        });
-      },
-      {
-        root: scrollFrameEl,
-        threshold: generateThreshold(1000),
+    let prevProgress;
+    const handleScroll = (e) => {
+      const progress = clamp(e.target.scrollTop / SQUISH_LENGTH, [0, 1]);
+      if (!(progress === 1 && prevProgress === 1)) {
+        dispatchSquishEvent(scrollFrameRef, progress);
       }
-    );
+      prevProgress = progress;
+    };
 
-    observer.observe(squishDriverEl);
+    scrollFrameEl.addEventListener('scroll', handleScroll, { passive: true });
     return () => {
-      observer.unobserve(squishDriverEl);
+      scrollFrameEl.removeEventListener('scroll', handleScroll, {
+        passive: true,
+      });
     };
   }, []);
 
   const addSquishListener = useCallback((listener) => {
-    if (!squishDriverRef.current) {
+    if (!scrollFrameRef.current) {
       return;
     }
-    squishDriverRef.current.addEventListener('squish', listener);
+    scrollFrameRef.current.addEventListener('squish', listener);
   }, []);
 
   const removeSquishListener = useCallback((listener) => {
-    if (!squishDriverRef.current) {
+    if (!scrollFrameRef.current) {
       return;
     }
-    squishDriverRef.current.removeEventListener('squish', listener);
+    scrollFrameRef.current.removeEventListener('squish', listener);
   }, []);
 
   const scrollToTop = useCallback(() => {
@@ -106,7 +101,6 @@ const Provider = ({ children }) => {
     () => ({
       state: {
         scrollFrameRef,
-        squishDriverRef,
         squishContentHeight,
       },
       actions: {

--- a/assets/src/dashboard/components/layout/scrollable.js
+++ b/assets/src/dashboard/components/layout/scrollable.js
@@ -22,7 +22,6 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import useLayoutContext from './useLayoutContext';
-import { SQUISH_LENGTH } from './provider';
 
 const ScrollContent = styled.div`
   position: absolute;
@@ -49,27 +48,13 @@ Inner.propTypes = {
   paddingTop: PropTypes.number,
 };
 
-const SquishRange = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: ${SQUISH_LENGTH}px;
-  pointer-events: none;
-`;
-
-SquishRange.propTypes = {
-  height: PropTypes.number,
-};
-
 const Scrollable = ({ children }) => {
   const {
-    state: { scrollFrameRef, squishDriverRef, squishContentHeight },
+    state: { scrollFrameRef, squishContentHeight },
   } = useLayoutContext();
 
   return (
     <ScrollContent ref={scrollFrameRef}>
-      <SquishRange ref={squishDriverRef} />
       <Inner paddingTop={squishContentHeight}>{children}</Inner>
     </ScrollContent>
   );

--- a/assets/src/dashboard/utils/test/throttleToAnimationFrame.js
+++ b/assets/src/dashboard/utils/test/throttleToAnimationFrame.js
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import throttleToAnimationFrame from '../throttleToAnimationFrame';
+
+const rafController = () => {
+  /**
+   * spys
+   */
+  let cancelAnimationFrameMock = null;
+  let requestAnimationFrameMock = null;
+  let nowMock = null;
+  /**
+   * local vars
+   */
+  let now = 0;
+  let frameIndex = 0;
+  let frameId = 0;
+  const queue = [];
+
+  const getFrameIndex = () => frameIndex;
+
+  const setPerfNow = (time) => {
+    nowMock = jest
+      .spyOn(window.performance, 'now')
+      .mockImplementation(() => time);
+  };
+
+  setPerfNow(now);
+  requestAnimationFrameMock = jest
+    .spyOn(window, 'requestAnimationFrame')
+    .mockImplementation((cb) => {
+      const currentFrameIndex = getFrameIndex();
+      if (!queue[currentFrameIndex]) {
+        queue[currentFrameIndex] = new Map();
+      }
+      frameId += 1;
+      queue[currentFrameIndex]?.set(frameId, cb);
+      return frameId;
+    });
+
+  cancelAnimationFrameMock = jest
+    .spyOn(window, 'cancelAnimationFrame')
+    .mockImplementation((id) => {
+      const currentFrameIndex = getFrameIndex();
+      queue[currentFrameIndex]?.delete(id);
+    });
+
+  return {
+    executeRafAt: (ms) => {
+      now = ms;
+      setPerfNow(now);
+      const lastFrame = frameIndex;
+      /**
+       * Set up new frame in case callbacks call rAF
+       */
+      frameIndex += 1;
+      /**
+       * Call each fn queued for the current frame and clear it after.
+       */
+      queue[lastFrame]?.forEach((cb) => cb(now));
+      queue[lastFrame]?.clear();
+    },
+    cleanup: () => {
+      nowMock?.mockRestore();
+      requestAnimationFrameMock?.mockRestore();
+      cancelAnimationFrameMock?.mockRestore();
+    },
+  };
+};
+
+describe('throttleToAnimationFrame', () => {
+  let rafMocker = null;
+  beforeEach(() => {
+    rafMocker = rafController();
+  });
+  afterEach(() => {
+    rafMocker?.cleanup();
+  });
+
+  it('calls the callback with args at the next animation frame', () => {
+    const callback = jest.fn();
+    const throttled = throttleToAnimationFrame(callback);
+
+    const args = ['test', 1, 2];
+    throttled(...args);
+    expect(callback).toHaveBeenCalledTimes(0);
+
+    rafMocker?.executeRafAt(400);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(...args);
+  });
+
+  it('calls the callback at most once per animation frame', () => {
+    const callback = jest.fn();
+    const throttled = throttleToAnimationFrame(callback);
+
+    /**
+     * Add one call to queue
+     */
+    throttled();
+    throttled();
+    throttled();
+    expect(callback).toHaveBeenCalledTimes(0);
+
+    /**
+     * Call all callbacks in animation frame queue.
+     */
+    rafMocker?.executeRafAt(400);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    /**
+     * Call anim frames a with no callbacks queued
+     */
+    rafMocker?.executeRafAt(500);
+    rafMocker?.executeRafAt(600);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls the callback the most recent args', () => {
+    const callback = jest.fn();
+    const throttled = throttleToAnimationFrame(callback);
+
+    const args1 = ['test', 1, 2];
+    const args2 = ['something else', 3, 4];
+    throttled(...args1);
+    throttled(...args2);
+    rafMocker?.executeRafAt(400);
+    expect(callback).toHaveBeenCalledWith(...args2);
+  });
+});

--- a/assets/src/dashboard/utils/throttleToAnimationFrame.js
+++ b/assets/src/dashboard/utils/throttleToAnimationFrame.js
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * External dependencies
- */
 
 export default (callback) => {
   let frameId = null;

--- a/assets/src/dashboard/utils/throttleToAnimationFrame.js
+++ b/assets/src/dashboard/utils/throttleToAnimationFrame.js
@@ -13,11 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies
+ */
 
-export { default as clamp } from './clamp';
-export { default as getCurrentYAxis } from './getCurrentYAxis';
-export { default as groupBy } from './groupBy';
-export { default as keyboardOnlyOutline } from './keyboardOnlyOutline';
-export { default as useFocusOut } from './useFocusOut';
-export { default as usePagePreviewSize } from './usePagePreviewSize';
-export { default as throttleToAnimationFrame } from './throttleToAnimationFrame';
+export default (callback) => {
+  let frameId = null;
+  return (...args) => {
+    if (frameId) {
+      cancelAnimationFrame(frameId);
+    }
+    frameId = requestAnimationFrame(() => {
+      frameId = null;
+      callback(...args);
+    });
+  };
+};


### PR DESCRIPTION
## Summary
Looked at subbing out `IntersectionObserver` with a throttled scroll event because `IntersectionObserver` wasn't firing reliably for every threshold. This was causing small noticeable ticks & sometimes ending at arbitrary values like `0.956` instead of 1.

After doing a performance audit on both, it seemed neither was a current bottleneck and performed about the same:
- *no throttling* - 60fps
- *4x slowdown* - 40fps
- *6x slowdown* - 30fps

I think if we want to make this more performant, we should get clever with the properties we're interpolating on `squish` events and make them more compositor friendly. currently animating `font-size` & `margin-top`.

If we animated `transform` instead, we would save around `2ms` per style update (on `no throttle`) eliminating `Style Recalc` & `Layout` passes. Which would save us around `12ms` of our `16.66ms` budget on something 6x slower than my macbook

## Relevant Technical Choices
- Changed `squish` event source to be a scroll event vs an intersection observer with multiple thresholds
- Added a `throttleToAnimationFrame` to wrap the scroll handler
- Added tests for `throttleToAnimationFrame` which I created a mock `rafScheduler` for if anyone needs to use this,

Fixes #
- ending on non-deterministic progress values (close to 1, but not 1)
- smoother scroll reactiveness. (updates squish from exact scroll on each animation frame unlike the intersection observer which inconsistently chose thresholds to fire)