### PR TITLE
Remove Delete Page shortcut tooltip

### DIFF
--- a/assets/src/edit-story/components/canvas/pagemenu/index.js
+++ b/assets/src/edit-story/components/canvas/pagemenu/index.js
@@ -148,7 +148,7 @@ function PageMenu() {
             )}
           </PageCount>
           <Space />
-          <WithTooltip title={__('Delete page', 'web-stories')} shortcut="del">
+          <WithTooltip title={__('Delete page', 'web-stories')}>
             <Icon
               onClick={handleDeletePage}
               aria-label={__('Delete Page', 'web-stories')}


### PR DESCRIPTION
## Summary

Remove del shortcut tooltip to delete page.

Fixes #1548