### PR TITLE
Dashboard: update storybook mock stories data 

### DIFF
--- a/assets/src/dashboard/storybookUtils/formattedStoriesArray.js
+++ b/assets/src/dashboard/storybookUtils/formattedStoriesArray.js
@@ -21,103 +21,15 @@ import moment from 'moment';
 
 const formattedStoriesArray = [
   {
-    id: 92,
+    id: 167,
     status: 'publish',
-    title: 'CAPYBaRaS can swim',
+    title: 'ORANGE SHAPES',
     modified: moment('04-04-2020', 'MM-DD-YYYY'),
-    created: '2020-04-23T21:16:57.000Z',
+    created: '2020-05-21T23:25:51.000Z',
     pages: [
       {
         elements: [
           {
-            type: 'image',
-            opacity: 100,
-            flip: {
-              vertical: false,
-              horizontal: false,
-            },
-            rotationAngle: 0,
-            scale: 100,
-            focalX: 50,
-            focalY: 50,
-            isFill: false,
-            resource: {
-              type: 'image',
-              mimeType: 'image/gif',
-              src:
-                'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming.gif',
-              width: 229,
-              height: 132,
-              posterId: 0,
-              id: 57,
-              title: 'capybara swimming',
-              alt: 'capybara swimming',
-              local: false,
-              sizes: {
-                medium: {
-                  file: 'capybara-swimming-300x168.gif',
-                  width: 300,
-                  height: 168,
-                  mime_type: 'image/gif',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming-300x168.gif',
-                },
-                thumbnail: {
-                  file: 'capybara-swimming-150x150.gif',
-                  width: 150,
-                  height: 150,
-                  mime_type: 'image/gif',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming-150x150.gif',
-                },
-                'web-stories-poster-portrait': {
-                  file: 'capybara-swimming-696x404.gif',
-                  width: 696,
-                  height: 404,
-                  mime_type: 'image/gif',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming-696x404.gif',
-                },
-                web_stories_thumbnail: {
-                  file: 'capybara-swimming-150x84.gif',
-                  width: 150,
-                  height: 84,
-                  mime_type: 'image/gif',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming-150x84.gif',
-                },
-                full: {
-                  file: 'capybara-swimming.gif',
-                  width: 720,
-                  height: 404,
-                  mime_type: 'image/gif',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming.gif',
-                },
-              },
-            },
-            x: 72,
-            y: 108,
-            width: 229,
-            height: 132,
-            mask: {
-              type: 'rectangle',
-              name: 'Rectangle',
-              path: 'M 0,0 1,0 1,1 0,1 0,0 Z',
-              ratio: 1,
-            },
-            id: '87cb6bad-dbf2-4ff7-ae6f-3a0200ba32f3',
-            isBackground: true,
-          },
-        ],
-        backgroundElementId: '87cb6bad-dbf2-4ff7-ae6f-3a0200ba32f3',
-        type: 'page',
-        id: '9e3e7280-6e7d-4ccc-8717-d2fa399a7b05',
-        backgroundOverlay: 'none',
-      },
-      {
-        elements: [
-          {
             opacity: 100,
             flip: {
               vertical: false,
@@ -127,9 +39,9 @@ const formattedStoriesArray = [
             lockAspectRatio: true,
             backgroundColor: {
               color: {
-                r: 255,
-                g: 255,
-                b: 255,
+                r: 222,
+                g: 134,
+                b: 24,
               },
             },
             isFill: false,
@@ -141,8 +53,9 @@ const formattedStoriesArray = [
               type: 'rectangle',
             },
             isBackground: true,
+            isDefaultBackground: true,
             type: 'shape',
-            id: '1d9cf4fc-12ea-4d69-b275-6ccd620fd8db',
+            id: '090a7330-f7e3-491f-bdb6-534e124a566f',
           },
           {
             opacity: 100,
@@ -152,261 +65,83 @@ const formattedStoriesArray = [
             },
             rotationAngle: 0,
             lockAspectRatio: true,
-            backgroundTextMode: 'NONE',
-            font: {
-              family: 'Open Sans',
-              service: 'fonts.google.com',
-            },
-            fontSize: 29,
             backgroundColor: {
               color: {
-                r: 196,
-                g: 196,
-                b: 196,
+                r: 146,
+                g: 66,
+                b: 171,
               },
             },
-            lineHeight: 1.3,
-            textAlign: 'initial',
-            padding: {
-              vertical: 0,
-              horizontal: 0,
-              locked: true,
-            },
-            type: 'text',
-            id: 'cb304ba9-8909-4276-8458-107d77899b50',
-            title: 'Heading',
-            content: '<span style="font-weight: 700">Page 2</span>\n',
-            x: 65,
-            y: 108,
-            width: 220,
-            height: 72,
+            isFill: false,
+            type: 'shape',
+            x: 48,
+            y: 142,
+            width: 383,
+            height: 367,
             scale: 100,
             focalX: 50,
             focalY: 50,
-            isFill: false,
-          },
-        ],
-        backgroundElementId: '1d9cf4fc-12ea-4d69-b275-6ccd620fd8db',
-        backgroundOverlay: 'none',
-        type: 'page',
-        id: '2ea61241-d1a6-4504-9f94-2ba927d78cdd',
-      },
-      {
-        elements: [
-          {
-            opacity: 100,
-            flip: {
-              vertical: false,
-              horizontal: false,
-            },
-            rotationAngle: 0,
-            lockAspectRatio: true,
-            backgroundColor: {
-              color: {
-                r: 255,
-                g: 255,
-                b: 255,
-              },
-            },
-            isFill: false,
-            x: 1,
-            y: 1,
-            width: 1,
-            height: 1,
             mask: {
-              type: 'rectangle',
+              type: 'star',
             },
-            isBackground: true,
-            id: 'a41aa0c2-c4fe-48b6-9484-3a1e12180361',
-            type: 'shape',
-          },
-          {
-            opacity: 100,
-            flip: {
-              vertical: false,
-              horizontal: false,
-            },
-            rotationAngle: 0,
-            lockAspectRatio: true,
-            backgroundTextMode: 'NONE',
-            font: {
-              family: 'Open Sans',
-              service: 'fonts.google.com',
-            },
-            fontSize: 29,
-            backgroundColor: {
-              color: {
-                r: 196,
-                g: 196,
-                b: 196,
-              },
-            },
-            lineHeight: 1.3,
-            textAlign: 'initial',
-            padding: {
-              vertical: 0,
-              horizontal: 0,
-              locked: true,
-            },
-            id: '481b72b6-aa8c-4bdb-8c8f-0871879aaab4',
-            title: 'Heading',
-            content: '<span style="font-weight: 700">Page 3</span>\n',
-            x: 65,
-            y: 108,
-            width: 220,
-            height: 72,
-            scale: 100,
-            focalX: 50,
-            focalY: 50,
-            isFill: false,
-            type: 'text',
+            id: '38f56700-3318-4e78-a990-4cec33a5ad54',
           },
         ],
-        backgroundElementId: 'a41aa0c2-c4fe-48b6-9484-3a1e12180361',
-        backgroundOverlay: 'none',
         type: 'page',
-        id: '1bbf9af0-c180-4ee7-be70-7a1ea6ed2de5',
+        id: '4636bed2-fffc-45d9-a166-e5c5fa9a2621',
       },
     ],
-    tags: [13, 15, 16, 14],
-    categories: [9, 11],
+    tags: [],
+    categories: [],
     author: 1,
     centerTargetAction: '',
     bottomTargetAction:
-      'http://localhost:8899/wp-admin/post.php?action=edit&post=92',
+      'http://localhost:8899/wp-admin/post.php?action=edit&post=167',
     originalStoryData: {
-      id: 92,
-      date: '2020-04-23T14:16:57',
-      date_gmt: '2020-04-23T21:16:57',
+      id: 167,
+      date: '2020-05-21T16:25:51',
+      date_gmt: '2020-05-21T23:25:51',
       guid: {
-        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=92',
-        raw: 'http://localhost:8899/?post_type=web-story&#038;p=92',
+        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=167',
+        raw: 'http://localhost:8899/?post_type=web-story&#038;p=167',
       },
-      modified: '2020-05-19T11:09:54',
-      modified_gmt: '2020-05-19T18:09:54',
+      modified: '2020-05-21T16:25:51',
+      modified_gmt: '2020-05-21T23:25:51',
       password: '',
-      slug: 'swimming-capy',
+      slug: 'orange-shapes',
       status: 'publish',
       type: 'web-story',
-      link: 'http://localhost:8899/stories/swimming-capy',
+      link: 'http://localhost:8899/stories/orange-shapes',
       title: {
-        raw: 'CAPYBaRaS can swim',
-        rendered: 'CAPYBaRaS can swim',
+        raw: 'ORANGE SHAPES',
+        rendered: 'ORANGE SHAPES',
       },
       content: {
         raw:
-          '<html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script><link href="https://fonts.googleapis.com/css2?display=swap&amp;family=Open+Sans" rel="stylesheet"/><style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript><style amp-custom="">\n              amp-story-grid-layer {\n                overflow: visible;\n              }\n\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: visible;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }\n\n              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }\n\n              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }\n\n              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }\n\n              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=92"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="CAPYBaRaS can swim" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="9e3e7280-6e7d-4ccc-8717-d2fa399a7b05" auto-advance-after="7s"><amp-story-grid-layer template="vertical"><div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"><div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-87cb6bad-dbf2-4ff7-ae6f-3a0200ba32f3" class="wrapper"><div style="position:absolute;width:308.41751%;height:100%;left:-104.20876%;top:0%"><amp-img layout="fill" src="http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming.gif" alt="capybara swimming"></amp-img></div></div></div></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"><div class="page-safe-area"></div></amp-story-grid-layer></amp-story-page><amp-story-page id="2ea61241-d1a6-4504-9f94-2ba927d78cdd" auto-advance-after="7s"><amp-story-grid-layer template="vertical"><div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"><div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-1d9cf4fc-12ea-4d69-b275-6ccd620fd8db" class="wrapper"><div class="fill" style="background-color:#fff"></div></div></div></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"><div class="page-safe-area"><div style="left:14.77273%;top:16.36364%;width:50%;height:10.90909%;opacity:1" id="el-cb304ba9-8909-4276-8458-107d77899b50" class="wrapper"><p class="fill" style="white-space:pre-wrap;margin:0;font-family:&quot;Open Sans&quot;;font-size:0.439394em;line-height:1.3;text-align:initial;padding:0% 0%;color:#000000"><span style="font-weight: 700">Page 2</span>\n</p></div></div></amp-story-grid-layer></amp-story-page><amp-story-page id="1bbf9af0-c180-4ee7-be70-7a1ea6ed2de5" auto-advance-after="7s"><amp-story-grid-layer template="vertical"><div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"><div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-a41aa0c2-c4fe-48b6-9484-3a1e12180361" class="wrapper"><div class="fill" style="background-color:#fff"></div></div></div></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"><div class="page-safe-area"><div style="left:14.77273%;top:16.36364%;width:50%;height:10.90909%;opacity:1" id="el-481b72b6-aa8c-4bdb-8c8f-0871879aaab4" class="wrapper"><p class="fill" style="white-space:pre-wrap;margin:0;font-family:&quot;Open Sans&quot;;font-size:0.439394em;line-height:1.3;text-align:initial;padding:0% 0%;color:#000000"><span style="font-weight: 700">Page 3</span>\n</p></div></div></amp-story-grid-layer></amp-story-page></amp-story></body></html>',
+          '<html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script><style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript><style amp-custom="">\n              amp-story-grid-layer {\n                overflow: visible;\n              }\n\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: visible;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }\n\n              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }\n\n              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }\n\n              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }\n\n              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=167"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="ORANGE SHAPES" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="4636bed2-fffc-45d9-a166-e5c5fa9a2621" auto-advance-after="7s"><amp-story-grid-layer template="vertical"><div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"><div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-090a7330-f7e3-491f-bdb6-534e124a566f" class="wrapper"><div class="fill" style="background-color:#de8618"></div></div></div></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"><div class="page-safe-area"><div style="left:10.90909%;top:21.51515%;width:87.04545%;height:55.60606%;opacity:1;clip-path:url(#mask-star-38f56700-3318-4e78-a990-4cec33a5ad54-output);-webkit-clip-path:url(#mask-star-38f56700-3318-4e78-a990-4cec33a5ad54-output)" id="el-38f56700-3318-4e78-a990-4cec33a5ad54" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-star-38f56700-3318-4e78-a990-4cec33a5ad54-output" transform="scale(1 1.051524710830705)" clipPathUnits="objectBoundingBox"><path d="M 0.50000026,0.78688566 0.19262278,0.95082018 0.2500004,0.6065577 0,0.36065594 0.34426194,0.31147556 0.50000026,0 0.65573858,0.31147556 1,0.36065594 0.75000014,0.6065577 0.80737774,0.95082018 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#9242ab"></div></div></div></amp-story-grid-layer></amp-story-page></amp-story></body></html>',
         rendered:
-          '<p><html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script><link href="https://fonts.googleapis.com/css2?display=swap&amp;family=Open+Sans" rel="stylesheet"/>\n<style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>\n<p><noscript></p>\n<style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>\n<p></noscript></p>\n<style amp-custom="">\n              amp-story-grid-layer {\n                overflow: visible;\n              }</p>\n<p>              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: visible;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }</p>\n<p>              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }</p>\n<p>              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }</p>\n<p>              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }</p>\n<p>              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style>\n<p><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=92"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="CAPYBaRaS can swim" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="9e3e7280-6e7d-4ccc-8717-d2fa399a7b05" auto-advance-after="7s"><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"></p>\n<div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-87cb6bad-dbf2-4ff7-ae6f-3a0200ba32f3" class="wrapper">\n<div style="position:absolute;width:308.41751%;height:100%;left:-104.20876%;top:0%"><amp-img layout="fill" src="http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming.gif" alt="capybara swimming"></amp-img></div>\n</div>\n</div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"></p>\n<div class="page-safe-area"></div>\n<p></amp-story-grid-layer></amp-story-page><amp-story-page id="2ea61241-d1a6-4504-9f94-2ba927d78cdd" auto-advance-after="7s"><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"></p>\n<div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-1d9cf4fc-12ea-4d69-b275-6ccd620fd8db" class="wrapper">\n<div class="fill" style="background-color:#fff"></div>\n</div>\n</div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"></p>\n<div class="page-safe-area">\n<div style="left:14.77273%;top:16.36364%;width:50%;height:10.90909%;opacity:1" id="el-cb304ba9-8909-4276-8458-107d77899b50" class="wrapper">\n<p class="fill" style="white-space:pre-wrap;margin:0;font-family:&quot;Open Sans&quot;;font-size:0.439394em;line-height:1.3;text-align:initial;padding:0% 0%;color:#000000"><span style="font-weight: 700">Page 2</span>\n</p>\n</div>\n</div>\n<p></amp-story-grid-layer></amp-story-page><amp-story-page id="1bbf9af0-c180-4ee7-be70-7a1ea6ed2de5" auto-advance-after="7s"><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"></p>\n<div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-a41aa0c2-c4fe-48b6-9484-3a1e12180361" class="wrapper">\n<div class="fill" style="background-color:#fff"></div>\n</div>\n</div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"></p>\n<div class="page-safe-area">\n<div style="left:14.77273%;top:16.36364%;width:50%;height:10.90909%;opacity:1" id="el-481b72b6-aa8c-4bdb-8c8f-0871879aaab4" class="wrapper">\n<p class="fill" style="white-space:pre-wrap;margin:0;font-family:&quot;Open Sans&quot;;font-size:0.439394em;line-height:1.3;text-align:initial;padding:0% 0%;color:#000000"><span style="font-weight: 700">Page 3</span>\n</p>\n</div>\n</div>\n<p></amp-story-grid-layer></amp-story-page></amp-story></body></html></p>\n',
+          '<p><html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script></p>\n<style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>\n<p><noscript></p>\n<style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>\n<p></noscript></p>\n<style amp-custom="">\n              amp-story-grid-layer {\n                overflow: visible;\n              }</p>\n<p>              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: visible;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }</p>\n<p>              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }</p>\n<p>              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }</p>\n<p>              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }</p>\n<p>              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style>\n<p><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=167"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="ORANGE SHAPES" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="4636bed2-fffc-45d9-a166-e5c5fa9a2621" auto-advance-after="7s"><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"></p>\n<div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-090a7330-f7e3-491f-bdb6-534e124a566f" class="wrapper">\n<div class="fill" style="background-color:#de8618"></div>\n</div>\n</div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"></p>\n<div class="page-safe-area">\n<div style="left:10.90909%;top:21.51515%;width:87.04545%;height:55.60606%;opacity:1;clip-path:url(#mask-star-38f56700-3318-4e78-a990-4cec33a5ad54-output);-webkit-clip-path:url(#mask-star-38f56700-3318-4e78-a990-4cec33a5ad54-output)" id="el-38f56700-3318-4e78-a990-4cec33a5ad54" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-star-38f56700-3318-4e78-a990-4cec33a5ad54-output" transform="scale(1 1.051524710830705)" clipPathUnits="objectBoundingBox"><path d="M 0.50000026,0.78688566 0.19262278,0.95082018 0.2500004,0.6065577 0,0.36065594 0.34426194,0.31147556 0.50000026,0 0.65573858,0.31147556 1,0.36065594 0.75000014,0.6065577 0.80737774,0.95082018 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#9242ab"></div>\n</div>\n</div>\n<p></amp-story-grid-layer></amp-story-page></amp-story></body></html></p>\n',
         protected: false,
         block_version: 0,
       },
       excerpt: {
         raw: '',
-        rendered: '<p>Page 2 Page 3</p>\n',
+        rendered: '',
         protected: false,
       },
       author: 1,
       featured_media: 0,
       template: '',
-      categories: [9, 11],
-      tags: [13, 15, 16, 14],
+      categories: [],
+      tags: [],
       permalink_template: 'http://localhost:8899/stories/%pagename%',
-      generated_slug: 'capybaras-can-swim',
+      generated_slug: 'orange-shapes',
       story_data: {
-        version: 17,
+        version: 19,
         pages: [
           {
             elements: [
               {
-                type: 'image',
-                opacity: 100,
-                flip: {
-                  vertical: false,
-                  horizontal: false,
-                },
-                rotationAngle: 0,
-                scale: 100,
-                focalX: 50,
-                focalY: 50,
-                isFill: false,
-                resource: {
-                  type: 'image',
-                  mimeType: 'image/gif',
-                  src:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming.gif',
-                  width: 229,
-                  height: 132,
-                  posterId: 0,
-                  id: 57,
-                  title: 'capybara swimming',
-                  alt: 'capybara swimming',
-                  local: false,
-                  sizes: {
-                    medium: {
-                      file: 'capybara-swimming-300x168.gif',
-                      width: 300,
-                      height: 168,
-                      mime_type: 'image/gif',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming-300x168.gif',
-                    },
-                    thumbnail: {
-                      file: 'capybara-swimming-150x150.gif',
-                      width: 150,
-                      height: 150,
-                      mime_type: 'image/gif',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming-150x150.gif',
-                    },
-                    'web-stories-poster-portrait': {
-                      file: 'capybara-swimming-696x404.gif',
-                      width: 696,
-                      height: 404,
-                      mime_type: 'image/gif',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming-696x404.gif',
-                    },
-                    web_stories_thumbnail: {
-                      file: 'capybara-swimming-150x84.gif',
-                      width: 150,
-                      height: 84,
-                      mime_type: 'image/gif',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming-150x84.gif',
-                    },
-                    full: {
-                      file: 'capybara-swimming.gif',
-                      width: 720,
-                      height: 404,
-                      mime_type: 'image/gif',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/capybara-swimming.gif',
-                    },
-                  },
-                },
-                x: 72,
-                y: 108,
-                width: 229,
-                height: 132,
-                mask: {
-                  type: 'rectangle',
-                  name: 'Rectangle',
-                  path: 'M 0,0 1,0 1,1 0,1 0,0 Z',
-                  ratio: 1,
-                },
-                id: '87cb6bad-dbf2-4ff7-ae6f-3a0200ba32f3',
-                isBackground: true,
-              },
-            ],
-            backgroundElementId: '87cb6bad-dbf2-4ff7-ae6f-3a0200ba32f3',
-            type: 'page',
-            id: '9e3e7280-6e7d-4ccc-8717-d2fa399a7b05',
-            backgroundOverlay: 'none',
-          },
-          {
-            elements: [
-              {
                 opacity: 100,
                 flip: {
                   vertical: false,
@@ -416,9 +151,9 @@ const formattedStoriesArray = [
                 lockAspectRatio: true,
                 backgroundColor: {
                   color: {
-                    r: 255,
-                    g: 255,
-                    b: 255,
+                    r: 222,
+                    g: 134,
+                    b: 24,
                   },
                 },
                 isFill: false,
@@ -430,8 +165,9 @@ const formattedStoriesArray = [
                   type: 'rectangle',
                 },
                 isBackground: true,
+                isDefaultBackground: true,
                 type: 'shape',
-                id: '1d9cf4fc-12ea-4d69-b275-6ccd620fd8db',
+                id: '090a7330-f7e3-491f-bdb6-534e124a566f',
               },
               {
                 opacity: 100,
@@ -441,122 +177,34 @@ const formattedStoriesArray = [
                 },
                 rotationAngle: 0,
                 lockAspectRatio: true,
-                backgroundTextMode: 'NONE',
-                font: {
-                  family: 'Open Sans',
-                  service: 'fonts.google.com',
-                },
-                fontSize: 29,
                 backgroundColor: {
                   color: {
-                    r: 196,
-                    g: 196,
-                    b: 196,
+                    r: 146,
+                    g: 66,
+                    b: 171,
                   },
                 },
-                lineHeight: 1.3,
-                textAlign: 'initial',
-                padding: {
-                  vertical: 0,
-                  horizontal: 0,
-                  locked: true,
-                },
-                type: 'text',
-                id: 'cb304ba9-8909-4276-8458-107d77899b50',
-                title: 'Heading',
-                content: '<span style="font-weight: 700">Page 2</span>\n',
-                x: 65,
-                y: 108,
-                width: 220,
-                height: 72,
+                isFill: false,
+                type: 'shape',
+                x: 48,
+                y: 142,
+                width: 383,
+                height: 367,
                 scale: 100,
                 focalX: 50,
                 focalY: 50,
-                isFill: false,
-              },
-            ],
-            backgroundElementId: '1d9cf4fc-12ea-4d69-b275-6ccd620fd8db',
-            backgroundOverlay: 'none',
-            type: 'page',
-            id: '2ea61241-d1a6-4504-9f94-2ba927d78cdd',
-          },
-          {
-            elements: [
-              {
-                opacity: 100,
-                flip: {
-                  vertical: false,
-                  horizontal: false,
-                },
-                rotationAngle: 0,
-                lockAspectRatio: true,
-                backgroundColor: {
-                  color: {
-                    r: 255,
-                    g: 255,
-                    b: 255,
-                  },
-                },
-                isFill: false,
-                x: 1,
-                y: 1,
-                width: 1,
-                height: 1,
                 mask: {
-                  type: 'rectangle',
+                  type: 'star',
                 },
-                isBackground: true,
-                id: 'a41aa0c2-c4fe-48b6-9484-3a1e12180361',
-                type: 'shape',
-              },
-              {
-                opacity: 100,
-                flip: {
-                  vertical: false,
-                  horizontal: false,
-                },
-                rotationAngle: 0,
-                lockAspectRatio: true,
-                backgroundTextMode: 'NONE',
-                font: {
-                  family: 'Open Sans',
-                  service: 'fonts.google.com',
-                },
-                fontSize: 29,
-                backgroundColor: {
-                  color: {
-                    r: 196,
-                    g: 196,
-                    b: 196,
-                  },
-                },
-                lineHeight: 1.3,
-                textAlign: 'initial',
-                padding: {
-                  vertical: 0,
-                  horizontal: 0,
-                  locked: true,
-                },
-                id: '481b72b6-aa8c-4bdb-8c8f-0871879aaab4',
-                title: 'Heading',
-                content: '<span style="font-weight: 700">Page 3</span>\n',
-                x: 65,
-                y: 108,
-                width: 220,
-                height: 72,
-                scale: 100,
-                focalX: 50,
-                focalY: 50,
-                isFill: false,
-                type: 'text',
+                id: '38f56700-3318-4e78-a990-4cec33a5ad54',
               },
             ],
-            backgroundElementId: 'a41aa0c2-c4fe-48b6-9484-3a1e12180361',
-            backgroundOverlay: 'none',
             type: 'page',
-            id: '1bbf9af0-c180-4ee7-be70-7a1ea6ed2de5',
+            id: '4636bed2-fffc-45d9-a166-e5c5fa9a2621',
           },
         ],
+        autoAdvance: true,
+        defaultPageDuration: 7,
       },
       featured_media_url: '',
       publisher_logo_url:
@@ -569,7 +217,7 @@ const formattedStoriesArray = [
       _links: {
         self: [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/92',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/167',
           },
         ],
         collection: [
@@ -590,67 +238,67 @@ const formattedStoriesArray = [
         ],
         'version-history': [
           {
-            count: 6,
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/92/revisions',
+            count: 1,
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/167/revisions',
           },
         ],
         'predecessor-version': [
           {
-            id: 149,
+            id: 168,
             href:
-              'http://localhost:8899/wp-json/wp/v2/web-story/92/revisions/149',
+              'http://localhost:8899/wp-json/wp/v2/web-story/167/revisions/168',
           },
         ],
         'wp:attachment': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/media?parent=92',
+            href: 'http://localhost:8899/wp-json/wp/v2/media?parent=167',
           },
         ],
         'wp:term': [
           {
             taxonomy: 'category',
             embeddable: true,
-            href: 'http://localhost:8899/wp-json/wp/v2/categories?post=92',
+            href: 'http://localhost:8899/wp-json/wp/v2/categories?post=167',
           },
           {
             taxonomy: 'post_tag',
             embeddable: true,
-            href: 'http://localhost:8899/wp-json/wp/v2/tags?post=92',
+            href: 'http://localhost:8899/wp-json/wp/v2/tags?post=167',
           },
         ],
         'wp:action-publish': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/92',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/167',
           },
         ],
         'wp:action-unfiltered-html': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/92',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/167',
           },
         ],
         'wp:action-assign-author': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/92',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/167',
           },
         ],
         'wp:action-create-categories': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/92',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/167',
           },
         ],
         'wp:action-assign-categories': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/92',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/167',
           },
         ],
         'wp:action-create-tags': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/92',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/167',
           },
         ],
         'wp:action-assign-tags': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/92',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/167',
           },
         ],
         curies: [
@@ -664,11 +312,11 @@ const formattedStoriesArray = [
     },
   },
   {
-    id: 147,
+    id: 165,
     status: 'draft',
-    title: 'Fighting COVID-19: ER DOCTORS EVERYWHERE (Copy)',
-    modified: moment('04-06-2020', 'MM-DD-YYYY'),
-    created: '2020-05-14T22:33:05.000Z',
+    title: 'GREEN SHAPES',
+    modified: moment('05-04-2020', 'MM-DD-YYYY'),
+    created: '2020-05-21T23:25:22.000Z',
     pages: [
       {
         elements: [
@@ -679,52 +327,26 @@ const formattedStoriesArray = [
               horizontal: false,
             },
             rotationAngle: 0,
+            lockAspectRatio: true,
             backgroundColor: {
               color: {
-                r: 255,
-                g: 255,
-                b: 255,
+                r: 19,
+                g: 144,
+                b: 20,
               },
             },
             isFill: false,
-            x: 8.923633420864867,
-            y: 54.621280085252785,
-            width: 146.66666666666666,
-            height: 146.66666666666666,
+            x: 1,
+            y: 1,
+            width: 1,
+            height: 1,
             mask: {
               type: 'rectangle',
             },
             isBackground: true,
+            isDefaultBackground: true,
             type: 'shape',
-            id: 'c4f3e766-0c8b-43b5-ba9b-ad6083b1331e',
-          },
-          {
-            opacity: 80,
-            flip: {
-              vertical: false,
-              horizontal: false,
-            },
-            rotationAngle: 0,
-            backgroundColor: {
-              color: {
-                r: 51,
-                g: 51,
-                b: 51,
-              },
-            },
-            isFill: false,
-            x: 0,
-            y: 0,
-            width: 439,
-            height: 661,
-            scale: 100,
-            focalX: 50,
-            focalY: 50,
-            mask: {
-              type: 'rectangle',
-            },
-            type: 'shape',
-            id: '718c2af2-c673-4d25-b906-1339c2fae397',
+            id: 'e8ee34f0-9af9-4106-9ce6-d475d5dd893a',
           },
           {
             opacity: 100,
@@ -733,76 +355,31 @@ const formattedStoriesArray = [
               horizontal: false,
             },
             rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 51,
+                g: 51,
+                b: 51,
+              },
+            },
+            isFill: false,
+            type: 'shape',
+            x: 72,
+            y: -66,
+            width: 147,
+            height: 792,
             scale: 100,
             focalX: 50,
             focalY: 50,
-            isFill: false,
-            resource: {
-              type: 'image',
-              mimeType: 'image/gif',
-              src:
-                'http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies.gif',
-              width: 220,
-              height: 124,
-              poster: '',
-              posterId: 0,
-              videoId: 55,
-              title: 'capybarawithpuppies',
-              alt: '',
-              local: false,
-              sizes: {
-                medium: {
-                  file: 'capybarawithpuppies-300x169.gif',
-                  width: 300,
-                  height: 169,
-                  mime_type: 'image/gif',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies-300x169.gif',
-                },
-                thumbnail: {
-                  file: 'capybarawithpuppies-150x150.gif',
-                  width: 150,
-                  height: 150,
-                  mime_type: 'image/gif',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies-150x150.gif',
-                },
-                web_stories_thumbnail: {
-                  file: 'capybarawithpuppies-150x84.gif',
-                  width: 150,
-                  height: 84,
-                  mime_type: 'image/gif',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies-150x84.gif',
-                },
-                full: {
-                  file: 'capybarawithpuppies.gif',
-                  width: 480,
-                  height: 270,
-                  mime_type: 'image/gif',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies.gif',
-                },
-              },
-            },
-            x: 109,
-            y: 139,
-            width: 220,
-            height: 437,
             mask: {
               type: 'rectangle',
-              name: 'Rectangle',
-              path: 'M 0,0 1,0 1,1 0,1 0,0 Z',
-              ratio: 1,
             },
-            type: 'image',
-            id: 'cb352b5a-3697-4b11-937b-aa5fe1d3c6cd',
+            id: '71ddb528-7d8f-4e54-b888-358680221f59',
           },
         ],
         type: 'page',
