### PR TITLE
Fix page nav hover style

### DIFF
--- a/assets/src/edit-story/components/canvas/pagenav/index.js
+++ b/assets/src/edit-story/components/canvas/pagenav/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 import { useCallback } from 'react';
 
@@ -43,6 +43,24 @@ const Wrapper = styled.div`
   & > * {
     pointer-events: initial;
   }
+`;
+
+const pageNavButtonsStyle = css`
+  &:focus {
+    opacity: 0.3;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+`;
+
+const LeftNavButton = styled(LeftArrow)`
+  ${pageNavButtonsStyle}
+`;
+
+const RightNavButton = styled(RightArrow)`
+  ${pageNavButtonsStyle}
 `;
 
 function PageNav({ isNext }) {
@@ -73,8 +91,8 @@ function PageNav({ isNext }) {
     height: PAGE_NAV_BUTTON_WIDTH,
   };
 
-  const PrevButton = isRTL ? RightArrow : LeftArrow;
-  const NextButton = isRTL ? LeftArrow : RightArrow;
+  const PrevButton = isRTL ? RightNavButton : LeftNavButton;
+  const NextButton = isRTL ? LeftNavButton : RightNavButton;
 
   if (isNext) {
     return (


### PR DESCRIPTION
## Summary

A simple PR that fixes page nav hover style behavior

## Relevant Technical Choices

I'm using CSS to override global focus style for button and adding a specific focus+hover behavior for page nav buttons.

## User-facing changes

Now page nav hover works properly using a mouse.

---

<!-- Please reference the issue(s) this PR addresses. -->

Solving #1181
