### PR TITLE
List table: add link to dashboard

### DIFF
--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -28,6 +28,8 @@
 
 namespace Google\Web_Stories;
 
+use WP_Screen;
+
 /**
  * Dashboard class.
  */
@@ -54,6 +56,7 @@ class Dashboard {
 	public function init() {
 		add_action( 'admin_menu', [ $this, 'add_menu_page' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+		add_action( 'admin_notices', [ $this, 'display_link_to_dashboard' ] );
 	}
 
 	/**
@@ -182,5 +185,41 @@ class Dashboard {
 			wp_styles()->registered['wp-admin']->deps,
 			[ 'forms' ]
 		);
+	}
+
+	/**
+	 * Displays a link to the Web Stories dashboard on the WordPress list table view.
+	 *
+	 * @return void
+	 */
+	public function display_link_to_dashboard() {
+		$screen = get_current_screen();
+
+		if ( ! $screen instanceof WP_Screen ) {
+			return;
+		}
+
+		if ( 'edit' !== $screen->base ) {
+			return;
+		}
+
+		if ( Story_Post_Type::POST_TYPE_SLUG !== $screen->post_type ) {
+			return;
+		}
+
+		$dashboard_url = add_query_arg(
+			[
+				'post_type' => Story_Post_Type::POST_TYPE_SLUG,
+				'page'      => 'stories-dashboard',
+			],
+			admin_url( 'edit.php' )
+		)
+		?>
+		<div style="margin-top: 20px;">
+			<a href="<?php echo esc_url( $dashboard_url ); ?>">
+				<?php _e( '&larr; Return to Web Stories Dashboard', 'web-stories' ); ?>
+			</a>
+		</div>
+		<?php
 	}
 }

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -217,7 +217,7 @@ class Dashboard {
 		?>
 		<div style="margin-top: 20px;">
 			<a href="<?php echo esc_url( $dashboard_url ); ?>">
-				<?php _e( '&larr; Return to Web Stories Dashboard', 'web-stories' ); ?>
+				<?php esc_html_e( '&larr; Return to Web Stories Dashboard', 'web-stories' ); ?>
 			</a>
 		</div>
 		<?php


### PR DESCRIPTION
## Summary

Adds a link from the WordPress list table screen to the Stories dashboard

## Relevant Technical Choices

Chose `admin_notices` hook as it seemed like thee best fit.

Did not hide the page title because a) it cannot be done without JS (or CSS) and b) would be poor for accessibility.

Other than on the screenshot, this uses default WordPress styling to maintain visual consistency.

## To-do

* [ ] Add referrer check?

## User-facing changes

<img width="706" alt="Screenshot 2020-05-19 at 18 11 52" src="https://user-images.githubusercontent.com/841956/82351110-71e71780-99fc-11ea-87e3-0956c7460c40.png">


## Testing Instructions

1. Visit Stories -> All Stories
1. Verify that there's a link to the dashboard

---

<!-- Please reference the issue(s) this PR addresses. -->

See #1488
See #1832
