### PR TITLE
Fix Page Menu Bar cutting off Layout and Text buttons.

### DIFF
--- a/assets/src/edit-story/components/canvas/pagemenu/index.js
+++ b/assets/src/edit-story/components/canvas/pagemenu/index.js
@@ -38,6 +38,7 @@ import { ReactComponent as Add } from '../../../icons/add_page.svg';
 import { ReactComponent as Layout } from '../../../icons/layout_helper.svg';
 import { ReactComponent as Text } from '../../../icons/text_helper.svg';
 import WithTooltip from '../../tooltip';
+import useCanvas from '../useCanvas';
 
 const HEIGHT = 28;
 
@@ -113,6 +114,9 @@ function PageMenu() {
     state: { currentPageNumber, currentPage },
     actions: { deleteCurrentPage, addPage },
   } = useStory();
+  const {
+    state: { pageSize },
+  } = useCanvas();
   const { isRTL } = useConfig();
 
   const handleDeletePage = useCallback(() => deleteCurrentPage(), [
@@ -140,14 +144,18 @@ function PageMenu() {
     <Wrapper>
       <Box>
         <Options>
-          <PageCount>
-            {sprintf(
-              /* translators: %s: Page number. */
-              __('Page %s', 'web-stories'),
-              currentPageNumber
-            )}
-          </PageCount>
-          <Space />
+          {pageSize.width > 280 && (
+            <>
+              <PageCount>
+                {sprintf(
+                  /* translators: %s: Page number. */
+                  __('Page %s', 'web-stories'),
+                  currentPageNumber
+                )}
+              </PageCount>
+              <Space />
+            </>
+          )}
           <WithTooltip title={__('Delete page', 'web-stories')}>
             <Icon
               onClick={handleDeletePage}


### PR DESCRIPTION
## Summary

This PR removes the page count label when on small screens as defined on https://github.com/google/web-stories-wp/issues/1127#issuecomment-624135123.

## Relevant Technical Choices

It's using the pageSize (e.g. canvas size) width as a reference to hiding the page count.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1127 
