### PR TITLE
#1516 Dashboard: Template Detail Pagination

### DIFF
--- a/assets/src/dashboard/app/views/templates/components.js
+++ b/assets/src/dashboard/app/views/templates/components.js
@@ -137,6 +137,10 @@ export const NavButton = styled(Button)`
     &:hover, &:active, &:focus {
       background-color: ${theme.colors.gray600};
       color: ${theme.colors.white};
+      @media ${theme.breakpoint.largeDisplayPhone} {
+        color: ${theme.colors.gray900};
+        background-color: transparent;
+       }
     }
     transition: background-color 300ms ease-in-out, color 300ms ease-in-out;
   `}
@@ -175,12 +179,6 @@ export const SmallDisplayPagination = styled.div(
       display: flex;
       justify-content: flex-start;
       margin: 0 0 10px;
-      > ${NavButton} {
-        &:hover, &:active, &:focus {
-          color: ${theme.colors.gray900};
-          background-color: transparent;
-         }
-      }
     }
   `
 );

--- a/assets/src/dashboard/app/views/templates/components.js
+++ b/assets/src/dashboard/app/views/templates/components.js
@@ -127,14 +127,18 @@ export const NavButton = styled(Button)`
     display: block;
     align-self: center;
     min-width: 0;
-    height: 40%;
-    color: ${theme.colors.gray900};
+    height: 40px;
+    width: 40px;
+    border-radius: 50%;
+    color: ${theme.colors.gray600};
     background-color: transparent;
-    border: none;
+    border: ${theme.borders.transparent};
 
     &:hover, &:active, &:focus {
-      color: ${theme.colors.bluePrimary};
+      background-color: ${theme.colors.gray600};
+      color: ${theme.colors.white};
     }
+    transition: background-color 300ms ease-in-out, color 300ms ease-in-out;
   `}
 `;
 

--- a/assets/src/dashboard/app/views/templates/components.js
+++ b/assets/src/dashboard/app/views/templates/components.js
@@ -133,6 +133,7 @@ export const NavButton = styled(Button)`
     color: ${theme.colors.gray600};
     background-color: transparent;
     border: ${theme.borders.transparent};
+    transition: background-color 300ms ease-in-out, color 300ms ease-in-out;
 
     &:hover, &:active, &:focus {
       background-color: ${theme.colors.gray600};
@@ -142,7 +143,6 @@ export const NavButton = styled(Button)`
         background-color: transparent;
        }
     }
-    transition: background-color 300ms ease-in-out, color 300ms ease-in-out;
   `}
 `;
 

--- a/assets/src/dashboard/app/views/templates/components.js
+++ b/assets/src/dashboard/app/views/templates/components.js
@@ -157,3 +157,30 @@ export const SubHeading = styled.h2`
   font-weight: 500;
   margin: 0 0 20px 0;
 `;
+
+export const LargeDisplayPagination = styled.div(
+  ({ theme }) => `
+    display: flex;
+    @media ${theme.breakpoint.largeDisplayPhone} {
+      display: none;
+    }
+  `
+);
+
+export const SmallDisplayPagination = styled.div(
+  ({ theme }) => `
+    display: none;
+    @media ${theme.breakpoint.largeDisplayPhone} {
+      width: 100%;
+      display: flex;
+      justify-content: flex-start;
+      margin: 0 0 10px;
+      > ${NavButton} {
+        &:hover, &:active, &:focus {
+          color: ${theme.colors.gray900};
+          background-color: transparent;
+         }
+      }
+    }
+  `
+);

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -44,7 +44,10 @@ import {
   TemplateNavBar,
   Layout,
 } from '../../../components';
-import { ICON_METRICS } from '../../../constants';
+import {
+  ICON_METRICS,
+  TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS,
+} from '../../../constants';
 import { clamp, usePagePreviewSize } from '../../../utils/';
 import { StoryGridView } from '../shared';
 
