### PR TITLE
[TASK] Foundation for interpreting story animations schema

### DIFF
--- a/assets/src/dashboard/animations/animationParts/bounce/index.js
+++ b/assets/src/dashboard/animations/animationParts/bounce/index.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useRef, useEffect } from 'react';
+/**
+ * Internal dependencies
+ */
+import FullSizeAbsolute from '../fullSizeAbsolute';
+import { WAAPIAnimationProps } from '../types';
+
+const keyframes = {
+  transform: [
+    'scale(0)',
+    'scale(1.27)',
+    'scale(0.84)',
+    'scale(0.84)',
+    'scale(1.1)',
+    'scale(1.1)',
+    'scale(0.95)',
+    'scale(0.95)',
+    'scale(1.03)',
+    'scale(1.03)',
+    'scale(0.98)',
+    'scale(0.98)',
+    'scale(1.02)',
+    'scale(1.02)',
+    'scale(0.99)',
+    'scale(0.99)',
+    'scale(1)',
+  ],
+  offset: [
+    0.0,
+    0.18,
+    0.28,
+    0.29,
+    0.4,
+    0.41,
+    0.52,
+    0.53,
+    0.6,
+    0.61,
+    0.7,
+    0.71,
+    0.8,
+    0.81,
+    0.9,
+    0.91,
+    1.0,
+  ],
+};
+
+const defaults = {
+  fill: 'forwards',
+  duration: 1500,
+};
+
+export function WAAPIBounce(args) {
+  const timings = {
+    ...defaults,
+    ...args,
+  };
+
+  const WAAPIAnimation = function ({ children, hoistAnimation }) {
+    const target = useRef(null);
+
+    useEffect(() => {
+      if (!target.current) {
+        return () => {};
+      }
+      const effect = new KeyframeEffect(target.current, keyframes, timings);
+      return hoistAnimation(new Animation(effect, document.timeline));
+    }, [hoistAnimation]);
+
+    return <FullSizeAbsolute ref={target}>{children}</FullSizeAbsolute>;
+  };
+  WAAPIAnimation.propTypes = WAAPIAnimationProps;
+  return WAAPIAnimation;
+}

