### PR TITLE
Dashboard: Create hook that encapsulates filter, sort, search, and pagination logic. Add tests for each caller and state permutation. 

### DIFF
--- a/assets/src/dashboard/components/table/index.js
+++ b/assets/src/dashboard/components/table/index.js
@@ -67,7 +67,7 @@ export const TableStatusHeaderCell = styled(TableHeaderCell)`
 `;
 
 export const TableAuthorHeaderCell = styled(TableHeaderCell)`
-  min-width: 100px;
+  min-width: 110px;
 `;
 
 export const TableTitleHeaderCell = styled(TableHeaderCell)`

--- a/assets/src/dashboard/utils/test/useStoryView.js
+++ b/assets/src/dashboard/utils/test/useStoryView.js
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useStoryView from '../useStoryView';
+import {
+  SORT_DIRECTION,
+  STORY_SORT_OPTIONS,
+  STORY_STATUSES,
+  VIEW_STYLE,
+} from '../../constants';
+
+describe('useStoryView()', function () {
+  it('should have the default options initially selected', function () {
+    const { result } = renderHook(
+      () => useStoryView({ filters: STORY_STATUSES, totalPages: 1 }),
+      {}
+    );
+
+    expect(result.current.filter.value).toBe(STORY_STATUSES[0].value);
+    expect(result.current.sort.value).toBe(STORY_SORT_OPTIONS.LAST_MODIFIED);
+    expect(result.current.sort.direction).toBe(SORT_DIRECTION.DESC);
+    expect(result.current.page.value).toBe(1);
+  });
+
+  it('should set the new filter when passed and reset the page.', function () {
+    const { result } = renderHook(
+      () => useStoryView({ filters: STORY_STATUSES, totalPages: 2 }),
+      {}
+    );
+
+    act(() => {
+      result.current.page.requestNextPage();
+    });
+    expect(result.current.page.value).toBe(2);
+
+    act(() => {
+      result.current.filter.set(STORY_STATUSES[1].value);
+    });
+    expect(result.current.filter.value).toBe(STORY_STATUSES[1].value);
+    expect(result.current.page.value).toBe(1);
+  });
+
+  it('should set the new sort when passed and reset the page.', function () {
+    const { result } = renderHook(
+      () => useStoryView({ filters: STORY_STATUSES, totalPages: 2 }),
+      {}
+    );
+
+    act(() => {
+      result.current.page.requestNextPage();
+    });
+    expect(result.current.page.value).toBe(2);
+
+    act(() => {
+      result.current.sort.set(STORY_SORT_OPTIONS.NAME);
+    });
+    expect(result.current.sort.value).toBe(STORY_SORT_OPTIONS.NAME);
+    expect(result.current.page.value).toBe(1);
+  });
+
+  it('should set the new search keyword when typed and reset the page.', function () {
+    const { result } = renderHook(
+      () => useStoryView({ filters: STORY_STATUSES, totalPages: 2 }),
+      {}
+    );
+
+    act(() => {
+      result.current.page.requestNextPage();
+    });
+    expect(result.current.page.value).toBe(2);
+
+    act(() => {
+      result.current.search.setKeyword('Harry Potter Story');
+    });
+    expect(result.current.search.keyword).toBe('Harry Potter Story');
+    expect(result.current.page.value).toBe(1);
+  });
+
+  it('should set the new view style when toggled.', function () {
+    const { result } = renderHook(
+      () => useStoryView({ filters: STORY_STATUSES, totalPages: 2 }),
+      {}
+    );
+
+    expect(result.current.view.style).toBe(VIEW_STYLE.GRID);
+
+    act(() => {
+      result.current.view.toggleStyle();
+    });
+    expect(result.current.view.style).toBe(VIEW_STYLE.LIST);
+  });
+
+  it('should set the sort direction to ASC when a NAME sort is selected and the view toggles to LIST.', function () {
+    const { result } = renderHook(
+      () => useStoryView({ filters: STORY_STATUSES, totalPages: 2 }),
+      {}
+    );
+
+    expect(result.current.view.style).toBe(VIEW_STYLE.GRID);
+    expect(result.current.sort.direction).toBe(SORT_DIRECTION.DESC);
+
+    act(() => {
+      result.current.sort.set(STORY_SORT_OPTIONS.NAME);
+    });
+    act(() => {
+      result.current.view.toggleStyle();
+    });
+
+    expect(result.current.view.style).toBe(VIEW_STYLE.LIST);
+    expect(result.current.sort.value).toBe(STORY_SORT_OPTIONS.NAME);
+    expect(result.current.sort.direction).toBe(SORT_DIRECTION.ASC);
+  });
+
+  it('should request the next page when called.', function () {
+    const { result } = renderHook(
+      () => useStoryView({ filters: STORY_STATUSES, totalPages: 2 }),
+      {}
+    );
+
+    act(() => {
+      result.current.page.requestNextPage();
+    });
+
+    expect(result.current.page.value).toBe(2);
+  });
+
+  it('should request the next page when called and not exceed maximum pages.', function () {
+    const { result } = renderHook(
+      () => useStoryView({ filters: STORY_STATUSES, totalPages: 2 }),
+      {}
+    );
+
+    act(() => {
+      result.current.page.requestNextPage();
+    });
+
+    expect(result.current.page.value).toBe(2);
+
+    act(() => {
+      result.current.page.requestNextPage();
+    });
+
+    expect(result.current.page.value).toBe(2);
+  });
+});

--- a/assets/src/dashboard/utils/useStoryView.js
+++ b/assets/src/dashboard/utils/useStoryView.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { SORT_DIRECTION, STORY_SORT_OPTIONS, VIEW_STYLE } from '../constants';
+import { clamp, usePagePreviewSize } from './index';
+
+export default function useStoryView({ filters, totalPages }) {
+  const [viewStyle, setViewStyle] = useState(VIEW_STYLE.GRID);
+  const [sort, _setSort] = useState(STORY_SORT_OPTIONS.LAST_MODIFIED);
+  const [filter, _setFilter] = useState(
+    filters.length > 0 ? filters[0].value : null
+  );
+  const [sortDirection, setSortDirection] = useState(SORT_DIRECTION.DESC);
+  const [page, setPage] = useState(1);
+  const [searchKeyword, _setSearchKeyword] = useState('');
+
+  const { pageSize } = usePagePreviewSize({
+    thumbnailMode: viewStyle === VIEW_STYLE.LIST,
+    isGrid: viewStyle === VIEW_STYLE.GRID,
+  });
+
+  const setPageClamped = useCallback(
+    (newPage) => {
+      const pageRange = [1, totalPages];
+      setPage(clamp(newPage, pageRange));
+    },
+    [totalPages]
+  );
+
+  const setSort = useCallback(
+    (newSort) => {
+      _setSort(newSort);
+      setPageClamped(1);
+    },
+    [setPageClamped]
+  );
+
+  const setFilter = useCallback(
+    (newFilter) => {
+      _setFilter(newFilter);
+      setPageClamped(1);
+    },
+    [setPageClamped]
+  );
+
+  const toggleViewStyle = useCallback(() => {
+    if (viewStyle === VIEW_STYLE.LIST) {
+      setViewStyle(VIEW_STYLE.GRID);
+    } else {
+      setViewStyle(VIEW_STYLE.LIST);
+      if (sort === STORY_SORT_OPTIONS.NAME) {
+        setSortDirection(SORT_DIRECTION.ASC);
+      } else {
+        setSortDirection(SORT_DIRECTION.DESC);
+      }
+    }
+  }, [sort, viewStyle]);
+
+  const setSearchKeyword = useCallback(
+    (newSearchKeyword) => {
+      setPageClamped(1);
+      _setSearchKeyword(newSearchKeyword);
+    },
+    [setPageClamped]
+  );
+
+  const requestNextPage = useCallback(() => setPageClamped(page + 1), [
+    page,
+    setPageClamped,
+  ]);
+
+  return useMemo(
+    () => ({
+      view: {
+        style: viewStyle,
+        toggleStyle: toggleViewStyle,
+        pageSize,
+      },
+      sort: {
+        value: sort,
+        direction: sortDirection,
+        set: setSort,
+        setDirection: setSortDirection,
+      },
+      filter: {
+        value: filter,
+        set: setFilter,
+      },
+      page: {
+        value: page,
+        set: setPage,
+        requestNextPage,
+      },
+      search: {
+        keyword: searchKeyword,
+        setKeyword: setSearchKeyword,
+      },
+    }),
+    [
+      viewStyle,
+      toggleViewStyle,
+      pageSize,
+      sort,
+      sortDirection,
+      setSort,
+      filter,
+      setFilter,
+      page,
+      requestNextPage,
+      searchKeyword,
+      setSearchKeyword,
+    ]
+  );
+}


### PR DESCRIPTION
## Summary

- Extracts out the filtering, sorting, view options, and search into a reusable hook.
- This will let us reuse most of the logic for the very similar Saved Templates page.

## Relevant Technical Choices

- useState + useCallback patterns in a custom hook
- Test default states and each action that can be called by the UI
- Group each option into a sub-object: `sort`, `filter`, `view,` and `page`.

Part of #1502 
