### PR TITLE
Dashboard: Adds Tooltips. Borders around Preview Cards

### DIFF
--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -68,11 +68,14 @@ const ListView = styled.div`
 `;
 
 const PreviewContainer = styled.div`
+  display: inline-block;
   position: relative;
+  overflow: hidden;
   width: ${({ theme }) => theme.previewWidth.thumbnail}px;
   height: ${({ theme }) => theme.previewWidth.thumbnail / PAGE_RATIO}px;
   vertical-align: middle;
-  display: inline-block;
+  border-radius: 4px;
+  border: ${({ theme }) => theme.storyPreview.border};
 `;
 
 const ArrowIcon = styled.div`

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -74,7 +74,7 @@ const PreviewContainer = styled.div`
   width: ${({ theme }) => theme.previewWidth.thumbnail}px;
   height: ${({ theme }) => theme.previewWidth.thumbnail / PAGE_RATIO}px;
   vertical-align: middle;
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.storyPreview.borderRadius}px;
   border: ${({ theme }) => theme.storyPreview.border};
 `;
 

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -31,7 +31,7 @@ import { ActionLabel } from './types';
 
 const PreviewPane = styled.div`
   position: relative;
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.storyPreview.borderRadius}px;
   height: ${({ cardSize }) => `${cardSize.height}px`};
   box-shadow: ${({ theme }) => theme.storyPreview.shadow};
   border: ${({ theme }) => theme.storyPreview.border};
@@ -51,7 +51,7 @@ const EditControls = styled.div`
   opacity: 0;
   transition: opacity ease-in-out 300ms;
   background: ${({ theme }) => theme.cardItem.previewOverlay};
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.storyPreview.borderRadius}px;
 
   &:hover {
     opacity: 1;

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -51,7 +51,7 @@ const EditControls = styled.div`
   opacity: 0;
   transition: opacity ease-in-out 300ms;
   background: ${({ theme }) => theme.cardItem.previewOverlay};