--- a/assets/src/dashboard/animations/animationParts/fullSizeAbsolute.js
+++ b/assets/src/dashboard/animations/animationParts/fullSizeAbsolute.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+export default styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+`;

--- a/assets/src/dashboard/animations/animationParts/index.js
+++ b/assets/src/dashboard/animations/animationParts/index.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { ANIMATION_TYPES } from '../constants';
+import { WAAPIBounce } from './bounce';
+
+function throughput() {
+  return ({ children }) => children;
+}
+
+export function WAAPI(type, args) {
+  const generator =
+    {
+      [ANIMATION_TYPES.BOUNCE]: WAAPIBounce,
+    }[type] || throughput;
+
+  return generator(args);
+}

--- a/assets/src/dashboard/animations/animationParts/test/index.js
+++ b/assets/src/dashboard/animations/animationParts/test/index.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { ANIMATION_TYPES } from '../../constants';
+import { WAAPI } from '..';
+
+describe('WAAPI', () => {
+  /**
+   * These aren't defined in jsdom so
+   * can't mock. So instead just adding
+   * them to the window and restoring
+   * incase they ever get support.
+   */
+  let KeyframeEffectTmp;
+  let AnimationTmp;
+  beforeEach(() => {
+    KeyframeEffectTmp = window.KeyframeEffect;
+    window.KeyframeEffect = function () {
+      return {};
+    };
+    AnimationTmp = window.Animation;
+    window.Animation = function () {
+      return {};
+    };
+  });
+  afterEach(() => {
+    window.KeyframeEffect = KeyframeEffectTmp;
+    window.Animation = AnimationTmp;
+  });
+
+  /**
+   * Ensures every animation type resolves
+   * to a react component as new animations
+   * are created
+   */
+  it.each(Object.keys(ANIMATION_TYPES))(
+    'type: %s returns a react component',
+    (type) => {
+      const args = {};
+      const WAAPIWrapper = WAAPI(type, args);
+      const { getByTestId } = render(
+        <WAAPIWrapper hoistAnimation={() => {}}>
+          <div data-testid="child-rendered" />
+        </WAAPIWrapper>
+      );
+      expect(getByTestId('child-rendered')).toBeDefined();
+    }
+  );
+});

--- a/assets/src/dashboard/animations/animationParts/types.js
+++ b/assets/src/dashboard/animations/animationParts/types.js
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+export const WAAPIAnimationProps = {
+  children: PropTypes.node.isRequired,
+  hoistAnimation: PropTypes.func,
+};

--- a/assets/src/dashboard/components/storyAnimation/WAAPIWrapper.js
+++ b/assets/src/dashboard/components/storyAnimation/WAAPIWrapper.js
@@ -40,7 +40,7 @@ function ComposableWrapper({ generators, hoistAnimation, children }) {
               </Composable>
             );
           };
-          Composed.propTypes = { children: PropTypes.children };
+          Composed.propTypes = { children: PropTypes.node };
           return Composed;
         },
         (props) => props.children

--- a/assets/src/dashboard/components/storyAnimation/WAAPIWrapper.js
+++ b/assets/src/dashboard/components/storyAnimation/WAAPIWrapper.js
@@ -53,7 +53,7 @@ function ComposableWrapper({ generators, hoistAnimation, children }) {
 ComposableWrapper.propTypes = {
   children: PropTypes.node.isRequired,
   generators: PropTypes.arrayOf(PropTypes.func),
-  hoistAnimation: PropTypes.func,
+  hoistAnimation: PropTypes.func.isRequired,
 };
 
 function WAAPIWrapper({ children, target }) {

--- a/assets/src/dashboard/components/storyAnimation/WAAPIWrapper.js
+++ b/assets/src/dashboard/components/storyAnimation/WAAPIWrapper.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+import PropTypes from 'prop-types';
+/**
+ * Internal dependencies
+ */
+import { WAAPI } from '../../animations/animationParts';
+import useStoryAnimationContext from './useStoryAnimationContext';
+
+function ComposableWrapper({ generators, hoistAnimation, children }) {
+  const ComposedWrapper = useMemo(
+    () =>
+      generators.reduce(
+        (Composable, generate) => {
+          // eslint-disable-next-line @wordpress/no-unused-vars-before-return
+          const WAAPIAnimation = generate(WAAPI);
+          const Composed = function (props) {
+            return (
+              <Composable>
+                <WAAPIAnimation hoistAnimation={hoistAnimation}>
+                  {props.children}
+                </WAAPIAnimation>
+              </Composable>
+            );
+          };
+          Composed.propTypes = { children: PropTypes.children };
+          return Composed;
+        },
+        (props) => props.children
+      ),
+    [generators, hoistAnimation]
+  );
+
+  return <ComposedWrapper>{children}</ComposedWrapper>;
+}
+ComposableWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  generators: PropTypes.arrayOf(PropTypes.func),
+  hoistAnimation: PropTypes.func,
+};
+
+function WAAPIWrapper({ children, target }) {
+  const {
+    state: { getAnimationGenerators },
+    actions: { hoistWAAPIAnimation },
+  } = useStoryAnimationContext();
+
+  return (
+    <ComposableWrapper
+      generators={getAnimationGenerators(target)}
+      hoistAnimation={hoistWAAPIAnimation}
+    >
+      {children}
+    </ComposableWrapper>
+  );
+}
+WAAPIWrapper.propTypes = {
+  children: PropTypes.node,
+  target: PropTypes.string,
+};
+
+export default WAAPIWrapper;

--- a/assets/src/dashboard/components/storyAnimation/index.js
+++ b/assets/src/dashboard/components/storyAnimation/index.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import Provider from './provider';
+import WAAPIWrapper from './WAAPIWrapper';
+
+const StoryAnimation = {
+  Provider,
+  WAAPIWrapper,
+};
+
+export default StoryAnimation;
+export { default as useStoryAnimationContext } from './useStoryAnimationContext';

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -106,17 +106,21 @@ function Provider(props) {
    * animations complete.
    */
   useEffect(() => {
+    // WAAPIAnimations.forEach((animation) => {
+    //   // createOnFinishPromise
+    //   animation.onfinish = onWAAPIFinishRef.current;
+    // });
     let cancel = () => {};
     if ('idle' === WAAPIAnimationState && WAAPIAnimations.length) {
-      const cancelablePromise = new Promise((resolve, reject) => {
+      new Promise((resolve, reject) => {
         cancel = reject;
         Promise.all(WAAPIAnimations.map(createOnFinishPromise)).then(() => {
           cancel = () => {};
           resolve();
         });
-      });
-      cancelablePromise
+      })
         .then(() => dispatchWAAPIAnimationState('complete'))
+        /* needed if promise gets canceled to swallow the error */
         .catch(() => {});
     }
     return cancel;
@@ -125,7 +129,7 @@ function Provider(props) {
   onWAAPIFinishRef.current = props.onWAAPIFinish;
   useEffect(() => {
     if ('complete' === WAAPIAnimationState) {
-      onWAAPIFinishRef.current();
+      onWAAPIFinishRef.current?.();
       dispatchWAAPIAnimationState('reset');
     }
   }, [WAAPIAnimationState]);

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -39,7 +39,7 @@ const WAAPIAnimationMachine = {
 };
 
 const WAAPIAnimationStateReducer = (state, action) => {
-  return WAAPIAnimationMachine[(state, action)] || state;
+  return WAAPIAnimationMachine[state][action] || state;
 };
 
 const createOnFinishPromise = (animation) => {
@@ -107,7 +107,7 @@ function Provider(props) {
    */
   useEffect(() => {
     let cancel = () => {};
-    if (['idle'].includes(WAAPIAnimationState)) {
+    if (['idle'].includes(WAAPIAnimationState) && WAAPIAnimations.length) {
       const cancelablePromise = new Promise((resolve, reject) => {
         cancel = reject;
         Promise.all(WAAPIAnimations.map(createOnFinishPromise)).then(() => {
@@ -116,9 +116,7 @@ function Provider(props) {
         });
       });
       cancelablePromise
-        .then(() => {
-          dispatchWAAPIAnimationState('complete');
-        })
+        .then(() => dispatchWAAPIAnimationState('complete'))
         .catch(() => {});
     }
     return cancel;

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -50,10 +50,10 @@ const createOnFinishPromise = (animation) => {
 
 function Provider(props) {
   const animationGeneratorMap = useMemo(() => {
-    return props.animations.reduce((map, animation) => {
-      const { target: targets, type, ...args } = animation;
+    return (props.animations || []).reduce((map, animation) => {
+      const { target, type, ...args } = animation;
 
-      targets.forEach((t) => {
+      (Array.isArray(target) ? target : [target]).forEach((t) => {
         const animationGenerators = map.get(t) || [];
         map.set(t, [...animationGenerators, (fn) => fn(type, args)]);
       });
@@ -107,7 +107,7 @@ function Provider(props) {
    */
   useEffect(() => {
     let cancel = () => {};
-    if (['idle'].includes(WAAPIAnimationState) && WAAPIAnimations.length) {
+    if ('idle' === WAAPIAnimationState && WAAPIAnimations.length) {
       const cancelablePromise = new Promise((resolve, reject) => {
         cancel = reject;
         Promise.all(WAAPIAnimations.map(createOnFinishPromise)).then(() => {
@@ -124,7 +124,7 @@ function Provider(props) {
 
   onWAAPIFinishRef.current = props.onWAAPIFinish;
   useEffect(() => {
-    if (['complete'].includes(WAAPIAnimationState)) {
+    if ('complete' === WAAPIAnimationState) {
       onWAAPIFinishRef.current();
       dispatchWAAPIAnimationState('reset');
     }

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -147,7 +147,7 @@ function Provider(props) {
 }
 
 Provider.propTypes = {
-  animations: PropTypes.object.isRequired,
+  animations: PropTypes.arrayOf(PropTypes.object).isRequired,
   children: PropTypes.node.isRequired,
   onWAAPIFinish: PropTypes.func,
 };

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useReducer,
+  useRef,
+} from 'react';
+import PropTypes from 'prop-types';
+
+const Context = createContext(null);
+
+const WAAPIAnimationMachine = {
+  idle: {
+    complete: 'complete',
+  },
+  complete: {
+    reset: 'idle',
+  },
+};
+
+const WAAPIAnimationStateReducer = (state, action) => {
+  return WAAPIAnimationMachine[(state, action)] || state;
+};
+
+const createOnFinishPromise = (animation) => {
+  return new Promise((resolve) => {
+    animation.onfinish = resolve;
+  });
+};
+
+function Provider(props) {
+  const animationGeneratorMap = useMemo(() => {
+    return props.animations.reduce((map, animation) => {
+      const { target: targets, type, ...args } = animation;
+
+      targets.forEach((t) => {
+        const animationGenerators = map.get(t) || [];
+        map.set(t, [...animationGenerators, (fn) => fn(type, args)]);
+      });
+
+      return map;
+    }, new Map());
+  }, [props.animations]);
+
+  const getAnimationGenerators = useCallback(
+    (target) => {
+      return animationGeneratorMap.get(target) || [];
+    },
+    [animationGeneratorMap]
+  );
+
+  /**
+   * WAAPI interface
+   */
+  const onWAAPIFinishRef = useRef(props.onWAAPIFinish);
+  const [WAAPIAnimationState, dispatchWAAPIAnimationState] = useReducer(
+    WAAPIAnimationStateReducer,
+    'idle'
+  );
+  const WAAPIAnimationMap = useMemo(() => new Map(), []);
+  const [WAAPIAnimations, setWAAPIAnimations] = useState([]);
+
+  const hoistWAAPIAnimation = useCallback(
+    (WAPPIAnimation) => {
+      const symbol = Symbol();
+      WAAPIAnimationMap.set(symbol, WAPPIAnimation);
+      setWAAPIAnimations(Array.from(WAAPIAnimationMap.values()));
+      return () => {
+        WAPPIAnimation?.cancel();
+        WAAPIAnimationMap.delete(symbol);
+        setWAAPIAnimations(Array.from(WAAPIAnimationMap.values()));
+      };
+    },
+    [WAAPIAnimationMap]
+  );
+
+  const playWAAPIAnimations = useCallback(() => {
+    WAAPIAnimations.forEach((animation) => animation?.play());
+  }, [WAAPIAnimations]);
+
+  /**
+   * Browser support for `animation.finished` is no good.
+   * https://developer.mozilla.org/en-US/docs/Web/API/Animation/finished
+   *
+   * So we're mimicking the spec by creating a new promise everytime all
+   * animations complete.
+   */
+  useEffect(() => {
+    let cancel = () => {};
+    if (['idle'].includes(WAAPIAnimationState)) {
+      const cancelablePromise = new Promise((resolve, reject) => {
+        cancel = reject;
+        Promise.all(WAAPIAnimations.map(createOnFinishPromise)).then(() => {
+          cancel = () => {};
+          resolve();
+        });
+      });
+      cancelablePromise
+        .then(() => {
+          dispatchWAAPIAnimationState('complete');
+        })
+        .catch(() => {});
+    }
+    return cancel;
+  }, [WAAPIAnimations, WAAPIAnimationState]);
+
+  onWAAPIFinishRef.current = props.onWAAPIFinish;
+  useEffect(() => {
+    if (['complete'].includes(WAAPIAnimationState)) {
+      onWAAPIFinishRef.current();
+      dispatchWAAPIAnimationState('reset');
+    }
+  }, [WAAPIAnimationState]);
+
+  const value = useMemo(
+    () => ({
+      state: {
+        getAnimationGenerators,
+      },
+      actions: {
+        hoistWAAPIAnimation,
+        playWAAPIAnimations,
+      },
+    }),
+    [getAnimationGenerators, hoistWAAPIAnimation, playWAAPIAnimations]
+  );
+
+  return <Context.Provider value={value}>{props.children}</Context.Provider>;
+}
+
+Provider.propTypes = {
+  animations: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
+  onWAAPIFinish: PropTypes.func,
+};
+
+export default Provider;
+export { Context as StoryAnimationContext };

--- a/assets/src/dashboard/components/storyAnimation/stories/index.js
+++ b/assets/src/dashboard/components/storyAnimation/stories/index.js
@@ -16,6 +16,7 @@
 /**
  * External dependencies
  */
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 /**
  * Internal dependencies
@@ -36,7 +37,7 @@ const PlayButton = () => {
   return <button onClick={playWAAPIAnimations}>{label}</button>;
 };
 
-function TomatoSquare() {
+function ColorSquare({ color }) {
   return (
     <div
       style={{
@@ -45,11 +46,14 @@ function TomatoSquare() {
         right: 0,
         bottom: 0,
         left: 0,
-        backgroundColor: 'tomato',
+        backgroundColor: color,
       }}
     />
   );
 }
+ColorSquare.propTypes = {
+  color: PropTypes.string,
+};
 
 function SquareWrapper({ children }) {
   return (
@@ -71,12 +75,18 @@ SquareWrapper.propTypes = {
 
 const animations = [{ target: ['some-id'], type: 'bounce' }];
 export function _default() {
+  const [state, setState] = useState(0);
   return (
-    <StoryAnimation.Provider animations={animations}>
+    <StoryAnimation.Provider
+      animations={animations}
+      onWAAPIFinish={() => {
+        setState((v) => v + 1);
+      }}
+    >
       <PlayButton />
       <SquareWrapper>
         <StoryAnimation.WAAPIWrapper target="some-id">
-          <TomatoSquare />
+          <ColorSquare color={state % 2 ? 'tomato' : 'green'} />
         </StoryAnimation.WAAPIWrapper>
       </SquareWrapper>
     </StoryAnimation.Provider>

--- a/assets/src/dashboard/components/storyAnimation/stories/index.js
+++ b/assets/src/dashboard/components/storyAnimation/stories/index.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+/**
+ * Internal dependencies
+ */
+import StoryAnimation, { useStoryAnimationContext } from '../index.js';
+
+export default {
+  title: 'Dashboard/Components/StoryAnimation',
+  component: StoryAnimation,
+};
+
+const PlayButton = () => {
+  const {
+    actions: { playWAAPIAnimations },
+  } = useStoryAnimationContext();
+
+  const label = 'play';
+  return <button onClick={playWAAPIAnimations}>{label}</button>;
+};
+
+function TomatoSquare() {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        backgroundColor: 'tomato',
+      }}
+    />
+  );
+}
+
+function SquareWrapper({ children }) {
+  return (
+    <div
+      style={{
+        position: 'relative',
+        marginTop: 20,
+        height: 50,
+        width: 50,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+SquareWrapper.propTypes = {
+  children: PropTypes.node,
+};
+
+const animations = [{ target: ['some-id'], type: 'bounce' }];
+export function _default() {
+  return (
+    <StoryAnimation.Provider animations={animations}>
+      <PlayButton />
+      <SquareWrapper>
+        <StoryAnimation.WAAPIWrapper target="some-id">
+          <TomatoSquare />
+        </StoryAnimation.WAAPIWrapper>
+      </SquareWrapper>
+    </StoryAnimation.Provider>
+  );
+}

--- a/assets/src/dashboard/components/storyAnimation/stories/index.js
+++ b/assets/src/dashboard/components/storyAnimation/stories/index.js
@@ -73,7 +73,10 @@ SquareWrapper.propTypes = {
   children: PropTypes.node,
 };
 
-const animations = [{ target: ['some-id'], type: 'bounce' }];
+const animations = [
+  { target: ['some-id'], type: 'bounce', duration: 1000 },
+  { target: ['some-id'], type: 'bounce', delay: 1000 },
+];
 export function _default() {
   const [state, setState] = useState(0);
   return (

--- a/assets/src/dashboard/components/storyAnimation/stories/index.js
+++ b/assets/src/dashboard/components/storyAnimation/stories/index.js
@@ -74,8 +74,8 @@ SquareWrapper.propTypes = {
 };
 
 const animations = [
-  { target: ['some-id'], type: 'bounce', duration: 1000 },
-  { target: ['some-id'], type: 'bounce', delay: 1000 },
+  { targets: ['some-id'], type: 'bounce', duration: 1000 },
+  { targets: ['some-id'], type: 'bounce', delay: 1000 },
 ];
 export function _default() {
   const [state, setState] = useState(0);

--- a/assets/src/dashboard/components/storyAnimation/test/WAAPIWrapper.js
+++ b/assets/src/dashboard/components/storyAnimation/test/WAAPIWrapper.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+jest.mock('..');
+jest.mock('../../../animations/animationParts');
+/**
+ * External dependencies
+ */
+import { render, within } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { WAAPI } from '../../../animations/animationParts';
+import { useStoryAnimationContext } from '..';
+const { default: StoryAnimations } = jest.requireActual('..');
+
+WAAPI.mockImplementation((type) => ({ children }) => (
+  <div data-testid={type}>{children}</div>
+));
+
+const types = ['anim-1', 'anim-2', 'anim-3'];
+
+useStoryAnimationContext.mockReturnValue({
+  state: {
+    getAnimationGenerators: () => types.map((type) => (fn) => fn(type, {})),
+  },
+  actions: {
+    hoistWAAPIAnimation: () => () => {},
+  },
+});
+
+describe('StoryAnimations.WAAPIWrapper', () => {
+  it('renders ascending generated animations top down', () => {
+    const { getByTestId } = render(
+      <StoryAnimations.Provider animations={[]}>
+        <StoryAnimations.WAAPIWrapper target="_">
+          <div />
+        </StoryAnimations.WAAPIWrapper>
+      </StoryAnimations.Provider>
+    );
+
+    for (let i = 0; i < types.length; i++) {
+      const parent = getByTestId(types[i]);
+      for (let j = 0; j < types.length; j++) {
+        expect(within(parent).getAllByTestId(types[j])).toHaveLength(
+          i > j ? 0 : 1
+        );
+      }
+    }
+  });
+});

--- a/assets/src/dashboard/components/storyAnimation/test/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/test/provider.js
@@ -20,7 +20,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 /**
  * Internal dependencies
  */
-import { createWrapperWithProps } from '../../../testUtils';
+import { createWrapperWithProps, flushPromiseQueue } from '../../../testUtils';
 import StoryAnimation, { useStoryAnimationContext } from '..';
 
 const defaultWAAPIAnimation = {
@@ -247,7 +247,7 @@ describe('StoryAnimation.Provider', () => {
            * trigger dispatch from resolved promise
            */
           await act(async () => {
-            await new Promise((resolve) => resolve());
+            await flushPromiseQueue();
           });
         };
 

--- a/assets/src/dashboard/components/storyAnimation/test/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/test/provider.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+import { createWrapperWithProps } from '../../../testUtils';
+import StoryAnimation, { useStoryAnimationContext } from '..';
+
+describe('StoryAnimation.Provider', () => {
+  describe('getAnimationGenerators(target)', () => {
+    it('calls all generators for a target', () => {
+      const target = 'some-target';
+      const animations = [
+        { target, type: 'TYPE1' },
+        { target, type: 'TYPE2' },
+        { target: 'other-target', type: 'TYPE1' },
+        { target: [target, 'other-target'], type: 'TYPE5' },
+      ];
+
+      const { result } = renderHook(() => useStoryAnimationContext(), {
+        wrapper: createWrapperWithProps(StoryAnimation.Provider, {
+          animations,
+        }),
+      });
+
+      const {
+        state: { getAnimationGenerators },
+      } = result.current;
+
+      expect(getAnimationGenerators(target)).toHaveLength(3);
+      expect(getAnimationGenerators('other-target')).toHaveLength(2);
+      expect(getAnimationGenerators('not used target')).toHaveLength(0);
+    });
+
+    it('calls generators for a target in ascending order', () => {
+      const target = 'some-target';
+      const args = { someProp: 1 };
+      const type = ['TYPE1', 'TYPE2', 'TYPE3'];
+      const animations = [
+        { target, type: type[0], ...args },
+        { target, type: type[1], ...args },
+        { target, type: type[2], ...args },
+      ];
+
+      const { result } = renderHook(() => useStoryAnimationContext(), {
+        wrapper: createWrapperWithProps(StoryAnimation.Provider, {
+          animations,
+        }),
+      });
+
+      const {
+        state: { getAnimationGenerators },
+      } = result.current;
+
+      const sample = jest.fn();
+      getAnimationGenerators(target).forEach((generator, i) => {
+        generator(sample);
+        expect(sample).toHaveBeenCalledWith(type[i], args);
+      });
+    });
+
+    it('calls generators for a target with propper args', () => {
+      const target = 'some-target';
+      const type = 'SOME_TYPE';
+      const args = [
+        { bounces: 3 },
+        { columns: 4, duration: 400 },
+        { blinks: 2, offset: 20, blarks: 6 },
+      ];
+      const animations = [
+        { target, type: type, ...args[0] },
+        { target, type: type, ...args[1] },
+        { target, type: type, ...args[2] },
+      ];
+
+      const { result } = renderHook(() => useStoryAnimationContext(), {
+        wrapper: createWrapperWithProps(StoryAnimation.Provider, {
+          animations,
+        }),
+      });
+
+      const {
+        state: { getAnimationGenerators },
+      } = result.current;
+
+      const sample = jest.fn();
+      getAnimationGenerators(target).forEach((generator, i) => {
+        generator(sample);
+        expect(sample).toHaveBeenCalledWith(type, args[i]);
+      });
+    });
+  });
+
+  describe('hoistWAAPIAnimation(WAAPIAnimation)', () => {
+    it('returns an unhoist function when called', () => {
+      const { result } = renderHook(() => useStoryAnimationContext(), {
+        wrapper: createWrapperWithProps(StoryAnimation.Provider, {
+          animations: [],
+        }),
+      });
+
+      const {
+        actions: { hoistWAAPIAnimation },
+      } = result.current;
+
+      const unhoist = hoistWAAPIAnimation({});
+
+      expect(typeof unhoist).toBe('function');
+    });
+  });
+
+  describe('playWAAPIAnimations()', () => {
+    it.todo('calls all hoisted animations `play()` method once');
+  });
+});

--- a/assets/src/dashboard/components/storyAnimation/test/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/test/provider.js
@@ -37,11 +37,12 @@ describe('StoryAnimation.Provider', () => {
   describe('getAnimationGenerators(target)', () => {
     it('calls all generators for a target', () => {
       const target = 'some-target';
+      const targets = [target];
       const animations = [
-        { target, type: 'TYPE1' },
-        { target, type: 'TYPE2' },
-        { target: 'other-target', type: 'TYPE1' },
-        { target: [target, 'other-target'], type: 'TYPE5' },
+        { targets, type: 'TYPE1' },
+        { targets, type: 'TYPE2' },
+        { targets: ['other-target'], type: 'TYPE1' },
+        { targets: [target, 'other-target'], type: 'TYPE5' },
       ];
 
       const { result } = renderHook(() => useStoryAnimationContext(), {
@@ -61,12 +62,13 @@ describe('StoryAnimation.Provider', () => {
 
     it('calls generators for a target in ascending order', () => {
       const target = 'some-target';
+      const targets = [target];
       const args = { someProp: 1 };
       const type = ['TYPE1', 'TYPE2', 'TYPE3'];
       const animations = [
-        { target, type: type[0], ...args },
-        { target, type: type[1], ...args },
-        { target, type: type[2], ...args },
+        { targets, type: type[0], ...args },
+        { targets, type: type[1], ...args },
+        { targets, type: type[2], ...args },
       ];
 
       const { result } = renderHook(() => useStoryAnimationContext(), {
@@ -88,6 +90,7 @@ describe('StoryAnimation.Provider', () => {
 
     it('calls generators for a target with propper args', () => {
       const target = 'some-target';
+      const targets = [target];
       const type = 'SOME_TYPE';
       const args = [
         { bounces: 3 },
@@ -95,9 +98,9 @@ describe('StoryAnimation.Provider', () => {
         { blinks: 2, offset: 20, blarks: 6 },
       ];
       const animations = [
-        { target, type: type, ...args[0] },
-        { target, type: type, ...args[1] },
-        { target, type: type, ...args[2] },
+        { targets, type: type, ...args[0] },
+        { targets, type: type, ...args[1] },
+        { targets, type: type, ...args[2] },
       ];
 
       const { result } = renderHook(() => useStoryAnimationContext(), {

--- a/assets/src/dashboard/components/storyAnimation/test/useStoryAnimationContext.js
+++ b/assets/src/dashboard/components/storyAnimation/test/useStoryAnimationContext.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+import StoryAnimation, { useStoryAnimationContext } from '..';
+
+describe('useStoryAnimationContext()', () => {
+  it('should throw an error if used oustide StroyAnimation.Provider', () => {
+    expect(() => {
+      const {
+        // eslint-disable-next-line no-unused-vars
+        result: { current },
+      } = renderHook(() => useStoryAnimationContext());
+    }).toThrow(
+      Error(
+        'Must use `useStoryAnimationContext()` within <StoryAnimation.Provider />'
+      )
+    );
+  });
+
+  it('should not throw an error if used inside StoryAnimation.Provider', () => {
+    const { result } = renderHook(() => useStoryAnimationContext(), {
+      wrapper: StoryAnimation.Provider,
+    });
+    expect(result.current.error).toBeUndefined();
+  });
+});

--- a/assets/src/dashboard/components/storyAnimation/useStoryAnimationContext.js
+++ b/assets/src/dashboard/components/storyAnimation/useStoryAnimationContext.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useContext } from 'react';
+/**
+ * Internal dependencies
+ */
+import { StoryAnimationContext } from './provider';
+
+function useStoryAnimationContext() {
+  const context = useContext(StoryAnimationContext);
+  if (!context) {
+    throw new Error(
+      'Must use `useStoryAnimationContext()` within <StoryAnimation.Provider />'
+    );
+  }
+  return context;
+}
+
+export default useStoryAnimationContext;

--- a/assets/src/dashboard/testUtils/createWrapperWithProps.js
+++ b/assets/src/dashboard/testUtils/createWrapperWithProps.js
@@ -13,6 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
 
-export { default as renderWithTheme } from './renderWithTheme';
-export { default as createWrapperWithProps } from './createWrapperWithProps';
+function createWrapperWithProps(Wrapper, props) {
+  const WrapperWithProps = function ({ children }) {
+    return <Wrapper {...props}>{children}</Wrapper>;
+  };
+  WrapperWithProps.propTypes = { children: PropTypes.node };
+  return WrapperWithProps;
+}
+
+export default createWrapperWithProps;

--- a/assets/src/dashboard/testUtils/flushPromiseQueue.js
+++ b/assets/src/dashboard/testUtils/flushPromiseQueue.js
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { default as flushPromiseQueue } from './flushPromiseQueue';
-export { default as renderWithTheme } from './renderWithTheme';
-export { default as createWrapperWithProps } from './createWrapperWithProps';
+function flushPromiseQueue() {
+  return new Promise((resolve) => resolve());
+}
+
+export default flushPromiseQueue;


### PR DESCRIPTION
## Summary
- Adds `StoryAnimation.Provider`
  - Interprets animations into generators for a given ID, rn used with WAAPI, but compatible with AMP
  - Adds a `playWAAPIAnimations()` method to control WAAPI animations
  - Adds an `onWAAPIFinish` prop that will fire everytime all hoisted animations complete (can use to increment page number)
- Adds `StoryAnimation.WAAPIWrapper`
  - Composes all animations for a target with later animations being children of earlier anims
  - Creates WAAPI animation part based off of type.
- Adds WAAPI animation part generator which given a type and that types args, creates & hoists animation as well as creating relevant markup for animation.
- Creates notion of `Animation Parts` which ties the `keyframe` & `timings` to markup given some args. right now only did this for `ANIMATION_TYPES.BOUNCE` but should be simple to port over old animation configs to this new pattern.

**example use:**
```
<StoryAnimation.Provider animations={[
  ...,
  { target: "some_uuid", type: <animation_type>, ...args }
]}>
...
  <div data-element-id="some_uuid" class="wrapper">
      <StoryAnimation.WAAPIWrapper target="some_uuid">
        <div />
      </StoryAnimation.WAAPIWrapper>
  </div>
