### PR TITLE
Dashboard: Fix external link to use new typography preset

### DIFF
--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -64,10 +64,8 @@ const Label = styled.span`
 `;
 
 const ExternalLink = styled.a`
+  ${TypographyPresets.Small};
   margin-right: 15px;
-  font-family: ${({ theme }) => theme.fonts.body2.family};
-  letter-spacing: ${({ theme }) => theme.fonts.body2.letterSpacing}em;
-  font-size: ${({ theme }) => theme.fonts.body2.size}px;
   color: ${({ theme }) => theme.colors.bluePrimary};
   font-weight: 500;
   cursor: pointer;


### PR DESCRIPTION
## Summary

The typography preset refactor was merged in and my PR #1832 needed to be rebased but it was merged in. This fixes the break on the list view because of that.

## Relevant Technical Choices

- Use new typography preset

## User-facing changes

None

## Testing Instructions

See that the List View works
