### PR TITLE
Fix destructuring exception

### DIFF
--- a/assets/src/edit-story/app/media/utils/getResourceFromMediaPicker.js
+++ b/assets/src/edit-story/app/media/utils/getResourceFromMediaPicker.js
@@ -43,7 +43,7 @@ const getResourceFromMediaPicker = (mediaPickerEl) => {
       width: posterWidth,
       height: posterHeight,
       generated: posterGenerated,
-    },
+    } = '',
     fileLength: lengthFormatted,
     sizes,
   } = mediaPickerEl;


### PR DESCRIPTION
When destructuring the PHP response, featured_media_src is undefined for images.

## User-facing changes

When tapping "Upload" and selecting (or uploading) an image and then tapping "Insert into Page", the image is now added to the canvas. Before, nothing happened.

Fixes #1752
