### PR TITLE
Dahboard: Remove template filters from view that aren't not ready yet

### DIFF
--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -203,26 +203,12 @@ function TemplatesGallery() {
                     onChange={onNewCategorySelected}
                   />
                   <Dropdown
-                    ariaLabel={__('Style Dropdown', 'web-stories')}
-                    type={DROPDOWN_TYPES.PANEL}
-                    placeholder={__('Style', 'web-stories')}
-                    items={[]}
-                    onChange={() => {}}
-                  />
-                  <Dropdown
                     ariaLabel={__('Color Dropdown', 'web-stories')}
                     type={DROPDOWN_TYPES.COLOR_PANEL}
                     placeholder={__('Color', 'web-stories')}
                     items={selectedColors}
                     onClear={clearAllColors}
                     onChange={onNewColorSelected}
-                  />
-                  <Dropdown
-                    ariaLabel={__('Layout Type Dropdown', 'web-stories')}
-                    type={DROPDOWN_TYPES.PANEL}
-                    placeholder={__('Layout Type', 'web-stories')}
-                    items={[]}
-                    onChange={() => {}}
                   />
                 </HeadingDropdownsContainer>
               </PageHeading>

--- a/assets/src/dashboard/app/views/templates/index.js
+++ b/assets/src/dashboard/app/views/templates/index.js
@@ -65,10 +65,12 @@ import useTemplateFilters from './templateFilters';
 const HeadingDropdownsContainer = styled.div`
   display: flex;
   align-items: baseline;
-  justify-content: space-evenly;
+  flex-direction: row;
+  justify-content: center;
+  width: 100%;
 
   ${DropdownContainer} {
-    margin-right: 10px;
+    margin: 0 10px;
     &:last-child {
       margin-right: 0;
     }


### PR DESCRIPTION
## Summary
In our dashboard sync this week we discussed #1511 and  #1512 template filter dropdowns. Since they won't be scoped out any time soon (not critical to release) I am hiding them from the view until they are ready. 

## Relevant Technical Choices
- Opted to center the 2 remaining dropdowns on explore templates to keep consistency in headers between that and my stories toggle button group. 

<img width="1294" alt="Screen Shot 2020-05-15 at 1 50 53 PM" src="https://user-images.githubusercontent.com/10720454/82095712-75a13400-96b4-11ea-9e2d-0a6a72de3edb.png">


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
