### PR TITLE
Dashboard: Update Focus Out to handle where mouse clicks start

### DIFF
--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -71,6 +71,10 @@ const DateHelperText = styled.span`
   }
 `;
 
+const RenameInput = styled(TextInput)`
+  max-width: 100%;
+`;
+
 const CardTitle = ({
   id,
   secondaryTitle,
@@ -102,12 +106,11 @@ const CardTitle = ({
   return (
     <StyledCardTitle>
       {editMode ? (
-        <InlineInputForm
-          onEditComplete={onEditComplete}
-          onEditCancel={onEditCancel}
-          value={title}
-          id={id}
-          label={__('Rename story', 'web-stories')}
+        <RenameInput
+          data-testid={'title-rename-input'}
+          value={newTitle}
+          onKeyDown={handleKeyPress}
+          onChange={handleChange}
         />
       ) : (
         <TitleStoryLink href={titleLink}>{title}</TitleStoryLink>

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -71,10 +71,6 @@ const DateHelperText = styled.span`
   }
 `;
 
-const RenameInput = styled(TextInput)`
-  max-width: 100%;
-`;
-
 const CardTitle = ({
   id,
   secondaryTitle,
@@ -106,11 +102,12 @@ const CardTitle = ({
   return (
     <StyledCardTitle>
       {editMode ? (
-        <RenameInput
-          data-testid={'title-rename-input'}
-          value={newTitle}
-          onKeyDown={handleKeyPress}
-          onChange={handleChange}
+        <InlineInputForm
+          onEditComplete={onEditComplete}
+          onEditCancel={onEditCancel}
+          value={title}
+          id={id}
+          label={__('Rename story', 'web-stories')}
         />
       ) : (
         <TitleStoryLink href={titleLink}>{title}</TitleStoryLink>

--- a/assets/src/dashboard/utils/useFocusOut.js
+++ b/assets/src/dashboard/utils/useFocusOut.js
@@ -20,7 +20,7 @@
 import { useLayoutEffect, useRef } from 'react';
 
 function useFocusOut(ref, callback, deps) {
-  const mouseDownInsideTarget = useRef();
+  const isMouseDownInNode = useRef(false);
 
   useLayoutEffect(() => {
     const node = ref.current;
@@ -36,13 +36,13 @@ function useFocusOut(ref, callback, deps) {
     };
 
     const onMouseDown = (evt) => {
-      mouseDownInsideTarget.current = node.contains(evt.target);
+      isMouseDownInNode.current = node.contains(evt.target);
     };
 
     const onMouseUp = (evt) => {
       const isInDocument = node.ownerDocument.contains(evt.target);
       const isInNode = node.contains(evt.target);
-      if (!isInNode && isInDocument && !mouseDownInsideTarget.current) {
+      if (!isInNode && isInDocument && !isMouseDownInNode.current) {
         callback();
       }
     };


### PR DESCRIPTION
## Summary

Adjusts the `useFocusOut` to account for where the mouse down starts. If the mouse down started in the focus area do not dismiss on mouse up. Outside clicks that started outside of the focus zone are treated as normal.

## Relevant Technical Choices

Divides the `click` into a `mousedown` and `mouseup` to see if the starting mouse down node is the focus node in question or not. 

## User-facing changes

Prevents the user from dismissing the edit field when they select the text and release the cursor outside of the input box.

## Testing Instructions

1. Go to the My Stories section on Dashboard
2. Pick a story to rename and select the rename option from the menu.
3. Select the text in the field and release your cursor outside of the input box.
4. The input box should remain focused.

Any clicks that started outside of the input box should dismiss the input as normal.

![Kapture 2020-05-27 at 17 23 21](https://user-images.githubusercontent.com/1738349/83078784-f90d3e80-a03f-11ea-9f2f-2b3c0bc44b1a.gif)


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1865 
