### PR TITLE
Dashboard: Add a link to see the classic WordPress view.

### DIFF
--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -55,6 +55,7 @@ import {
   StoryListView,
   HeaderToggleButtonContainer,
 } from '../shared';
+import { useConfig } from '../../config';
 
 const DefaultBodyText = styled.p`
   font-family: ${({ theme }) => theme.fonts.body1.family};
@@ -91,6 +92,8 @@ function MyStories() {
     filters: STORY_STATUSES,
     totalPages,
   });
+
+  const { wpListURL } = useConfig();
 
   const resultsLabel = useDashboardResultsLabel({
     isActiveSearch: Boolean(search.keyword),
@@ -179,13 +182,14 @@ function MyStories() {
         currentSort={sort.value}
         pageSortOptions={STORY_SORT_MENU_ITEMS}
         handleSortChange={sort.set}
+        wpListURL={wpListURL}
         sortDropdownAriaLabel={__(
           'Choose sort option for display',
           'web-stories'
         )}
       />
     );
-  }, [sort, resultsLabel, view]);
+  }, [sort, resultsLabel, view, wpListURL]);
 
   const BodyContent = useMemo(() => {
     if (orderedStories.length > 0) {

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * External dependencies
  */
 import styled from 'styled-components';
@@ -49,6 +54,7 @@ const SortDropdown = styled(Dropdown)`
 const ControlsContainer = styled.div`
   display: flex;
   justify-content: center;
+  align-items: center;
 `;
 
 const Label = styled.span`
@@ -56,6 +62,17 @@ const Label = styled.span`
   letter-spacing: ${({ theme }) => theme.fonts.body2.letterSpacing}em;
   font-size: ${({ theme }) => theme.fonts.body2.size}px;
   color: ${({ theme }) => theme.colors.gray500};