-  border-radius: 8px;
+  border-radius: 4px;
 
   &:hover {
     opacity: 1;

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -33,6 +33,8 @@ const PreviewPane = styled.div`
   position: relative;
   border-radius: 8px;
   height: ${({ cardSize }) => `${cardSize.height}px`};
+  box-shadow: ${({ theme }) => theme.storyPreview.shadow};
+  border: ${({ theme }) => theme.storyPreview.border};
   width: 100%;
   overflow: hidden;
   z-index: -1;

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -31,7 +31,7 @@ import { ActionLabel } from './types';
 
 const PreviewPane = styled.div`
   position: relative;
-  border-radius: 8px;
+  border-radius: 4px;
   height: ${({ cardSize }) => `${cardSize.height}px`};
   box-shadow: ${({ theme }) => theme.storyPreview.shadow};
   border: ${({ theme }) => theme.storyPreview.border};

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -72,3 +72,4 @@ export { default as TypeaheadInput } from './typeaheadInput';
 export { default as TypeaheadOptions } from './typeaheadOptions';
 export { ViewHeader } from './typography';
 export { default as ViewStyleBar } from './viewStyleBar';
+export { default as Tooltip } from './tooltip';

--- a/assets/src/dashboard/components/table/index.js
+++ b/assets/src/dashboard/components/table/index.js
@@ -60,6 +60,7 @@ export const TableDateHeaderCell = styled(TableHeaderCell)`
 
 export const TableStatusHeaderCell = styled(TableHeaderCell)`
   display: table-cell;
+  min-width: 100px;
 
   @media ${({ theme }) => theme.breakpoint.tablet} {
     display: none;

--- a/assets/src/dashboard/components/tooltip/index.js
+++ b/assets/src/dashboard/components/tooltip/index.js
@@ -43,6 +43,7 @@ export const Container = styled.div.attrs({
   position: relative;
   height: inherit;
   width: inherit;
+  display: inline-flex;
 `;
 
 export default function Tooltip({ children, content, position }) {

--- a/assets/src/dashboard/components/tooltip/index.js
+++ b/assets/src/dashboard/components/tooltip/index.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import propTypes from 'prop-types';
+import styled from 'styled-components';
+import { useState } from 'react';
+
+export const Content = styled.div`
+  visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
+  width: max-content;
+  position: absolute;
+  right: 0;
+  border-radius: 2px;
+  padding: 10px;
+  background: ${({ theme }) => theme.tooltip.background};
+  color: ${({ theme }) => theme.tooltip.color};
+  opacity: ${({ visible }) => (visible ? 1 : 0)};
+  transition: opacity linear 200ms;
+`;
+
+export const Container = styled.div.attrs({
+  ['data-testid']: 'tooltip-container',
+})`
+  position: relative;
+  height: inherit;
+  width: inherit;
+`;
+
+export default function Tooltip({ children, label }) {
+  const [showTooltip, setShowTooltip] = useState(false);
+  return (
+    <Container
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      {children}
+      <Content visible={showTooltip}>{label}</Content>
+    </Container>
+  );
+}
+
+Tooltip.propTypes = {
+  children: propTypes.node.isRequired,
+  label: propTypes.string.isRequired,
+};

--- a/assets/src/dashboard/components/tooltip/stories/tooltip.js
+++ b/assets/src/dashboard/components/tooltip/stories/tooltip.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { text, select } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import styled from 'styled-components';
+import Tooltip from '../';
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export default {
+  title: 'Dashboard/Components/Tooltip',
+  component: Tooltip,
+};
+
+export const _default = () => {
+  const positionValues = {
+    left: 'left',
+    right: 'right',
+    center: 'center',
+  };
+  const position = select('Position', positionValues, 'left');
+  return (
+    <Container>
+      <Tooltip
+        position={position}
+        content={text('tooltipContent', 'Tooltip Content')}
+      >
+        <button>{text('buttonTitle', 'Hover Over Me')}</button>
+      </Tooltip>
+    </Container>
+  );
+};

--- a/assets/src/dashboard/components/tooltip/test/tooltip.js
+++ b/assets/src/dashboard/components/tooltip/test/tooltip.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { act } from 'react-dom/test-utils';
+import { renderWithTheme } from '../../../testUtils/';
+import Tooltip from '../';
+
+describe('<Tooltip />', function () {
+  it('should be not visible when the mouse is not hovering over the container', function () {
+    const { getByText } = renderWithTheme(
+      <Tooltip label="Grid View">
+        <div />
+      </Tooltip>
+    );
+
+    expect(getByText('Grid View')).not.toBeVisible();
+  });
+
+  it('should be visible when the mouse is hovering over the container', function () {
+    const { getByTestId, getByText } = renderWithTheme(
+      <Tooltip label="Grid View">
+        <div />
+      </Tooltip>
+    );
+
+    const mouseEvent = new MouseEvent('mouseover', {
+      bubbles: true,
+      cancelable: false,
+    });
+
+    act(() => {
+      fireEvent(getByTestId('tooltip-container'), mouseEvent);
+    });
+
+    expect(getByText('Grid View')).toBeVisible();
+  });
+});

--- a/assets/src/dashboard/components/tooltip/test/tooltip.js
+++ b/assets/src/dashboard/components/tooltip/test/tooltip.js
@@ -28,7 +28,7 @@ import Tooltip from '../';
 describe('<Tooltip />', function () {
   it('should be not visible when the mouse is not hovering over the container', function () {
     const { getByText } = renderWithTheme(
-      <Tooltip label="Grid View">
+      <Tooltip content="Grid View">
         <div />
       </Tooltip>
     );
@@ -38,7 +38,7 @@ describe('<Tooltip />', function () {
 
   it('should be visible when the mouse is hovering over the container', function () {
     const { getByTestId, getByText } = renderWithTheme(
-      <Tooltip label="Grid View">
+      <Tooltip content="Grid View">
         <div />
       </Tooltip>
     );

--- a/assets/src/dashboard/components/viewStyleBar.js
+++ b/assets/src/dashboard/components/viewStyleBar.js
@@ -24,7 +24,6 @@ import { __ } from '@wordpress/i18n';
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useRef } from 'react';
 
 /**
  * Internal dependencies
@@ -70,10 +69,9 @@ const GridIcon = styled(GridSVG).attrs(ICON_METRICS.VIEW_STYLE)`
 `;
 
 export default function ViewStyleBar({ onPress, layoutStyle }) {
-  const toggleRef = useRef();
   return (
-    <Container ref={toggleRef}>
-      <Tooltip label={VIEW_STYLE_LABELS[layoutStyle]}>
+    <Container>
+      <Tooltip content={VIEW_STYLE_LABELS[layoutStyle]} position="right">
         <ToggleButton
           aria-label={__(
             'Toggle between showing stories as a grid or list.',

--- a/assets/src/dashboard/components/viewStyleBar.js
+++ b/assets/src/dashboard/components/viewStyleBar.js
@@ -24,6 +24,7 @@ import { __ } from '@wordpress/i18n';
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { useRef } from 'react';
 
 /**
  * Internal dependencies
@@ -31,7 +32,8 @@ import styled from 'styled-components';
 
 import { ReactComponent as GridSVG } from '../icons/grid.svg';
 import { ReactComponent as ListSVG } from '../icons/list.svg';
-import { ICON_METRICS, VIEW_STYLE } from '../constants';
+import { ICON_METRICS, VIEW_STYLE, VIEW_STYLE_LABELS } from '../constants';
+import Tooltip from './tooltip';
 
 const Container = styled.div`
   display: flex;
@@ -68,18 +70,21 @@ const GridIcon = styled(GridSVG).attrs(ICON_METRICS.VIEW_STYLE)`
 `;
 
 export default function ViewStyleBar({ onPress, layoutStyle }) {
+  const toggleRef = useRef();
   return (
-    <Container>
-      <ToggleButton
-        aria-label={__(
-          'Toggle between showing stories as a grid or list.',
-          'web-stories'
-        )}
-        onClick={onPress}
-      >
-        {layoutStyle === VIEW_STYLE.GRID && <ListIcon />}
-        {layoutStyle === VIEW_STYLE.LIST && <GridIcon />}
-      </ToggleButton>
+    <Container ref={toggleRef}>
+      <Tooltip label={VIEW_STYLE_LABELS[layoutStyle]}>
+        <ToggleButton
+          aria-label={__(
+            'Toggle between showing stories as a grid or list.',
+            'web-stories'
+          )}
+          onClick={onPress}
+        >
+          {layoutStyle === VIEW_STYLE.GRID && <ListIcon />}
+          {layoutStyle === VIEW_STYLE.LIST && <GridIcon />}
+        </ToggleButton>
+      </Tooltip>
     </Container>
   );
 }

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -102,6 +102,11 @@ export const VIEW_STYLE = {
   LIST: 'LIST',
 };
 
+export const VIEW_STYLE_LABELS = {
+  [VIEW_STYLE.GRID]: __('Grid View', 'web-stories'),
+  [VIEW_STYLE.LIST]: __('List View', 'web-stories'),
+};
+
 export const ICON_METRICS = {
   VIEW_STYLE: { width: 17, height: 14 },
   UP_DOWN_ARROW: { width: 16, height: 16 },

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -128,6 +128,14 @@ const theme = {
   floatingTab: {
     shadow: '0px 2px 8px rgba(0, 0, 0, 0.17)',
   },
+  storyPreview: {
+    shadow: '1px 1px 5px hsla(0, 0%, 0%, 0.15)',
+    border: `1px solid ${colors.gray75}`,
+  },
+  tooltip: {
+    background: colors.gray900,
+    color: colors.white,
+  },
   navBar: {
     height: 64,
   },

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -131,6 +131,7 @@ const theme = {
   storyPreview: {
     shadow: '1px 1px 5px hsla(0, 0%, 0%, 0.15)',
     border: `1px solid ${colors.gray75}`,
+    borderRadius: 4,
   },
   tooltip: {
     background: colors.gray900,


### PR DESCRIPTION
Adds tooltip components and overlay to view toggle.

Secondarily adds borders around the preview cards and prevents off-canvas elements from showing up.

<img width="221" alt="Screen Shot 2020-05-14 at 8 54 13 PM" src="https://user-images.githubusercontent.com/1738349/82003090-16e0a980-9625-11ea-87e1-8fe713c7f3ea.png">
<img width="387" alt="Screen Shot 2020-05-14 at 8 31 06 PM" src="https://user-images.githubusercontent.com/1738349/82002925-b9e4f380-9624-11ea-9b24-144f82cc3d52.png">

## Relevant Technical Choices

- Uses mouse events to control visibility of the tooltip since they are more predictable and controllable  

Fixes #1489
