### PR TITLE
Remove recursive useMedia usage in useUploader

### DIFF
--- a/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
+++ b/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
@@ -31,7 +31,7 @@ function useUploadVideoFrame({ updateMediaElement }) {
   const {
     actions: { updateMedia },
   } = useAPI();
-  const { uploadFile } = useUploader(false);
+  const { uploadFile } = useUploader();
   const { storyId } = useConfig();
   const {
     actions: { updateElementsByResourceId },

--- a/assets/src/edit-story/app/uploader/test/useUploader.js
+++ b/assets/src/edit-story/app/uploader/test/useUploader.js
@@ -24,7 +24,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import ConfigContext from '../../config/context';
 import useUploader from '../useUploader';
 
-function setup(args, refreshLibrary = false) {
+function setup(args) {
   const configValue = {
     api: {},
     allowedMimeTypes: {
@@ -43,7 +43,7 @@ function setup(args, refreshLibrary = false) {
       {params.children}
     </ConfigContext.Provider>
   );
-  const { result } = renderHook(() => useUploader(refreshLibrary), { wrapper });
+  const { result } = renderHook(() => useUploader(), { wrapper });
   return {
     uploadFile: result.current.uploadFile,
     isValidType: result.current.isValidType,

--- a/assets/src/edit-story/app/uploader/useUploader.js
+++ b/assets/src/edit-story/app/uploader/useUploader.js
@@ -29,13 +29,9 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { useAPI } from '../../app/api';
 import { useConfig } from '../config';
-import { useMedia } from '../media';
 import createError from '../../utils/createError';
 
-function useUploader(refreshLibrary = true) {
-  const {
-    actions: { resetWithFetch },
-  } = useMedia();
+function useUploader() {
   const {
     actions: { uploadMedia },
   } = useAPI();
@@ -116,11 +112,7 @@ function useUploader(refreshLibrary = true) {
       post: storyId,
     };
 
-    const promise = uploadMedia(file, additionalData);
-    if (refreshLibrary) {
-      promise.finally(resetWithFetch);
-    }
-    return promise;
+    return uploadMedia(file, additionalData);
   };
 
   return {


### PR DESCRIPTION
Remove recursive useMedia usage in useUploader.
This PR is a no-op.

MediaProvider uses useUploader which uses useMedia, which causes resetWithFetch to be null. useContextSelector throws an exception which makes this bug more noticeable.

refreshLibrary=true isn't actually needed, as a refresh isn't necessary after an upload, see #1848.
