### PR TITLE
WIP: POC: Jest-based intergration test with full-editor fixture

### DIFF
--- a/assets/src/edit-story/app/test/_utils.js
+++ b/assets/src/edit-story/app/test/_utils.js
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import React, { useCallback, useState, useMemo, forwardRef } from 'react';
+import { render, act, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import App from '../index';
+import APIProvider from '../api/apiProvider';
+import Context from '../api/context';
+import { TEXT_ELEMENT_DEFAULT_FONT } from '../font/defaultFonts';
+import Layout from '../layout';
+
+jest.mock('../api/apiProvider');
+
+const DEFAULT_CONFIG = {
+  storyId: 1,
+  api: {},
+  allowedMimeTypes: {
+    image: ['image/png', 'image/jpeg', 'image/jpg', 'image/gif'],
+    video: ['video/mp4'],
+  },
+  allowedFileTypes: ['png', 'jpeg', 'jpg', 'gif', 'mp4'],
+};
+
+export class Fixture {
+  constructor() {
+    this._config = { ...DEFAULT_CONFIG };
+
+    this.apiProviderFixture_ = new APIProviderFixture();
+    APIProvider.mockImplementation(this.apiProviderFixture_.Component);
+
+    this._componentStubs = new Map();
+    const origCreateElement = React.createElement;
+    jest
+      .spyOn(React, 'createElement')
+      .mockImplementation((type, props, ...children) => {
+        if (!props?._wrapped) {
+          const stubs = this._componentStubs.get(type);
+          if (stubs) {
+            const match = stubs.find((stub) => {
+              if (!stub._matcher) {
+                return true;
+              }
+              return stub._matcher(props);
+            });
+            if (match) {
+              type = match._wrapper;
+            }
+          }
+        }
+        return origCreateElement(type, props, ...children);
+      });
+
+    this._layoutStub = this.stubComponent(Layout);
+
+    this._fireEvent = new FixtureFireEvent();
+
+    this._container = null;
+  }
+
+  restore() {
+    jest.restoreAllMocks();
+  }
+
+  get container() {
+    return this._container;
+  }
+
+  get fireEvent() {
+    return this._fireEvent;
+  }
+
+  stubComponent(component, matcher) {
+    const stub = new ComponentStub(this, component, matcher);
+    let stubs = this._componentStubs.get(component);
+    if (!stubs) {
+      stubs = [];
+      this._componentStubs.set(component, stubs);
+    }
+    stubs.push(stub);
+    return stub;
+  }
+
+  render() {
+    const { container } = render(<App config={this._config} />);
+    this._container = container;
+
+    // @todo: find a stable way to wait for the story to fully render. Can be
+    // implemented via `waitFor`.
+    return Promise.resolve();
+  }
+
+  renderHook(func) {
+    return this._layoutStub.renderHook(func);
+  }
+
+  act(callback) {
+    let responsePromise;
+    return Promise.resolve(
+      act(() => {
+        responsePromise = callback();
+      })
+    ).then(() => responsePromise);
+  }
+
+  querySelector(selector) {
+    return this._container.querySelector(selector);
+  }
+}
+
+class ComponentStub {
+  constructor(fixture, Component, matcher) {
+    this._fixture = fixture;
+    this._matcher = matcher;
+    this._implementation = null;
+
+    this._props = null;
+
+    let setRefresher;
+    this._refresh = () => {
+      act(() => {
+        if (setRefresher) {
+          setRefresher((v) => v + 1);
+        }
+      });
+    };
+
+    const pendingHooks = [];
+    this._pushPendingHook = (func) => {
+      let resolver;
+      const promise = new Promise((resolve) => {
+        resolver = resolve;
+      });
+      pendingHooks.push(() => {
+        const result = func();
+        resolver(result);
+      });
+      this._refresh();
+      return promise;
+    };
+
+    this._wrapper = forwardRef((props, ref) => {
+      this._props = props;
+
+      const [refresher, setRefresherInternal] = useState(0);
+      setRefresher = setRefresherInternal;
+      const hooks = useMemo(
+        () => {
+          const hooksToExecute = pendingHooks.slice(0);
+          pendingHooks.length = 0;
+          return hooksToExecute;
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [refresher]
+      );
+
+      const Impl = useMemo(
+        () => {
+          if (this._implementation) {
+            return forwardRef(this._implementation);
+          }
+          return Component;
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [refresher]
+      );
+
+      return (
+        <HookExecutor key={refresher} hooks={hooks}>
+          <Impl _wrapped={true} ref={ref} {...props} />
+        </HookExecutor>
+      );
+    });
+  }
+
+  get props() {
+    return this._props;
+  }
+
+  mockImplementation(implementation) {
+    this._implementation = implementation;
+    this._refresh();
+    return this;
+  }
+
+  renderHook(func) {
+    return this._fixture.act(() => this._pushPendingHook(func));
+  }
+}
+
+class FixtureFireEvent {
+  pointerDown(element, options = {}) {
+    const { pointerType = 'mouse' } = options;
+
+    fireEvent.pointerDown(element, options);
+    if (pointerType === 'mouse') {
+      fireEvent.mouseDown(element, options);
+    }
+  }
+
+  pointerUp(element, options = {}) {
+    const { pointerType = 'mouse' } = options;
+
+    fireEvent.pointerUp(element, options);
+    if (pointerType === 'mouse') {
+      fireEvent.mouseUp(element, options);
+    }
+  }
+
+  mouseDown(element, options = {}) {
+    this.pointerDown(element, { ...options, pointerType: 'mouse' });
+  }
+
+  mouseUp(element, options = {}) {
+    this.pointerUp(element, { ...options, pointerType: 'mouse' });
+  }
+
+  click(element, options = {}) {
+    this.pointerDown(element, options);
+    this.pointerUp(element, options);
+    fireEvent.click(element, options);
+  }
+}
+
+function HookExecutor({ hooks, children }) {
+  hooks.forEach((func) => func());
+  return children;
+}
+
+class APIProviderFixture {
+  constructor() {
+    this._comp = ({ children }) => {
+      const getStoryById = useCallback(
+        // @todo: put this to __db__/
+        () =>
+          actPromise({
+            title: { raw: 'Auto Draft' },
+            status: 'draft',
+            author: 1,
+            slug: '',
+            date_gmt: '2020-05-06T22:32:37',
+            modified: '2020-05-06T22:32:37',
+            excerpt: { raw: '' },
+            link: 'http://stories.local/?post_type=web-story&p=1',
+            story_data: [],
+            featured_media: 0,
+            featured_media_url: '',
+            publisher_logo_url:
+              'http://stories.local/wp-content/plugins/web-stories/assets/images/logo.png',
+            permalink_template: 'http://stories3.local/stories/%pagename%/',
+            style_presets: { textStyles: [], fillColors: [], textColors: [] },
+            password: '',
+          }),
+        []
+      );
+
+      const autoSaveById = useCallback(() => jest.fn(), []);
+      const saveStoryById = useCallback(() => jest.fn(), []);
+      const deleteStoryById = useCallback(() => jest.fn(), []);
+
+      const getAllFonts = useCallback(() => {
+        // @todo: put actual data to __db__/
+        return actPromise(
+          [TEXT_ELEMENT_DEFAULT_FONT].map((font) => ({
+            name: font.family,
+            value: font.family,
+            ...font,
+          }))
+        );
+      }, []);
+
+      const getMedia = useCallback(({ mediaType, searchTerm, pagingNum }) => {
+        // @todo: arg support
+        // @todo: put actual data to __db__/
+        return actPromise({ data: [], headers: {} });
+      }, []);
+      const uploadMedia = useCallback(() => jest.fn(), []);
+      const updateMedia = useCallback(() => jest.fn(), []);
+
+      const getLinkMetadata = useCallback(() => jest.fn(), []);
+
+      const getAllStatuses = useCallback(() => jest.fn(), []);
+      const getAllUsers = useCallback(() => jest.fn(), []);
+
+      const state = {
+        actions: {
+          autoSaveById,
+          getStoryById,
+          getMedia,
+          getLinkMetadata,
+          saveStoryById,
+          deleteStoryById,
+          getAllFonts,
+          getAllStatuses,
+          getAllUsers,
+          uploadMedia,
+          updateMedia,
+        },
+      };
+      return <Context.Provider value={state}>{children}</Context.Provider>;
+    };
+  }
+
+  get Component() {
+    return this._comp;
+  }
+}
+
+function actPromise(value) {
+  const promise = Promise.resolve(value);
+  return {
+    then(callback, errback) {
+      return actPromise(
+        promise.then(
+          (result) => act(() => callback(result)),
+          (reason) => act(() => errback(reason))
+        )
+      );
+    },
+    catch(errback) {
+      return actPromise(promise.catch((reason) => act(() => errback(reason))));
+    },
+    finally(callback) {
+      return actPromise(
+        promise.finally((result) => act(() => callback(result)))
+      );
+    },
+  };
+}

--- a/assets/src/edit-story/app/test/_utils.js
+++ b/assets/src/edit-story/app/test/_utils.js
@@ -19,6 +19,7 @@
  */
 import React, { useCallback, useState, useMemo, forwardRef } from 'react';
 import { render, act, fireEvent } from '@testing-library/react';
+import puppeteer from 'puppeteer';
 
 /**
  * Internal dependencies
@@ -345,4 +346,37 @@ function actPromise(value) {
       );
     },
   };
+}
+
+export async function browserDebug() {
+  const browser = await puppeteer.launch({
+    headless: false,
+    defaultViewport: null,
+  });
+  const page = await browser.newPage();
+  await page.evaluate((head, body) => {
+    document.open();
+    document.write('<!DOCTYPE html>');
+    document.write('<html>');
+
+    document.write('<head>');
+    document.write(`
+      <style>
+        body {
+          margin: 0;
+          width: 100vw;
+          height: 100vh;
+        }
+      </style>
+    `);
+    document.write(head);
+    document.write('</head>');
+
+    document.write('<body>');
+    document.write(body);
+    document.write('</body>');
+
+    document.write('</html>');
+    document.close();
+  }, document.head.innerHTML, document.body.innerHTML);
 }

--- a/assets/src/edit-story/components/canvas/editLayer.js
+++ b/assets/src/edit-story/components/canvas/editLayer.js
@@ -90,6 +90,7 @@ function EditLayerForElement({ element }) {
   return (
     <LayerWithGrayout
       ref={ref}
+      data-testid="editLayer"
       grayout={editModeGrayout}
       zIndex={Z_INDEX.EDIT}
       onPointerDown={(evt) => {

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -96,6 +96,7 @@ function FrameElement({ element }) {
   return (
     <Wrapper
       ref={elementRef}
+      data-testid="frame"
       data-element-id={id}
       {...box}
       onMouseDown={(evt) => {

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -203,8 +203,10 @@ function useLayoutParamsCssVars() {
 
 const PageArea = forwardRef(({ children, showDangerZone }, ref) => {
   return (
-    <PageAreaFullbleedContainer>
-      <PageAreaSafeZone ref={ref}>{children}</PageAreaSafeZone>
+    <PageAreaFullbleedContainer data-testid="fullbleed">
+      <PageAreaSafeZone ref={ref} data-testid="safezone">
+        {children}
+      </PageAreaSafeZone>
       {showDangerZone && (
         <>
           <PageAreaDangerZoneTop />

--- a/assets/src/edit-story/elements/text/edit.js
+++ b/assets/src/edit-story/elements/text/edit.js
@@ -198,7 +198,7 @@ function TextEdit({
   }, [font, maybeEnqueueFontStyle]);
 
   return (
-    <Wrapper ref={wrapperRef} onClick={onClick}>
+    <Wrapper ref={wrapperRef} onClick={onClick} data-testid="textEditor">
       <TextBox ref={textBoxRef} {...textProps}>
         <RichTextEditor
           ref={editorRef}

--- a/assets/src/edit-story/elements/text/frame.js
+++ b/assets/src/edit-story/elements/text/frame.js
@@ -140,6 +140,7 @@ function TextFrame({ element: { id, content, ...rest }, wrapperRef }) {
   return (
     <Element
       ref={elementRef}
+      data-testid="textFrame"
       dangerouslySetInnerHTML={{ __html: content }}
       {...props}
     />

--- a/assets/src/edit-story/elements/text/test/edit.integr.js
+++ b/assets/src/edit-story/elements/text/test/edit.integr.js
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { Editor, EditorState } from 'draft-js';
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../app/test/_utils';
+import { useStory } from '../../../app/story';
+import { useInsertElement } from '../../../components/canvas';
+import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
+import { getSelectionForAll } from '../util';
+
+describe('TextEdit integration', () => {
+  let fixture;
+  let editorStub;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    editorStub = fixture.stubComponent(Editor);
+    editorStub.mockImplementation((props, ref) => (
+      <div ref={ref} contentEditable={true} />
+    ));
+
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  it('should render ok', () => {
+    expect(
+      fixture.container.querySelector('[data-testid="fullbleed"]')
+    ).toBeTruthy();
+  });
+
+  describe('add a text', () => {
+    let element;
+    let frame;
+
+    beforeEach(async () => {
+      const insertElement = await fixture.renderHook(() => useInsertElement());
+      element = await fixture.act(() =>
+        insertElement('text', {
+          font: TEXT_ELEMENT_DEFAULT_FONT,
+          content: 'hello world!',
+        })
+      );
+
+      frame = fixture.querySelector(
+        `[data-element-id="${element.id}"] [data-testid="textFrame"]`
+      );
+    });
+
+    it('should render initial content', () => {
+      expect(frame).toHaveTextContent('hello world!');
+    });
+
+    describe('edit mode', () => {
+      let editor;
+      let editLayer;
+
+      beforeEach(() => {
+        fixture.fireEvent.click(frame);
+        editor = fixture.querySelector('[data-testid="textEditor"]');
+        editLayer = fixture.querySelector('[data-testid="editLayer"]');
+      });
+
+      it('should mount editor', () => {
+        expect(editor).toBeTruthy();
+        expect(editorStub.props.editorState).toBeTruthy();
+        expect(editLayer).toBeTruthy();
+      });
+
+      describe('handle a command', () => {
+        beforeEach(async () => {
+          // Select all.
+          await fixture.act(() => {
+            const { onChange, editorState } = editorStub.props;
+            onChange(
+              EditorState.forceSelection(
+                editorState,
+                getSelectionForAll(editorState.getCurrentContent())
+              )
+            );
+          });
+
+          // Run a command.
+          await fixture.act(() => {
+            const { handleKeyCommand, editorState } = editorStub.props;
+            return handleKeyCommand('bold', editorState);
+          });
+        });
+
+        it('should exit and save', async () => {
+          // Exit edit mode.
+          fixture.fireEvent.mouseDown(editLayer);
+
+          expect(
+            fixture.querySelector('[data-testid="textEditor"]')
+          ).toBeNull();
+
+          // The element is still selected and updated.
+          const storyContext = await fixture.renderHook(() => useStory());
+          expect(storyContext.state.selectedElementIds).toStrictEqual([
+            element.id,
+          ]);
+          expect(storyContext.state.selectedElements[0].content).toStrictEqual(
+            '<strong>hello world!</strong>'
+          );
+
+          // The content is updated in the frame.
+          expect(frame.innerHTML).toStrictEqual(
+            '<strong>hello world!</strong>'
+          );
+        });
+      });
+    });
+  });
+});

--- a/assets/src/edit-story/elements/text/test/edit.integr.js
+++ b/assets/src/edit-story/elements/text/test/edit.integr.js
@@ -22,13 +22,13 @@ import { Editor, EditorState } from 'draft-js';
 /**
  * Internal dependencies
  */
-import { Fixture } from '../../../app/test/_utils';
+import { Fixture, browserDebug } from '../../../app/test/_utils';
 import { useStory } from '../../../app/story';
 import { useInsertElement } from '../../../components/canvas';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
 import { getSelectionForAll } from '../util';
 
-describe('TextEdit integration', () => {
+describe.only('TextEdit integration', () => {
   let fixture;
   let editorStub;
 
@@ -131,6 +131,8 @@ describe('TextEdit integration', () => {
           expect(frame.innerHTML).toStrictEqual(
             '<strong>hello world!</strong>'
           );
+
+          await browserDebug();
         });
       });
     });


### PR DESCRIPTION
Partial for #1721.

Another concept: use current jest setup for integration tests. Full editor is setup with all externals mocked out and, unfortunately, without on-the-browser testing (at least initially).

Start reviewing with `assets/src/edit-story/elements/text/test/edit.integr.js` file. This is the key piece: it showcases the testing script. Key points in this test:
* The testing APIs are either the same as for unit tests, or made to look similar.
* An integration test always creates a `Fixture` object. It has a bunch of setup functions to get the initial data convenient for testing. By default it starts as a "New story" with one empty page. This is all for free since it uses the exact the same code our editor uses.
* The test can mock any existing component and give it a fake implementation. In this case, DraftJS editor is mocked away. I'm not happy about it, but it uses too many browser APIs that are not available for the jest environment. If we at some point figure out a way to run these tests on the browser, we can skip this mocks and everything should still work.
* Every component mock is also a spy. It records last used props. And we can make it count number of renders, etc.
* Besides DarftJS and WP API calls - everything else is unmocked and the test is fairly representative.

The test itself reads as following:
```
TextEdit integration
  > add a text
    - should render initial content
  > edit mode
    - should mount editor
    > handle a command
      - should exit and save
```

IMHO this is a fairly natural structure. At each fork, we can easily add more scenarios and more "should ..." tests.

The `Fixture` class is pretty messy right now. Some key points:
* It allows Component mocking by stubbing the `React.createElement`.
* It's more async. Most of calls are expected to do `await fixture.doThat()` to ensure that all phases of the story editor are updtaed.
* In some cases, a `Promise` is indirected via `act(() => )` calls.
* A hook can be rendered in a context of any component! This is cool, b/c a test can naturally see what the component is seeing inside. And can check reducer states, etc. By default, the `renderHook` is executed against `Layout` component. This is just for convenience because many key hooks are resolved against `StoryProvider` and `MediaProvider` which are both above it.
* I also re-export `fireEvent`. The difference from the original `fireEvent` is that the sequences of events are executed. E.g. an integration test should not worry about knowing whether we use a `mousedown` or `pointerdown`. The test should just use pointer events for most of things and our `fireEvent` would execute the correct event sequence based on the pointer type.

