### PR TITLE
Dashboard: Add base layout for Saved Templates View

### DIFF
--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -27,26 +27,26 @@ import { useRef } from 'react';
 /**
  * Internal dependencies
  */
-import getAllTemplates from '../../../templates';
-import {
-  BodyViewOptions,
-  BodyWrapper,
-  PageHeading,
-  StoryGridView,
-} from '../shared';
+import { TransformProvider } from '../../../../edit-story/components/transform';
+import { UnitsProvider } from '../../../../edit-story/units';
+import { InfiniteScroller, Layout } from '../../../components';
 import useStoryView, {
   PagePropTypes,
   SearchPropTypes,
   SortPropTypes,
   ViewPropTypes,
 } from '../../../utils/useStoryView';
-import { InfiniteScroller, Layout } from '../../../components';
+import getAllTemplates from '../../../templates';
 import { StoriesPropType } from '../../../types';
-import { UnitsProvider } from '../../../../edit-story/units';
 import { reshapeTemplateObject } from '../../api/useTemplateApi';
 import { useConfig } from '../../config';
-import { TransformProvider } from '../../../../edit-story/components/transform';
 import FontProvider from '../../font/fontProvider';
+import {
+  BodyViewOptions,
+  BodyWrapper,
+  PageHeading,
+  StoryGridView,
+} from '../shared';
 
 function Header({ search, stories, view, sort }) {
   const listBarLabel = sprintf(

--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -17,19 +17,142 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import { useRef } from 'react';
 
 /**
  * Internal dependencies
  */
-import { ViewHeader } from '../../../components';
+import getAllTemplates from '../../../templates';
+import {
+  BodyViewOptions,
+  BodyWrapper,
+  PageHeading,
+  StoryGridView,
+} from '../shared';
+import useStoryView, {
+  PagePropTypes,
+  SearchPropTypes,
+  SortPropTypes,
+  ViewPropTypes,
+} from '../../../utils/useStoryView';
+import { InfiniteScroller, Layout } from '../../../components';
+import { StoriesPropType } from '../../../types';
+import { UnitsProvider } from '../../../../edit-story/units';
+import { reshapeTemplateObject } from '../../api/useTemplateApi';
+import { useConfig } from '../../config';
+import { TransformProvider } from '../../../../edit-story/components/transform';
+import FontProvider from '../../font/fontProvider';
 
-function SavedTemplates() {
+function Header({ search, stories, view, sort }) {
+  const listBarLabel = sprintf(
+    /* translators: %s: number of templates */
+    _n(
+      '%s total template',
+      '%s total templates',
+      stories.length,
+      'web-stories'
+    ),
+    stories.length
+  );
   return (
-    <div>
-      <ViewHeader>{__('Saved Templates', 'web-stories')}</ViewHeader>
-    </div>
+    <Layout.Squishable>
+      <PageHeading
+        defaultTitle={__('Saved Templates', 'web-stories')}
+        searchPlaceholder={__('Search Templates', 'web-stories')}
+        stories={stories}
+        handleTypeaheadChange={search.setKeyword}
+        typeaheadValue={search.keyword}
+      />
+      <BodyViewOptions
+        listBarLabel={listBarLabel}
+        layoutStyle={view.style}
+        currentSort={sort.value}
+        handleSortChange={sort.set}
+        sortDropdownAriaLabel={__(
+          'Choose sort option for display',
+          'web-stories'
+        )}
+      />
+    </Layout.Squishable>
   );
 }
 
+function Content({ stories, view, page }) {
+  return (
+    <Layout.Scrollable>
+      <FontProvider>
+        <TransformProvider>
+          <UnitsProvider pageSize={view.pageSize}>
+            <BodyWrapper>
+              <StoryGridView
+                stories={stories}
+                centerActionLabel={__('View', 'web-stories')}
+                bottomActionLabel={__('Use template', 'web-stories')}
+                isTemplate
+              />
+              <InfiniteScroller
+                allDataLoadedMessage={__('No more templates.', 'web-stories')}
+                isLoading={false}
+                canLoadMore={false}
+                onLoadMore={page.requestNextPage}
+              />
+            </BodyWrapper>
+          </UnitsProvider>
+        </TransformProvider>
+      </FontProvider>
+    </Layout.Scrollable>
+  );
+}
+
+function SavedTemplates() {
+  const config = useConfig();
+  const { search, view, page, sort } = useStoryView({
+    filters: [],
+    totalPages: 1,
+  });
+
+  /**
+   * A placeholder to just have template data in the view for now.
+   */
+  const mockTemplates = useRef(
+    getAllTemplates(config).map(reshapeTemplateObject(false))
+  );
+
+  return (
+    <Layout.Provider>
+      <Header
+        view={view}
+        search={search}
+        stories={mockTemplates.current}
+        sort={sort}
+      />
+      <Content
+        view={view}
+        page={page}
+        sort={sort}
+        stories={mockTemplates.current}
+      />
+    </Layout.Provider>
+  );
+}
+
+Header.propTypes = {
+  view: ViewPropTypes.isRequired,
+  search: SearchPropTypes.isRequired,
+  sort: SortPropTypes.isRequired,
+  stories: StoriesPropType,
+};
+
+Content.propTypes = {
+  view: ViewPropTypes.isRequired,
+  page: PagePropTypes.isRequired,
+  stories: StoriesPropType,
+};
+
 export default SavedTemplates;
+export { Header as SavedTemplatesHeader, Content as SavedTemplatesContent };

--- a/assets/src/dashboard/app/views/savedTemplates/test/savedTemplates.js
+++ b/assets/src/dashboard/app/views/savedTemplates/test/savedTemplates.js
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+/**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react';
+import { SavedTemplatesContent, SavedTemplatesHeader } from '../index';
+import { renderWithTheme } from '../../../../testUtils';
+import { STORY_SORT_OPTIONS, VIEW_STYLE } from '../../../../constants';
+import LayoutProvider from '../../../../components/layout/provider';
+
+const fakeStories = [
+  {
+    id: 1,
+    status: 'publish',
+    title: 'Story A',
+    pages: [{ id: '10' }],
+    centerTargetAction: () => {},
+    bottomTargetAction: () => {},
+  },
+  {
+    id: 2,
+    status: 'draft',
+    title: 'Story B',
+    pages: [{ id: '20' }],
+    centerTargetAction: () => {},
+    bottomTargetAction: () => {},
+  },
+  {
+    id: 3,
+    status: 'publish',
+    title: 'Story C',
+    pages: [{ id: '30' }],
+    centerTargetAction: () => {},
+    bottomTargetAction: () => {},
+  },
+];
+
+jest.mock('../../../../components/previewPage.js', () => () => null);
+jest.mock('../../../../app/font/fontProvider.js', () => ({ children }) =>
+  children
+);
+
+describe('<SavedTemplates />', function () {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should render with the correct count label and search keyword.', function () {
+    const { getByPlaceholderText, getByText } = renderWithTheme(
+      <LayoutProvider>
+        <SavedTemplatesHeader
+          stories={fakeStories}
+          search={{ keyword: 'Harry Potter', setKeyword: jest.fn() }}
+          sort={{ value: STORY_SORT_OPTIONS.NAME, set: jest.fn() }}
+          view={{
+            style: VIEW_STYLE.GRID,
+            pageSize: { width: 200, height: 300 },
+          }}
+        />
+      </LayoutProvider>
+    );
+    expect(getByPlaceholderText('Search Templates').value).toBe('Harry Potter');
+    expect(getByText('3 total templates')).toBeInTheDocument();
+  });
+
+  it('should call the set keyword function when new text is searched', function () {
+    const setKeywordFn = jest.fn();
+    const { getByPlaceholderText } = renderWithTheme(
+      <LayoutProvider>
+        <SavedTemplatesHeader
+          stories={fakeStories}
+          search={{ keyword: 'Harry Potter', setKeyword: setKeywordFn }}
+          sort={{ value: STORY_SORT_OPTIONS.NAME, set: jest.fn() }}
+          view={{
+            style: VIEW_STYLE.GRID,
+            pageSize: { width: 200, height: 300 },
+          }}
+        />
+      </LayoutProvider>
+    );
+    fireEvent.change(getByPlaceholderText('Search Templates'), {
+      target: { value: 'Hermione Granger' },
+    });
+    expect(setKeywordFn).toHaveBeenCalledWith('Hermione Granger');
+  });
+
+  it('should call the set sort function when a new sort is selected', function () {
+    const setSortFn = jest.fn();
+    const { getAllByText, getByText } = renderWithTheme(
+      <LayoutProvider>
+        <SavedTemplatesHeader
+          stories={fakeStories}
+          search={{ keyword: 'Harry Potter', setKeyword: jest.fn() }}
+          sort={{ value: STORY_SORT_OPTIONS.NAME, set: setSortFn }}
+          view={{
+            style: VIEW_STYLE.GRID,
+            pageSize: { width: 200, height: 300 },
+          }}
+        />
+      </LayoutProvider>
+    );
+    fireEvent.click(getAllByText('Name')[0].parentElement);
+    fireEvent.click(getByText('Last modified'));
+
+    expect(setSortFn).toHaveBeenCalledWith('modified');
+  });
+
+  it('should render the content grid with the correct story count.', function () {
+    const { getAllByText } = renderWithTheme(
+      <LayoutProvider>
+        <SavedTemplatesContent
+          stories={fakeStories}
+          page={{
+            requestNextPage: jest.fn(),
+          }}
+          view={{
+            style: VIEW_STYLE.GRID,
+            pageSize: { width: 200, height: 300 },
+          }}
+        />
+      </LayoutProvider>
+    );
+
+    expect(getAllByText('Use template')).toHaveLength(fakeStories.length);
+  });
+});

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -32,6 +32,7 @@ import {
 import BodyWrapper from './bodyWrapper';
 
 const DisplayFormatContainer = styled.div`
+  height: ${({ theme }) => theme.formatContainer.height}px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -97,7 +98,7 @@ const BodyViewOptions = ({
 
 BodyViewOptions.propTypes = {
   currentSort: PropTypes.string.isRequired,
-  handleLayoutSelect: PropTypes.func.isRequired,
+  handleLayoutSelect: PropTypes.func,
   handleSortChange: PropTypes.func.isRequired,
   layoutStyle: PropTypes.string.isRequired,
   listBarLabel: PropTypes.string.isRequired,

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -168,7 +168,7 @@ const Dropdown = ({
   };
 
   const handleMenuItemSelect = (item) => {
-    if (type === DROPDOWN_TYPES.PANEL || DROPDOWN_TYPES.COLOR_PANEL) {
+    if (type === DROPDOWN_TYPES.PANEL || type === DROPDOWN_TYPES.COLOR_PANEL) {
       onChange(item);
       return;
     }

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -131,6 +131,9 @@ const theme = {
   typeahead: {
     borderRadius: 100,
   },
+  formatContainer: {
+    height: 44,
+  },
   expandedTypeahead: {
     borderRadius: 8,
     boxShadow:

--- a/assets/src/dashboard/utils/useStoryView.js
+++ b/assets/src/dashboard/utils/useStoryView.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { useCallback, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -133,3 +134,35 @@ export default function useStoryView({ filters, totalPages }) {
     ]
   );
 }
+
+export const ViewPropTypes = PropTypes.shape({
+  style: PropTypes.oneOf(Object.values(VIEW_STYLE)),
+  toggleStyle: PropTypes.func,
+  pageSize: PropTypes.shape({
+    width: PropTypes.number,
+    height: PropTypes.number,
+  }),
+});
+
+export const FilterPropTypes = PropTypes.shape({
+  value: PropTypes.number,
+  set: PropTypes.func,
+});
+
+export const SortPropTypes = PropTypes.shape({
+  value: PropTypes.oneOf(Object.values(STORY_SORT_OPTIONS)),
+  set: PropTypes.func,
+  direction: PropTypes.oneOf(Object.values(SORT_DIRECTION)),
+  setDirection: PropTypes.func,
+});
+
+export const PagePropTypes = PropTypes.shape({
+  value: PropTypes.number,
+  set: PropTypes.func,
+  requestNextPage: PropTypes.func,
+});
+
+export const SearchPropTypes = PropTypes.shape({
+  keyword: PropTypes.string,
+  setKeyword: PropTypes.func,
+});


### PR DESCRIPTION
## Summary

This adds the header, grid, and infinite scroll components to the Saved Templates layout with mocked template stories.

<img width="1169" alt="Screen Shot 2020-05-08 at 2 29 19 PM" src="https://user-images.githubusercontent.com/1738349/81449616-43d51e00-9146-11ea-8f67-922c9108c04d.png">

Increases test coverage by adding tests for our search, sort, filter, and story grid components.

## Relevant Technical Choices

- Divides the layout into two functions: content and header
- Uses the story hook that brings in the logic for sorting, filtering, searching

## To-do

- Connect to eventual saved templates API
- Consult with Sam on Grid View/List View toggle

Part of #1502 
