### PR TITLE
Increase timeout for visual regression test

### DIFF
--- a/assets/src/edit-story/components/panels/layer/test/layer.js
+++ b/assets/src/edit-story/components/panels/layer/test/layer.js
@@ -88,6 +88,6 @@ describe('Layer', () => {
         failureThreshold: 0.01,
         failureThresholdType: 'percent',
       });
-    });
+    }, 10000);
   });
 });


### PR DESCRIPTION
Increasing the default timeout for this test seems only fair as it does a lot more (i.e. start the browser).