### PR TITLE
Add per-status counts to REST API responses

### DIFF
--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -366,7 +366,7 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 			$posts_query->query( $query_args );
 			$statuses_count[ $status ] = absint( $posts_query->found_posts );
 		}
-		// Encode the this array as headers do not support passing an array.
+		// Encode the array as headers do not support passing an array.
 		$encoded_statuses = wp_json_encode( $statuses_count );
 		if ( $encoded_statuses ) {
 			$response->header( 'X-WP-TotalByStatus', $encoded_statuses );

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -26,9 +26,10 @@
 
 namespace Google\Web_Stories\REST_API;
 
-use Google\Web_Stories\Dashboard;
+
 use Google\Web_Stories\Story_Post_Type;
 use stdClass;
+use WP_Query;
 use WP_Error;
 use WP_Post;
 use WP_REST_Posts_Controller;

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -250,6 +250,10 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 			return $response;
 		}
 
+		if ( 'edit' !== $request['context'] ) {
+			return $response;
+		}
+
 		// Retrieve the list of registered collection query parameters.
 		$registered = $this->get_collection_params();
 		$args       = [];
@@ -352,15 +356,14 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 		}
 
 		// Add counts for other statuses.
-		$headers                             = $response->get_headers();
-		$statuses                            = [ 'publish', 'draft' ];
-		$statuses_count                      = [ 'all' => $headers['X-WP-Total'] ];
-		$query_args_status                   = $query_args;
-		$query_args_status['posts_per_page'] = 1;
+		$headers                      = $response->get_headers();
+		$statuses                     = [ 'publish', 'draft' ];
+		$statuses_count               = [ 'all' => $headers['X-WP-Total'] ];
+		$query_args['posts_per_page'] = 1;
 		foreach ( $statuses as $status ) {
-			$posts_query                      = new WP_Query();
-			$query_args_status['post_status'] = [ $status ];
-			$posts_query->query( $query_args_status );
+			$posts_query               = new WP_Query();
+			$query_args['post_status'] = [ $status ];
+			$posts_query->query( $query_args );
 			$statuses_count[ $status ] = absint( $posts_query->found_posts );
 		}
 		// Encode the this array as headers do not support passing an array.

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -26,7 +26,6 @@
 
 namespace Google\Web_Stories\REST_API;
 
-
 use Google\Web_Stories\Story_Post_Type;
 use stdClass;
 use WP_Query;
