### PR TITLE
Use use-context-selector versions of createContext, useContext

### DIFF
--- a/assets/src/edit-story/app/api/context.js
+++ b/assets/src/edit-story/app/api/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ state: {}, actions: {} });

--- a/assets/src/edit-story/app/api/useAPI.js
+++ b/assets/src/edit-story/app/api/useAPI.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useAPI() {
-  return useContext(Context);
+function useAPI(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useAPI;

--- a/assets/src/edit-story/app/config/context.js
+++ b/assets/src/edit-story/app/config/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({});

--- a/assets/src/edit-story/app/config/useConfig.js
+++ b/assets/src/edit-story/app/config/useConfig.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useConfig() {
-  return useContext(Context);
+function useConfig(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useConfig;

--- a/assets/src/edit-story/app/font/context.js
+++ b/assets/src/edit-story/app/font/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ state: {}, actions: {} });

--- a/assets/src/edit-story/app/font/useFont.js
+++ b/assets/src/edit-story/app/font/useFont.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useFont() {
-  return useContext(Context);
+function useFont(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useFont;

--- a/assets/src/edit-story/app/history/context.js
+++ b/assets/src/edit-story/app/history/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ state: {}, actions: {} });

--- a/assets/src/edit-story/app/history/useHistory.js
+++ b/assets/src/edit-story/app/history/useHistory.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useHistory() {
-  return useContext(Context);
+function useHistory(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useHistory;

--- a/assets/src/edit-story/app/media/context.js
+++ b/assets/src/edit-story/app/media/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ state: {}, actions: {} });

--- a/assets/src/edit-story/app/media/useMedia.js
+++ b/assets/src/edit-story/app/media/useMedia.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useMedia() {
-  return useContext(Context);
+function useMedia(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useMedia;

--- a/assets/src/edit-story/app/snackbar/context.js
+++ b/assets/src/edit-story/app/snackbar/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({});

--- a/assets/src/edit-story/app/snackbar/useSnackbar.js
+++ b/assets/src/edit-story/app/snackbar/useSnackbar.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useSnackbar() {
-  return useContext(Context);
+function useSnackbar(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useSnackbar;

--- a/assets/src/edit-story/app/story/context.js
+++ b/assets/src/edit-story/app/story/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ state: {}, actions: {} });

--- a/assets/src/edit-story/app/story/useStory.js
+++ b/assets/src/edit-story/app/story/useStory.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useStory() {
-  return useContext(Context);
+function useStory(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useStory;

--- a/assets/src/edit-story/components/canvas/context.js
+++ b/assets/src/edit-story/components/canvas/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ actions: {}, state: {} });

--- a/assets/src/edit-story/components/canvas/useCanvas.js
+++ b/assets/src/edit-story/components/canvas/useCanvas.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useCanvas() {
-  return useContext(Context);
+function useCanvas(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useCanvas;

--- a/assets/src/edit-story/components/dropTargets/context.js
+++ b/assets/src/edit-story/components/dropTargets/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ state: {}, actions: {} });

--- a/assets/src/edit-story/components/dropTargets/useDropTargets.js
+++ b/assets/src/edit-story/components/dropTargets/useDropTargets.js
@@ -17,18 +17,15 @@
 /**
  * WordPress dependencies
  */
-/**
- * External dependencies
- */
-import { useContext } from 'react';
 
 /**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useDropTargets() {
-  return useContext(Context);
+function useDropTargets(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useDropTargets;

--- a/assets/src/edit-story/components/form/context.js
+++ b/assets/src/edit-story/components/form/context.js
@@ -15,9 +15,9 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({
   isMultiple: false,

--- a/assets/src/edit-story/components/form/useFormContext.js
+++ b/assets/src/edit-story/components/form/useFormContext.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useFormContext() {
-  return useContext(Context);
+function useFormContext(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useFormContext;

--- a/assets/src/edit-story/components/inspector/context.js
+++ b/assets/src/edit-story/components/inspector/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ state: {}, actions: {}, tabs: {}, refs: {} });

--- a/assets/src/edit-story/components/inspector/useInspector.js
+++ b/assets/src/edit-story/components/inspector/useInspector.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useInspector() {
-  return useContext(Context);
+function useInspector(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useInspector;

--- a/assets/src/edit-story/components/keyboard/context.js
+++ b/assets/src/edit-story/components/keyboard/context.js
@@ -15,9 +15,9 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/components/keyboard/index.js
+++ b/assets/src/edit-story/components/keyboard/index.js
@@ -18,12 +18,13 @@
  * External dependencies
  */
 import Mousetrap from 'mousetrap';
-import { useContext, useEffect, createRef, useState } from 'react';
+import { useEffect, createRef, useState } from 'react';
 
 /**
  * Internal dependencies
  */
 import useBatchingCallback from '../../utils/useBatchingCallback';
+import { useContext } from '../../utils/context';
 import Context from './context';
 
 const PROP = '__WEB_STORIES_MT__';

--- a/assets/src/edit-story/components/library/context.js
+++ b/assets/src/edit-story/components/library/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ tabs: {} });

--- a/assets/src/edit-story/components/library/useLibrary.js
+++ b/assets/src/edit-story/components/library/useLibrary.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useLibrary() {
-  return useContext(Context);
+function useLibrary(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useLibrary;

--- a/assets/src/edit-story/components/overlay/context.js
+++ b/assets/src/edit-story/components/overlay/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ container: null, layer: null });

--- a/assets/src/edit-story/components/overlay/index.js
+++ b/assets/src/edit-story/components/overlay/index.js
@@ -18,8 +18,13 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { forwardRef, useContext } from 'react';
 import { createPortal } from 'react-dom';
+import { forwardRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useContext } from '../../utils/context';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/components/panels/panel/context.js
+++ b/assets/src/edit-story/components/panels/panel/context.js
@@ -15,9 +15,9 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../../utils/context';
 
 const panelContext = createContext({ state: {}, actions: {} });
 

--- a/assets/src/edit-story/components/panels/panel/shared/content.js
+++ b/assets/src/edit-story/components/panels/panel/shared/content.js
@@ -19,8 +19,12 @@
  */
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { useContext } from 'react';
 import { rgba } from 'polished';
+
+/**
+ * Internal dependencies
+ */
+import { useContext } from '../../../../utils/context';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -19,7 +19,11 @@
  */
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { useContext, useCallback } from 'react';
+import { useCallback } from 'react';
+
+/**
+ * Internal dependencies
+ */
 import { rgba } from 'polished';
 
 /**
@@ -34,6 +38,7 @@ import useInspector from '../../../inspector/useInspector';
 import panelContext from '../context';
 import { ReactComponent as Arrow } from '../../../../icons/arrow.svg';
 import { PANEL_COLLAPSED_THRESHOLD } from '../panel';
+import { useContext } from '../../../../utils/context';
 import DragHandle from './handle';
 
 function getBackgroundColor(isPrimary, isSecondary, theme) {

--- a/assets/src/edit-story/components/panels/stylePreset/resize.js
+++ b/assets/src/edit-story/components/panels/stylePreset/resize.js
@@ -17,7 +17,12 @@
 /**
  * External dependencies
  */
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useContext } from '../../../utils/context';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/components/reorderable/context.js
+++ b/assets/src/edit-story/components/reorderable/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ state: {}, actions: {} });

