### PR TITLE
Dashboard: bug fix - button wrap on hover

### DIFF
--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -31,6 +31,7 @@ const StyledButton = styled.button`
 
   font-weight: ${({ theme }) => theme.typography.weight.bold};
   align-items: center;
+  justify-content: center;
   color: ${({ theme }) => theme.colors.white};
   cursor: pointer;
   border: ${({ theme }) => theme.borders.transparent};
@@ -40,6 +41,7 @@ const StyledButton = styled.button`
   opacity: 0.75;
   padding: 4px 12px;
   text-decoration: none;
+  text-align: center;
 
   &:focus,
   &:active,


### PR DESCRIPTION
## Summary
certain viewports wrap button text, in initial component for buttons overlooked `text-align: center`. 

## Relevant Technical Choices
- Adding `text-align: center` for buttons that wrap 
- Adding `justify-content: center` to ensure vertical centering as well as horizontal. 

## To-do

## User-facing changes
- 'open in editor' buttons visible on focus/hover of stories should now always be centered even if it wraps. 
Demo (note that the grid resize is lagging in responsive mode): https://drive.google.com/file/d/1Xb119L-pq4XHhnyD-WLEdKV3suebYGP5/view?usp=sharing


## Testing Instructions
Resize the browser, see that bug is gone. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2151 
