### PR TITLE
Remove obsolete `Domain Path` plugin header

### DIFF
--- a/web-stories.php
+++ b/web-stories.php
@@ -16,7 +16,6 @@
  * Requires at least: 5.3
  * Requires PHP: 5.6
  * Text Domain: web-stories
- * Domain Path: /languages/
  * License: Apache License 2.0
  * License URI: https://www.apache.org/licenses/LICENSE-2.0
  */


### PR DESCRIPTION
This is not needed because we don't bundle translations with the plugin. Translations are handled by WordPress & WordPress.org language packs.