...
</StoryAnimation.Provider>
```

## Relevant Technical Choices
**Web Animations API - Grouping**
Basically had to add some notion of grouping on top of the web animations api. Accomplished this 
by just hoisting all `Animation` objects up into the provider. We can then create any group operations we'd like on the hoisted animations. rn only `play` & `onfinish` supported.

**Animation Parts**
Animation schema is basically looks like:
`{ type: 'ANIM_TYPE', ...args }` which we transform into `ANIM_TYPE(args) => ReactWrapperComponent`. This should be a pretty extensible in the future for applying to amp-animations or any other animation package. Possibly maleable enough to add a `ANIMATION_TYPE.SEQUENCE` or anything else in the future because we just pass relevant `args` to a function that creates a react component.


## To-do
- Port over rest of animation configs to animation parts and add containers
- Create `<StoryAnimation.AMPWrapper />` which follows the animation parts pattern
- Create `AMP(type, args)` animation part generator (should be able to leverage @mariano-formidable amp-animation animator work here)
- Create amp-animation methods in provider (should mostly be passing around animation id names which should be nice)

## How to test
**Unit**
 Run unit tests & make sure they pass.

**QA**
Open up storybook and go to `Dashboard > Components > StoryAnimation > default` this should show a square that has nested `BOUNCE` animations applied to it and alternates between red & green color each time all the animations finish


---
