### PR TITLE
Dashboard: Search UI Updates

### DIFF
--- a/assets/src/dashboard/components/typeaheadInput/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/index.js
@@ -38,11 +38,9 @@ const SearchContainer = styled.div`
   display: flex;
   align-items: flex-end;
   flex-direction: column;
-  border-radius: ${({ theme, isOpen }) =>
-    isOpen ? `${theme.expandedTypeahead.borderRadius}px` : 'none'};
+  border-radius: ${({ theme }) => `${theme.expandedTypeahead.borderRadius}px`};
   border: none;
-  box-shadow: ${({ theme, isOpen }) =>
-    isOpen ? theme.expandedTypeahead.boxShadow : 'none'};
+  background: none;
 
   @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
     flex: ${({ isExpanded }) => (isExpanded ? '1 0 100%' : '0 1 40px')};
@@ -59,16 +57,11 @@ const InputContainer = styled.div`
   display: flex;
   width: 100%;
   padding: 5px 8px;
-  border-radius: ${({ theme, isOpen }) =>
-    isOpen ? 'none' : `${theme.typeahead.borderRadius}px`};
-  border: none;
-  border-bottom: ${({ theme, isOpen }) => isOpen && theme.borders.gray50};
+  border-radius: ${({ theme }) => `${theme.typeahead.borderRadius}px`};
+  border: 1px solid ${({ theme }) => theme.colors.gray50};
   color: ${({ theme }) => theme.colors.gray500};
-  background-color: ${({ theme }) => theme.colors.gray50};
+  background-color: ${({ theme }) => theme.colors.gray25};
 `;
-InputContainer.propTypes = {
-  isOpen: PropTypes.bool,
-};
 
 const ControlVisibilityContainer = styled.div`
   position: relative;
@@ -95,7 +88,7 @@ const StyledInput = styled.input`
   letter-spacing: ${({ theme }) => theme.fonts.typeaheadInput.letterSpacing}em;
   font-weight: ${({ theme }) => theme.fonts.typeaheadInput.weight};
   text-overflow: ellipsis;
-  color: ${({ theme }) => theme.colors.gray};
+  color: ${({ theme }) => theme.colors.gray900};
   background-color: transparent;
   border: none;
 
@@ -117,7 +110,7 @@ const SearchButton = styled.button`
   border: none;
   background-color: transparent;
   color: ${({ theme }) => theme.colors.gray300};
-  height: 18px;
+  height: 16px;
   & > svg {
     height: 100%;
   }