-        id: '01ac6bd7-f94b-4f2d-8fd0-2f3981c31828',
-        backgroundElementId: 'c4f3e766-0c8b-43b5-ba9b-ad6083b1331e',
-        backgroundOverlay: 'none',
+        id: '43b8f6b8-0966-4b53-9cda-a95f0837e099',
       },
     ],
     tags: [],
@@ -810,31 +387,31 @@ const formattedStoriesArray = [
     author: 1,
     centerTargetAction: '',
     bottomTargetAction:
-      'http://localhost:8899/wp-admin/post.php?action=edit&post=147',
+      'http://localhost:8899/wp-admin/post.php?action=edit&post=165',
     originalStoryData: {
-      id: 147,
-      date: '2020-05-14T15:33:05',
-      date_gmt: '2020-05-14T22:33:05',
+      id: 165,
+      date: '2020-05-21T16:25:22',
+      date_gmt: '2020-05-21T23:25:22',
       guid: {
-        rendered: 'http://localhost:8899/?post_type=web-story&p=147',
-        raw: 'http://localhost:8899/?post_type=web-story&p=147',
+        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=165',
+        raw: 'http://localhost:8899/?post_type=web-story&#038;p=165',
       },
-      modified: '2020-05-14T15:33:05',
-      modified_gmt: '2020-05-14T22:33:05',
+      modified: '2020-05-21T16:25:22',
+      modified_gmt: '2020-05-21T23:25:22',
       password: '',
-      slug: '',
+      slug: 'green-shapes',
       status: 'draft',
       type: 'web-story',
-      link: 'http://localhost:8899/?post_type=web-story&p=147',
+      link: 'http://localhost:8899/?post_type=web-story&p=165',
       title: {
-        raw: 'Fighting COVID-19: ER DOCTORS EVERYWHERE (Copy)',
-        rendered: 'Fighting COVID-19: ER DOCTORS EVERYWHERE (Copy)',
+        raw: 'GREEN SHAPES',
+        rendered: 'GREEN SHAPES',
       },
       content: {
         raw:
-          '<html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script><style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript><style amp-custom="">\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: hidden;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }\n\n              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }\n\n              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }\n\n              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }\n\n              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=25"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="Fighting COVID-19: ER DOCTORS EVERYWHERE" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="01ac6bd7-f94b-4f2d-8fd0-2f3981c31828" auto-advance-after="el-cb352b5a-3697-4b11-937b-aa5fe1d3c6cd-media"><amp-story-grid-layer template="vertical"><div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"><div style="left:0%;top:0%;width:100%;height:100%;opacity:1" id="el-c4f3e766-0c8b-43b5-ba9b-ad6083b1331e" class="wrapper"><div class="fill" style="background-color:#fff"></div></div></div></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"><div class="page-safe-area"><div style="left:0%;top:0%;width:99.77273%;height:100.15152%;opacity:0.8;clip-path:url(#mask-rectangle-718c2af2-c673-4d25-b906-1339c2fae397-output);-webkit-clip-path:url(#mask-rectangle-718c2af2-c673-4d25-b906-1339c2fae397-output)" id="el-718c2af2-c673-4d25-b906-1339c2fae397" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-718c2af2-c673-4d25-b906-1339c2fae397-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#333"></div></div><div style="left:24.77273%;top:21.06061%;width:50%;height:66.21212%;opacity:1;clip-path:url(#mask-rectangle-cb352b5a-3697-4b11-937b-aa5fe1d3c6cd-output);-webkit-clip-path:url(#mask-rectangle-cb352b5a-3697-4b11-937b-aa5fe1d3c6cd-output)" id="el-cb352b5a-3697-4b11-937b-aa5fe1d3c6cd" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-cb352b5a-3697-4b11-937b-aa5fe1d3c6cd-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0 Z"></path></clipPath></defs></svg><div style="position:absolute;width:352.41935%;height:100%;left:-126.20967%;top:0%"><amp-img layout="fill" src="http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies.gif" alt=""></amp-img></div></div></div></amp-story-grid-layer></amp-story-page></amp-story></body></html>',
+          '<html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script><style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript><style amp-custom="">\n              amp-story-grid-layer {\n                overflow: visible;\n              }\n\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: visible;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }\n\n              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }\n\n              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }\n\n              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }\n\n              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=165"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="GREEN SHAPES" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="43b8f6b8-0966-4b53-9cda-a95f0837e099" auto-advance-after="7s"><amp-story-grid-layer template="vertical"><div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"><div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-e8ee34f0-9af9-4106-9ce6-d475d5dd893a" class="wrapper"><div class="fill" style="background-color:#139014"></div></div></div></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"><div class="page-safe-area"><div style="left:16.36364%;top:-10%;width:33.40909%;height:120%;opacity:1;clip-path:url(#mask-rectangle-71ddb528-7d8f-4e54-b888-358680221f59-output);-webkit-clip-path:url(#mask-rectangle-71ddb528-7d8f-4e54-b888-358680221f59-output)" id="el-71ddb528-7d8f-4e54-b888-358680221f59" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-71ddb528-7d8f-4e54-b888-358680221f59-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#333"></div></div></div></amp-story-grid-layer></amp-story-page></amp-story></body></html>',
         rendered:
-          '<p><html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script></p>\n<style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>\n<p><noscript></p>\n<style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>\n<p></noscript></p>\n<style amp-custom="">\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: hidden;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }</p>\n<p>              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }</p>\n<p>              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }</p>\n<p>              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }</p>\n<p>              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style>\n<p><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=25"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="Fighting COVID-19: ER DOCTORS EVERYWHERE" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="01ac6bd7-f94b-4f2d-8fd0-2f3981c31828" auto-advance-after="el-cb352b5a-3697-4b11-937b-aa5fe1d3c6cd-media"><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"></p>\n<div style="left:0%;top:0%;width:100%;height:100%;opacity:1" id="el-c4f3e766-0c8b-43b5-ba9b-ad6083b1331e" class="wrapper">\n<div class="fill" style="background-color:#fff"></div>\n</div>\n</div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"></p>\n<div class="page-safe-area">\n<div style="left:0%;top:0%;width:99.77273%;height:100.15152%;opacity:0.8;clip-path:url(#mask-rectangle-718c2af2-c673-4d25-b906-1339c2fae397-output);-webkit-clip-path:url(#mask-rectangle-718c2af2-c673-4d25-b906-1339c2fae397-output)" id="el-718c2af2-c673-4d25-b906-1339c2fae397" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-718c2af2-c673-4d25-b906-1339c2fae397-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#333"></div>\n</div>\n<div style="left:24.77273%;top:21.06061%;width:50%;height:66.21212%;opacity:1;clip-path:url(#mask-rectangle-cb352b5a-3697-4b11-937b-aa5fe1d3c6cd-output);-webkit-clip-path:url(#mask-rectangle-cb352b5a-3697-4b11-937b-aa5fe1d3c6cd-output)" id="el-cb352b5a-3697-4b11-937b-aa5fe1d3c6cd" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-cb352b5a-3697-4b11-937b-aa5fe1d3c6cd-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0 Z"></path></clipPath></defs></svg></p>\n<div style="position:absolute;width:352.41935%;height:100%;left:-126.20967%;top:0%"><amp-img layout="fill" src="http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies.gif" alt=""></amp-img></div>\n</div>\n</div>\n<p></amp-story-grid-layer></amp-story-page></amp-story></body></html></p>\n',
+          '<p><html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script></p>\n<style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>\n<p><noscript></p>\n<style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>\n<p></noscript></p>\n<style amp-custom="">\n              amp-story-grid-layer {\n                overflow: visible;\n              }</p>\n<p>              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: visible;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }</p>\n<p>              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }</p>\n<p>              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }</p>\n<p>              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }</p>\n<p>              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style>\n<p><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=165"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="GREEN SHAPES" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="43b8f6b8-0966-4b53-9cda-a95f0837e099" auto-advance-after="7s"><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"></p>\n<div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-e8ee34f0-9af9-4106-9ce6-d475d5dd893a" class="wrapper">\n<div class="fill" style="background-color:#139014"></div>\n</div>\n</div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"></p>\n<div class="page-safe-area">\n<div style="left:16.36364%;top:-10%;width:33.40909%;height:120%;opacity:1;clip-path:url(#mask-rectangle-71ddb528-7d8f-4e54-b888-358680221f59-output);-webkit-clip-path:url(#mask-rectangle-71ddb528-7d8f-4e54-b888-358680221f59-output)" id="el-71ddb528-7d8f-4e54-b888-358680221f59" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-71ddb528-7d8f-4e54-b888-358680221f59-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#333"></div>\n</div>\n</div>\n<p></amp-story-grid-layer></amp-story-page></amp-story></body></html></p>\n',
         protected: false,
         block_version: 0,
       },
@@ -849,9 +426,9 @@ const formattedStoriesArray = [
       categories: [],
       tags: [],
       permalink_template: 'http://localhost:8899/stories/%pagename%',
-      generated_slug: 'fighting-covid-19-er-doctors-everywhere-copy',
+      generated_slug: 'green-shapes',
       story_data: {
-        version: 12,
+        version: 19,
         pages: [
           {
             elements: [
@@ -862,52 +439,26 @@ const formattedStoriesArray = [
                   horizontal: false,
                 },
                 rotationAngle: 0,
+                lockAspectRatio: true,
                 backgroundColor: {
                   color: {
-                    r: 255,
-                    g: 255,
-                    b: 255,
+                    r: 19,
+                    g: 144,
+                    b: 20,
                   },
                 },
                 isFill: false,
-                x: 8.923633420864867,
-                y: 54.621280085252785,
-                width: 146.66666666666666,
-                height: 146.66666666666666,
+                x: 1,
+                y: 1,
+                width: 1,
+                height: 1,
                 mask: {
                   type: 'rectangle',
                 },
                 isBackground: true,
+                isDefaultBackground: true,
                 type: 'shape',
-                id: 'c4f3e766-0c8b-43b5-ba9b-ad6083b1331e',
-              },
-              {
-                opacity: 80,
-                flip: {
-                  vertical: false,
-                  horizontal: false,
-                },
-                rotationAngle: 0,
-                backgroundColor: {
-                  color: {
-                    r: 51,
-                    g: 51,
-                    b: 51,
-                  },
-                },
-                isFill: false,
-                x: 0,
-                y: 0,
-                width: 439,
-                height: 661,
-                scale: 100,
-                focalX: 50,
-                focalY: 50,
-                mask: {
-                  type: 'rectangle',
-                },
-                type: 'shape',
-                id: '718c2af2-c673-4d25-b906-1339c2fae397',
+                id: 'e8ee34f0-9af9-4106-9ce6-d475d5dd893a',
               },
               {
                 opacity: 100,
@@ -916,75 +467,623 @@ const formattedStoriesArray = [
                   horizontal: false,
                 },
                 rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 51,
+                    g: 51,
+                    b: 51,
+                  },
+                },
+                isFill: false,
+                type: 'shape',
+                x: 72,
+                y: -66,
+                width: 147,
+                height: 792,
                 scale: 100,
                 focalX: 50,
                 focalY: 50,
-                isFill: false,
-                resource: {
-                  type: 'image',
-                  mimeType: 'image/gif',
-                  src:
-                    'http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies.gif',
-                  width: 220,
-                  height: 124,
-                  poster: '',
-                  posterId: 0,
-                  videoId: 55,
-                  title: 'capybarawithpuppies',
-                  alt: '',
-                  local: false,
-                  sizes: {
-                    medium: {
-                      file: 'capybarawithpuppies-300x169.gif',
-                      width: 300,
-                      height: 169,
-                      mime_type: 'image/gif',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies-300x169.gif',
-                    },
-                    thumbnail: {
-                      file: 'capybarawithpuppies-150x150.gif',
-                      width: 150,
-                      height: 150,
-                      mime_type: 'image/gif',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies-150x150.gif',
-                    },
-                    web_stories_thumbnail: {
-                      file: 'capybarawithpuppies-150x84.gif',
-                      width: 150,
-                      height: 84,
-                      mime_type: 'image/gif',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies-150x84.gif',
-                    },
-                    full: {
-                      file: 'capybarawithpuppies.gif',
-                      width: 480,
-                      height: 270,
-                      mime_type: 'image/gif',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/capybarawithpuppies.gif',
-                    },
-                  },
-                },
-                x: 109,
-                y: 139,
-                width: 220,
-                height: 437,
                 mask: {
                   type: 'rectangle',
-                  name: 'Rectangle',
-                  path: 'M 0,0 1,0 1,1 0,1 0,0 Z',
-                  ratio: 1,
                 },
-                type: 'image',
-                id: 'cb352b5a-3697-4b11-937b-aa5fe1d3c6cd',
+                id: '71ddb528-7d8f-4e54-b888-358680221f59',
               },
             ],
             type: 'page',
-            id: '01ac6bd7-f94b-4f2d-8fd0-2f3981c31828',
-            backgroundElementId: 'c4f3e766-0c8b-43b5-ba9b-ad6083b1331e',
+            id: '43b8f6b8-0966-4b53-9cda-a95f0837e099',
+          },
+        ],
+        autoAdvance: true,
+        defaultPageDuration: 7,
+      },
+      featured_media_url: '',
+      publisher_logo_url:
+        'http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png',
+      style_presets: {
+        fillColors: [],
+        textColors: [],
+        textStyles: [],
+      },
+      _links: {
+        self: [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/165',
+          },
+        ],
+        collection: [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story',
+          },
+        ],
+        about: [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/types/web-story',
+          },
+        ],
+        author: [
+          {
+            embeddable: true,
+            href: 'http://localhost:8899/wp-json/wp/v2/users/1',
+          },
+        ],
+        'version-history': [
+          {
+            count: 1,
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/165/revisions',
+          },
+        ],
+        'predecessor-version': [
+          {
+            id: 166,
+            href:
+              'http://localhost:8899/wp-json/wp/v2/web-story/165/revisions/166',
+          },
+        ],
+        'wp:attachment': [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/media?parent=165',
+          },
+        ],
+        'wp:term': [
+          {
+            taxonomy: 'category',
+            embeddable: true,
+            href: 'http://localhost:8899/wp-json/wp/v2/categories?post=165',
+          },
+          {
+            taxonomy: 'post_tag',
+            embeddable: true,
+            href: 'http://localhost:8899/wp-json/wp/v2/tags?post=165',
+          },
+        ],
+        'wp:action-publish': [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/165',
+          },
+        ],
+        'wp:action-unfiltered-html': [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/165',
+          },
+        ],
+        'wp:action-assign-author': [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/165',
+          },
+        ],
+        'wp:action-create-categories': [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/165',
+          },
+        ],
+        'wp:action-assign-categories': [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/165',
+          },
+        ],
+        'wp:action-create-tags': [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/165',
+          },
+        ],
+        'wp:action-assign-tags': [
+          {
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/165',
+          },
+        ],
+        curies: [
+          {
+            name: 'wp',
+            href: 'https://api.w.org/{rel}',
+            templated: true,
+          },
+        ],
+      },
+    },
+  },
+  {
+    id: 163,
+    status: 'draft',
+    title: 'RED SHAPES',
+    modified: moment('05-21-2020', 'MM-DD-YYYY'),
+    created: '2020-05-21T23:24:47.000Z',
+    pages: [
+      {
+        elements: [
+          {
+            opacity: 100,
+            flip: {
+              vertical: false,
+              horizontal: false,
+            },
+            rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 244,
+                g: 6,
+                b: 6,
+              },
+            },
+            isFill: false,
+            x: 1,
+            y: 1,
+            width: 1,
+            height: 1,
+            mask: {
+              type: 'rectangle',
+            },
+            isBackground: true,
+            isDefaultBackground: true,
+            type: 'shape',
+            id: '3757b9af-1760-44d4-baf7-89554bc6a3e0',
+          },
+          {
+            opacity: 100,
+            flip: {
+              vertical: false,
+              horizontal: false,
+            },
+            rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 189,
+                g: 146,
+                b: 146,
+              },
+            },
+            isFill: false,
+            type: 'shape',
+            x: 79,
+            y: 19,
+            width: 147,
+            height: 147,
+            scale: 100,
+            focalX: 50,
+            focalY: 50,
+            mask: {
+              type: 'blob-4',
+            },
+            id: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+          },
+          {
+            opacity: 100,
+            flip: {
+              vertical: false,
+              horizontal: false,
+            },
+            rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 189,
+                g: 146,
+                b: 146,
+              },
+            },
+            isFill: false,
+            type: 'shape',
+            width: 147,
+            height: 147,
+            scale: 100,
+            focalX: 50,
+            focalY: 50,
+            mask: {
+              type: 'blob-4',
+            },
+            basedOn: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+            id: '44151a8d-1ccf-4160-8d7f-960a8b1d5317',
+            x: 281,
+            y: 165,
+          },
+          {
+            opacity: 100,
+            flip: {
+              vertical: false,
+              horizontal: false,
+            },
+            rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 189,
+                g: 146,
+                b: 146,
+              },
+            },
+            isFill: false,
+            type: 'shape',
+            width: 147,
+            height: 147,
+            scale: 100,
+            focalX: 50,
+            focalY: 50,
+            mask: {
+              type: 'blob-4',
+            },
+            basedOn: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+            id: '955810aa-a872-4696-b671-0161842f6e65',
+            x: 328,
+            y: -54,
+          },
+          {
+            opacity: 100,
+            flip: {
+              vertical: false,
+              horizontal: false,
+            },
+            rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 189,
+                g: 146,
+                b: 146,
+              },
+            },
+            isFill: false,
+            type: 'shape',
+            width: 147,
+            height: 147,
+            scale: 100,
+            focalX: 50,
+            focalY: 50,
+            mask: {
+              type: 'blob-4',
+            },
+            basedOn: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+            id: '57b1ad44-3110-4c28-9586-e5bb58400c74',
+            x: 22,
+            y: 262,
+          },
+          {
+            opacity: 100,
+            flip: {
+              vertical: false,
+              horizontal: false,
+            },
+            rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 189,
+                g: 146,
+                b: 146,
+              },
+            },
+            isFill: false,
+            type: 'shape',
+            width: 147,
+            height: 147,
+            scale: 100,
+            focalX: 50,
+            focalY: 50,
+            mask: {
+              type: 'blob-4',
+            },
+            basedOn: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+            id: '067d16be-d9d6-4cc7-9f90-c7526b0bd798',
+            x: 255,
+            y: 354,
+          },
+          {
+            opacity: 100,
+            flip: {
+              vertical: false,
+              horizontal: false,
+            },
+            rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 189,
+                g: 146,
+                b: 146,
+              },
+            },
+            isFill: false,
+            type: 'shape',
+            width: 147,
+            height: 147,
+            scale: 100,
+            focalX: 50,
+            focalY: 50,
+            mask: {
+              type: 'blob-4',
+            },
+            basedOn: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+            id: '97a4babd-e9b3-4ce9-9662-e2939d12792e',
+            x: 0,
+            y: 444,
+          },
+        ],
+        type: 'page',
+        id: '480f4d3a-9900-47b5-9537-41e94602d6d8',
+        backgroundOverlay: 'none',
+      },
+    ],
+    tags: [],
+    categories: [],
+    author: 1,
+    centerTargetAction: '',
+    bottomTargetAction:
+      'http://localhost:8899/wp-admin/post.php?action=edit&post=163',
+    originalStoryData: {
+      id: 163,
+      date: '2020-05-21T16:24:47',
+      date_gmt: '2020-05-21T23:24:47',
+      guid: {
+        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=163',
+        raw: 'http://localhost:8899/?post_type=web-story&#038;p=163',
+      },
+      modified: '2020-05-21T16:24:47',
+      modified_gmt: '2020-05-21T23:24:47',
+      password: '',
+      slug: 'red-shapes',
+      status: 'draft',
+      type: 'web-story',
+      link: 'http://localhost:8899/?post_type=web-story&p=163',
+      title: {
+        raw: 'RED SHAPES',
+        rendered: 'RED SHAPES',
+      },
+      content: {
+        raw:
+          '<html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script><style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript><style amp-custom="">\n              amp-story-grid-layer {\n                overflow: visible;\n              }\n\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: visible;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }\n\n              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }\n\n              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }\n\n              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }\n\n              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=163"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="RED SHAPES" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="480f4d3a-9900-47b5-9537-41e94602d6d8" auto-advance-after="7s"><amp-story-grid-layer template="vertical"><div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"><div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-3757b9af-1760-44d4-baf7-89554bc6a3e0" class="wrapper"><div class="fill" style="background-color:#f40606"></div></div></div></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"><div class="page-safe-area"><div style="left:17.95455%;top:2.87879%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-a6539988-668b-4be2-bac4-9f6f218feb51-output);-webkit-clip-path:url(#mask-blob-4-a6539988-668b-4be2-bac4-9f6f218feb51-output)" id="el-a6539988-668b-4be2-bac4-9f6f218feb51" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-a6539988-668b-4be2-bac4-9f6f218feb51-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#bd9292"></div></div><div style="left:63.86364%;top:25%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-44151a8d-1ccf-4160-8d7f-960a8b1d5317-output);-webkit-clip-path:url(#mask-blob-4-44151a8d-1ccf-4160-8d7f-960a8b1d5317-output)" id="el-44151a8d-1ccf-4160-8d7f-960a8b1d5317" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-44151a8d-1ccf-4160-8d7f-960a8b1d5317-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#bd9292"></div></div><div style="left:74.54545%;top:-8.18182%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-955810aa-a872-4696-b671-0161842f6e65-output);-webkit-clip-path:url(#mask-blob-4-955810aa-a872-4696-b671-0161842f6e65-output)" id="el-955810aa-a872-4696-b671-0161842f6e65" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-955810aa-a872-4696-b671-0161842f6e65-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#bd9292"></div></div><div style="left:5%;top:39.69697%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-57b1ad44-3110-4c28-9586-e5bb58400c74-output);-webkit-clip-path:url(#mask-blob-4-57b1ad44-3110-4c28-9586-e5bb58400c74-output)" id="el-57b1ad44-3110-4c28-9586-e5bb58400c74" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-57b1ad44-3110-4c28-9586-e5bb58400c74-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#bd9292"></div></div><div style="left:57.95455%;top:53.63636%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-067d16be-d9d6-4cc7-9f90-c7526b0bd798-output);-webkit-clip-path:url(#mask-blob-4-067d16be-d9d6-4cc7-9f90-c7526b0bd798-output)" id="el-067d16be-d9d6-4cc7-9f90-c7526b0bd798" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-067d16be-d9d6-4cc7-9f90-c7526b0bd798-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#bd9292"></div></div><div style="left:0%;top:67.27273%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-97a4babd-e9b3-4ce9-9662-e2939d12792e-output);-webkit-clip-path:url(#mask-blob-4-97a4babd-e9b3-4ce9-9662-e2939d12792e-output)" id="el-97a4babd-e9b3-4ce9-9662-e2939d12792e" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-97a4babd-e9b3-4ce9-9662-e2939d12792e-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#bd9292"></div></div></div></amp-story-grid-layer></amp-story-page></amp-story></body></html>',
+        rendered:
+          '<p><html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script></p>\n<style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>\n<p><noscript></p>\n<style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>\n<p></noscript></p>\n<style amp-custom="">\n              amp-story-grid-layer {\n                overflow: visible;\n              }</p>\n<p>              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: visible;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }</p>\n<p>              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }</p>\n<p>              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }</p>\n<p>              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }</p>\n<p>              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style>\n<p><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=163"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="RED SHAPES" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="480f4d3a-9900-47b5-9537-41e94602d6d8" auto-advance-after="7s"><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"></p>\n<div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-3757b9af-1760-44d4-baf7-89554bc6a3e0" class="wrapper">\n<div class="fill" style="background-color:#f40606"></div>\n</div>\n</div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"></p>\n<div class="page-safe-area">\n<div style="left:17.95455%;top:2.87879%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-a6539988-668b-4be2-bac4-9f6f218feb51-output);-webkit-clip-path:url(#mask-blob-4-a6539988-668b-4be2-bac4-9f6f218feb51-output)" id="el-a6539988-668b-4be2-bac4-9f6f218feb51" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-a6539988-668b-4be2-bac4-9f6f218feb51-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#bd9292"></div>\n</div>\n<div style="left:63.86364%;top:25%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-44151a8d-1ccf-4160-8d7f-960a8b1d5317-output);-webkit-clip-path:url(#mask-blob-4-44151a8d-1ccf-4160-8d7f-960a8b1d5317-output)" id="el-44151a8d-1ccf-4160-8d7f-960a8b1d5317" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-44151a8d-1ccf-4160-8d7f-960a8b1d5317-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#bd9292"></div>\n</div>\n<div style="left:74.54545%;top:-8.18182%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-955810aa-a872-4696-b671-0161842f6e65-output);-webkit-clip-path:url(#mask-blob-4-955810aa-a872-4696-b671-0161842f6e65-output)" id="el-955810aa-a872-4696-b671-0161842f6e65" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-955810aa-a872-4696-b671-0161842f6e65-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#bd9292"></div>\n</div>\n<div style="left:5%;top:39.69697%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-57b1ad44-3110-4c28-9586-e5bb58400c74-output);-webkit-clip-path:url(#mask-blob-4-57b1ad44-3110-4c28-9586-e5bb58400c74-output)" id="el-57b1ad44-3110-4c28-9586-e5bb58400c74" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-57b1ad44-3110-4c28-9586-e5bb58400c74-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#bd9292"></div>\n</div>\n<div style="left:57.95455%;top:53.63636%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-067d16be-d9d6-4cc7-9f90-c7526b0bd798-output);-webkit-clip-path:url(#mask-blob-4-067d16be-d9d6-4cc7-9f90-c7526b0bd798-output)" id="el-067d16be-d9d6-4cc7-9f90-c7526b0bd798" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-067d16be-d9d6-4cc7-9f90-c7526b0bd798-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#bd9292"></div>\n</div>\n<div style="left:0%;top:67.27273%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-blob-4-97a4babd-e9b3-4ce9-9662-e2939d12792e-output);-webkit-clip-path:url(#mask-blob-4-97a4babd-e9b3-4ce9-9662-e2939d12792e-output)" id="el-97a4babd-e9b3-4ce9-9662-e2939d12792e" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-blob-4-97a4babd-e9b3-4ce9-9662-e2939d12792e-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.714844 0.179688 C 0.777344 0.207031 0.835938 0.265625 0.875 0.335938 C 0.914062 0.402344 0.9375 0.484375 0.917969 0.554688 C 0.898438 0.625 0.839844 0.683594 0.78125 0.730469 C 0.722656 0.78125 0.664062 0.816406 0.597656 0.835938 C 0.535156 0.859375 0.464844 0.859375 0.394531 0.847656 C 0.324219 0.832031 0.257812 0.800781 0.207031 0.75 C 0.15625 0.699219 0.125 0.628906 0.101562 0.550781 C 0.0820312 0.472656 0.0742188 0.386719 0.109375 0.324219 C 0.144531 0.265625 0.222656 0.230469 0.296875 0.203125 C 0.371094 0.175781 0.433594 0.160156 0.503906 0.152344 C 0.574219 0.144531 0.648438 0.148438 0.714844 0.179688 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#bd9292"></div>\n</div>\n</div>\n<p></amp-story-grid-layer></amp-story-page></amp-story></body></html></p>\n',
+        protected: false,
+        block_version: 0,
+      },
+      excerpt: {
+        raw: '',
+        rendered: '',
+        protected: false,
+      },
+      author: 1,
+      featured_media: 0,
+      template: '',
+      categories: [],
+      tags: [],
+      permalink_template: 'http://localhost:8899/stories/%pagename%',
+      generated_slug: 'red-shapes',
+      story_data: {
+        version: 19,
+        pages: [
+          {
+            elements: [
+              {
+                opacity: 100,
+                flip: {
+                  vertical: false,
+                  horizontal: false,
+                },
+                rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 244,
+                    g: 6,
+                    b: 6,
+                  },
+                },
+                isFill: false,
+                x: 1,
+                y: 1,
+                width: 1,
+                height: 1,
+                mask: {
+                  type: 'rectangle',
+                },
+                isBackground: true,
+                isDefaultBackground: true,
+                type: 'shape',
+                id: '3757b9af-1760-44d4-baf7-89554bc6a3e0',
+              },
+              {
+                opacity: 100,
+                flip: {
+                  vertical: false,
+                  horizontal: false,
+                },
+                rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 189,
+                    g: 146,
+                    b: 146,
+                  },
+                },
+                isFill: false,
+                type: 'shape',
+                x: 79,
+                y: 19,
+                width: 147,
+                height: 147,
+                scale: 100,
+                focalX: 50,
+                focalY: 50,
+                mask: {
+                  type: 'blob-4',
+                },
+                id: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+              },
+              {
+                opacity: 100,
+                flip: {
+                  vertical: false,
+                  horizontal: false,
+                },
+                rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 189,
+                    g: 146,
+                    b: 146,
+                  },
+                },
+                isFill: false,
+                type: 'shape',
+                width: 147,
+                height: 147,
+                scale: 100,
+                focalX: 50,
+                focalY: 50,
+                mask: {
+                  type: 'blob-4',
+                },
+                basedOn: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+                id: '44151a8d-1ccf-4160-8d7f-960a8b1d5317',
+                x: 281,
+                y: 165,
+              },
+              {
+                opacity: 100,
+                flip: {
+                  vertical: false,
+                  horizontal: false,
+                },
+                rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 189,
+                    g: 146,
+                    b: 146,
+                  },
+                },
+                isFill: false,
+                type: 'shape',
+                width: 147,
+                height: 147,
+                scale: 100,
+                focalX: 50,
+                focalY: 50,
+                mask: {
+                  type: 'blob-4',
+                },
+                basedOn: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+                id: '955810aa-a872-4696-b671-0161842f6e65',
+                x: 328,
+                y: -54,
+              },
+              {
+                opacity: 100,
+                flip: {
+                  vertical: false,
+                  horizontal: false,
+                },
+                rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 189,
+                    g: 146,
+                    b: 146,
+                  },
+                },
+                isFill: false,
+                type: 'shape',
+                width: 147,
+                height: 147,
+                scale: 100,
+                focalX: 50,
+                focalY: 50,
+                mask: {
+                  type: 'blob-4',
+                },
+                basedOn: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+                id: '57b1ad44-3110-4c28-9586-e5bb58400c74',
+                x: 22,
+                y: 262,
+              },
+              {
+                opacity: 100,
+                flip: {
+                  vertical: false,
+                  horizontal: false,
+                },
+                rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 189,
+                    g: 146,
+                    b: 146,
+                  },
+                },
+                isFill: false,
+                type: 'shape',
+                width: 147,
+                height: 147,
+                scale: 100,
+                focalX: 50,
+                focalY: 50,
+                mask: {
+                  type: 'blob-4',
+                },
+                basedOn: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+                id: '067d16be-d9d6-4cc7-9f90-c7526b0bd798',
+                x: 255,
+                y: 354,
+              },
+              {
+                opacity: 100,
+                flip: {
+                  vertical: false,
+                  horizontal: false,
+                },
+                rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 189,
+                    g: 146,
+                    b: 146,
+                  },
+                },
+                isFill: false,
+                type: 'shape',
+                width: 147,
+                height: 147,
+                scale: 100,
+                focalX: 50,
+                focalY: 50,
+                mask: {
+                  type: 'blob-4',
+                },
+                basedOn: 'a6539988-668b-4be2-bac4-9f6f218feb51',
+                id: '97a4babd-e9b3-4ce9-9662-e2939d12792e',
+                x: 0,
+                y: 444,
+              },
+            ],
+            type: 'page',
+            id: '480f4d3a-9900-47b5-9537-41e94602d6d8',
             backgroundOverlay: 'none',
           },
         ],
