### PR TITLE
[Feature] Play and iterate through story pages on dashboard

### DIFF
--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -34,8 +34,6 @@ import {
   CardTitle,
   CardPreviewContainer,
   ActionLabel,
-  PreviewPage,
-  PreviewErrorBoundary,
 } from '../../../components';
 import { STORY_CONTEXT_MENU_ACTIONS } from '../../../constants';
 import {
@@ -130,6 +128,7 @@ const StoryGridView = ({
         <CardGridItem key={story.id} isTemplate={isTemplate}>
           <CardPreviewContainer
             pageSize={pageSize}
+            story={story}
             centerAction={{
               targetAction: story.centerTargetAction,
               label: centerActionLabelByStatus[story.status],
@@ -138,11 +137,7 @@ const StoryGridView = ({
               targetAction: story.bottomTargetAction,
               label: bottomActionLabel,
             }}
-          >
-            <PreviewErrorBoundary>
-              <PreviewPage page={story.pages[0]} />
-            </PreviewErrorBoundary>
-          </CardPreviewContainer>
+          />
           {!isTemplate && (
             <DetailRow>
               <CardTitle

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -135,9 +135,6 @@ const CardPreviewContainer = ({
     }
   }, [cardState]);
 
-  const inervalDuration = story.originalStoryData?.story_data?.autoAdvance
-    ? story.originalStoryData?.story_data?.defaultPageDuration * 1000
-    : DEFAULT_STORY_PAGE_ADVANCE_DURATION;
   useEffect(() => {
     let intervalId;
     if (CARD_STATE.ACTIVE === cardState) {
@@ -150,12 +147,12 @@ const CardPreviewContainer = ({
        */
       intervalId = setInterval(
         () => setPageIndex((v) => clamp(v + 1, [0, storyPages.length - 1])),
-        inervalDuration
+        DEFAULT_STORY_PAGE_ADVANCE_DURATION
       );
     }
 
     return () => intervalId && clearInterval(intervalId);
-  }, [storyPages.length, cardState, inervalDuration]);
+  }, [storyPages.length, cardState]);
 
   return (
     <>

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -125,7 +125,7 @@ const CardPreviewContainer = ({
   const [cardState, dispatch] = useReducer(cardReducer, CARD_STATE.IDLE);
   const [pageIndex, setPageIndex] = useState(0);
   const containElem = useRef(null);
-  const storyPages = story.pages || [];
+  const storyPages = story?.pages || [];
 
   useFocusOut(containElem, () => dispatch(CARD_ACTION.DEACTIVATE), []);
 

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -110,10 +110,12 @@ const CardPreviewContainer = ({
   bottomAction,
   story,
   pageSize,
+  children,
 }) => {
   const [cardState, dispatch] = useReducer(cardReducer, 'idle');
   const [pageIndex, setPageIndex] = useState(0);
   const containElem = useRef(null);
+  const storyPages = story.pages || [];
 
   useFocusOut(containElem, () => dispatch('deactivate'), []);
 
@@ -134,23 +136,24 @@ const CardPreviewContainer = ({
        * doesn't switch before the animations finishes.
        */
       intervalId = setInterval(
-        () => setPageIndex((v) => clamp(v + 1, [0, story.pages.length - 1])),
+        () => setPageIndex((v) => clamp(v + 1, [0, storyPages.length - 1])),
         2000
       );
     }
 
     return () => intervalId && clearInterval(intervalId);
-  }, [story.pages.length, cardState]);
+  }, [storyPages.length, cardState]);
 
   return (
     <>
       <PreviewPane cardSize={pageSize}>
         <PreviewErrorBoundary>
           <PreviewPage
-            page={story.pages[pageIndex]}
+            page={storyPages[pageIndex]}
             animationState={'active' === cardState ? 'animate' : 'idle'}
           />
         </PreviewErrorBoundary>
+        {children}
       </PreviewPane>
       <EditControls
         ref={containElem}
@@ -188,6 +191,7 @@ const ActionButtonPropType = PropTypes.shape({
 });
 
 CardPreviewContainer.propTypes = {
+  children: PropTypes.node,
   centerAction: ActionButtonPropType,
   bottomAction: ActionButtonPropType.isRequired,
   pageSize: PageSizePropType.isRequired,

--- a/assets/src/dashboard/components/cardGridItem/stories/index.js
+++ b/assets/src/dashboard/components/cardGridItem/stories/index.js
@@ -67,6 +67,7 @@ export const _default = () => {
             label: 'Preview',
           }}
           pageSize={{ width: 210, height: 316 }}
+          story={{}}
         >
           <Card>{text('Sample Story Content', 'Sample Story')}</Card>
         </CardPreviewContainer>
@@ -97,6 +98,7 @@ export const _publishedStory = () => {
             label: 'Preview',
           }}
           pageSize={{ width: 210, height: 316 }}
+          story={{}}
         >
           <Card>{text('Sample Story Content', 'Sample Story')}</Card>
         </CardPreviewContainer>
@@ -129,6 +131,7 @@ export const _contextMenu = () => {
               label: 'Preview',
             }}
             pageSize={{ width: 210, height: 316 }}
+            story={{}}
           >
             <Card>{text('Sample Story Content', 'Sample Story')}</Card>
           </CardPreviewContainer>

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -43,7 +43,7 @@ function PreviewPageController({ page, animationState }) {
       key={id}
       page={page}
       element={{ id, ...rest }}
-      animationMode={true}
+      isAnimatable
     />
   ));
 }

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -24,6 +24,7 @@ import PropTypes from 'prop-types';
  */
 import DisplayElement from '../../edit-story/components/canvas/displayElement';
 import StoryPropTypes from '../../edit-story/types';
+import { STORY_PAGE_STATE } from '../constants';
 import StoryAnimation, { useStoryAnimationContext } from './storyAnimation';
 
 function PreviewPageController({ page, animationState }) {
@@ -42,7 +43,7 @@ function PreviewPageController({ page, animationState }) {
       key={id}
       page={page}
       element={{ id, ...rest }}
-      animationMode="WAAPI"
+      animationMode={true}
     />
   ));
 }
@@ -64,7 +65,7 @@ function PreviewPage({ page, animationState = 'idle', onAnimationComplete }) {
 
 PreviewPage.propTypes = {
   page: StoryPropTypes.page.isRequired,
-  animationState: PropTypes.oneOf(['animate', 'idle']),
+  animationState: PropTypes.oneOf(Object.values(STORY_PAGE_STATE)),
   onAnimationComplete: PropTypes.func,
 };
 

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -13,21 +13,59 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies
+ */
+import { useEffect } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import DisplayElement from '../../edit-story/components/canvas/displayElement';
 import StoryPropTypes from '../../edit-story/types';
+import StoryAnimation, { useStoryAnimationContext } from './storyAnimation';
 
-function PreviewPage({ page }) {
+function PreviewPageController({ page, animationState }) {
+  const {
+    actions: { playWAAPIAnimations },
+  } = useStoryAnimationContext();
+
+  useEffect(() => {
+    if ('animate' === animationState) {
+      playWAAPIAnimations();
+    }
+  }, [animationState, playWAAPIAnimations]);
+
   return page.elements.map(({ id, ...rest }) => (
-    <DisplayElement key={id} page={page} element={{ id, ...rest }} />
+    <DisplayElement
+      key={id}
+      page={page}
+      element={{ id, ...rest }}
+      animationMode="WAAPI"
+    />
   ));
+}
+
+function PreviewPage({ page, animationState = 'idle', onAnimationComplete }) {
+  return (
+    <StoryAnimation.Provider
+      animations={page.animations}
+      onWAAPIFinish={onAnimationComplete}
+    >
+      <PreviewPageController
+        page={page}
+        animationState={animationState}
+        onAnimationComplete={onAnimationComplete}
+      />
+    </StoryAnimation.Provider>
+  );
 }
 
 PreviewPage.propTypes = {
   page: StoryPropTypes.page.isRequired,
+  animationState: PropTypes.oneOf(['animate', 'idle']),
+  onAnimationComplete: PropTypes.func,
 };
 
 export default PreviewPage;

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -28,11 +28,12 @@ import {
 } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
+import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
  */
-import { AnimationPart } from '../../animations/parts';
+import { AnimationPart, throughput } from '../../animations/parts';
 
 const Context = createContext(null);
 
@@ -56,18 +57,22 @@ const createOnFinishPromise = (animation) => {
 };
 
 function Provider({ animations, children, onWAAPIFinish }) {
+  const enableAnimation = useFeature('enableAnimation');
   const animationPartsMap = useMemo(() => {
     return (animations || []).reduce((map, animation) => {
       const { targets, type, ...args } = animation;
 
       (targets || []).forEach((t) => {
         const generatedParts = map.get(t) || [];
-        map.set(t, [...generatedParts, AnimationPart(type, args)]);
+        map.set(t, [
+          ...generatedParts,
+          enableAnimation ? AnimationPart(type, args) : throughput(),
+        ]);
       });
 
       return map;
     }, new Map());
-  }, [animations]);
+  }, [animations, enableAnimation]);
 
   const providerId = useMemo(() => uuidv4(), []);
 

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -166,7 +166,7 @@ function Provider({ animations, children, onWAAPIFinish }) {
 }
 
 Provider.propTypes = {
-  animations: PropTypes.arrayOf(PropTypes.object).isRequired,
+  animations: PropTypes.arrayOf(PropTypes.object),
   children: PropTypes.node.isRequired,
   onWAAPIFinish: PropTypes.func,
 };

--- a/assets/src/dashboard/components/storyAnimation/test/WAAPIWrapper.js
+++ b/assets/src/dashboard/components/storyAnimation/test/WAAPIWrapper.js
@@ -17,7 +17,9 @@
 /**
  * External dependencies
  */
+jest.mock('flagged');
 import { render } from '@testing-library/react';
+import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -26,6 +28,8 @@ import * as useStoryAnimationContext from '../useStoryAnimationContext';
 import StoryAnimation from '..';
 
 describe('StoryAnimation.WAAPIWrapper', () => {
+  useFeature.mockImplementation(() => true);
+
   it('renders composed animations top down', () => {
     const useStoryAnimationContextMock = jest.spyOn(
       useStoryAnimationContext,
@@ -36,7 +40,7 @@ describe('StoryAnimation.WAAPIWrapper', () => {
       <div data-testid={type}>{children}</div>
     );
 
-    useStoryAnimationContextMock.mockReturnValue({
+    useStoryAnimationContextMock.mockImplementation(() => ({
       actions: {
         hoistWAAPIAnimation: () => () => {},
         getAnimationParts: () => [
@@ -45,7 +49,7 @@ describe('StoryAnimation.WAAPIWrapper', () => {
           { WAAPIAnimation: mock('anim-3') },
         ],
       },
-    });
+    }));
 
     const { container } = render(
       <StoryAnimation.Provider animations={[]}>

--- a/assets/src/dashboard/components/storyAnimation/test/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/test/provider.js
@@ -17,6 +17,8 @@
 /**
  * External dependencies
  */
+jest.mock('flagged');
+import { useFeature } from 'flagged';
 import { renderHook, act } from '@testing-library/react-hooks';
 
 /**
@@ -37,6 +39,8 @@ const mockWAAPIAnimation = (overrides = {}) => ({
 });
 
 describe('StoryAnimation.Provider', () => {
+  useFeature.mockImplementation(() => true);
+
   describe('getAnimationParts(target)', () => {
     it('gets all generated parts for a target', () => {
       const target = 'some-target';

--- a/assets/src/dashboard/components/storyAnimation/test/useStoryAnimationContext.js
+++ b/assets/src/dashboard/components/storyAnimation/test/useStoryAnimationContext.js
@@ -17,7 +17,9 @@
 /**
  * External dependencies
  */
+jest.mock('flagged');
 import { renderHook } from '@testing-library/react-hooks';
+import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -25,6 +27,8 @@ import { renderHook } from '@testing-library/react-hooks';
 import StoryAnimation, { useStoryAnimationContext } from '..';
 
 describe('useStoryAnimationContext()', () => {
+  useFeature.mockImplementation(() => true);
+
   it('should throw an error if used oustide StroyAnimation.Provider', () => {
     expect(() => {
       const {

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -19,6 +19,8 @@
  */
 import { __ } from '@wordpress/i18n';
 
+export const DEFAULT_STORY_PAGE_ADVANCE_DURATION = 2000;
+
 export const STORY_CONTEXT_MENU_ACTIONS = {
   OPEN_IN_EDITOR: 'open-in-editor-action',
   PREVIEW: 'preview-action',
@@ -128,4 +130,9 @@ export const STORY_VIEWING_LABELS = {
   [STORY_STATUS.ALL]: __('Viewing all stories', 'web-stories'),
   [STORY_STATUS.DRAFT]: __('Viewing drafts', 'web-stories'),
   [STORY_STATUS.PUBLISHED]: __('Viewing published stories', 'web-stories'),
+};
+
+export const STORY_PAGE_STATE = {
+  IDLE: 'idle',
+  ANIMATE: 'animate',
 };

--- a/assets/src/dashboard/index.js
+++ b/assets/src/dashboard/index.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { render } from 'react-dom';
+import { FlagsProvider } from 'flagged';
 
 /**
  * Internal dependencies
@@ -30,16 +31,22 @@ import './style.css'; // This way the general dashboard styles are loaded before
  *
  * @param {string} id       ID of the root element to render the screen in.
  * @param {Object} config   Story editor settings.
+ * @param {Object} flags    The flags for the application.
  */
-const initialize = (id, config) => {
+const initialize = (id, config, flags) => {
   const appElement = document.getElementById(id);
 
-  render(<App config={config} />, appElement);
+  render(
+    <FlagsProvider features={flags}>
+      <App config={config} />
+    </FlagsProvider>,
+    appElement
+  );
 };
 
 const initializeWithConfig = () => {
-  const { id, config } = window.webStoriesDashboardSettings;
-  initialize(id, config);
+  const { id, config, flags } = window.webStoriesDashboardSettings;
+  initialize(id, config, flags);
 };
 
 if ('loading' === document.readyState) {

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -19,7 +19,6 @@
  */
 import styled from 'styled-components';
 import { useRef, useState } from 'react';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -60,9 +59,8 @@ const ReplacementContainer = styled.div`
   opacity: ${({ hasReplacement }) => (hasReplacement ? 1 : 0)};
 `;
 
-function AnimationWrapper({ children, id, animationMode }) {
-  const enableAnimation = useFeature('enableAnimation');
-  return enableAnimation && animationMode ? (
+function AnimationWrapper({ children, id, isAnimatable }) {
+  return isAnimatable ? (
     <StoryAnimation.WAAPIWrapper target={id}>
       {children}
     </StoryAnimation.WAAPIWrapper>
@@ -71,12 +69,12 @@ function AnimationWrapper({ children, id, animationMode }) {
   );
 }
 AnimationWrapper.propTypes = {
-  animationMode: PropTypes.bool.isRequired,
+  isAnimatable: PropTypes.bool.isRequired,
   children: PropTypes.arrayOf(PropTypes.node),
   id: PropTypes.string,
 };
 
-function DisplayElement({ element, previewMode, page, animationMode = false }) {
+function DisplayElement({ element, previewMode, page, isAnimatable = false }) {
   const {
     actions: { getBox },
   } = useUnits();
@@ -128,7 +126,7 @@ function DisplayElement({ element, previewMode, page, animationMode = false }) {
 
   return (
     <Wrapper ref={wrapperRef} data-element-id={id} {...box}>
-      <AnimationWrapper id={id} animationMode={animationMode}>
+      <AnimationWrapper id={id} isAnimatable={isAnimatable}>
         <WithMask
           element={element}
           fill={true}
@@ -161,7 +159,7 @@ DisplayElement.propTypes = {
   previewMode: PropTypes.bool,
   element: StoryPropTypes.element.isRequired,
   page: StoryPropTypes.page,
-  animationMode: PropTypes.bool,
+  isAnimatable: PropTypes.bool,
 };
 
 export default DisplayElement;

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -35,6 +35,7 @@ import { useTransformHandler } from '../transform';
 import { useUnits } from '../../units';
 import WithMask from '../../masks/display';
 import { generateOverlayStyles } from '../../utils/backgroundOverlay';
+import StoryAnimation from '../../../dashboard/components/storyAnimation';
 
 const Wrapper = styled.div`
 	${elementWithPosition}
@@ -51,13 +52,38 @@ const BackgroundOverlay = styled.div`
   top: 0;
   left: 0;
 `;
+
 const ReplacementContainer = styled.div`
   transition: opacity 0.25s cubic-bezier(0, 0, 0.54, 1);
   pointer-events: none;
   opacity: ${({ hasReplacement }) => (hasReplacement ? 1 : 0)};
 `;
 
-function DisplayElement({ element, previewMode, page }) {
+function AnimationWrapper({ children, id, animationMode }) {
+  switch (animationMode) {
+    case 'WAAPI':
+      return (
+        <StoryAnimation.WAAPIWrapper target={id}>
+          {children}
+        </StoryAnimation.WAAPIWrapper>
+      );
+    case 'AMP':
+    default:
+      return children;
+  }
+}
+AnimationWrapper.propTypes = {
+  animationMode: PropTypes.oneOf(['none', 'WAAPI', 'AMP']).isRequired,
+  children: PropTypes.arrayOf(PropTypes.node),
+  id: PropTypes.string,
+};
+
+function DisplayElement({
+  element,
+  previewMode,
+  page,
+  animationMode = 'none',
+}) {
   const {
     actions: { getBox },
   } = useUnits();
@@ -109,29 +135,31 @@ function DisplayElement({ element, previewMode, page }) {
 
   return (
     <Wrapper ref={wrapperRef} data-element-id={id} {...box}>
-      <WithMask
-        element={element}
-        fill={true}
-        box={box}
-        style={{
-          opacity: opacity ? opacity / 100 : null,
-        }}
-        previewMode={previewMode}
-      >
-        <Display element={element} previewMode={previewMode} box={box} />
-        {!previewMode && (
-          <ReplacementContainer hasReplacement={Boolean(replacementElement)}>
-            {replacementElement && (
-              <Replacement element={replacementElement} box={box} />
-            )}
-          </ReplacementContainer>
+      <AnimationWrapper id={id} animationMode={animationMode}>
+        <WithMask
+          element={element}
+          fill={true}
+          box={box}
+          style={{
+            opacity: opacity ? opacity / 100 : null,
+          }}
+          previewMode={previewMode}
+        >
+          <Display element={element} previewMode={previewMode} box={box} />
+          {!previewMode && (
+            <ReplacementContainer hasReplacement={Boolean(replacementElement)}>
+              {replacementElement && (
+                <Replacement element={replacementElement} box={box} />
+              )}
+            </ReplacementContainer>
+          )}
+        </WithMask>
+        {Boolean(isBackground) && Boolean(page?.backgroundOverlay) && (
+          <BackgroundOverlay
+            style={generateOverlayStyles(page?.backgroundOverlay)}
+          />
         )}
-      </WithMask>
-      {Boolean(isBackground) && Boolean(page?.backgroundOverlay) && (
-        <BackgroundOverlay
-          style={generateOverlayStyles(page?.backgroundOverlay)}
-        />
-      )}
+      </AnimationWrapper>
     </Wrapper>
   );
 }
@@ -140,6 +168,7 @@ DisplayElement.propTypes = {
   previewMode: PropTypes.bool,
   element: StoryPropTypes.element.isRequired,
   page: StoryPropTypes.page,
+  animationMode: PropTypes.oneOf(['none', 'WAAPI', 'AMP']),
 };
 
 export default DisplayElement;

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -19,6 +19,7 @@
  */
 import styled from 'styled-components';
 import { useRef, useState } from 'react';
+import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -60,30 +61,22 @@ const ReplacementContainer = styled.div`
 `;
 
 function AnimationWrapper({ children, id, animationMode }) {
-  switch (animationMode) {
-    case 'WAAPI':
-      return (
-        <StoryAnimation.WAAPIWrapper target={id}>
-          {children}
-        </StoryAnimation.WAAPIWrapper>
-      );
-    case 'AMP':
-    default:
-      return children;
-  }
+  const enableAnimation = useFeature('enableAnimation');
+  return enableAnimation && animationMode ? (
+    <StoryAnimation.WAAPIWrapper target={id}>
+      {children}
+    </StoryAnimation.WAAPIWrapper>
+  ) : (
+    children
+  );
 }
 AnimationWrapper.propTypes = {
-  animationMode: PropTypes.oneOf(['none', 'WAAPI', 'AMP']).isRequired,
+  animationMode: PropTypes.bool.isRequired,
   children: PropTypes.arrayOf(PropTypes.node),
   id: PropTypes.string,
 };
 
-function DisplayElement({
-  element,
-  previewMode,
-  page,
-  animationMode = 'none',
-}) {
+function DisplayElement({ element, previewMode, page, animationMode = false }) {
   const {
     actions: { getBox },
   } = useUnits();
@@ -168,7 +161,7 @@ DisplayElement.propTypes = {
   previewMode: PropTypes.bool,
   element: StoryPropTypes.element.isRequired,
   page: StoryPropTypes.page,
-  animationMode: PropTypes.oneOf(['none', 'WAAPI', 'AMP']),
+  animationMode: PropTypes.bool,
 };
 
 export default DisplayElement;

--- a/assets/src/edit-story/index.js
+++ b/assets/src/edit-story/index.js
@@ -39,7 +39,6 @@ const initialize = (id, config, flags) => {
 
   // see http://reactcommunity.org/react-modal/accessibility/
   Modal.setAppElement(appElement);
-
   render(
     <FlagsProvider features={flags}>
       <App config={config} />

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -171,6 +171,15 @@ class Dashboard {
 						'fonts'   => '/web-stories/v1/fonts',
 					],
 				],
+				'flags'  => [
+					/**
+					 * Description: Enables user facing animations.
+					 * Author: @littlemilkstudio
+					 * Issue: 1897
+					 * Creation date: 2020-05-21
+					 */
+					'enableAnimation' => false,
+				],
 			]
 		);
 


### PR DESCRIPTION
## Summary
- Adds logic to `CardPreviewContainer` to play and iterate through pages on hover/focus
- Adds focus region logic so if any of `CardPreviewContainer` children are focused, the whole card has focus styling
- Integrates animation wrapper into display element, but is only added if you specify an  `animationMode={'none' | 'WAAPI' | 'AMP'}` prop. default is 'none'.
- Modifies `PreviewPage` to take an `animationState={'idle' | 'animate'}` a prop value of `animate` plays any of the stories animations.
- Adds an `onAnimationEnd` prop to `PreviewPage` that fires each time an animation completes.

## Relevant Technical Choices
**Backwards Compatibility**
Tries to make all components backwards compatible, so these should all be enhancements, not breaking changes.

**Animation Interface**
I wanted the story's animation interface to mimic traditional css animations as much as possible. I did this by exposing an `onAnimationComplete` prop and an `animationState` prop that should behave like a css class to a user of the component. You simply apply the `animate` value to `animationState` and the component plays the story animation. I imagine we can add further states down the road like `pause`.

## To-do
- Add pause or stop functionality to `StoryAnimation.Provider` and utilize in `PagePreview` so we can stop & reset animations as soon as you hover off.
- Fine tune story page iteration behavior. Need to pull this off of story schema when that gets added & may want to consider adding something that doesn't allow the story page to iterate mid-animation?

## User-facing changes
In the dashboard on the grid view. if you hover or focus cards now, they should play animations and iterate through story pages.

## Testing Instructions
Hover and focus on stories in `Dashboard -> My Stories -> grid view` and see pages iterate onn a 2 second cycle. 

Also go through template pages and make sure nothing broke.

## Screenshots
![focus-slideshow](https://user-images.githubusercontent.com/35983235/82354929-bbb10d00-99be-11ea-9edd-73b2fd18329d.gif)


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
