### PR TITLE
Dashboard: Show decoded story titles

### DIFF
--- a/assets/src/dashboard/app/api/test/useStoryApi.js
+++ b/assets/src/dashboard/app/api/test/useStoryApi.js
@@ -39,7 +39,7 @@ describe('reshapeStoryObject', () => {
       status: 'draft',
       type: 'web-story',
       link: 'http://localhost:8899/?post_type=web-story&p=27',
-      title: { rendered: 'Carlos Draft' },
+      title: { raw: 'Carlos Draft' },
       content: {
         rendered: `<p><html amp="" lang="en"><head><meta charSet="utf…></amp-story-page></amp-story></body></html></p>`,
         protected: false,
@@ -82,7 +82,7 @@ describe('reshapeStoryObject', () => {
       status: 'draft',
       type: 'web-story',
       link: 'http://localhost:8899/?post_type=web-story&p=27',
-      title: { rendered: 'Carlos Draft' },
+      title: { raw: 'Carlos Draft' },
       content: {
         rendered: `<p><html amp="" lang="en"><head><meta charSet="utf…></amp-story-page></amp-story></body></html></p>`,
         protected: false,
@@ -117,7 +117,7 @@ describe('reshapeStoryObject', () => {
       status: 'draft',
       type: 'web-story',
       link: 'http://localhost:8899/?post_type=web-story&p=27',
-      title: { rendered: 'Carlos Draft' },
+      title: { raw: 'Carlos Draft' },
       content: {
         rendered: `<p><html amp="" lang="en"><head><meta charSet="utf…></amp-story-page></amp-story></body></html></p>`,
         protected: false,

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -64,7 +64,7 @@ export function reshapeStoryObject(editStoryURL) {
     return {
       id,
       status,
-      title: title.rendered,
+      title: title.raw,
       modified: moment(modified),
       created: moment(date),
       pages: storyData.pages,


### PR DESCRIPTION

## Summary
swapping to use the decoded html version of the title we have access …to to turn html symbols like `&amp;` or `&#8211;`  into text characters like  `&` or `...`

## Relevant Technical Choices

- we were using the `title.rendered` value returned when we fetch stories from the api, but since these have the encoded html characters shown as part of the title string, we are now using `title.raw` which has the decoded version.  

<img width="971" alt="Screen Shot 2020-05-11 at 4 24 51 PM" src="https://user-images.githubusercontent.com/10720454/81622387-b4c64100-93a5-11ea-8a0b-13725bc2b662.png">

![edit story name decoded](https://user-images.githubusercontent.com/10720454/81622206-281b8300-93a5-11ea-8ee5-0cbe46fbb9d8.gif)

![rename 2](https://user-images.githubusercontent.com/10720454/81622169-1639e000-93a5-11ea-93ea-fadd56d99bd3.gif)


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1725
