### PR TITLE
Use correct input value for "Add color preset" from Color Picker

### DIFF
--- a/assets/src/edit-story/components/colorPicker/colorPicker.js
+++ b/assets/src/edit-story/components/colorPicker/colorPicker.js
@@ -165,7 +165,7 @@ function ColorPicker({
             onChange={updateCurrentColor}
             showOpacity={hasOpacity}
           />
-          {renderFooter && renderFooter(generatedColor)}
+          {renderFooter && renderFooter(color)}
         </Body>
       </Container>
     </CSSTransition>

--- a/assets/src/edit-story/components/panels/stylePreset/colorPresetActions.js
+++ b/assets/src/edit-story/components/panels/stylePreset/colorPresetActions.js
@@ -42,7 +42,7 @@ const ActionsWrapper = styled.div`
 const AddColorPreset = styled.button`
   background: transparent;
   border: none;
-  color: ${({ theme }) => rgba(theme.colors.fg.v1, 0.84)};
+  color: ${({ theme }) => rgba(theme.colors.fg.v7, 0.84)};
   cursor: pointer;
   padding: 12px 0px;
   line-height: 18px;


### PR DESCRIPTION
Fix the link style.

## Summary

<!-- A brief description of what this PR does. -->
Fixes using incorrect value for rendering the footer of Color Picker.

Also restores the style of the link based on Figma.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- Adding as color preset from Color Picker works again.
- The color of the link is changed based on Figma.
<!-- Please describe your changes. -->

## Testing Instructions

1. Add a Text (or a Shape)
2. Open the Color Picker for the text
3. Choose a Color
4. Click on "Add to Color Preset"
5. See the color appearing under Presets

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1853
