### PR TITLE
Added call to delete API for media in apiProvider

### DIFF
--- a/assets/src/edit-story/app/api/apiProvider.js
+++ b/assets/src/edit-story/app/api/apiProvider.js
@@ -195,6 +195,22 @@ function APIProvider({ children }) {
   );
 
   /**
+   * Delete existing media.
+   *
+   * @param  {number} mediaId
+   * @return {Promise} Media Object Promise.
+   */
+  const deleteMedia = useCallback(
+    (mediaId) => {
+      return apiFetch({
+        path: `${media}/${mediaId}/?force=true`,
+        method: 'DELETE',
+      });
+    },
+    [media]
+  );
+
+  /**
    * Gets metadata (title, favicon, etc.) from
    * a provided URL.
    *
@@ -237,6 +253,7 @@ function APIProvider({ children }) {
       getAllUsers,
       uploadMedia,
       updateMedia,
+      deleteMedia,
     },
   };
 

--- a/assets/src/edit-story/app/api/apiProvider.js
+++ b/assets/src/edit-story/app/api/apiProvider.js
@@ -203,7 +203,8 @@ function APIProvider({ children }) {
   const deleteMedia = useCallback(
     (mediaId) => {
       return apiFetch({
-        path: `${media}/${mediaId}/?force=true`,
+        path: `${media}/${mediaId}`,
+        data: { force: true },
         method: 'DELETE',
       });
     },


### PR DESCRIPTION
## Summary
Adds a new method in apiProvider which calls the delete API for media items.

## Relevant Technical Choices
Had to use `force=true` parameter for it to work, if anyone knows why / alternatives please comment below :)

## Issues
This is part of #1319 