+`;
+
+const ExternalLink = styled.a`
+  margin-right: 15px;
+  font-family: ${({ theme }) => theme.fonts.body2.family};
+  letter-spacing: ${({ theme }) => theme.fonts.body2.letterSpacing}em;
+  font-size: ${({ theme }) => theme.fonts.body2.size}px;
+  color: ${({ theme }) => theme.colors.bluePrimary};
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
 `;
 
 const BodyViewOptions = ({
@@ -85,11 +102,18 @@ const BodyViewOptions = ({
           </StorySortDropdownContainer>
         )}
         {showGridToggle && (
-          <ViewStyleBar
-            label={resultsLabel}
-            layoutStyle={layoutStyle}
-            onPress={handleLayoutSelect}
-          />
+          <ControlsContainer>
+            {layoutStyle === VIEW_STYLE.LIST && (
+              <ExternalLink href="edit.php?post_type=web-story">
+                {__('See classic WP list view', 'web-stories')}
+              </ExternalLink>
+            )}
+            <ViewStyleBar
+              label={resultsLabel}
+              layoutStyle={layoutStyle}
+              onPress={handleLayoutSelect}
+            />
+          </ControlsContainer>
         )}
       </ControlsContainer>
     </DisplayFormatContainer>

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -75,7 +75,7 @@ const ExternalLink = styled.a`
   text-decoration: none;
 `;
 
-const BodyViewOptions = ({
+export default function BodyViewOptions({
   currentSort,
   handleLayoutSelect,
   handleSortChange,
@@ -84,41 +84,44 @@ const BodyViewOptions = ({
   pageSortOptions = [],
   showGridToggle,
   sortDropdownAriaLabel,
-}) => (
-  <StandardViewContentGutter>
-    <DisplayFormatContainer>
-      <Label>{resultsLabel}</Label>
-      <ControlsContainer>
-        {layoutStyle === VIEW_STYLE.GRID && (
-          <StorySortDropdownContainer>
-            <SortDropdown
-              alignment="flex-end"
-              ariaLabel={sortDropdownAriaLabel}
-              items={pageSortOptions}
-              type={DROPDOWN_TYPES.MENU}
-              value={currentSort}
-              onChange={(newSort) => handleSortChange(newSort.value)}
-            />
-          </StorySortDropdownContainer>
-        )}
-        {showGridToggle && (
-          <ControlsContainer>
-            {layoutStyle === VIEW_STYLE.LIST && (
-              <ExternalLink href="edit.php?post_type=web-story">
-                {__('See classic WP list view', 'web-stories')}
-              </ExternalLink>
-            )}
-            <ViewStyleBar
-              label={resultsLabel}
-              layoutStyle={layoutStyle}
-              onPress={handleLayoutSelect}
-            />
-          </ControlsContainer>
-        )}
-      </ControlsContainer>
-    </DisplayFormatContainer>
-  </StandardViewContentGutter>
-);
+  wpListURL,
+}) {
+  return (
+    <StandardViewContentGutter>
+      <DisplayFormatContainer>
+        <Label>{resultsLabel}</Label>
+        <ControlsContainer>
+          {layoutStyle === VIEW_STYLE.GRID && (
+            <StorySortDropdownContainer>
+              <SortDropdown
+                alignment="flex-end"
+                ariaLabel={sortDropdownAriaLabel}
+                items={pageSortOptions}
+                type={DROPDOWN_TYPES.MENU}
+                value={currentSort}
+                onChange={(newSort) => handleSortChange(newSort.value)}
+              />
+            </StorySortDropdownContainer>
+          )}
+          {showGridToggle && (
+            <ControlsContainer>
+              {layoutStyle === VIEW_STYLE.LIST && wpListURL && (
+                <ExternalLink href={wpListURL}>
+                  {__('See classic WP list view', 'web-stories')}
+                </ExternalLink>
+              )}
+              <ViewStyleBar
+                label={resultsLabel}
+                layoutStyle={layoutStyle}
+                onPress={handleLayoutSelect}
+              />
+            </ControlsContainer>
+          )}
+        </ControlsContainer>
+      </DisplayFormatContainer>
+    </StandardViewContentGutter>
+  );
+}
 
 BodyViewOptions.propTypes = {
   currentSort: PropTypes.string.isRequired,
@@ -126,6 +129,7 @@ BodyViewOptions.propTypes = {
   handleSortChange: PropTypes.func.isRequired,
   layoutStyle: PropTypes.string.isRequired,
   resultsLabel: PropTypes.string.isRequired,
+  wpListURL: PropTypes.string,
   pageSortOptions: PropTypes.arrayOf(
     PropTypes.shape({
       value: PropTypes.string,
@@ -135,4 +139,3 @@ BodyViewOptions.propTypes = {
   showGridToggle: PropTypes.bool,
   sortDropdownAriaLabel: PropTypes.string.isRequired,
 };
-export default BodyViewOptions;

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -141,6 +141,15 @@ class Dashboard {
 			)
 		);
 
+		$classic_wp_list_url = admin_url(
+			add_query_arg(
+				[
+					'post_type' => 'web-story',
+				],
+				'edit.php'
+			)
+		);
+
 		wp_localize_script(
 			self::SCRIPT_HANDLE,
 			'webStoriesDashboardSettings',
@@ -150,6 +159,7 @@ class Dashboard {
 					'isRTL'        => is_rtl(),
 					'newStoryURL'  => $new_story_url,
 					'editStoryURL' => $edit_story_url,
+					'wpListURL'    => $classic_wp_list_url,
 					'assetsURL'    => WEBSTORIES_ASSETS_URL,
 					'version'      => WEBSTORIES_VERSION,
 					'api'          => [


### PR DESCRIPTION
## Summary

Adds a "View Classic WP List View" link to the List View for My Stories.

## Relevant Technical Choices

- Styled component a tag

## To-do

- The PHP-side of this which takes you from the native WP list view back to the new Dashboard list view.

## User-facing changes

- Adds a new link next to the Grid/List toggle

<img width="202" alt="Screen Shot 2020-05-18 at 4 13 28 PM" src="https://user-images.githubusercontent.com/1738349/82260345-b43c2600-9922-11ea-903a-03782af53882.png">

## Testing Instructions

1. Visit "My Stories" on the Dashboad
2. Switch to the List View using the toggle icon
3. Click the "See Classic..." link
4. Verify you are taken to the Wordpress List View

See #1488 
