### PR TITLE
Dashboard: Updated anim tool to support custom props per animation type

### DIFF
--- a/assets/src/dashboard/animations/constants.js
+++ b/assets/src/dashboard/animations/constants.js
@@ -47,5 +47,6 @@ export const FIELD_TYPES = {
   DROPDOWN: 'dropdown',
   HIDDEN: 'hidden',
   NUMBER: 'number',
+  FLOAT: 'float',
   TEXT: 'text',
 };

--- a/assets/src/dashboard/animations/constants.js
+++ b/assets/src/dashboard/animations/constants.js
@@ -42,3 +42,10 @@ export const AXIS = {
   X: 'x',
   Y: 'y',
 };
+
+export const FIELD_TYPES = {
+  DROPDOWN: 'dropdown',
+  HIDDEN: 'hidden',
+  NUMBER: 'number',
+  TEXT: 'text',
+};

--- a/assets/src/dashboard/animations/parts/blinkOn/animationProps.js
+++ b/assets/src/dashboard/animations/parts/blinkOn/animationProps.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES } from '../../constants';
+import { DEFAULT_BLINKS } from './index';
+
+export default {
+  blinkCount: {
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: DEFAULT_BLINKS,
+  },
+};

--- a/assets/src/dashboard/animations/parts/blinkOn/index.js
+++ b/assets/src/dashboard/animations/parts/blinkOn/index.js
@@ -27,8 +27,9 @@ import SimpleAnimation from '../simpleAnimation';
 import generateLookupMap from '../../utils/generateLookupMap';
 import padArray from '../../utils/padArray';
 
+export const DEFAULT_BLINKS = 10;
+
 const AVAILABLE_OPACITY = [0, 0.25, 0.75, 1];
-const DEFAULT_BLINKS = 10;
 
 const defaults = {
   fill: 'forwards',

--- a/assets/src/dashboard/animations/parts/defaultAnimationProps.js
+++ b/assets/src/dashboard/animations/parts/defaultAnimationProps.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { ANIMATION_TYPES, FIELD_TYPES } from '../constants';
+
+export default {
+  id: {
+    type: FIELD_TYPES.HIDDEN,
+  },
+  type: {
+    label: 'Animation Type',
+    type: FIELD_TYPES.DROPDOWN,
+    values: Object.values(ANIMATION_TYPES),
+  },
+  duration: {
+    label: 'Duration (ms)',
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: 1000,
+  },
+  delay: {
+    label: 'Delay (ms)',
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: 0,
+  },
+  direction: {
+    type: FIELD_TYPES.DROPDOWN,
+    values: ['normal', 'reverse', 'alternate', 'alternate-reverse'],
+    defaultValue: 'normal',
+  },
+  easing: {
+    type: FIELD_TYPES.TEXT,
+  },
+  fill: {
+    type: FIELD_TYPES.DROPDOWN,
+    values: ['backwards', 'forwards', 'both', 'none'],
+    defaultValue: 'forwards',
+  },
+  iterations: {
+    tooltip: 'Valid values are numerical or the word "infinity"',
+    type: FIELD_TYPES.TEXT,
+  },
+};

--- a/assets/src/dashboard/animations/parts/fade/animationProps.js
+++ b/assets/src/dashboard/animations/parts/fade/animationProps.js
@@ -22,12 +22,12 @@ import { FIELD_TYPES } from '../../constants';
 export default {
   fadeFrom: {
     tooltip: 'Valid values range from 0 to 1',
-    type: FIELD_TYPES.NUMBER,
+    type: FIELD_TYPES.FLOAT,
     defaultValue: 0,
   },
   fadeTo: {
     tooltip: 'Valid values range from 0 to 1',
-    type: FIELD_TYPES.NUMBER,
+    type: FIELD_TYPES.FLOAT,
     defaultValue: 1,
   },
 };

--- a/assets/src/dashboard/animations/parts/fade/animationProps.js
+++ b/assets/src/dashboard/animations/parts/fade/animationProps.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES } from '../../constants';
+
+export default {
+  fadeFrom: {
+    tooltip: 'Valid values range from 0 to 1',
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: 0,
+  },
+  fadeTo: {
+    tooltip: 'Valid values range from 0 to 1',
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: 1,
+  },
+};