@@ -1002,7 +1101,7 @@ const formattedStoriesArray = [
       _links: {
         self: [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/147',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/163',
           },
         ],
         collection: [
@@ -1023,689 +1122,67 @@ const formattedStoriesArray = [
         ],
         'version-history': [
           {
-            count: 0,
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/147/revisions',
-          },
-        ],
-        'wp:attachment': [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/media?parent=147',
-          },
-        ],
-        'wp:term': [
-          {
-            taxonomy: 'category',
-            embeddable: true,
-            href: 'http://localhost:8899/wp-json/wp/v2/categories?post=147',
-          },
-          {
-            taxonomy: 'post_tag',
-            embeddable: true,
-            href: 'http://localhost:8899/wp-json/wp/v2/tags?post=147',
-          },
-        ],
-        'wp:action-publish': [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/147',
-          },
-        ],
-        'wp:action-unfiltered-html': [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/147',
-          },
-        ],
-        'wp:action-assign-author': [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/147',
-          },
-        ],
-        'wp:action-create-categories': [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/147',
-          },
-        ],
-        'wp:action-assign-categories': [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/147',
-          },
-        ],
-        'wp:action-create-tags': [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/147',
-          },
-        ],
-        'wp:action-assign-tags': [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/147',
-          },
-        ],
-        curies: [
-          {
-            name: 'wp',
-            href: 'https://api.w.org/{rel}',
-            templated: true,
-          },
-        ],
-      },
-    },
-  },
-  {
-    id: 39,
-    status: 'publish',
-    title: "taco tuesday menu for rosita's",
-    modified: moment('05-04-2020', 'MM-DD-YYYY'),
-    created: '2020-04-02T06:10:54.000Z',
-    pages: [
-      {
-        elements: [
-          {
-            opacity: 100,
-            flip: {
-              vertical: false,
-              horizontal: false,
-            },
-            rotationAngle: 0,
-            backgroundColor: {
-              color: {
-                r: 255,
-                g: 255,
-                b: 255,
-              },
-            },
-            isFill: false,
-            x: 28.28050513436558,
-            y: 15.798762728965317,
-            width: 146.66666666666666,
-            height: 146.66666666666666,
-            mask: {
-              type: 'rectangle',
-            },
-            isBackground: true,
-            type: 'shape',
-            id: 'd1f9f7f0-6734-4307-b91b-b18dafea10f2',
-          },
-          {
-            opacity: 100,
-            flip: {
-              vertical: false,
-              horizontal: false,
-            },
-            rotationAngle: 0,
-            scale: 100,
-            focalX: 50,
-            focalY: 50,
-            isFill: false,
-            resource: {
-              type: 'image',
-              mimeType: 'image/jpeg',
-              src:
-                'http://localhost:8899/wp-content/uploads/2020/04/The-Best-Classic-Tacos-550.jpg',
-              width: 220,
-              height: 220,
-              videoId: 46,
-              alt: '',
-              sizes: {
-                thumbnail: {
-                  height: 150,
-                  width: 150,
-                  url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/The-Best-Classic-Tacos-550-150x150.jpg',
-                  orientation: 'landscape',
-                },
-                medium: {
-                  height: 300,
-                  width: 300,
-                  url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/The-Best-Classic-Tacos-550-300x300.jpg',
-                  orientation: 'landscape',
-                },
-                full: {
-                  url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/The-Best-Classic-Tacos-550.jpg',
-                  height: 550,
-                  width: 550,
-                  orientation: 'landscape',
-                },
-              },
-            },
-            x: 0,
-            y: -1,
-            width: 440,
-            height: 661,
-            mask: {
-              type: 'rectangle',
-              name: 'Rectangle',
-              path: 'M 0,0 1,0 1,1 0,1 0,0',
-              ratio: 1,
-            },
-            type: 'image',
-            id: 'cbc058ed-fad4-4882-8d4f-cf9b4b921b91',
-          },
-          {
-            opacity: 90,
-            flip: {
-              vertical: false,
-              horizontal: false,
-            },
-            rotationAngle: 0,
-            backgroundTextMode: 'NONE',
-            bold: false,
-            fontFamily: 'Paprika',
-            fontFallback: ['cursive'],
-            fontWeight: 400,
-            fontSize: 60,
-            fontStyle: 'normal',
-            color: {
-              color: {
-                r: 46,
-                g: 47,
-                b: 158,
-              },
-            },
-            letterSpacing: 0,
-            lineHeight: 1.3,
-            textAlign: 'initial',
-            textDecoration: 'none',
-            padding: {
-              vertical: 0,
-              horizontal: 0,
-            },
-            content: 'Tacos',
-            backgroundColor: {
-              color: {
-                r: 196,
-                g: 196,
-                b: 196,
-              },
-            },
-            x: 110,
-            y: 10,
-            width: 220,
-            height: 77,
-            scale: 100,
-            focalX: 50,
-            focalY: 50,
-            isFill: false,
-            type: 'text',
-            id: '02a01d27-1d3e-44b8-a7d7-90e976e4d78c',
-          },
-          {
-            opacity: 100,
-            flip: {
-              vertical: false,
-              horizontal: false,
-            },
-            rotationAngle: 0,
-            backgroundTextMode: 'FILL',
-            bold: false,
-            fontFamily: 'Paprika',
-            fontFallback: ['cursive'],
-            fontWeight: 400,
-            fontSize: 30,
-            fontStyle: 'normal',
-            color: {
-              color: {
-                r: 32,
-                g: 74,
-                b: 215,
-              },
-            },
-            letterSpacing: 0,
-            lineHeight: 1.3,
-            textAlign: 'initial',
-            textDecoration: 'none',
-            padding: {
-              vertical: 0,
-              horizontal: 0,
-            },
-            id: '53659f81-6ab9-437c-bcea-7c42ec10f6e2',
-            title: 'Subheading',
-            content: 'ellos, ellos no',
-            backgroundColor: {
-              type: 'conic',
-              stops: [
-                {
-                  color: {
-                    r: 199,
-                    g: 17,
-                    b: 17,
-                    a: 0.6,
-                  },
-                  position: 0,
-                },
-                {
-                  color: {
-                    r: 199,
-                    g: 17,
-                    b: 17,
-                    a: 0.6,
-                  },
-                  position: 1,
-                },
-              ],
-              rotation: 0.5,
-            },
-            x: 180,
-            y: 146,
-            width: 261,
-            height: 38,
-            scale: 100,
-            focalX: 50,
-            focalY: 50,
-            isFill: false,
-            type: 'text',
-          },
-          {
-            opacity: 100,
-            flip: {
-              vertical: false,
-              horizontal: false,
-            },
-            rotationAngle: 0,
-            backgroundColor: {
-              color: {
-                r: 51,
-                g: 51,
-                b: 51,
-              },
-            },
-            isFill: false,
-            x: 62,
-            y: 330,
-            width: 158,
-            height: 147,
-            scale: 100,
-            focalX: 50,
-            focalY: 50,
-            mask: {
-              type: 'heart',
-            },
-            type: 'shape',
-            id: '202a2046-3317-478c-a944-f41e837528c2',
-          },
-        ],
-        type: 'page',
-        id: 'f1ffaa13-ccba-4a32-9e46-5540e38ad953',
-        backgroundElementId: 'd1f9f7f0-6734-4307-b91b-b18dafea10f2',
-        backgroundOverlay: 'none',
-      },
-    ],
-    tags: [],
-    categories: [],
-    author: 1,
-    centerTargetAction: '',
-    bottomTargetAction:
-      'http://localhost:8899/wp-admin/post.php?action=edit&post=39',
-    originalStoryData: {
-      id: 39,
-      date: '2020-04-01T23:10:54',
-      date_gmt: '2020-04-02T06:10:54',
-      guid: {
-        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=39',
-        raw: 'http://localhost:8899/?post_type=web-story&#038;p=39',
-      },
-      modified: '2020-05-14T15:32:46',
-      modified_gmt: '2020-05-14T22:32:46',
-      password: '',
-      slug: 'taco-tuesday-menu-for-rositas',
-      status: 'publish',
-      type: 'web-story',
-      link: 'http://localhost:8899/stories/taco-tuesday-menu-for-rositas',
-      title: {
-        raw: "taco tuesday menu for rosita's",
-        rendered: 'taco tuesday menu for rosita&#8217;s',
-      },
-      content: {
-        raw:
-          '<html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script><style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript><style amp-custom="">\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: hidden;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }\n\n              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }\n\n              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }\n\n              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }\n\n              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=39"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="taco tuesday menu for rosita&#x27;s" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="f1ffaa13-ccba-4a32-9e46-5540e38ad953"><amp-story-grid-layer template="vertical"><div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"><div style="left:0%;top:0%;width:100%;height:100%;opacity:1" id="el-d1f9f7f0-6734-4307-b91b-b18dafea10f2" class="wrapper"><div class="fill" style="background-color:#fff"></div></div></div></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"><div class="page-safe-area"><div style="left:0%;top:-0.15152%;width:100%;height:100.15152%;opacity:1;clip-path:url(#mask-rectangle-cbc058ed-fad4-4882-8d4f-cf9b4b921b91-output);-webkit-clip-path:url(#mask-rectangle-cbc058ed-fad4-4882-8d4f-cf9b4b921b91-output)" id="el-cbc058ed-fad4-4882-8d4f-cf9b4b921b91" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-cbc058ed-fad4-4882-8d4f-cf9b4b921b91-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0"></path></clipPath></defs></svg><div style="position:absolute;width:150.22728%;height:100%;left:-25.11364%;top:0%"><amp-img layout="fill" src="http://localhost:8899/wp-content/uploads/2020/04/The-Best-Classic-Tacos-550.jpg" alt=""></amp-img></div></div><div style="left:25%;top:1.51515%;width:50%;height:11.66667%;opacity:0.9" id="el-02a01d27-1d3e-44b8-a7d7-90e976e4d78c" class="wrapper"><p class="fill" style="white-space:pre-wrap;margin:0;font-family:Paprika,cursive;font-size:0.909091em;font-style:normal;font-weight:400;line-height:1.3;letter-spacing:0em;text-align:initial;text-decoration:none;padding:0% 0%;color:#2e2f9e">Tacos</p></div><div style="left:40.90909%;top:22.12121%;width:59.31818%;height:5.75758%;opacity:1" id="el-53659f81-6ab9-437c-bcea-7c42ec10f6e2" class="wrapper"><p class="fill" style="white-space:pre-wrap;margin:0;font-family:Paprika,cursive;font-size:0.454545em;font-style:normal;font-weight:400;line-height:1.3;letter-spacing:0em;text-align:initial;text-decoration:none;padding:0% 0%;color:#204ad7;background-image:conic-gradient(from 0.5turn, rgba(199,17,17,0.6) 0turn, rgba(199,17,17,0.6) 1turn)">ellos, ellos no</p></div><div style="left:14.09091%;top:50%;width:35.90909%;height:22.27273%;opacity:1;clip-path:url(#mask-heart-202a2046-3317-478c-a944-f41e837528c2-output);-webkit-clip-path:url(#mask-heart-202a2046-3317-478c-a944-f41e837528c2-output)" id="el-202a2046-3317-478c-a944-f41e837528c2" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-heart-202a2046-3317-478c-a944-f41e837528c2-output" transform="scale(1 1.075533375284871)" clipPathUnits="objectBoundingBox"><path d="M.99834689.27724859C.98374997.1165844.87003101.00001922.7277144.00001922c-.0948137 0-.18162681.05102248-.23047608.13279699C.44883142.04998394.36557613 0 .27228183 0 .12998435 0 .01624632.1165652.00166847.27722932c-.00115382.007097-.00588463.0444451.00850059.10535296.0207321.0878518.06861968.1677608.13845102.23103404l.34838744.31615494.35436847-.31613565c.0698315-.0632926.1177191-.14318227.13845114-.23105333.0143856-.0608885.009655-.0982371.00852-.10533369z"></path></clipPath></defs></svg><div class="fill" style="background-color:#333"></div></div></div></amp-story-grid-layer></amp-story-page></amp-story></body></html>',
-        rendered:
-          '<p><html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script></p>\n<style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>\n<p><noscript></p>\n<style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>\n<p></noscript></p>\n<style amp-custom="">\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: hidden;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }</p>\n<p>              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }</p>\n<p>              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }</p>\n<p>              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }</p>\n<p>              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style>\n<p><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=39"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="taco tuesday menu for rosita&#x27;s" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="f1ffaa13-ccba-4a32-9e46-5540e38ad953"><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"></p>\n<div style="left:0%;top:0%;width:100%;height:100%;opacity:1" id="el-d1f9f7f0-6734-4307-b91b-b18dafea10f2" class="wrapper">\n<div class="fill" style="background-color:#fff"></div>\n</div>\n</div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"></p>\n<div class="page-safe-area">\n<div style="left:0%;top:-0.15152%;width:100%;height:100.15152%;opacity:1;clip-path:url(#mask-rectangle-cbc058ed-fad4-4882-8d4f-cf9b4b921b91-output);-webkit-clip-path:url(#mask-rectangle-cbc058ed-fad4-4882-8d4f-cf9b4b921b91-output)" id="el-cbc058ed-fad4-4882-8d4f-cf9b4b921b91" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-cbc058ed-fad4-4882-8d4f-cf9b4b921b91-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0"></path></clipPath></defs></svg></p>\n<div style="position:absolute;width:150.22728%;height:100%;left:-25.11364%;top:0%"><amp-img layout="fill" src="http://localhost:8899/wp-content/uploads/2020/04/The-Best-Classic-Tacos-550.jpg" alt=""></amp-img></div>\n</div>\n<div style="left:25%;top:1.51515%;width:50%;height:11.66667%;opacity:0.9" id="el-02a01d27-1d3e-44b8-a7d7-90e976e4d78c" class="wrapper">\n<p class="fill" style="white-space:pre-wrap;margin:0;font-family:Paprika,cursive;font-size:0.909091em;font-style:normal;font-weight:400;line-height:1.3;letter-spacing:0em;text-align:initial;text-decoration:none;padding:0% 0%;color:#2e2f9e">Tacos</p>\n</div>\n<div style="left:40.90909%;top:22.12121%;width:59.31818%;height:5.75758%;opacity:1" id="el-53659f81-6ab9-437c-bcea-7c42ec10f6e2" class="wrapper">\n<p class="fill" style="white-space:pre-wrap;margin:0;font-family:Paprika,cursive;font-size:0.454545em;font-style:normal;font-weight:400;line-height:1.3;letter-spacing:0em;text-align:initial;text-decoration:none;padding:0% 0%;color:#204ad7;background-image:conic-gradient(from 0.5turn, rgba(199,17,17,0.6) 0turn, rgba(199,17,17,0.6) 1turn)">ellos, ellos no</p>\n</div>\n<div style="left:14.09091%;top:50%;width:35.90909%;height:22.27273%;opacity:1;clip-path:url(#mask-heart-202a2046-3317-478c-a944-f41e837528c2-output);-webkit-clip-path:url(#mask-heart-202a2046-3317-478c-a944-f41e837528c2-output)" id="el-202a2046-3317-478c-a944-f41e837528c2" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-heart-202a2046-3317-478c-a944-f41e837528c2-output" transform="scale(1 1.075533375284871)" clipPathUnits="objectBoundingBox"><path d="M.99834689.27724859C.98374997.1165844.87003101.00001922.7277144.00001922c-.0948137 0-.18162681.05102248-.23047608.13279699C.44883142.04998394.36557613 0 .27228183 0 .12998435 0 .01624632.1165652.00166847.27722932c-.00115382.007097-.00588463.0444451.00850059.10535296.0207321.0878518.06861968.1677608.13845102.23103404l.34838744.31615494.35436847-.31613565c.0698315-.0632926.1177191-.14318227.13845114-.23105333.0143856-.0608885.009655-.0982371.00852-.10533369z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#333"></div>\n</div>\n</div>\n<p></amp-story-grid-layer></amp-story-page></amp-story></body></html></p>\n',
-        protected: false,
-        block_version: 0,
-      },
-      excerpt: {
-        raw: '',
-        rendered: '<p>Tacos ellos, ellos no</p>\n',
-        protected: false,
-      },
-      author: 1,
-      featured_media: 0,
-      template: '',
-      categories: [],
-      tags: [],
-      permalink_template: 'http://localhost:8899/stories/%pagename%',
-      generated_slug: 'taco-tuesday-menu-for-rositas',
-      story_data: {
-        version: 12,
-        pages: [
-          {
-            elements: [
-              {
-                opacity: 100,
-                flip: {
-                  vertical: false,
-                  horizontal: false,
-                },
-                rotationAngle: 0,
-                backgroundColor: {
-                  color: {
-                    r: 255,
-                    g: 255,
-                    b: 255,
-                  },
-                },
-                isFill: false,
-                x: 28.28050513436558,
-                y: 15.798762728965317,
-                width: 146.66666666666666,
-                height: 146.66666666666666,
-                mask: {
-                  type: 'rectangle',
-                },
-                isBackground: true,
-                type: 'shape',
-                id: 'd1f9f7f0-6734-4307-b91b-b18dafea10f2',
-              },
-              {
-                opacity: 100,
-                flip: {
-                  vertical: false,
-                  horizontal: false,
-                },
-                rotationAngle: 0,
-                scale: 100,
-                focalX: 50,
-                focalY: 50,
-                isFill: false,
-                resource: {
-                  type: 'image',
-                  mimeType: 'image/jpeg',
-                  src:
-                    'http://localhost:8899/wp-content/uploads/2020/04/The-Best-Classic-Tacos-550.jpg',
-                  width: 220,
-                  height: 220,
-                  videoId: 46,
-                  alt: '',
-                  sizes: {
-                    thumbnail: {
-                      height: 150,
-                      width: 150,
-                      url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/The-Best-Classic-Tacos-550-150x150.jpg',
-                      orientation: 'landscape',
-                    },
-                    medium: {
-                      height: 300,
-                      width: 300,
-                      url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/The-Best-Classic-Tacos-550-300x300.jpg',
-                      orientation: 'landscape',
-                    },
-                    full: {
-                      url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/The-Best-Classic-Tacos-550.jpg',
-                      height: 550,
-                      width: 550,
-                      orientation: 'landscape',
-                    },
-                  },
-                },
-                x: 0,
-                y: -1,
-                width: 440,
-                height: 661,
-                mask: {
-                  type: 'rectangle',
-                  name: 'Rectangle',
-                  path: 'M 0,0 1,0 1,1 0,1 0,0',
-                  ratio: 1,
-                },
-                type: 'image',
-                id: 'cbc058ed-fad4-4882-8d4f-cf9b4b921b91',
-              },
-              {
-                opacity: 90,
-                flip: {
-                  vertical: false,
-                  horizontal: false,
-                },
-                rotationAngle: 0,
-                backgroundTextMode: 'NONE',
-                bold: false,
-                fontFamily: 'Paprika',
-                fontFallback: ['cursive'],
-                fontWeight: 400,
-                fontSize: 60,
-                fontStyle: 'normal',
-                color: {
-                  color: {
-                    r: 46,
-                    g: 47,
-                    b: 158,
-                  },
-                },
-                letterSpacing: 0,
-                lineHeight: 1.3,
-                textAlign: 'initial',
-                textDecoration: 'none',
-                padding: {
-                  vertical: 0,
-                  horizontal: 0,
-                },
-                content: 'Tacos',
-                backgroundColor: {
-                  color: {
-                    r: 196,
-                    g: 196,
-                    b: 196,
-                  },
-                },
-                x: 110,
-                y: 10,
-                width: 220,
-                height: 77,
-                scale: 100,
-                focalX: 50,
-                focalY: 50,
-                isFill: false,
-                type: 'text',
-                id: '02a01d27-1d3e-44b8-a7d7-90e976e4d78c',
-              },
-              {
-                opacity: 100,
-                flip: {
-                  vertical: false,
-                  horizontal: false,
-                },
-                rotationAngle: 0,
-                backgroundTextMode: 'FILL',
-                bold: false,
-                fontFamily: 'Paprika',
-                fontFallback: ['cursive'],
-                fontWeight: 400,
-                fontSize: 30,
-                fontStyle: 'normal',
-                color: {
-                  color: {
-                    r: 32,
-                    g: 74,
-                    b: 215,
-                  },
-                },
-                letterSpacing: 0,
-                lineHeight: 1.3,
-                textAlign: 'initial',
-                textDecoration: 'none',
-                padding: {
-                  vertical: 0,
-                  horizontal: 0,
-                },
-                id: '53659f81-6ab9-437c-bcea-7c42ec10f6e2',
-                title: 'Subheading',
-                content: 'ellos, ellos no',
-                backgroundColor: {
-                  type: 'conic',
-                  stops: [
-                    {
-                      color: {
-                        r: 199,
-                        g: 17,
-                        b: 17,
-                        a: 0.6,
-                      },
-                      position: 0,
-                    },
-                    {
-                      color: {
-                        r: 199,
-                        g: 17,
-                        b: 17,
-                        a: 0.6,
-                      },
-                      position: 1,
-                    },
-                  ],
-                  rotation: 0.5,
-                },
-                x: 180,
-                y: 146,
-                width: 261,
-                height: 38,
-                scale: 100,
-                focalX: 50,
-                focalY: 50,
-                isFill: false,
-                type: 'text',
-              },
-              {
-                opacity: 100,
-                flip: {
-                  vertical: false,
-                  horizontal: false,
-                },
-                rotationAngle: 0,
-                backgroundColor: {
-                  color: {
-                    r: 51,
-                    g: 51,
-                    b: 51,
-                  },
-                },
-                isFill: false,
-                x: 62,
-                y: 330,
-                width: 158,
-                height: 147,
-                scale: 100,
-                focalX: 50,
-                focalY: 50,
-                mask: {
-                  type: 'heart',
-                },
-                type: 'shape',
-                id: '202a2046-3317-478c-a944-f41e837528c2',
-              },
-            ],
-            type: 'page',
-            id: 'f1ffaa13-ccba-4a32-9e46-5540e38ad953',
-            backgroundElementId: 'd1f9f7f0-6734-4307-b91b-b18dafea10f2',
-            backgroundOverlay: 'none',
-          },
-        ],
-      },
-      featured_media_url: '',
-      publisher_logo_url:
-        'http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png',
-      style_presets: {
-        fillColors: [],
-        textColors: [],
-        textStyles: [],
-      },
-      _links: {
-        self: [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/39',
-          },
-        ],
-        collection: [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story',
-          },
-        ],
-        about: [
-          {
-            href: 'http://localhost:8899/wp-json/wp/v2/types/web-story',
-          },
-        ],
-        author: [
-          {
-            embeddable: true,
-            href: 'http://localhost:8899/wp-json/wp/v2/users/1',
-          },
-        ],
-        'version-history': [
-          {
-            count: 4,
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/39/revisions',
+            count: 1,
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/163/revisions',
           },
         ],
         'predecessor-version': [
           {
-            id: 146,
+            id: 164,
             href:
-              'http://localhost:8899/wp-json/wp/v2/web-story/39/revisions/146',
+              'http://localhost:8899/wp-json/wp/v2/web-story/163/revisions/164',
           },
         ],
         'wp:attachment': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/media?parent=39',
+            href: 'http://localhost:8899/wp-json/wp/v2/media?parent=163',
           },
         ],
         'wp:term': [
           {
             taxonomy: 'category',
             embeddable: true,
-            href: 'http://localhost:8899/wp-json/wp/v2/categories?post=39',
+            href: 'http://localhost:8899/wp-json/wp/v2/categories?post=163',
           },
           {
             taxonomy: 'post_tag',
             embeddable: true,
-            href: 'http://localhost:8899/wp-json/wp/v2/tags?post=39',
+            href: 'http://localhost:8899/wp-json/wp/v2/tags?post=163',
           },
         ],
         'wp:action-publish': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/39',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/163',
           },
         ],
         'wp:action-unfiltered-html': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/39',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/163',
           },
         ],
         'wp:action-assign-author': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/39',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/163',
           },
         ],
         'wp:action-create-categories': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/39',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/163',
           },
         ],
         'wp:action-assign-categories': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/39',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/163',
           },
         ],
         'wp:action-create-tags': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/39',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/163',
           },
         ],
         'wp:action-assign-tags': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/39',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/163',
           },
         ],
         curies: [
@@ -1719,27 +1196,27 @@ const formattedStoriesArray = [
     },
   },
   {
-    id: 144,
+    id: 161,
     status: 'draft',
-    title: 'Harry Potter',
-    modified: moment('04-14-2020', 'MM-DD-YYYY'),
-    created: '2020-05-14T22:31:25.000Z',
+    title: 'BLUE SHAPES',
+    modified: moment('05-20-2020', 'MM-DD-YYYY'),
+    created: '2020-05-21T23:24:06.000Z',
     pages: [
       {
         elements: [
           {
-            type: 'shape',
             opacity: 100,
             flip: {
               vertical: false,
               horizontal: false,
             },
             rotationAngle: 0,
+            lockAspectRatio: true,
             backgroundColor: {
               color: {
-                r: 211,
-                g: 12,
-                b: 12,
+                r: 32,
+                g: 23,
+                b: 153,
               },
             },
             isFill: false,
@@ -1751,194 +1228,101 @@ const formattedStoriesArray = [
               type: 'rectangle',
             },
             isBackground: true,
-            id: '688f9f54-1e28-41ea-9ee8-023ba8e83732',
+            isDefaultBackground: true,
+            type: 'shape',
+            id: '43935b21-22fe-4dda-9f78-0107a99ea15b',
           },
           {
-            type: 'image',
             opacity: 100,
             flip: {
               vertical: false,
               horizontal: false,
             },
             rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 51,
+                g: 51,
+                b: 51,
+              },
+            },
+            isFill: false,
+            type: 'shape',
+            x: 38,
+            y: 0,
+            width: 147,
+            height: 147,
             scale: 100,
             focalX: 50,
             focalY: 50,
-            isFill: false,
-            resource: {
-              type: 'image',
-              mimeType: 'image/jpeg',
-              src:
-                'http://localhost:8899/wp-content/uploads/2020/04/snape.jpeg',
-              width: 229,
-              height: 177,
-              posterId: 0,
-              id: 75,
-              title: 'snape',
-              alt: 'snape',
-              local: false,
-              sizes: {
-                medium: {
-                  file: 'snape-300x225.jpeg',
-                  width: 300,
-                  height: 225,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/snape-300x225.jpeg',
-                },
-                thumbnail: {
-                  file: 'snape-150x150.jpeg',
-                  width: 150,
-                  height: 150,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/snape-150x150.jpeg',
-                },
-                medium_large: {
-                  file: 'snape-768x576.jpeg',
-                  width: 768,
-                  height: 576,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/snape-768x576.jpeg',
-                },
-                'web-stories-poster-portrait': {
-                  file: 'snape-696x703.jpeg',
-                  width: 696,
-                  height: 703,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/snape-696x703.jpeg',
-                },
-                'web-stories-poster-square': {
-                  file: 'snape-928x703.jpeg',
-                  width: 928,
-                  height: 703,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/snape-928x703.jpeg',
-                },
-                'web-stories-poster-landscape': {
-                  file: 'snape-928x696.jpeg',
-                  width: 928,
-                  height: 696,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/snape-928x696.jpeg',
-                },
-                web_stories_thumbnail: {
-                  file: 'snape-150x113.jpeg',
-                  width: 150,
-                  height: 113,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/snape-150x113.jpeg',
-                },
-                full: {
-                  file: 'snape.jpeg',
-                  width: 937,
-                  height: 703,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/snape.jpeg',
-                },
-              },
-            },
-            x: 116,
-            y: 60,
-            width: 229,
-            height: 177,
             mask: {
-              type: 'rectangle',
-              name: 'Rectangle',
-              path: 'M 0,0 1,0 1,1 0,1 0,0 Z',
-              ratio: 1,
+              type: 'circle',
             },
-            id: '6bdb427a-c47f-4ae1-9122-7ee17eb83f01',
+            id: 'e61c25b4-a128-42b4-9b33-cb97a8d320e6',
           },
           {
-            type: 'image',
             opacity: 100,
             flip: {
               vertical: false,
               horizontal: false,
             },
             rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 51,
+                g: 51,
+                b: 51,
+              },
+            },
+            isFill: false,
+            type: 'shape',
+            x: 220,
+            y: 159,
+            width: 158,
+            height: 147,
             scale: 100,
             focalX: 50,
             focalY: 50,
-            isFill: false,
-            resource: {
-              type: 'image',
-              mimeType: 'image/jpeg',
-              src:
-                'http://localhost:8899/wp-content/uploads/2020/04/hpyoung.jpg',
-              width: 229,
-              height: 308,
-              posterId: 0,
-              id: 74,
-              title: 'MSDHAPO EC040',
-              alt: 'MSDHAPO EC040',
-              local: false,
-              sizes: {
-                medium: {
-                  file: 'hpyoung-230x300.jpg',
-                  width: 230,
-                  height: 300,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/hpyoung-230x300.jpg',
-                },
-                thumbnail: {
-                  file: 'hpyoung-150x150.jpg',
-                  width: 150,
-                  height: 150,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/hpyoung-150x150.jpg',
-                },
-                'web-stories-poster-landscape': {
-                  file: 'hpyoung-600x696.jpg',
-                  width: 600,
-                  height: 696,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/hpyoung-600x696.jpg',
-                },
-                web_stories_thumbnail: {
-                  file: 'hpyoung-150x196.jpg',
-                  width: 150,
-                  height: 196,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/hpyoung-150x196.jpg',
-                },
-                full: {
-                  file: 'hpyoung.jpg',
-                  width: 600,
-                  height: 783,
-                  mime_type: 'image/jpeg',
-                  source_url:
-                    'http://localhost:8899/wp-content/uploads/2020/04/hpyoung.jpg',
-                },
+            mask: {
+              type: 'heart',
+            },
+            id: '28b36842-d272-4146-9a3f-ff841c7b2de4',
+          },
+          {
+            opacity: 100,
+            flip: {
+              vertical: false,
+              horizontal: false,
+            },
+            rotationAngle: 0,
+            lockAspectRatio: true,
+            backgroundColor: {
+              color: {
+                r: 51,
+                g: 51,
+                b: 51,
               },
             },
-            x: 64,
-            y: 292,
-            width: 229,
-            height: 308,
+            isFill: false,
+            type: 'shape',
+            x: 51,
+            y: 373,
+            width: 169,
+            height: 147,
+            scale: 100,
+            focalX: 50,
+            focalY: 50,
             mask: {
-              type: 'rectangle',
-              name: 'Rectangle',
-              path: 'M 0,0 1,0 1,1 0,1 0,0 Z',
-              ratio: 1,
+              type: 'hexagon',
             },
-            id: '66f19dad-562b-466d-911c-1413bbd15bbc',
+            id: '2e657723-725c-43a3-9dcc-7f4bc09fad8b',
           },
         ],
-        backgroundElementId: '688f9f54-1e28-41ea-9ee8-023ba8e83732',
         type: 'page',
-        id: '15bc9b2c-7ec1-4ef4-b6f2-7ae2248e0851',
+        id: 'f904febe-1c3e-4694-a6aa-666d0ed03959',
+        backgroundOverlay: 'solid',
       },
     ],
     tags: [],
