### PR TITLE
Dashboard: Explore templates sort options (UI only)

### DIFF
--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -40,6 +40,7 @@ import {
   VIEW_STYLE,
   STORY_STATUSES,
   DASHBOARD_VIEWS,
+  STORY_SORT_MENU_ITEMS,
 } from '../../../constants';
 import { ReactComponent as PlayArrowSvg } from '../../../icons/playArrow.svg';
 import { useDashboardResultsLabel, useStoryView } from '../../../utils';
@@ -185,6 +186,7 @@ function MyStories() {
         layoutStyle={view.style}
         handleLayoutSelect={view.toggleStyle}
         currentSort={sort.value}
+        pageSortOptions={STORY_SORT_MENU_ITEMS}
         handleSortChange={sort.set}
         sortDropdownAriaLabel={__(
           'Choose sort option for display',

--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -30,7 +30,12 @@ import { useRef } from 'react';
 import { TransformProvider } from '../../../../edit-story/components/transform';
 import { UnitsProvider } from '../../../../edit-story/units';
 import { InfiniteScroller, Layout } from '../../../components';
-import { SAVED_TEMPLATES_STATUSES, DASHBOARD_VIEWS } from '../../../constants';
+import {
+  DASHBOARD_VIEWS,
+  SAVED_TEMPLATES_STATUSES,
+  STORY_SORT_MENU_ITEMS,
+} from '../../../constants';
+
 import useDashboardResultsLabel from '../../../utils/useDashboardResultsLabel';
 import useStoryView, {
   FilterPropTypes,
@@ -50,7 +55,6 @@ import {
   PageHeading,
   StoryGridView,
 } from '../shared';
-import { STORY_SORT_MENU_ITEMS } from '../../../constants';
 
 function Header({ filter, search, sort, stories, view }) {
   const resultsLabel = useDashboardResultsLabel({

--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -50,6 +50,7 @@ import {
   PageHeading,
   StoryGridView,
 } from '../shared';
+import { STORY_SORT_MENU_ITEMS } from '../../../constants';
 
 function Header({ filter, search, sort, stories, view }) {
   const resultsLabel = useDashboardResultsLabel({
@@ -72,6 +73,7 @@ function Header({ filter, search, sort, stories, view }) {
         resultsLabel={resultsLabel}
         layoutStyle={view.style}
         currentSort={sort.value}
+        pageSortOptions={STORY_SORT_MENU_ITEMS}
         handleSortChange={sort.set}
         sortDropdownAriaLabel={__(
           'Choose sort option for display',

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -24,11 +24,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { Dropdown, ViewStyleBar } from '../../../components';
-import {
-  STORY_SORT_MENU_ITEMS,
-  DROPDOWN_TYPES,
-  VIEW_STYLE,
-} from '../../../constants';
+import { DROPDOWN_TYPES, VIEW_STYLE } from '../../../constants';
 import BodyWrapper from './bodyWrapper';
 
 const DisplayFormatContainer = styled.div`
@@ -65,6 +61,7 @@ const BodyViewOptions = ({
   handleSortChange,
   resultsLabel,
   layoutStyle,
+  pageSortOptions = [],
   showGridToggle,
   sortDropdownAriaLabel,
 }) => (
@@ -77,7 +74,7 @@ const BodyViewOptions = ({
             <SortDropdown
               alignment="flex-end"
               ariaLabel={sortDropdownAriaLabel}
-              items={STORY_SORT_MENU_ITEMS}
+              items={pageSortOptions}
               type={DROPDOWN_TYPES.MENU}
               value={currentSort}
               onChange={(newSort) => handleSortChange(newSort.value)}
@@ -102,6 +99,12 @@ BodyViewOptions.propTypes = {
   handleSortChange: PropTypes.func.isRequired,
   layoutStyle: PropTypes.string.isRequired,
   resultsLabel: PropTypes.string.isRequired,
+  pageSortOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      label: PropTypes.string,
+    })
+  ),
   showGridToggle: PropTypes.bool,
   sortDropdownAriaLabel: PropTypes.string.isRequired,
 };

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -42,9 +42,10 @@ import { DropdownContainer } from '../../../components/dropdown';
 import {
   VIEW_STYLE,
   DROPDOWN_TYPES,
-  STORY_SORT_OPTIONS,
   DASHBOARD_VIEWS,
   TEMPLATES_GALLERY_STATUS,
+  TEMPLATES_GALLERY_SORT_MENU_ITEMS,
+  TEMPLATES_GALLERY_SORT_OPTIONS,
 } from '../../../constants';
 import { clamp, usePagePreviewSize } from '../../../utils/';
 import useDashboardResultsLabel from '../../../utils/useDashboardResultsLabel';
@@ -77,7 +78,7 @@ function TemplatesGallery() {
   const [viewStyle, setViewStyle] = useState(VIEW_STYLE.GRID);
   const [currentPage, setCurrentPage] = useState(1);
   const [currentTemplateSort, setCurrentTemplateSort] = useState(
-    STORY_SORT_OPTIONS.LAST_MODIFIED
+    TEMPLATES_GALLERY_SORT_OPTIONS.POPULAR
   );
   const { pageSize } = usePagePreviewSize({
     thumbnailMode: viewStyle === VIEW_STYLE.LIST,
@@ -227,6 +228,7 @@ function TemplatesGallery() {
                 layoutStyle={viewStyle}
                 handleLayoutSelect={handleViewStyleBarButtonSelected}
                 currentSort={currentTemplateSort}
+                pageSortOptions={TEMPLATES_GALLERY_SORT_MENU_ITEMS}
                 handleSortChange={setCurrentTemplateSort}
                 sortDropdownAriaLabel={__(
                   'Choose sort option for display',

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -66,7 +66,6 @@ export const STORY_SORT_OPTIONS = {
   NAME: 'title',
   DATE_CREATED: 'date',
   LAST_MODIFIED: 'modified',
-  LAST_OPENED: 'modified',
   CREATED_BY: 'story_author',
 };
 
@@ -74,7 +73,6 @@ export const ORDER_BY_SORT = {
   [STORY_SORT_OPTIONS.NAME]: SORT_DIRECTION.ASC,
   [STORY_SORT_OPTIONS.DATE_CREATED]: SORT_DIRECTION.DESC,
   [STORY_SORT_OPTIONS.LAST_MODIFIED]: SORT_DIRECTION.DESC,
-  [STORY_SORT_OPTIONS.LAST_OPENED]: SORT_DIRECTION.DESC,
   [STORY_SORT_OPTIONS.CREATED_BY]: SORT_DIRECTION.ASC,
 };
 
@@ -90,10 +88,6 @@ export const STORY_SORT_MENU_ITEMS = [
   {
     label: __('Last modified', 'web-stories'), // default
     value: STORY_SORT_OPTIONS.LAST_MODIFIED,
-  },
-  {
-    label: __('Last opened', 'web-stories'),
-    value: STORY_SORT_OPTIONS.LAST_OPENED,
   },
   {
     label: __('Created by', 'web-stories'),

--- a/assets/src/dashboard/constants/templates.js
+++ b/assets/src/dashboard/constants/templates.js
@@ -144,3 +144,18 @@ export const TEMPLATES_GALLERY_STATUS = {
 export const TEMPLATES_GALLERY_VIEWING_LABELS = {
   [TEMPLATES_GALLERY_STATUS.ALL]: __('Viewing all templates', 'web-stories'),
 };
+export const TEMPLATES_GALLERY_SORT_OPTIONS = {
+  POPULAR: 'popular',
+  RECENT: 'recent',
+};
+
+export const TEMPLATES_GALLERY_SORT_MENU_ITEMS = [
+  {
+    label: __('Popular', 'web-stories'),
+    value: TEMPLATES_GALLERY_SORT_OPTIONS.POPULAR,
+  },
+  {
+    label: __('Recent', 'web-stories'),
+    value: TEMPLATES_GALLERY_SORT_OPTIONS.RECENT,
+  },
+];


### PR DESCRIPTION
## Summary
Following new design video to have explore templates sort options default to popular and have options for popular and recently viewed.  **This does not add sorting functionality, we do not have an API yet for this :)** 

## Relevant Technical Choices
- make dropdown sort options a prop to pass in so that values can be different since explore templates has different options
- set sort menu items for each of the views. 

<img width="286" alt="Screen Shot 2020-05-12 at 4 14 06 PM" src="https://user-images.githubusercontent.com/10720454/81754692-a8a4b700-946b-11ea-8d33-90d375a17921.png">

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1506 
