### PR TITLE
Karma: intergration fixture and text/edit test

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -212,6 +212,9 @@
       "rules": {
         "testing-library/no-debug": "error",
         "testing-library/no-dom-import": "error"
+      },
+      "globals": {
+        "karmaPuppeteer": "readonly"
       }
     },
     {

--- a/assets/src/edit-story/components/canvas/editLayer.js
+++ b/assets/src/edit-story/components/canvas/editLayer.js
@@ -90,6 +90,7 @@ function EditLayerForElement({ element }) {
   return (
     <LayerWithGrayout
       ref={ref}
+      data-testid="editLayer"
       grayout={editModeGrayout}
       zIndex={Z_INDEX.EDIT}
       onPointerDown={(evt) => {

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -217,9 +217,11 @@ const PageArea = forwardRef(
     ref
   ) => {
     return (
-      <PageAreaFullbleedContainer ref={fullbleedRef}>
+      <PageAreaFullbleedContainer ref={fullbleedRef} data-testid="fullbleed">
         <PageAreaOverflowHidden>
-          <PageAreaSafeZone ref={ref}>{children}</PageAreaSafeZone>
+          <PageAreaSafeZone ref={ref} data-testid="safezone">
+            {children}
+          </PageAreaSafeZone>
           {showDangerZone && (
             <>
               <PageAreaDangerZoneTop />

--- a/assets/src/edit-story/components/mediaPicker/test/useMediaPicker.js
+++ b/assets/src/edit-story/components/mediaPicker/test/useMediaPicker.js
@@ -16,7 +16,7 @@
 /**
  * External dependencies
  */
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 
 /**
  * Internal dependencies
@@ -65,6 +65,8 @@ describe('useMediaPicker', () => {
     const evt = {
       preventDefault: jest.fn(),
     };
-    expect(openMediaPicker(evt)).toBe(false);
+    act(() => {
+      expect(openMediaPicker(evt)).toBe(false);
+    });
   });
 });

--- a/assets/src/edit-story/components/mediaPicker/useMediaPicker.js
+++ b/assets/src/edit-story/components/mediaPicker/useMediaPicker.js
@@ -47,8 +47,12 @@ export default function useMediaPicker({
   } = useConfig();
   const { showSnackbar } = useSnackbar();
   useEffect(() => {
-    // Work around that forces default tab as upload tab.
-    wp.media.controller.Library.prototype.defaults.contentUserSetting = false;
+    try {
+      // Work around that forces default tab as upload tab.
+      wp.media.controller.Library.prototype.defaults.contentUserSetting = false;
+    } catch (e) {
+      // Silence.
+    }
   });
   useEffect(() => {
     try {

--- a/assets/src/edit-story/components/panels/textStyle/textStyle.js
+++ b/assets/src/edit-story/components/panels/textStyle/textStyle.js
@@ -131,6 +131,7 @@ function StylePanel({ selectedElements, pushUpdate }) {
           }
         />
         <ToggleButton
+          data-testid="boldToggle"
           icon={<BoldIcon />}
           value={isBold}
           iconWidth={9}

--- a/assets/src/edit-story/elements/text/edit.js
+++ b/assets/src/edit-story/elements/text/edit.js
@@ -218,7 +218,7 @@ function TextEdit({
   }, [font, fontFaceSetConfigs, maybeEnqueueFontStyle]);
 
   return (
-    <Wrapper ref={wrapperRef} onClick={onClick}>
+    <Wrapper ref={wrapperRef} onClick={onClick} data-testid="textEditor">
       <TextBox ref={textBoxRef} {...textProps}>
         <RichTextEditor
           ref={editorRef}

--- a/assets/src/edit-story/elements/text/frame.js
+++ b/assets/src/edit-story/elements/text/frame.js
@@ -140,6 +140,7 @@ function TextFrame({ element: { id, content, ...rest }, wrapperRef }) {
   return (
     <Element
       ref={elementRef}
+      data-testid="textFrame"
       dangerouslySetInnerHTML={{ __html: content }}
       {...props}
     />

--- a/assets/src/edit-story/elements/text/karma/edit.karma.js
+++ b/assets/src/edit-story/elements/text/karma/edit.karma.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma/fixture';
+import { useStory } from '../../../app/story';
+import { useInsertElement } from '../../../components/canvas';
+import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
+
+describe('TextEdit integration', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  it('should render ok', () => {
+    expect(
+      fixture.container.querySelector('[data-testid="fullbleed"]')
+    ).toBeTruthy();
+  });
+
+  describe('add a text', () => {
+    let element;
+    let frame;
+
+    beforeEach(async () => {
+      const insertElement = await fixture.renderHook(() => useInsertElement());
+      element = await fixture.act(() =>
+        insertElement('text', {
+          font: TEXT_ELEMENT_DEFAULT_FONT,
+          content: 'hello world!',
+        })
+      );
+
+      frame = fixture.querySelector(
+        `[data-element-id="${element.id}"] [data-testid="textFrame"]`
+      );
+    });
+
+    it('should render initial content', () => {
+      expect(frame.textContent).toEqual('hello world!');
+    });
+
+    describe('edit mode', () => {
+      let editor;
+      let editLayer;
+      let boldToggle;
+
+      beforeEach(async () => {
+        // @todo: hide behind `fireEvent`-like API.
+        await fixture.act(async () => {
+          await karmaPuppeteer.click(frame);
+        });
+        editor = fixture.querySelector('[data-testid="textEditor"]');
+        editLayer = fixture.querySelector('[data-testid="editLayer"]');
+        boldToggle = fixture.querySelector('[data-testid="boldToggle"]');
+      });
+
+      it('should mount editor', () => {
+        expect(editor).toBeTruthy();
+        expect(editLayer).toBeTruthy();
+      });
+
+      it('should handle a commnad, exit and save', async () => {
+        const draft = editor.querySelector('[contenteditable="true"]');
+        await fixture.act(async () => {
+          await karmaPuppeteer.focus(draft);
+        });
+
+        // Select all.
+        await fixture.act(async () => {
+          await karmaPuppeteer.click(draft, { clickCount: 3 });
+        });
+
+        expect(boldToggle.checked).toEqual(false);
+
+        // @todo: Linux uses ctrlKey.
+        fireEvent.keyDown(draft, {
+          key: 'b',
+          code: 'KeyB',
+          keyCode: 66,
+          metaKey: true,
+        });
+
+        expect(boldToggle.checked).toEqual(true);
+
+        // Exit edit mode.
+        fixture.fireEvent.mouseDown(editLayer);
+
+        expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull();
+
+        // The element is still selected and updated.
+        const storyContext = await fixture.renderHook(() => useStory());
+        expect(storyContext.state.selectedElementIds).toEqual([element.id]);
+        expect(storyContext.state.selectedElements[0].content).toEqual(
+          '<span style="font-weight: 700">hello world!</span>'
+        );
+
+        // The content is updated in the frame.
+        expect(frame.innerHTML).toEqual(
+          '<span style="font-weight: 700">hello world!</span>'
+        );
+      });
+    });
+  });
+});

--- a/assets/src/edit-story/elements/text/karma/edit.karma.js
+++ b/assets/src/edit-story/elements/text/karma/edit.karma.js
@@ -15,14 +15,9 @@
  */
 
 /**
- * External dependencies
- */
-import { fireEvent } from '@testing-library/react';
-
-/**
  * Internal dependencies
  */
-import { Fixture } from '../../../karma/fixture';
+import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
 import { useInsertElement } from '../../../components/canvas';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
@@ -74,10 +69,7 @@ describe('TextEdit integration', () => {
       let boldToggle;
 
       beforeEach(async () => {
-        // @todo: hide behind `fireEvent`-like API.
-        await fixture.act(async () => {
-          await karmaPuppeteer.click(frame);
-        });
+        await fixture.events.click(frame);
         editor = fixture.querySelector('[data-testid="textEditor"]');
         editLayer = fixture.querySelector('[data-testid="editLayer"]');
         boldToggle = fixture.querySelector('[data-testid="boldToggle"]');
@@ -90,19 +82,17 @@ describe('TextEdit integration', () => {
 
       it('should handle a commnad, exit and save', async () => {
         const draft = editor.querySelector('[contenteditable="true"]');
-        await fixture.act(async () => {
-          await karmaPuppeteer.focus(draft);
-        });
+        await fixture.events.focus(draft);
 
         // Select all.
-        await fixture.act(async () => {
-          await karmaPuppeteer.click(draft, { clickCount: 3 });
-        });
+        await fixture.events.click(draft, { clickCount: 3 });
 
         expect(boldToggle.checked).toEqual(false);
 
         // @todo: Linux uses ctrlKey.
-        fireEvent.keyDown(draft, {
+        // @todo: would be preferable to be more semantic here. E.g.
+        // `keys('mod+B')`.
+        await fixture.events.keyDown(draft, {
           key: 'b',
           code: 'KeyB',
           keyCode: 66,
@@ -112,7 +102,7 @@ describe('TextEdit integration', () => {
         expect(boldToggle.checked).toEqual(true);
 
         // Exit edit mode.
-        fixture.fireEvent.mouseDown(editLayer);
+        await fixture.events.mouseDown(editLayer);
 
         expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull();
 

--- a/assets/src/edit-story/karma/fixture.js
+++ b/assets/src/edit-story/karma/fixture.js
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import React, { useCallback, useState, useMemo, forwardRef } from 'react';
+import { render, act, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import App from '../app/index';
+import APIProvider from '../app/api/apiProvider';
+import APIContext from '../app/api/context';
+import { TEXT_ELEMENT_DEFAULT_FONT } from '../app/font/defaultFonts';
+import Layout from '../app/layout';
+
+const DEFAULT_CONFIG = {
+  storyId: 1,
+  api: {},
+  allowedMimeTypes: {
+    image: ['image/png', 'image/jpeg', 'image/jpg', 'image/gif'],
+    video: ['video/mp4'],
+  },
+  allowedFileTypes: ['png', 'jpeg', 'jpg', 'gif', 'mp4'],
+  capabilities: {},
+};
+
+export class Fixture {
+  constructor() {
+    this._config = { ...DEFAULT_CONFIG };
+
+    this._componentStubs = new Map();
+    const origCreateElement = React.createElement;
+    spyOn(React, 'createElement').and.callFake((type, props, ...children) => {
+      if (!props?._wrapped) {
+        const stubs = this._componentStubs.get(type);
+        if (stubs) {
+          const match = stubs.find((stub) => {
+            if (!stub._matcher) {
+              return true;
+            }
+            return stub._matcher(props);
+          });
+          if (match) {
+            type = match._wrapper;
+          }
+        }
+      }
+      return origCreateElement(type, props, ...children);
+    });
+
+    this.apiProviderFixture_ = new APIProviderFixture();
+    this.stubComponent(APIProvider).callFake(
+      this.apiProviderFixture_.Component
+    );
+
+    this._layoutStub = this.stubComponent(Layout);
+
+    this._fireEvent = new FixtureFireEvent();
+
+    this._container = null;
+  }
+
+  restore() {}
+
+  get container() {
+    return this._container;
+  }
+
+  get fireEvent() {
+    return this._fireEvent;
+  }
+
+  stubComponent(component, matcher) {
+    const stub = new ComponentStub(this, component, matcher);
+    let stubs = this._componentStubs.get(component);
+    if (!stubs) {
+      stubs = [];
+      this._componentStubs.set(component, stubs);
+    }
+    stubs.push(stub);
+    return stub;
+  }
+
+  render() {
+    const { container } = render(
+      <App key={Math.random()} config={this._config} />
+    );
+    this._container = container;
+
+    // @todo: find a stable way to wait for the story to fully render. Can be
+    // implemented via `waitFor`.
+    return Promise.resolve();
+  }
+
+  renderHook(func) {
+    return this._layoutStub.renderHook(func);
+  }
+
+  act(callback) {
+    let responsePromise;
+    return Promise.resolve(
+      act(async () => {
+        responsePromise = callback();
+      })
+    ).then(() => responsePromise);
+  }
+
+  querySelector(selector) {
+    return this._container.querySelector(selector);
+  }
+}
+
+class ComponentStub {
+  constructor(fixture, Component, matcher) {
+    this._fixture = fixture;
+    this._matcher = matcher;
+    this._implementation = null;
+
+    this._props = null;
+
+    let setRefresher;
+    this._refresh = () => {
+      act(() => {
+        if (setRefresher) {
+          setRefresher((v) => v + 1);
+        }
+      });
+    };
+
+    const pendingHooks = [];
+    this._pushPendingHook = (func) => {
+      let resolver;
+      const promise = new Promise((resolve) => {
+        resolver = resolve;
+      });
+      pendingHooks.push(() => {
+        const result = func();
+        resolver(result);
+      });
+      this._refresh();
+      return promise;
+    };
+
+    const Wrapper = forwardRef((props, ref) => {
+      this._props = props;
+
+      const [refresher, setRefresherInternal] = useState(0);
+      setRefresher = setRefresherInternal;
+      const hooks = useMemo(
+        () => {
+          const hooksToExecute = pendingHooks.slice(0);
+          pendingHooks.length = 0;
+          return hooksToExecute;
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [refresher]
+      );
+
+      const Impl = useMemo(
+        () => {
+          if (this._implementation) {
+            const MockImpl = forwardRef((fProps, fRef) =>
+              this._implementation(fProps, fRef)
+            );
+            MockImpl.displayName = `Stub(${
+              Component.displayName || Component.name || ''
+            })`;
+            return MockImpl;
+          }
+          return Component;
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [refresher]
+      );
+
+      return (
+        <HookExecutor key={refresher} hooks={hooks}>
+          <Impl _wrapped={true} ref={ref} {...props} />
+        </HookExecutor>
+      );
+    });
+    Wrapper.displayName = `Mock(${
+      Component.displayName || Component.name || ''
+    })`;
+    this._wrapper = Wrapper;
+  }
+
+  get and() {
+    return this;
+  }
+
+  get props() {
+    return this._props;
+  }
+
+  mockImplementation(implementation) {
+    this._implementation = implementation;
+    this._refresh();
+    return this;
+  }
+
+  callFake(implementation) {
+    return this.mockImplementation(implementation);
+  }
+
+  renderHook(func) {
+    return this._fixture.act(() => this._pushPendingHook(func));
+  }
+}
+
+class FixtureFireEvent {
+  pointerDown(element, options = {}) {
+    const { pointerType = 'mouse' } = options;
+
+    fireEvent.pointerDown(element, options);
+    if (pointerType === 'mouse') {
+      fireEvent.mouseDown(element, options);
+    }
+  }
+
+  pointerUp(element, options = {}) {
+    const { pointerType = 'mouse' } = options;
+
+    fireEvent.pointerUp(element, options);
+    if (pointerType === 'mouse') {
+      fireEvent.mouseUp(element, options);
+    }
+  }
+
+  mouseDown(element, options = {}) {
+    this.pointerDown(element, { ...options, pointerType: 'mouse' });
+  }
+
+  mouseUp(element, options = {}) {
+    this.pointerUp(element, { ...options, pointerType: 'mouse' });
+  }
+
+  click(element, options = {}) {
+    this.pointerDown(element, options);
+    this.pointerUp(element, options);
+    fireEvent.click(element, options);
+  }
+}
+
+function HookExecutor({ hooks, children }) {
+  hooks.forEach((func) => func());
+  return children;
+}
+
+class APIProviderFixture {
+  constructor() {
+    // eslint-disable-next-line react/prop-types
+    const Comp = ({ children }) => {
+      const getStoryById = useCallback(
+        // @todo: put this to __db__/
+        () =>
+          actPromise({
+            title: { raw: 'Auto Draft' },
+            status: 'draft',
+            author: 1,
+            slug: '',
+            date_gmt: '2020-05-06T22:32:37',
+            modified: '2020-05-06T22:32:37',
+            excerpt: { raw: '' },
+            link: 'http://stories.local/?post_type=web-story&p=1',
+            story_data: [],
+            featured_media: 0,
+            featured_media_url: '',
+            publisher_logo_url:
+              'http://stories.local/wp-content/plugins/web-stories/assets/images/logo.png',
+            permalink_template: 'http://stories3.local/stories/%pagename%/',
+            style_presets: { textStyles: [], fillColors: [], textColors: [] },
+            password: '',
+          }),
+        []
+      );
+
+      const autoSaveById = useCallback(
+        () => jasmine.createSpy('autoSaveById'),
+        []
+      );
+      const saveStoryById = useCallback(
+        () => jasmine.createSpy('saveStoryById'),
+        []
+      );
+      const deleteStoryById = useCallback(
+        () => jasmine.createSpy('deleteStoryById'),
+        []
+      );
+
+      const getAllFonts = useCallback(() => {
+        // @todo: put actual data to __db__/
+        return actPromise(
+          [TEXT_ELEMENT_DEFAULT_FONT].map((font) => ({
+            name: font.family,
+            value: font.family,
+            ...font,
+          }))
+        );
+      }, []);
+
+      // eslint-disable-next-line no-unused-vars
+      const getMedia = useCallback(({ mediaType, searchTerm, pagingNum }) => {
+        // @todo: arg support
+        // @todo: put actual data to __db__/
+        return actPromise({ data: [], headers: {} });
+      }, []);
+      const uploadMedia = useCallback(
+        () => jasmine.createSpy('uploadMedia'),
+        []
+      );
+      const updateMedia = useCallback(
+        () => jasmine.createSpy('updateMedia'),
+        []
+      );
+
+      const getLinkMetadata = useCallback(
+        () => jasmine.createSpy('getLinkMetadata'),
+        []
+      );
+
+      const getAllStatuses = useCallback(
+        () => jasmine.createSpy('getAllStatuses'),
+        []
+      );
+      const getAllUsers = useCallback(
+        () => jasmine.createSpy('getAllUsers'),
+        []
+      );
+
+      const state = {
+        actions: {
+          autoSaveById,
+          getStoryById,
+          getMedia,
+          getLinkMetadata,
+          saveStoryById,
+          deleteStoryById,
+          getAllFonts,
+          getAllStatuses,
+          getAllUsers,
+          uploadMedia,
+          updateMedia,
+        },
+      };
+      return (
+        <APIContext.Provider value={state}>{children}</APIContext.Provider>
+      );
+    };
+    Comp.displayName = 'Fixture(APIProvider)';
+    this._comp = Comp;
+  }
+
+  get Component() {
+    return this._comp;
+  }
+}
+
+function actPromise(value) {
+  const promise = Promise.resolve(value);
+  return {
+    then(callback, errback) {
+      return actPromise(
+        promise.then(
+          (result) => act(async () => callback(result)),
+          (reason) => act(async () => errback(reason))
+        )
+      );
+    },
+    catch(errback) {
+      return actPromise(
+        promise.catch((reason) => act(async () => errback(reason)))
+      );
+    },
+    finally(callback) {
+      return actPromise(
+        promise.finally((result) => act(async () => callback(result)))
+      );
+    },
+  };
+}

--- a/assets/src/edit-story/karma/fixtureEvents.js
+++ b/assets/src/edit-story/karma/fixtureEvents.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* global karmaPuppeteer */
+
+/**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react';
+
+/**
+ * Events utility. Uses native and synthetic events as needed.
+ */
+class FixtureEvents {
+  /**
+   * @param {function():Promise} act
+   */
+  constructor(act) {
+    this._act = act;
+  }
+
+  /**
+   * See https://github.com/puppeteer/puppeteer/blob/v3.0.4/docs/api.md#pageclickselector-options.
+   *
+   * @param {Element} target The event target.
+   * @param {Object} options The event options.
+   * @return {!Promise} The promise when the event handling is complete.
+   */
+  click(target, options = {}) {
+    return this._act(() => karmaPuppeteer.click(target, options));
+  }
+
+  /**
+   * See https://github.com/puppeteer/puppeteer/blob/v3.0.4/docs/api.md#pagefocusselector.
+   *
+   * @param {Element} target The event target.
+   * @param {Object} options The event options.
+   * @return {!Promise} The promise when the event handling is complete.
+   */
+  focus(target, options = {}) {
+    return this._act(() => karmaPuppeteer.focus(target, options));
+  }
+
+  // @todo: look for a native way to implement this. See Puppeteer's
+  // Keyboard API (https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-keyboard).
+  keyDown(element, options = {}) {
+    fireEvent.keyDown(element, options);
+    return Promise.resolve();
+  }
+
+  // @todo: look for a native way to implement this. See Puppeteer's
+  // Mouse API (https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-mouse).
+  pointerDown(element, options = {}) {
+    const { pointerType = 'mouse' } = options;
+    fireEvent.pointerDown(element, options);
+    if (pointerType === 'mouse') {
+      fireEvent.mouseDown(element, options);
+    }
+    return Promise.resolve();
+  }
+
+  // @todo: look for a native way to implement this.
+  pointerUp(element, options = {}) {
+    const { pointerType = 'mouse' } = options;
+    fireEvent.pointerUp(element, options);
+    if (pointerType === 'mouse') {
+      fireEvent.mouseUp(element, options);
+    }
+    return Promise.resolve();
+  }
+
+  // @todo: look for a native way to implement this.
+  mouseDown(element, options = {}) {
+    return this.pointerDown(element, { ...options, pointerType: 'mouse' });
+  }
+
+  // @todo: look for a native way to implement this.
+  mouseUp(element, options = {}) {
+    return this.pointerUp(element, { ...options, pointerType: 'mouse' });
+  }
+}
+
+export default FixtureEvents;

--- a/assets/src/edit-story/karma/fixtureEvents.js
+++ b/assets/src/edit-story/karma/fixtureEvents.js
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-/* global karmaPuppeteer */
-
 /**
  * External dependencies
  */

--- a/assets/src/edit-story/karma/index.js
+++ b/assets/src/edit-story/karma/index.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { Fixture } from './fixture';

--- a/assets/src/edit-story/utils/test/textMeasurements.js
+++ b/assets/src/edit-story/utils/test/textMeasurements.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { calculateTextHeight } from '../textMeasurements';
+
+describe('textMeasurements', () => {
+  let element;
+
+  beforeEach(() => {
+    element = {
+      id: '123',
+      content: 'Content 1',
+      backgroundColor: {
+        color: {
+          r: 255,
+          g: 0,
+          b: 0,
+          a: 0.3,
+        },
+      },
+      font: {
+        family: 'Roboto',
+      },
+      fontSize: 16,
+      textAlign: 'left',
+      type: 'text',
+      x: 10,
+      y: 10,
+      width: 50,
+      height: 50,
+      rotationAngle: 0,
+      padding: {
+        vertical: 0,
+        horizontal: 0,
+      },
+      box: { width: 1080 },
+    };
+  });
+
+  it('should create the measuring element', () => {
+    calculateTextHeight(element, 100);
+    const measurer = document.body['__WEB_STORIES_MEASURER__'];
+
+    // Text is output as an element.
+    expect(measurer.children).toHaveLength(1);
+    expect(measurer.children[0].tagName).toBe('P');
+    expect(measurer.children[0].style.fontSize).toBe('16px');
+    expect(measurer).toHaveTextContent('Content 1');
+
+    // The "web-stories-content" class ensures that the editor markup and
+    // text output do not conflict with each other. For instance,
+    // `<b>` is styled with a regular `font-weight: bold`.
+    expect(measurer.classList.contains('web-stories-content')).toBe(true);
+
+    // The most important measurer styles.
+    expect(measurer.style).toMatchObject({
+      boxSizing: 'border-box',
+      position: 'fixed',
+      zIndex: '-1',
+      visibility: 'hidden',
+    });
+  });
+
+  it('should re-render the measuring element', () => {
+    calculateTextHeight(element, 100);
+    const measurer = document.body['__WEB_STORIES_MEASURER__'];
+    expect(measurer.children[0].style.fontSize).toBe('16px');
+
+    // Re-render.
+    const element2 = { ...element, fontSize: 20, content: 'Content 2' };
+    calculateTextHeight(element2, 100);
+
+    // Text is output as an element.
+    expect(measurer.children).toHaveLength(1);
+    expect(measurer.children[0].tagName).toBe('P');
+    expect(measurer.children[0].style.fontSize).toBe('20px');
+    expect(measurer).toHaveTextContent('Content 2');
+  });
+});

--- a/assets/src/edit-story/utils/textMeasurements.js
+++ b/assets/src/edit-story/utils/textMeasurements.js
@@ -48,9 +48,8 @@ const MEASURER_PROPS = {
   dataToStyleY: (y) => `${y}px`,
 };
 
+const MEASURER_NODE = '__WEB_STORIES_MEASURER__';
 const LAST_ELEMENT = '__WEB_STORIES_LASTEL__';
-
-let measurerNode = null;
 
 export function calculateTextHeight(element, width) {
   const measurer = getOrCreateMeasurer(element);
@@ -80,12 +79,14 @@ export function calculateFitTextFontSize(element, width, height) {
 }
 
 function getOrCreateMeasurer(element) {
+  let measurerNode = document.body[MEASURER_NODE];
   if (!measurerNode) {
     measurerNode = document.createElement('div');
     measurerNode.id = '__web-stories-text-measurer';
     measurerNode.className = 'web-stories-content';
     setStyles(measurerNode, MEASURER_STYLES);
     document.body.appendChild(measurerNode);
+    document.body[MEASURER_NODE] = measurerNode;
   }
   // Very unfortunately `ReactDOM.render()` is not synchoronous. Thus, we
   // have to use `renderToStaticMarkup()` markup instead and do manual

--- a/karma/karma-puppeteer-client/.eslintrc
+++ b/karma/karma-puppeteer-client/.eslintrc
@@ -15,6 +15,9 @@
         "no-unused-vars": "off",
         "prefer-rest-params": "off",
         "prefer-spread": "off"
+      },
+      "globals": {
+        "karmaPuppeteer": "writable"
       }
     }
   ]

--- a/karma/karma-puppeteer-client/client.js
+++ b/karma/karma-puppeteer-client/client.js
@@ -15,7 +15,6 @@
  */
 
 ;(function (global) {
-  /* global karmaPuppeteer */
   'use strict'
 
   function noCleanup() {}


### PR DESCRIPTION
Partial for #1721.

Blocked by #1712.

See also Jest version in https://github.com/google/web-stories-wp/pull/1617

The concept: set up the full editor with all externals mocked out.

Start reviewing with `assets/src/edit-story/elements/text/karma/edit.karma.js` file. This is the key piece: it showcases the testing script. Key points in this test:
* The testing APIs are either the same as for unit tests, or made to look similar.
* An integration test always creates a `Fixture` object. It has a bunch of setup functions to get the initial data convenient for testing. By default it starts as a "New story" with one empty page. This is all for free since it uses the exact the same code our editor uses.
* The test can mock any existing component and give it a fake implementation.
* Every component mock is also a spy. It records last used props. And we can make it count number of renders, etc.
* Besides WP API calls - everything else is unmocked and the test is fairly representative.

The test itself reads as following:
```
TextEdit integration
  > add a text
    - should render initial content
  > edit mode
    - should mount editor
    > handle a command
      - should exit and save
```

IMHO this is a fairly natural structure. At each fork, we can easily add more scenarios and more "should ..." tests.

The `Fixture` class is pretty messy right now. Some key points:
* It allows Component mocking by stubbing the `React.createElement`.
* It's more async. Most of calls are expected to do `await fixture.doThat()` to ensure that all phases of the story editor are updated.
* In some cases, a `Promise` is indirected via `act(() => )` calls.
* A hook can be rendered in a context of any component! This is cool, b/c a test can naturally see what the component is seeing inside. And can check reducer states, etc. By default, the `renderHook` is executed against `Layout` component. This is just for convenience because many key hooks are resolved against `StoryProvider` and `MediaProvider` which are both above it.
* I also re-export `fireEvent`. The difference from the original `fireEvent` is that the sequences of events are executed. E.g. an integration test should not worry about knowing whether we use a `mousedown` or `pointerdown`. The test should just use pointer events for most of things and our `fireEvent` would execute the correct event sequence based on the pointer type.


