### PR TITLE
Dashboard: Navigation Hover Styles 

### DIFF
--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -29,8 +29,9 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { clamp, throttleToAnimationFrame } from '../../utils';
+import theme from '../../theme';
 
-export const SQUISH_LENGTH = 90;
+export const SQUISH_LENGTH = theme.pageStructure.initialTopMargin;
 export const SQUISH_CSS_VAR = '--squish-progress';
 
 export const dispatchSquishEvent = (el, progress) => {

--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -28,10 +28,10 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import { DASHBOARD_TOP_MARGIN } from '../../constants/pageStructure';
 import { clamp, throttleToAnimationFrame } from '../../utils';
-import theme from '../../theme';
 
-export const SQUISH_LENGTH = theme.pageStructure.initialTopMargin;
+export const SQUISH_LENGTH = DASHBOARD_TOP_MARGIN;
 export const SQUISH_CSS_VAR = '--squish-progress';
 
 export const dispatchSquishEvent = (el, progress) => {

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -29,7 +29,6 @@ import { useCallback, useRef } from 'react';
 /**
  * Internal dependencies
  */
-import Button from '../button';
 import { resolveRoute, useRouteHistory } from '../../app/router';
 import { useConfig } from '../../app/config';
 import { DASHBOARD_LEFT_NAV_WIDTH } from '../../constants/pageStructure';
@@ -49,6 +48,7 @@ import {
   LogoPlaceholder,
   NavLink,
   Rule,
+  NavButton,
 } from './navigationComponents';
 
 export const AppFrame = styled.div`
@@ -83,7 +83,7 @@ export const LeftRailContainer = styled.nav.attrs({
   bottom: 0;
   width: ${DASHBOARD_LEFT_NAV_WIDTH}px;
   background: ${({ theme }) => theme.colors.white};
-  border-right: ${({ theme }) => theme.leftRail.border};
+  border-right: ${({ theme }) => theme.borders.gray50};
   z-index: ${Z_INDEX.LAYOUT_FIXED};
   transition: transform 0.25s ${BEZIER.outCubic}, visibility 0.25s linear;
 
@@ -135,9 +135,9 @@ export function LeftRail() {
       <div ref={upperContentRef}>
         <LogoPlaceholder />
         <Content>
-          <Button type={BUTTON_TYPES.CTA} href={newStoryURL} isLink>
+          <NavButton type={BUTTON_TYPES.CTA} href={newStoryURL} isLink>
             {__('Create New Story', 'web-stories')}
-          </Button>
+          </NavButton>
         </Content>
         <Content>
           {primaryPaths.map((path) => (
@@ -165,7 +165,7 @@ export function LeftRail() {
       </div>
       <Content>
         <AppInfo>
-          {__('\u00A9 Google 2020', 'web-stories')}
+          {__('\u00A9 2020 Google', 'web-stories')}
           <br />
           {__('Version', 'web-stories')}&nbsp;
           {version}

--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -19,50 +19,71 @@
  */
 import styled from 'styled-components';
 
+/**
+ * Internal dependencies
+ */
+import Button from '../button';
+
 export const Content = styled.div`
   display: flex;
   flex-direction: column;
-  padding: ${({ theme }) => theme.leftRail.contentPadding}px;
-`;
-
-export const NavLink = styled.a`
-  margin: 0 0 20px ${({ theme }) => theme.leftRail.inset}px;
-  font-family: ${({ theme }) => theme.fonts.tab.family};
-  font-size: ${({ theme }) => theme.fonts.tab.size}px;
-  font-weight: ${({ active }) => (active ? '500' : 'normal')};
-  line-height: ${({ theme }) => theme.fonts.tab.lineHeight}px;
-  letter-spacing: ${({ theme }) => theme.fonts.tab.letterSpacing}em;
-  text-decoration: none;
-  color: ${({ theme, active }) =>
-    active ? theme.colors.gray900 : theme.colors.gray600};
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-
-  @media ${({ theme }) => theme.breakpoint.min} {
-    font-size: ${({ theme }) => theme.fonts.tab.minSize}px;
+  margin: 20px 0;
+  > * {
+    margin: 20px;
   }
 `;
 
-export const Rule = styled.div`
-  height: 1px;
-  margin-left: ${({ theme }) =>
-    theme.leftRail.contentPadding + theme.leftRail.inset}px;
-  background-color: ${({ theme }) => theme.colors.gray50};
+export const NavButton = styled(Button)`
+  margin-bottom: 0;
 `;
 
-export const AppInfo = styled.div`
-  margin-left: ${({ theme }) => theme.leftRail.inset}px;
-  color: ${({ theme }) => theme.colors.gray500};
-  font-family: ${({ theme }) => theme.fonts.smallLabel.family};
-  font-size: ${({ theme }) => theme.fonts.smallLabel.size}px;
-  letter-spacing: ${({ theme }) => theme.fonts.smallLabel.letterSpacing};
-`;
+export const NavLink = styled.a(
+  ({ theme, active }) => `
+    padding: 4px 20px;
+    margin: 4px 0;
+    font-family: ${theme.fonts.tab.family};
+    font-size: ${theme.fonts.tab.size}px;
+    font-weight: ${active ? '500' : 'normal'};
+    line-height: ${theme.fonts.tab.lineHeight}px;
+    letter-spacing: ${theme.fonts.tab.letterSpacing}em;
+    text-decoration: none;
+    color: ${active ? theme.colors.gray900 : theme.colors.gray600};
 
-export const LogoPlaceholder = styled.div`
-  height: 40px;
-  width: 145px;
-  margin: ${({ theme }) => theme.leftRail.logoMargin};
-  background-color: ${({ theme }) => theme.colors.gray100};
-`;
+    &:focus {
+      color: ${active ? theme.colors.gray900 : theme.colors.gray600};
+    }
+    &:hover {
+      color: ${active ? theme.colors.gray900 : theme.colors.gray600};
+      background-color: ${theme.colors.gray50};
+    }
+    @media ${theme.breakpoint.min} {
+      font-size: ${theme.fonts.tab.minSize}px;
+    }
+  `
+);
+
+export const Rule = styled.div(
+  ({ theme }) => `
+    height: 1px;
+    margin-left: 20px;
+    background-color: ${theme.colors.gray50};
+  `
+);
+
+export const AppInfo = styled.div(
+  ({ theme }) => `
+    color: ${theme.colors.gray500};
+    font-family: ${theme.fonts.smallLabel.family};
+    font-size: ${theme.fonts.smallLabel.size}px;
+    letter-spacing: ${theme.fonts.smallLabel.letterSpacing};
+  `
+);
+
+export const LogoPlaceholder = styled.div(
+  ({ theme }) => `
+    height: 40px;
+    width: 145px;
+    margin: ${theme.leftRail.logoMargin};
+    background-color: ${theme.colors.gray100};
+  `
+);

--- a/assets/src/dashboard/constants/pageStructure.js
+++ b/assets/src/dashboard/constants/pageStructure.js
@@ -24,3 +24,4 @@ export const PAGE_RATIO = PAGE_WIDTH / PAGE_HEIGHT;
 export const WP_LEFT_NAV_WIDTH = 38;
 export const DASHBOARD_LEFT_NAV_WIDTH = 190;
 export const VIEWPORT_WP_LEFT_NAV_HIDES = 783;
+export const DASHBOARD_TOP_MARGIN = 45;

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -108,9 +108,6 @@ const theme = {
   leftRail: {
     logoMargin: '75px auto 20px',
   },
-  pageStructure: {
-    initialTopMargin: 45,
-  },
   text: {
     shadow: '0px 1px 1px rgba(0, 0, 0, 1)',
   },

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -106,10 +106,10 @@ const theme = {
     },
   },
   leftRail: {
-    border: borders.gray50,
-    contentPadding: 20,
-    inset: 8,
     logoMargin: '75px auto 20px',
+  },
+  pageStructure: {
+    initialTopMargin: 45,
   },
   text: {
     shadow: '0px 1px 1px rgba(0, 0, 0, 1)',


### PR DESCRIPTION
## Summary
Gives hover background color to dashboard left nav. Updates copyright from `Google 2020` to `2020 Google` per designs. 

## Relevant Technical Choices
- To get the background color across the entire width of the nav I had to adjust the nav's spacing from using margin on the container to applying margin to children so that links can remove it and opt for padding. 
- Tweaks to the top margin for the header to get it more lined up with the nav/higher up on load to take up less space. I think this is going to take some finesse after we get text or a logo in that left hand corer. 
- Moved space values from theme to nav for leftNav, I think it makes more sense in the component. It's not getting reused and this way it's clear what's going on as margin and padding get flipped for the links. 

### Designs 
![Screen Shot 2020-05-13 at 3 01 01 PM](https://user-images.githubusercontent.com/10720454/81878013-985c0d00-953b-11ea-8d7d-329bb2fc8e3c.png)

### Updates 
![nav hover](https://user-images.githubusercontent.com/10720454/81877977-78c4e480-953b-11ea-9f13-e65e0665011f.gif)

## To Do
- [ ] I want to understand how to use the keyboard specific class better to eliminate that blue focus on buttons unless the keyboard's in use. I will do that separately after higher priority things are done. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1486 
