### PR TITLE
Dashboard: Focus rename input when the rename menu item is selected

### DIFF
--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -81,7 +81,7 @@ const CardTitle = ({
     if (inputContainerRef.current && editMode) {
       inputContainerRef.current.firstChild?.focus();
     }
-  }, [inputContainerRef, editMode]);
+  }, [editMode]);
 
   const handleChange = useCallback(({ target }) => {
     setNewTitle(target.value);

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -76,6 +76,12 @@ const CardTitle = ({
     },
     [editMode]
   );
+
+  useEffect(() => {
+    if (inputContainerRef.current && editMode) {
+      inputContainerRef.current.firstChild?.focus();
+    }
+  }, [inputContainerRef, editMode]);
 
   const handleChange = useCallback(({ target }) => {
     setNewTitle(target.value);

--- a/assets/src/dashboard/components/cardGridItem/test/cartTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/test/cartTitle.js
@@ -48,5 +48,6 @@ describe('CardTitle', () => {
     );
 
     expect(getByTestId('title-rename-input')).toBeDefined();
+    expect(getByTestId('title-rename-input')).toHaveFocus();
   });
 });

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -56,6 +56,8 @@ AnimationBar.propTypes = {
 };
 
 const ToggleButton = styled.button`
+  cursor: pointer;
+
   ${({ theme, isActive }) => `
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

Select the input box when rename is picked from the menu

![Kapture 2020-05-06 at 15 00 34](https://user-images.githubusercontent.com/1738349/81223161-2fa8e980-8fab-11ea-917c-fb555653db78.gif)


## Relevant Technical Choices

- Used the `useEffect` hook to focus the child of the ref, the input, when the card title is in edit mode

Fixes #1592 
Fixes #1594 