### PR TITLE
Deploy plugin bundle to wiki repo for easier QA

### DIFF
--- a/.github/workflows/cleanup-pr-assets.yml
+++ b/.github/workflows/cleanup-pr-assets.yml
@@ -1,0 +1,34 @@
+# This workflow removes any assets created for manual QA testing
+# from the GitHub Wiki repository once a pull request is closed.
+#
+# See https://github.com/google/web-stories-wp/issues/1398
+
+name: Clean up PR assets for closed PRs
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  remove-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository }}.wiki
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prune PR files
+        run: |
+          rm -rf "refs/pull/${{ github.event.pull_request.number }}"
+          git add .
+          git status
+          git diff --staged --quiet && echo 'No changes to commit; exiting!' && exit 0
+          git commit -m "Prune refs/pull/${{ github.event.pull_request.number }}"
+          git push origin master
+        env:
+          GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
+          GIT_AUTHOR_NAME: ${{ github.actor }}
+          GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ github.actor }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -447,18 +447,68 @@ jobs:
 
       - name: Bundle plugin
         run: |
+          npm run build:js
           npm run build:plugin
           npm run bundle-plugin web-stories.zip
           npm run bundle-plugin web-stories-composer.zip -- --composer
 
+      - name: Bundle development version
+        run: |
+          rm -rf assets/css/* assets/js/*
+          NODE_ENV=development npx webpack
+          npm run build:plugin
+          npm run bundle-plugin web-stories-dev.zip
+
       - name: Upload full bundle
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: web-stories.zip
           path: build/web-stories.zip
 
       - name: Upload composer bundle
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: web-stories-composer.zip
           path: build/web-stories-composer.zip
+
+      - name: Upload development bundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: web-stories-composer.zip
+          path: build/web-stories-dev.zip
+
+      - name: Upload bundles in combined ZIP file
+        uses: actions/upload-artifact@v2
+        with:
+          name: All ZIP Files
+          path: build/*.zip
+
+  deploy-to-wiki:
+    name: Deploy artefacts to wiki for easier QA testing
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.repository }}.wiki
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download combined ZIP file
+        uses: actions/download-artifact@v2
+        with:
+          name: All ZIP Files
+          path: ${{ github.ref }}
+
+      - name: Commit updates
+        run: |
+          git add .
+          git status
+          git commit -m "Build and publish ${{ github.ref }}"
+          git pull --no-edit --quiet
+          git push origin master
+        env:
+          GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
+          GIT_AUTHOR_NAME: ${{ github.actor }}
+          GIT_COMMITTER_EMAIL: ${{ github.actor }}@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ github.actor }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -474,7 +474,7 @@ jobs:
       - name: Upload development bundle
         uses: actions/upload-artifact@v2
         with:
-          name: web-stories-composer.zip
+          name: web-stories-dev.zip
           path: build/web-stories-dev.zip
 
       - name: Upload bundles in combined ZIP file


### PR DESCRIPTION
## Summary

This is needed for enabling usage of a QA Tester plugin as pioneered by Site Kit.

---

See #1398
