### PR TITLE
Karma: testing small and big canvas

### DIFF
--- a/assets/src/edit-story/karma/_init.js
+++ b/assets/src/edit-story/karma/_init.js
@@ -174,6 +174,22 @@ beforeEach(() => {
   document.body.appendChild(rootEl);
   const body = rootEl.querySelector('test-body');
 
+  // just temporary
+  let clientX = -100;
+  let clientY = -100;
+  const innerCursor = document.body.appendChild(document.createElement('div'));
+  innerCursor.style =
+    'width:0px; height:0px; border-left: 10px solid red; border-bottom: 10px solid transparent; position:absolute; top:0; left:0; z-index:999; pointer-events:none;';
+  document.addEventListener('mousemove', (e) => {
+    clientX = e.clientX;
+    clientY = e.clientY;
+  });
+  const render = () => {
+    innerCursor.style.transform = `translate(${clientX}px,${clientY}px)`;
+    requestAnimationFrame(render);
+  };
+  requestAnimationFrame(render);
+
   spyOnProperty(document, 'documentElement', 'get').and.returnValue(rootEl);
   spyOnProperty(document, 'body', 'get').and.returnValue(body);
   // @todo: ideally we can find a way to use a new <head> for each test, but

--- a/assets/src/edit-story/karma/cuj/lasso.cuj.karma.js
+++ b/assets/src/edit-story/karma/cuj/lasso.cuj.karma.js
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../';
+import { useStory } from '../../app/story';
+import { useInsertElement } from '../../components/canvas';
+import createSolid from '../../utils/createSolid';
+import useCanvas from '../../components/canvas/useCanvas';
+import {
+  dataToEditorY as dataToEditorYorg,
+  dataToEditorX as dataToEditorXorg,
+} from '../../units';
+import { PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
+
+let dataToEditorX;
+let dataToEditorY;
+
+fdescribe('CUJ: Lasso selection', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+
+    await fixture.render();
+    await new Promise((r) => setTimeout(r, 0)); // to get correct pageSize, can be moved to render?
+
+    const canvasContext = await fixture.renderHook(() => useCanvas());
+    const {
+      state: { pageSize },
+    } = canvasContext;
+    dataToEditorX = (x) => dataToEditorXorg(x, pageSize.width);
+    dataToEditorY = (y) => dataToEditorYorg(y, pageSize.height);
+
+    //eslint-disable-next-line no-console
+    console.log(pageSize.height);
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  it('should render ok', () => {
+    expect(
+      fixture.container.querySelector('[data-testid="fullbleed"]')
+    ).toBeTruthy();
+  });
+
+  describe('add elements', () => {
+    let shapes = Array(6);
+    let shapesFrames;
+
+    beforeEach(async () => {
+      const insertElement = await fixture.renderHook(() => useInsertElement());
+      const shapeProps = {
+        backgroundColor: createSolid(255, 0, 0),
+        x: PAGE_WIDTH - 110,
+        y: 0,
+        width: 110,
+        height: 110,
+      };
+
+      shapes[0] = await fixture.act(() => insertElement('shape', shapeProps));
+      shapes[1] = await fixture.act(() =>
+        insertElement('shape', {
+          ...shapeProps,
+          x: PAGE_WIDTH - 220,
+          y: 110,
+          backgroundColor: createSolid(0, 255, 0),
+        })
+      );
+      shapes[2] = await fixture.act(() =>
+        insertElement('shape', {
+          ...shapeProps,
+          x: PAGE_WIDTH - 330,
+          y: 220,
+          backgroundColor: createSolid(0, 0, 255),
+        })
+      );
+
+      shapes[3] = await fixture.act(() =>
+        insertElement('shape', {
+          ...shapeProps,
+          x: PAGE_WIDTH - 110,
+          y: PAGE_HEIGHT - 110,
+          backgroundColor: createSolid(255, 0, 0),
+        })
+      );
+      shapes[4] = await fixture.act(() =>
+        insertElement('shape', {
+          ...shapeProps,
+          x: PAGE_WIDTH - 220,
+          y: PAGE_HEIGHT - 220,
+          backgroundColor: createSolid(0, 255, 0),
+        })
+      );
+      shapes[5] = await fixture.act(() =>
+        insertElement('shape', {
+          ...shapeProps,
+          x: PAGE_WIDTH - 330,
+          y: PAGE_HEIGHT - 330,
+          backgroundColor: createSolid(0, 0, 255),
+        })
+      );
+      shapes[5] = await fixture.act(() =>
+        insertElement('shape', {
+          ...shapeProps,
+          x: 0,
+          y: PAGE_HEIGHT - 330 - 110 / 2,
+          backgroundColor: createSolid(51, 51, 51),
+        })
+      );
+
+      shapesFrames = shapes.map((shape) =>
+        fixture.querySelector(`[data-element-id="${shape.id}"]`)
+      );
+    });
+
+    describe('selection', () => {
+      beforeEach(async () => {
+        await fixture.events.mouse.move(0, 0);
+      });
+
+      it('should select green elements', async () => {
+        await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
+          moveRel(shapesFrames[1], dataToEditorX(30), dataToEditorY(-30), {
+            steps: 200,
+          }),
+          down(),
+          moveRel(shapesFrames[4], '100%', '100%', { steps: 200 }),
+          moveBy(dataToEditorX(-30), dataToEditorY(30), { steps: 200 }),
+          up(),
+        ]);
+
+        await fixture.snapshot('green elements selected');
+
+        const storyContext = await fixture.renderHook(() => useStory());
+        expect(storyContext.state.selectedElementIds).toEqual([
+          shapes[1].id,
+          shapes[4].id,
+        ]);
+      });
+    });
+  });
+});

