### PR TITLE
Added clear button to Media search pane

### DIFF
--- a/assets/src/edit-story/components/form/text.js
+++ b/assets/src/edit-story/components/form/text.js
@@ -63,13 +63,12 @@ const ClearBtn = styled.button`
   position: absolute;
   right: 8px;
   appearance: none;
-  background: ${({ theme }) => rgba(theme.colors.fg.v0, 0.54)};
-  width: 16px;
-  height: 16px;
+  background-color: ${({ theme, showBackground }) =>
+    showBackground ? rgba(theme.colors.fg.v0, 0.54) : `transparent`};
   border: none;
-  padding: 0px;
+  padding: 4px;
   border-radius: 50%;
-  display: flex;
+  display: inline-flex;
   justify-content: center;
   align-items: center;
   cursor: pointer;
@@ -89,12 +88,26 @@ function TextInput({
   flexBasis,
   disabled,
   clear,
+  clearIcon,
+  showClearIconBackground,
   placeholder,
   ...rest
 }) {
   const isMultiple = value === MULTIPLE_VALUE;
   value = isMultiple ? '' : value;
   placeholder = isMultiple ? __('multiple', 'web-stories') : placeholder;
+
+  const onClear = (evt) => {
+    onChange('');
+    if (evt.target.form) {
+      evt.target.form.dispatchEvent(
+        new window.Event('submit', { cancelable: true })
+      );
+    }
+    if (onBlur) {
+      onBlur();
+    }
+  };
 
   return (
     <Container
@@ -123,20 +136,8 @@ function TextInput({
         }}
       />
       {Boolean(value) && clear && (
-        <ClearBtn
-          onClick={(evt) => {
-            onChange('');
-            if (evt.target.form) {
-              evt.target.form.dispatchEvent(
-                new window.Event('submit', { cancelable: true })
-              );
-            }
-            if (onBlur) {
-              onBlur();
-            }
-          }}
-        >
-          <CloseIcon />
+        <ClearBtn onClick={onClear} showBackground={showClearIconBackground}>
+          {clearIcon ?? <CloseIcon />}
         </ClearBtn>
       )}
     </Container>
@@ -153,6 +154,8 @@ TextInput.propTypes = {
   flexBasis: PropTypes.number,
   textCenter: PropTypes.bool,
   clear: PropTypes.bool,
+  clearIcon: PropTypes.any,
+  showClearIconBackground: PropTypes.bool,
   placeholder: PropTypes.string,
 };
 
@@ -162,6 +165,7 @@ TextInput.defaultProps = {
   flexBasis: 100,
   textCenter: false,
   clear: false,
+  showClearIconBackground: true,
   placeholder: null,
 };
 

--- a/assets/src/edit-story/components/library/common/searchInput.js
+++ b/assets/src/edit-story/components/library/common/searchInput.js
@@ -20,15 +20,14 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
  * Internal dependencies
  */
 import { ReactComponent as Close } from '../../../icons/close.svg';
 import { TextInput } from '../../form';
-
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
 
 const SearchField = styled.div`
   position: relative;

--- a/assets/src/edit-story/components/library/common/searchInput.js
+++ b/assets/src/edit-story/components/library/common/searchInput.js
@@ -19,7 +19,11 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { rgba } from 'polished';
+/**
+ * Internal dependencies
+ */
+import { ReactComponent as Close } from '../../../icons/close.svg';
+import { TextInput } from '../../form';
 
 /**
  * WordPress dependencies
@@ -32,27 +36,18 @@ const SearchField = styled.div`
   align-items: center;
 `;
 
-const Search = styled.input.attrs({ type: 'text' })`
+const Search = styled(TextInput)`
   width: 100%;
-  background: ${({ theme }) => rgba(theme.colors.fg.v0, 0.3)};
+  flex-grow: 1;
   border: none;
   border-radius: 4px;
-  color: ${({ theme }) => theme.colors.fg.v1};
   padding: 8px 16px 8px 16px;
-  font-family: ${({ theme }) => theme.fonts.body1.family};
-  font-size: ${({ theme }) => theme.fonts.body1.size};
-  letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing};
-  line-height: ${({ theme }) => theme.fonts.body1.lineHeight};
-  &::placeholder {
-    color: ${({ theme }) => rgba(theme.colors.fg.v1, 0.54)};
-  }
-  &:focus {
-    background: ${({ theme }) => theme.colors.bg.v13};
-    color: ${({ theme }) => theme.colors.bg.v0};
-  }
-  &:focus::placeholder {
-    color: ${({ theme }) => rgba(theme.colors.bg.v0, 0.54)};
-  }
+`;
+
+const CloseIcon = styled(Close)`
+  width: 14px;
+  height: 14px;
+  color: ${({ theme }) => theme.colors.fg.v1};
 `;
 
 export default function SearchInput({
@@ -69,6 +64,9 @@ export default function SearchInput({
         onChange={onChange}
         disabled={disabled}
         aria-label={__('Search from library', 'web-stories')}
+        clear
+        clearIcon={<CloseIcon />}
+        showClearIconBackground={false}
       />
     </SearchField>
   );

--- a/assets/src/edit-story/components/library/panes/media/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/mediaPane.js
@@ -170,16 +170,16 @@ function MediaPane(props) {
   /**
    * Handle search term changes.
    *
-   * @param {Object} evt Doc Event
+   * @param {string} value the new search term.
    */
-  const onSearch = (evt) => {
-    setSearchTerm({ searchTerm: evt.target.value });
+  const onSearch = (value) => {
+    setSearchTerm({ searchTerm: value });
   };
 
   /**
    * Filter REST API calls and re-request API.
    *
-   * @param {string} filter Value that is passed to rest api to filter.
+   * @param {string} value that is passed to rest api to filter.
    */
   const onFilter = useCallback(
     (filter) => () => {


### PR DESCRIPTION
## Summary

Adds a clear button according to [Figma](https://www.figma.com/file/Cd9iacVknHK62RO4pRwb68/Stories-Editor?node-id=8617%3A46576).

| Before | After |
| ------------- | ------------- |
| <img width="267" alt="Screen Shot 2020-06-05 at 11 30 04 am" src="https://user-images.githubusercontent.com/1552225/83826822-3a78aa80-a720-11ea-9128-e843c52a860e.png">  | <img width="269" alt="Screen Shot 2020-06-05 at 11 28 57 am" src="https://user-images.githubusercontent.com/1552225/83826848-4cf2e400-a720-11ea-8646-0f7bbea402de.png">  |
| <img width="269" alt="Screen Shot 2020-06-05 at 11 30 14 am" src="https://user-images.githubusercontent.com/1552225/83826837-449aa900-a720-11ea-8192-4dfb8def351c.png">  | <img width="266" alt="Screen Shot 2020-06-05 at 11 29 11 am" src="https://user-images.githubusercontent.com/1552225/83826862-5419f200-a720-11ea-8464-5b6d5b9d559e.png">  |

## Relevant Technical Choices

I reused the existing `TextInput` and added some more customization options.

Fixes #701 
