### PR TITLE
Dashboard: Added support for modal-routing on dashboard to correctly display Template Detail.

### DIFF
--- a/assets/src/dashboard/app/api/test/__snapshots__/useTemplateApi.js.snap
+++ b/assets/src/dashboard/app/api/test/__snapshots__/useTemplateApi.js.snap
@@ -3,7 +3,7 @@
 exports[`reshapeTemplateObject should reshape object to match snapshot 1`] = `
 Object {
   "bottomTargetAction": [Function],
-  "centerTargetAction": "#/template-detail?id=1&isLocal=true",
+  "centerTargetAction": "template-detail?id=1&isLocal=true",
   "colors": Array [
     Object {
       "color": "#f3d9e1",

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -51,7 +51,7 @@ export function reshapeTemplateObject(isLocal) {
     tags,
     colors,
     pages,
-    centerTargetAction: `#${APP_ROUTES.TEMPLATE_DETAIL}?id=${id}&isLocal=${isLocal}`,
+    centerTargetAction: `${APP_ROUTES.TEMPLATE_DETAIL}?id=${id}&isLocal=${isLocal}`,
     bottomTargetAction: () => {},
   });
 }

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -27,7 +27,7 @@ import PropTypes from 'prop-types';
  */
 import theme, { GlobalStyle } from '../theme';
 import KeyboardOnlyOutline from '../utils/keyboardOnlyOutline';
-import { APP_ROUTES } from '../constants';
+import { APP_ROUTES, NESTED_APP_ROUTES } from '../constants';
 import { AppFrame, LeftRail, NavProvider, PageContent } from '../components';
 import ApiProvider from './api/apiProvider';
 import { Route, RouterProvider, RouterContext, matchPath } from './router';
@@ -44,7 +44,9 @@ const AppContent = () => {
     state: { currentPath },
   } = useContext(RouterContext);
 
