### PR TITLE
Add more permission checks

### DIFF
--- a/assets/src/edit-story/app/api/apiProvider.js
+++ b/assets/src/edit-story/app/api/apiProvider.js
@@ -35,7 +35,7 @@ import Context from './context';
 
 function APIProvider({ children }) {
   const {
-    api: { stories, media, fonts, link, users, statuses },
+    api: { stories, media, fonts, link, users },
   } = useConfig();
 
   const getStoryById = useCallback(
@@ -221,11 +221,6 @@ function APIProvider({ children }) {
     );
   }, [fonts]);
 
-  const getAllStatuses = useCallback(() => {
-    const path = addQueryArgs(statuses, { context: `edit` });
-    return apiFetch({ path });
-  }, [statuses]);
-
   const getAllUsers = useCallback(() => {
     return apiFetch({ path: addQueryArgs(users, { per_page: '-1' }) });
   }, [users]);
@@ -239,7 +234,6 @@ function APIProvider({ children }) {
       saveStoryById,
       deleteStoryById,
       getAllFonts,
-      getAllStatuses,
       getAllUsers,
       uploadMedia,
       updateMedia,

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -171,6 +171,7 @@ function Publish() {
   const {
     state: { isUploading },
   } = useMedia();
+  const { capabilities } = useConfig();
 
   const refreshPostEditURL = useRefreshPostEditURL(storyId);
   const hasFutureDate = Date.now() < Date.parse(date);
@@ -183,8 +184,12 @@ function Publish() {
   const text = hasFutureDate
     ? __('Schedule', 'web-stories')
     : __('Publish', 'web-stories');
+
   return (
-    <Primary onClick={handlePublish} isDisabled={isSaving || isUploading}>
+    <Primary
+      onClick={handlePublish}
+      isDisabled={!capabilities?.hasPublishAction || isSaving || isUploading}
+    >
       {text}
     </Primary>
   );

--- a/assets/src/edit-story/components/header/test/buttons.js
+++ b/assets/src/edit-story/components/header/test/buttons.js
@@ -39,7 +39,8 @@ function setupButtons(extraStoryProps, extraMetaProps) {
     actions: { saveStory, autoSave },
   };
   const configValue = {
-    previewLink: 'https://example.com?preview_id=1679&preview_nonce=b5ea827939&preview=true',
+    previewLink:
+      'https://example.com?preview_id=1679&preview_nonce=b5ea827939&preview=true',
     capabilities: {
       hasPublishAction: true,
     },

--- a/assets/src/edit-story/components/header/test/buttons.js
+++ b/assets/src/edit-story/components/header/test/buttons.js
@@ -39,8 +39,10 @@ function setupButtons(extraStoryProps, extraMetaProps) {
     actions: { saveStory, autoSave },
   };
   const configValue = {
-    previewLink:
-      'https://example.com?preview_id=1679&preview_nonce=b5ea827939&preview=true',
+    previewLink: 'https://example.com?preview_id=1679&preview_nonce=b5ea827939&preview=true',
+    capabilities: {
+      hasPublishAction: true,
+    },
   };
   const { getByText, container } = renderWithTheme(
     <ConfigContext.Provider value={configValue}>

--- a/assets/src/edit-story/components/inspector/document/status.js
+++ b/assets/src/edit-story/components/inspector/document/status.js
@@ -45,8 +45,7 @@ const BoxedTextInput = styled(TextInput)`
 
 function StatusPanel() {
   const {
-    actions: { loadStatuses, loadUsers },
-    state: { statuses },
+    actions: { loadUsers },
   } = useInspector();
 
   const {
@@ -59,7 +58,6 @@ function StatusPanel() {
   const { capabilities } = useConfig();
 
   useEffect(() => {
-    loadStatuses();
     loadUsers();
   });
 
@@ -69,17 +67,20 @@ function StatusPanel() {
       name: __('Draft', 'web-stories'),
       helper: __('Visible to just me', 'web-stories'),
     },
-    {
+  ];
+
+  if (capabilities?.hasPublishAction) {
+    visibilityOptions.push({
       value: 'publish',
       name: __('Public', 'web-stories'),
       helper: __('Visible to everyone', 'web-stories'),
-    },
-    {
+    });
+    visibilityOptions.push({
       value: 'private',
       name: __('Private', 'web-stories'),
       helper: __('Visible to site admins & editors only', 'web-stories'),
-    },
-  ];
+    });
+  }
 
   const passwordProtected = 'protected';
   // @todo Add this back once we have FE implementation, too.
@@ -145,32 +146,30 @@ function StatusPanel() {
 
   return (
     <SimplePanel name="status" title={__('Status & Visibility', 'web-stories')}>
-      {capabilities && capabilities.hasPublishAction && statuses && (
-        <>
-          <Row>
-            <RadioGroup
-              options={visibilityOptions}
-              onChange={handleChangeVisibility}
-              value={getStatusValue(status)}
-            />
-          </Row>
-          {passwordProtected === status && (
-            <>
-              <Row>
-                <BoxedTextInput
-                  label={__('Password', 'web-stories')}
-                  value={password}
-                  onChange={handleChangePassword}
-                  placeholder={__('Enter a password', 'web-stories')}
-                />
-              </Row>
-              <HelperText isWarning={password && password.length > 20}>
-                {__('Must not exceed 20 characters', 'web-stories')}
-              </HelperText>
-            </>
-          )}
-        </>
-      )}
+      <>
+        <Row>
+          <RadioGroup
+            options={visibilityOptions}
+            onChange={handleChangeVisibility}
+            value={getStatusValue(status)}
+          />
+        </Row>
+        {passwordProtected === status && (
+          <>
+            <Row>
+              <BoxedTextInput
+                label={__('Password', 'web-stories')}
+                value={password}
+                onChange={handleChangePassword}
+                placeholder={__('Enter a password', 'web-stories')}
+              />
+            </Row>
+            <HelperText isWarning={password && password.length > 20}>
+              {__('Must not exceed 20 characters', 'web-stories')}
+            </HelperText>
+          </>
+        )}
+      </>
       <Button onClick={handleRemoveStory} fullWidth>
         {__('Move to trash', 'web-stories')}
       </Button>

--- a/assets/src/edit-story/components/inspector/document/test/status.js
+++ b/assets/src/edit-story/components/inspector/document/test/status.js
@@ -34,7 +34,6 @@ function setupPanel(
 ) {
   const updateStory = jest.fn();
   const deleteStory = jest.fn();
-  const loadStatuses = jest.fn();
   const loadUsers = jest.fn();
 
   const config = { timeFormat: 'g:i a', capabilities };
@@ -44,23 +43,8 @@ function setupPanel(
     },
     actions: { updateStory, deleteStory },
   };
-  const statuses = [
-    {
-      value: 'draft',
-      name: 'Draft',
-    },
-    {
-      value: 'publish',
-      name: 'Public',
-    },
-    {
-      value: 'private',
-      name: 'Private',
-    },
-  ];
   const inspectorContextValue = {
-    actions: { loadStatuses, loadUsers },
-    state: { statuses },
+    actions: { loadUsers },
   };
   const { getByText, queryByText } = renderWithTheme(
     <ConfigContext.Provider value={config}>

--- a/assets/src/edit-story/components/inspector/document/test/status.js
+++ b/assets/src/edit-story/components/inspector/document/test/status.js
@@ -45,6 +45,7 @@ function setupPanel(
   };
   const inspectorContextValue = {
     actions: { loadUsers },
+    state: {},
   };
   const { getByText, queryByText } = renderWithTheme(
     <ConfigContext.Provider value={config}>
@@ -77,7 +78,7 @@ describe('StatusPanel', () => {
     const { queryByText } = setupPanel({
       hasPublishAction: false,
     });
-    expect(queryByText('Draft')).toBeNull();
+    expect(queryByText('Public')).toBeNull();
   });
 
   it('should update the story when clicking on status', () => {

--- a/assets/src/edit-story/components/inspector/inspectorProvider.js
+++ b/assets/src/edit-story/components/inspector/inspectorProvider.js
@@ -34,7 +34,7 @@ const PREPUBLISH = 'prepublish';
 
 function InspectorProvider({ children }) {
   const {
-    actions: { getAllStatuses, getAllUsers },
+    actions: { getAllUsers },
   } = useAPI();
   const {
     state: { selectedElementIds, currentPage },
@@ -43,13 +43,11 @@ function InspectorProvider({ children }) {
 
   const [tab, setTab] = useState(DESIGN);
   const [users, setUsers] = useState([]);
-  const [statuses, setStatuses] = useState([]);
   const [inspectorContentHeight, setInspectorContentHeight] = useState(null);
   const inspectorContentRef = useRef();
   const tabRef = useRef(tab);
 
   const [isUsersLoading, setIsUsersLoading] = useState(false);
-  const [isStatusesLoading, setIsStatusesLoading] = useState(false);
 
   const setInspectorContentNode = useCallback((node) => {
     inspectorContentRef.current = node;
@@ -75,25 +73,6 @@ function InspectorProvider({ children }) {
     }
   }, [currentPage]);
 
-  const loadStatuses = useCallback(() => {
-    if (!isStatusesLoading && statuses.length === 0) {
-      setIsStatusesLoading(true);
-      getAllStatuses()
-        .then((data) => {
-          data = Object.values(data);
-          data = data.filter(({ show_in_list: isShown }) => isShown);
-          const saveData = data.map(({ slug, name }) => ({
-            value: slug,
-            name,
-          }));
-          setStatuses(saveData);
-        })
-        .finally(() => {
-          setIsStatusesLoading(false);
-        });
-    }
-  }, [isStatusesLoading, statuses.length, getAllStatuses]);
-
   const loadUsers = useCallback(() => {
     if (!isUsersLoading && users.length === 0) {
       setIsUsersLoading(true);
@@ -116,7 +95,6 @@ function InspectorProvider({ children }) {
     state: {
       tab,
       users,
-      statuses,
       inspectorContentHeight,
       isUsersLoading,
     },
@@ -125,7 +103,6 @@ function InspectorProvider({ children }) {
     },
     actions: {
       setTab,
-      loadStatuses,
       loadUsers,
       setInspectorContentNode,
     },

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -385,12 +385,11 @@ class Story_Post_Type {
 					'hasUploadMediaAction'  => $has_upload_media_action,
 				],
 				'api'              => [
-					'stories'  => sprintf( '/wp/v2/%s', $rest_base ),
-					'media'    => '/wp/v2/media',
-					'users'    => '/wp/v2/users',
-					'statuses' => '/wp/v2/statuses',
-					'fonts'    => '/web-stories/v1/fonts',
-					'link'     => '/web-stories/v1/link',
+					'stories' => sprintf( '/wp/v2/%s', $rest_base ),
+					'media'   => '/wp/v2/media',
+					'users'   => '/wp/v2/users',
+					'fonts'   => '/web-stories/v1/fonts',
+					'link'    => '/web-stories/v1/link',
 				],
 				'metadata'         => [
 					'publisher'       => self::get_publisher_data(),


### PR DESCRIPTION
## Summary

When testing the editor a subscriber, I that neither the publish story button wasn't disabled. Also none of the current status were showing. 

In this PR,
- Add a check on the publish button. 
- Remove REST API call to status API as this data is not longer used. 
- Allow user that can not publish to select draft. 

## Relevant Technical Choices

- The removal of the call to the status api, is needed but seemed like a good idea. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Current
![Screenshot 2020-05-18 at 18 09 48](https://user-images.githubusercontent.com/237508/82240740-d6d63b00-9932-11ea-8c0f-74b189cb9ca6.png)

After this PR
![Screenshot 2020-05-18 at 18 08 04](https://user-images.githubusercontent.com/237508/82240592-92e33600-9932-11ea-8000-241fb884f0f1.png)


<!-- Please describe your changes. -->

## Testing Instructions

- Login as contributor
- try to publish story. 

---

<!-- Please reference the issue(s) this PR addresses. -->

See #1390