--- a/assets/src/edit-story/components/reorderable/reorderableScroller.js
+++ b/assets/src/edit-story/components/reorderable/reorderableScroller.js
@@ -19,7 +19,12 @@
  */
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { useEffect, useState, useCallback, useContext } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useContext } from '../../utils/context';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/components/reorderable/useReorderable.js
+++ b/assets/src/edit-story/components/reorderable/useReorderable.js
@@ -15,20 +15,13 @@
  */
 
 /**
- * WordPress dependencies
- */
-/**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useReorderable() {
-  return useContext(Context);
+function useReorderable(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useReorderable;

--- a/assets/src/edit-story/components/richText/context.js
+++ b/assets/src/edit-story/components/richText/context.js
@@ -15,9 +15,9 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 const RichTextContext = createContext({ state: {}, actions: {} });
 

--- a/assets/src/edit-story/components/richText/useRichText.js
+++ b/assets/src/edit-story/components/richText/useRichText.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
-import RichTextContext from './context';
+import { identity, useContextSelector } from '../../utils/context';
+import Context from './context';
 
-function useRichText() {
-  return useContext(RichTextContext);
+function useRichText(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useRichText;

--- a/assets/src/edit-story/components/transform/context.js
+++ b/assets/src/edit-story/components/transform/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({ actions: {}, state: {} });

--- a/assets/src/edit-story/components/transform/useTransform.js
+++ b/assets/src/edit-story/components/transform/useTransform.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useTransform() {
-  return useContext(Context);
+function useTransform(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useTransform;

--- a/assets/src/edit-story/components/uploadDropTarget/context.js
+++ b/assets/src/edit-story/components/uploadDropTarget/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../../utils/context';
 
 export default createContext({});

--- a/assets/src/edit-story/components/uploadDropTarget/use.js
+++ b/assets/src/edit-story/components/uploadDropTarget/use.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../../utils/context';
 import Context from './context';
 
-function useUploadDropTarget() {
-  return useContext(Context);
+function useUploadDropTarget(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useUploadDropTarget;

--- a/assets/src/edit-story/theme.js
+++ b/assets/src/edit-story/theme.js
@@ -18,13 +18,13 @@
  * External dependencies
  */
 import { createGlobalStyle, ThemeContext } from 'styled-components';
