### PR TITLE
Dashboard: Detail View Performance Enhancements + Routing Fixes

### DIFF
--- a/assets/src/dashboard/app/font/fontProvider.js
+++ b/assets/src/dashboard/app/font/fontProvider.js
@@ -54,7 +54,15 @@ function FontProvider({ children }) {
   );
 
   useEffect(() => {
-    getAllFonts().then(setFonts);
+    let mounted = true;
+    getAllFonts().then((newFonts) => {
+      if (mounted) {
+        setFonts(newFonts);
+      }
+    });
+    return () => {
+      mounted = false;
+    };
   }, [getAllFonts]);
 
   const maybeEnqueueFontStyle = useLoadFontFiles({ getFontByName });

--- a/assets/src/dashboard/app/router/index.js
+++ b/assets/src/dashboard/app/router/index.js
@@ -20,4 +20,9 @@
 
 export { default as RouterProvider, RouterContext } from './routerProvider';
 export { default as useRouteHistory } from './useRouteHistory';
-export { default as Route, matchPath, resolveRoute } from './route';
+export {
+  default as Route,
+  matchPath,
+  resolveRoute,
+  resolveRelatedTemplateRoute,
+} from './route';

--- a/assets/src/dashboard/app/router/route.js
+++ b/assets/src/dashboard/app/router/route.js
@@ -38,6 +38,14 @@ export function parentRoute() {
   }
 }
 
