### PR TITLE
Add default value to DISABLE_PREVENT

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -98,7 +98,7 @@ const sharedConfig = {
     new MiniCssExtractPlugin({
       filename: '../css/[name].css',
     }),
-    new webpack.EnvironmentPlugin(['DISABLE_PREVENT']),
+    new webpack.EnvironmentPlugin({ DISABLE_PREVENT: false }),
   ].filter(Boolean),
   optimization: {
     minimizer: [


### PR DESCRIPTION
## Summary
Adds `false` as default value for DISABLE_PREVENT to fix this warning:
<img width="766" alt="Screenshot 2020-05-11 at 11 43 18" src="https://user-images.githubusercontent.com/3294597/81547817-aa438180-937c-11ea-95ca-3e48666b2835.png">

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
