### PR TITLE
add allow-empty-input in linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
   },
   "lint-staged": {
     "*.js": "eslint --fix",
-    "*.(js|css)": "stylelint --fix",
+    "*.(js|css)": "stylelint --fix --allow-empty-input",
     "*.md": [
       "eslint --fix",
       "markdownlint -f"


### PR DESCRIPTION
add allow-empty-input in linter so that changes in storybook js don't fail in pre-commit

Prevents this:

```
husky > pre-commit (node v12.16.2)
✔ Preparing...
⚠ Running tasks...
  ✔ Running tasks for *.js
  ❯ Running tasks for *.(js|css)
    ✖ stylelint --fix [FAILED]
  ↓ No staged files match *.md [SKIPPED]
  ↓ No staged files match *.php [SKIPPED]
  ↓ No staged files match *.(xml|xml.dist) [SKIPPED]
  ↓ No staged files match *.yml [SKIPPED]
↓ Skipped because of errors from tasks. [SKIPPED]
✔ Reverting to original state because of errors...
✔ Cleaning up... 

✖ stylelint --fix:
Error: No files matching the pattern ".storybook/stories/playground/index.js" were found.
    at /Users/diegovar/Development/projects/web-stories-wp/node_modules/stylelint/lib/standalone.js:211:12
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
husky > pre-commit hook failed (add --no-verify to bypass)
```