@@ -1946,31 +1330,31 @@ const formattedStoriesArray = [
     author: 1,
     centerTargetAction: '',
     bottomTargetAction:
-      'http://localhost:8899/wp-admin/post.php?action=edit&post=144',
+      'http://localhost:8899/wp-admin/post.php?action=edit&post=161',
     originalStoryData: {
-      id: 144,
-      date: '2020-05-14T15:31:25',
-      date_gmt: '2020-05-14T22:31:25',
+      id: 161,
+      date: '2020-05-21T16:24:06',
+      date_gmt: '2020-05-21T23:24:06',
       guid: {
-        rendered: 'http://localhost:8899/?post_type=web-story&p=144',
-        raw: 'http://localhost:8899/?post_type=web-story&p=144',
+        rendered: 'http://localhost:8899/?post_type=web-story&#038;p=161',
+        raw: 'http://localhost:8899/?post_type=web-story&#038;p=161',
       },
-      modified: '2020-05-14T15:31:25',
-      modified_gmt: '2020-05-14T22:31:25',
+      modified: '2020-05-21T16:24:06',
+      modified_gmt: '2020-05-21T23:24:06',
       password: '',
-      slug: '',
+      slug: 'blue-shapes',
       status: 'draft',
       type: 'web-story',
-      link: 'http://localhost:8899/?post_type=web-story&p=144',
+      link: 'http://localhost:8899/?post_type=web-story&p=161',
       title: {
-        raw: 'Harry Potter? (Copy)',
-        rendered: 'Harry Potter? (Copy)',
+        raw: 'BLUE SHAPES',
+        rendered: 'BLUE SHAPES',
       },
       content: {
         raw:
-          '<html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script><style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript><style amp-custom="">\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: hidden;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }\n\n              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }\n\n              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }\n\n              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }\n\n              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=90"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="Harry Potter?" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="15bc9b2c-7ec1-4ef4-b6f2-7ae2248e0851" auto-advance-after="7s"><amp-story-grid-layer template="vertical"><div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"><div style="left:0%;top:0%;width:100%;height:100%;opacity:1" id="el-688f9f54-1e28-41ea-9ee8-023ba8e83732" class="wrapper"><div class="fill" style="background-color:#d30c0c"></div></div></div></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"><div class="page-safe-area"><div style="left:26.36364%;top:9.09091%;width:52.04545%;height:26.81818%;opacity:1;clip-path:url(#mask-rectangle-6bdb427a-c47f-4ae1-9122-7ee17eb83f01-output);-webkit-clip-path:url(#mask-rectangle-6bdb427a-c47f-4ae1-9122-7ee17eb83f01-output)" id="el-6bdb427a-c47f-4ae1-9122-7ee17eb83f01" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-6bdb427a-c47f-4ae1-9122-7ee17eb83f01-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0 Z"></path></clipPath></defs></svg><div style="position:absolute;width:100%;height:100%;left:0%;top:0%"><amp-img layout="fill" src="http://localhost:8899/wp-content/uploads/2020/04/snape.jpeg" alt="snape"></amp-img></div></div><div style="left:14.54545%;top:44.24242%;width:52.04545%;height:46.66667%;opacity:1;clip-path:url(#mask-rectangle-66f19dad-562b-466d-911c-1413bbd15bbc-output);-webkit-clip-path:url(#mask-rectangle-66f19dad-562b-466d-911c-1413bbd15bbc-output)" id="el-66f19dad-562b-466d-911c-1413bbd15bbc" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-66f19dad-562b-466d-911c-1413bbd15bbc-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0 Z"></path></clipPath></defs></svg><div style="position:absolute;width:100.00002%;height:100%;left:-0.00001%;top:0%"><amp-img layout="fill" src="http://localhost:8899/wp-content/uploads/2020/04/hpyoung.jpg" alt="MSDHAPO EC040"></amp-img></div></div></div></amp-story-grid-layer></amp-story-page></amp-story></body></html>',
+          '<html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script><style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript><style amp-custom="">\n              amp-story-grid-layer {\n                overflow: visible;\n              }\n\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: visible;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }\n\n              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }\n\n              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }\n\n              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }\n\n              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=161"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="BLUE SHAPES" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="f904febe-1c3e-4694-a6aa-666d0ed03959" auto-advance-after="7s"><amp-story-grid-layer template="vertical"><div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"><div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-43935b21-22fe-4dda-9f78-0107a99ea15b" class="wrapper"><div class="fill" style="background-color:#201799"></div></div></div></amp-story-grid-layer><amp-story-grid-layer template="vertical"><div class="page-background-overlay-area" style="background-color:rgba(0,0,0,0.3)"></div></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"><div class="page-safe-area"><div style="left:8.63636%;top:0%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-circle-e61c25b4-a128-42b4-9b33-cb97a8d320e6-output);-webkit-clip-path:url(#mask-circle-e61c25b4-a128-42b4-9b33-cb97a8d320e6-output)" id="el-e61c25b4-a128-42b4-9b33-cb97a8d320e6" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-circle-e61c25b4-a128-42b4-9b33-cb97a8d320e6-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.5 0 C 0.777344 0 1 0.222656 1 0.5 C 1 0.777344 0.777344 1 0.5 1 C 0.222656 1 0 0.777344 0 0.5 C 0 0.222656 0.222656 0 0.5 0 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#333"></div></div><div style="left:50%;top:24.09091%;width:35.90909%;height:22.27273%;opacity:1;clip-path:url(#mask-heart-28b36842-d272-4146-9a3f-ff841c7b2de4-output);-webkit-clip-path:url(#mask-heart-28b36842-d272-4146-9a3f-ff841c7b2de4-output)" id="el-28b36842-d272-4146-9a3f-ff841c7b2de4" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-heart-28b36842-d272-4146-9a3f-ff841c7b2de4-output" transform="scale(1 1.075533375284871)" clipPathUnits="objectBoundingBox"><path d="M.99834689.27724859C.98374997.1165844.87003101.00001922.7277144.00001922c-.0948137 0-.18162681.05102248-.23047608.13279699C.44883142.04998394.36557613 0 .27228183 0 .12998435 0 .01624632.1165652.00166847.27722932c-.00115382.007097-.00588463.0444451.00850059.10535296.0207321.0878518.06861968.1677608.13845102.23103404l.34838744.31615494.35436847-.31613565c.0698315-.0632926.1177191-.14318227.13845114-.23105333.0143856-.0608885.009655-.0982371.00852-.10533369 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#333"></div></div><div style="left:11.59091%;top:56.51515%;width:38.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-hexagon-2e657723-725c-43a3-9dcc-7f4bc09fad8b-output);-webkit-clip-path:url(#mask-hexagon-2e657723-725c-43a3-9dcc-7f4bc09fad8b-output)" id="el-2e657723-725c-43a3-9dcc-7f4bc09fad8b" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-hexagon-2e657723-725c-43a3-9dcc-7f4bc09fad8b-output" transform="scale(1 1.15473441108545)" clipPathUnits="objectBoundingBox"><path d="m 0.74863333,0 h -0.494535 L 0,0.42896111 0.25409833,0.86611944 h 0.494535 L 1,0.42896111 Z"></path></clipPath></defs></svg><div class="fill" style="background-color:#333"></div></div></div></amp-story-grid-layer></amp-story-page></amp-story></body></html>',
         rendered:
-          '<p><html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script></p>\n<style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>\n<p><noscript></p>\n<style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>\n<p></noscript></p>\n<style amp-custom="">\n              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: hidden;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }</p>\n<p>              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }</p>\n<p>              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }</p>\n<p>              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }</p>\n<p>              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style>\n<p><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=90"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="Harry Potter?" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="15bc9b2c-7ec1-4ef4-b6f2-7ae2248e0851" auto-advance-after="7s"><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"></p>\n<div style="left:0%;top:0%;width:100%;height:100%;opacity:1" id="el-688f9f54-1e28-41ea-9ee8-023ba8e83732" class="wrapper">\n<div class="fill" style="background-color:#d30c0c"></div>\n</div>\n</div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"></p>\n<div class="page-safe-area">\n<div style="left:26.36364%;top:9.09091%;width:52.04545%;height:26.81818%;opacity:1;clip-path:url(#mask-rectangle-6bdb427a-c47f-4ae1-9122-7ee17eb83f01-output);-webkit-clip-path:url(#mask-rectangle-6bdb427a-c47f-4ae1-9122-7ee17eb83f01-output)" id="el-6bdb427a-c47f-4ae1-9122-7ee17eb83f01" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-6bdb427a-c47f-4ae1-9122-7ee17eb83f01-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0 Z"></path></clipPath></defs></svg></p>\n<div style="position:absolute;width:100%;height:100%;left:0%;top:0%"><amp-img layout="fill" src="http://localhost:8899/wp-content/uploads/2020/04/snape.jpeg" alt="snape"></amp-img></div>\n</div>\n<div style="left:14.54545%;top:44.24242%;width:52.04545%;height:46.66667%;opacity:1;clip-path:url(#mask-rectangle-66f19dad-562b-466d-911c-1413bbd15bbc-output);-webkit-clip-path:url(#mask-rectangle-66f19dad-562b-466d-911c-1413bbd15bbc-output)" id="el-66f19dad-562b-466d-911c-1413bbd15bbc" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-rectangle-66f19dad-562b-466d-911c-1413bbd15bbc-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0,0 1,0 1,1 0,1 0,0 Z"></path></clipPath></defs></svg></p>\n<div style="position:absolute;width:100.00002%;height:100%;left:-0.00001%;top:0%"><amp-img layout="fill" src="http://localhost:8899/wp-content/uploads/2020/04/hpyoung.jpg" alt="MSDHAPO EC040"></amp-img></div>\n</div>\n</div>\n<p></amp-story-grid-layer></amp-story-page></amp-story></body></html></p>\n',
+          '<p><html amp="" lang="en"><head><meta charSet="utf-8"/><meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/><script async="" src="https://cdn.ampproject.org/v0.js"></script><script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script></p>\n<style amp-boilerplate="">body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style>\n<p><noscript></p>\n<style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style>\n<p></noscript></p>\n<style amp-custom="">\n              amp-story-grid-layer {\n                overflow: visible;\n              }</p>\n<p>              .page-background-area,\n              .page-background-overlay-area,\n              .page-safe-area {\n                position: absolute;\n                overflow: visible;\n                top: 0;\n                bottom: 0;\n                left: 0;\n                right: 0;\n              }</p>\n<p>              .page-cta-area {\n                position: absolute;\n                overflow: hidden;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                height: calc(100 * var(--story-page-vh, 1vh));\n              }</p>\n<p>              .page-background-area img, .page-background-area video {\n                object-fit: cover;\n              }</p>\n<p>              .wrapper {\n                position: absolute;\n                overflow: hidden;\n              }</p>\n<p>              .fill {\n                position: absolute;\n                top: 0;\n                left: 0;\n                right: 0;\n                bottom: 0;\n                margin: 0;\n              }\n              </style>\n<p><meta name="web-stories-replace-head-start"/><link rel="canonical" href="http://localhost:8899/?post_type=web-story&amp;p=161"/><meta name="web-stories-replace-head-end"/></head><body><amp-story standalone="standalone" publisher="Web Stories Dev" publisher-logo-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-wordpress-publisher-logo.png" title="BLUE SHAPES" poster-portrait-src="http://localhost:8899/wp-content/plugins/web-stories/assets/images/fallback-poster.jpg"><amp-story-page id="f904febe-1c3e-4694-a6aa-666d0ed03959" auto-advance-after="7s"><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-area" style="background-color:white;background-image:linear-gradient(45deg, #999999 25%, transparent 25%),\n      linear-gradient(-45deg, #999999 25%, transparent 25%),\n      linear-gradient(45deg, transparent 75%, #999999 75%),\n      linear-gradient(-45deg, transparent 75%, #999999 75%);background-size:20px 20px;background-position:0 0, 0 10px, 10px -10px, -10px 0px"></p>\n<div style="left:0%;top:-9.25926%;width:100%;height:118.51852%;opacity:1" id="el-43935b21-22fe-4dda-9f78-0107a99ea15b" class="wrapper">\n<div class="fill" style="background-color:#201799"></div>\n</div>\n</div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical"></p>\n<div class="page-background-overlay-area" style="background-color:rgba(0,0,0,0.3)"></div>\n<p></amp-story-grid-layer><amp-story-grid-layer template="vertical" aspect-ratio="440:660"></p>\n<div class="page-safe-area">\n<div style="left:8.63636%;top:0%;width:33.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-circle-e61c25b4-a128-42b4-9b33-cb97a8d320e6-output);-webkit-clip-path:url(#mask-circle-e61c25b4-a128-42b4-9b33-cb97a8d320e6-output)" id="el-e61c25b4-a128-42b4-9b33-cb97a8d320e6" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-circle-e61c25b4-a128-42b4-9b33-cb97a8d320e6-output" transform="scale(1 1)" clipPathUnits="objectBoundingBox"><path d="M 0.5 0 C 0.777344 0 1 0.222656 1 0.5 C 1 0.777344 0.777344 1 0.5 1 C 0.222656 1 0 0.777344 0 0.5 C 0 0.222656 0.222656 0 0.5 0 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#333"></div>\n</div>\n<div style="left:50%;top:24.09091%;width:35.90909%;height:22.27273%;opacity:1;clip-path:url(#mask-heart-28b36842-d272-4146-9a3f-ff841c7b2de4-output);-webkit-clip-path:url(#mask-heart-28b36842-d272-4146-9a3f-ff841c7b2de4-output)" id="el-28b36842-d272-4146-9a3f-ff841c7b2de4" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-heart-28b36842-d272-4146-9a3f-ff841c7b2de4-output" transform="scale(1 1.075533375284871)" clipPathUnits="objectBoundingBox"><path d="M.99834689.27724859C.98374997.1165844.87003101.00001922.7277144.00001922c-.0948137 0-.18162681.05102248-.23047608.13279699C.44883142.04998394.36557613 0 .27228183 0 .12998435 0 .01624632.1165652.00166847.27722932c-.00115382.007097-.00588463.0444451.00850059.10535296.0207321.0878518.06861968.1677608.13845102.23103404l.34838744.31615494.35436847-.31613565c.0698315-.0632926.1177191-.14318227.13845114-.23105333.0143856-.0608885.009655-.0982371.00852-.10533369 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#333"></div>\n</div>\n<div style="left:11.59091%;top:56.51515%;width:38.40909%;height:22.27273%;opacity:1;clip-path:url(#mask-hexagon-2e657723-725c-43a3-9dcc-7f4bc09fad8b-output);-webkit-clip-path:url(#mask-hexagon-2e657723-725c-43a3-9dcc-7f4bc09fad8b-output)" id="el-2e657723-725c-43a3-9dcc-7f4bc09fad8b" class="wrapper"><svg width="0" height="0"><defs><clipPath id="mask-hexagon-2e657723-725c-43a3-9dcc-7f4bc09fad8b-output" transform="scale(1 1.15473441108545)" clipPathUnits="objectBoundingBox"><path d="m 0.74863333,0 h -0.494535 L 0,0.42896111 0.25409833,0.86611944 h 0.494535 L 1,0.42896111 Z"></path></clipPath></defs></svg></p>\n<div class="fill" style="background-color:#333"></div>\n</div>\n</div>\n<p></amp-story-grid-layer></amp-story-page></amp-story></body></html></p>\n',
         protected: false,
         block_version: 0,
       },
@@ -1985,25 +1369,25 @@ const formattedStoriesArray = [
       categories: [],
       tags: [],
       permalink_template: 'http://localhost:8899/stories/%pagename%',
-      generated_slug: 'harry-potter-copy',
+      generated_slug: 'blue-shapes',
       story_data: {
-        version: 15,
+        version: 19,
         pages: [
           {
             elements: [
               {
-                type: 'shape',
                 opacity: 100,
                 flip: {
                   vertical: false,
                   horizontal: false,
                 },
                 rotationAngle: 0,
+                lockAspectRatio: true,
                 backgroundColor: {
                   color: {
-                    r: 211,
-                    g: 12,
-                    b: 12,
+                    r: 32,
+                    g: 23,
+                    b: 153,
                   },
                 },
                 isFill: false,
@@ -2015,196 +1399,105 @@ const formattedStoriesArray = [
                   type: 'rectangle',
                 },
                 isBackground: true,
-                id: '688f9f54-1e28-41ea-9ee8-023ba8e83732',
+                isDefaultBackground: true,
+                type: 'shape',
+                id: '43935b21-22fe-4dda-9f78-0107a99ea15b',
               },
               {
-                type: 'image',
                 opacity: 100,
                 flip: {
                   vertical: false,
                   horizontal: false,
                 },
                 rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 51,
+                    g: 51,
+                    b: 51,
+                  },
+                },
+                isFill: false,
+                type: 'shape',
+                x: 38,
+                y: 0,
+                width: 147,
+                height: 147,
                 scale: 100,
                 focalX: 50,
                 focalY: 50,
-                isFill: false,
-                resource: {
-                  type: 'image',
-                  mimeType: 'image/jpeg',
-                  src:
-                    'http://localhost:8899/wp-content/uploads/2020/04/snape.jpeg',
-                  width: 229,
-                  height: 177,
-                  posterId: 0,
-                  id: 75,
-                  title: 'snape',
-                  alt: 'snape',
-                  local: false,
-                  sizes: {
-                    medium: {
-                      file: 'snape-300x225.jpeg',
-                      width: 300,
-                      height: 225,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/snape-300x225.jpeg',
-                    },
-                    thumbnail: {
-                      file: 'snape-150x150.jpeg',
-                      width: 150,
-                      height: 150,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/snape-150x150.jpeg',
-                    },
-                    medium_large: {
-                      file: 'snape-768x576.jpeg',
-                      width: 768,
-                      height: 576,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/snape-768x576.jpeg',
-                    },
-                    'web-stories-poster-portrait': {
-                      file: 'snape-696x703.jpeg',
-                      width: 696,
-                      height: 703,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/snape-696x703.jpeg',
-                    },
-                    'web-stories-poster-square': {
-                      file: 'snape-928x703.jpeg',
-                      width: 928,
-                      height: 703,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/snape-928x703.jpeg',
-                    },
-                    'web-stories-poster-landscape': {
-                      file: 'snape-928x696.jpeg',
-                      width: 928,
-                      height: 696,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/snape-928x696.jpeg',
-                    },
-                    web_stories_thumbnail: {
-                      file: 'snape-150x113.jpeg',
-                      width: 150,
-                      height: 113,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/snape-150x113.jpeg',
-                    },
-                    full: {
-                      file: 'snape.jpeg',
-                      width: 937,
-                      height: 703,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/snape.jpeg',
-                    },
-                  },
-                },
-                x: 116,
-                y: 60,
-                width: 229,
-                height: 177,
                 mask: {
-                  type: 'rectangle',
-                  name: 'Rectangle',
-                  path: 'M 0,0 1,0 1,1 0,1 0,0 Z',
-                  ratio: 1,
+                  type: 'circle',
                 },
-                id: '6bdb427a-c47f-4ae1-9122-7ee17eb83f01',
+                id: 'e61c25b4-a128-42b4-9b33-cb97a8d320e6',
               },
               {
-                type: 'image',
                 opacity: 100,
                 flip: {
                   vertical: false,
                   horizontal: false,
                 },
                 rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 51,
+                    g: 51,
+                    b: 51,
+                  },
+                },
+                isFill: false,
+                type: 'shape',
+                x: 220,
+                y: 159,
+                width: 158,
+                height: 147,
                 scale: 100,
                 focalX: 50,
                 focalY: 50,
-                isFill: false,
-                resource: {
-                  type: 'image',
-                  mimeType: 'image/jpeg',
-                  src:
-                    'http://localhost:8899/wp-content/uploads/2020/04/hpyoung.jpg',
-                  width: 229,
-                  height: 308,
-                  posterId: 0,
-                  id: 74,
-                  title: 'MSDHAPO EC040',
-                  alt: 'MSDHAPO EC040',
-                  local: false,
-                  sizes: {
-                    medium: {
-                      file: 'hpyoung-230x300.jpg',
-                      width: 230,
-                      height: 300,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/hpyoung-230x300.jpg',
-                    },
-                    thumbnail: {
-                      file: 'hpyoung-150x150.jpg',
-                      width: 150,
-                      height: 150,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/hpyoung-150x150.jpg',
-                    },
-                    'web-stories-poster-landscape': {
-                      file: 'hpyoung-600x696.jpg',
-                      width: 600,
-                      height: 696,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/hpyoung-600x696.jpg',
-                    },
-                    web_stories_thumbnail: {
-                      file: 'hpyoung-150x196.jpg',
-                      width: 150,
-                      height: 196,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/hpyoung-150x196.jpg',
-                    },
-                    full: {
-                      file: 'hpyoung.jpg',
-                      width: 600,
-                      height: 783,
-                      mime_type: 'image/jpeg',
-                      source_url:
-                        'http://localhost:8899/wp-content/uploads/2020/04/hpyoung.jpg',
-                    },
+                mask: {
+                  type: 'heart',
+                },
+                id: '28b36842-d272-4146-9a3f-ff841c7b2de4',
+              },
+              {
+                opacity: 100,
+                flip: {
+                  vertical: false,
+                  horizontal: false,
+                },
+                rotationAngle: 0,
+                lockAspectRatio: true,
+                backgroundColor: {
+                  color: {
+                    r: 51,
+                    g: 51,
+                    b: 51,
                   },
                 },
-                x: 64,
-                y: 292,
-                width: 229,
-                height: 308,
+                isFill: false,
+                type: 'shape',
+                x: 51,
+                y: 373,
+                width: 169,
+                height: 147,
+                scale: 100,
+                focalX: 50,
+                focalY: 50,
                 mask: {
-                  type: 'rectangle',
-                  name: 'Rectangle',
-                  path: 'M 0,0 1,0 1,1 0,1 0,0 Z',
-                  ratio: 1,
+                  type: 'hexagon',
                 },
-                id: '66f19dad-562b-466d-911c-1413bbd15bbc',
+                id: '2e657723-725c-43a3-9dcc-7f4bc09fad8b',
               },
             ],
-            backgroundElementId: '688f9f54-1e28-41ea-9ee8-023ba8e83732',
             type: 'page',
-            id: '15bc9b2c-7ec1-4ef4-b6f2-7ae2248e0851',
+            id: 'f904febe-1c3e-4694-a6aa-666d0ed03959',
+            backgroundOverlay: 'solid',
           },
         ],
+        autoAdvance: true,
+        defaultPageDuration: 7,
       },
       featured_media_url: '',
       publisher_logo_url:
@@ -2217,7 +1510,7 @@ const formattedStoriesArray = [
       _links: {
         self: [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/144',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/161',
           },
         ],
         collection: [
@@ -2238,60 +1531,67 @@ const formattedStoriesArray = [
         ],
         'version-history': [
           {
-            count: 0,
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/144/revisions',
+            count: 1,
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/161/revisions',
+          },
+        ],
+        'predecessor-version': [
+          {
+            id: 162,
+            href:
+              'http://localhost:8899/wp-json/wp/v2/web-story/161/revisions/162',
           },
         ],
         'wp:attachment': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/media?parent=144',
+            href: 'http://localhost:8899/wp-json/wp/v2/media?parent=161',
           },
         ],
         'wp:term': [
           {
             taxonomy: 'category',
             embeddable: true,
-            href: 'http://localhost:8899/wp-json/wp/v2/categories?post=144',
+            href: 'http://localhost:8899/wp-json/wp/v2/categories?post=161',
           },
           {
             taxonomy: 'post_tag',
             embeddable: true,
-            href: 'http://localhost:8899/wp-json/wp/v2/tags?post=144',
+            href: 'http://localhost:8899/wp-json/wp/v2/tags?post=161',
           },
         ],
         'wp:action-publish': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/144',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/161',
           },
         ],
         'wp:action-unfiltered-html': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/144',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/161',
           },
         ],
         'wp:action-assign-author': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/144',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/161',
           },
         ],
         'wp:action-create-categories': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/144',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/161',
           },
         ],
         'wp:action-assign-categories': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/144',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/161',
           },
         ],
         'wp:action-create-tags': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/144',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/161',
           },
         ],
         'wp:action-assign-tags': [
           {
-            href: 'http://localhost:8899/wp-json/wp/v2/web-story/144',
+            href: 'http://localhost:8899/wp-json/wp/v2/web-story/161',
           },
         ],
         curies: [


### PR DESCRIPTION
## Summary
Follows up earlier PR that added my stories views to storybook. Only use shapes and background colors for dummy story data to avoid local host image issues

## Testing Instructions
- Now if you go to Dashboard/Components/myStories/Content you should see shapes and colors. Since we don't have the utils necessary to render stories deeper in components you still won't see the colors/shapes in places like StoryGridView. But the myStories should show them for Default, All Data Fetched, All Data Fetched As List.  Note that it will not show on Stories View because this is just the stories component inside Content, does not have providers. 

<img width="767" alt="Screen Shot 2020-05-21 at 4 29 35 PM" src="https://user-images.githubusercontent.com/10720454/82616008-c74c3180-9b80-11ea-98e4-f8ec5263f01a.png">


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
