### PR TITLE
Dashboard: Complete the Saved Templates UI to the currently spec’d out state

### DIFF
--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -93,7 +93,7 @@ function Content({ stories, view, page }) {
                 stories={stories}
                 centerActionLabel={__('View', 'web-stories')}
                 bottomActionLabel={__('Use template', 'web-stories')}
-                isTemplate
+                isSavedTemplate
               />
               <InfiniteScroller
                 allDataLoadedMessage={__('No more templates.', 'web-stories')}

--- a/assets/src/dashboard/app/views/shared/stories/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/storyGridView.js
@@ -45,6 +45,7 @@ export const _default = () => {
       trashStory={action('trashStory button clicked')}
       duplicateStory={action('duplicateStory button clicked')}
       isTemplate={boolean('isTemplate')}
+      isSavedTemplate={boolean('isSavedTemplate')}
     />
   );
 };

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -139,13 +139,13 @@ const StoryGridView = ({
             <DetailRow>
               <CardTitle
                 title={story.title}
-                status={story.status}
+                status={isSavedTemplate ? undefined : story.status}
                 secondaryTitle={
                   isSavedTemplate
                     ? __('Google', 'web-stories')
                     : users[story.author]?.name
                 }
-                displayDate={!isSavedTemplate && story.modified}
+                displayDate={isSavedTemplate ? undefined : story.modified}
                 editMode={titleRenameId === story.id}
                 onEditComplete={(newTitle) =>
                   handleOnRenameStory(story, newTitle)

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -139,13 +139,13 @@ const StoryGridView = ({
             <DetailRow>
               <CardTitle
                 title={story.title}
-                status={isSavedTemplate ? undefined : story.status}
+                status={story?.status}
                 secondaryTitle={
                   isSavedTemplate
                     ? __('Google', 'web-stories')
                     : users[story.author]?.name
                 }
-                displayDate={isSavedTemplate ? undefined : story.modified}
+                displayDate={story?.modified}
                 editMode={titleRenameId === story.id}
                 onEditComplete={(newTitle) =>
                   handleOnRenameStory(story, newTitle)

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -64,6 +64,7 @@ const StoryGridView = ({
   trashStory,
   duplicateStory,
   isTemplate,
+  isSavedTemplate,
 }) => {
   const [contextMenuId, setContextMenuId] = useState(-1);
   const [titleRenameId, setTitleRenameId] = useState(-1);
@@ -139,8 +140,12 @@ const StoryGridView = ({
               <CardTitle
                 title={story.title}
                 status={story.status}
-                author={users[story.author]?.name}
-                displayDate={story.modified}
+                secondaryTitle={
+                  isSavedTemplate
+                    ? __('Google', 'web-stories')
+                    : users[story.author]?.name
+                }
+                displayDate={!isSavedTemplate && story.modified}
                 editMode={titleRenameId === story.id}
                 onEditComplete={(newTitle) =>
                   handleOnRenameStory(story, newTitle)
@@ -163,6 +168,7 @@ const StoryGridView = ({
 
 StoryGridView.propTypes = {
   isTemplate: PropTypes.bool,
+  isSavedTemplate: PropTypes.bool,
   stories: StoriesPropType,
   users: UsersPropType,
   centerActionLabel: ActionLabel,

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -70,7 +70,7 @@ const DateHelperText = styled.span`
 `;
 
 const CardTitle = ({
-  author,
+  secondaryTitle,
   title,
   status,
   displayDate,
@@ -113,6 +113,9 @@ const CardTitle = ({
   );
 
   const displayDateText = useMemo(() => {
+    if (!displayDate) {
+      return null;
+    }
     return status === STORY_STATUS.PUBLISHED
       ? sprintf(
           /* translators: %s: last modified date */
@@ -146,17 +149,17 @@ const CardTitle = ({
         )}
         {displayDateText}
       </TitleBodyText>
-      {author && <TitleBodyText>{author}</TitleBodyText>}
+      {secondaryTitle && <TitleBodyText>{secondaryTitle}</TitleBodyText>}
     </StyledCardTitle>
   );
 };
 
 CardTitle.propTypes = {
   title: PropTypes.string.isRequired,
-  author: PropTypes.string,
+  secondaryTitle: PropTypes.string,
   status: PropTypes.oneOf(Object.values(STORY_STATUS)),
   editMode: PropTypes.bool,
-  displayDate: PropTypes.object.isRequired,
+  displayDate: PropTypes.object,
   onEditComplete: PropTypes.func.isRequired,
   onEditCancel: PropTypes.func.isRequired,
 };

--- a/assets/src/dashboard/components/cardGridItem/test/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/test/cardTitle.js
@@ -71,4 +71,18 @@ describe('CardTitle', () => {
 
     expect(getByText('draft')).toBeDefined();
   });
+
+  it('should render Card Title with an author', () => {
+    const { getByText } = renderWithTheme(
+      <CardTitle
+        title="Sample Story"
+        secondaryTitle="Harry Potter"
+        displayDate={moment('01/20/2020', 'MM/DD/YYYY')}
+        onEditCancel={jest.fn}
+        onEditComplete={jest.fn}
+      />
+    );
+
+    expect(getByText('Harry Potter')).toBeInTheDocument();
+  });
 });

--- a/assets/src/dashboard/components/cardGridItem/test/cartTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/test/cartTitle.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
  * Internal dependencies
  */
 import CardTitle from '../cardTitle';
@@ -26,7 +31,7 @@ describe('CardTitle', () => {
     const { getByText, queryByTestId } = renderWithTheme(
       <CardTitle
         title="Sample Story"
-        displayDate={new Date()}
+        displayDate={moment('01/20/2020', 'MM/DD/YYYY')}
         onEditCancel={jest.fn}
         onEditComplete={jest.fn}
         editMode={false}
@@ -41,7 +46,7 @@ describe('CardTitle', () => {
     const { getByTestId } = renderWithTheme(
       <CardTitle
         title="Sample Story"
-        displayDate="01/20/2020"
+        displayDate={moment('01/20/2020', 'MM/DD/YYYY')}
         onEditCancel={jest.fn}
         onEditComplete={jest.fn}
         editMode={true}
@@ -56,7 +61,7 @@ describe('CardTitle', () => {
     const { getByText } = renderWithTheme(
       <CardTitle
         title="Sample Story"
-        displayDate="4/30/2020"
+        displayDate={moment('04/23/2020', 'MM/DD/YYYY')}
         status={STORY_STATUS.DRAFT}
         onEditCancel={jest.fn}
         onEditComplete={jest.fn}

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -104,6 +104,7 @@ export const STORY_STATUS = {
   ALL: 'publish,draft',
   PUBLISHED: 'publish',
   DRAFT: 'draft',
+  TEMPLATE: 'template',
 };
 
 export const STORY_STATUSES = [

--- a/assets/src/dashboard/utils/getFormattedDisplayDate.js
+++ b/assets/src/dashboard/utils/getFormattedDisplayDate.js
@@ -26,20 +26,18 @@ import moment from 'moment';
 
 export function isToday(displayDate) {
   const today = moment().startOf('day');
-
-  return displayDate.isAfter(today);
+  return displayDate.isSame(today, 'd');
 }
 
 export function isYesterday(displayDate) {
-  const yesterday = moment().subtract(1, 'days').date();
-
-  return displayDate.date() === yesterday;
+  const yesterday = moment().subtract(1, 'days').startOf('day');
+  return displayDate.isSame(yesterday, 'd');
 }
 
 export default function getFormattedDisplayDate(date) {
   const displayDate = moment.isMoment(date) ? date : moment(date);
   if (isToday(displayDate)) {
-    return moment(displayDate).fromNow();
+    return displayDate.fromNow();
   } else if (isYesterday(displayDate)) {
     return __('yesterday', 'web-stories');
   }


### PR DESCRIPTION
Comp

<img width="1104" alt="Screen Shot 2020-05-13 at 2 18 11 PM" src="https://user-images.githubusercontent.com/1738349/81858173-e4518680-9528-11ea-9606-fa2cf86a239a.png">
<img width="447" alt="Screen Shot 2020-05-13 at 2 18 19 PM" src="https://user-images.githubusercontent.com/1738349/81858176-e4ea1d00-9528-11ea-8f3c-37e98b039c46.png">

## Relevant Technical Choices

Since Saved Templates will a huge amount of overlap between stories,  we introduce another prop to toggle the view. Both will have rename, duplication, delete.

Adjust the last of the date formatter tests to use a secondary format param to drop the deprecation warning.

Closes #1502 
