### PR TITLE
Use useMemo for context values

### DIFF
--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 /**
  * Internal dependencies
@@ -135,30 +135,49 @@ function CanvasProvider({ children }) {
 
   useCanvasCopyPaste();
 
-  const state = {
-    state: {
+  const state = useMemo(
+    () => ({
+      state: {
+        pageContainer,
+        fullbleedContainer,
+        nodesById,
+        editingElement,
+        editingElementState,
+        isEditing: Boolean(editingElement),
+        lastSelectionEvent,
+        pageSize,
+      },
+      actions: {
+        setPageContainer,
+        setFullbleedContainer,
+        setNodeForElement,
+        setEditingElement: setEditingElementWithoutState,
+        setEditingElementWithState,
+        clearEditing,
+        handleSelectElement,
+        selectIntersection,
+        setPageSize,
+      },
+    }),
+    [
       pageContainer,
       fullbleedContainer,
       nodesById,
       editingElement,
       editingElementState,
-      isEditing: Boolean(editingElement),
       lastSelectionEvent,
       pageSize,
-    },
-    actions: {
       setPageContainer,
       setFullbleedContainer,
       setNodeForElement,
-      setEditingElement: setEditingElementWithoutState,
+      setEditingElementWithoutState,
       setEditingElementWithState,
       clearEditing,
       handleSelectElement,
       selectIntersection,
       setPageSize,
-    },
-  };
-
+    ]
+  );
   return (
     <Context.Provider value={state}>
       <UnitsProvider pageSize={pageSize}>{children}</UnitsProvider>

--- a/assets/src/edit-story/components/canvas/useEditingElement.js
+++ b/assets/src/edit-story/components/canvas/useEditingElement.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useReducer, useCallback, useState } from 'react';
+import { useReducer, useCallback, useMemo, useState } from 'react';
 
 function useEditingElement() {
   const [state, dispatch] = useReducer(reducer, {
@@ -44,15 +44,26 @@ function useEditingElement() {
   );
 
   const { editingElement, editingElementState } = state;
-  return {
-    nodesById,
-    editingElement,
-    editingElementState,
-    setEditingElementWithState,
-    setEditingElementWithoutState,
-    clearEditing,
-    setNodeForElement,
-  };
+  return useMemo(
+    () => ({
+      nodesById,
+      editingElement,
+      editingElementState,
+      setEditingElementWithState,
+      setEditingElementWithoutState,
+      clearEditing,
+      setNodeForElement,
+    }),
+    [
+      nodesById,
+      editingElement,
+      editingElementState,
+      setEditingElementWithState,
+      setEditingElementWithoutState,
+      clearEditing,
+      setNodeForElement,
+    ]
+  );
 }
 
 function reducer(state, { editingElement, editingElementState = {} }) {

--- a/assets/src/edit-story/components/library/libraryProvider.js
+++ b/assets/src/edit-story/components/library/libraryProvider.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 /**
  * Internal dependencies
@@ -44,18 +44,21 @@ function LibraryProvider({ children }) {
   const [tab, setTab] = useState(MEDIA);
   const insertElement = useInsertElement();
 
-  const state = {
-    state: {
-      tab,
-    },
-    actions: {
-      setTab,
-      insertElement,
-    },
-    data: {
-      tabs: TABS,
-    },
-  };
+  const state = useMemo(
+    () => ({
+      state: {
+        tab,
+      },
+      actions: {
+        setTab,
+        insertElement,
+      },
+      data: {
+        tabs: TABS,
+      },
+    }),
+    [tab, insertElement]
+  );
 
   return <Context.Provider value={state}>{children}</Context.Provider>;
 }


### PR DESCRIPTION
## Summary

Use useMemo for context values (where it avoid re-renders), as per go/story-editor-context-perf:
https://docs.google.com/document/d/18m9HamHkOvvTrv-mSOJawha0K4KTdn49HrnfXShULDI/edit#heading=h.21vtkbcpsflf

React profiler of scrolling through media after this series of changes:
https://share.getcloudapp.com/YEu14qDg

---

Addresses #1466
