### PR TITLE
Loading should only show when actively fetching more media results

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -310,7 +310,7 @@ function MediaPane(props) {
                   />
                 ))}
             </Column>
-            {hasMore && (
+            {isMediaLoading && (
               <Loading ref={refContainerFooter}>
                 {__('Loading…', 'web-stories')}
               </Loading>


### PR DESCRIPTION
## Summary

Show media loading indictor only when we are actively fetching more media results.

Fixes #1572 
