### PR TITLE
Add additional sorting value to ensure the same order of found posts

### DIFF
--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -232,7 +232,7 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 		if ( ! $current_user ) {
 			return $orderby;
 		}
-		return $wpdb->prepare( 'wp_posts.post_author = %s DESC, wp_posts.post_author DESC', $current_user );
+		return $wpdb->prepare( 'wp_posts.post_author = %s DESC, wp_posts.post_author DESC, wp_posts.post_modified DESC', $current_user );
 	}
 
 	/**

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -86,7 +86,7 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 
 		$orderby = $controller->filter_posts_orderby( $initial_orderby, $query );
 
-		$this->assertEquals( $orderby, "wp_posts.post_author = '" . self::$user_id . "' DESC, wp_posts.post_author DESC" );
+		$this->assertEquals( $orderby, "wp_posts.post_author = '" . self::$user_id . "' DESC, wp_posts.post_author DESC, wp_posts.post_modified DESC" );
 	}
 
 	public function test_filter_posts_orderby_irrelevant_query() {


### PR DESCRIPTION
## Summary
Adds additional sorting value to ensure the same order of found posts. Otherwise, there could be duplicate entries on different pages.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1726
