### PR TITLE
Dashboard: renaming filteredStories prop throughout components/views

### DIFF
--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -193,7 +193,7 @@ function MyStories() {
             updateStory={updateStory}
             createTemplateFromStory={createTemplateFromStory}
             duplicateStory={duplicateStory}
-            filteredStories={orderedStories}
+            stories={orderedStories}
             centerActionLabel={
               <>
                 <PlayArrowIcon />
@@ -206,7 +206,7 @@ function MyStories() {
       case VIEW_STYLE.LIST:
         return (
           <StoryListView
-            filteredStories={orderedStories}
+            stories={orderedStories}
             storySort={currentStorySort}
             sortDirection={currentListSortDirection}
             handleSortChange={handleNewStorySort}
@@ -297,7 +297,7 @@ function MyStories() {
               <PageHeading
                 defaultTitle={__('My Stories', 'web-stories')}
                 searchPlaceholder={__('Search Stories', 'web-stories')}
-                filteredStories={orderedStories}
+                stories={orderedStories}
                 handleTypeaheadChange={handleTypeaheadChange}
                 typeaheadValue={typeaheadValue}
               >

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -94,7 +94,7 @@ const PageHeading = ({
   defaultTitle,
   searchPlaceholder,
   centerContent = false,
-  filteredStories = [],
+  stories = [],
   handleTypeaheadChange,
   typeaheadValue = '',
 }) => {
@@ -111,7 +111,7 @@ const PageHeading = ({
             <TypeaheadSearch
               placeholder={searchPlaceholder}
               currentValue={typeaheadValue}
-              filteredStories={filteredStories}
+              stories={stories}
               handleChange={handleTypeaheadChange}
             />
           </SearchInner>
@@ -129,7 +129,7 @@ PageHeading.propTypes = {
   centerContent: PropTypes.bool,
   defaultTitle: PropTypes.string.isRequired,
   searchPlaceholder: PropTypes.string,
-  filteredStories: StoriesPropType,
+  stories: StoriesPropType,
   handleTypeaheadChange: PropTypes.func,
   typeaheadValue: PropTypes.string,
 };

--- a/assets/src/dashboard/app/views/shared/stories/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/stories/pageHeading.js
@@ -41,7 +41,7 @@ export const _default = () => {
   return (
     <PageHeading
       centerContent={boolean('Center Inner Content', false)}
-      filteredStories={[]}
+      stories={[]}
       handleTypeaheadChange={(value) => action('Search with value: ', value)}
       defaultTitle={text('Page Heading', 'My Stories')}
       searchPlaceholder={text('Search Placeholder', 'Find Stories')}

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -55,7 +55,7 @@ const StoryGrid = styled(CardGrid)`
 `;
 
 const StoryGridView = ({
-  filteredStories,
+  stories,
   centerActionLabel,
   bottomActionLabel,
   createTemplateFromStory,
@@ -117,7 +117,7 @@ const StoryGridView = ({
 
   return (
     <StoryGrid>
-      {filteredStories.map((story) => (
+      {stories.map((story) => (
         <CardGridItem key={story.id} isTemplate={isTemplate}>
           <CardPreviewContainer
             centerAction={{
@@ -160,7 +160,7 @@ const StoryGridView = ({
 
 StoryGridView.propTypes = {
   isTemplate: PropTypes.bool,
-  filteredStories: StoriesPropType,
+  stories: StoriesPropType,
   centerActionLabel: ActionLabel,
   bottomActionLabel: ActionLabel,
   createTemplateFromStory: PropTypes.func,

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -111,7 +111,7 @@ const AuthorTableHeaderCell = styled(TableHeaderCell)`
 `;
 
 export default function StoryListView({
-  filteredStories,
+  stories,
   storySort,
   handleSortChange,
   handleSortDirectionChange,
@@ -192,7 +192,7 @@ export default function StoryListView({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {filteredStories.map((story) => (
+          {stories.map((story) => (
             <TableRow key={`story-${story.id}`}>
               <TablePreviewCell>
                 <PreviewContainer>
@@ -217,7 +217,7 @@ export default function StoryListView({
 }
 
 StoryListView.propTypes = {
-  filteredStories: StoriesPropType,
+  stories: StoriesPropType,
   tags: TagsPropType,
   categories: CategoriesPropType,
   users: UsersPropType,

--- a/assets/src/dashboard/app/views/shared/typeaheadSearch.js
+++ b/assets/src/dashboard/app/views/shared/typeaheadSearch.js
@@ -28,17 +28,17 @@ export default function TypeaheadSearch({
   placeholder = '',
   handleChange,
   currentValue = '',
-  filteredStories = [],
+  stories = [],
 }) {
   const typeaheadMenuOptions = useMemo(() => {
     // todo add different option sets, value and label won't always be the same
-    return filteredStories.map((filteredStory) => {
+    return stories.map((story) => {
       return {
-        label: filteredStory.title,
-        value: filteredStory.title,
+        label: story.title,
+        value: story.title,
       };
     });
-  }, [filteredStories]);
+  }, [stories]);
 
   return (
     <TypeaheadInput
@@ -56,7 +56,7 @@ TypeaheadSearch.propTypes = {
   placeholder: PropTypes.string,
   handleChange: PropTypes.func.isRequired,
   currentValue: PropTypes.string,
-  filteredStories: PropTypes.arrayOf(
+  stories: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -244,7 +244,7 @@ function TemplateDetail() {
                     </SubHeading>
                     <UnitsProvider pageSize={pageSize}>
                       <StoryGridView
-                        filteredStories={relatedTemplates}
+                        stories={relatedTemplates}
                         centerActionLabel={__('View', 'web-stories')}
                         bottomActionLabel={__('Use template', 'web-stories')}
                         isTemplate

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -149,7 +149,7 @@ function TemplatesGallery() {
       return (
         <BodyWrapper>
           <StoryGridView
-            filteredStories={orderedTemplates}
+            stories={orderedTemplates}
             centerActionLabel={__('View', 'web-stories')}
             bottomActionLabel={__('Use template', 'web-stories')}
             isTemplate
@@ -184,7 +184,7 @@ function TemplatesGallery() {
                 centerContent
                 defaultTitle={__('Templates', 'web-stories')}
                 searchPlaceholder={__('Template Stories', 'web-stories')}
-                filteredStories={orderedTemplates}
+                stories={orderedTemplates}
                 handleTypeaheadChange={setTypeaheadValue}
                 typeaheadValue={typeaheadValue}
               >


### PR DESCRIPTION
## Summary
Back when we started the dashboard we were doing some filtering on the front end of stories, that prop name (`filteredStories`) became the defacto prop name for the stories getting passed to the typeahead, grid, and list view. It's not filtered, updating this to just be `stories` which is more descriptive. 

_everything should work as it currently does, just name updates_ 