### PR TITLE
Dashboard: Migrate templates on load to latest version

### DIFF
--- a/assets/src/dashboard/templates/getTemplates.js
+++ b/assets/src/dashboard/templates/getTemplates.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { migrate } from '../../edit-story/migration/migrate';
 import { memoize } from '../utils';
 import beauty from './raw/beauty.json';
 import cooking from './raw/cooking.json';
@@ -34,7 +35,7 @@ export function getImageFile(url) {
 }
 
 export function loadTemplate(title, data, imageBaseUrl) {
-  return {
+  const template = {
     ...data,
     pages: (data.pages || []).map((page) => ({
       ...page,
@@ -51,6 +52,10 @@ export function loadTemplate(title, data, imageBaseUrl) {
       }),
     })),
   };
+
+  const migratedTemplate = migrate(template, template.version);
+
+  return migratedTemplate;
 }
 
 export function loadTemplates(imageBaseUrl) {


### PR DESCRIPTION
## Summary

This PR migrates our template data to the latest version when they're first loaded into the app.

## Relevant Technical Choices

Since we load all 8 templates at once, I couldn't really migrate them one at a time, so instead I save off migrated results into a hash.  This way each template will only be processed once (on load) and won't be re-processed until the app is fully reloaded by the user.

## User-facing changes

- None

## Testing Instructions

- Go to the "Explore Templates" and make sure the page loads.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2120 
