### PR TITLE
#1784 Dashboard: Add counts by story status to header UI

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -123,10 +123,10 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
           parse: false,
         });
 
-        // TODO add headers for totals by status and have header reflect search
-        // only update totals when data is different
-        const totalStories = parseInt(response.headers.get('X-WP-Total'));
         const totalPages = parseInt(response.headers.get('X-WP-TotalPages'));
+        const totalStoriesByStatus = JSON.parse(
+          response.headers.get('X-WP-TotalByStatus')
+        );
 
         const serverStoryResponse = await response.json();
 
@@ -139,7 +139,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
           payload: {
             stories: reshapedStories,
             totalPages,
-            totalStories,
+            totalStoriesByStatus,
             page,
           },
         });
@@ -184,7 +184,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
         });
         dispatch({
           type: STORY_ACTION_TYPES.TRASH_STORY,
-          payload: { id: story.id },
+          payload: { id: story.id, storyStatus: story.status },
         });
       } catch (e) {
         // eslint-disable-next-line no-console

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -123,10 +123,12 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
           parse: false,
         });
 
-        const totalPages = parseInt(response.headers.get('X-WP-TotalPages'));
-        const totalStoriesByStatus = JSON.parse(
-          response.headers.get('X-WP-TotalByStatus')
-        );
+        const totalPages =
+          response.headers && parseInt(response.headers.get('X-WP-TotalPages'));
+
+        const totalStoriesByStatus =
+          response.headers &&
+          JSON.parse(response.headers.get('X-WP-TotalByStatus'));
 
         const serverStoryResponse = await response.json();
 

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -33,7 +33,7 @@ export const defaultStoriesState = {
   isLoading: false,
   stories: {},
   storiesOrderById: [],
-  totalStories: null,
+  totalStoriesByStatus: {},
   totalPages: null,
 };
 
