### PR TITLE
Dashboard: click story title action

### DIFF
--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -90,6 +90,7 @@ describe('ApiProvider', () => {
       '123': {
         bottomTargetAction: 'editStory&post=123',
         centerTargetAction: '',
+        editStoryLink: 'editStory&post=123',
         id: 123,
         modified: moment('1970-01-01T00:00:00.000Z'),
         created: moment('1970-01-01T00:00:00.000Z'),
@@ -160,6 +161,7 @@ describe('ApiProvider', () => {
       '123': {
         bottomTargetAction: 'editStory&post=123',
         centerTargetAction: '',
+        editStoryLink: 'editStory&post=123',
         id: 123,
         modified: moment('1970-01-01T00:00:00.000Z'),
         created: moment('1970-01-01T00:00:00.000Z'),
@@ -243,6 +245,7 @@ describe('ApiProvider', () => {
       '123': {
         bottomTargetAction: 'editStory&post=123',
         centerTargetAction: '',
+        editStoryLink: 'editStory&post=123',
         id: 123,
         modified: moment('1970-01-01T00:00:00.000Z'),
         created: moment('1970-01-01T00:00:00.000Z'),
@@ -278,6 +281,7 @@ describe('ApiProvider', () => {
       '456': {
         bottomTargetAction: 'editStory&post=456',
         centerTargetAction: '',
+        editStoryLink: 'editStory&post=456',
         id: 456,
         modified: moment('1970-01-01T00:00:00.000Z'),
         created: moment('1970-01-01T00:00:00.000Z'),

--- a/assets/src/dashboard/app/api/test/useStoryApi.js
+++ b/assets/src/dashboard/app/api/test/useStoryApi.js
@@ -66,6 +66,7 @@ describe('reshapeStoryObject', () => {
       pages: [{ id: 0, elements: [] }],
       centerTargetAction: '',
       bottomTargetAction: 'http://editstory.com?action=edit&post=27',
+      editStoryLink: 'http://editstory.com?action=edit&post=27',
     });
   });
 

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -69,6 +69,7 @@ export function reshapeStoryObject(editStoryURL) {
       author,
       centerTargetAction: '',
       bottomTargetAction: `${editStoryURL}&post=${id}`,
+      editStoryLink: `${editStoryURL}&post=${id}`,
       originalStoryData,
     };
   };

--- a/assets/src/dashboard/app/views/myStories/content/test/content.js
+++ b/assets/src/dashboard/app/views/myStories/content/test/content.js
@@ -32,6 +32,7 @@ const fakeStories = [
     pages: [{ id: '10' }],
     centerTargetAction: () => {},
     bottomTargetAction: () => {},
+    editStoryLink: () => {},
   },
   {
     id: 2,
@@ -40,6 +41,7 @@ const fakeStories = [
     pages: [{ id: '20' }],
     centerTargetAction: () => {},
     bottomTargetAction: () => {},
+    editStoryLink: () => {},
   },
   {
     id: 3,
@@ -48,6 +50,7 @@ const fakeStories = [
     pages: [{ id: '30' }],
     centerTargetAction: () => {},
     bottomTargetAction: () => {},
+    editStoryLink: () => {},
   },
 ];
 

--- a/assets/src/dashboard/app/views/myStories/content/test/storiesView.js
+++ b/assets/src/dashboard/app/views/myStories/content/test/storiesView.js
@@ -34,6 +34,7 @@ const fakeStories = [
     pages: [{ id: '10' }],
     centerTargetAction: () => {},
     bottomTargetAction: () => {},
+    editStoryLink: () => {},
   },
   {
     id: 2,
@@ -42,6 +43,7 @@ const fakeStories = [
     pages: [{ id: '20' }],
     centerTargetAction: () => {},
     bottomTargetAction: () => {},
+    editStoryLink: () => {},
   },
   {
     id: 3,
@@ -50,6 +52,7 @@ const fakeStories = [
     pages: [{ id: '30' }],
     centerTargetAction: () => {},
     bottomTargetAction: () => {},
+    editStoryLink: () => {},
   },
 ];
 

--- a/assets/src/dashboard/app/views/myStories/header/test/header.js
+++ b/assets/src/dashboard/app/views/myStories/header/test/header.js
@@ -40,6 +40,7 @@ const fakeStories = [
     pages: [{ id: '10' }],
     centerTargetAction: () => {},
     bottomTargetAction: () => {},
+    editStoryLink: () => {},
   },
   {
     id: 2,
@@ -48,6 +49,7 @@ const fakeStories = [
     pages: [{ id: '20' }],
     centerTargetAction: () => {},
     bottomTargetAction: () => {},
+    editStoryLink: () => {},
   },
   {
     id: 3,
@@ -56,6 +58,7 @@ const fakeStories = [
     pages: [{ id: '30' }],
     centerTargetAction: () => {},
     bottomTargetAction: () => {},
+    editStoryLink: () => {},
   },
 ];
 

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -142,6 +142,7 @@ const StoryGridView = ({
             <DetailRow>
               <CardTitle
                 title={story.title}
+                titleLink={story.editStoryLink}
                 status={story?.status}
                 secondaryTitle={
                   isSavedTemplate

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -34,6 +34,7 @@ import { getFormattedDisplayDate, useFocusOut } from '../../utils/';
 import { TextInput } from '../input';
 import { DashboardStatusesPropType } from '../../types';
 import { Paragraph2 } from '../typography';
+import { Link } from '../link';
 
 const StyledCardTitle = styled.div`
   padding-top: 12px;
@@ -41,8 +42,10 @@ const StyledCardTitle = styled.div`
   overflow: hidden;
 `;
 
-const StyledTitle = styled(Paragraph2)`
-  margin: 0;
+const TitleStoryLink = styled(Link)`
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 2px;
   color: ${({ theme }) => theme.colors.gray900};
   font-weight: ${({ theme }) => theme.typography.weight.bold};
   white-space: nowrap;
@@ -71,6 +74,7 @@ const DateHelperText = styled.span`
 const CardTitle = ({
   secondaryTitle,
   title,
+  titleLink,
   status,
   displayDate,
   editMode,
@@ -140,7 +144,7 @@ const CardTitle = ({
           />
         </div>
       ) : (
-        <StyledTitle>{title}</StyledTitle>
+        <TitleStoryLink href={titleLink}>{title}</TitleStoryLink>
       )}
       <TitleBodyText>
         {status === STORY_STATUS.DRAFT && (
@@ -155,6 +159,7 @@ const CardTitle = ({
 
 CardTitle.propTypes = {
   title: PropTypes.string.isRequired,
+  titleLink: PropTypes.string.isRequired,
   secondaryTitle: PropTypes.string,
   status: DashboardStatusesPropType,
   editMode: PropTypes.bool,

--- a/assets/src/dashboard/components/link/index.js
+++ b/assets/src/dashboard/components/link/index.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * * External dependencies
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { TypographyPresets } from '../typography';
+
+export const Link = styled.a`
+  ${TypographyPresets.Small};
+  margin: 0;
+  text-decoration: none;
+  color: ${({ theme }) => theme.colors.bluePrimary};
+  cursor: pointer;
+  border-bottom: ${({ theme }) => theme.borders.transparent};
+
+  &:hover,
+  &:focus,
+  &:active {
+    color: currentColor;
+    box-shadow: none;
+    border-bottom: 1px solid currentColor;
+    outline: 0;
+  }
+`;

--- a/assets/src/dashboard/components/link/index.js
+++ b/assets/src/dashboard/components/link/index.js
@@ -15,9 +15,6 @@
  */
 
 /**
- * * External dependencies
- */
-/**
  * External dependencies
  */
 import styled from 'styled-components';

--- a/assets/src/dashboard/components/link/stories/index.js
+++ b/assets/src/dashboard/components/link/stories/index.js
@@ -15,12 +15,13 @@
  */
 
 /**
- * Internal dependencies
- */
-/**
  * External dependencies
  */
 import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
 import { Link } from '../';
 
 export default {

--- a/assets/src/dashboard/components/link/stories/index.js
+++ b/assets/src/dashboard/components/link/stories/index.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import { Link } from '../';
+
+export default {
+  title: 'Dashboard/Components/Link',
+  component: Link,
+};
+
+const CurrentColorLink = styled(Link)`
+  color: black;
+`;
+
+export const _default = () => {
+  return (
+    <>
+      <Link href="#">{'Demo link extended from Typography'}</Link>
+      <br />
+      <CurrentColorLink href="#">
+        {'Demo link extended from Typography'}
+      </CurrentColorLink>
+    </>
+  );
+};

--- a/assets/src/dashboard/storybookUtils/formattedStoriesArray.js
+++ b/assets/src/dashboard/storybookUtils/formattedStoriesArray.js
@@ -97,6 +97,8 @@ const formattedStoriesArray = [
     centerTargetAction: '',
     bottomTargetAction:
       'http://localhost:8899/wp-admin/post.php?action=edit&post=167',
+    editStoryLink:
+      'http://localhost:8899/wp-admin/post.php?action=edit&post=167',
     originalStoryData: {
       id: 167,
       date: '2020-05-21T16:25:51',
@@ -387,6 +389,8 @@ const formattedStoriesArray = [
     author: 1,
     centerTargetAction: '',
     bottomTargetAction:
+      'http://localhost:8899/wp-admin/post.php?action=edit&post=165',
+    editStoryLink:
       'http://localhost:8899/wp-admin/post.php?action=edit&post=165',
     originalStoryData: {
       id: 165,
@@ -829,6 +833,8 @@ const formattedStoriesArray = [
     author: 1,
     centerTargetAction: '',
     bottomTargetAction:
+      'http://localhost:8899/wp-admin/post.php?action=edit&post=163',
+    editStoryLink:
       'http://localhost:8899/wp-admin/post.php?action=edit&post=163',
     originalStoryData: {
       id: 163,
@@ -1330,6 +1336,8 @@ const formattedStoriesArray = [
     author: 1,
     centerTargetAction: '',
     bottomTargetAction:
+      'http://localhost:8899/wp-admin/post.php?action=edit&post=161',
+    editStoryLink:
       'http://localhost:8899/wp-admin/post.php?action=edit&post=161',
     originalStoryData: {
       id: 161,


### PR DESCRIPTION
## Summary
Turns the story title on dashboard grid into a link to edit the story

## Relevant Technical Choices
- New component called `Link` to handle text links (so far we've just got CTAs and nav links so this was new). Modeled off of material ui link but updated the underline text to use border bottom for nicer spacing. 
- the edit story link is already composed as `bottomAction` but I opted to add it in separately in the story object structure as `editStoryLink` to allow it semantically to be passed into the card and immediately known - plus this keeps the actions/links separate if we ever decide the bottom action on preview hover should be different from where the link goes on story titles. 
- Added a little margin bottom between the title and the rest of the card text to make more room for the hover/focus style

## To-do
- Do we want this same functionality on the list view? I think we're trying to keep that view as simple as possible right now, not looking for functionality of that view to match the grid but I wanted to double check. 

## User-facing changes
- Now the story titles on the grid items are links. 
![story title is a link now](https://user-images.githubusercontent.com/10720454/83291208-d47aa900-a19c-11ea-9745-302be85a3bac.gif)


## Testing Instructions
- Go to dashboard and see that story titles are links now. Clicking the link or hitting 'enter' on the link in focus should take you to the edit story view for that story. 
- There's also a Link section of storybook now if you want to see that too. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1867 