--- a/assets/src/dashboard/animations/parts/flip/animationProps.js
+++ b/assets/src/dashboard/animations/parts/flip/animationProps.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES, ROTATION, AXIS } from '../../constants';
+
+export default {
+  axis: {
+    type: FIELD_TYPES.DROPDOWN,
+    values: [AXIS.X, AXIS.Y],
+    defaultValue: AXIS.Y,
+  },
+  rotation: {
+    type: FIELD_TYPES.DROPDOWN,
+    values: [ROTATION.CLOCKWISE, ROTATION.COUNTER_CLOCKWISE],
+    defaultValue: ROTATION.CLOCKWISE,
+  },
+};

--- a/assets/src/dashboard/animations/parts/floatOn/animationProps.js
+++ b/assets/src/dashboard/animations/parts/floatOn/animationProps.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES, DIRECTION } from '../../constants';
+
+export default {
+  direction: {
+    type: FIELD_TYPES.DROPDOWN,
+    values: [
+      DIRECTION.TOP_TO_BOTTOM,
+      DIRECTION.BOTTOM_TO_TOP,
+      DIRECTION.LEFT_TO_RIGHT,
+      DIRECTION.RIGHT_TO_LEFT,
+    ],
+    defaultValue: DIRECTION.BOTTOM_TO_TOP,
+  },
+};

--- a/assets/src/dashboard/animations/parts/index.js
+++ b/assets/src/dashboard/animations/parts/index.js
@@ -26,6 +26,15 @@ import { AnimationMove } from './move';
 import { AnimationSpin } from './spin';
 import { AnimationZoom } from './zoom';
 
+import defaultAnimationProps from './defaultAnimationProps';
+import blinkOnProps from './blinkOn/animationProps';
+import fadeProps from './fade/animationProps';
+import flipProps from './flip/animationProps';
+import floatOnProps from './floatOn/animationProps';
+import moveProps from './move/animationProps';
+import spinProps from './spin/animationProps';
+import zoomProps from './zoom/animationProps';
+
 export function throughput() {
   return {
     id: -1,
@@ -50,4 +59,29 @@ export function AnimationPart(type, args) {
     }[type] || throughput;
 
   return generator(args);
+}
+
+export function AnimationProps(type) {
+  const customProps = {
+    [ANIMATION_TYPES.BLINK_ON]: blinkOnProps,
+    [ANIMATION_TYPES.FADE]: fadeProps,
+    [ANIMATION_TYPES.FLIP]: flipProps,
+    [ANIMATION_TYPES.FLOAT_ON]: floatOnProps,
+    [ANIMATION_TYPES.MOVE]: moveProps,
+    [ANIMATION_TYPES.SPIN]: spinProps,
+    [ANIMATION_TYPES.ZOOM]: zoomProps,
+  };
+
+  const { type: animationType, ...remaining } = defaultAnimationProps;
+
+  return {
+    type,
+    props: {
+      // This order is important.
+      // Type first, then custom props, then defaults.
+      type: animationType,
+      ...(customProps[type] || {}),
+      ...remaining,
+    },
+  };
 }

--- a/assets/src/dashboard/animations/parts/move/animationProps.js
+++ b/assets/src/dashboard/animations/parts/move/animationProps.js
@@ -21,11 +21,11 @@ import { FIELD_TYPES } from '../../constants';
 
 export default {
   offsetX: {
-    type: FIELD_TYPES.NUMBER,
+    type: FIELD_TYPES.FLOAT,
     defaultValue: 0,
   },
   offsetY: {
-    type: FIELD_TYPES.NUMBER,
+    type: FIELD_TYPES.FLOAT,
     defaultValue: 0,
   },
 };

--- a/assets/src/dashboard/animations/parts/move/animationProps.js
+++ b/assets/src/dashboard/animations/parts/move/animationProps.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES } from '../../constants';
+
+export default {
+  offsetX: {
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: 0,
+  },
+  offsetY: {
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: 0,
+  },
+};

--- a/assets/src/dashboard/animations/parts/spin/animationProps.js
+++ b/assets/src/dashboard/animations/parts/spin/animationProps.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES, ROTATION } from '../../constants';
+
+export default {
+  rotation: {
+    type: FIELD_TYPES.DROPDOWN,
+    values: [
+      ROTATION.CLOCKWISE,
+      ROTATION.COUNTER_CLOCKWISE,
+      ROTATION.PING_PONG,
+    ],
+    defaultValue: ROTATION.CLOCKWISE,
+  },
+};

--- a/assets/src/dashboard/animations/parts/zoom/animationProps.js
+++ b/assets/src/dashboard/animations/parts/zoom/animationProps.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES } from '../../constants';
+
+export default {
+  zoomFrom: {
+    tooltip: 'Valid values range from 0 to 1',
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: 0,
+  },
+  zoomTo: {
+    tooltip: 'Valid values range from 0 to 1',
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: 1,
+  },
+};

