### PR TITLE
Use node version from nvm config for bundle-size action

### DIFF
--- a/.github/workflows/continuous-integration-bundle-size.yml
+++ b/.github/workflows/continuous-integration-bundle-size.yml
@@ -10,6 +10,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '${{ steps.nvm.outputs.NVMRC }}'
+
+      - name: Setup npm cache
+        uses: pat-s/always-upload-cache@v1.1.4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-${{ env.cache-name }}-
+            ${{ runner.os }}-npm-
+            ${{ runner.os }}-
+
       - name: Bundle size check
         uses: preactjs/compressed-size-action@v2
         with:


### PR DESCRIPTION
Might help prevent flakiness of this build job.

Background: this project uses `.nvmrc` to specify the Node version that this project works best with and has been tested against. It ensures that everyone runs the project with the same Node version via Node Version Manager (nvm).

Now, on a CI environment the default Node version might change, and might not be the same as the one we define in `.nvmrc`. This can cause issues, for example when installing modules with binaries that were compiled against a different Node version.

It is important that all tools work with the same node version.

This PR makes sure the compressed-size-action uses the same Node version as all other workflows and aspects of the project: the one specified in `.nvmrc`.

**tl;dr**: When the bundle-size workflow runs and executes `npm install`, it will now use whatever Node version we specifcy in `.nvmrc` rather than using the CI's default Node version.