-import { useContext } from 'react';
 import { rgba } from 'polished';
 
 /**
  * Internal dependencies
  */
 import { SCROLLBAR_WIDTH } from './constants';
+import { identity, useContextSelector } from './utils/context';
 
 export const GlobalStyle = createGlobalStyle`
 	*,
@@ -76,8 +76,8 @@ export const GlobalStyle = createGlobalStyle`
   }
 `;
 
-export function useTheme() {
-  return useContext(ThemeContext);
+export function useTheme(selector) {
+  return useContextSelector(ThemeContext, selector ?? identity);
 }
 
 const theme = {

--- a/assets/src/edit-story/units/context.js
+++ b/assets/src/edit-story/units/context.js
@@ -15,8 +15,8 @@
  */
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { createContext } from 'react';
+import { createContext } from '../utils/context';
 
 export default createContext({ actions: {}, state: {} });

--- a/assets/src/edit-story/units/useUnits.js
+++ b/assets/src/edit-story/units/useUnits.js
@@ -15,17 +15,13 @@
  */
 
 /**
- * External dependencies
- */
-import { useContext } from 'react';
-
-/**
  * Internal dependencies
  */
+import { identity, useContextSelector } from '../utils/context';
 import Context from './context';
 
-function useUnits() {
-  return useContext(Context);
+function useUnits(selector) {
+  return useContextSelector(Context, selector ?? identity);
 }
 
 export default useUnits;

--- a/assets/src/edit-story/utils/usePreventWindowUnload.js
+++ b/assets/src/edit-story/utils/usePreventWindowUnload.js
@@ -17,7 +17,12 @@
 /**
  * External dependencies
  */
-import { useCallback, createContext, useContext } from 'react';
+import { useCallback } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { createContext, useContext } from './context';
 
 const PreventUnloadContext = createContext({ listeners: new Map() });
 


### PR DESCRIPTION
## Summary

Switch to using createContext, useContext (without adding selectors just yet) from use-context-selector as per go/story-editor-context-perf:
https://docs.google.com/document/d/18m9HamHkOvvTrv-mSOJawha0K4KTdn49HrnfXShULDI/edit#heading=h.21vtkbcpsflf

This will allow specific attributes of the context state to be selected without re-rendering after every context state change.

React profiler of scrolling through media after this series of changes:
https://share.getcloudapp.com/YEu14qDg

Next PR:
https://github.com/google/web-stories-wp/pull/1705

## To-do

Next steps:
- Add selector functions to useContextSelectorShallow calls.
- Fix recursion between useMemo and useUploader (pre-existing bug).
- Add useMemo at the end of each context provider.
- Use Pure Components for simple components.
- Prevent action functions from depending on state changes.

---

Fixes #1466
