### PR TITLE
WIP: a sample for a e2e test

### DIFF
--- a/assets/src/edit-story/app/index.js
+++ b/assets/src/edit-story/app/index.js
@@ -20,6 +20,7 @@
 import { ThemeProvider, StyleSheetManager } from 'styled-components';
 import stylisRTLPlugin from 'stylis-plugin-rtl';
 import PropTypes from 'prop-types';
+
 /**
  * Internal dependencies
  */

--- a/assets/src/edit-story/app/media/mediaProvider.js
+++ b/assets/src/edit-story/app/media/mediaProvider.js
@@ -29,6 +29,9 @@ import useMediaReducer from './useMediaReducer';
 import useUploadMedia from './useUploadMedia';
 import Context from './context';
 import { getResourceFromAttachment } from './utils';
+import providerWithProfile from '../../utils/providerWithProfile';
+
+const Provider = providerWithProfile('MediaProvider', Context.Provider);
 
 function MediaProvider({ children }) {
   const { state, actions } = useMediaReducer();
@@ -169,7 +172,7 @@ function MediaProvider({ children }) {
     },
   };
 
-  return <Context.Provider value={context}>{children}</Context.Provider>;
+  return <Provider value={context}>{children}</Provider>;
 }
 
 MediaProvider.propTypes = {

--- a/assets/src/edit-story/app/story/storyProvider.js
+++ b/assets/src/edit-story/app/story/storyProvider.js
@@ -33,6 +33,9 @@ import usePageBackgrounds from './effects/usePageBackgrounds';
 import useStoryReducer from './useStoryReducer';
 import useDeleteStory from './actions/useDeleteStory';
 import useAutoSave from './actions/useAutoSave';
+import providerWithProfile from '../../utils/providerWithProfile';
+
+const Provider = providerWithProfile('StoryProvider', Context.Provider);
 
 function StoryProvider({ storyId, children }) {
   const {
@@ -140,7 +143,7 @@ function StoryProvider({ storyId, children }) {
     },
   };
 
-  return <Context.Provider value={state}>{children}</Context.Provider>;
+  return <Provider value={state}>{children}</Provider>;
 }
 
 StoryProvider.propTypes = {

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -96,6 +96,7 @@ function FrameElement({ element }) {
   return (
     <Wrapper
       ref={elementRef}
+      data-testid="frame"
       data-element-id={id}
       {...box}
       onMouseDown={(evt) => {

--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -80,6 +80,7 @@ function FramesLayer() {
   return (
     <Layer
       ref={ref}
+      data-testid="FramesLayer"
       pointerEvents="none"
       // Use `-1` to ensure that there's a default target to focus if
       // there's no selection, but it's not reacheable by keyboard

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -203,8 +203,8 @@ function useLayoutParamsCssVars() {
 
 const PageArea = forwardRef(({ children, showDangerZone }, ref) => {
   return (
-    <PageAreaFullbleedContainer>
-      <PageAreaSafeZone ref={ref}>{children}</PageAreaSafeZone>
+    <PageAreaFullbleedContainer data-testid="fullbleed">
+      <PageAreaSafeZone data-testid="safezone" ref={ref}>{children}</PageAreaSafeZone>
       {showDangerZone && (
         <>
           <PageAreaDangerZoneTop />

--- a/assets/src/edit-story/components/canvas/selectionCanvas.js
+++ b/assets/src/edit-story/components/canvas/selectionCanvas.js
@@ -149,6 +149,8 @@ function SelectionCanvas({ children }) {
 
   const onMouseUp = () => {
     if (lassoModeRef.current === LassoMode.ON) {
+      // QQQQQ: remove, debugging.
+      // throw new Error('CATASTROPHIC FAILURE ON LASSO');
       const [lx, ly, lwidth, lheight] = getLassoBox();
       const x = editorToDataX(lx - pageContainer.offsetLeft);
       const y = editorToDataY(ly - pageContainer.offsetTop);

--- a/assets/src/edit-story/components/library/panes/media/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaElement.js
@@ -118,6 +118,7 @@ const MediaElement = ({
   onInsert,
 }) => {
   const {
+    id: resourceId,
     src,
     type,
     width: originalWidth,
@@ -185,7 +186,7 @@ const MediaElement = ({
       }
     }
     return (
-      <Container>
+      <Container data-testid="mediaElement" data-id={resourceId}>
         <Image
           key={src}
           src={imageSrc}

--- a/assets/src/edit-story/utils/providerWithProfile.js
+++ b/assets/src/edit-story/utils/providerWithProfile.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef } from 'react';
+
+function providerWithProfile(name, provider) {
+  const Provider = provider;
+  return function({value, children}) {
+    const valueRef = useRef(null);
+    const state = value.state;
+    pushExportTestData(name, state);
+    pushExportTestStats('rendered', name);
+    if (value !== valueRef.current) {
+      valueRef.current = value;
+      pushExportTestStats('changed', name);
+    }
+    return <Provider value={value}>{children}</Provider>;
+  };
+}
+
+function pushExportTestData(name, payload) {
+  if (!window.storyEditorExports) {
+    window.storyEditorExports = {};
+  }
+  window.storyEditorExports[name] = payload;
+}
+
+function pushExportTestStats(name, value) {
+  if (!window.storyEditorStats) {
+    window.storyEditorStats = {};
+  }
+  if (!window.storyEditorStats[name]) {
+    window.storyEditorStats[name] = [];
+  }
+  if (!window.storyEditorStats[name].includes(value)) {
+    window.storyEditorStats[name].push(value);
+  }
+}
+
+const isDevelopment = process.env.NODE_ENV !== 'production';
+export default isDevelopment ? providerWithProfile : (unusedName, provider) => provider;

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,24 +1,15 @@
-/*
- * Copyright 2020 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 module.exports = {
   launch: {
+    // TODO: parameter to rerun tests on a couple of viewport types.
+    defaultViewport: {
+      width: 1600,
+      height: 900,
+      deviceScaleFactor: 1,
+    },
     headless: process.env.PUPPETEER_HEADLESS !== 'false',
     slowMo: parseInt(process.env.PUPPETEER_SLOWMO) || 0,
+    devtools: process.env.PUPPETEER_DEVTOOLS === 'true',
     dumpio: true,
     product: process.env.PUPPETEER_PRODUCT || 'chrome',
   },
-};
+}

--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -173,6 +173,7 @@ async function runAxeTestsForStoriesEditor() {
       'landmark-unique',
       'page-has-heading-one',
       'region',
+      'scrollable-region-focusable',
     ],
   });
 }

--- a/tests/e2e/specs/edit-story/example.js
+++ b/tests/e2e/specs/edit-story/example.js
@@ -17,12 +17,57 @@
 /**
  * Internal dependencies
  */
-import { createNewStory } from '../../utils';
+import { createNewStory, exportData, popStats } from '../../utils';
 
-describe('Example Spec', () => {
-  it('should be able to create a blank story', async () => {
+// To debug:
+// 1. Set `PUPPETEER_DEVTOOLS=true`
+// 2. Insert `await jestPuppeteer.debug()` in the test being debugged.
+
+describe('Selection with new element', () => {
+  let safezoneBox;
+
+  beforeEach(async () => {
     await createNewStory();
 
-    await expect(page).toMatchElement('input[placeholder="Add title"]');
+    // Click on a first media image.
+    await expect(page).toClick('[data-testid="mediaElement"] img');
+
+    // Find and measure the safe zone.
+    const safezone = await expect(page).toMatchElement('[data-testid="FramesLayer"] [data-testid="safezone"]');
+    safezoneBox = await safezone.boundingBox();
+  });
+
+  it('should auto-select, unselect, and reselect via lasso', async () => {
+    const iniStoryState = await exportData(page, 'StoryProvider');
+    expect(iniStoryState.selectedElements).toHaveLength(1);
+    const {id: elementId, width, height, x, y} = iniStoryState.selectedElements[0];
+
+    // Find and measure the frame.
+    const frame = await expect(page).toMatchElement(`[data-testid="frame"][data-element-id="${elementId}"]`);
+    const box = await frame.boundingBox();
+
+    // Check that the measurements match the element's data.
+    expect(box.width).toBe(width);
+    expect(box.height).toBe(height);
+    expect(box.x - safezoneBox.x).toBe(x);
+    expect(box.y - safezoneBox.y).toBe(y);
+    await popStats(page);
+
+    // Unselect: move mouse just outside the safe zone and do mouse down.
+    await page.mouse.move(safezoneBox.x - 5, box.y);
+    await page.mouse.down();
+    const unselectedStoryState = await exportData(page, 'StoryProvider');
+    expect(unselectedStoryState.selectedElements).toHaveLength(0);
+    const unselectedStats = await popStats(page);
+    expect(unselectedStats.changed).toEqual(['StoryProvider']);
+
+    // Use lasso.
+    await page.mouse.move(box.x + 5, box.y + 5, {steps: 10});
+    await page.mouse.up();
+    const lassoSelectedStoryState = await exportData(page, 'StoryProvider');
+    expect(lassoSelectedStoryState.selectedElements).toHaveLength(1);
+    expect(lassoSelectedStoryState.selectedElements[0].id).toBe(elementId);
+    const lassoSelectedStats = await popStats(page);
+    expect(lassoSelectedStats.changed).toEqual(['StoryProvider']);
   });
 });

--- a/tests/e2e/specs/edit-story/example.js
+++ b/tests/e2e/specs/edit-story/example.js
@@ -25,9 +25,18 @@ import { createNewStory, exportData, popStats } from '../../utils';
 
 describe('Selection with new element', () => {
   let safezoneBox;
+  let errors;
 
   beforeEach(async () => {
     await createNewStory();
+
+    errors = [];
+    page.on('error', (error) => {
+      errors.push({cat: 'error', error});
+    });
+    page.on('pageerror', (error) => {
+      errors.push({cat: 'pageerror', error});
+    });
 
     // Click on a first media image.
     await expect(page).toClick('[data-testid="mediaElement"] img');
@@ -35,6 +44,10 @@ describe('Selection with new element', () => {
     // Find and measure the safe zone.
     const safezone = await expect(page).toMatchElement('[data-testid="FramesLayer"] [data-testid="safezone"]');
     safezoneBox = await safezone.boundingBox();
+  });
+
+  afterEach(() => {
+    expect(errors).toHaveLength(0);
   });
 
   it('should auto-select, unselect, and reselect via lasso', async () => {

--- a/tests/e2e/utils/test-data.js
+++ b/tests/e2e/utils/test-data.js
@@ -14,5 +14,17 @@
  * limitations under the License.
  */
 
-export { createNewStory } from './create-new-story';
-export { exportData, popStats } from './test-data';
+export function exportData(page, name) {
+  return page.evaluate(
+    (name) => window.storyEditorExports && window.storyEditorExports[name],
+    name
+  );
+}
+
+export function popStats(page) {
+  return page.evaluate(() => {
+    const value = window.storyEditorStats;
+    window.storyEditorStats = null;
+    return value;
+  });
+}


### PR DESCRIPTION
A quick prototype to see what kind of integration tests could be helpful.

Notes:

* The test itself is a single file `tests/e2e/specs/edit-story/example.js`. Start reviewing with this file. The hope that we could eventually make the test script to feel "natural".
* Most of element access is done via `data-testid`. However, canvas itself is operated with clientX/Y. The reason is that non-essential setup/discovery for test should be easy to do.
* The hope is to eventually build out interactive utils to drive clientX/Y relative to some major anchors, such the canvas, or a particular element. This way the test could be expressed "move mouse x+=20px from the canvas element".
* The test currently fails, because the lasso selection was broken by the safezone.
* The story's data model is used in the test. It's exported in a very ugly way for now. But the concept itself makes sense to me: the end result of anything that happens in the editor is the new data model. So it makes sense to use it in the integration test.
* I experimented with adding some stats to tests. Also extremely ugly at this time. But the idea is this: for any interaction we could do a high level check: what major pieces were updated and/or forced to rerender.