@@ -66,7 +66,12 @@ function storyReducer(state, action) {
         storiesOrderById: state.storiesOrderById.filter(
           (id) => id !== action.payload.id
         ),
-        totalStories: state.totalStories - 1,
+        totalStoriesByStatus: {
+          ...state.totalStoriesByStatus,
+          all: state.totalStoriesByStatus.all - 1,
+          [action.payload.storyStatus]:
+            state.totalStoriesByStatus[action.payload.storyStatus] - 1,
+        },
         stories: Object.keys(state.stories).reduce((memo, storyId) => {
           if (parseInt(storyId) !== action.payload.id) {
             memo[storyId] = state.stories[storyId];
@@ -79,7 +84,12 @@ function storyReducer(state, action) {
       return {
         ...state,
         storiesOrderById: [action.payload.id, ...state.storiesOrderById],
-        totalStories: state.totalStories + 1,
+        totalStoriesByStatus: {
+          ...state.totalStoriesByStatus,
+          all: state.totalStoriesByStatus.all + 1,
+          [action.payload.status]:
+            state.totalStoriesByStatus[action.payload.status] + 1,
+        },
         stories: {
           ...state.stories,
           [action.payload.id]: action.payload,
@@ -110,7 +120,7 @@ function storyReducer(state, action) {
         storiesOrderById: uniqueStoryIds,
         stories: { ...state.stories, ...groupBy(action.payload.stories, 'id') },
         totalPages: action.payload.totalPages,
-        totalStories: action.payload.totalStories,
+        totalStoriesByStatus: action.payload.totalStoriesByStatus,
         allPagesFetched: action.payload.page >= action.payload.totalPages,
       };
     }

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -25,9 +25,99 @@ describe('storyReducer', () => {
     isLoading: false,
     stories: {},
     storiesOrderById: [],
-    totalStories: null,
+    totalStoriesByStatus: {},
     totalPages: null,
   };
+
+  it(`should update stories state when ${ACTION_TYPES.TRASH_STORY} is called`, () => {
+    const result = storyReducer(
+      {
+        ...initialState,
+        storiesOrderById: [94, 65, 78, 12],
+        stories: {
+          94: { id: 94, status: 'draft', title: 'my test story 1' },
+          65: { id: 65, status: 'publish', title: 'my test story 2' },
+          78: { id: 78, status: 'draft', title: 'my test story 3' },
+          12: { id: 12, status: 'draft', title: 'my test story 4' },
+        },
+        totalStoriesByStatus: {
+          all: 44,
+          draft: 40,
+          publish: 4,
+        },
+        totalPages: 4,
+      },
+      {
+        type: ACTION_TYPES.TRASH_STORY,
+        payload: {
+          id: 65,
+          storyStatus: 'publish',
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      isError: false,
+      storiesOrderById: [94, 78, 12],
+      stories: {
+        94: { id: 94, status: 'draft', title: 'my test story 1' },
+        78: { id: 78, status: 'draft', title: 'my test story 3' },
+        12: { id: 12, status: 'draft', title: 'my test story 4' },
+      },
+      totalStoriesByStatus: {
+        all: 43,
+        draft: 40,
+        publish: 3,
+      },
+      totalPages: 4,
+    });
+  });
+
+  it(`should update stories state when ${ACTION_TYPES.DUPLICATE_STORY} is called`, () => {
+    const result = storyReducer(
+      {
+        ...initialState,
+        storiesOrderById: [94, 65, 78, 12],
+        stories: {
+          94: { id: 94, status: 'draft', title: 'my test story 1' },
+          65: { id: 65, status: 'publish', title: 'my test story 2' },
+          78: { id: 78, status: 'draft', title: 'my test story 3' },
+          12: { id: 12, status: 'draft', title: 'my test story 4' },
+        },
+        totalStoriesByStatus: {
+          all: 44,
+          draft: 40,
+          publish: 4,
+        },
+        totalPages: 4,
+      },
+      {
+        type: ACTION_TYPES.DUPLICATE_STORY,
+        payload: { id: 95, status: 'draft', title: 'my test story 1 - copy' },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      isError: false,
+      storiesOrderById: [95, 94, 65, 78, 12],
+      stories: {
+        94: { id: 94, status: 'draft', title: 'my test story 1' },
+        95: { id: 95, status: 'draft', title: 'my test story 1 - copy' },
+        65: { id: 65, status: 'publish', title: 'my test story 2' },
+        78: { id: 78, status: 'draft', title: 'my test story 3' },
+        12: { id: 12, status: 'draft', title: 'my test story 4' },
+      },
+      totalStoriesByStatus: {
+        all: 45,
+        draft: 41,
+        publish: 4,
+      },
+      totalPages: 4,
+    });
+  });
+
   it(`should update stories state when ${ACTION_TYPES.FETCH_STORIES_SUCCESS} is called`, () => {
     const result = storyReducer(initialState, {
       type: ACTION_TYPES.FETCH_STORIES_SUCCESS,
@@ -35,11 +125,15 @@ describe('storyReducer', () => {
         page: 1,
         stories: [
           { id: 94, status: 'draft', title: 'my test story 1' },
-          { id: 65, status: 'published', title: 'my test story 2' },
+          { id: 65, status: 'publish', title: 'my test story 2' },
           { id: 78, status: 'draft', title: 'my test story 3' },
           { id: 12, status: 'draft', title: 'my test story 4' },
         ],
-        totalStories: 33,
+        totalStoriesByStatus: {
+          all: 44,
+          draft: 40,
+          publish: 4,
+        },
         totalPages: 4,
       },
     });
@@ -50,11 +144,15 @@ describe('storyReducer', () => {
       storiesOrderById: [94, 65, 78, 12],
       stories: {
         94: { id: 94, status: 'draft', title: 'my test story 1' },
-        65: { id: 65, status: 'published', title: 'my test story 2' },
+        65: { id: 65, status: 'publish', title: 'my test story 2' },
         78: { id: 78, status: 'draft', title: 'my test story 3' },
         12: { id: 12, status: 'draft', title: 'my test story 4' },
       },
-      totalStories: 33,
+      totalStoriesByStatus: {
+        all: 44,
+        draft: 40,
+        publish: 4,
+      },
       totalPages: 4,
       allPagesFetched: false,
     });
@@ -69,11 +167,15 @@ describe('storyReducer', () => {
           page: 2,
           stories: [
             { id: 94, status: 'draft', title: 'my test story 1' },
-            { id: 65, status: 'published', title: 'my test story 2' },
+            { id: 65, status: 'publish', title: 'my test story 2' },
             { id: 78, status: 'draft', title: 'my test story 3' },
             { id: 12, status: 'draft', title: 'my test story 4' },
           ],
-          totalStories: 8,
+          totalStoriesByStatus: {
+            all: 18,
+            draft: 14,
+            publish: 4,
+          },
           totalPages: 2,
         },
       }
@@ -84,11 +186,15 @@ describe('storyReducer', () => {
       storiesOrderById: [55, 99, 10, 3, 94, 65, 78, 12],
       stories: {
         94: { id: 94, status: 'draft', title: 'my test story 1' },
-        65: { id: 65, status: 'published', title: 'my test story 2' },
+        65: { id: 65, status: 'publish', title: 'my test story 2' },
         78: { id: 78, status: 'draft', title: 'my test story 3' },
         12: { id: 12, status: 'draft', title: 'my test story 4' },
       },
-      totalStories: 8,
+      totalStoriesByStatus: {
+        all: 18,
+        draft: 14,
+        publish: 4,
+      },
       totalPages: 2,
       allPagesFetched: true,
     });
@@ -130,14 +236,14 @@ describe('storyReducer', () => {
         ...initialState,
         stories: {
           94: { id: 94, status: 'draft', title: 'my test story 1' },
-          65: { id: 65, status: 'published', title: 'my test story 2' },
+          65: { id: 65, status: 'publish', title: 'my test story 2' },
           78: { id: 78, status: 'draft', title: 'my test story 3' },
           12: { id: 12, status: 'draft', title: 'my test story 4' },
         },
       },
       {
         type: ACTION_TYPES.UPDATE_STORY,
-        payload: { id: 65, status: 'published', title: 'new title for story' },
+        payload: { id: 65, status: 'publish', title: 'new title for story' },
       }
     );
 
@@ -145,7 +251,7 @@ describe('storyReducer', () => {
       ...initialState,
       stories: {
         94: { id: 94, status: 'draft', title: 'my test story 1' },
-        65: { id: 65, status: 'published', title: 'new title for story' },
+        65: { id: 65, status: 'publish', title: 'new title for story' },
         78: { id: 78, status: 'draft', title: 'my test story 3' },
         12: { id: 12, status: 'draft', title: 'my test story 4' },
       },

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -237,7 +237,11 @@ function MyStories() {
                       handleClick: () => filter.set(storyStatus.value),
                       key: storyStatus.value,
                       isActive: filter.value === storyStatus.value,
-                      text: storyStatus.label,
+                      text: `${storyStatus.label} ${
+                        totalStoriesByStatus[storyStatus.status]
+                          ? `(${totalStoriesByStatus[storyStatus.status]})`
+                          : ''
+                      }`,
                     };
                   })}
                 />

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -219,7 +219,7 @@ function MyStories() {
   ]);
 
   const HeaderToggleButtons = useMemo(() => {
-    if (orderedStories.length <= 0) {
+    if (Object.keys(totalStoriesByStatus) === 0) {
       return null;
     }
 
@@ -240,7 +240,7 @@ function MyStories() {
         />
       </HeaderToggleButtonContainer>
     );
-  }, [filter, orderedStories.length, totalStoriesByStatus]);
+  }, [filter, totalStoriesByStatus]);
 
   return (
     <FontProvider>

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -218,6 +218,30 @@ function MyStories() {
     storiesView,
   ]);
 
+  const HeaderToggleButtons = useMemo(() => {
+    if (orderedStories.length <= 0) {
+      return null;
+    }
+
+    return (
+      <HeaderToggleButtonContainer>
+        <ToggleButtonGroup
+          buttons={STORY_STATUSES.map((storyStatus) => {
+            return {
+              handleClick: () => filter.set(storyStatus.value),
+              key: storyStatus.value,
+              isActive: filter.value === storyStatus.value,
+              disabled: totalStoriesByStatus[storyStatus.status] <= 0,
+              text: `${storyStatus.label} (${
+                totalStoriesByStatus?.[storyStatus.status]
+              })`,
+            };
+          })}
+        />
+      </HeaderToggleButtonContainer>
+    );
+  }, [filter, orderedStories.length, totalStoriesByStatus]);
+
   return (
     <FontProvider>
       <TransformProvider>
@@ -230,22 +254,7 @@ function MyStories() {
               handleTypeaheadChange={search.setKeyword}
               typeaheadValue={search.keyword}
             >
-              <HeaderToggleButtonContainer>
-                <ToggleButtonGroup
-                  buttons={STORY_STATUSES.map((storyStatus) => {
-                    return {
-                      handleClick: () => filter.set(storyStatus.value),
-                      key: storyStatus.value,
-                      isActive: filter.value === storyStatus.value,
-                      text: `${storyStatus.label} ${
-                        totalStoriesByStatus[storyStatus.status]
-                          ? `(${totalStoriesByStatus[storyStatus.status]})`
-                          : ''
-                      }`,
-                    };
-                  })}
-                />
-              </HeaderToggleButtonContainer>
+              {HeaderToggleButtons}
             </PageHeading>
             {storiesViewControls}
           </Layout.Squishable>

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -78,7 +78,7 @@ function MyStories() {
         isLoading,
         stories,
         storiesOrderById,
-        totalStories,
+        totalStoriesByStatus,
         totalPages,
       },
       tags,
@@ -95,7 +95,7 @@ function MyStories() {
   const resultsLabel = useDashboardResultsLabel({
     isActiveSearch: Boolean(search.keyword),
     currentFilter: filter.value,
-    totalResults: totalStories,
+    totalResults: totalStoriesByStatus?.all,
     view: DASHBOARD_VIEWS.MY_STORIES,
   });
 

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -219,7 +219,10 @@ function MyStories() {
   ]);
 
   const HeaderToggleButtons = useMemo(() => {
-    if (Object.keys(totalStoriesByStatus).length === 0) {
+    if (
+      totalStoriesByStatus &&
+      Object.keys(totalStoriesByStatus).length === 0
+    ) {
       return null;
     }
 
@@ -231,10 +234,12 @@ function MyStories() {
               handleClick: () => filter.set(storyStatus.value),
               key: storyStatus.value,
               isActive: filter.value === storyStatus.value,
-              disabled: totalStoriesByStatus[storyStatus.status] <= 0,
-              text: `${storyStatus.label} (${
+              disabled: totalStoriesByStatus?.[storyStatus.status] <= 0,
+              text: `${storyStatus.label} ${
                 totalStoriesByStatus?.[storyStatus.status]
-              })`,
+                  ? `(${totalStoriesByStatus?.[storyStatus.status]})`
+                  : ''
+              }`,
             };
           })}
         />

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -219,7 +219,7 @@ function MyStories() {
   ]);
 
   const HeaderToggleButtons = useMemo(() => {
-    if (Object.keys(totalStoriesByStatus) === 0) {
+    if (Object.keys(totalStoriesByStatus).length === 0) {
       return null;
     }
 

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -77,6 +77,10 @@ const ToggleButton = styled.button`
     ${KEYBOARD_USER_SELECTOR} &:focus {
         border: 1px solid ${theme.colors.action};
     }
+    &:disabled {
+      color: ${theme.colors.gray400};
+      cursor: default;
+    }
   `}
 `;
 
@@ -152,13 +156,14 @@ const ToggleButtonGroup = ({ buttons }) => {
   return (
     <>
       <ToggleButtonContainer ref={containerRef}>
-        {buttons.map(({ isActive, handleClick, key, text }, idx) => (
+        {buttons.map(({ isActive, handleClick, key, text, ...rest }, idx) => (
           <ToggleButton
             {...(isActive ? { ref: activeRef } : {})}
             type="button"
             onClick={(e) => handleButtonClick(e, handleClick)}
             key={key || `toggle_button_${idx}`}
             isActive={isActive}
+            {...rest}
           >
             {text}
           </ToggleButton>

--- a/assets/src/dashboard/components/toggleButtonGroup/stories/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/stories/index.js
@@ -49,6 +49,7 @@ export const _default = () => {
             },
             key: storyStatus.value,
             isActive: status === storyStatus.value,
+            disabled: storyStatus.status === 'publish',
             text: storyStatus.label,
           };
         })}

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -107,9 +107,21 @@ export const STORY_ITEM_CENTER_ACTION_LABELS = {
 };
 
 export const STORY_STATUSES = [
-  { label: __('All Stories', 'web-stories'), value: STORY_STATUS.ALL },
-  { label: __('Drafts', 'web-stories'), value: STORY_STATUS.DRAFT },
-  { label: __('Published', 'web-stories'), value: STORY_STATUS.PUBLISHED },
+  {
+    label: __('All Stories', 'web-stories'),
+    value: STORY_STATUS.ALL,
+    status: 'all',
+  },
+  {
+    label: __('Drafts', 'web-stories'),
+    value: STORY_STATUS.DRAFT,
+    status: STORY_STATUS.DRAFT,
+  },
+  {
+    label: __('Published', 'web-stories'),
+    value: STORY_STATUS.PUBLISHED,
+    status: STORY_STATUS.PUBLISHED,
+  },
 ];
 
 export const STORY_VIEWING_LABELS = {

--- a/assets/src/dashboard/utils/test/useDashboardResultsLabel.js
+++ b/assets/src/dashboard/utils/test/useDashboardResultsLabel.js
@@ -32,6 +32,18 @@ import {
 import useDashboardResultsLabel from '../useDashboardResultsLabel';
 
 describe('useGenericResultsLabel()', function () {
+  it(`should return an empty string to display if there is no currentFilter supplied`, function () {
+    const { result } = renderHook(
+      () =>
+        useDashboardResultsLabel({
+          currentFilter: null,
+          view: DASHBOARD_VIEWS.MY_STORIES,
+        }),
+      {}
+    );
+    expect(result.current).toBe('');
+  });
+
   // my stories
   it(`should have default options initially selected for ${DASHBOARD_VIEWS.MY_STORIES}`, function () {
     const { result } = renderHook(

--- a/assets/src/dashboard/utils/useDashboardResultsLabel.js
+++ b/assets/src/dashboard/utils/useDashboardResultsLabel.js
@@ -36,13 +36,14 @@ export default function useDashboardResultsLabel({
   view,
 }) {
   const resultsLabel = useMemo(() => {
+    const defaultLabel = RESULT_LABELS[view]?.[currentFilter] || '';
     return isActiveSearch
       ? sprintf(
           /* translators: %s: number of results */
           _n('%s result', '%s results', totalResults, 'web-stories'),
           totalResults
         )
-      : RESULT_LABELS[view][currentFilter];
+      : defaultLabel;
   }, [isActiveSearch, totalResults, view, currentFilter]);
 
   return resultsLabel;

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -368,6 +368,7 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 		$query_args['fields']                 = 'ids';
 		$query_args['posts_per_page']         = 1;
 		$query_args['update_post_meta_cache'] = false;
+		$query_args['update_post_term_cache'] = false;
 
 		foreach ( $statuses as $key => $status ) {
 			$posts_query               = new WP_Query();

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -368,7 +368,6 @@ class Stories_Controller extends WP_REST_Posts_Controller {
 		$query_args['fields']                 = 'ids';
 		$query_args['posts_per_page']         = 1;
 		$query_args['update_post_meta_cache'] = false;
-		$query_args['update_post_term_cache'] = false;
 
 		foreach ( $statuses as $key => $status ) {
 			$posts_query               = new WP_Query();


### PR DESCRIPTION
## Summary
Exposing the counts by status in the my stories header to show how many of each status stories there are. 

## Relevant Technical Choices
- Updating to use new `X-WP-TotalByStatus` header in (#1120 ) to get total stories separated by status
- Adds reducer tests for trashing and duplicating stories, updates fetch stories test. 
- Updates storybook to show what a disabled toggle button in a group would look like 
- Memoizes `HeaderToggleButtons` to avoid rendering buttons that have no data
- Adds `disabled` to buttons in this group to check if the count is 0
- Updates ToggleButtonGroup to pass in the `...rest` to easily allow for things like `disabled` state moving forward. 


## To-do
- I reopened #1120 because while implementing this I realized that the **all** count is subjective to the queried status! Infrastructure team is fixing. Should have 0 work on the UI to update from it. 

## Testing 
- You should now see counts by status in your my stories dashboard view.
- When you duplicate a _published_ story you should see drafts and all add 1
- When you duplicate a _draft_ story you should see drafts and all add 1
- When you trash a _published_ story you should see published and all subtract 1
- When you trash a _draft_ story you should see drafts and all subtract 1 
- If you search you should see all totals update to reflect your total number of results 
- If a status has 0 items you should not be able to click on that status but the headers should still show up. 

### Demos by action 

#### Duplicate a Draft Story 
![duplicate counts](https://user-images.githubusercontent.com/10720454/81993720-2c40de00-95fb-11ea-8ea9-b2dbd41728d6.gif)
-------
#### Duplicate a published story
![duplicate published story updates draft count](https://user-images.githubusercontent.com/10720454/81993733-32cf5580-95fb-11ea-9245-6aca297751e7.gif)
-------
#### Trash a published story
![published trash updates published](https://user-images.githubusercontent.com/10720454/81993736-3662dc80-95fb-11ea-8428-93170ed5a529.gif)
-------
#### No results 
<img width="1111" alt="Screen Shot 2020-05-14 at 3 53 23 PM" src="https://user-images.githubusercontent.com/10720454/81993751-4084db00-95fb-11ea-92d2-4ba9ff56344b.png">
-------
#### KNOWN BUG (listed in to dos) 
![known count bug](https://user-images.githubusercontent.com/10720454/81993747-3b279080-95fb-11ea-88e8-33a932f2bf44.gif)








---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1784 
