### PR TITLE
Dashboard: add temporary Web Stories title

### DIFF
--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -26,7 +26,7 @@ import cssLerp from '../../../utils/cssLerp';
 import { StoriesPropType } from '../../../types';
 import { DASHBOARD_LEFT_NAV_WIDTH } from '../../../constants/pageStructure';
 import {
-  Heading1,
+  TypographyPresets,
   NavMenuButton,
   StandardViewContentGutter,
 } from '../../../components';
@@ -36,7 +36,9 @@ const Container = styled.div`
   padding: 10px 0 0;
 `;
 
-const StyledHeader = styled(Heading1)`
+const StyledHeader = styled.h2`
+  ${TypographyPresets.ExtraExtraLarge};
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
   display: flex;
   justify-content: flex-start;
   align-items: center;

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -45,10 +45,10 @@ import { useNavContext } from '../navProvider';
 import {
   AppInfo,
   Content,
-  LogoPlaceholder,
   NavLink,
   Rule,
   NavButton,
+  WebStoriesLogo,
 } from './navigationComponents';
 
 export const AppFrame = styled.div`
@@ -133,7 +133,7 @@ export function LeftRail() {
       isOpen={sideBarVisible}
     >
       <div ref={upperContentRef}>
-        <LogoPlaceholder />
+        <WebStoriesLogo />
         <Content>
           <NavButton type={BUTTON_TYPES.CTA} href={newStoryURL} isLink>
             {__('Create New Story', 'web-stories')}

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -48,7 +48,7 @@ import {
   NavLink,
   Rule,
   NavButton,
-  WebStoriesLogo,
+  WebStoriesHeading,
 } from './navigationComponents';
 
 export const AppFrame = styled.div`
@@ -133,7 +133,11 @@ export function LeftRail() {
       isOpen={sideBarVisible}
     >
       <div ref={upperContentRef}>
-        <WebStoriesLogo />
+        <Content>
+          <WebStoriesHeading>
+            {__('Web Stories', 'web-stories')}
+          </WebStoriesHeading>
+        </Content>
         <Content>
           <NavButton type={BUTTON_TYPES.CTA} href={newStoryURL} isLink>
             {__('Create New Story', 'web-stories')}

--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -78,3 +78,7 @@ export const LogoPlaceholder = styled.div(
     background-color: ${theme.colors.gray100};
   `
 );
+
+export const WebStoriesLogo = styled.h1`
+  font-family: ${({ theme }) => theme.typography.family.secondary};
+`;

--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -36,6 +36,7 @@ export const Content = styled.div`
 
 export const NavButton = styled(Button)`
   margin-bottom: 0;
+  margin-top: 0;
 `;
 
 export const NavLink = styled.a`
@@ -70,15 +71,16 @@ export const AppInfo = styled.div`
   color: ${({ theme }) => theme.colors.gray500};
 `;
 
-export const LogoPlaceholder = styled.div(
-  ({ theme }) => `
-    height: 40px;
-    width: 145px;
-    margin: ${theme.leftRail.logoMargin};
-    background-color: ${theme.colors.gray100};
-  `
-);
-
-export const WebStoriesLogo = styled.h1`
+export const WebStoriesHeading = styled.h1`
+  width: 100%;
+  margin-bottom: 0;
   font-family: ${({ theme }) => theme.typography.family.secondary};
+  line-height: 1em;
+  letter-spacing: -0.01em;
+  text-align: center;
+  text-transform: uppercase;
+  font-size: 24px;
+  font-weight: 400;
+  color: ${({ theme }) => theme.colors.gray900};
+  align-self: center;
 `;

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -43,7 +43,7 @@ export function useTheme() {
 
 const themeFonts = {
   primary: "'Google Sans', sans-serif",
-  secondary: 'Roboto',
+  secondary: "'Roboto', sans-serif",
 };
 
 const colors = {

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -174,15 +174,8 @@ class Dashboard {
 		);
 
 		wp_register_style(
-			'google-sans',
-			'https://fonts.googleapis.com/css?family=Google+Sans|Google+Sans:b|Google+Sans:500',
-			[],
-			WEBSTORIES_VERSION
-		);
-
-		wp_register_style(
-			'roboto',
-			'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400&display=swap',
+			'google-fonts',
+			'https://fonts.googleapis.com/css?family=Google+Sans|Google+Sans:b|Google+Sans:500|Roboto:400',
 			[],
 			WEBSTORIES_VERSION
 		);
@@ -190,7 +183,7 @@ class Dashboard {
 		wp_enqueue_style(
 			self::SCRIPT_HANDLE,
 			WEBSTORIES_PLUGIN_DIR_URL . 'assets/css/' . self::SCRIPT_HANDLE . '.css',
-			[ 'google-sans', 'roboto' ],
+			[ 'google-fonts' ],
 			$version
 		);
 

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -179,14 +179,6 @@ class Dashboard {
 			[],
 			WEBSTORIES_VERSION
 		);
-		
-		wp_enqueue_style(
-			self::SCRIPT_HANDLE,
-			WEBSTORIES_PLUGIN_DIR_URL . 'assets/css/' . self::SCRIPT_HANDLE . '.css',
-			[ 'google-sans' ],
-			$version
-		);
-
 
 		wp_register_style(
 			'roboto',
@@ -194,11 +186,11 @@ class Dashboard {
 			[],
 			WEBSTORIES_VERSION
 		);
-
+		
 		wp_enqueue_style(
 			self::SCRIPT_HANDLE,
 			WEBSTORIES_PLUGIN_DIR_URL . 'assets/css/' . self::SCRIPT_HANDLE . '.css',
-			[ 'roboto' ],
+			[ 'google-sans', 'roboto' ],
 			$version
 		);
 

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -182,7 +182,7 @@ class Dashboard {
 
 		wp_register_style(
 			'roboto',
-			'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900&display=swap',
+			'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400&display=swap',
 			[],
 			WEBSTORIES_VERSION
 		);

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -179,11 +179,26 @@ class Dashboard {
 			[],
 			WEBSTORIES_VERSION
 		);
-
+		
 		wp_enqueue_style(
 			self::SCRIPT_HANDLE,
 			WEBSTORIES_PLUGIN_DIR_URL . 'assets/css/' . self::SCRIPT_HANDLE . '.css',
 			[ 'google-sans' ],
+			$version
+		);
+
+
+		wp_register_style(
+			'roboto',
+			'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900&display=swap',
+			[],
+			WEBSTORIES_VERSION
+		);
+
+		wp_enqueue_style(
+			self::SCRIPT_HANDLE,
+			WEBSTORIES_PLUGIN_DIR_URL . 'assets/css/' . self::SCRIPT_HANDLE . '.css',
+			[ 'roboto' ],
 			$version
 		);
 


### PR DESCRIPTION
## Summary
Removes the gray block that was placeholding a logo and puts in 'WEB STORIES' text instead
<img width="428" alt="Screen Shot 2020-05-20 at 2 44 28 PM" src="https://user-images.githubusercontent.com/10720454/82500716-cba51b80-9aa8-11ea-99c5-960aa798d789.png">

## Relevant Technical Choices
- Adds roboto to fonts in Dashboard includes 
- Make pageHeader have an `h2` to respect hierarchy of lead `h1` here. 
- Handle title typography outside of theme typography since it's unique. 

## User-facing changes
- Removes gray box on left nav and replaces it with "WEB STORIES" 

## Testing Instructions
- See text/title update in dashboard and in Storybook Dashboard/Components/LeftRail


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1485
