### PR TITLE
Dashboard: Story Hover Button UI Update 

### DIFF
--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -41,8 +41,8 @@ import {
   STORY_STATUSES,
   DASHBOARD_VIEWS,
   STORY_SORT_MENU_ITEMS,
+  STORY_ITEM_CENTER_ACTION_LABELS,
 } from '../../../constants';
-import { ReactComponent as PlayArrowSvg } from '../../../icons/playArrow.svg';
 import { useDashboardResultsLabel, useStoryView } from '../../../utils';
 import { ApiContext } from '../../api/apiProvider';
 import FontProvider from '../../font/fontProvider';
@@ -64,10 +64,6 @@ const DefaultBodyText = styled.p`
   letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing}em;
   color: ${({ theme }) => theme.colors.gray200};
   margin: 40px 20px;
-`;
-
-const PlayArrowIcon = styled(PlayArrowSvg).attrs({ width: 11, height: 14 })`
-  margin-right: 9px;
 `;
 
 function MyStories() {
@@ -138,12 +134,7 @@ function MyStories() {
             duplicateStory={duplicateStory}
             stories={orderedStories}
             users={users}
-            centerActionLabel={
-              <>
-                <PlayArrowIcon />
-                {__('Preview', 'web-stories')}
-              </>
-            }
+            centerActionLabelByStatus={STORY_ITEM_CENTER_ACTION_LABELS}
             bottomActionLabel={__('Open in editor', 'web-stories')}
           />
         );

--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -55,6 +55,7 @@ import {
   PageHeading,
   StoryGridView,
 } from '../shared';
+import { TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS } from '../../../constants';
 
 function Header({ filter, search, sort, stories, view }) {
   const resultsLabel = useDashboardResultsLabel({
@@ -97,7 +98,9 @@ function Content({ stories, view, page }) {
             <BodyWrapper>
               <StoryGridView
                 stories={stories}
-                centerActionLabel={__('View', 'web-stories')}
+                centerActionLabelByStatus={
+                  TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS
+                }
                 bottomActionLabel={__('Use template', 'web-stories')}
                 isSavedTemplate
               />

--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -34,8 +34,8 @@ import {
   DASHBOARD_VIEWS,
   SAVED_TEMPLATES_STATUSES,
   STORY_SORT_MENU_ITEMS,
+  TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS,
 } from '../../../constants';
-
 import useDashboardResultsLabel from '../../../utils/useDashboardResultsLabel';
 import useStoryView, {
   FilterPropTypes,
@@ -55,7 +55,6 @@ import {
   PageHeading,
   StoryGridView,
 } from '../shared';
-import { TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS } from '../../../constants';
 
 function Header({ filter, search, sort, stories, view }) {
   const resultsLabel = useDashboardResultsLabel({

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -171,7 +171,7 @@ StoryGridView.propTypes = {
   isSavedTemplate: PropTypes.bool,
   stories: StoriesPropType,
   users: UsersPropType,
-  centerActionLabelByStatus: ActionLabel,
+  centerActionLabelByStatus: PropTypes.objectOf(PropTypes.string),
   bottomActionLabel: ActionLabel,
   createTemplateFromStory: PropTypes.func,
   updateStory: PropTypes.func,

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -57,7 +57,7 @@ const StoryGrid = styled(CardGrid)`
 const StoryGridView = ({
   stories,
   users,
-  centerActionLabel,
+  centerActionLabelByStatus,
   bottomActionLabel,
   createTemplateFromStory,
   updateStory,
@@ -124,7 +124,7 @@ const StoryGridView = ({
           <CardPreviewContainer
             centerAction={{
               targetAction: story.centerTargetAction,
-              label: centerActionLabel,
+              label: centerActionLabelByStatus[story.status],
             }}
             bottomAction={{
               targetAction: story.bottomTargetAction,
@@ -171,7 +171,7 @@ StoryGridView.propTypes = {
   isSavedTemplate: PropTypes.bool,
   stories: StoriesPropType,
   users: UsersPropType,
-  centerActionLabel: ActionLabel,
+  centerActionLabelByStatus: ActionLabel,
   bottomActionLabel: ActionLabel,
   createTemplateFromStory: PropTypes.func,
   updateStory: PropTypes.func,

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -46,6 +46,7 @@ import {
   TEMPLATES_GALLERY_STATUS,
   TEMPLATES_GALLERY_SORT_MENU_ITEMS,
   TEMPLATES_GALLERY_SORT_OPTIONS,
+  TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS,
 } from '../../../constants';
 import { clamp, usePagePreviewSize } from '../../../utils/';
 import useDashboardResultsLabel from '../../../utils/useDashboardResultsLabel';
@@ -152,7 +153,9 @@ function TemplatesGallery() {
         <BodyWrapper>
           <StoryGridView
             stories={orderedTemplates}
-            centerActionLabel={__('View', 'web-stories')}
+            centerActionLabelByStatus={
+              TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS
+            }
             bottomActionLabel={__('Use template', 'web-stories')}
             isTemplate
           />

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -36,10 +36,9 @@ const StyledButton = styled.button`
   border: ${({ theme }) => theme.borders.transparent};
   border-radius: ${({ theme }) => theme.button.borderRadius}px;
   display: flex;
-  height: 40px;
   min-width: 100px;
   opacity: 0.75;
-  padding: 0 10px;
+  padding: 4px 16px;
   text-decoration: none;
 
   &:focus,

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -38,7 +38,7 @@ const StyledButton = styled.button`
   display: flex;
   min-width: 100px;
   opacity: 0.75;
-  padding: 4px 16px;
+  padding: 4px 12px;
   text-decoration: none;
 
   &:focus,

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -71,6 +71,7 @@ const CtaButton = styled(StyledButton)`
 `;
 
 const SecondaryButton = styled(StyledButton)`
+  border-radius: 0px;
   background-color: transparent;
   text-shadow: ${({ theme }) => theme.text.shadow};
 
@@ -87,7 +88,14 @@ const StyledChildren = styled.span`
   display: flex;
   justify-content: center;
   align-items: center;
+
+  border-bottom: ${({ isSecondary }) =>
+    isSecondary ? '0.1em solid currentColor' : 'none'};
 `;
+
+StyledChildren.propTypes = {
+  isSecondary: PropTypes.bool,
+};
 
 const Button = ({
   children,
@@ -110,7 +118,9 @@ const Button = ({
       disabled={isDisabled}
       {...rest}
     >
-      <StyledChildren>{children}</StyledChildren>
+      <StyledChildren isSecondary={type === BUTTON_TYPES.SECONDARY}>
+        {children}
+      </StyledChildren>
     </StyledButtonByType>
   );
 };

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -74,10 +74,6 @@ const EmptyActionContainer = styled(ActionContainer)`
   padding: 40px;
 `;
 
-const BottomActionButton = styled(Button)`
-  width: 100%;
-`;
-
 const getActionAttributes = (targetAction) =>
   typeof targetAction === 'string'
     ? { href: resolveRoute(targetAction), isLink: true }
@@ -102,11 +98,9 @@ const CardPreviewContainer = ({ centerAction, bottomAction, children }) => {
           </ActionContainer>
         )}
         <ActionContainer>
-          <BottomActionButton
-            {...getActionAttributes(bottomAction.targetAction)}
-          >
+          <Button {...getActionAttributes(bottomAction.targetAction)}>
             {bottomAction.label}
-          </BottomActionButton>
+          </Button>
         </ActionContainer>
       </EditControls>
     </>

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -70,6 +70,7 @@ const ActionContainer = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
+  text-transform: uppercase;
 `;
 
 const EmptyActionContainer = styled(ActionContainer)`

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -54,7 +54,6 @@ const EditControls = styled.div`
   &:hover {
     opacity: 1;
   }
-
   @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
     button,
     a {
@@ -68,6 +67,9 @@ const EditControls = styled.div`
 
 const ActionContainer = styled.div`
   padding: 20px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
 `;
 
 const EmptyActionContainer = styled(ActionContainer)`

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -74,12 +74,6 @@ const EmptyActionContainer = styled(ActionContainer)`
   padding: 40px;
 `;
 
-const CenterActionButton = styled(Button)`
-  width: 100%;
-  font-size: 22px;
-  line-height: 22px;
-`;
-
 const BottomActionButton = styled(Button)`
   width: 100%;
 `;
@@ -99,12 +93,12 @@ const CardPreviewContainer = ({ centerAction, bottomAction, children }) => {
         <EmptyActionContainer />
         {centerAction && (
           <ActionContainer>
-            <CenterActionButton
+            <Button
               type={BUTTON_TYPES.SECONDARY}
               {...getActionAttributes(centerAction.targetAction)}
             >
               {centerAction.label}
-            </CenterActionButton>
+            </Button>
           </ActionContainer>
         )}
         <ActionContainer>

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -29,9 +29,10 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { STORY_STATUS, TEMPLATES_GALLERY_STATUS } from '../../constants';
+import { STORY_STATUS } from '../../constants';
 import { getFormattedDisplayDate, useFocusOut } from '../../utils/';
 import { TextInput } from '../input';
+import { DashboardStatusesPropType } from '../../types';
 
 const StyledCardTitle = styled.div`
   font-family: ${({ theme }) => theme.fonts.storyGridItem.family};
@@ -157,10 +158,7 @@ const CardTitle = ({
 CardTitle.propTypes = {
   title: PropTypes.string.isRequired,
   secondaryTitle: PropTypes.string,
-  status: PropTypes.oneOf([
-    ...Object.values(STORY_STATUS),
-    ...Object.values(TEMPLATES_GALLERY_STATUS),
-  ]),
+  status: DashboardStatusesPropType,
   editMode: PropTypes.bool,
   displayDate: PropTypes.object,
   onEditComplete: PropTypes.func.isRequired,

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -29,7 +29,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { STORY_STATUS } from '../../constants';
+import { STORY_STATUS, TEMPLATES_GALLERY_STATUS } from '../../constants';
 import { getFormattedDisplayDate, useFocusOut } from '../../utils/';
 import { TextInput } from '../input';
 
@@ -157,7 +157,10 @@ const CardTitle = ({
 CardTitle.propTypes = {
   title: PropTypes.string.isRequired,
   secondaryTitle: PropTypes.string,
-  status: PropTypes.oneOf(Object.values(STORY_STATUS)),
+  status: PropTypes.oneOf([
+    ...Object.values(STORY_STATUS),
+    ...Object.values(TEMPLATES_GALLERY_STATUS),
+  ]),
   editMode: PropTypes.bool,
   displayDate: PropTypes.object,
   onEditComplete: PropTypes.func.isRequired,

--- a/assets/src/dashboard/components/dropdown/test/dropdown.js
+++ b/assets/src/dashboard/components/dropdown/test/dropdown.js
@@ -30,7 +30,7 @@ describe('Dropdown', () => {
   const onClickMock = jest.fn();
 
   it('should render a <Dropdown /> button by default', () => {
-    const { getByRole } = renderWithTheme(
+    const wrapper = renderWithTheme(
       <Dropdown
         placeholder="placeholder text"
         ariaLabel="my dropdown test"
@@ -41,7 +41,10 @@ describe('Dropdown', () => {
       />
     );
 
-    const DropdownButton = getByRole('button');
+    const DropdownButton = wrapper.getByRole('button');
+    const PopoverMenu = wrapper.getByTestId('popover-menu');
+    const DropdownMenu = window.getComputedStyle(PopoverMenu).display;
     expect(DropdownButton).toBeDefined();
+    expect(DropdownMenu).toBe('none');
   });
 });

--- a/assets/src/dashboard/components/dropdown/test/dropdown.js
+++ b/assets/src/dashboard/components/dropdown/test/dropdown.js
@@ -29,7 +29,7 @@ describe('Dropdown', () => {
   ];
   const onClickMock = jest.fn();
 
-  it('should render a <Dropdown /> by default', () => {
+  it('should render a <Dropdown /> button by default', () => {
     const { getByRole } = renderWithTheme(
       <Dropdown
         placeholder="placeholder text"
@@ -42,10 +42,6 @@ describe('Dropdown', () => {
     );
 
     const DropdownButton = getByRole('button');
-    const DropdownPopoverMenu = getByRole('list');
-
     expect(DropdownButton).toBeDefined();
-
-    expect(DropdownPopoverMenu).toBeDefined();
   });
 });

--- a/assets/src/dashboard/components/multiPartPill/index.js
+++ b/assets/src/dashboard/components/multiPartPill/index.js
@@ -33,7 +33,9 @@ const PillContainer = styled.div`
 const PillPart = styled.div`
   display: flex;
   align-items: center;
-
+  span {
+    border-bottom: none;
+  }
   &:nth-child(n + 2) {
     &:before {
       content: '';

--- a/assets/src/dashboard/components/popoverMenu/popover.js
+++ b/assets/src/dashboard/components/popoverMenu/popover.js
@@ -25,21 +25,22 @@ import { Z_INDEX } from '../../constants';
 
 const Popover = styled.div(
   ({ isOpen }) => `
-  opacity: 0; 
-  pointer-events: none;
-  background-color: transparent;
-  margin: 5px 0 0;
-  ${
-    isOpen &&
-    `
     position: absolute;
-    z-index: ${Z_INDEX.POPOVER_MENU};
-    opacity: 1;
-    pointer-events: auto;
+    display: none;
+    margin: 5px 0 0;
+    opacity: 0; 
+    background-color: transparent;
+    pointer-events: none;
+    ${
+      isOpen &&
+      `
+        display: block;
+        z-index: ${Z_INDEX.POPOVER_MENU};
+        opacity: 1;
+        pointer-events: auto;
+      `
+    }
   `
-  }
-
-`
 );
 
 Popover.propTypes = {

--- a/assets/src/dashboard/components/popoverMenu/popover.js
+++ b/assets/src/dashboard/components/popoverMenu/popover.js
@@ -23,14 +23,24 @@ import styled from 'styled-components';
  */
 import { Z_INDEX } from '../../constants';
 
-const Popover = styled.div`
-  position: absolute;
-  z-index: ${Z_INDEX.POPOVER_MENU};
-  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
-  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
+const Popover = styled.div(
+  ({ isOpen }) => `
+  opacity: 0; 
+  pointer-events: none;
   background-color: transparent;
   margin: 5px 0 0;
-`;
+  ${
+    isOpen &&
+    `
+    position: absolute;
+    z-index: ${Z_INDEX.POPOVER_MENU};
+    opacity: 1;
+    pointer-events: auto;
+  `
+  }
+
+`
+);
 
 Popover.propTypes = {
   className: PropTypes.string,

--- a/assets/src/dashboard/components/popoverMenu/popoverStandard.js
+++ b/assets/src/dashboard/components/popoverMenu/popoverStandard.js
@@ -25,7 +25,7 @@ import Shadow from './shadow';
 
 const PopoverStandard = ({ className, children, isOpen }) => {
   return (
-    <Popover isOpen={isOpen} className={className}>
+    <Popover isOpen={isOpen} className={className} data-testid="popover-menu">
       <Shadow />
       {children}
     </Popover>

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -94,12 +94,24 @@ export const STORY_SORT_MENU_ITEMS = [
     value: STORY_SORT_OPTIONS.CREATED_BY,
   },
 ];
+
 export const STORY_STATUS = {
   ALL: 'publish,draft',
   PUBLISHED: 'publish',
   DRAFT: 'draft',
-  TEMPLATE: 'template',
 };
+
+export const STORY_ITEM_CENTER_ACTION_LABELS = {
+  [STORY_STATUS.PUBLISHED]: __('View', 'web-stories'),
+  [STORY_STATUS.DRAFT]: __('Preview', 'web-stories'),
+};
+
+// export const STORY_STATUS = {
+//   ALL: 'publish,draft',
+//   PUBLISHED: 'publish',
+//   DRAFT: 'draft',
+//   TEMPLATE: 'template',
+// };
 
 export const STORY_STATUSES = [
   { label: __('All Stories', 'web-stories'), value: STORY_STATUS.ALL },

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -106,13 +106,6 @@ export const STORY_ITEM_CENTER_ACTION_LABELS = {
   [STORY_STATUS.DRAFT]: __('Preview', 'web-stories'),
 };
 
-// export const STORY_STATUS = {
-//   ALL: 'publish,draft',
-//   PUBLISHED: 'publish',
-//   DRAFT: 'draft',
-//   TEMPLATE: 'template',
-// };
-
 export const STORY_STATUSES = [
   { label: __('All Stories', 'web-stories'), value: STORY_STATUS.ALL },
   { label: __('Drafts', 'web-stories'), value: STORY_STATUS.DRAFT },

--- a/assets/src/dashboard/constants/templates.js
+++ b/assets/src/dashboard/constants/templates.js
@@ -138,7 +138,7 @@ export const TEMPLATE_COLOR_ITEMS = [
 ];
 
 export const TEMPLATES_GALLERY_STATUS = {
-  ALL: 'ALL',
+  ALL: 'template',
 };
 
 export const TEMPLATES_GALLERY_VIEWING_LABELS = {
@@ -159,3 +159,7 @@ export const TEMPLATES_GALLERY_SORT_MENU_ITEMS = [
     value: TEMPLATES_GALLERY_SORT_OPTIONS.RECENT,
   },
 ];
+
+export const TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS = {
+  template: __('View', 'web-stories'),
+};

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -23,10 +23,16 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import StoryPropTypes from '../edit-story/types';
+import { STORY_STATUS, TEMPLATES_GALLERY_STATUS } from './constants';
+
+export const DashboardStatusesPropType = PropTypes.oneOf([
+  ...Object.values(STORY_STATUS),
+  ...Object.values(TEMPLATES_GALLERY_STATUS),
+]);
 
 export const StoryPropType = PropTypes.shape({
   id: PropTypes.number.isRequired,
-  status: PropTypes.oneOf(['publish', 'draft', 'template']).isRequired,
+  status: DashboardStatusesPropType,
   title: PropTypes.string.isRequired,
   pages: PropTypes.arrayOf(StoryPropTypes.page),
   modified: PropTypes.object,


### PR DESCRIPTION
## Summary
Updates the button ui for primary and secondary types to new designs. Allows text displayed to be dynamic based on story/template status. 

## Relevant Technical Choices
- Added center label object constants based on story/template status to make label text dynamic.
- Found a bug with the popover menus on sorts where when collapsed it was still 'sorting' if you clicked around on the area where the menu shows up when it's open - so fixed that by adding display to control interaction while maintaining positioning of menu as a whole. 

## To-do
- need to fix up the constants files once my PR for #1505 is merged - did some organization there i don't want to conflict with. 

### Old Hover Buttons 
![Screen Shot 2020-05-13 at 11 27 20 AM](https://user-images.githubusercontent.com/10720454/81850384-c1b17480-950c-11ea-8dcc-681a9e138623.png)

### New Hover Buttons 
<img width="200" alt="Screen Shot 2020-05-13 at 4 52 46 PM" src="https://user-images.githubusercontent.com/10720454/81877553-3d75e600-953a-11ea-9936-c5cc3978e577.png">


### Designs 
![68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3565396463643961396666356466646166666364663133322f66356666633561342d613633642d346633662d623030352d346234356262356330623035](https://user-images.githubusercontent.com/10720454/81850523-f4f40380-950c-11ea-8134-5256d652e628.png)

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1524 