@@ -245,7 +248,9 @@ function TemplateDetail() {
                     <UnitsProvider pageSize={pageSize}>
                       <StoryGridView
                         stories={relatedTemplates}
-                        centerActionLabel={__('View', 'web-stories')}
+                        centerActionLabelByStatus={
+                          TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS
+                        }
                         bottomActionLabel={__('Use template', 'web-stories')}
                         isTemplate
                       />

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -168,7 +168,7 @@ function TemplateDetail() {
         onClick={() => switchToTemplateByOffset(-1)}
         disabled={!orderedTemplates?.length || activeTemplateIndex === 0}
       >
-        <LeftArrow {...ICON_METRICS.LEFT_RIGHT_ARROW} />
+        <LeftArrow {...ICON_METRICS.LEFT_RIGHT_ARROW} aria-hidden={true} />
       </NavButton>
     );
 
@@ -181,7 +181,7 @@ function TemplateDetail() {
           activeTemplateIndex === orderedTemplates.length - 1
         }
       >
-        <RightArrow {...ICON_METRICS.LEFT_RIGHT_ARROW} />
+        <RightArrow {...ICON_METRICS.LEFT_RIGHT_ARROW} aria-hidden={true} />
       </NavButton>
     );
 

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -57,9 +57,11 @@ import {
   ColumnContainer,
   Column,
   DetailContainer,
+  LargeDisplayPagination,
   MetadataContainer,
   NavButton,
   RowContainer,
+  SmallDisplayPagination,
   SubHeading,
   Text,
   Title,
@@ -210,9 +212,15 @@ function TemplateDetail() {
             </Layout.Fixed>
             <Layout.Scrollable>
               <ContentContainer>
+                <SmallDisplayPagination>
+                  {PrevButton}
+                  {NextButton}
+                </SmallDisplayPagination>
                 <ColumnContainer>
                   <Column>
-                    {PrevButton}
+                    <LargeDisplayPagination>
+                      {PrevButton}
+                    </LargeDisplayPagination>
                     <CardGallery>{previewPages}</CardGallery>
                   </Column>
                   <Column>
@@ -237,7 +245,9 @@ function TemplateDetail() {
                         <ColorList colors={template.colors} size={30} />
                       </MetadataContainer>
                     </DetailContainer>
-                    {NextButton}
+                    <LargeDisplayPagination>
+                      {NextButton}
+                    </LargeDisplayPagination>
                   </Column>
                 </ColumnContainer>
                 {relatedTemplates.length > 0 && (

--- a/assets/src/dashboard/components/bookmark-chip/index.js
+++ b/assets/src/dashboard/components/bookmark-chip/index.js
@@ -29,17 +29,17 @@ import { ReactComponent as BookmarkOutline } from '../../icons/bookmark-outline.
 
 const chipSize = {
   [CHIP_TYPES.STANDARD]: {
-    container: '40px',
+    container: '28px',
     icon: {
-      height: '18px',
-      width: '14px',
+      height: '16px',
+      width: '12px',
     },
   },
   [CHIP_TYPES.SMALL]: {
-    container: '32px',
+    container: '20px',
     icon: {
-      height: '14px',
-      width: '10px',
+      height: '12px',
+      width: '8px',
     },
   },
 };
@@ -53,6 +53,7 @@ const ChipContainer = styled.button`
   color: ${({ theme }) => theme.colors.gray500};
   cursor: pointer;
   display: flex;
+  padding: 5px;
   height: ${({ chipType }) => chipSize[chipType].container};
   width: ${({ chipType }) => chipSize[chipType].container};
 

--- a/assets/src/dashboard/components/templateNavBar/index.js
+++ b/assets/src/dashboard/components/templateNavBar/index.js
@@ -56,10 +56,6 @@ const Nav = styled.nav`
   `}
 `;
 
-const ActionLink = styled(Button)`
-  padding: 0 24px;
-`;
-
 const Container = styled.div`
   display: flex;
   align-items: center;
@@ -89,9 +85,9 @@ export function TemplateNavBar() {
       </Container>
       <Container>
         <BookmarkToggle />
-        <ActionLink type={BUTTON_TYPES.CTA} href={'#'} isLink={true}>
+        <Button type={BUTTON_TYPES.CTA} href={'#'} isLink={true}>
           {__('USE TEMPLATE', 'web-stories')}
-        </ActionLink>
+        </Button>
       </Container>
     </Nav>
   );


### PR DESCRIPTION
## Summary
Add hover on pagination of detail template view to match designs. 
Add separation of pagination for view that's stacked vs split.

## Relevant Technical Choices
- Separating out the navigation elements with media queries to show/hide them when the flow stacks instead of having the arrows one on left top and other on bottom right. 
- Fix detail template grid view that needed an updated prop that was forgotten 
- Set aria-hidden to svgs inside button
- Please note that I only considered down to a standard iPad view since smaller viewports are not at this time being focused on. 

![Screen Shot 2020-05-14 at 10 25 58 AM](https://user-images.githubusercontent.com/10720454/81966942-11587480-95cf-11ea-8c8d-a2d02d0abe74.png)
![hover pagination](https://user-images.githubusercontent.com/10720454/81967183-67c5b300-95cf-11ea-8566-4c04a8517dee.gif)


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1516 
