### PR TITLE
#1490 Dashboard: Stories Sort Dropdown Update

### DIFF
--- a/assets/src/dashboard/app/views/savedTemplates/test/savedTemplates.js
+++ b/assets/src/dashboard/app/views/savedTemplates/test/savedTemplates.js
@@ -117,7 +117,7 @@ describe('<SavedTemplates />', function () {
         />
       </LayoutProvider>
     );
-    fireEvent.click(getAllByText('Name')[0].parentElement);
+    fireEvent.click(getAllByText('Author')[0].parentElement);
     fireEvent.click(getByText('Last modified'));
 
     expect(setSortFn).toHaveBeenCalledWith('modified');

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -39,7 +39,7 @@ const DisplayFormatContainer = styled.div`
 `;
 
 const StorySortDropdownContainer = styled.div`
-  margin: auto 0 auto auto;
+  margin: auto 8px;
   align-self: flex-end;
 `;
 

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -78,7 +78,7 @@ const BodyViewOptions = ({
               alignment="flex-end"
               ariaLabel={sortDropdownAriaLabel}
               items={STORY_SORT_MENU_ITEMS}
-              type={DROPDOWN_TYPES.TRANSPARENT_MENU}
+              type={DROPDOWN_TYPES.MENU}
               value={currentSort}
               onChange={(newSort) => handleSortChange(newSort.value)}
             />

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -24,7 +24,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 /**
  * Internal dependencies
@@ -158,7 +158,8 @@ const Dropdown = ({
   ...rest
 }) => {
   const [showMenu, setShowMenu] = useState(false);
-  const dropdownRef = useRef();
+  const dropdownRef = useRef(null);
+  const dropdownButtonRef = useRef(null);
 
   const handleFocusOut = useCallback(() => {
     setShowMenu(false);
@@ -171,6 +172,14 @@ const Dropdown = ({
       setShowMenu(!showMenu);
     }
   };
+
+  useEffect(() => {
+    if (showMenu && dropdownRef.current) {
+      // we need to maintain focus of the dropdown component as a whole
+      // but the button should lose focus as menu is open and focus moves there
+      dropdownButtonRef.current.blur();
+    }
+  }, [showMenu]);
 
   const handleMenuItemSelect = (item) => {
     if (type === DROPDOWN_TYPES.PANEL || type === DROPDOWN_TYPES.COLOR_PANEL) {
@@ -199,12 +208,21 @@ const Dropdown = ({
     };
     return value && getCurrentLabel();
   }, [value, items]);
+
+  const currentValueIndex = useMemo(() => {
+    const activeItem = items.find((item) => {
+      return item.value === value;
+    });
+    return items.indexOf(activeItem);
+  }, [items, value]);
+
   const hasSelectedItems = selectedItems.length > 0;
 
   return (
     <DropdownContainer ref={dropdownRef} {...rest}>
       <Label aria-label={ariaLabel} alignment={alignment}>
         <InnerDropdown
+          ref={dropdownButtonRef}
           onClick={handleInnerDropdownClick}
           isOpen={showMenu}
           disabled={disabled}
@@ -257,6 +275,7 @@ const Dropdown = ({
         />
       ) : (
         <StyledPopoverMenu
+          currentValueIndex={currentValueIndex}
           isOpen={showMenu}
           items={items}
           onSelect={handleMenuItemSelect}

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -62,7 +62,7 @@ const Label = styled.label`
 `;
 
 export const InnerDropdown = styled.button`
-  ${({ theme, disabled, type, isOpen, hasSelectedItems }) => `
+  ${({ theme, disabled, type, hasSelectedItems }) => `
     display: inline-flex;
     justify-content: center;
     align-items: center;
@@ -71,8 +71,11 @@ export const InnerDropdown = styled.button`
     padding-left: ${hasSelectedItems ? '10px' : '20px'};
     margin: 0;
     background-color: ${
-      theme.dropdown[type][isOpen ? 'activeBackground' : 'background']
+      hasSelectedItems
+        ? theme.colors.blueLight
+        : theme.dropdown[type].background
     };
+
     border-radius: ${theme.dropdown[type].borderRadius}px;
     border: ${theme.dropdown[type].border};
     color: ${theme.colors.gray600};
@@ -83,15 +86,18 @@ export const InnerDropdown = styled.button`
     letter-spacing: ${theme.fonts.dropdown.letterSpacing}em;
     line-height: ${theme.fonts.dropdown.lineHeight}px;
 
-    &:hover {
-      background-color: ${theme.dropdown[type].activeBackground};
+    &:hover,
+    &:active {
+      background-color: ${
+        hasSelectedItems
+          ? theme.colors.blueLight
+          : theme.dropdown[type].activeBackground
+      };
     }
 
     &:focus {
       border: ${theme.borders.action};
     }
-
-    background-color: ${hasSelectedItems ? theme.colors.blueLight : 'inherit'};
 
     &:disabled {
       color: ${theme.colors.gray400};
@@ -255,7 +261,6 @@ const Dropdown = ({
           isOpen={showMenu}
           items={items}
           onSelect={handleMenuItemSelect}
-          framelessButton={type === DROPDOWN_TYPES.TRANSPARENT_MENU}
         />
       )}
     </DropdownContainer>

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -62,7 +62,7 @@ const Label = styled.label`
 `;
 
 export const InnerDropdown = styled.button`
-  ${({ theme, disabled, type, hasSelectedItems }) => `
+  ${({ theme, disabled, type, isOpen, hasSelectedItems }) => `
     display: inline-flex;
     justify-content: center;
     align-items: center;
@@ -73,7 +73,7 @@ export const InnerDropdown = styled.button`
     background-color: ${
       hasSelectedItems
         ? theme.colors.blueLight
-        : theme.dropdown[type].background
+        : theme.dropdown[type][isOpen ? 'activeBackground' : 'background']
     };
 
     border-radius: ${theme.dropdown[type].borderRadius}px;
@@ -86,8 +86,7 @@ export const InnerDropdown = styled.button`
     letter-spacing: ${theme.fonts.dropdown.letterSpacing}em;
     line-height: ${theme.fonts.dropdown.lineHeight}px;
 
-    &:hover,
-    &:active {
+    &:hover {
       background-color: ${
         hasSelectedItems
           ? theme.colors.blueLight

--- a/assets/src/dashboard/components/dropdown/stories/index.js
+++ b/assets/src/dashboard/components/dropdown/stories/index.js
@@ -77,28 +77,6 @@ export const _default = () => {
   );
 };
 
-export const _transparent = () => {
-  const [value, setValue] = useState();
-
-  return (
-    <DropdownWrapper>
-      <Dropdown
-        ariaLabel={text('ariaLabel', 'my dropdown description')}
-        items={demoItems}
-        disabled={boolean('disabled')}
-        value={value}
-        type={DROPDOWN_TYPES.TRANSPARENT_MENU}
-        placeholder={text('placeholder', 'Select Value')}
-        onChange={(item) => {
-          action(`clicked on dropdown item ${item.value}`)(item);
-          setValue(item.value);
-        }}
-      />
-      <FillerContainer />
-    </DropdownWrapper>
-  );
-};
-
 const categoryDemoData = [
   {
     label: <span>{__('All Categories', 'web-stories')}</span>,

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -123,10 +123,10 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
 
   useEffect(() => {
     if (listRef.current && isOpen) {
-      listRef.current[currentValueIndex || 'firstChild']?.focus();
+      listRef.current[currentValueIndex]?.focus();
     }
     setHoveredIndex(currentValueIndex);
-  }, [currentValueIndex, isOpen, items]);
+  }, [currentValueIndex, isOpen]);
 
   const renderMenuItem = useCallback(
     (item, index) => {

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -75,7 +75,7 @@ const Separator = styled.li`
   width: 100%;
 `;
 
-const Menu = ({ isOpen, items, onSelect, framelessButton }) => {
+const Menu = ({ isOpen, items, onSelect }) => {
   const [hoveredIndex, setHoveredIndex] = useState(0);
   const listRef = useRef(null);
 
@@ -151,7 +151,7 @@ const Menu = ({ isOpen, items, onSelect, framelessButton }) => {
   }, []);
 
   return (
-    <MenuContainer framelessButton={framelessButton}>
+    <MenuContainer>
       {items.map((item, index) => {
         if (item.separator) {
           return renderSeparator(index);
@@ -166,7 +166,6 @@ export const MenuProps = {
   items: PropTypes.arrayOf(DROPDOWN_ITEM_PROP_TYPE).isRequired,
   isOpen: PropTypes.bool,
   onSelect: PropTypes.func,
-  framelessButton: PropTypes.bool,
 };
 
 Menu.propTypes = MenuProps;

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -32,29 +32,31 @@ export const MenuContainer = styled.ul`
   border-radius: 8px;
   display: flex;
   flex-direction: column;
-  margin: ${({ framelessButton }) => (framelessButton ? '0' : '20px 0')};
+  margin: 0;
   min-width: 210px;
   overflow: hidden;
-  padding: 0;
+  padding: 5px 0;
+  pointer-events: auto;
 `;
 MenuContainer.propTypes = {
   isOpen: PropTypes.bool,
 };
 
-export const MenuItem = styled.li`
-  padding: 14px 16px;
-  background: ${({ isHovering, theme }) =>
-    isHovering ? theme.colors.gray50 : 'none'};
-  color: ${({ theme }) => theme.colors.gray700};
-  cursor: ${({ isDisabled }) => (isDisabled ? 'default' : 'pointer')};
-  display: flex;
-  font-family: ${({ theme }) => theme.fonts.popoverMenu.family};
-  font-size: ${({ theme }) => theme.fonts.popoverMenu.size}px;
-  line-height: ${({ theme }) => theme.fonts.popoverMenu.lineHeight}px;
-  font-weight: ${({ theme }) => theme.fonts.popoverMenu.weight};
-  letter-spacing: ${({ theme }) => theme.fonts.popoverMenu.letterSpacing}em;
-  width: 100%;
-`;
+export const MenuItem = styled.li(
+  ({ theme, isDisabled, isHovering }) => `
+    padding: 5px 25px;
+    background: ${isHovering ? theme.colors.gray25 : 'none'};
+    color: ${theme.colors.gray700};
+    cursor: ${isDisabled ? 'default' : 'pointer'};
+    display: flex;
+    font-family: ${theme.fonts.popoverMenu.family};
+    font-size: ${theme.fonts.popoverMenu.size}px;
+    line-height: ${theme.fonts.popoverMenu.lineHeight}px;
+    font-weight: ${theme.fonts.popoverMenu.weight};
+    letter-spacing: ${theme.fonts.popoverMenu.letterSpacing}em;
+    width: 100%;
+  `
+);
 
 MenuItem.propTypes = {
   isDisabled: PropTypes.bool,

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -75,8 +75,8 @@ const Separator = styled.li`
   width: 100%;
 `;
 
-const Menu = ({ isOpen, items, onSelect }) => {
-  const [hoveredIndex, setHoveredIndex] = useState(0);
+const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
+  const [hoveredIndex, setHoveredIndex] = useState(currentValueIndex);
   const listRef = useRef(null);
 
   // eslint-disable-next-line consistent-return
@@ -89,7 +89,7 @@ const Menu = ({ isOpen, items, onSelect }) => {
             if (hoveredIndex > 0) {
               setHoveredIndex(hoveredIndex - 1);
               if (listRef.current) {
-                listRef.current.scrollToItem(hoveredIndex - 1);
+                listRef.current.children[hoveredIndex - 1].focus();
               }
             }
             break;
@@ -99,7 +99,7 @@ const Menu = ({ isOpen, items, onSelect }) => {
             if (hoveredIndex < items.length - 1) {
               setHoveredIndex(hoveredIndex + 1);
               if (listRef.current) {
-                listRef.current.scrollToItem(hoveredIndex + 1);
+                listRef.current.children[hoveredIndex + 1].focus();
               }
             }
             break;
@@ -122,11 +122,11 @@ const Menu = ({ isOpen, items, onSelect }) => {
   }, [hoveredIndex, items, onSelect, isOpen]);
 
   useEffect(() => {
-    if (listRef.current) {
-      listRef.current.scrollToItem(0);
+    if (listRef.current && isOpen) {
+      listRef.current[currentValueIndex || 'firstChild']?.focus();
     }
-    setHoveredIndex(0);
-  }, [items]);
+    setHoveredIndex(currentValueIndex);
+  }, [currentValueIndex, isOpen, items]);
 
   const renderMenuItem = useCallback(
     (item, index) => {
@@ -151,7 +151,7 @@ const Menu = ({ isOpen, items, onSelect }) => {
   }, []);
 
   return (
-    <MenuContainer>
+    <MenuContainer ref={listRef}>
       {items.map((item, index) => {
         if (item.separator) {
           return renderSeparator(index);
@@ -164,6 +164,7 @@ const Menu = ({ isOpen, items, onSelect }) => {
 
 export const MenuProps = {
   items: PropTypes.arrayOf(DROPDOWN_ITEM_PROP_TYPE).isRequired,
+  currentValueIndex: PropTypes.number,
   isOpen: PropTypes.bool,
   onSelect: PropTypes.func,
 };

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -45,8 +45,8 @@ MenuContainer.propTypes = {
 export const MenuItem = styled.li(
   ({ theme, isDisabled, isHovering }) => `
     padding: 5px 25px;
-    background: ${isHovering ? theme.colors.gray25 : 'none'};
-    color: ${theme.colors.gray700};
+    background: ${isHovering && !isDisabled ? theme.colors.gray25 : 'none'};
+    color: ${isDisabled ? theme.colors.gray400 : theme.colors.gray700};
     cursor: ${isDisabled ? 'default' : 'pointer'};
     display: flex;
     font-family: ${theme.fonts.popoverMenu.family};

--- a/assets/src/dashboard/components/popoverMenu/popover.js
+++ b/assets/src/dashboard/components/popoverMenu/popover.js
@@ -28,6 +28,8 @@ const Popover = styled.div`
   z-index: ${Z_INDEX.POPOVER_MENU};
   opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
   pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
+  background-color: transparent;
+  margin: 10px 0 0;
 `;
 
 Popover.propTypes = {

--- a/assets/src/dashboard/components/popoverMenu/popover.js
+++ b/assets/src/dashboard/components/popoverMenu/popover.js
@@ -29,7 +29,7 @@ const Popover = styled.div`
   opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
   pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
   background-color: transparent;
-  margin: 10px 0 0;
+  margin: 5px 0 0;
 `;
 
 Popover.propTypes = {

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -48,8 +48,8 @@ Menu.propTypes = {
   isOpen: PropTypes.bool,
 };
 
-const MenuItem = styled.li`
-  ${({ theme, isDisabled, isHovering }) => `
+const MenuItem = styled.li(
+  ({ theme, isDisabled, isHovering }) => `
     padding: 10px 20px;
     background: ${isHovering ? theme.colors.gray25 : 'none'};
     color: ${theme.colors.gray700};
@@ -61,9 +61,8 @@ const MenuItem = styled.li`
     font-weight: ${theme.fonts.typeaheadOptions.weight};
     letter-spacing: ${theme.fonts.typeaheadOptions.letterSpacing}em;
     width: 100%;
-  `}
-`;
-
+  `
+);
 MenuItem.propTypes = {
   isDisabled: PropTypes.bool,
   isHovering: PropTypes.bool,

--- a/assets/src/dashboard/components/viewStyleBar.js
+++ b/assets/src/dashboard/components/viewStyleBar.js
@@ -35,13 +35,13 @@ import { ICON_METRICS, VIEW_STYLE } from '../constants';
 
 const Container = styled.div`
   display: flex;
-  justify-content: flex-start;
+  justify-content: flex-end;
   align-items: center;
 `;
 
 const ToggleButton = styled.button`
   border: none;
-  padding: 15px 15px 15px 0;
+  padding: 0;
   background: transparent;
   cursor: pointer;
 

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -31,7 +31,6 @@ export const CHIP_TYPES = {
 };
 
 export const DROPDOWN_TYPES = {
-  TRANSPARENT_MENU: 'transparentMenu',
   MENU: 'menu',
   PANEL: 'panel',
   COLOR_PANEL: 'color_panel',

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -157,7 +157,7 @@ export const ITEMS_PER_PAGE = 10;
 
 export const STORY_SORT_OPTIONS = {
   LAST_MODIFIED: 'modified',
-  LAST_OPENED: 'modified',
+  LAST_OPENED: false,
   DATE_CREATED: 'date',
   CREATED_BY: 'story_author',
   NAME: 'title',
@@ -178,11 +178,11 @@ export const ORDER_BY_SORT = {
 
 export const STORY_SORT_MENU_ITEMS = [
   {
-    label: __('Last modified WIP', 'web-stories'), // default
+    label: __('Last modified', 'web-stories'), // default
     value: STORY_SORT_OPTIONS.LAST_MODIFIED,
   },
   {
-    label: __('Last opened WIP', 'web-stories'),
+    label: __('Last opened', 'web-stories'),
     value: STORY_SORT_OPTIONS.LAST_OPENED,
   },
   {

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -156,11 +156,11 @@ export const STORY_CONTEXT_MENU_ITEMS = [
 export const ITEMS_PER_PAGE = 10;
 
 export const STORY_SORT_OPTIONS = {
-  NAME: 'title',
-  DATE_CREATED: 'date',
   LAST_MODIFIED: 'modified',
   LAST_OPENED: 'modified',
+  DATE_CREATED: 'date',
   CREATED_BY: 'story_author',
+  NAME: 'title',
 };
 
 export const SORT_DIRECTION = {
@@ -169,33 +169,34 @@ export const SORT_DIRECTION = {
 };
 
 export const ORDER_BY_SORT = {
-  [STORY_SORT_OPTIONS.NAME]: SORT_DIRECTION.ASC,
-  [STORY_SORT_OPTIONS.DATE_CREATED]: SORT_DIRECTION.DESC,
   [STORY_SORT_OPTIONS.LAST_MODIFIED]: SORT_DIRECTION.DESC,
   [STORY_SORT_OPTIONS.LAST_OPENED]: SORT_DIRECTION.DESC,
+  [STORY_SORT_OPTIONS.DATE_CREATED]: SORT_DIRECTION.DESC,
   [STORY_SORT_OPTIONS.CREATED_BY]: SORT_DIRECTION.ASC,
+  [STORY_SORT_OPTIONS.NAME]: SORT_DIRECTION.ASC,
 };
 
 export const STORY_SORT_MENU_ITEMS = [
   {
-    label: __('Name', 'web-stories'),
-    value: STORY_SORT_OPTIONS.NAME,
+    label: __('Last modified WIP', 'web-stories'), // default
+    value: STORY_SORT_OPTIONS.LAST_MODIFIED,
+  },
+  {
+    label: __('Last opened WIP', 'web-stories'),
+    value: STORY_SORT_OPTIONS.LAST_OPENED,
   },
   {
     label: __('Date created', 'web-stories'),
     value: STORY_SORT_OPTIONS.DATE_CREATED,
   },
+
   {
-    label: __('Last modified', 'web-stories'), // default
-    value: STORY_SORT_OPTIONS.LAST_MODIFIED,
-  },
-  {
-    label: __('Last opened', 'web-stories'),
-    value: STORY_SORT_OPTIONS.LAST_OPENED,
-  },
-  {
-    label: __('Created by', 'web-stories'), // owner first then alpha
+    label: __('Author', 'web-stories'),
     value: STORY_SORT_OPTIONS.CREATED_BY,
+  },
+  {
+    label: __('Title', 'web-stories'),
+    value: STORY_SORT_OPTIONS.NAME,
   },
 ];
 

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -89,7 +89,6 @@ const theme = {
       borderRadius: 40,
       border: borders.gray50,
       arrowColor: colors.bluePrimary,
-      height: 48,
     },
     [DROPDOWN_TYPES.COLOR_PANEL]: {
       background: 'transparent',
@@ -97,23 +96,13 @@ const theme = {
       borderRadius: 40,
       border: borders.gray50,
       arrowColor: colors.bluePrimary,
-      height: 48,
     },
     [DROPDOWN_TYPES.MENU]: {
-      background: colors.gray25,
-      activeBackground: colors.gray25,
+      background: 'transparent',
+      activeBackground: 'transparent',
       borderRadius: 4,
       border: 'none',
       arrowColor: colors.gray300,
-      height: 48,
-    },
-    [DROPDOWN_TYPES.TRANSPARENT_MENU]: {
-      background: 'transparent',
-      activeBackground: 'transparent',
-      borderRadius: 0,
-      border: 'none',
-      arrowColor: colors.gray300,
-      height: 40,
     },
   },
   leftRail: {

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -101,7 +101,7 @@ const theme = {
       background: 'transparent',
       activeBackground: 'transparent',
       borderRadius: 4,
-      border: 'none',
+      border: borders.transparent,
       arrowColor: colors.gray300,
     },
   },


### PR DESCRIPTION
## Summary
Updates the my stories sort dropdown ui to new designs. 

**(This update)**
![updated ui dropdown](https://user-images.githubusercontent.com/10720454/81617289-023cb100-939a-11ea-9dc6-8f1f3beba4ed.gif)

**(Design from https://drive.google.com/drive/u/0/folders/1onGbNRFVAalJXtbYYFigSbdG-nHUE7As)**
![dropdown ui design vid](https://user-images.githubusercontent.com/10720454/81617445-50ea4b00-939a-11ea-8918-50eb98a1f666.gif)


## Relevant Technical Choices
- Was able to remove the frameless/transparent option for dropdowns since we are gaining consistency in what a dropdown looks like! 🎉  
- Updated the spacing a bit on the bodyViewOptions shared component to get that toggle button lined up with the left edge and give some space to the dropdown button when it's active and shows that active state. 
- Tried to match the updates to the typeahead for color and spacing
- Set the `last opened` sort option to `false` and opened this ticket: https://github.com/google/web-stories-wp/issues/1727 and commented on the CUJ spreadsheet. hoping that having this be false in the UI eliminates some confusion about why it wasn't working. Separating out the API work from this ticket to not hold things up. 

## To-do

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1490
