### PR TITLE
Animate Active Story Page In Template Detail

### DIFF
--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -213,7 +213,7 @@ function TemplateDetail() {
                     <LargeDisplayPagination>
                       {PrevButton}
                     </LargeDisplayPagination>
-                    <CardGallery template={template} />
+                    <CardGallery story={template} />
                   </Column>
                   <Column>
                     <DetailContainer>

--- a/assets/src/dashboard/app/views/templates/detail.js
+++ b/assets/src/dashboard/app/views/templates/detail.js
@@ -17,41 +17,37 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
-
+import { sprintf, __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useEffect, useState, useContext, useMemo, useCallback } from 'react';
-
+import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { useConfig } from '../../config';
-import useRouteHistory from '../../router/useRouteHistory';
-import { ApiContext } from '../../api/apiProvider';
 import { TransformProvider } from '../../../../edit-story/components/transform';
 import { UnitsProvider } from '../../../../edit-story/units';
-
-import FontProvider from '../../font/fontProvider';
 import {
   CardGallery,
   ColorList,
   DetailViewContentGutter,
+  Layout,
   PaginationButton,
-  PreviewPage,
   Pill,
   TemplateNavBar,
-  Layout,
 } from '../../../components';
 import { TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS } from '../../../constants';
 import { clamp, usePagePreviewSize } from '../../../utils/';
-import { StoryGridView } from '../shared';
+import { ApiContext } from '../../api/apiProvider';
+import { useConfig } from '../../config';
+import FontProvider from '../../font/fontProvider';
 import { resolveRelatedTemplateRoute } from '../../router';
+import useRouteHistory from '../../router/useRouteHistory';
+import { StoryGridView } from '../shared';
 import {
   ByLine,
-  ColumnContainer,
   Column,
+  ColumnContainer,
   DetailContainer,
   LargeDisplayPagination,
   MetadataContainer,
@@ -66,15 +62,16 @@ function TemplateDetail() {
   const [template, setTemplate] = useState(null);
   const [relatedTemplates, setRelatedTemplates] = useState([]);
   const [orderedTemplates, setOrderedTemplates] = useState([]);
-  const [previewPages, setPreviewPages] = useState([]);
-
   const { pageSize } = usePagePreviewSize({ isGrid: true });
+  const { isRTL } = useConfig();
+
   const {
     state: {
       queryParams: { id: templateId, isLocal },
     },
     actions,
   } = useRouteHistory();
+
   const {
     state: {
       templates: { templates, templatesOrderById },
@@ -87,11 +84,8 @@ function TemplateDetail() {
       },
     },
   } = useContext(ApiContext);
-  const { isRTL } = useConfig();
 
   useEffect(() => {
-    setPreviewPages([]);
-
     if (!templateId) {
       return;
     }
@@ -119,9 +113,6 @@ function TemplateDetail() {
       templatesOrderById.map(
         (templateByOrderId) => templates[templateByOrderId]
       )
-    );
-    setPreviewPages(
-      template.pages.map((page) => <PreviewPage key={page.id} page={page} />)
     );
   }, [fetchRelatedTemplates, template, templates, templatesOrderById]);
 
@@ -222,7 +213,7 @@ function TemplateDetail() {
                     <LargeDisplayPagination>
                       {PrevButton}
                     </LargeDisplayPagination>
-                    <CardGallery>{previewPages}</CardGallery>
+                    <CardGallery template={template} />
                   </Column>
                   <Column>
                     <DetailContainer>

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -39,15 +39,15 @@ const MINI_CARD_WIDTH = 75;
 const CARD_GAP = 15;
 const CARD_WRAPPER_BUFFER = 12;
 
-function CardGallery({ template }) {
+function CardGallery({ story }) {
   const [dimensionMultiplier, setDimensionMultiplier] = useState(null);
   const [activePageIndex, setActivePageIndex] = useState(0);
   const [pages, setPages] = useState([]);
   const containerRef = useRef();
 
   useEffect(() => {
-    setPages(template.pages || []);
-  }, [template]);
+    setPages(story.pages || []);
+  }, [story]);
 
   const metrics = useMemo(() => {
     if (!dimensionMultiplier) {
@@ -100,7 +100,7 @@ function CardGallery({ template }) {
 
   useEffect(() => {
     setActivePageIndex(0);
-  }, [template]);
+  }, [story]);
 
   return (
     <GalleryContainer ref={containerRef} maxWidth={MAX_WIDTH}>
@@ -140,7 +140,7 @@ function CardGallery({ template }) {
 }
 
 CardGallery.propTypes = {
-  template: StoryPropType.isRequired,
+  story: StoryPropType.isRequired,
 };
 
 export default CardGallery;

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -17,27 +17,20 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-import {
-  useRef,
-  useEffect,
-  useState,
-  useMemo,
-  useCallback,
-  Children,
-} from 'react';
-
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { PAGE_RATIO } from '../../constants/pageStructure';
 import { UnitsProvider } from '../../../edit-story/units';
+import { PAGE_RATIO, STORY_PAGE_STATE } from '../../constants';
+import { StoryPropType } from '../../types';
+import PreviewPage from '../previewPage';
 import {
   ActiveCard,
   GalleryContainer,
+  MiniCard,
   MiniCardsContainer,
   MiniCardWrapper,
-  MiniCard,
 } from './components';
 
 const MAX_WIDTH = 680;
@@ -46,22 +39,15 @@ const MINI_CARD_WIDTH = 75;
 const CARD_GAP = 15;
 const CARD_WRAPPER_BUFFER = 12;
 
-function CardGallery({ children }) {
+function CardGallery({ template }) {
   const [dimensionMultiplier, setDimensionMultiplier] = useState(null);
-  const [activeCardIndex, setActiveCardIndex] = useState(0);
-  const [cards, setCards] = useState([]);
+  const [activePageIndex, setActivePageIndex] = useState(0);
+  const [pages, setPages] = useState([]);
   const containerRef = useRef();
 
   useEffect(() => {
-    const count = Children.count(children);
-    if (count > 1) {
-      setCards(children);
-    } else if (count === 1) {
-      setCards([children]);
-    } else if (count === 0) {
-      setCards([]);
-    }
-  }, [children]);
+    setPages(template.pages || []);
+  }, [template]);
 
   const metrics = useMemo(() => {
     if (!dimensionMultiplier) {
@@ -87,7 +73,7 @@ function CardGallery({ children }) {
   }, [dimensionMultiplier]);
 
   const handleMiniCardClick = useCallback((index) => {
-    setActiveCardIndex(index);
+    setActivePageIndex(index);
   }, []);
 
   const updateContainerSize = useCallback(() => {
@@ -113,8 +99,8 @@ function CardGallery({ children }) {
   }, [updateContainerSize]);
 
   useEffect(() => {
-    setActiveCardIndex(0);
-  }, [children]);
+    setActivePageIndex(0);
+  }, [template]);
 
   return (
     <GalleryContainer ref={containerRef} maxWidth={MAX_WIDTH}>
@@ -124,23 +110,28 @@ function CardGallery({ children }) {
             rowHeight={metrics.miniWrapperSize.height}
             gap={metrics.gap}
           >
-            {cards.map((card, index) => (
+            {pages.map((page, index) => (
               <MiniCardWrapper
                 key={index}
-                isSelected={index === activeCardIndex}
+                isSelected={index === activePageIndex}
                 {...metrics.miniWrapperSize}
                 onClick={() => handleMiniCardClick(index)}
               >
-                <MiniCard {...metrics.miniCardSize}>{card}</MiniCard>
+                <MiniCard {...metrics.miniCardSize}>
+                  <PreviewPage page={page} />
+                </MiniCard>
               </MiniCardWrapper>
             ))}
           </MiniCardsContainer>
         </UnitsProvider>
       )}
-      {metrics.activeCardSize && cards[activeCardIndex] && (
+      {metrics.activeCardSize && pages[activePageIndex] && (
         <UnitsProvider pageSize={metrics.activeCardSize}>
           <ActiveCard {...metrics.activeCardSize}>
-            {cards[activeCardIndex]}
+            <PreviewPage
+              page={pages[activePageIndex]}
+              animationState={STORY_PAGE_STATE.ANIMATE}
+            />
           </ActiveCard>
         </UnitsProvider>
       )}
@@ -149,7 +140,7 @@ function CardGallery({ children }) {
 }
 
 CardGallery.propTypes = {
-  children: PropTypes.node.isRequired,
+  template: StoryPropType.isRequired,
 };
 
 export default CardGallery;

--- a/assets/src/dashboard/components/cardGallery/test/cardGallery.js
+++ b/assets/src/dashboard/components/cardGallery/test/cardGallery.js
@@ -22,18 +22,30 @@ import { fireEvent } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+jest.mock('../../previewPage');
+import PreviewPage from '../../previewPage';
 import { renderWithTheme } from '../../../testUtils/';
 import CardGallery from '../';
 
+const createMockTemplate = (pages) => ({
+  id: 1,
+  title: 'some-template',
+  pages,
+});
+
 describe('CardGallery', () => {
+  PreviewPage.mockImplementation(({ page }) => <div data-testid={page.name} />);
+
   it('should render CardGallery', () => {
+    const template = createMockTemplate([
+      { id: 'id-1', name: 'test-child' },
+      { id: 'id-2', name: 'test-child' },
+      { id: 'id-3', name: 'test-child' },
+      { id: 'id-4', name: 'test-child' },
+    ]);
+
     const { getAllByTestId } = renderWithTheme(
-      <CardGallery>
-        <div data-testid={'test-child'}>{'Item 1'}</div>
-        <div data-testid={'test-child'}>{'Item 2'}</div>
-        <div data-testid={'test-child'}>{'Item 3'}</div>
-        <div data-testid={'test-child'}>{'Item 4'}</div>
-      </CardGallery>
+      <CardGallery template={template} />
     );
 
     // totalCards = childrenCount + activeCardCount (there is only 1 active card at a time)
@@ -42,13 +54,15 @@ describe('CardGallery', () => {
   });
 
   it('should set first child as active child', () => {
+    const template = createMockTemplate([
+      { id: 'id-1', name: 'active-child' },
+      { id: 'id-2', name: 'non-active-child' },
+      { id: 'id-3', name: 'non-active-child' },
+      { id: 'id-4', name: 'non-active-child' },
+    ]);
+
     const { getAllByTestId } = renderWithTheme(
-      <CardGallery>
-        <div data-testid={'active-child'}>{'Item 1'}</div>
-        <div>{'Item 2'}</div>
-        <div>{'Item 3'}</div>
-        <div>{'Item 4'}</div>
-      </CardGallery>
+      <CardGallery template={template} />
     );
 
     // The active child should always appear twice
@@ -56,13 +70,15 @@ describe('CardGallery', () => {
   });
 
   it('should change active child to the child that is clicked on', () => {
+    const template = createMockTemplate([
+      { id: 'id-1', name: 'other-child' },
+      { id: 'id-2', name: 'other-child' },
+      { id: 'id-3', name: 'test-child' },
+      { id: 'id-4', name: 'other-child' },
+    ]);
+
     const { getAllByTestId } = renderWithTheme(
-      <CardGallery>
-        <div>{'Item 1'}</div>
-        <div>{'Item 2'}</div>
-        <div data-testid={'test-child'}>{'Item 3'}</div>
-        <div>{'Item 4'}</div>
-      </CardGallery>
+      <CardGallery template={template} />
     );
 
     // When the child is not active, it should only appear once

--- a/assets/src/dashboard/components/cardGallery/test/cardGallery.js
+++ b/assets/src/dashboard/components/cardGallery/test/cardGallery.js
@@ -45,7 +45,7 @@ describe('CardGallery', () => {
     ]);
 
     const { getAllByTestId } = renderWithTheme(
-      <CardGallery template={template} />
+      <CardGallery story={template} />
     );
 
     // totalCards = childrenCount + activeCardCount (there is only 1 active card at a time)
@@ -62,7 +62,7 @@ describe('CardGallery', () => {
     ]);
 
     const { getAllByTestId } = renderWithTheme(
-      <CardGallery template={template} />
+      <CardGallery story={template} />
     );
 
     // The active child should always appear twice
@@ -78,7 +78,7 @@ describe('CardGallery', () => {
     ]);
 
     const { getAllByTestId } = renderWithTheme(
-      <CardGallery template={template} />
+      <CardGallery story={template} />
     );
 
     // When the child is not active, it should only appear once

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -178,7 +178,7 @@ class Dashboard {
 					 * Issue: 1897
 					 * Creation date: 2020-05-21
 					 */
-					'enableAnimation' => false,
+					'enableAnimation' => true,
 				],
 			]
 		);

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -178,7 +178,7 @@ class Dashboard {
 					 * Issue: 1897
 					 * Creation date: 2020-05-21
 					 */
-					'enableAnimation' => true,
+					'enableAnimation' => false,
 				],
 			]
 		);


### PR DESCRIPTION
## Summary
Adds play on mount for templates detail view according to this mockup:
https://drive.google.com/drive/u/1/folders/1onGbNRFVAalJXtbYYFigSbdG-nHUE7As

Currently this can't be seen because we have a feature flag in place to disable animations. We also haven't applied any animations to the templates, just certain stories.

## Relevant Technical Choices
- Alters `Detail` view to only care about template story data instead of turning that into components
- `CardGallery` now takes a pure data story and uses that data to generate preview pages who's animation state are now controlled by the active page

## To-do
Start Working on adding animations to the templates.

## User-facing changes
None

## Testing Instructions

Just click through template details view. Should not error out or see any changes when compared to master.

---

Fixes #
- https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/1513
- https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/1888
- https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/1517