+export function resolveRelatedTemplateRoute(relatedTemplate) {
+  return (
+    window.location.href.split('#')[1].split('?')[0] +
+    '?' +
+    relatedTemplate.centerTargetAction.split('?')[1]
+  );
+}
+
 export function resolveRoute(route) {
   if (
     route.toLowerCase().startsWith('http://') ||

--- a/assets/src/dashboard/app/router/route.js
+++ b/assets/src/dashboard/app/router/route.js
@@ -40,7 +40,7 @@ export function parentRoute() {
 
 export function resolveRelatedTemplateRoute(relatedTemplate) {
   return (
-    window.location.href.split('#')[1].split('?')[0] +
+    window.location.hash.split('#')[1].split('?')[0] +
     '?' +
     relatedTemplate.centerTargetAction.split('?')[1]
   );

--- a/assets/src/dashboard/app/router/test/route.js
+++ b/assets/src/dashboard/app/router/test/route.js
@@ -17,7 +17,11 @@
 /**
  * Internal dependencies
  */
-import { parentRoute, resolveRoute } from '../route';
+import {
+  parentRoute,
+  resolveRoute,
+  resolveRelatedTemplateRoute,
+} from '../route';
 
 describe('Route', function () {
   afterEach(() => {
@@ -58,5 +62,14 @@ describe('Route', function () {
 
   it('should create a route hash when the path is empty', function () {
     expect(resolveRoute('')).toBe('#/');
+  });
+
+  it('should create a route hash when the path is empty!', function () {
+    window.location.hash = '#/saved-templates/template-detail?id=2';
+    expect(
+      resolveRelatedTemplateRoute({
+        centerTargetAction: 'template-detail?id=1&local=false',
+      })
+    ).toBe('/saved-templates/template-detail?id=1&local=false');
   });
 });

--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /**
  * Internal dependencies
@@ -123,12 +123,12 @@ function SavedTemplates() {
     totalPages: 1,
   });
 
-  /**
-   * A placeholder to just have template data in the view for now.
-   */
-  const mockTemplates = useRef(
-    getAllTemplates(config).map(reshapeTemplateObject(false))
-  );
+  const [mockTemplates, setMockTemplates] = useState([]);
+
+  useEffect(() => {
+    const templates = getAllTemplates(config).map(reshapeTemplateObject(false));
+    setMockTemplates(templates);
+  }, [config]);
 
   return (
     <Layout.Provider>
@@ -136,15 +136,10 @@ function SavedTemplates() {
         filter={filter}
         view={view}
         search={search}
-        stories={mockTemplates.current}
+        stories={mockTemplates}
         sort={sort}
       />
-      <Content
-        view={view}
-        page={page}
-        sort={sort}
-        stories={mockTemplates.current}
-      />
+      <Content view={view} page={page} sort={sort} stories={mockTemplates} />
     </Layout.Provider>
   );
 }

--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
  * Internal dependencies

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -71,6 +71,7 @@ function TemplateDetail() {
   const [template, setTemplate] = useState(null);
   const [relatedTemplates, setRelatedTemplates] = useState([]);
   const [orderedTemplates, setOrderedTemplates] = useState([]);
+  const [previewPages, setPreviewPages] = useState([]);
 
   const { pageSize } = usePagePreviewSize({ isGrid: true });
   const {
@@ -94,6 +95,8 @@ function TemplateDetail() {
   const { isRTL } = useConfig();
 
   useEffect(() => {
+    setPreviewPages([]);
+
     if (!templateId) {
       return;
     }
@@ -122,6 +125,9 @@ function TemplateDetail() {
         (templateByOrderId) => templates[templateByOrderId]
       )
     );
+    setPreviewPages(
+      template.pages.map((page) => <PreviewPage key={page.id} page={page} />)
+    );
   }, [fetchRelatedTemplates, template, templates, templatesOrderById]);
 
   const { byLine } = useMemo(() => {
@@ -145,13 +151,6 @@ function TemplateDetail() {
 
     return orderedTemplates.findIndex((t) => t.id === template?.id);
   }, [orderedTemplates, template?.id]);
-
-  const previewPages = useMemo(
-    () =>
-      template &&
-      template.pages.map((page) => <PreviewPage key={page.id} page={page} />),
-    [template]
-  );
 
   const switchToTemplateByOffset = useCallback(
     (offset) => {

--- a/assets/src/dashboard/components/cardGallery/components.js
+++ b/assets/src/dashboard/components/cardGallery/components.js
@@ -45,25 +45,28 @@ export const MiniCardWrapper = styled.div`
     width: ${width}px;
     height: ${height}px;
     overflow: hidden;
-    ${isSelected ? `border: 3px solid ${theme.colors.bluePrimary600}` : ``}
+    ${isSelected ? `border: 3px solid ${theme.colors.bluePrimary600}` : ''}
   `}
 `;
 
-export const MiniCard = styled.div`
-  ${({ width, height }) => `
+export const MiniCard = styled.div(
+  ({ width, height, theme }) => `
     position: relative;
     width: ${width}px;
     height: ${height}px;
     overflow: hidden;
     cursor: pointer;
-  `}
-`;
+    border: ${theme.storyPreview.border};
+  `
+);
 
-export const ActiveCard = styled.div`
-  ${({ height, width }) => `
+export const ActiveCard = styled.div(
+  ({ height, width, theme }) => `
     position: relative;
     width: ${width}px;
     height: ${height}px;
     overflow: hidden;
-  `}
-`;
+    border: ${theme.storyPreview.border};
+    box-shadow: ${theme.storyPreview.shadow};
+  `
+);

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -137,7 +137,7 @@ function CardGallery({ children }) {
           </MiniCardsContainer>
         </UnitsProvider>
       )}
-      {metrics.activeCardSize && (
+      {metrics.activeCardSize && cards[activeCardIndex] && (
         <UnitsProvider pageSize={metrics.activeCardSize}>
           <ActiveCard {...metrics.activeCardSize}>
             {cards[activeCardIndex]}

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -40,7 +40,7 @@ const CARD_GAP = 15;
 const CARD_WRAPPER_BUFFER = 12;
 
 function CardGallery({ children }) {
-  const [dimensionMultiplier, setDimensionMultiplier] = useState(1);
+  const [dimensionMultiplier, setDimensionMultiplier] = useState(null);
   const [activeCardIndex, setActiveCardIndex] = useState(0);
 
   const containerRef = useRef();
@@ -50,38 +50,28 @@ function CardGallery({ children }) {
     [children]
   );
 
-  const { activeCardWidth, miniCardWidth, gap } = useMemo(
-    () => ({
-      activeCardWidth: ACTIVE_CARD_WIDTH * dimensionMultiplier,
-      miniCardWidth: MINI_CARD_WIDTH * dimensionMultiplier,
+  const metrics = useMemo(() => {
+    if (!dimensionMultiplier) {
+      return {};
+    }
+    const activeCardWidth = ACTIVE_CARD_WIDTH * dimensionMultiplier;
+    const miniCardWidth = MINI_CARD_WIDTH * dimensionMultiplier;
+    return {
+      activeCardSize: {
+        width: activeCardWidth,
+        height: activeCardWidth / PAGE_RATIO,
+      },
+      miniCardSize: {
+        width: miniCardWidth,
+        height: miniCardWidth / PAGE_RATIO,
+      },
+      miniWrapperSize: {
+        width: miniCardWidth + CARD_WRAPPER_BUFFER,
+        height: miniCardWidth / PAGE_RATIO + CARD_WRAPPER_BUFFER,
+      },
       gap: CARD_GAP * dimensionMultiplier,
-    }),
-    [dimensionMultiplier]
-  );
-
-  const activeCardSize = useMemo(
-    () => ({
-      width: activeCardWidth,
-      height: activeCardWidth / PAGE_RATIO,
-    }),
-    [activeCardWidth]
-  );
-
-  const miniCardSize = useMemo(
-    () => ({
-      width: miniCardWidth,
-      height: miniCardWidth / PAGE_RATIO,
-    }),
-    [miniCardWidth]
-  );
-
-  const miniWrapperCardSize = useMemo(
-    () => ({
-      width: miniCardWidth + CARD_WRAPPER_BUFFER,
-      height: miniCardWidth / PAGE_RATIO + CARD_WRAPPER_BUFFER,
-    }),
-    [miniCardWidth]
-  );
+    };
+  }, [dimensionMultiplier]);
 
   const handleMiniCardClick = useCallback((index) => {
     setActiveCardIndex(index);
@@ -115,23 +105,32 @@ function CardGallery({ children }) {
 
   return (
     <GalleryContainer ref={containerRef} maxWidth={MAX_WIDTH}>
-      <UnitsProvider pageSize={miniCardSize}>
-        <MiniCardsContainer rowHeight={miniWrapperCardSize.height} gap={gap}>
-          {cards.map((card, index) => (
-            <MiniCardWrapper
-              key={index}
-              isSelected={index === activeCardIndex}
-              {...miniWrapperCardSize}
-              onClick={() => handleMiniCardClick(index)}
-            >
-              <MiniCard {...miniCardSize}>{card}</MiniCard>
-            </MiniCardWrapper>
-          ))}
-        </MiniCardsContainer>
-      </UnitsProvider>
-      <UnitsProvider pageSize={activeCardSize}>
-        <ActiveCard {...activeCardSize}>{cards[activeCardIndex]}</ActiveCard>
-      </UnitsProvider>
+      {metrics.miniCardSize && (
+        <UnitsProvider pageSize={metrics.miniCardSize}>
+          <MiniCardsContainer
+            rowHeight={metrics.miniWrapperSize.height}
+            gap={metrics.gap}
+          >
+            {cards.map((card, index) => (
+              <MiniCardWrapper
+                key={index}
+                isSelected={index === activeCardIndex}
+                {...metrics.miniWrapperSize}
+                onClick={() => handleMiniCardClick(index)}
+              >
+                <MiniCard {...metrics.miniCardSize}>{card}</MiniCard>
+              </MiniCardWrapper>
+            ))}
+          </MiniCardsContainer>
+        </UnitsProvider>
+      )}
+      {metrics.activeCardSize && (
+        <UnitsProvider pageSize={metrics.activeCardSize}>
+          <ActiveCard {...metrics.activeCardSize}>
+            {cards[activeCardIndex]}
+          </ActiveCard>
+        </UnitsProvider>
+      )}
     </GalleryContainer>
   );
 }

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -18,7 +18,14 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useRef, useEffect, useState, useMemo, useCallback } from 'react';
+import {
+  useRef,
+  useEffect,
+  useState,
+  useMemo,
+  useCallback,
+  Children,
+} from 'react';
 
 /**
  * Internal dependencies
@@ -42,13 +49,19 @@ const CARD_WRAPPER_BUFFER = 12;
 function CardGallery({ children }) {
   const [dimensionMultiplier, setDimensionMultiplier] = useState(null);
   const [activeCardIndex, setActiveCardIndex] = useState(0);
-
+  const [cards, setCards] = useState([]);
   const containerRef = useRef();
 
-  const cards = useMemo(
-    () => (Array.isArray(children) ? [...children] : [children]),
-    [children]
-  );
+  useEffect(() => {
+    const count = Children.count(children);
+    if (count > 1) {
+      setCards(children);
+    } else if (count === 1) {
+      setCards([children]);
+    } else if (count === 0) {
+      setCards([]);
+    }
+  }, [children]);
 
   const metrics = useMemo(() => {
     if (!dimensionMultiplier) {


### PR DESCRIPTION
## Summary

This PR improves the performance of loading the detail view. It can have over 9 different preview cards. Previously we were loading them synchronously via `useRef` or `useMemo`. Now we want the page to load, and then set them using `useState` that way we are not blocked. We also sequentially load the related after the template itself has loaded.

Also fixes the initial scale-jumping where the cards shrunk into correct position. Now cards render at the correct size with no jump.

<img width="972" alt="Screen Shot 2020-05-21 at 9 43 08 AM" src="https://user-images.githubusercontent.com/1738349/82586625-7c6cf280-9b5d-11ea-9f12-fa13a1bbdab4.png">


## Relevant Technical Choices

- Creates a route resolver for when jumping to one detail view to the next
- Fixes the Dashboard Font Provider to effectively cancel the request if the Provider has been unmounted (this fixes an intermittent bug)
- Uses `setState` pattern to sequentially load expensive card data rather than `useMemo` which blocks on initial render.


## User-facing changes

- This is mostly performance improvements and bug fixes.
- The detail page should load faster and not crash intermittently. 
- The preview cards now have borders around all of them and a shadow around the active. This helps light-colored templates not blend in.

## Testing Instructions

- Visit the Template Gallery section on the Dashboard and View any Template. See that the page loads faster and there is no more scale-jumping.

Fixes #1863