--- a/assets/src/edit-story/karma/fixture.js
+++ b/assets/src/edit-story/karma/fixture.js
@@ -28,7 +28,7 @@ import App from '../app/index';
 import APIProvider from '../app/api/apiProvider';
 import APIContext from '../app/api/context';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../app/font/defaultFonts';
-import Layout from '../app/layout';
+import { WorkspaceLayout } from '../components/workspace/layout';
 import FixtureEvents from './fixtureEvents';
 
 const DEFAULT_CONFIG = {
@@ -92,7 +92,7 @@ export class Fixture {
       this.apiProviderFixture_.Component
     );
 
-    this._layoutStub = this.stubComponent(Layout);
+    this._layoutStub = this.stubComponent(WorkspaceLayout);
 
     this._events = new FixtureEvents(this.act.bind(this));
 

--- a/assets/src/edit-story/karma/fixtureEvents.js
+++ b/assets/src/edit-story/karma/fixtureEvents.js
@@ -253,7 +253,7 @@ class Mouse {
       if (typeof rel === 'number') {
         return rel;
       }
-      if (rel.endsWidth('%')) {
+      if (rel.endsWith('%')) {
         const percent = parseFloat(rel) / 100;
         return size * percent;
       }


### PR DESCRIPTION
## Summary

This topic has already been raised [here](https://github.com/google/web-stories-wp/pull/1880/files#r431238400). I also experienced it in [this test](https://github.com/google/web-stories-wp/pull/1973/commits/3a078854bfadb38b460b3aba9d8d79f6472cddb5).

> This goes straight to the zoomed-vs-unzoomed editor nuances. Any thoughts how we could be addressing this? We could:
> 
> 1. Always start puppeteer with a big enough viewport to fit the unzoomed editor, but then we will be missing zoomed tests.
> 2. Run all tests automatically with two zoom factors: unzoomed and zoomed. But it might be hard to write tests?

This PR checks how convoluted will be the canvas size agnostic test. In this case, it's all about getting the pageSize and then `dataToEditor` calls. Most of it can be moved inside Fixture if desired.

Based on the new proposal for mouse events sequence https://github.com/google/web-stories-wp/pull/2125 with `moveRel` and `moveBy`.
