### PR TITLE
Fix initial height of preset panel

### DIFF
--- a/assets/src/edit-story/components/panels/stylePreset/panel.js
+++ b/assets/src/edit-story/components/panels/stylePreset/panel.js
@@ -24,6 +24,10 @@ import { useCallback, useEffect, useState } from 'react';
  */
 import { useStory } from '../../../app/story';
 import stripHTML from '../../../utils/stripHTML';
+import {
+  COLOR_PRESETS_PER_ROW,
+  STYLE_PRESETS_PER_ROW,
+} from '../../../constants';
 import { Panel } from './../panel';
 import { getShapePresets, getTextPresets } from './utils';
 import PresetsHeader from './header';
@@ -163,11 +167,24 @@ function StylePresetPanel() {
     }
   };
 
-  // @Todo confirm initial height.
+  const rowHeight = 35;
+
+  // Assume at least 2 rows if there's at least 1 preset:
+  // One for presets, one for the label.
+  const colorRows =
+    colorPresets.length > 0
+      ? Math.max(2, colorPresets.length / COLOR_PRESETS_PER_ROW)
+      : 0;
+  const styleRows =
+    textStyles.length > 0
+      ? Math.max(2, textStyles.length / STYLE_PRESETS_PER_ROW)
+      : 0;
+  const initialHeight = (colorRows + styleRows) * rowHeight;
+
   return (
     <Panel
       name="stylepreset"
-      initialHeight={Math.min(200, window.innerHeight / 3)}
+      initialHeight={Math.min(initialHeight, window.innerHeight / 3)}
       resizeable
     >
       <PresetsHeader

--- a/assets/src/edit-story/components/panels/stylePreset/presetGroup.js
+++ b/assets/src/edit-story/components/panels/stylePreset/presetGroup.js
@@ -25,9 +25,11 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { useKeyDownEffect } from '../../keyboard';
+import {
+  COLOR_PRESETS_PER_ROW,
+  STYLE_PRESETS_PER_ROW,
+} from '../../../constants';
 
-const COLORS_PER_ROW = 6;
-const STYLES_PER_ROW = 3;
 const PRESET_HEIGHT = 35;
 
 const Group = styled.div`
@@ -75,7 +77,8 @@ function PresetGroup({ presets, itemRenderer, type, label }) {
       // When the user navigates in the color presets using the arrow keys,
       // Let's change the active index accordingly, to indicate which preset should be focused
       if (groupRef.current) {
-        const rowLength = 'color' === type ? COLORS_PER_ROW : STYLES_PER_ROW;
+        const rowLength =
+          'color' === type ? COLOR_PRESETS_PER_ROW : STYLE_PRESETS_PER_ROW;
         const diff = getIndexDiff(key, rowLength);
         const maxIndex = presets.length - 1;
         const val = (activeIndex ?? 0) + diff;
@@ -91,7 +94,9 @@ function PresetGroup({ presets, itemRenderer, type, label }) {
   );
 
   const buttonWidth =
-    'color' === type ? 100 / COLORS_PER_ROW : 100 / STYLES_PER_ROW;
+    'color' === type
+      ? 100 / COLOR_PRESETS_PER_ROW
+      : 100 / STYLE_PRESETS_PER_ROW;
   return (
     <>
       <Label>{label}</Label>

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -36,6 +36,9 @@ export const ALLOWED_EDITOR_PAGE_WIDTHS = [440, 280, 240];
 
 export const FULLBLEED_RATIO = 9 / 16;
 
+export const COLOR_PRESETS_PER_ROW = 6;
+export const STYLE_PRESETS_PER_ROW = 3;
+
 // Default device pixel ratio.
 export const DEFAULT_DPR = 0.5;
 


### PR DESCRIPTION
## Summary

Adjusts the initial height of the preset panel based on how many presets are present.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

Uses the number of existing preset rows for determining the initial height instead of a static value.
This ensure that no empty space is assigned to preset panel if there are no presets.
<!-- Please describe your changes. -->

## To-do

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1555