@@ -87,7 +86,7 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 	/**
 	 * Prepares a single story output for response. Add post_content_filtered field to output.
 	 *
-	 * @param WP_Post         $post Post object.
+	 * @param int|WP_Post     $post Post object or post id.
 	 * @param WP_REST_Request $request Request object.
 	 *
 	 * @return WP_REST_Response Response object.
@@ -377,11 +376,12 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 		$posts = [];
 
 		foreach ( $query_result as $post ) {
-			if ( ! $this->check_read_permission( $post ) ) {
+			$_post = get_post( $post );
+			if ( ! $this->check_read_permission( $_post ) ) {
 				continue;
 			}
 
-			$data    = $this->prepare_item_for_response( $post, $request );
+			$data    = $this->prepare_item_for_response( $_post, $request );
 			$posts[] = $this->prepare_response_for_collection( $data );
 		}
 

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -243,7 +243,214 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 	 */
 	public function get_items( $request ) {
 		add_filter( 'posts_orderby', [ $this, 'filter_posts_orderby' ], 10, 2 );
-		$response = parent::get_items( $request );
+
+		// @codeCoverageIgnoreStart
+		// Ensure a search string is set in case the orderby is set to 'relevance'.
+		if ( ! empty( $request['orderby'] ) && 'relevance' === $request['orderby'] && empty( $request['search'] ) ) {
+			return new WP_Error(
+				'rest_no_search_term_defined',
+				__( 'You need to define a search term to order by relevance.', 'web-stories' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		// Ensure an include parameter is set in case the orderby is set to 'include'.
+		if ( ! empty( $request['orderby'] ) && 'include' === $request['orderby'] && empty( $request['include'] ) ) {
+			return new WP_Error(
+				'rest_orderby_include_missing_include',
+				__( 'You need to define an include parameter to order by include.', 'web-stories' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		// Retrieve the list of registered collection query parameters.
+		$registered = $this->get_collection_params();
+		$args       = [];
+
+		/*
+		 * This array defines mappings between public API query parameters whose
+		 * values are accepted as-passed, and their internal WP_Query parameter
+		 * name equivalents (some are the same). Only values which are also
+		 * present in $registered will be set.
+		 */
+		$parameter_mappings = [
+			'author'         => 'author__in',
+			'author_exclude' => 'author__not_in',
+			'exclude'        => 'post__not_in',
+			'include'        => 'post__in',
+			'menu_order'     => 'menu_order',
+			'offset'         => 'offset',
+			'order'          => 'order',
+			'orderby'        => 'orderby',
+			'page'           => 'paged',
+			'parent'         => 'post_parent__in',
+			'parent_exclude' => 'post_parent__not_in',
+			'search'         => 's',
+			'slug'           => 'post_name__in',
+			'status'         => 'post_status',
+		];
+
+		/*
+		 * For each known parameter which is both registered and present in the request,
+		 * set the parameter's value on the query $args.
+		 */
+		foreach ( $parameter_mappings as $api_param => $wp_param ) {
+			if ( isset( $registered[ $api_param ], $request[ $api_param ] ) ) {
+				$args[ $wp_param ] = $request[ $api_param ];
+			}
+		}
+
+		// Check for & assign any parameters which require special handling or setting.
+		$args['date_query'] = [];
+
+		// Set before into date query. Date query must be specified as an array of an array.
+		if ( isset( $registered['before'], $request['before'] ) ) {
+			$args['date_query'][0]['before'] = $request['before'];
+		}
+
+		// Set after into date query. Date query must be specified as an array of an array.
+		if ( isset( $registered['after'], $request['after'] ) ) {
+			$args['date_query'][0]['after'] = $request['after'];
+		}
+
+		// Ensure our per_page parameter overrides any provided posts_per_page filter.
+		if ( isset( $registered['per_page'] ) ) {
+			$args['posts_per_page'] = $request['per_page'];
+		}
+
+		// Force the post_type argument, since it's not a user input variable.
+		$args['post_type'] = $this->post_type;
+
+		/**
+		 * Filters the query arguments for a request.
+		 *
+		 * Enables adding extra arguments or setting defaults for a post collection request.
+		 *
+		 * @link https://developer.wordpress.org/reference/classes/wp_query/
+		 *
+		 * @param array           $args    Key value array of query var to query value.
+		 * @param WP_REST_Request $request The request used.
+		 */
+		$args       = apply_filters( "rest_{$this->post_type}_query", $args, $request );
+		$query_args = $this->prepare_items_query( $args, $request );
+
+		$taxonomies = wp_list_filter( get_object_taxonomies( $this->post_type, 'objects' ), [ 'show_in_rest' => true ] );
+
+		if ( ! empty( $request['tax_relation'] ) ) {
+			$query_args['tax_query'] = [ 'relation' => $request['tax_relation'] ]; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+		}
+
+		foreach ( $taxonomies as $taxonomy ) {
+			$base        = ! empty( $taxonomy->rest_base ) ? $taxonomy->rest_base : $taxonomy->name;
+			$tax_exclude = $base . '_exclude';
+
+			if ( ! empty( $request[ $base ] ) ) {
+				$query_args['tax_query'][] = [
+					'taxonomy'         => $taxonomy->name,
+					'field'            => 'term_id',
+					'terms'            => $request[ $base ],
+					'include_children' => false,
+				];
+			}
+
+			if ( ! empty( $request[ $tax_exclude ] ) ) {
+				$query_args['tax_query'][] = [
+					'taxonomy'         => $taxonomy->name,
+					'field'            => 'term_id',
+					'terms'            => $request[ $tax_exclude ],
+					'include_children' => false,
+					'operator'         => 'NOT IN',
+				];
+			}
+		}
+
+		$posts_query  = new WP_Query();
+		$query_result = $posts_query->query( $query_args );
+
+
+		// Allow access to all password protected posts if the context is edit.
+		if ( 'edit' === $request['context'] ) {
+			add_filter( 'post_password_required', '__return_false' );
+		}
+
+		$posts = [];
+
+		foreach ( $query_result as $post ) {
+			if ( ! $this->check_read_permission( $post ) ) {
+				continue;
+			}
+
+			$data    = $this->prepare_item_for_response( $post, $request );
+			$posts[] = $this->prepare_response_for_collection( $data );
+		}
+
+		// Reset filter.
+		if ( 'edit' === $request['context'] ) {
+			remove_filter( 'post_password_required', '__return_false' );
+		}
+
+		$page        = (int) $query_args['paged'];
+		$total_posts = $posts_query->found_posts;
+
+		if ( $total_posts < 1 ) {
+			// Out-of-bounds, run the query again without LIMIT for total count.
+			unset( $query_args['paged'] );
+
+			$count_query = new WP_Query();
+			$count_query->query( $query_args );
+			$total_posts = $count_query->found_posts;
+		}
+
+		$max_pages = ceil( $total_posts / (int) $posts_query->query_vars['posts_per_page'] );
+
+		if ( $page > $max_pages && $total_posts > 0 ) {
+			return new WP_Error(
+				'rest_post_invalid_page_number',
+				__( 'The page number requested is larger than the number of pages available.', 'web-stories' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$response = rest_ensure_response( $posts );
+
+		$response->header( 'X-WP-Total', (int) $total_posts );
+		$response->header( 'X-WP-TotalPages', (int) $max_pages );
+		// @codeCoverageIgnoreEnd
+		// Add counts for other statuses.
+		$statuses                            = [ 'publish', 'draft' ];
+		$statuses_count                      = [ 'all' => (int) $total_posts ];
+		$query_args_status                   = $query_args;
+		$query_args_status['posts_per_page'] = 1;
+		foreach ( $statuses as $status ) {
+			$posts_query                      = new WP_Query();
+			$query_args_status['post_status'] = [ $status ];
+			$posts_query->query( $query_args_status );
+			$statuses_count[ $status ] = absint( $posts_query->found_posts );
+		}
+		// Encode the this array as headers do not support passing an array.
+		$response->header( 'X-WP-TotalByStatus', wp_json_encode( $statuses_count ) );
+		// @codeCoverageIgnoreStart
+		$request_params = $request->get_query_params();
+		$base           = add_query_arg( urlencode_deep( $request_params ), rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ) );
+
+		if ( $page > 1 ) {
+			$prev_page = $page - 1;
+
+			if ( $prev_page > $max_pages ) {
+				$prev_page = $max_pages;
+			}
+
+			$prev_link = add_query_arg( 'page', $prev_page, $base );
+			$response->link_header( 'prev', $prev_link );
+		}
+		if ( $max_pages > $page ) {
+			$next_page = $page + 1;
+			$next_link = add_query_arg( 'page', $next_page, $base );
+
+			$response->link_header( 'next', $next_link );
+		}
+		// @codeCoverageIgnoreEnd
+
 		remove_filter( 'posts_orderby', [ $this, 'filter_posts_orderby' ], 10 );
 		return $response;
 	}

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -35,7 +35,7 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$post_type = \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG;
 
 		$factory->post->create_many(
-			3,
+			7,
 			[
 				'post_status' => 'publish',
 				'post_author' => self::$user_id,
@@ -44,7 +44,7 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		);
 
 		$factory->post->create_many(
-			7,
+			3,
 			[
 				'post_status' => 'draft',
 				'post_author' => self::$user_id,

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -86,6 +86,7 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		wp_set_current_user( self::$user_id );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/web-story' );
 		$request->set_param( 'author', self::$user_id );
+		$request->set_param( 'status', [ 'publish', 'draft' ] );
 		$request->set_param( 'context', 'edit' );
 		$response = rest_get_server()->dispatch( $request );
 		$headers  = $response->get_headers();

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -94,10 +94,6 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$statues        = $headers['X-WP-TotalByStatus'];
 		$statues_decode = json_decode( $statues );
 
-		$this->assertArrayHasKey( 'all', $statues_decode );
-		$this->assertArrayHasKey( 'publish', $statues_decode );
-		$this->assertArrayHasKey( 'draft', $statues_decode );
-
 		$this->assertEquals( 10, $statues_decode['all'] );
 		$this->assertEquals( 7, $statues_decode['publish'] );
 		$this->assertEquals( 3, $statues_decode['draft'] );

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -92,7 +92,11 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$headers  = $response->get_headers();
 		$this->assertEquals( 10, $headers['X-WP-Total'] );
 		$statues        = $headers['X-WP-TotalByStatus'];
-		$statues_decode = json_decode( $statues );
+		$statues_decode = json_decode( $statues, true );
+
+		$this->assertArrayHasKey( 'all', $statues_decode );
+		$this->assertArrayHasKey( 'publish', $statues_decode );
+		$this->assertArrayHasKey( 'draft', $statues_decode );
 
 		$this->assertEquals( 10, $statues_decode['all'] );
 		$this->assertEquals( 7, $statues_decode['publish'] );

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -31,6 +31,26 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 				'role' => 'administrator',
 			]
 		);
+
+		$post_type = \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG;
+
+		$factory->post->create_many(
+			3,
+			[
+				'post_status' => 'publish',
+				'post_author' => self::$user_id,
+				'post_type'   => $post_type,
+			]
+		);
+
+		$factory->post->create_many(
+			7,
+			[
+				'post_status' => 'draft',
+				'post_author' => self::$user_id,
+				'post_type'   => $post_type,
+			]
+		);
 	}
 
 	public static function wpTearDownAfterClass() {
@@ -59,6 +79,26 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 
 		$this->assertArrayHasKey( '/wp/v2/web-story', $routes );
 		$this->assertCount( 2, $routes['/wp/v2/web-story'] );
+	}
+
+
+	public function test_get_items() {
+		$request = new WP_REST_Request( 'GET', '/wp/v2/web-story' );
+		$request->set_param( 'author', [ self::$user_id ] );
+		$request->set_param( 'context', 'edit' );
+		$response = rest_get_server()->dispatch( $request );
+		$headers  = $response->get_headers();
+		$this->assertEquals( 10, $headers['X-WP-Total'] );
+		$statues        = $headers['X-WP-TotalByStatus'];
+		$statues_decode = json_decode( $statues );
+
+		$this->assertArrayHasKey( 'all', $statues_decode );
+		$this->assertArrayHasKey( 'publish', $statues_decode );
+		$this->assertArrayHasKey( 'draft', $statues_decode );
+
+		$this->assertEquals( 10, $statues_decode['all'] );
+		$this->assertEquals( 7, $statues_decode['publish'] );
+		$this->assertEquals( 3, $statues_decode['draft'] );
 	}
 
 	public function test_get_item_schema() {

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -83,11 +83,13 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 
 
 	public function test_get_items() {
+		wp_set_current_user( self::$user_id );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/web-story' );
 		$request->set_param( 'author', self::$user_id );
 		$request->set_param( 'context', 'edit' );
-		$response       = rest_get_server()->dispatch( $request );
-		$headers        = $response->get_headers();
+		$response = rest_get_server()->dispatch( $request );
+		$headers  = $response->get_headers();
+		$this->assertEquals( 10, $headers['X-WP-Total'] );
 		$statues        = $headers['X-WP-TotalByStatus'];
 		$statues_decode = json_decode( $statues );
 

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -84,11 +84,10 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 
 	public function test_get_items() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/web-story' );
-		$request->set_param( 'author', [ self::$user_id ] );
+		$request->set_param( 'author', self::$user_id );
 		$request->set_param( 'context', 'edit' );
-		$response = rest_get_server()->dispatch( $request );
-		$headers  = $response->get_headers();
-		$this->assertEquals( 10, $headers['X-WP-Total'] );
+		$response       = rest_get_server()->dispatch( $request );
+		$headers        = $response->get_headers();
 		$statues        = $headers['X-WP-TotalByStatus'];
 		$statues_decode = json_decode( $statues );
 


### PR DESCRIPTION
## Summary

Add statuses count to the headers named `X-WP-TotalByStatus` of a REST API response. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1120
