### PR TITLE
Ignore looping media when getting the longest video

### DIFF
--- a/assets/src/edit-story/output/test/page.js
+++ b/assets/src/edit-story/output/test/page.js
@@ -117,7 +117,7 @@ describe('Page output', () => {
             height: 1920,
             width: 1080,
             rotationAngle: 0,
-            loop: true,
+            loop: false,
             resource: {
               type: 'video',
               mimeType: 'video/mp4',
@@ -144,7 +144,6 @@ describe('Page output', () => {
         autoplay="autoplay"
         id="el-baz-media"
         layout="fill"
-        loop="loop"
         poster="https://example.com/poster.png"
       >
         <source
@@ -156,6 +155,46 @@ describe('Page output', () => {
     await expect(
       queryByAutoAdvanceAfter(container, 'el-baz-media')
     ).toBeInTheDocument();
+  });
+
+  it('should ignore looping video for auto-advance-after and set default instead', async () => {
+    const props = {
+      id: 'foo',
+      backgroundColor: { type: 'solid', color: { r: 255, g: 255, b: 255 } },
+      page: {
+        id: 'bar',
+        elements: [
+          {
+            id: 'baz',
+            type: 'video',
+            mimeType: 'video/mp4',
+            scale: 1,
+            origRatio: 9 / 16,
+            x: 50,
+            y: 100,
+            height: 1920,
+            width: 1080,
+            rotationAngle: 0,
+            loop: true,
+            resource: {
+              type: 'video',
+              mimeType: 'video/mp4',
+              id: 123,
+              src: 'https://example.com/video.mp4',
+              poster: 'https://example.com/poster.png',
+              height: 1920,
+              width: 1080,
+              length: 99,
+            },
+          },
+        ],
+      },
+      autoAdvance: true,
+      defaultPageDuration: 7,
+    };
+
+    const { container } = render(<PageOutput {...props} />);
+    await expect(queryByAutoAdvanceAfter(container, '7s')).toBeInTheDocument();
   });
 
   describe('AMP validation', () => {

--- a/assets/src/edit-story/output/utils/getLongestMediaElement.js
+++ b/assets/src/edit-story/output/utils/getLongestMediaElement.js
@@ -27,9 +27,10 @@ import { getDefinitionForType } from '../../elements';
  */
 function getLongestMediaElement(elements) {
   return elements
-    .filter(({ type }) => {
+    .filter(({ type, loop }) => {
       const { isMedia } = getDefinitionForType(type);
-      return isMedia;
+      // Ensure looping media is not considered.
+      return isMedia && !loop;
     })
     .reduce((longest, element) => {
       if (!element?.resource?.length) {

--- a/assets/src/edit-story/output/utils/test/getLongestMediaElement.js
+++ b/assets/src/edit-story/output/utils/test/getLongestMediaElement.js
@@ -33,6 +33,19 @@ describe('getLongestMediaElement', () => {
     });
   });
 
+  it('should ignore looping media', () => {
+    const elements = [
+      { type: 'video', resource: { length: 1 } },
+      { type: 'video', resource: { length: 10 } },
+      { type: 'video', resource: { length: 15 }, loop: true },
+    ];
+
+    expect(getLongestMediaElement(elements)).toStrictEqual({
+      type: 'video',
+      resource: { length: 10 },
+    });
+  });
+
   it('should ignore images', () => {
     const elements = [{ type: 'image' }];
 


### PR DESCRIPTION
## Summary

Ignores looping videos when detecting the longest video.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

Filters the looping videos out before detecting the longes by length.
<!-- Please describe your changes. -->

## To-do
-
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Looping videos are ignored for auto-advance purposes and auto-advance works again when the looping video of the page is also the longest.
<!-- Please describe your changes. -->

## Testing Instructions
 
1. Add a Page
2. Add 2 videos on the page
3. Check which video is longer and assign looping for the longer video
4. Add a second page and add another looping video to the second page.
5. Add one more Page, a third page (OK to leave empty).
6. View the Story
7. Verify that the first Page auto-advances based on the length of the shorter video.
8. Verify that the second Page auto-advances based on the default value (7 seconds by default).
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1795 
