### PR TITLE
Dashboard: Add feature flag for in-progress views.

### DIFF
--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -39,7 +39,6 @@ import {
   primaryPaths,
   secondaryPaths,
   Z_INDEX,
-  APP_ROUTES,
 } from '../../constants';
 
 import useFocusOut from '../../utils/useFocusOut';

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -24,7 +24,8 @@ import { __ } from '@wordpress/i18n';
  */
 
 import styled from 'styled-components';
-import { useCallback, useRef, useLayoutEffect } from 'react';
+import { useCallback, useRef, useLayoutEffect, useMemo } from 'react';
+import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -38,6 +39,7 @@ import {
   primaryPaths,
   secondaryPaths,
   Z_INDEX,
+  APP_ROUTES,
 } from '../../constants';
 
 import useFocusOut from '../../utils/useFocusOut';
@@ -102,6 +104,7 @@ export function LeftRail() {
   const { newStoryURL, version } = useConfig();
   const leftRailRef = useRef(null);
   const upperContentRef = useRef(null);
+  const enableInProgressViews = useFeature('enableInProgressViews');
 
   const {
     state: { sideBarVisible },
@@ -120,6 +123,20 @@ export function LeftRail() {
     },
     [toggleSideBar, leftRailRef, upperContentRef]
   );
+
+  const enabledPaths = useMemo(() => {
+    if (enableInProgressViews) {
+      return primaryPaths;
+    }
+    return primaryPaths.filter((path) => !path.inProgress);
+  }, [enableInProgressViews]);
+
+  const enabledSecondaryPaths = useMemo(() => {
+    if (enableInProgressViews) {
+      return secondaryPaths;
+    }
+    return secondaryPaths.filter((path) => !path.inProgress);
+  }, [enableInProgressViews]);
 
   const handleSideBarClose = useCallback(() => {
     if (sideBarVisible) {
@@ -157,7 +174,7 @@ export function LeftRail() {
         </Content>
         <Content>
           <NavList>
-            {primaryPaths.map((path) => (
+            {enabledPaths.map((path) => (
               <NavListItem key={path.value}>
                 <NavLink
                   active={path.value === state.currentPath}
@@ -172,7 +189,7 @@ export function LeftRail() {
         <Rule />
         <Content>
           <NavList>
-            {secondaryPaths.map((path) => (
+            {enabledSecondaryPaths.map((path) => (
               <NavListItem key={path.value}>
                 <NavLink
                   active={path.value === state.currentPath}

--- a/assets/src/dashboard/components/pageStructure/test/pageStructure.js
+++ b/assets/src/dashboard/components/pageStructure/test/pageStructure.js
@@ -15,13 +15,15 @@
  */
 
 /**
- * Internal dependencies
- */
-/**
  * External dependencies
  */
 import { useState } from 'react';
 import { fireEvent } from '@testing-library/react';
+import { FlagsProvider } from 'flagged';
+
+/**
+ * Internal dependencies
+ */
 import { renderWithTheme } from '../../../testUtils';
 import { LeftRail } from '../index';
 import NavProvider, { NavContext } from '../../navProvider';
@@ -30,9 +32,11 @@ import { primaryPaths } from '../../../constants';
 describe('<LeftRail />', () => {
   it('should be visible by default in a regular viewport.', () => {
     const wrapper = renderWithTheme(
-      <NavProvider>
-        <LeftRail />
-      </NavProvider>
+      <FlagsProvider features={{ enableInProgressViews: false }}>
+        <NavProvider>
+          <LeftRail />
+        </NavProvider>
+      </FlagsProvider>
     );
 
     const leftRail = wrapper.getByTestId('dashboard-left-rail');
@@ -59,9 +63,11 @@ describe('<LeftRail />', () => {
       );
     };
     const wrapper = renderWithTheme(
-      <MockedNavProvider toggleSideBar={toggleSideBarFn}>
-        <LeftRail />
-      </MockedNavProvider>
+      <FlagsProvider features={{ enableInProgressViews: false }}>
+        <MockedNavProvider toggleSideBar={toggleSideBarFn}>
+          <LeftRail />
+        </MockedNavProvider>
+      </FlagsProvider>
     );
 
     expect(toggleSideBarFn).not.toHaveBeenCalled();

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -80,6 +80,7 @@ export const primaryPaths = [
   {
     value: APP_ROUTES.SAVED_TEMPLATES,
     label: __('Saved Templates', 'web-stories'),
+    inProgress: true,
   },
   {
     value: APP_ROUTES.TEMPLATES_GALLERY,
@@ -91,10 +92,12 @@ export const secondaryPaths = [
   {
     value: APP_ROUTES.EDITOR_SETTINGS,
     label: __('Editor Settings', 'web-stories'),
+    inProgress: true,
   },
   {
     value: APP_ROUTES.SUPPORT,
     label: __('Support', 'web-stories'),
+    inProgress: true,
   },
 ];
 

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -179,6 +179,13 @@ class Dashboard {
 					 * Creation date: 2020-05-21
 					 */
 					'enableAnimation' => false,
+					/**
+					 * Description: Enables in-progress views to be accessed.
+					 * Author: @carlos-kelly
+					 * Issue: 2081
+					 * Creation date: 2020-05-28
+					 */
+					'enableInProgressViews' => false,
 				],
 			]
 		);


### PR DESCRIPTION
## Summary

Hides the Saved Templates, Settings, and Support views behind a feature flag.

## Relevant Technical Choices

- Uses the in-place feature flag system to handle the toggle.
## Testing Instructions

- See that those views are not visible or accessible when the feature flag is off.
---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2081 