@@ -134,7 +127,7 @@ const ClearInputButton = styled.button`
   padding: 0;
   color: ${({ theme }) => theme.colors.gray600};
   cursor: pointer;
-  height: 14px;
+  height: 12px;
 
   & > svg {
     height: 100%;
@@ -169,20 +162,6 @@ const TypeaheadInput = ({
   const isInputExpanded = useMemo(() => {
     return menuFocused || inputValue.length > 0;
   }, [menuFocused, inputValue]);
-
-  const filteredItems = useMemo(() => {
-    if (!isFiltering) {
-      return items;
-    }
-    return items.filter((item) => {
-      const lowerInputValue = inputValue.toLowerCase().trim();
-
-      return (
-        item.label.toLowerCase().includes(lowerInputValue) ||
-        item.value.toLowerCase().includes(lowerInputValue)
-      );
-    });
-  }, [items, inputValue, isFiltering]);
 
   const focusInput = useCallback(() => {
     inputRef.current.focus();
@@ -225,7 +204,7 @@ const TypeaheadInput = ({
       isOpen={isMenuOpen}
       isExpanded={isInputExpanded}
     >
-      <InputContainer isOpen={isMenuOpen}>
+      <InputContainer>
         <SearchButton
           onClick={() => {
             setMenuFocused(true);
@@ -268,9 +247,9 @@ const TypeaheadInput = ({
       {isMenuOpen && (
         <TypeaheadOptions
           isOpen={isMenuOpen}
-          items={filteredItems}
+          items={items}
           maxItemsVisible={maxItemsVisible}
-          onSelect={filteredItems && handleMenuItemSelect}
+          onSelect={items && handleMenuItemSelect}
         />
       )}
     </SearchContainer>

--- a/assets/src/dashboard/components/typeaheadInput/stories/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/stories/index.js
@@ -20,6 +20,7 @@
 import { action } from '@storybook/addon-actions';
 import { boolean, number, text } from '@storybook/addon-knobs';
 import { useState } from 'react';
+import styled from 'styled-components';
 /**
  * Internal dependencies
  */
@@ -40,46 +41,32 @@ const items = [
   { label: 'Basil', value: 'basil' },
   { label: 'water', value: 'agua' },
 ];
+
+const Container = styled.div`
+  width: 400px;
+  margin: 50px 100px;
+  padding: 40px;
+  background-color: white;
+`;
 export const _default = () => {
   const [value, setValue] = useState('');
   return (
-    <TypeaheadInput
-      inputId={'demo-search-component'}
-      items={items}
-      onChange={(inputValue) => {
-        if (!inputValue) {
-          setValue('');
-        }
-        action(`input changed ${inputValue}`)(inputValue);
-      }}
-      maxItemsVisible={number('maxItemsVisible', 7)}
-      value={value}
-      placeholder={text('placeholder', 'Search Stories')}
-      ariaLabel={text('ariaLabel', 'my search for seasonings')}
-      disabled={boolean('disabled')}
-    />
-  );
-};
-
-export const _filterLoadedSearchItems = () => {
-  const [value, setValue] = useState('Sports');
-  return (
-    <TypeaheadInput
-      inputId={'demo-search-component'}
-      items={items}
-      isFiltering={true}
-      onChange={(inputValue) => {
-        if (!inputValue) {
-          setValue('');
-        }
-        action(`input changed ${inputValue}`)(inputValue);
-        setValue(inputValue);
-      }}
-      value={value}
-      maxItemsVisible={number('maxItemsVisible')}
-      placeholder={text('placeholder', 'Search Stories')}
-      ariaLabel={text('ariaLabel', 'my search for seasonings')}
-      disabled={boolean('disabled')}
-    />
+    <Container>
+      <TypeaheadInput
+        inputId={'demo-search-component'}
+        items={items}
+        onChange={(inputValue) => {
+          if (!inputValue) {
+            setValue('');
+          }
+          action(`input changed ${inputValue}`)(inputValue);
+        }}
+        maxItemsVisible={number('maxItemsVisible', 7)}
+        value={value}
+        placeholder={text('placeholder', 'Search Stories')}
+        ariaLabel={text('ariaLabel', 'my search for seasonings')}
+        disabled={boolean('disabled')}
+      />
+    </Container>
   );
 };

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -29,20 +29,20 @@ import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
 
 export const Menu = styled.ul`
   ${({ theme, isOpen }) => `
-  width: 100%;
-  align-items: flex-start;
-  background-color: ${theme.colors.white};
-  box-shadow: ${theme.expandedTypeahead.boxShadow};
-  border-radius: 5px;
-  display: flex;
-  flex-direction: column;
-  margin: 5px 0 0;
-  opacity: ${isOpen ? 1 : 0};
-  overflow: hidden;
-  padding: 5px 0;
-  pointer-events: ${isOpen ? 'auto' : 'none'};
-  z-index: ${Z_INDEX.TYPEAHEAD_OPTIONS};
-`}
+    width: 100%;
+    align-items: flex-start;
+    background-color: ${theme.colors.white};
+    box-shadow: ${theme.expandedTypeahead.boxShadow};
+    border-radius: 5px;
+    display: flex;
+    flex-direction: column;
+    margin: 5px 0 0;
+    opacity: ${isOpen ? 1 : 0};
+    overflow: hidden;
+    padding: 5px 0;
+    pointer-events: ${isOpen ? 'auto' : 'none'};
+    z-index: ${Z_INDEX.TYPEAHEAD_OPTIONS};
+  `}
 `;
 Menu.propTypes = {
   isOpen: PropTypes.bool,
@@ -50,18 +50,18 @@ Menu.propTypes = {
 
 const MenuItem = styled.li`
   ${({ theme, isDisabled, isHovering }) => `
-padding: 10px 20px;
-background: ${isHovering ? theme.colors.gray25 : 'none'};
-color: ${theme.colors.gray700};
-cursor: ${isDisabled ? 'default' : 'pointer'};
-display: flex;
-font-family: ${theme.fonts.typeaheadOptions.family};
-font-size: ${theme.fonts.typeaheadOptions.size}px;
-line-height: ${theme.fonts.typeaheadOptions.lineHeight}px;
-font-weight: ${theme.fonts.typeaheadOptions.weight};
-letter-spacing: ${theme.fonts.typeaheadOptions.letterSpacing}em;
-width: 100%;
-`}
+    padding: 10px 20px;
+    background: ${isHovering ? theme.colors.gray25 : 'none'};
+    color: ${theme.colors.gray700};
+    cursor: ${isDisabled ? 'default' : 'pointer'};
+    display: flex;
+    font-family: ${theme.fonts.typeaheadOptions.family};
+    font-size: ${theme.fonts.typeaheadOptions.size}px;
+    line-height: ${theme.fonts.typeaheadOptions.lineHeight}px;
+    font-weight: ${theme.fonts.typeaheadOptions.weight};
+    letter-spacing: ${theme.fonts.typeaheadOptions.letterSpacing}em;
+    width: 100%;
+  `}
 `;
 
 MenuItem.propTypes = {

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -28,36 +28,40 @@ import { KEYS, Z_INDEX } from '../../constants';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
 
 export const Menu = styled.ul`
+  ${({ theme, isOpen }) => `
   width: 100%;
   align-items: flex-start;
-  background-color: ${({ theme }) => theme.colors.white};
+  background-color: ${theme.colors.white};
+  box-shadow: ${theme.expandedTypeahead.boxShadow};
+  border-radius: 5px;
   display: flex;
   flex-direction: column;
-  margin: 0;
-  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  margin: 5px 0 0;
+  opacity: ${isOpen ? 1 : 0};
   overflow: hidden;
-  padding: 0;
-  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
+  padding: 5px 0;
+  pointer-events: ${isOpen ? 'auto' : 'none'};
   z-index: ${Z_INDEX.TYPEAHEAD_OPTIONS};
+`}
 `;
 Menu.propTypes = {
   isOpen: PropTypes.bool,
 };
 
 const MenuItem = styled.li`
-  padding: 14px 16px 14px 44px;
-  background: ${({ isHovering, theme }) =>
-    isHovering ? theme.colors.gray50 : 'none'};
-  color: ${({ theme }) => theme.colors.gray700};
-  cursor: ${({ isDisabled }) => (isDisabled ? 'default' : 'pointer')};
-  display: flex;
-  font-family: ${({ theme }) => theme.fonts.typeaheadOptions.family};
-  font-size: ${({ theme }) => theme.fonts.typeaheadOptions.size}px;
-  line-height: ${({ theme }) => theme.fonts.typeaheadOptions.lineHeight}px;
-  font-weight: ${({ theme }) => theme.fonts.typeaheadOptions.weight};
-  letter-spacing: ${({ theme }) =>
-    theme.fonts.typeaheadOptions.letterSpacing}em;
-  width: 100%;
+  ${({ theme, isDisabled, isHovering }) => `
+padding: 10px 20px;
+background: ${isHovering ? theme.colors.gray25 : 'none'};
+color: ${theme.colors.gray700};
+cursor: ${isDisabled ? 'default' : 'pointer'};
+display: flex;
+font-family: ${theme.fonts.typeaheadOptions.family};
+font-size: ${theme.fonts.typeaheadOptions.size}px;
+line-height: ${theme.fonts.typeaheadOptions.lineHeight}px;
+font-weight: ${theme.fonts.typeaheadOptions.weight};
+letter-spacing: ${theme.fonts.typeaheadOptions.letterSpacing}em;
+width: 100%;
+`}
 `;
 
 MenuItem.propTypes = {


### PR DESCRIPTION
## Summary
Updates the search component in Dashboard to new designs (exploreTemplatesAndDetailPageAndFilter recording). Tightens up space, adjusts colors, shrink the icons a little bit, adjust the expanded container to have space between input and options. 

## Relevant Technical Choices
- update styles 
- remove internal filtering as an option in the typeaheadInput - we're doing all of that external, now that we know that is happening we can just delete this as an option. 

## Screenshots & Demo
![new search demo](https://user-images.githubusercontent.com/10720454/81121065-c8276700-8ee2-11ea-88ec-f4d33237d817.gif)

### Screenshots from design video vs branch 

#### Empty Design
<img width="248" alt="Screen Shot 2020-05-05 at 2 58 44 PM" src="https://user-images.githubusercontent.com/10720454/81121074-cbbaee00-8ee2-11ea-8868-ea4748fca38f.png">

#### Empty Branch
![Screen Shot 2020-05-05 at 2 59 15 PM](https://user-images.githubusercontent.com/10720454/81121082-cc538480-8ee2-11ea-8547-23a0673665ba.png)


#### Active Design 
<img width="260" alt="Screen Shot 2020-05-05 at 2 58 57 PM" src="https://user-images.githubusercontent.com/10720454/81121076-cbbaee00-8ee2-11ea-84d7-452221f51da0.png">

#### Active Branch 
![Screen Shot 2020-05-05 at 2 59 22 PM](https://user-images.githubusercontent.com/10720454/81121084-cc538480-8ee2-11ea-969d-8bbf2a2ce729.png)

#### Filled In Design 
<img width="240" alt="Screen Shot 2020-05-05 at 2 59 07 PM" src="https://user-images.githubusercontent.com/10720454/81121079-cc538480-8ee2-11ea-82f3-1c04386265dc.png">

#### Filled in Branch
![Screen Shot 2020-05-05 at 2 59 29 PM](https://user-images.githubusercontent.com/10720454/81121087-ccec1b00-8ee2-11ea-9cd2-d7774cf8dae1.png)