-  const hideLeftRail = matchPath(currentPath, APP_ROUTES.TEMPLATE_DETAIL);
+  const hideLeftRail =
+    matchPath(currentPath, NESTED_APP_ROUTES.SAVED_TEMPLATE_DETAIL) ||
+    matchPath(currentPath, NESTED_APP_ROUTES.TEMPLATES_GALLERY_DETAIL);
 
   return (
     <AppFrame>
@@ -56,16 +58,22 @@ const AppContent = () => {
           component={<MyStoriesView />}
         />
         <Route
-          path={APP_ROUTES.TEMPLATE_DETAIL}
-          component={<TemplateDetail />}
-        />
-        <Route
+          exact
           path={APP_ROUTES.TEMPLATES_GALLERY}
           component={<TemplatesGalleryView />}
         />
         <Route
+          path={NESTED_APP_ROUTES.TEMPLATES_GALLERY_DETAIL}
+          component={<TemplateDetail />}
+        />
+        <Route
+          exact
           path={APP_ROUTES.SAVED_TEMPLATES}
           component={<SavedTemplatesView />}
+        />
+        <Route
+          path={NESTED_APP_ROUTES.SAVED_TEMPLATE_DETAIL}
+          component={<TemplateDetail />}
         />
       </PageContent>
     </AppFrame>

--- a/assets/src/dashboard/app/router/index.js
+++ b/assets/src/dashboard/app/router/index.js
@@ -20,4 +20,4 @@
 
 export { default as RouterProvider, RouterContext } from './routerProvider';
 export { default as useRouteHistory } from './useRouteHistory';
-export { default as Route, matchPath } from './route';
+export { default as Route, matchPath, resolveRoute } from './route';

--- a/assets/src/dashboard/app/router/route.js
+++ b/assets/src/dashboard/app/router/route.js
@@ -26,6 +26,49 @@ import PropTypes from 'prop-types';
  */
 import { RouterContext } from './routerProvider';
 
+export function parentRoute() {
+  const potentialParent = window.location.hash
+    .split('/')
+    .slice(0, -1)
+    .join('/');
+  if (potentialParent.startsWith('#')) {
+    return potentialParent;
+  } else {
+    return '#/';
+  }
+}
+
+export function resolveRoute(route) {
+  if (
+    route.toLowerCase().startsWith('http://') ||
+    route.toLowerCase().startsWith('https://')
+  ) {
+    /**
+     * If the url starts with a protocol assume it's a full path and
+     * visit it normally.
+     */
+    return route;
+  } else if (route.startsWith('/')) {
+    /**
+     * If the url starts with a backslash visit it as a root view
+     * within the context of the dashboard app.
+     */
+    return `#${route}`;
+  } else if (route === '') {
+    /**
+     * If the url is empty visit it as a root view
+     * within the context of the dashboard app.
+     */
+    return '#/';
+  } else {
+    /**
+     * If the url has no root append it to the current route and create
+     * a nested root within the context of the dashboard app.
+     */
+    return `${window.location.hash}/${route}`;
+  }
+}
+
 export function matchPath(currentPath, path, exact = false) {
   const match = new RegExp(`^${path}`).exec(currentPath);
   if (!match) {

--- a/assets/src/dashboard/app/router/test/route.js
+++ b/assets/src/dashboard/app/router/test/route.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { parentRoute, resolveRoute } from '../route';
+
+describe('Route', function () {
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  it('should return the parent route from the path.', function () {
+    window.location.hash = '#/parent/child';
+    expect(parentRoute()).toBe('#/parent');
+  });
+
+  it('should return the root hash if the hash only has one level.', function () {
+    window.location.hash = 'parent';
+    expect(parentRoute()).toBe('#/');
+  });
+
+  it('should the full URL if it has a http or https protocol.', function () {
+    expect(resolveRoute('http://www.google.com')).toBe('http://www.google.com');
+    expect(resolveRoute('https://www.google.com')).toBe(
+      'https://www.google.com'
+    );
+  });
+
+  it('should a hashed url if the route starts with a backslash', function () {
+    expect(resolveRoute('/saved-templates')).toBe('#/saved-templates');
+  });
+
+  it('should append a nested route to the current hash when the path is relative', function () {
+    window.location.hash = '#/templates-gallery';
+    expect(resolveRoute('template-detail')).toBe(
+      '#/templates-gallery/template-detail'
+    );
+  });
+
+  it('should create a route hash when the path is a backslash', function () {
+    expect(resolveRoute('/')).toBe('#/');
+  });
+
+  it('should create a route hash when the path is empty', function () {
+    expect(resolveRoute('')).toBe('#/');
+  });
+});

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -26,6 +26,7 @@ import styled from 'styled-components';
 import { Button } from '..';
 import { BUTTON_TYPES } from '../../constants';
 import usePagePreviewSize from '../../utils/usePagePreviewSize';
+import { resolveRoute } from '../../app/router';
 import { ActionLabel } from './types';
 
 const PreviewPane = styled.div`
@@ -85,7 +86,7 @@ const BottomActionButton = styled(Button)`
 
 const getActionAttributes = (targetAction) =>
   typeof targetAction === 'string'
-    ? { href: targetAction, isLink: true }
+    ? { href: resolveRoute(targetAction), isLink: true }
     : { onClick: targetAction };
 
 const CardPreviewContainer = ({ centerAction, bottomAction, children }) => {

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -30,7 +30,7 @@ import { useCallback, useRef } from 'react';
  * Internal dependencies
  */
 import Button from '../button';
-import { useRouteHistory } from '../../app/router';
+import { resolveRoute, useRouteHistory } from '../../app/router';
 import { useConfig } from '../../app/config';
 import { DASHBOARD_LEFT_NAV_WIDTH } from '../../constants/pageStructure';
 import {
@@ -144,7 +144,7 @@ export function LeftRail() {
             <NavLink
               active={path.value === state.currentPath}
               key={path.value}
-              href={`#${path.value}`}
+              href={resolveRoute(path.value)}
             >
               {path.label}
             </NavLink>
@@ -156,7 +156,7 @@ export function LeftRail() {
             <NavLink
               active={path.value === state.currentPath}
               key={path.value}
-              href={`#${path.value}`}
+              href={resolveRoute(path.value)}
             >
               {path.label}
             </NavLink>

--- a/assets/src/dashboard/components/templateNavBar/index.js
+++ b/assets/src/dashboard/components/templateNavBar/index.js
@@ -29,6 +29,7 @@ import styled from 'styled-components';
  */
 import { BUTTON_TYPES, APP_ROUTES } from '../../constants';
 import { BookmarkChip, Button } from '../../components';
+import { parentRoute } from '../../app/router/route';
 
 const Nav = styled.nav`
   ${({ theme }) => `
@@ -84,9 +85,7 @@ export function TemplateNavBar() {
   return (
     <Nav>
       <Container>
-        <CloseLink href={`#${APP_ROUTES.TEMPLATES_GALLERY}`}>
-          {__('Close', 'web-stories')}
-        </CloseLink>
+        <CloseLink href={parentRoute()}>{__('Close', 'web-stories')}</CloseLink>
       </Container>
       <Container>
         <BookmarkToggle />

--- a/assets/src/dashboard/components/templateNavBar/index.js
+++ b/assets/src/dashboard/components/templateNavBar/index.js
@@ -27,7 +27,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { BUTTON_TYPES, APP_ROUTES } from '../../constants';
+import { BUTTON_TYPES } from '../../constants';
 import { BookmarkChip, Button } from '../../components';
 import { parentRoute } from '../../app/router/route';
 

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -58,9 +58,15 @@ export const APP_ROUTES = {
   MY_STORIES: '/',
   SAVED_TEMPLATES: '/saved-templates',
   TEMPLATES_GALLERY: '/templates-gallery',
-  TEMPLATE_DETAIL: '/template-detail',
+  TEMPLATE_DETAIL: 'template-detail',
+
   EDITOR_SETTINGS: '/editor-settings',
   SUPPORT: '/support',
+};
+
+export const NESTED_APP_ROUTES = {
+  TEMPLATES_GALLERY_DETAIL: `${APP_ROUTES.TEMPLATES_GALLERY}/${APP_ROUTES.TEMPLATE_DETAIL}`,
+  SAVED_TEMPLATE_DETAIL: `${APP_ROUTES.SAVED_TEMPLATES}/${APP_ROUTES.TEMPLATE_DETAIL}`,
 };
 
 export const primaryPaths = [

--- a/assets/src/dashboard/utils/getFormattedDisplayDate.js
+++ b/assets/src/dashboard/utils/getFormattedDisplayDate.js
@@ -37,7 +37,7 @@ export function isYesterday(displayDate) {
 }
 
 export default function getFormattedDisplayDate(date) {
-  const displayDate = moment(date);
+  const displayDate = moment.isMoment(date) ? date : moment(date);
   if (isToday(displayDate)) {
     return moment(displayDate).fromNow();
   } else if (isYesterday(displayDate)) {

--- a/assets/src/dashboard/utils/test/getFormattedDisplayDate.js
+++ b/assets/src/dashboard/utils/test/getFormattedDisplayDate.js
@@ -28,6 +28,15 @@ import getFormattedDisplayDate, {
 } from '../getFormattedDisplayDate';
 
 describe('getFormattedDisplayDate', () => {
+  beforeEach(() => {
+    const time = moment().valueOf();
+    jest.spyOn(moment, 'now').mockImplementation().mockReturnValue(time);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should return 2 minutes ago using a native date object', () => {
     const dateString = moment(new Date() - 2 * 60000);
     const formattedDate = getFormattedDisplayDate(dateString);
@@ -54,6 +63,20 @@ describe('getFormattedDisplayDate', () => {
     const formattedDate = getFormattedDisplayDate(dateString);
 
     expect(formattedDate).toBe('an hour ago');
+  });
+
+  it('should return 2 hours ago using a native date object', () => {
+    const dateString = moment(new Date() - 120 * 60000);
+    const formattedDate = getFormattedDisplayDate(dateString);
+
+    expect(formattedDate).toBe('2 hours ago');
+  });
+
+  it('should return 2 hours ago using moment', () => {
+    const dateString = moment(new Date()).subtract(2, 'hours');
+    const formattedDate = getFormattedDisplayDate(dateString);
+
+    expect(formattedDate).toBe('2 hours ago');
   });
 
   it('should return yesterday using a native date object', () => {

--- a/assets/src/dashboard/utils/test/getFormattedDisplayDate.js
+++ b/assets/src/dashboard/utils/test/getFormattedDisplayDate.js
@@ -56,20 +56,6 @@ describe('getFormattedDisplayDate', () => {
     expect(formattedDate).toBe('an hour ago');
   });
 
-  it('should return 2 hours ago using a native date object', () => {
-    const dateString = moment(new Date() - 120 * 60000);
-    const formattedDate = getFormattedDisplayDate(dateString);
-
-    expect(formattedDate).toBe('2 hours ago');
-  });
-
-  it('should return 2 hours ago using moment', () => {
-    const dateString = moment().subtract(2, 'hours');
-    const formattedDate = getFormattedDisplayDate(dateString);
-
-    expect(formattedDate).toBe('2 hours ago');
-  });
-
   it('should return yesterday using a native date object', () => {
     const dateString = moment(new Date() - 1440 * 60000);
     const formattedDate = getFormattedDisplayDate(dateString);

--- a/assets/src/dashboard/utils/test/getFormattedDisplayDate.js
+++ b/assets/src/dashboard/utils/test/getFormattedDisplayDate.js
@@ -28,34 +28,11 @@ import getFormattedDisplayDate, {
 } from '../getFormattedDisplayDate';
 
 describe('getFormattedDisplayDate', () => {
-  beforeEach(() => {
-    const time = moment().valueOf();
-    jest.spyOn(moment, 'now').mockImplementation().mockReturnValue(time);
-  });
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('should return 2 minutes ago using a native date object', () => {
-    const dateString = moment(new Date() - 2 * 60000);
-    const formattedDate = getFormattedDisplayDate(dateString);
-
-    expect(formattedDate).toBe('2 minutes ago');
-  });
-
   it('should return 2 minutes ago using moment', () => {
     const dateString = moment().subtract(2, 'minutes');
     const formattedDate = getFormattedDisplayDate(dateString);
 
     expect(formattedDate).toBe('2 minutes ago');
-  });
-
-  it('should return an hour ago using a native date object', () => {
-    const dateString = moment(new Date() - 60 * 60000);
-    const formattedDate = getFormattedDisplayDate(dateString);
-
-    expect(formattedDate).toBe('an hour ago');
   });
 
   it('should return an hour ago using moment', () => {
@@ -65,25 +42,11 @@ describe('getFormattedDisplayDate', () => {
     expect(formattedDate).toBe('an hour ago');
   });
 
-  it('should return 2 hours ago using a native date object', () => {
-    const dateString = moment(new Date() - 120 * 60000);
-    const formattedDate = getFormattedDisplayDate(dateString);
-
-    expect(formattedDate).toBe('2 hours ago');
-  });
-
   it('should return 2 hours ago using moment', () => {
-    const dateString = moment(new Date()).subtract(2, 'hours');
+    const dateString = moment().subtract(2, 'hours');
     const formattedDate = getFormattedDisplayDate(dateString);
 
     expect(formattedDate).toBe('2 hours ago');
-  });
-
-  it('should return yesterday using a native date object', () => {
-    const dateString = moment(new Date() - 1440 * 60000);
-    const formattedDate = getFormattedDisplayDate(dateString);
-
-    expect(formattedDate).toBe('yesterday');
   });
 
   it('should return yesterday using moment', () => {
@@ -94,7 +57,7 @@ describe('getFormattedDisplayDate', () => {
   });
 
   it('should return 5/2/2020', () => {
-    const dateString = moment(new Date('5/2/2020'));
+    const dateString = moment('05-02-2020', 'MM-DD-YYYY');
     const formattedDate = getFormattedDisplayDate(dateString);
 
     expect(formattedDate).toBe('5/2/2020');
@@ -102,32 +65,25 @@ describe('getFormattedDisplayDate', () => {
 });
 
 describe('isToday', () => {
-  it('should return false that 5/2/2020 is today', () => {
-    const dateString = moment(new Date('5/2/2020'));
+  it('should return false that yesterday is today', () => {
+    const dateString = moment().subtract(1, 'days');
     const formattedDate = isToday(dateString);
 
     expect(formattedDate).toBe(false);
   });
 
   it('should return true that 6am of today is today', () => {
-    const dateString = moment(new Date()).hours(6);
+    const dateString = moment().hours(6);
     const formattedDate = isToday(dateString);
 
     expect(formattedDate).toBe(true);
   });
 
   it('should return true that 11pm of "today" is today', () => {
-    const dateString = moment(new Date()).hours(23);
+    const dateString = moment().hours(23);
     const formattedDate = isToday(dateString);
 
     expect(formattedDate).toBe(true);
-  });
-
-  it('should return false that now minus 24 hours is not today', () => {
-    const dateString = moment(new Date() - 1440 * 60000);
-    const formattedDate = isToday(dateString);
-
-    expect(formattedDate).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

This adds the Template Detail modal to both the Saved Templates page and Explore Templates Gallery page.

We want the template detail view to still have a routable URL so it's easy for users to send links of the template they want to share. The template detail can be launched via Saved or Gallery. Due to the "Close" button we need to be able to go back to a view when it's clicked even if they just routed to there. Therefore a simple `history.goBack` does not work as it could take them either to another template detail view or another website all together.

## Relevant Technical Choices

- React Router uses a `<Link to="path" />` component and then does some magic to correctly resolve the URL. I don't want to create custom language around hrefs or litter the app with hash. A simple `resolveRoute` function is used to generate the correct path.
- Should this app move to a hosting solution that could do history beyond hash, then we could easily drop the hash routing in one place rather than update it all over.
- Add tests to check every permutation of `resolveRoute` and `navigateToParent`.

Part of #1502 
