### PR TITLE
Dashboard: Add typography presets & clean up theme fonts

### DIFF
--- a/assets/src/dashboard/animations/stories/flip.js
+++ b/assets/src/dashboard/animations/stories/flip.js
@@ -107,7 +107,7 @@ const Flip = ({ name, duration, content, containerStyle, direction }) => {
                 style={{
                   display: 'inline-block',
                   fontSize: '48px',
-                  fontFamily: theme.fonts.heading1.family,
+                  fontFamily: theme.typography.family.primary,
                   fontWeight: 600,
                   color,
                   textTransform: 'uppercase',

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -36,6 +36,7 @@ import {
   Layout,
   StandardViewContentGutter,
   ToggleButtonGroup,
+  TypographyPresets,
 } from '../../../components';
 import {
   VIEW_STYLE,
@@ -57,11 +58,7 @@ import {
 } from '../shared';
 
 const DefaultBodyText = styled.p`
-  font-family: ${({ theme }) => theme.fonts.body1.family};
-  font-weight: ${({ theme }) => theme.fonts.body1.weight};
-  font-size: ${({ theme }) => theme.fonts.body1.size}px;
-  line-height: ${({ theme }) => theme.fonts.body1.lineHeight}px;
-  letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing}em;
+  ${TypographyPresets.Medium};
   color: ${({ theme }) => theme.colors.gray200};
   margin: 40px 20px;
 `;

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -22,7 +22,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import styled from 'styled-components';
 import { useContext, useEffect, useMemo } from 'react';
 
 /**
@@ -36,7 +35,7 @@ import {
   Layout,
   StandardViewContentGutter,
   ToggleButtonGroup,
-  TypographyPresets,
+  DefaultParagraph1,
 } from '../../../components';
 import {
   VIEW_STYLE,
@@ -56,12 +55,6 @@ import {
   StoryListView,
   HeaderToggleButtonContainer,
 } from '../shared';
-
-const DefaultBodyText = styled.p`
-  ${TypographyPresets.Medium};
-  color: ${({ theme }) => theme.colors.gray200};
-  margin: 40px 20px;
-`;
 
 function MyStories() {
   const {
@@ -202,9 +195,9 @@ function MyStories() {
     }
 
     return (
-      <DefaultBodyText>
+      <DefaultParagraph1>
         {__('Create a story to get started!', 'web-stories')}
-      </DefaultBodyText>
+      </DefaultParagraph1>
     );
   }, [
     orderedStories.length,

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -27,6 +27,7 @@ import {
   Dropdown,
   StandardViewContentGutter,
   ViewStyleBar,
+  TypographyPresets,
 } from '../../../components';
 import { DROPDOWN_TYPES, VIEW_STYLE } from '../../../constants';
 
@@ -52,9 +53,7 @@ const ControlsContainer = styled.div`
 `;
 
 const Label = styled.span`
-  font-family: ${({ theme }) => theme.fonts.body2.family};
-  letter-spacing: ${({ theme }) => theme.fonts.body2.letterSpacing}em;
-  font-size: ${({ theme }) => theme.fonts.body2.size}px;
+  ${TypographyPresets.Small}
   color: ${({ theme }) => theme.colors.gray500};
 `;
 

--- a/assets/src/dashboard/app/views/shared/noResults.js
+++ b/assets/src/dashboard/app/views/shared/noResults.js
@@ -28,10 +28,9 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { TypographyPresets } from '../../../components';
+import { Paragraph1 } from '../../../components';
 
-const NoResultsText = styled.p`
-  ${TypographyPresets.Medium}
+const NoResultsText = styled(Paragraph1)`
   color: ${({ theme }) => theme.colors.gray200};
   margin: 40px 20px;
 `;

--- a/assets/src/dashboard/app/views/shared/noResults.js
+++ b/assets/src/dashboard/app/views/shared/noResults.js
@@ -23,26 +23,20 @@ import { __, sprintf } from '@wordpress/i18n';
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 
 /**
  * Internal dependencies
  */
-import { Paragraph1 } from '../../../components';
-
-const NoResultsText = styled(Paragraph1)`
-  color: ${({ theme }) => theme.colors.gray200};
-  margin: 40px 20px;
-`;
+import { DefaultParagraph1 } from '../../../components';
 
 const NoResults = ({ typeaheadValue }) => (
-  <NoResultsText>
+  <DefaultParagraph1>
     {sprintf(
       /* translators: %s: search term. */
       __('Sorry, we couldn\'t find any results matching "%s"', 'web-stories'),
       typeaheadValue
     )}
-  </NoResultsText>
+  </DefaultParagraph1>
 );
 
 NoResults.propTypes = {

--- a/assets/src/dashboard/app/views/shared/noResults.js
+++ b/assets/src/dashboard/app/views/shared/noResults.js
@@ -25,12 +25,13 @@ import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
+/**
+ * Internal dependencies
+ */
+import { TypographyPresets } from '../../../components';
+
 const NoResultsText = styled.p`
-  font-family: ${({ theme }) => theme.fonts.body1.family};
-  font-weight: ${({ theme }) => theme.fonts.body1.weight};
-  font-size: ${({ theme }) => theme.fonts.body1.size}px;
-  line-height: ${({ theme }) => theme.fonts.body1.lineHeight}px;
-  letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing}em;
+  ${TypographyPresets.Medium}
   color: ${({ theme }) => theme.colors.gray200};
   margin: 40px 20px;
 `;

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -26,7 +26,7 @@ import cssLerp from '../../../utils/cssLerp';
 import { StoriesPropType } from '../../../types';
 import { DASHBOARD_LEFT_NAV_WIDTH } from '../../../constants/pageStructure';
 import {
-  ViewHeader,
+  Heading1,
   NavMenuButton,
   StandardViewContentGutter,
 } from '../../../components';
@@ -36,7 +36,7 @@ const Container = styled.div`
   padding: 10px 0 0;
 `;
 
-const StyledHeader = styled(ViewHeader)`
+const StyledHeader = styled(Heading1)`
   display: flex;
   justify-content: flex-start;
   align-items: center;

--- a/assets/src/dashboard/app/views/templates/components.js
+++ b/assets/src/dashboard/app/views/templates/components.js
@@ -22,12 +22,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import {
-  Button,
-  TypographyPresets,
-  Heading2,
-  Paragraph2,
-} from '../../../components';
+import { Button, TypographyPresets, Paragraph2 } from '../../../components';
 
 export const ColumnContainer = styled.section`
   ${({ theme }) => `
@@ -66,7 +61,8 @@ export const Column = styled.div`
   `}
 `;
 
-export const Title = styled(Heading2)`
+export const Title = styled.h1`
+  ${TypographyPresets.ExtraLarge}
   color: ${({ theme }) => theme.colors.gray900};
 `;
 

--- a/assets/src/dashboard/app/views/templates/components.js
+++ b/assets/src/dashboard/app/views/templates/components.js
@@ -22,7 +22,12 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { Button, TypographyPresets } from '../../../components';
+import {
+  Button,
+  TypographyPresets,
+  Heading2,
+  Paragraph2,
+} from '../../../components';
 
 export const ColumnContainer = styled.section`
   ${({ theme }) => `
@@ -61,21 +66,18 @@ export const Column = styled.div`
   `}
 `;
 
-export const Title = styled.h2`
-  ${TypographyPresets.ExtraLarge}
+export const Title = styled(Heading2)`
   color: ${({ theme }) => theme.colors.gray900};
 `;
 
-export const ByLine = styled.p`
-  ${TypographyPresets.Small}
-  ${({ theme }) => `
+export const ByLine = styled(Paragraph2)(
+  ({ theme }) => `
     margin: 0 0 20px;
     color: ${theme.colors.gray400};
-  `}
-`;
+  `
+);
 
-export const Text = styled.p`
-  ${TypographyPresets.Small}
+export const Text = styled(Paragraph2)`
   ${({ theme }) => `
     margin: 0 0 20px;
     color: ${theme.colors.gray900};

--- a/assets/src/dashboard/app/views/templates/components.js
+++ b/assets/src/dashboard/app/views/templates/components.js
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { Button } from '../../../components';
+import { Button, TypographyPresets } from '../../../components';
 
 export const ColumnContainer = styled.section`
   ${({ theme }) => `
@@ -62,33 +62,22 @@ export const Column = styled.div`
 `;
 
 export const Title = styled.h2`
-  ${({ theme }) => `
-    margin: 0;
-    font-family: ${theme.fonts.heading4.family};
-    font-size: ${theme.fonts.heading4.size}px;
-    font-weight: ${theme.fonts.heading4.weight};
-    line-height: ${theme.fonts.heading4.lineHeight}px;
-    color: ${theme.colors.gray900};
-  `}
+  ${TypographyPresets.ExtraLarge}
+  color: ${({ theme }) => theme.colors.gray900};
 `;
 
 export const ByLine = styled.p`
+  ${TypographyPresets.Small}
   ${({ theme }) => `
     margin: 0 0 20px;
-    font-family: ${theme.fonts.body2.family};
-    font-size: ${theme.fonts.body2.size}px;
-    line-height: ${theme.fonts.body2.lineHeight}px;
     color: ${theme.colors.gray400};
   `}
 `;
 
 export const Text = styled.p`
+  ${TypographyPresets.Small}
   ${({ theme }) => `
     margin: 0 0 20px;
-    font-family: ${theme.fonts.body2.family};
-    font-size: ${theme.fonts.body2.size}px;
-    line-height: ${theme.fonts.body2.lineHeight}px;
-    letter-spacing: ${theme.fonts.body2.letterSpacing}em;
     color: ${theme.colors.gray900};
   `}
 `;
@@ -137,12 +126,9 @@ export const RowContainer = styled.section`
 `;
 
 export const SubHeading = styled.h2`
-  font-family: ${({ theme }) => theme.fonts.heading3.family};
-  font-size: ${({ theme }) => theme.fonts.heading3.size}px;
-  line-height: ${({ theme }) => theme.fonts.heading3.lineHeight}px;
-  letter-spacing: ${({ theme }) => theme.fonts.heading3.letterSpacing}em;
-  font-weight: 500;
-  margin: 0 0 20px 0;
+  ${TypographyPresets.Large}
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
+  margin-bottom: 20px;
 `;
 
 export const LargeDisplayPagination = styled.div(

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -24,12 +24,12 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { BUTTON_TYPES, KEYBOARD_USER_SELECTOR } from '../../constants';
+import { TypographyPresets } from '../typography';
 
 const StyledButton = styled.button`
-  font-family: ${({ theme }) => theme.fonts.button.family};
-  font-size: ${({ theme }) => theme.fonts.button.size}px;
-  font-weight: ${({ theme }) => theme.fonts.button.weight};
-  line-height: ${({ theme }) => theme.fonts.button.lineHeight}px;
+  ${TypographyPresets.Small};
+
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
   align-items: center;
   color: ${({ theme }) => theme.colors.white};
   cursor: pointer;

--- a/assets/src/dashboard/components/cardGrid/stories/index.js
+++ b/assets/src/dashboard/components/cardGrid/stories/index.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import moment from 'moment';
 import { text } from '@storybook/addon-knobs';
 
 /**
@@ -58,7 +59,7 @@ const StorybookGridItem = (
       title="Story Title"
       author={'Ron Weasley'}
       status={STORY_STATUS.DRAFT}
-      displayDate={'Modified 2 minutes ago'}
+      displayDate={moment().subtract(2, 'minutes')}
     />
   </CardGridItem>
 );

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -33,23 +33,22 @@ import { STORY_STATUS } from '../../constants';
 import { getFormattedDisplayDate, useFocusOut } from '../../utils/';
 import { TextInput } from '../input';
 import { DashboardStatusesPropType } from '../../types';
-import { TypographyPresets } from '../typography';
+import { Paragraph2 } from '../typography';
 
 const StyledCardTitle = styled.div`
-  ${TypographyPresets.Small}
-  font-weight: ${({ theme }) => theme.typography.weight.bold};
   padding-top: 12px;
   max-width: 90%;
 `;
 
-const StyledTitle = styled.p`
+const StyledTitle = styled(Paragraph2)`
   color: ${({ theme }) => theme.colors.gray900};
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 `;
 
-const TitleBodyText = styled.p`
+const TitleBodyText = styled(Paragraph2)`
   color: ${({ theme }) => theme.colors.gray500};
   font-weight: ${({ theme }) => theme.typography.weight.light};
 `;

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -33,29 +33,25 @@ import { STORY_STATUS } from '../../constants';
 import { getFormattedDisplayDate, useFocusOut } from '../../utils/';
 import { TextInput } from '../input';
 import { DashboardStatusesPropType } from '../../types';
+import { TypographyPresets } from '../typography';
 
 const StyledCardTitle = styled.div`
-  font-family: ${({ theme }) => theme.fonts.storyGridItem.family};
-  font-size: ${({ theme }) => theme.fonts.storyGridItem.size}px;
-  font-weight: 500;
-  letter-spacing: ${({ theme }) => theme.fonts.storyGridItem.letterSpacing}em;
-  line-height: ${({ theme }) => theme.fonts.storyGridItem.lineHeight}px;
+  ${TypographyPresets.Small}
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
   padding-top: 12px;
   max-width: 90%;
 `;
 
 const StyledTitle = styled.p`
   color: ${({ theme }) => theme.colors.gray900};
-  margin: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 `;
 
 const TitleBodyText = styled.p`
-  margin: 0;
   color: ${({ theme }) => theme.colors.gray500};
-  font-weight: 300;
+  font-weight: ${({ theme }) => theme.typography.weight.light};
 `;
 
 const DateHelperText = styled.span`

--- a/assets/src/dashboard/components/cardGridItem/stories/index.js
+++ b/assets/src/dashboard/components/cardGridItem/stories/index.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import moment from 'moment';
 import { actions } from '@storybook/addon-actions';
 
 /**
@@ -71,7 +72,7 @@ export const _default = () => {
         <CardTitle
           title="How to be a leader in the apocalpyse"
           author="Rick Grimes"
-          displayDate="4/4/2020"
+          displayDate={moment('04-04-2020', 'MM-DD-YYYY')}
           status={STORY_STATUS.DRAFT}
         />
       </CardGridItem>
@@ -98,7 +99,7 @@ export const _publishedStory = () => {
         <CardTitle
           title="The 6 fingered man"
           author="Inigo Moñtoya"
-          displayDate="4/19/2020"
+          displayDate={moment('04-19-2020', 'MM-DD-YYYY')}
           status={STORY_STATUS.PUBLISHED}
         />
       </CardGridItem>
@@ -129,7 +130,7 @@ export const _contextMenu = () => {
               title="Story Title"
               author="storybook author"
               status={STORY_STATUS.DRAFT}
-              displayDate={new Date()}
+              displayDate={moment('05-02-2020', 'MM-DD-YYYY')}
             />
             <CardItemMenu
               onMoreButtonSelected={setContextMenuId}

--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -40,6 +40,7 @@ import { ColorDot } from '../colorDot';
 import PopoverMenu from '../popoverMenu';
 import PopoverPanel from '../popoverPanel';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
+import { TypographyPresets } from '../typography';
 
 const dropdownLabelType = {
   [DROPDOWN_TYPES.PANEL]: PILL_LABEL_TYPES.DEFAULT,
@@ -62,6 +63,7 @@ const Label = styled.label`
 `;
 
 export const InnerDropdown = styled.button`
+  ${TypographyPresets.Small}
   ${({ theme, disabled, type, isOpen, hasSelectedItems }) => `
     display: inline-flex;
     justify-content: center;
@@ -75,16 +77,10 @@ export const InnerDropdown = styled.button`
         ? theme.colors.blueLight
         : theme.dropdown[type][isOpen ? 'activeBackground' : 'background']
     };
-
     border-radius: ${theme.dropdown[type].borderRadius}px;
     border: ${theme.dropdown[type].border};
     color: ${theme.colors.gray600};
     cursor: ${disabled ? 'inherit' : 'pointer'};
-    font-family: ${theme.fonts.dropdown.family};
-    font-size: ${theme.fonts.dropdown.size}px;
-    font-weight: ${theme.fonts.dropdown.weight};
-    letter-spacing: ${theme.fonts.dropdown.letterSpacing}em;
-    line-height: ${theme.fonts.dropdown.lineHeight}px;
 
     &:hover {
       background-color: ${

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -75,6 +75,7 @@ export { default as ToggleButtonGroup } from './toggleButtonGroup';
 export { default as TypeaheadInput } from './typeaheadInput';
 export { default as TypeaheadOptions } from './typeaheadOptions';
 export {
+  DefaultParagraph1,
   Heading1,
   Heading2,
   Paragraph1,

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -74,6 +74,12 @@ export { TemplateNavBar } from './templateNavBar';
 export { default as ToggleButtonGroup } from './toggleButtonGroup';
 export { default as TypeaheadInput } from './typeaheadInput';
 export { default as TypeaheadOptions } from './typeaheadOptions';
-export { ViewHeader, TypographyPresets } from './typography';
+export {
+  Heading1,
+  Heading2,
+  Paragraph1,
+  Paragraph2,
+  TypographyPresets,
+} from './typography';
 export { default as ViewStyleBar } from './viewStyleBar';
 export { default as Tooltip } from './tooltip';

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -74,6 +74,6 @@ export { TemplateNavBar } from './templateNavBar';
 export { default as ToggleButtonGroup } from './toggleButtonGroup';
 export { default as TypeaheadInput } from './typeaheadInput';
 export { default as TypeaheadOptions } from './typeaheadOptions';
-export { ViewHeader } from './typography';
+export { ViewHeader, TypographyPresets } from './typography';
 export { default as ViewStyleBar } from './viewStyleBar';
 export { default as Tooltip } from './tooltip';

--- a/assets/src/dashboard/components/infiniteScroller/index.js
+++ b/assets/src/dashboard/components/infiniteScroller/index.js
@@ -25,13 +25,15 @@ import { useEffect, useRef, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
+/**
+ * Internal dependencies
+ */
+import { TypographyPresets } from '../typography';
+
 const ScrollMessage = styled.div`
+  ${TypographyPresets.Small}
   width: 100%;
   margin: 40px auto;
-  font-family: ${({ theme }) => theme.fonts.body2.family};
-  font-size: ${({ theme }) => theme.fonts.body2.size}px;
-  font-weight: ${({ theme }) => theme.fonts.body2.weight};
-  line-height: ${({ theme }) => theme.fonts.body2.lineHeight}px;
   text-align: center;
   color: ${({ theme }) => theme.colors.gray500};
 `;

--- a/assets/src/dashboard/components/input/index.js
+++ b/assets/src/dashboard/components/input/index.js
@@ -19,12 +19,18 @@
  */
 import styled from 'styled-components';
 
+/**
+ * Internal dependencies
+ */
+import { TypographyPresets } from '../typography';
+
 export const TextInput = styled.input`
+  ${TypographyPresets.Small}
   margin: 0;
-  padding: ${({ theme }) => theme.fonts.textInput.padding};
+  padding: 1px 8px;
   border-radius: 6px;
-  border: ${({ theme }) => theme.fonts.textInput.border};
-  font-family: ${({ theme }) => theme.fonts.textInput.family};
-  font-size: ${({ theme }) => theme.fonts.textInput.size}px;
-  letter-spacing: ${({ theme }) => theme.fonts.textInput.letterSpacing}em;
+  border: ${({ theme }) => theme.borders.gray100};
+  &:active {
+    border: ${({ theme }) => theme.borders.action};
+  }
 `;

--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -23,6 +23,7 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import Button from '../button';
+import { TypographyPresets } from '../typography';
 
 export const Content = styled.div`
   display: flex;
@@ -37,15 +38,12 @@ export const NavButton = styled(Button)`
   margin-bottom: 0;
 `;
 
-export const NavLink = styled.a(
-  ({ theme, active }) => `
+export const NavLink = styled.a`
+  ${TypographyPresets.Medium}
+  ${({ theme, active }) => `
     padding: 4px 20px;
     margin: 4px 0;
-    font-family: ${theme.fonts.tab.family};
-    font-size: ${theme.fonts.tab.size}px;
-    font-weight: ${active ? '500' : 'normal'};
-    line-height: ${theme.fonts.tab.lineHeight}px;
-    letter-spacing: ${theme.fonts.tab.letterSpacing}em;
+    font-weight: ${theme.typography.weight[active ? 'bold' : 'normal']};
     text-decoration: none;
     color: ${active ? theme.colors.gray900 : theme.colors.gray600};
 
@@ -56,11 +54,8 @@ export const NavLink = styled.a(
       color: ${active ? theme.colors.gray900 : theme.colors.gray600};
       background-color: ${theme.colors.gray50};
     }
-    @media ${theme.breakpoint.min} {
-      font-size: ${theme.fonts.tab.minSize}px;
-    }
-  `
-);
+  `}
+`;
 
 export const Rule = styled.div(
   ({ theme }) => `
@@ -70,14 +65,10 @@ export const Rule = styled.div(
   `
 );
 
-export const AppInfo = styled.div(
-  ({ theme }) => `
-    color: ${theme.colors.gray500};
-    font-family: ${theme.fonts.smallLabel.family};
-    font-size: ${theme.fonts.smallLabel.size}px;
-    letter-spacing: ${theme.fonts.smallLabel.letterSpacing};
-  `
-);
+export const AppInfo = styled.div`
+  ${TypographyPresets.Small}
+  color: ${({ theme }) => theme.colors.gray500};
+`;
 
 export const LogoPlaceholder = styled.div(
   ({ theme }) => `

--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -66,7 +66,7 @@ export const Rule = styled.div(
 );
 
 export const AppInfo = styled.div`
-  ${TypographyPresets.Small}
+  ${TypographyPresets.ExtraSmall}
   color: ${({ theme }) => theme.colors.gray500};
 `;
 

--- a/assets/src/dashboard/components/pill/components.js
+++ b/assets/src/dashboard/components/pill/components.js
@@ -27,21 +27,16 @@ import { ReactComponent as CheckmarkIcon } from '../../icons/checkmark.svg';
 import { ReactComponent as CloseIcon } from '../../icons/close.svg';
 import { BEZIER } from '../../constants';
 import { visuallyHiddenStyles } from '../../utils/visuallyHiddenStyles';
+import { TypographyPresets } from '../typography';
 
 export const ACTIVE_CHOICE_ICON_SIZE = 16;
 export const ACTIVE_CHOICE_LEFT_MARGIN = 4;
 
-export const PillContainer = styled.label(
-  ({ theme }) => `
-    display: inline-flex;
-    justify-content: center;
-    font-family: ${theme.fonts.pill.family};
-    font-weight: ${theme.fonts.pill.weight};
-    font-size: ${theme.fonts.pill.size}px;
-    line-height: ${theme.fonts.pill.lineHeight}px;
-    letter-spacing: ${theme.fonts.pill.letterSpacing}em;
-`
-);
+export const PillContainer = styled.label`
+  ${TypographyPresets.Small}
+  display: inline-flex;
+  justify-content: center;
+`;
 
 export const PillInput = styled.input`
   ${visuallyHiddenStyles}

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -25,6 +25,7 @@ import styled from 'styled-components';
  */
 import { KEYS } from '../../constants';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
+import { TypographyPresets } from '../typography';
 
 export const MenuContainer = styled.ul`
   align-items: flex-start;
@@ -42,21 +43,17 @@ MenuContainer.propTypes = {
   isOpen: PropTypes.bool,
 };
 
-export const MenuItem = styled.li(
-  ({ theme, isDisabled, isHovering }) => `
+export const MenuItem = styled.li`
+  ${TypographyPresets.Small}
+  ${({ theme, isDisabled, isHovering }) => `
     padding: 5px 25px;
     background: ${isHovering && !isDisabled ? theme.colors.gray25 : 'none'};
     color: ${isDisabled ? theme.colors.gray400 : theme.colors.gray700};
     cursor: ${isDisabled ? 'default' : 'pointer'};
     display: flex;
-    font-family: ${theme.fonts.popoverMenu.family};
-    font-size: ${theme.fonts.popoverMenu.size}px;
-    line-height: ${theme.fonts.popoverMenu.lineHeight}px;
-    font-weight: ${theme.fonts.popoverMenu.weight};
-    letter-spacing: ${theme.fonts.popoverMenu.letterSpacing}em;
     width: 100%;
-  `
-);
+  `}
+`;
 
 MenuItem.propTypes = {
   isDisabled: PropTypes.bool,

--- a/assets/src/dashboard/components/table/index.js
+++ b/assets/src/dashboard/components/table/index.js
@@ -18,13 +18,15 @@
  * External dependencies
  */
 import styled from 'styled-components';
+/**
+ * Internal dependencies
+ */
+import { TypographyPresets } from '../typography';
 
 export const Table = styled.table`
+  ${TypographyPresets.Small}
   border-collapse: collapse;
   width: inherit;
-  font-family: ${({ theme }) => theme.fonts.table.family};
-  font-size: ${({ theme }) => theme.fonts.table.size}px;
-  letter-spacing: ${({ theme }) => theme.fonts.table.letterSpacing}em;
 `;
 
 export const TableBody = styled.tbody``;
@@ -37,7 +39,7 @@ export const TableHeader = styled.thead`
 
 export const TableHeaderCell = styled.th`
   padding: ${({ theme }) => theme.table.headerCellPadding}px;
-  font-weight: ${({ theme }) => theme.fonts.table.weight};
+  font-weight: ${({ theme }) => theme.typography.weight.normal};
   color: ${({ theme }) => theme.colors.gray500};
   text-align: left;
 `;
@@ -98,8 +100,8 @@ export const TableRow = styled.tr``;
 
 export const TableCell = styled.td`
   padding: ${({ theme }) => theme.table.cellPadding}px;
-  font-weight: ${({ theme }) => theme.fonts.table.weight};
-  font-size: ${({ theme }) => theme.fonts.table.size}px;
+  font-weight: ${({ theme }) => theme.typography.weight.normal};
+  font-size: ${({ theme }) => theme.typography.presets.s.size}px;
   color: ${({ theme }) => theme.colors.gray900};
   height: ${({ theme }) => theme.table.cellPadding * 2 + 50}px;
   vertical-align: middle;

--- a/assets/src/dashboard/components/templateNavBar/index.js
+++ b/assets/src/dashboard/components/templateNavBar/index.js
@@ -30,6 +30,7 @@ import styled from 'styled-components';
 import { BUTTON_TYPES } from '../../constants';
 import { BookmarkChip, Button } from '../../components';
 import { parentRoute } from '../../app/router/route';
+import { TypographyPresets } from '../typography';
 
 const Nav = styled.nav`
   ${({ theme }) => `
@@ -66,12 +67,8 @@ const BookmarkToggle = styled(BookmarkChip)`
 `;
 
 const CloseLink = styled.a`
+  ${TypographyPresets.Medium}
   ${({ theme }) => `
-    font-family: ${theme.fonts.body1.family};
-    font-size: ${theme.fonts.body1.size}px;
-    font-weight: ${theme.fonts.body1.weight};
-    line-height: ${theme.fonts.body1.lineHeight}px;
-    letter-spacing: ${theme.fonts.body1.letterSpacing}em;
     text-decoration: none;
     color: ${theme.colors.gray700};
   `}

--- a/assets/src/dashboard/components/templateNavBar/index.js
+++ b/assets/src/dashboard/components/templateNavBar/index.js
@@ -70,6 +70,7 @@ const CloseLink = styled.a`
   ${TypographyPresets.Medium}
   ${({ theme }) => `
     text-decoration: none;
+    font-weight: ${theme.typography.weight.bold};
     color: ${theme.colors.gray700};
   `}
 `;

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -32,6 +32,7 @@ import ResizeObserver from 'resize-observer-polyfill';
  * Internal dependencies
  */
 import { KEYBOARD_USER_SELECTOR, BEZIER } from '../../constants';
+import { TypographyPresets } from '../typography';
 
 const ToggleButtonContainer = styled.div`
   display: flex;
@@ -56,6 +57,7 @@ AnimationBar.propTypes = {
 };
 
 const ToggleButton = styled.button`
+  ${TypographyPresets.Medium}
   cursor: pointer;
 
   ${({ theme, isActive }) => `
@@ -66,11 +68,6 @@ const ToggleButton = styled.button`
     border: none;
     padding: 0;
     margin: 0;
-    font-size: ${theme.fonts.body1.size}px;
-    font-family: ${theme.fonts.body1.family};
-    font-weight: ${theme.fonts.body1.weight}};
-    line-height: ${theme.fonts.body1.lineHeight}px;
-    letter-spacing: ${theme.fonts.body1.letterSpacing}em;
     color: ${isActive ? theme.colors.gray900 : theme.colors.gray600};
     background-color: transparent;
 

--- a/assets/src/dashboard/components/toggleButtonGroup/index.js
+++ b/assets/src/dashboard/components/toggleButtonGroup/index.js
@@ -68,6 +68,7 @@ const ToggleButton = styled.button`
     border: none;
     padding: 0;
     margin: 0;
+    font-weight: ${theme.typography.weight.bold};
     color: ${isActive ? theme.colors.gray900 : theme.colors.gray600};
     background-color: transparent;
 

--- a/assets/src/dashboard/components/tooltip/index.js
+++ b/assets/src/dashboard/components/tooltip/index.js
@@ -20,8 +20,13 @@
 import propTypes from 'prop-types';
 import styled from 'styled-components';
 import { useState, useRef, useMemo, useEffect } from 'react';
+/**
+ * Internal dependencies
+ */
+import { TypographyPresets } from '../typography';
 
 export const Content = styled.div`
+  ${TypographyPresets.Small}
   visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
   position: absolute;
   border-radius: 2px;

--- a/assets/src/dashboard/components/typeaheadInput/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/index.js
@@ -33,6 +33,7 @@ import { ReactComponent as SearchIcon } from '../../icons/search.svg';
 import { ReactComponent as CloseIcon } from '../../icons/close.svg';
 import useFocusOut from '../../utils/useFocusOut';
 import TypeaheadOptions from '../typeaheadOptions';
+import { TypographyPresets } from '../typography';
 
 const SearchContainer = styled.div`
   display: flex;
@@ -78,15 +79,12 @@ ControlVisibilityContainer.propTypes = {
 };
 
 const StyledInput = styled.input`
+  ${TypographyPresets.Small}
   position: relative;
   height: 100%;
   width: 100%;
   padding: 0 0 0 7.5px;
-  font-family: ${({ theme }) => theme.fonts.typeaheadInput.family};
-  font-size: ${({ theme }) => theme.fonts.typeaheadInput.size}px;
-  line-height: ${({ theme }) => theme.fonts.typeaheadInput.lineHeight}px;
-  letter-spacing: ${({ theme }) => theme.fonts.typeaheadInput.letterSpacing}em;
-  font-weight: ${({ theme }) => theme.fonts.typeaheadInput.weight};
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
   text-overflow: ellipsis;
   color: ${({ theme }) => theme.colors.gray900};
   background-color: transparent;

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -26,6 +26,7 @@ import { useEffect, useState, useRef } from 'react';
  */
 import { KEYS, Z_INDEX } from '../../constants';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
+import { TypographyPresets } from '../typography';
 
 export const Menu = styled.ul`
   ${({ theme, isOpen }) => `
@@ -48,21 +49,17 @@ Menu.propTypes = {
   isOpen: PropTypes.bool,
 };
 
-const MenuItem = styled.li(
-  ({ theme, isDisabled, isHovering }) => `
+const MenuItem = styled.li`
+  ${TypographyPresets.Small}
+  ${({ theme, isDisabled, isHovering }) => `
     padding: 10px 20px;
     background: ${isHovering ? theme.colors.gray25 : 'none'};
     color: ${theme.colors.gray700};
     cursor: ${isDisabled ? 'default' : 'pointer'};
     display: flex;
-    font-family: ${theme.fonts.typeaheadOptions.family};
-    font-size: ${theme.fonts.typeaheadOptions.size}px;
-    line-height: ${theme.fonts.typeaheadOptions.lineHeight}px;
-    font-weight: ${theme.fonts.typeaheadOptions.weight};
-    letter-spacing: ${theme.fonts.typeaheadOptions.letterSpacing}em;
     width: 100%;
-  `
-);
+  `}
+`;
 MenuItem.propTypes = {
   isDisabled: PropTypes.bool,
   isHovering: PropTypes.bool,

--- a/assets/src/dashboard/components/typography.js
+++ b/assets/src/dashboard/components/typography.js
@@ -17,18 +17,78 @@
 /**
  * External dependencies
  */
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-export const ViewHeader = styled.h1`
-  font-family: ${({ theme }) => theme.fonts.heading1.family};
-  font-size: ${({ theme }) => theme.fonts.heading1.size}px;
-  line-height: ${({ theme }) => theme.fonts.heading1.lineHeight}px;
-  letter-spacing: ${({ theme }) => theme.fonts.heading1.letterSpacing}em;
-  font-weight: 500;
-  margin: 0;
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    font-size: ${({ theme }) => theme.fonts.heading1.minSize}px;
-    line-height: ${({ theme }) => theme.fonts.heading1.minLineHeight}px;
-    letter-spacing: ${({ theme }) => theme.fonts.heading1.minLetterSpacing}em;
-  }
-`;
+const ExtraExtraLarge = css(
+  ({ theme }) => `
+    font-size: ${theme.typography.presets.xxl.size}px;
+    font-family: ${theme.typography.presets.xxl.family};
+    font-weight: ${theme.typography.weight.normal};
+    line-height: ${theme.typography.presets.xxl.lineHeight}px;
+    letter-spacing: ${theme.typography.presets.xxl.letterSpacing}em;
+
+    @media ${theme.breakpoint.smallDisplayPhone} {
+      font-size: ${theme.typography.presets.xxl.minSize}px;
+      line-height: ${theme.typography.presets.xxl.minLineHeight}px;
+      letter-spacing: ${theme.typography.presets.xxl.minLetterSpacing}em;
+    }
+  `
+);
+
+const ExtraLarge = css(
+  ({ theme }) => `
+    font-size: ${theme.typography.presets.xl.size}px;
+    font-family: ${theme.typography.presets.xl.family};
+    font-weight: ${theme.typography.weight.normal};
+    line-height: ${theme.typography.presets.xl.lineHeight}px;
+    letter-spacing: ${theme.typography.presets.xl.letterSpacing}em;
+  `
+);
+
+const Large = css(
+  ({ theme }) => `
+    font-size: ${theme.typography.presets.l.size}px;
+    font-family: ${theme.typography.presets.l.family};
+    font-weight: ${theme.typography.weight.normal};
+    line-height: ${theme.typography.presets.l.lineHeight}px;
+    letter-spacing: ${theme.typography.presets.l.letterSpacing}em;
+  `
+);
+
+const Medium = css(
+  ({ theme }) => `
+    font-size: ${theme.typography.presets.m.size}px;
+    font-family: ${theme.typography.presets.m.family};
+    font-weight: ${theme.typography.weight.normal};
+    line-height: ${theme.typography.presets.m.lineHeight}px;
+    letter-spacing: ${theme.typography.presets.m.letterSpacing}em;
+    @media ${theme.breakpoint.smallDisplayPhone} {
+      font-size: ${theme.typography.presets.m.minSize}px;
+    }
+  `
+);
+
+const Small = css(
+  ({ theme }) => `
+    font-size: ${theme.typography.presets.s.size}px;
+    font-family: ${theme.typography.presets.s.family};
+    font-weight: ${theme.typography.weight.normal};
+    line-height: ${theme.typography.presets.s.lineHeight}px;
+    letter-spacing: ${theme.typography.presets.s.letterSpacing}em;
+  `
+);
+
+export const ViewHeader = styled.h1(
+  ({ theme }) => `
+    ${ExtraExtraLarge}
+    font-weight: ${theme.typography.weight.bold};
+  `
+);
+
+export const TypographyPresets = {
+  ExtraExtraLarge,
+  ExtraLarge,
+  Large,
+  Medium,
+  Small,
+};

--- a/assets/src/dashboard/components/typography/index.js
+++ b/assets/src/dashboard/components/typography/index.js
@@ -19,75 +19,63 @@
  */
 import styled, { css } from 'styled-components';
 
-const ExtraExtraLarge = css(
-  ({ theme }) => `
-    font-size: ${theme.typography.presets.xxl.size}px;
-    font-family: ${theme.typography.presets.xxl.family};
-    font-weight: ${theme.typography.weight.normal};
-    line-height: ${theme.typography.presets.xxl.lineHeight}px;
-    letter-spacing: ${theme.typography.presets.xxl.letterSpacing}em;
+const ExtraExtraLarge = ({ theme }) => css`
+  font-size: ${theme.typography.presets.xxl.size}px;
+  font-family: ${theme.typography.presets.xxl.family};
+  font-weight: ${theme.typography.weight.normal};
+  line-height: ${theme.typography.presets.xxl.lineHeight}px;
+  letter-spacing: ${theme.typography.presets.xxl.letterSpacing}em;
 
-    @media ${theme.breakpoint.smallDisplayPhone} {
-      font-size: ${theme.typography.presets.xxl.minSize}px;
-      line-height: ${theme.typography.presets.xxl.minLineHeight}px;
-      letter-spacing: ${theme.typography.presets.xxl.minLetterSpacing}em;
-    }
-  `
-);
+  @media ${theme.breakpoint.smallDisplayPhone} {
+    font-size: ${theme.typography.presets.xxl.minSize}px;
+    line-height: ${theme.typography.presets.xxl.minLineHeight}px;
+    letter-spacing: ${theme.typography.presets.xxl.minLetterSpacing}em;
+  }
+`;
 
-const ExtraLarge = css(
-  ({ theme }) => `
-    font-size: ${theme.typography.presets.xl.size}px;
-    font-family: ${theme.typography.presets.xl.family};
-    font-weight: ${theme.typography.weight.normal};
-    line-height: ${theme.typography.presets.xl.lineHeight}px;
-    letter-spacing: ${theme.typography.presets.xl.letterSpacing}em;
-  `
-);
+const ExtraLarge = ({ theme }) => css`
+  font-size: ${theme.typography.presets.xl.size}px;
+  font-family: ${theme.typography.presets.xl.family};
+  font-weight: ${theme.typography.weight.normal};
+  line-height: ${theme.typography.presets.xl.lineHeight}px;
+  letter-spacing: ${theme.typography.presets.xl.letterSpacing}em;
+`;
 
-const Large = css(
-  ({ theme }) => `
-    font-size: ${theme.typography.presets.l.size}px;
-    font-family: ${theme.typography.presets.l.family};
-    font-weight: ${theme.typography.weight.normal};
-    line-height: ${theme.typography.presets.l.lineHeight}px;
-    letter-spacing: ${theme.typography.presets.l.letterSpacing}em;
-  `
-);
+const Large = ({ theme }) => css`
+  font-size: ${theme.typography.presets.l.size}px;
+  font-family: ${theme.typography.presets.l.family};
+  font-weight: ${theme.typography.weight.normal};
+  line-height: ${theme.typography.presets.l.lineHeight}px;
+  letter-spacing: ${theme.typography.presets.l.letterSpacing}em;
+`;
 
-const Medium = css(
-  ({ theme }) => `
-    font-size: ${theme.typography.presets.m.size}px;
-    font-family: ${theme.typography.presets.m.family};
-    font-weight: ${theme.typography.weight.normal};
-    line-height: ${theme.typography.presets.m.lineHeight}px;
-    letter-spacing: ${theme.typography.presets.m.letterSpacing}em;
-    
-    @media ${theme.breakpoint.smallDisplayPhone} {
-      font-size: ${theme.typography.presets.m.minSize}px;
-    }
-  `
-);
+const Medium = ({ theme }) => css`
+  font-size: ${theme.typography.presets.m.size}px;
+  font-family: ${theme.typography.presets.m.family};
+  font-weight: ${theme.typography.weight.normal};
+  line-height: ${theme.typography.presets.m.lineHeight}px;
+  letter-spacing: ${theme.typography.presets.m.letterSpacing}em;
 
-const Small = css(
-  ({ theme }) => `
-    font-size: ${theme.typography.presets.s.size}px;
-    font-family: ${theme.typography.presets.s.family};
-    font-weight: ${theme.typography.weight.normal};
-    line-height: ${theme.typography.presets.s.lineHeight}px;
-    letter-spacing: ${theme.typography.presets.s.letterSpacing}em;
-  `
-);
+  @media ${theme.breakpoint.smallDisplayPhone} {
+    font-size: ${theme.typography.presets.m.minSize}px;
+  }
+`;
 
-const ExtraSmall = css(
-  ({ theme }) => `
-    font-size: ${theme.typography.presets.xs.size}px;
-    font-family: ${theme.typography.presets.xs.family};
-    font-weight: ${theme.typography.weight.normal};
-    line-height: ${theme.typography.presets.xs.lineHeight}px;
-    letter-spacing: ${theme.typography.presets.xs.letterSpacing}em;
-  `
-);
+const Small = ({ theme }) => css`
+  font-size: ${theme.typography.presets.s.size}px;
+  font-family: ${theme.typography.presets.s.family};
+  font-weight: ${theme.typography.weight.normal};
+  line-height: ${theme.typography.presets.s.lineHeight}px;
+  letter-spacing: ${theme.typography.presets.s.letterSpacing}em;
+`;
+
+const ExtraSmall = ({ theme }) => css`
+  font-size: ${theme.typography.presets.xs.size}px;
+  font-family: ${theme.typography.presets.xs.family};
+  font-weight: ${theme.typography.weight.normal};
+  line-height: ${theme.typography.presets.xs.lineHeight}px;
+  letter-spacing: ${theme.typography.presets.xs.letterSpacing}em;
+`;
 
 export const Heading1 = styled.h1`
   ${ExtraExtraLarge}

--- a/assets/src/dashboard/components/typography/index.js
+++ b/assets/src/dashboard/components/typography/index.js
@@ -62,6 +62,7 @@ const Medium = css(
     font-weight: ${theme.typography.weight.normal};
     line-height: ${theme.typography.presets.m.lineHeight}px;
     letter-spacing: ${theme.typography.presets.m.letterSpacing}em;
+    
     @media ${theme.breakpoint.smallDisplayPhone} {
       font-size: ${theme.typography.presets.m.minSize}px;
     }
@@ -100,6 +101,11 @@ export const Heading2 = styled.h2`
 
 export const Paragraph1 = styled.p`
   ${Medium}
+`;
+
+export const DefaultParagraph1 = styled(Paragraph1)`
+  color: ${({ theme }) => theme.colors.gray200};
+  margin: 40px 20px;
 `;
 
 export const Paragraph2 = styled.p`

--- a/assets/src/dashboard/components/typography/index.js
+++ b/assets/src/dashboard/components/typography/index.js
@@ -87,18 +87,14 @@ export const Heading2 = styled.h2`
   font-weight: ${({ theme }) => theme.typography.weight.bold};
 `;
 
-export const Paragraph1 = styled.p`
-  ${Medium}
-`;
+export const Paragraph1 = styled.p(Medium);
 
 export const DefaultParagraph1 = styled(Paragraph1)`
   color: ${({ theme }) => theme.colors.gray200};
   margin: 40px 20px;
 `;
 
-export const Paragraph2 = styled.p`
-  ${Small}
-`;
+export const Paragraph2 = styled.p(Small);
 
 export const TypographyPresets = {
   ExtraExtraLarge,

--- a/assets/src/dashboard/components/typography/index.js
+++ b/assets/src/dashboard/components/typography/index.js
@@ -78,6 +78,16 @@ const Small = css(
   `
 );
 
+const ExtraSmall = css(
+  ({ theme }) => `
+    font-size: ${theme.typography.presets.xs.size}px;
+    font-family: ${theme.typography.presets.xs.family};
+    font-weight: ${theme.typography.weight.normal};
+    line-height: ${theme.typography.presets.xs.lineHeight}px;
+    letter-spacing: ${theme.typography.presets.xs.letterSpacing}em;
+  `
+);
+
 export const Heading1 = styled.h1`
   ${ExtraExtraLarge}
   font-weight: ${({ theme }) => theme.typography.weight.bold};
@@ -85,6 +95,7 @@ export const Heading1 = styled.h1`
 
 export const Heading2 = styled.h2`
   ${ExtraLarge}
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
 `;
 
 export const Paragraph1 = styled.p`
@@ -101,4 +112,5 @@ export const TypographyPresets = {
   Large,
   Medium,
   Small,
+  ExtraSmall,
 };

--- a/assets/src/dashboard/components/typography/index.js
+++ b/assets/src/dashboard/components/typography/index.js
@@ -78,12 +78,22 @@ const Small = css(
   `
 );
 
-export const ViewHeader = styled.h1(
-  ({ theme }) => `
-    ${ExtraExtraLarge}
-    font-weight: ${theme.typography.weight.bold};
-  `
-);
+export const Heading1 = styled.h1`
+  ${ExtraExtraLarge}
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
+`;
+
+export const Heading2 = styled.h2`
+  ${ExtraLarge}
+`;
+
+export const Paragraph1 = styled.p`
+  ${Medium}
+`;
+
+export const Paragraph2 = styled.p`
+  ${Small}
+`;
 
 export const TypographyPresets = {
   ExtraExtraLarge,

--- a/assets/src/dashboard/components/typography/stories/index.js
+++ b/assets/src/dashboard/components/typography/stories/index.js
@@ -17,7 +17,13 @@
 /**
  * Internal dependencies
  */
-import { Heading1, Heading2, Paragraph1, Paragraph2 } from '../';
+import {
+  Heading1,
+  Heading2,
+  Paragraph1,
+  Paragraph2,
+  DefaultParagraph1,
+} from '../';
 
 export default {
   title: 'Dashboard/Components/Typography',
@@ -26,9 +32,13 @@ export default {
 
 export const _default = () => (
   <>
-    <Heading1>{'h1 Heading'}</Heading1>
-    <Heading2>{'h2 Heading'}</Heading2>
-    <Paragraph1>{'Larger Body Text'}</Paragraph1>
-    <Paragraph2>{'Smaller Body Text'}</Paragraph2>
+    <Heading1>{'<Heading1> - h1 Heading'}</Heading1>
+    <Heading2>{'<Heading2> - h2 Heading'}</Heading2>
+    <Paragraph1>{'<Paragraph1> - Larger Body Text'}</Paragraph1>
+    <Paragraph2>{'<Paragraph2> - Smaller Body Text'}</Paragraph2>
+    <hr />
+    <DefaultParagraph1>
+      {'<DefaultParagraph1> - used for default and helper text on dashboard'}
+    </DefaultParagraph1>
   </>
 );

--- a/assets/src/dashboard/components/typography/stories/index.js
+++ b/assets/src/dashboard/components/typography/stories/index.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Heading1, Heading2, Paragraph1, Paragraph2 } from '../';
+
+export default {
+  title: 'Dashboard/Components/Typography',
+  component: Heading1,
+};
+
+export const _default = () => (
+  <>
+    <Heading1>{'h1 Heading'}</Heading1>
+    <Heading2>{'h2 Heading'}</Heading2>
+    <Paragraph1>{'Larger Body Text'}</Paragraph1>
+    <Paragraph2>{'Smaller Body Text'}</Paragraph2>
+  </>
+);

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -172,7 +172,7 @@ const theme = {
     presets: {
       xxl: {
         family: themeFonts.primary,
-        size: 26,
+        size: 32,
         minSize: 18,
         lineHeight: 53,
         minLineHeight: 43,

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -31,6 +31,10 @@ export const GlobalStyle = createGlobalStyle`
 	*::before {
 		box-sizing: border-box;
     }
+    
+  h1, h2, h3, h4, h5, h6, p, a {
+    margin: 0;
+  }
 `;
 
 export function useTheme() {
@@ -157,117 +161,55 @@ const theme = {
     desktopWidth: 595,
     tabletWidth: 395,
   },
-  fonts: {
-    heading1: {
-      family: themeFonts.primary,
-      size: 26,
-      minSize: 18,
-      lineHeight: 53,
-      minLineHeight: 43,
-      letterSpacing: -0.005,
-      minLetterSpacing: -0.01,
+  typography: {
+    family: { ...themeFonts },
+    weight: {
+      normal: '400',
+      light: '300',
+      bold: '500',
+      bolder: '700',
     },
-    heading3: {
-      family: themeFonts.primary,
-      size: 20,
-      lineHeight: 28,
-      letterSpacing: -0.01,
-      weight: 500,
-    },
-    heading4: {
-      family: themeFonts.primary,
-      size: 28,
-      lineHeight: 35,
-      weight: 500,
-    },
-    body1: {
-      family: themeFonts.primary,
-      size: 16,
-      weight: 500,
-      lineHeight: 22,
-      letterSpacing: 0.001,
-    },
-    body2: {
-      family: themeFonts.primary,
-      size: 14,
-      lineHeight: 22,
-      letterSpacing: 0.015,
-    },
-    tab: {
-      family: themeFonts.primary,
-      size: 16,
-      minSize: 12,
-      lineHeight: 20,
-      letterSpacing: 0.01,
-      weight: '500',
-    },
-    smallLabel: {
-      family: themeFonts.primary,
-      size: 12,
-      minSize: 10,
-      letterSpacing: '0.01em',
-    },
-    button: {
-      family: themeFonts.primary,
-      size: 14,
-      lineHeight: 20,
-      weight: '500',
-    },
-    pill: {
-      family: themeFonts.primary,
-      weight: 400,
-      size: 14,
-      lineHeight: 20,
-      letterSpacing: 0.01,
-    },
-    popoverMenu: {
-      family: themeFonts.primary,
-      size: 14,
-      lineHeight: 20,
-      weight: '400',
-      letterSpacing: 0.01,
-    },
-    dropdown: {
-      family: themeFonts.primary,
-      size: 14,
-      lineHeight: 20,
-      weight: '400',
-      letterSpacing: 0.01,
-    },
-    textInput: {
-      family: themeFonts.primary,
-      size: 13,
-      border: borders.gray100,
-      activeBorder: borders.bluePrimary,
-      weight: '400',
-      letterSpacing: 0.01,
-      padding: '1px 8px',
-    },
-    storyGridItem: {
-      family: themeFonts.primary,
-      size: 14,
-      lineHeight: 20,
-      letterSpacing: 0.01,
-    },
-    table: {
-      family: themeFonts.primary,
-      size: 14,
-      weight: 'normal',
-      letterSpacing: 0.01,
-    },
-    typeaheadInput: {
-      family: themeFonts.primary,
-      size: 14,
-      lineHeight: 20,
-      weight: '500',
-      letterSpacing: 0.01,
-    },
-    typeaheadOptions: {
-      family: themeFonts.primary,
-      size: 14,
-      lineHeight: 20,
-      weight: '400',
-      letterSpacing: 0.01,
+    presets: {
+      xxl: {
+        family: themeFonts.primary,
+        size: 26,
+        minSize: 18,
+        lineHeight: 53,
+        minLineHeight: 43,
+        letterSpacing: -0.005,
+        minLetterSpacing: -0.01,
+      },
+      xl: {
+        family: themeFonts.primary,
+        size: 28,
+        lineHeight: 35,
+        letterSpacing: -0.01,
+      },
+      l: {
+        family: themeFonts.primary,
+        size: 20,
+        lineHeight: 28,
+        letterSpacing: -0.01,
+      },
+      m: {
+        family: themeFonts.primary,
+        size: 16,
+        lineHeight: 22,
+        letterSpacing: 0.01,
+        minSize: 12,
+      },
+      s: {
+        family: themeFonts.primary,
+        size: 14,
+        lineHeight: 20,
+        letterSpacing: 0.01,
+      },
+      xs: {
+        family: themeFonts.primary,
+        size: 12,
+        minSize: 10,
+        letterSpacing: 0.01,
+      },
     },
   },
   detailViewContentGutter: {


### PR DESCRIPTION
## Summary
There should be minimal visible change here. Drying up the theme fonts that were by component to use xxl - xs sizes to try and help regulate font sizes to be consistent. 

## Relevant Technical Choices
- Added new `typography` section to theme which replaces `fonts` and separates out font weights, families, and adds presets. Presets work the same way that the fonts by component worked.
- Moved `Components/typography.js` to `Components/typography/index.js`
- Added some css presets to import to our text components. Named them `ExtraExtraLarge` through `ExtraSmall`. Opted to write out the abbreviation (xxl for instance) because I think it reads better for normal sizes like `Small` rather than `s`. 
- Also added 2 heading and paragraph elements that can be imported. I wanted to remain element agnostic for the presets so that we can keep our heading outlines proper and not based on whatever size is called for. You'll see I updated the headings for the template details page that got off by 1 level. These element presets aren't super in use, but I wanted to leave them to establish patterns and start a storybook for typography. 


## User-facing changes
- the font size on the input to rename titles is 14px instead of 13px. I think the continuity for it to be the same, set size is more important.
- The default 13px for card title area is now 14px which is the font size we've been using everywhere else
- Tooltip set to 14px, wasn't getting a font size before

## Testing Instructions
- Review Dashboard storybook components and UI and see that styles for typography are getting applied just like before. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