--- a/assets/src/dashboard/animations/parts/zoom/animationProps.js
+++ b/assets/src/dashboard/animations/parts/zoom/animationProps.js
@@ -22,12 +22,12 @@ import { FIELD_TYPES } from '../../constants';
 export default {
   zoomFrom: {
     tooltip: 'Valid values range from 0 to 1',
-    type: FIELD_TYPES.NUMBER,
+    type: FIELD_TYPES.FLOAT,
     defaultValue: 0,
   },
   zoomTo: {
     tooltip: 'Valid values range from 0 to 1',
-    type: FIELD_TYPES.NUMBER,
+    type: FIELD_TYPES.FLOAT,
     defaultValue: 1,
   },
 };

--- a/assets/src/dashboard/app/views/storyAnimTool/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/index.js
@@ -148,7 +148,6 @@ function StoryAnimTool() {
   const handleAddOrUpdateAnimation = useCallback(
     (animation) => {
       const story = { ...activeStory };
-
       const animationWithTargets = {
         ...animation,
         targets: [...Object.values(selectedElementIds)],

--- a/assets/src/dashboard/app/views/storyAnimTool/timeline/components.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/timeline/components.js
@@ -80,7 +80,7 @@ export const CancelButton = styled.button`
 
 export const AnimationPanel = styled.div`
   padding: 20px;
-  width: 350px;
+  width: 400px;
   height: 100%;
   overflow: scroll;
 `;
@@ -90,6 +90,10 @@ export const FormField = styled.div`
   justify-content: space-between;
   width: 100%;
   margin-bottom: 10px;
+
+  > label {
+    text-transform: capitalize;
+  }
 `;
 
 export const TimelineAnimation = styled.div(

--- a/assets/src/dashboard/app/views/storyAnimTool/timeline/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/timeline/index.js
@@ -73,6 +73,17 @@ function renderFormField(name, type, value, options, onChange) {
         </select>
       );
 
+    case FIELD_TYPES.FLOAT:
+      return (
+        <input
+          name={name}
+          type="number"
+          value={value}
+          onFocus={handleInputFocus}
+          onChange={onChange}
+        />
+      );
+
     default:
       return (
         <input
@@ -85,6 +96,8 @@ function renderFormField(name, type, value, options, onChange) {
       );
   }
 }
+
+const animationTypes = Object.values(ANIMATION_TYPES);
 
 function Timeline({
   story,
@@ -99,11 +112,9 @@ function Timeline({
 }) {
   const [formFields, setFormFields] = useState({});
 
-  const animationTypes = useMemo(() => Object.values(ANIMATION_TYPES), []);
-
   const { type: selectedAnimationType, props: animationProps } = useMemo(
     () => AnimationProps(formFields.type || animationTypes[0]),
-    [formFields.type, animationTypes]
+    [formFields.type]
   );
 
   const defaultFieldValues = useMemo(
@@ -146,16 +157,21 @@ function Timeline({
       // defaultFieldValues will always have the correct
       // fields to save off, so using as the source of keys
       const animation = {
-        ...Object.keys(defaultFieldValues).reduce(
-          (acc, name) => ({
+        ...Object.keys(defaultFieldValues).reduce((acc, name) => {
+          const type = animationProps[name].type;
+          let formatter = (value) => value;
+
+          if (type === FIELD_TYPES.NUMBER) {
+            formatter = parseInt;
+          } else if (type === FIELD_TYPES.FLOAT) {
+            formatter = parseFloat;
+          }
+
+          return {
             ...acc,
-            [name]:
-              animationProps[name].type === FIELD_TYPES.NUMBER
-                ? parseInt(formFields[name])
-                : formFields[name],
-          }),
-          {}
-        ),
+            [name]: formatter(formFields[name]),
+          };
+        }, {}),
         // iterations can have numbers or the word 'infinity' as
         // valid values
         iterations: isNaN(parseInt(formFields.iterations))

--- a/assets/src/dashboard/app/views/storyAnimTool/timeline/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/timeline/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -25,7 +25,8 @@ import { v4 as uuidv4 } from 'uuid';
  * Internal dependencies
  */
 import { StoryPropType } from '../../../../types';
-import { ANIMATION_TYPES } from '../../../../animations/constants';
+import { ANIMATION_TYPES, FIELD_TYPES } from '../../../../animations/constants';
+import { AnimationProps } from '../../../../animations/parts';
 import {
   Container,
   AnimationList,
@@ -41,11 +42,48 @@ import {
   TimelineBar,
 } from './components';
 
+function handleInputFocus(e) {
+  e.target.select();
+}
+
 function getOffsetAndWidth(totalDuration, duration, delay) {
   return {
     offset: (delay / totalDuration) * 100,
     width: (duration / totalDuration) * 100,
   };
+}
+
+function renderFormField(name, type, value, options, onChange) {
+  switch (type) {
+    case FIELD_TYPES.HIDDEN:
+      return (
+        value && (
+          <input name={name} readOnly type={FIELD_TYPES.HIDDEN} value={value} />
+        )
+      );
+
+    case FIELD_TYPES.DROPDOWN:
+      return (
+        <select name={name} value={value} onBlur={onChange} onChange={onChange}>
+          {options.map((option) => (
+            <option key={option} value={option}>
+              {option.toUpperCase()}
+            </option>
+          ))}
+        </select>
+      );
+
+    default:
+      return (
+        <input
+          name={name}
+          type={type}
+          value={value}
+          onFocus={handleInputFocus}
+          onChange={onChange}
+        />
+      );
+  }
 }
 
 function Timeline({
@@ -59,6 +97,30 @@ function Timeline({
   onAnimationDelete,
   onToggleTargetSelect,
 }) {
+  const [formFields, setFormFields] = useState({});
+
+  const animationTypes = useMemo(() => Object.values(ANIMATION_TYPES), []);
+
+  const { type: selectedAnimationType, props: animationProps } = useMemo(
+    () => AnimationProps(formFields.type || animationTypes[0]),
+    [formFields.type, animationTypes]
+  );
+
+  const defaultFieldValues = useMemo(
+    () =>
+      Object.keys(animationProps).reduce(
+        (acc, prop) => ({
+          ...acc,
+          [prop]:
+            typeof animationProps[prop].defaultValue !== 'undefined'
+              ? animationProps[prop].defaultValue
+              : '',
+        }),
+        {}
+      ),
+    [animationProps]
+  );
+
   const animations = useMemo(
     () => story.pages[activePageIndex].animations || [],
     [story, activePageIndex]
@@ -81,19 +143,59 @@ function Timeline({
         return;
       }
 
+      // defaultFieldValues will always have the correct
+      // fields to save off, so using as the source of keys
       const animation = {
-        id: e.target.id.value || uuidv4(),
-        type: e.target.type.value,
-        duration: parseInt(e.target.duration.value),
-        delay: parseInt(e.target.delay.value),
+        ...Object.keys(defaultFieldValues).reduce(
+          (acc, name) => ({
+            ...acc,
+            [name]:
+              animationProps[name].type === FIELD_TYPES.NUMBER
+                ? parseInt(formFields[name])
+                : formFields[name],
+          }),
+          {}
+        ),
+        // iterations can have numbers or the word 'infinity' as
+        // valid values
+        iterations: isNaN(parseInt(formFields.iterations))
+          ? formFields.iterations
+          : parseInt(formFields.iterations),
+        id: formFields.id || uuidv4(),
+        type: formFields.type,
       };
 
-      e.target.reset();
+      onAddOrUpdateAnimation(
+        Object.keys(animation)
+          .filter((name) => typeof animation[name] !== 'undefined')
+          .reduce(
+            (acc, name) => ({
+              ...acc,
+              [name]: animation[name],
+            }),
+            {}
+          )
+      );
 
-      onAddOrUpdateAnimation(animation);
+      setFormFields(defaultFieldValues);
     },
-    [isAnimationSaveable, onAddOrUpdateAnimation]
+    [
+      formFields,
+      isAnimationSaveable,
+      onAddOrUpdateAnimation,
+      animationProps,
+      defaultFieldValues,
+    ]
   );
+
+  const handleOnChange = useCallback((e) => {
+    const { name, value } = e.target;
+
+    setFormFields((prevFormFields) => ({
+      ...prevFormFields,
+      [name]: value,
+    }));
+  }, []);
 
   const handleToggleTargetSelect = useCallback(
     (e) => {
@@ -107,8 +209,9 @@ function Timeline({
     (e) => {
       e.preventDefault();
       onAnimationSelect('');
+      setFormFields(defaultFieldValues);
     },
-    [onAnimationSelect]
+    [onAnimationSelect, defaultFieldValues]
   );
 
   const handleDeleteClick = useCallback(
@@ -120,11 +223,24 @@ function Timeline({
     [onAnimationDelete]
   );
 
-  const handleInputFocus = useCallback((e) => e.target.select(), []);
-
   useEffect(() => {
     onToggleTargetSelect(false);
   }, [activeAnimation, onToggleTargetSelect]);
+
+  useEffect(() => {
+    setFormFields((prevFormFields) => ({
+      ...defaultFieldValues,
+      ...prevFormFields,
+      type: selectedAnimationType,
+    }));
+  }, [selectedAnimationType, defaultFieldValues]);
+
+  useEffect(() => {
+    setFormFields((prevFormFields) => ({
+      ...prevFormFields,
+      ...activeAnimation,
+    }));
+  }, [activeAnimation]);
 
   return (
     <>
@@ -165,75 +281,46 @@ function Timeline({
           ))}
         </AnimationList>
         <AnimationPanel>
-          <form onSubmit={handleAnimationSubmit}>
-            <FormField>
-              <label>{'Animation Type'}</label>
-              <select
-                key={`animation-type: ${activeAnimation.id}`}
-                name="type"
-                defaultValue={activeAnimation.type}
-              >
-                {Object.values(ANIMATION_TYPES).map((animType) => (
-                  <option key={animType} value={animType}>
-                    {animType.toUpperCase()}
-                  </option>
-                ))}
-              </select>
-            </FormField>
+          {Object.keys(formFields).length > 0 && (
+            <form onSubmit={handleAnimationSubmit}>
+              {Object.keys(animationProps).map((name) => (
+                <FormField key={name}>
+                  {animationProps[name].type !== FIELD_TYPES.HIDDEN && (
+                    <label title={animationProps[name].tooltip}>
+                      {animationProps[name].label || name}
+                    </label>
+                  )}
+                  {renderFormField(
+                    name,
+                    animationProps[name].type,
+                    formFields[name],
+                    animationProps[name].values,
+                    handleOnChange
+                  )}
+                </FormField>
+              ))}
 
-            <FormField>
-              <label>{'Duration (ms)'}</label>
-              <input
-                key={`animation-duration: ${activeAnimation.id}`}
-                name="duration"
-                type="number"
-                defaultValue={activeAnimation.duration || 1000}
-                onFocus={handleInputFocus}
-              />
-            </FormField>
+              <FormField>
+                <label>{'Targets'}</label>
+                <button onClick={handleToggleTargetSelect}>
+                  {isElementSelectable
+                    ? 'Target(s) Selected'
+                    : 'Select Target(s)'}
+                </button>
+              </FormField>
 
-            <FormField>
-              <label>{'Delay (ms)'}</label>
-              <input
-                key={`animation-delay: ${activeAnimation.id}`}
-                name="delay"
-                type="number"
-                defaultValue={activeAnimation.delay || 0}
-                onFocus={handleInputFocus}
-              />
-            </FormField>
-
-            <FormField>
-              <label>{'Targets'}</label>
-              <button onClick={handleToggleTargetSelect}>
-                {isElementSelectable
-                  ? 'Target(s) Selected'
-                  : 'Select Target(s)'}
-              </button>
-            </FormField>
-
-            {isAnimationSaveable && (
-              <>
-                <input
-                  key={`animation-id: ${activeAnimation.id}`}
-                  name="id"
-                  type="hidden"
-                  defaultValue={activeAnimation.id}
-                />
-
-                {!isElementSelectable && (
-                  <>
-                    <input type="submit" value="Submit" />
-                    {activeAnimation.id && (
-                      <CancelButton onClick={handleCancelClick}>
-                        {'Cancel'}
-                      </CancelButton>
-                    )}
-                  </>
-                )}
-              </>
-            )}
-          </form>
+              {isAnimationSaveable && !isElementSelectable && (
+                <>
+                  <input type="submit" readOnly value="Submit" />
+                  {activeAnimation.id && (
+                    <CancelButton onClick={handleCancelClick}>
+                      {'Cancel'}
+                    </CancelButton>
+                  )}
+                </>
+              )}
+            </form>
+          )}
         </AnimationPanel>
       </Container>
     </>


### PR DESCRIPTION
## Summary

This PR updates our `story-anim-tool` so the `AnimationPanel` can support custom props per animation part _and_ it also supports the other common Web Animation API props.

## Relevant Technical Choices

Created a very simple data schema to generate the appropriate form field per animation type.

## User-facing changes

None

## Testing Instructions

The tool works as it did before (instructions can be found here: https://github.com/google/web-stories-wp/pull/1765), but now the Animation Panel (the form next to the Timeline) will add/remove fields as you change animation types.

Fixes #2039 

## Screenshot

Switching different types:
![animation_panel](https://user-images.githubusercontent.com/40646372/83084525-088b8800-a03e-11ea-84d4-cfe7325888ed.gif)

