### PR TITLE
Dashboard - refactor grid to resize with story ratio

### DIFF
--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -85,6 +85,7 @@ function MyStories() {
 
   const { pageSize } = usePagePreviewSize({
     thumbnailMode: viewStyle === VIEW_STYLE.LIST,
+    isGrid: viewStyle === VIEW_STYLE.GRID,
   });
   const {
     actions: {
@@ -291,38 +292,38 @@ function MyStories() {
   return (
     <FontProvider>
       <TransformProvider>
-        <UnitsProvider pageSize={pageSize}>
-          <Layout.Provider>
-            <Layout.Squishable>
-              <PageHeading
-                defaultTitle={__('My Stories', 'web-stories')}
-                searchPlaceholder={__('Search Stories', 'web-stories')}
-                stories={orderedStories}
-                handleTypeaheadChange={handleTypeaheadChange}
-                typeaheadValue={typeaheadValue}
-              >
-                <HeaderToggleButtonContainer>
-                  <ToggleButtonGroup
-                    buttons={STORY_STATUSES.map((storyStatus) => {
-                      return {
-                        handleClick: () =>
-                          handleFilterStatusUpdate(storyStatus.value),
-                        key: storyStatus.value,
-                        isActive: status === storyStatus.value,
-                        text: storyStatus.label,
-                      };
-                    })}
-                  />
-                </HeaderToggleButtonContainer>
-              </PageHeading>
-              {storiesViewControls}
-            </Layout.Squishable>
-            <Layout.Scrollable>{BodyContent}</Layout.Scrollable>
-            <Layout.Fixed>
-              <ScrollToTop />
-            </Layout.Fixed>
-          </Layout.Provider>
-        </UnitsProvider>
+        <Layout.Provider>
+          <Layout.Squishable>
+            <PageHeading
+              defaultTitle={__('My Stories', 'web-stories')}
+              searchPlaceholder={__('Search Stories', 'web-stories')}
+              stories={orderedStories}
+              handleTypeaheadChange={handleTypeaheadChange}
+              typeaheadValue={typeaheadValue}
+            >
+              <HeaderToggleButtonContainer>
+                <ToggleButtonGroup
+                  buttons={STORY_STATUSES.map((storyStatus) => {
+                    return {
+                      handleClick: () =>
+                        handleFilterStatusUpdate(storyStatus.value),
+                      key: storyStatus.value,
+                      isActive: status === storyStatus.value,
+                      text: storyStatus.label,
+                    };
+                  })}
+                />
+              </HeaderToggleButtonContainer>
+            </PageHeading>
+            {storiesViewControls}
+          </Layout.Squishable>
+          <Layout.Scrollable>
+            <UnitsProvider pageSize={pageSize}>{BodyContent}</UnitsProvider>
+          </Layout.Scrollable>
+          <Layout.Fixed>
+            <ScrollToTop />
+          </Layout.Fixed>
+        </Layout.Provider>
       </TransformProvider>
     </FontProvider>
   );

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -24,6 +24,7 @@ import PropTypes from 'prop-types';
  */
 import cssLerp from '../../../utils/cssLerp';
 import { StoriesPropType } from '../../../types';
+import { DASHBOARD_LEFT_NAV_WIDTH } from '../../../constants/pageStructure';
 import { ViewHeader, NavMenuButton } from '../../../components';
 import BodyWrapper from './bodyWrapper';
 import TypeaheadSearch from './typeaheadSearch';
@@ -69,7 +70,7 @@ const SearchInner = styled.div`
   position: absolute;
   top: 0;
   right: 0;
-  width: min(190px, 100%);
+  width: min(${DASHBOARD_LEFT_NAV_WIDTH}px, 100%);
   display: flex;
   justify-content: flex-end;
 `;

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -50,10 +50,10 @@ import {
 import {
   ICON_METRICS,
   ORDER_BY_SORT,
-  PAGE_RATIO,
   SORT_DIRECTION,
   STORY_SORT_OPTIONS,
 } from '../../../constants';
+import { PAGE_RATIO } from '../../../constants/pageStructure';
 import PreviewErrorBoundary from '../../../components/previewErrorBoundary';
 import { ReactComponent as ArrowIconSvg } from '../../../icons/download.svg';
 

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -64,7 +64,7 @@ import {
 
 function TemplateDetail() {
   const [template, setTemplate] = useState(null);
-  const { pageSize } = usePagePreviewSize();
+  const { pageSize } = usePagePreviewSize({ isGrid: true });
   const {
     state: {
       queryParams: { id: templateId, isLocal },

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -77,6 +77,7 @@ function TemplatesGallery() {
   );
   const { pageSize } = usePagePreviewSize({
     thumbnailMode: viewStyle === VIEW_STYLE.LIST,
+    isGrid: viewStyle === VIEW_STYLE.GRID,
   });
   const {
     state: {

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -23,7 +23,7 @@ import { useRef, useEffect, useState, useMemo, useCallback } from 'react';
 /**
  * Internal dependencies
  */
-import { PAGE_RATIO } from '../../constants';
+import { PAGE_RATIO } from '../../constants/pageStructure';
 import { UnitsProvider } from '../../../edit-story/units';
 import {
   ActiveCard,

--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -26,19 +26,34 @@ import styled from 'styled-components';
 import usePagePreviewSize from '../../utils/usePagePreviewSize';
 
 const DashboardGrid = styled.div`
+  ${({ columnHeight, columnWidth, theme }) => `
   display: grid;
   width: 100%;
-  grid-column-gap: 1vw;
+  grid-column-gap: ${theme.grid.columnGap.desktop}px;
   grid-row-gap: 20px;
-  grid-template-columns: ${({ columnWidth }) =>
-    `repeat(auto-fill, minmax(${columnWidth}px, 1fr))`};
+  grid-template-columns:
+    repeat(auto-fill, ${columnWidth}px);
+  grid-template-rows: minmax(${columnHeight}px, auto);
 
-  grid-template-rows: ${({ columnHeight }) =>
-    `minmax(${columnHeight}px, auto)`};
+  ${theme.breakpoint.tablet} {
+    grid-column-gap: ${theme.grid.columnGap.tablet}px;
+  }
+  ${theme.breakpoint.largeDisplayPhone} {
+    grid-column-gap: ${theme.grid.columnGap.largeDisplayPhone}px;
+  }
+  ${theme.breakpoint.smallDisplayPhone} {
+    grid-column-gap: ${theme.grid.columnGap.smallDisplayPhone}px;
+  }
+  ${theme.breakpoint.min} {
+    grid-column-gap: ${theme.grid.columnGap.min}px;
+  }
+
+`}
 `;
 
 const CardGrid = ({ children }) => {
-  const { pageSize } = usePagePreviewSize();
+  const { pageSize } = usePagePreviewSize({ isGrid: true });
+
   return (
     <DashboardGrid columnWidth={pageSize.width} columnHeight={pageSize.height}>
       {children}

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -32,7 +32,7 @@ const PreviewPane = styled.div`
   position: relative;
   border-radius: 8px;
   height: ${({ cardSize }) => `${cardSize.height}px`};
-  width: ${({ cardSize }) => `${cardSize.width}px`};
+  width: 100%;
   overflow: hidden;
   z-index: -1;
 `;
@@ -89,7 +89,7 @@ const getActionAttributes = (targetAction) =>
     : { onClick: targetAction };
 
 const CardPreviewContainer = ({ centerAction, bottomAction, children }) => {
-  const { pageSize } = usePagePreviewSize();
+  const { pageSize } = usePagePreviewSize({ isGrid: true });
 
   return (
     <>

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -29,7 +29,6 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { CARD_TITLE_AREA_HEIGHT } from '../../constants';
 import { TextInput } from '../input';
 import useFocusOut from '../../utils/useFocusOut';
 
@@ -41,7 +40,6 @@ const StyledCardTitle = styled.div`
   line-height: ${({ theme }) => theme.fonts.storyGridItem.lineHeight}px;
   padding-top: 12px;
   max-width: 80%;
-  height: ${CARD_TITLE_AREA_HEIGHT}px;
 `;
 
 const StyledTitle = styled.p`

--- a/assets/src/dashboard/components/cardGridItem/index.js
+++ b/assets/src/dashboard/components/cardGridItem/index.js
@@ -23,13 +23,12 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import usePagePreviewSize from '../../utils/usePagePreviewSize';
 import { MoreVerticalButton } from './cardItemMenu';
 import { ActionLabel } from './types';
 
 const StyledCard = styled.div`
   margin: 0;
-  width: ${({ cardSize }) => `${cardSize.width}px`};
+  width: 100%;
   display: flex;
   flex-direction: column;
 
@@ -39,13 +38,7 @@ const StyledCard = styled.div`
 `;
 
 const CardGridItem = ({ children, isTemplate }) => {
-  const { pageSize } = usePagePreviewSize();
-
-  return (
-    <StyledCard cardSize={pageSize} isTemplate={isTemplate}>
-      {children}
-    </StyledCard>
-  );
+  return <StyledCard isTemplate={isTemplate}>{children}</StyledCard>;
 };
 
 CardGridItem.propTypes = {

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -32,6 +32,7 @@ import { useCallback, useRef } from 'react';
 import Button from '../button';
 import { useRouteHistory } from '../../app/router';
 import { useConfig } from '../../app/config';
+import { DASHBOARD_LEFT_NAV_WIDTH } from '../../constants/pageStructure';
 import {
   BEZIER,
   BUTTON_TYPES,
@@ -39,6 +40,7 @@ import {
   secondaryPaths,
   Z_INDEX,
 } from '../../constants';
+
 import useFocusOut from '../../utils/useFocusOut';
 import { useNavContext } from '../navProvider';
 import {
@@ -62,7 +64,8 @@ export const PageContent = styled.div`
   top: 0;
   right: 0;
   bottom: 0;
-  left: ${({ fullWidth }) => (fullWidth ? '0' : 'max(15%, 190px)')};
+  left: ${({ fullWidth }) =>
+    fullWidth ? '0' : `${DASHBOARD_LEFT_NAV_WIDTH}px`};
 
   @media ${({ theme }) => theme.breakpoint.tablet} {
     left: 0;
@@ -78,7 +81,7 @@ export const LeftRailContainer = styled.nav.attrs({
   flex-direction: column;
   top: 0;
   bottom: 0;
-  width: max(15%, 190px);
+  width: ${DASHBOARD_LEFT_NAV_WIDTH}px;
   background: ${({ theme }) => theme.colors.white};
   border-right: ${({ theme }) => theme.leftRail.border};
   z-index: ${Z_INDEX.LAYOUT_FIXED};

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -19,11 +19,6 @@
  */
 import { __ } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import { PAGE_HEIGHT, PAGE_WIDTH } from '../../edit-story/constants';
-
 export const BUTTON_TYPES = {
   CTA: 'cta',
   PRIMARY: 'primary',
@@ -57,9 +52,6 @@ export const Z_INDEX = {
   TYPEAHEAD_OPTIONS: 10,
   POPOVER_PANEL: 10,
 };
-
-export const PAGE_RATIO = PAGE_WIDTH / PAGE_HEIGHT;
-export const CARD_TITLE_AREA_HEIGHT = 80;
 
 export const APP_ROUTES = {
   MY_STORIES: '/',

--- a/assets/src/dashboard/constants/pageStructure.js
+++ b/assets/src/dashboard/constants/pageStructure.js
@@ -13,6 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * Internal dependencies
+ */
+import { PAGE_HEIGHT, PAGE_WIDTH } from '../../edit-story/constants';
+
+export const PAGE_RATIO = PAGE_WIDTH / PAGE_HEIGHT;
+
 export const WP_LEFT_NAV_WIDTH = 38;
 export const DASHBOARD_LEFT_NAV_WIDTH = 190;
 export const VIEWPORT_WP_LEFT_NAV_HIDES = 783;

--- a/assets/src/dashboard/constants/pageStructure.js
+++ b/assets/src/dashboard/constants/pageStructure.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const WP_LEFT_NAV_WIDTH = 38;
+export const DASHBOARD_LEFT_NAV_WIDTH = 190;
+export const VIEWPORT_WP_LEFT_NAV_HIDES = 783;

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -273,9 +273,26 @@ const theme = {
       desktop: 20,
       min: 10,
     },
+    // specific to detail template
     large: {
       desktop: 80,
       tablet: 40,
+    },
+  },
+  pageHorizontalGutter: {
+    desktop: 20,
+    tablet: 20,
+    largeDisplayPhone: 20,
+    smallDisplayPhone: 10,
+    min: 10,
+  },
+  grid: {
+    columnGap: {
+      desktop: 10,
+      tablet: 10,
+      largeDisplayPhone: 10,
+      smallDisplayPhone: 10,
+      min: 10,
     },
   },
   previewWidth: {

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -89,7 +89,7 @@ export default function usePagePreviewSize(options = {}) {
 
   const [debounceAvailableContainerSpace] = useDebouncedCallback(() => {
     setAvailableContainerSpace(getTrueInnerWidth());
-  }, 800);
+  }, 250);
 
   const [bp, setBp] = useState(getCurrentBp(availableContainerSpace));
 

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -104,10 +104,9 @@ export default function usePagePreviewSize(options = {}) {
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  }, [thumbnailMode, availableContainerSpace, debounceAvailableContainerSpace]);
+  }, [thumbnailMode, debounceAvailableContainerSpace]);
 
   useEffect(() => setBp(getCurrentBp(availableContainerSpace)), [
-    setBp,
     availableContainerSpace,
   ]);
 

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -20,12 +20,12 @@ import { useEffect, useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { PAGE_RATIO } from '../constants';
 import theme from '../theme';
 import {
-  WP_LEFT_NAV_WIDTH,
   DASHBOARD_LEFT_NAV_WIDTH,
+  PAGE_RATIO,
   VIEWPORT_WP_LEFT_NAV_HIDES,
+  WP_LEFT_NAV_WIDTH,
 } from '../constants/pageStructure';
 
 const descendingBreakpointKeys = Object.keys(theme.breakpoint.raw).sort(

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -31,11 +31,10 @@ import {
 const descendingBreakpointKeys = Object.keys(theme.breakpoint.raw).sort(
   (a, b) => theme.breakpoint.raw[b] - theme.breakpoint.raw[a]
 );
-const getCurrentBp = (availableContainerSpace) => {
-  return descendingBreakpointKeys.reduce((current, bp) => {
+const getCurrentBp = (availableContainerSpace) =>
+  descendingBreakpointKeys.reduce((current, bp) => {
     return availableContainerSpace <= theme.breakpoint.raw[bp] ? bp : current;
   }, descendingBreakpointKeys[0]);
-};
 
 // To determine the size of a story page we take the default page size according to breakpoint
 // and then find the remaining width in the given space that the dashboard is showing stories in

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -17,6 +17,8 @@
  * External dependencies
  */
 import { useEffect, useMemo, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+
 /**
  * Internal dependencies
  */
@@ -85,6 +87,10 @@ export default function usePagePreviewSize(options = {}) {
     getTrueInnerWidth()
   );
 
+  const [debounceAvailableContainerSpace] = useDebouncedCallback(() => {
+    setAvailableContainerSpace(getTrueInnerWidth());
+  }, 800);
+
   const [bp, setBp] = useState(getCurrentBp(availableContainerSpace));
 
   useEffect(() => {
@@ -92,13 +98,13 @@ export default function usePagePreviewSize(options = {}) {
       return () => {};
     }
 
-    const handleResize = () => setAvailableContainerSpace(getTrueInnerWidth());
+    const handleResize = () => debounceAvailableContainerSpace();
 
     window.addEventListener('resize', handleResize);
     return () => {
       window.removeEventListener('resize', handleResize);
     };
-  }, [thumbnailMode, availableContainerSpace]);
+  }, [thumbnailMode, availableContainerSpace, debounceAvailableContainerSpace]);
 
   useEffect(() => setBp(getCurrentBp(availableContainerSpace)), [
     setBp,


### PR DESCRIPTION
## Summary
Our dashboard has a grid. And each grid item is a story and those stories need to have proper ratios. Because of the utils we're using through edit-story to get motion and fonts (and everything else) we need these grid items to be exact numbers, that's kind of tricky when the viewport can be any size! This update gets the grid responsive so we don't have to see those huge gutters in some viewport sizes. 

## Relevant Technical Choices
- I'm calculating the available space we have in a grid row through the usePageSize hook. I'm doing this because we need to know if the pageSize in question is part of a grid before we get to the grid, so using the container width is irrelevant. 
- I'm subtracting the width of the wp left nav, the dashboard left nav, the page gutter and the column gutter as necessary depending on viewport size. I tried to lean on theme breakpoints as much as possible, where I couldn't I set up a new constants/pageStructrue 
- I needed the left nav to stay a fixed width so I got rid of the minmax on it and just have it set to 190px if it's visible. I think this is fine since it really doesn't ever need more space than that and the excess, when it is there, is better used on the grid. 

### 1586px - Old
![old 1586](https://user-images.githubusercontent.com/10720454/81112957-4e887c80-8ed4-11ea-9dfc-5b2dee91673f.png)
### 1586px - New
![new 1586](https://user-images.githubusercontent.com/10720454/81112987-59dba800-8ed4-11ea-845a-bb4047f519a3.png)

### 1136px - Old
![old 1136](https://user-images.githubusercontent.com/10720454/81112955-4defe600-8ed4-11ea-8c32-3cc6c754d885.png)
### 1136px - New
![new 1136](https://user-images.githubusercontent.com/10720454/81112992-5d6f2f00-8ed4-11ea-950c-583088440379.png)

### 761px - Old
![old 761](https://user-images.githubusercontent.com/10720454/81112946-4b8d8c00-8ed4-11ea-9252-38af18ebea97.png)
### 761px - New
![new 761](https://user-images.githubusercontent.com/10720454/81112997-5ea05c00-8ed4-11ea-9618-a178365613f6.png)
