### PR TITLE
Dashboard: Removed branded logos from templates and updated to latest data version

### DIFF
--- a/assets/src/dashboard/templates/data/cooking.js
+++ b/assets/src/dashboard/templates/data/cooking.js
@@ -16,7 +16,7 @@
 
 export default function (imageBaseUrl) {
   return {
-    version: 17,
+    version: 19,
     pages: [
       {
         elements: [
@@ -46,6 +46,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '900a850f-fb71-4262-84f0-d6b803224ac7',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -141,45 +142,7 @@ export default function (imageBaseUrl) {
             type: 'text',
             id: 'be108bc9-3a51-48c4-b495-24be6163e44c',
             content:
-              '<span style="font-weight: 700; color: #fff">Food &amp;  Stuff</span>',
-          },
-          {
-            opacity: 100,
-            flip: {
-              vertical: false,
-              horizontal: false,
-            },
-            rotationAngle: 0,
-            lockAspectRatio: true,
-            scale: 100,
-            focalX: 50,
-            focalY: 50,
-            isFill: false,
-            resource: {
-              type: 'image',
-              mimeType: 'image/png',
-              src: `${imageBaseUrl}/images/templates/cooking/cooking_icon_logo.png`,
-              width: 56,
-              height: 12,
-              posterId: 0,
-              id: 466,
-              title: 'cooking_icon_logo',
-              alt: 'cooking_icon_logo',
-              local: false,
-              sizes: {},
-            },
-            x: 165,
-            y: 59,
-            width: 111,
-            height: 24,
-            mask: {
-              type: 'rectangle',
-              name: 'Rectangle',
-              path: 'M 0,0 1,0 1,1 0,1 0,0 Z',
-              ratio: 1,
-            },
-            type: 'image',
-            id: '0134d8b1-1c28-47d3-b7ba-1649a629173f',
+              '<span style="font-weight: 700; color: #fff">Food &amp; Stuff</span>',
           },
           {
             opacity: 100,
@@ -301,8 +264,36 @@ export default function (imageBaseUrl) {
             x: 418,
             y: 19.5,
           },
+          {
+            opacity: 100,
+            flip: {
+              vertical: false,
+              horizontal: false,
+            },
+            rotationAngle: 0,
+            lockAspectRatio: false,
+            backgroundColor: {
+              color: {
+                r: 255,
+                g: 255,
+                b: 255,
+              },
+            },
+            isFill: false,
+            type: 'shape',
+            x: 164.5,
+            y: 59,
+            width: 111,
+            height: 24,
+            scale: 100,
+            focalX: 50,
+            focalY: 50,
+            mask: {
+              type: 'rectangle',
+            },
+            id: '6a95b60a-c661-409e-b983-ebfdc7464df6',
+          },
         ],
-        backgroundElementId: '900a850f-fb71-4262-84f0-d6b803224ac7',
         type: 'page',
         id: 'dd6a669f-ff4b-4633-8eb4-c601e98b40f1',
       },
@@ -334,6 +325,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             id: 'b8ea29e5-ce25-4204-8660-afe56bb6b952',
             type: 'shape',
+            isDefaultBackground: true,
           },
           {
             opacity: 15,
@@ -607,7 +599,6 @@ export default function (imageBaseUrl) {
             y: 19.5,
           },
         ],
-        backgroundElementId: 'b8ea29e5-ce25-4204-8660-afe56bb6b952',
         backgroundOverlay: 'none',
         type: 'page',
         id: '434c112e-3463-4dc6-aa8e-cb97f13a4e8e',
@@ -640,6 +631,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             id: '268f9f40-cce2-4d37-899e-ea2422f8df7b',
             type: 'shape',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -1135,7 +1127,6 @@ export default function (imageBaseUrl) {
             id: '6d8358b9-7bf1-4982-ae88-963409073fcf',
           },
         ],
-        backgroundElementId: '268f9f40-cce2-4d37-899e-ea2422f8df7b',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'a378f919-785d-4ff2-8f8c-e7922a221cbf',
@@ -1168,6 +1159,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             id: '10cd0ef0-78ac-41f8-9e90-810376fb7a0e',
             type: 'shape',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -1836,7 +1828,6 @@ export default function (imageBaseUrl) {
             y: 499,
           },
         ],
-        backgroundElementId: '10cd0ef0-78ac-41f8-9e90-810376fb7a0e',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'e6314f4e-5a59-425c-a6a3-b0a3ecff301c',
@@ -2266,10 +2257,31 @@ export default function (imageBaseUrl) {
             y: 106,
           },
         ],
-        backgroundElementId: '85bf1bf4-8ef0-4408-9fd1-755769555106',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'b08e5e3d-08c8-4865-b82f-20a04e8f6fc7',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: 'e59627e9-eb83-4ce5-bf83-17f22851ed1c',
+        },
       },
       {
         elements: [
@@ -2299,6 +2311,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             id: '353201ca-58e7-487f-b6f7-6360c5b72aa9',
             type: 'shape',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -3700,7 +3713,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 249, 238, 1)"><span style="font-weight: 700">recipes with\npersimmon</span></span>',
           },
         ],
-        backgroundElementId: '353201ca-58e7-487f-b6f7-6360c5b72aa9',
         backgroundOverlay: 'none',
         type: 'page',
         id: '4ce57acc-c58e-40ab-8a3d-87f6dc5fb106',
@@ -3733,6 +3745,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             id: '9b628714-3fa2-490a-b766-4cf019ebe394',
             type: 'shape',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -4078,7 +4091,7 @@ export default function (imageBaseUrl) {
             x: 41,
             y: 438,
             content:
-              '<span style="color: rgba(255, 146, 46, 1)"><span style="font-weight: 700">Squash Soup&nbsp;\n with Persimmon</span></span>',
+              '<span style="color: rgba(255, 146, 46, 1)"><span style="font-weight: 700">Squash Soup&nbsp;\nwith Persimmon</span></span>',
           },
           {
             opacity: 100,
@@ -4626,7 +4639,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(103, 100, 97, 1)">Beginner</span>',
           },
         ],
-        backgroundElementId: '9b628714-3fa2-490a-b766-4cf019ebe394',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'c0a40237-d827-4aa3-b3ca-01e668dc90aa',
@@ -4659,6 +4671,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             id: '7805eaf2-f323-4b3e-8c2b-a328f3e95056',
             type: 'shape',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -5048,7 +5061,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(103, 100, 97, 1)">Lorem ipsum dolor sit amet, consectetur adipiscing elit integer auctor sollicitudin dolor, vel lacinia mi vehicula sed. Sed semper tortor est, et scelerisque lorem finibus efficitur maecenas vel aliquet nisl curabitur sollicitudin libero.</span>',
           },
         ],
-        backgroundElementId: '7805eaf2-f323-4b3e-8c2b-a328f3e95056',
         backgroundOverlay: 'none',
         type: 'page',
         id: '11f60c54-4345-4979-8f10-edf4b43c7f44',
@@ -5081,6 +5093,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             id: '25cbd8d2-adac-46e7-8cbb-24ef7536a9f5',
             type: 'shape',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -6033,7 +6046,7 @@ export default function (imageBaseUrl) {
             x: 143,
             y: 437,
             content:
-              '<span style="color: rgba(103, 100, 97, 1)">Easy brunch recipes that  will impress your guests</span>',
+              '<span style="color: rgba(103, 100, 97, 1)">Easy brunch recipes that will impress your guests</span>',
           },
           {
             opacity: 100,
@@ -6126,7 +6139,6 @@ export default function (imageBaseUrl) {
             y: 572.5,
           },
         ],
-        backgroundElementId: '25cbd8d2-adac-46e7-8cbb-24ef7536a9f5',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'e8a21c0b-1db7-4777-b25d-b7d9a51b10fe',

--- a/assets/src/dashboard/templates/data/diy.js
+++ b/assets/src/dashboard/templates/data/diy.js
@@ -841,7 +841,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/images/templates/diy/diy_page4_page5_bg-1.jpg`,
+              src: `${imageBaseUrl}/images/templates/diy/diy_page4_page5_bg.jpg`,
               width: 220,
               height: 275,
               posterId: 0,
@@ -963,7 +963,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/images/templates/diy/diy_page4_page5_bg-1.jpg`,
+              src: `${imageBaseUrl}/images/templates/diy/diy_page4_page5_bg.jpg`,
               width: 220,
               height: 275,
               posterId: 0,
@@ -1709,7 +1709,7 @@ export default function (imageBaseUrl) {
             x: 42,
             y: 399,
             content:
-              '<span style="color: rgba(255, 255, 255, 1)">DC390B 18V Circular Saw</span>',
+              '<span style="color: rgba(255, 255, 255, 1)">18V Circular Saw</span>',
           },
           {
             font: {
@@ -1753,7 +1753,7 @@ export default function (imageBaseUrl) {
             x: 42,
             y: 432,
             content:
-              '<span style="color: rgba(255, 255, 255, 1)">The DC390B 18V Cordless Circular Saw features 3,700 rpm for fast rip and cross cuts, carbide tip blade to maintain sharpness, and high strength shoe and upper guard for increased durability.</span>',
+              '<span style="color: rgba(255, 255, 255, 1)">The 18V Cordless Circular Saw features 3,700 rpm for fast rip and cross cuts, carbide tip blade to maintain sharpness, and high strength shoe and upper guard for increased durability.</span>',
           },
           {
             font: {
@@ -2683,7 +2683,7 @@ export default function (imageBaseUrl) {
             link: {
               url: 'http://google.com',
               icon: null,
-              desc: 'DC390B 18V Circular Saw',
+              desc: '18V Circular Saw',
             },
           },
           {
@@ -2749,7 +2749,7 @@ export default function (imageBaseUrl) {
               url: 'http://google.com',
               icon: null,
               desc:
-                'The DC390B 18V Cordless Circular Saw features 3,700 rpm for fast rip and cross cuts, carbide tip...',
+                'The 18V Cordless Circular Saw features 3,700 rpm for fast rip and cross cuts, carbide tip...',
             },
           },
           {
@@ -2815,7 +2815,7 @@ export default function (imageBaseUrl) {
               url: 'http://google.com',
               icon: null,
               desc:
-                'The DC390B 18V Cordless Circular Saw features 3,700 rpm for fast rip and cross cuts, carbide tip...',
+                'The 18V Cordless Circular Saw features 3,700 rpm for fast rip and cross cuts, carbide tip...',
             },
           },
         ],

--- a/assets/src/dashboard/templates/data/diy.js
+++ b/assets/src/dashboard/templates/data/diy.js
@@ -16,7 +16,7 @@
 
 export default function (imageBaseUrl) {
   return {
-    version: 17,
+    version: 19,
     pages: [
       {
         elements: [
@@ -46,6 +46,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: 'acc2f8e0-b819-4adf-9b9f-7bf7c878d7b9',
+            isDefaultBackground: true,
           },
           {
             type: 'image',
@@ -343,7 +344,6 @@ export default function (imageBaseUrl) {
             id: 'a0f67513-d98a-43f4-bb0b-ad3383051452',
           },
         ],
-        backgroundElementId: 'acc2f8e0-b819-4adf-9b9f-7bf7c878d7b9',
         type: 'page',
         id: 'd47afc22-71b7-4303-9917-96f9a31ad38a',
         backgroundOverlay: 'none',
@@ -376,6 +376,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: '6d60fa52-25c3-4207-acea-45c2c9680fcf',
+            isDefaultBackground: true,
           },
           {
             type: 'image',
@@ -508,7 +509,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 115, 36, 1)">THE OUTDOORS</span>',
           },
         ],
-        backgroundElementId: '6d60fa52-25c3-4207-acea-45c2c9680fcf',
         backgroundOverlay: 'none',
         type: 'page',
         id: '6a6ddf2d-7f98-405a-8c95-76b0440f9b30',
@@ -541,6 +541,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: 'a848ae15-78c1-488a-9c2f-befbc69a1fb3',
+            isDefaultBackground: true,
           },
           {
             type: 'image',
@@ -775,7 +776,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(250, 244, 234, 1)">Always pay particular attention to the terrain, soil and weather influences of your landscape.</span>',
           },
         ],
-        backgroundElementId: 'a848ae15-78c1-488a-9c2f-befbc69a1fb3',
         backgroundOverlay: 'none',
         type: 'page',
         id: '6a5fbd97-2e43-4f7a-a672-6b1b90f8a625',
@@ -808,6 +808,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: '5249418e-8fb7-46d7-8af1-835671d52f2b',
+            isDefaultBackground: true,
           },
           {
             type: 'image',
@@ -840,7 +841,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/images/templates/diy/diy_page4_page5_bg.jpg`,
+              src: `${imageBaseUrl}/images/templates/diy/diy_page4_page5_bg-1.jpg`,
               width: 220,
               height: 275,
               posterId: 0,
@@ -940,7 +941,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 115, 36, 1)">THE\nFOUNDA\nTION</span>',
           },
         ],
-        backgroundElementId: '5249418e-8fb7-46d7-8af1-835671d52f2b',
         backgroundOverlay: 'none',
         type: 'page',
         id: '3164a2b3-10c7-42b8-bcea-38292c8427f5',
@@ -963,7 +963,7 @@ export default function (imageBaseUrl) {
             resource: {
               type: 'image',
               mimeType: 'image/jpeg',
-              src: `${imageBaseUrl}/images/templates/diy/diy_page4_page5_bg.jpg`,
+              src: `${imageBaseUrl}/images/templates/diy/diy_page4_page5_bg-1.jpg`,
               width: 220,
               height: 275,
               posterId: 0,
@@ -1014,7 +1014,7 @@ export default function (imageBaseUrl) {
             basedOn: '4b5a41ea-1f3c-4f52-8ee7-6e314d66e9f2',
             id: '969611ae-3a4b-45b5-b075-38ffb5abdce1',
             x: -1,
-            y: 490,
+            y: 491,
           },
           {
             type: 'shape',
@@ -1215,10 +1215,31 @@ export default function (imageBaseUrl) {
             id: 'e3adc9ce-fa17-45b6-a26b-6ec2fd532d3d',
           },
         ],
-        backgroundElementId: '486b6a5d-60f2-4e23-861c-0e16220e6c76',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'cb4d4a6b-5b3c-4513-8732-96e6e86751b2',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: '0f06a768-d7d7-48c3-94fd-0d200978ef7c',
+        },
       },
       {
         elements: [
@@ -1490,10 +1511,31 @@ export default function (imageBaseUrl) {
             id: 'a125ec6e-4254-4130-916d-e86d6d71aabb',
           },
         ],
-        backgroundElementId: '86db87f7-47d4-49e3-b714-8e28bf6c64e1',
         backgroundOverlay: 'none',
         type: 'page',
         id: '8f462228-45f9-459c-a091-da058c60bd62',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: 'f903e641-0485-4da0-be58-66e0cc614467',
+        },
       },
       {
         elements: [
@@ -1523,6 +1565,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: '6f62cb45-cbe8-484a-9f9b-0204fd653ded',
+            isDefaultBackground: true,
           },
           {
             type: 'image',
@@ -1795,7 +1838,6 @@ export default function (imageBaseUrl) {
             id: '21029d0a-58a3-4719-a1f9-4d8f47b9da16',
           },
         ],
-        backgroundElementId: '6f62cb45-cbe8-484a-9f9b-0204fd653ded',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'eb4fdaf0-52c9-46bb-acb7-91408e671880',
@@ -1828,6 +1870,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: '4ee0756d-c9b1-4914-a3cf-e0b41a442367',
+            isDefaultBackground: true,
           },
           {
             type: 'shape',
@@ -2417,7 +2460,6 @@ export default function (imageBaseUrl) {
             id: '60f07480-c8af-42f9-953a-98569b97ffe7',
           },
         ],
-        backgroundElementId: '4ee0756d-c9b1-4914-a3cf-e0b41a442367',
         backgroundOverlay: 'none',
         type: 'page',
         id: '7dc22ed5-579e-4988-9f9c-97b2cd2ff068',
@@ -2777,10 +2819,31 @@ export default function (imageBaseUrl) {
             },
           },
         ],
-        backgroundElementId: '1b7b64ba-ee71-4edf-be38-d30753ac39ef',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'd25a2dd8-b784-4818-81d3-cc70a6aad6ab',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: 'e982349a-5439-458d-937e-5a72701cfbad',
+        },
       },
       {
         elements: [
@@ -2810,6 +2873,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: '82dea0d1-dbc5-41e5-9ed7-409bcb672830',
+            isDefaultBackground: true,
           },
           {
             type: 'shape',
@@ -3677,7 +3741,6 @@ export default function (imageBaseUrl) {
             id: '563f7eeb-2251-4191-b3be-a269c0d42158',
           },
         ],
-        backgroundElementId: '82dea0d1-dbc5-41e5-9ed7-409bcb672830',
         backgroundOverlay: 'none',
         type: 'page',
         id: '5c295574-87a0-4ae7-b548-699e0bd47fdf',

--- a/assets/src/dashboard/templates/data/entertainment.js
+++ b/assets/src/dashboard/templates/data/entertainment.js
@@ -16,7 +16,7 @@
 
 export default function (imageBaseUrl) {
   return {
-    version: 17,
+    version: 19,
     pages: [
       {
         elements: [
@@ -46,6 +46,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '17bad711-de31-4f09-8d30-f83ade1d6f2a',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -388,7 +389,6 @@ export default function (imageBaseUrl) {
             id: '5090769d-8a55-4ef6-aff3-544872d653e4',
           },
         ],
-        backgroundElementId: '17bad711-de31-4f09-8d30-f83ade1d6f2a',
         type: 'page',
         id: '04df622c-0d7f-4760-a06c-e88d9d9ac435',
       },
@@ -420,6 +420,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '7a27a752-537d-4dcd-9677-5926437c0e19',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -723,7 +724,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 255, 255, 1)">New Artists</span>',
           },
         ],
-        backgroundElementId: '7a27a752-537d-4dcd-9677-5926437c0e19',
         backgroundOverlay: 'none',
         type: 'page',
         id: '9670b092-e11b-433e-aa8a-659e4ee982c9',
@@ -756,6 +756,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '03d49bf5-7b5e-4d7c-b09e-7c3ebde20c94',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -1148,7 +1149,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 255, 255, 1)">– Miley Cyrus</span>',
           },
         ],
-        backgroundElementId: '03d49bf5-7b5e-4d7c-b09e-7c3ebde20c94',
         backgroundOverlay: 'none',
         type: 'page',
         id: '73e07f65-ae5a-4a85-8802-7ea5cfaa45b2',
@@ -1181,6 +1181,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '87fe44ec-dfa5-450c-8250-1859f8e4fe07',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -1485,7 +1486,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 255, 255, 1)"><span style="font-weight: 700">SPOTLIGHT</span></span>',
           },
         ],
-        backgroundElementId: '87fe44ec-dfa5-450c-8250-1859f8e4fe07',
         backgroundOverlay: 'none',
         type: 'page',
         id: '582c5a25-6f17-4107-8e60-6ae4721c932f',
@@ -1518,6 +1518,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '923c69d0-84f6-4223-8f7e-8fd7f0d0363f',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -2135,7 +2136,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 255, 255, 1)"><span style="font-style: italic">3 out of 5</span></span>',
           },
         ],
-        backgroundElementId: '923c69d0-84f6-4223-8f7e-8fd7f0d0363f',
         backgroundOverlay: 'none',
         type: 'page',
         id: '7494b712-c8d0-4189-a85c-32aa52a22032',
@@ -2168,6 +2168,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '3fb75a52-ac04-4979-9a26-c28e725c3ed3',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -2665,7 +2666,6 @@ export default function (imageBaseUrl) {
             id: 'c8ed9d0e-4f8d-4549-80cc-a5b3dd9caa8e',
           },
         ],
-        backgroundElementId: '3fb75a52-ac04-4979-9a26-c28e725c3ed3',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'fd60f532-b619-4162-8df9-d8241cc88e45',
@@ -2698,6 +2698,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: 'f1d3853d-aa0a-4bfc-8b40-d09c94153814',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -3001,7 +3002,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 255, 255, 1)">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam vel dui erat. Curabitur sit amet venenatis felis. In ac ornare lacus. Integer vitae lacus a lectus eleifend finibus.</span>',
           },
         ],
-        backgroundElementId: 'f1d3853d-aa0a-4bfc-8b40-d09c94153814',
         backgroundOverlay: 'none',
         type: 'page',
         id: '877c2ef2-1faa-4a7b-9f5b-364dcfa3d856',
@@ -3034,6 +3034,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '777737d1-e79e-4f4e-9708-cf5a41962d77',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -3602,7 +3603,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 255, 255, 1)">This summer’s must-see blockbusters</span>',
           },
         ],
-        backgroundElementId: '777737d1-e79e-4f4e-9708-cf5a41962d77',
         backgroundOverlay: 'none',
         type: 'page',
         id: '3d0dbbd3-70c0-4376-b1bf-c8015def1050',
@@ -3635,6 +3635,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: 'ffce028c-042d-4b3c-a489-3cc31162ed10',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -4640,7 +4641,6 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 255, 255, 1)">See More</span>',
           },
         ],
-        backgroundElementId: 'ffce028c-042d-4b3c-a489-3cc31162ed10',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'f4ea7828-e328-47e6-bf9d-a786ab192ee1',

--- a/assets/src/dashboard/templates/data/travel.js
+++ b/assets/src/dashboard/templates/data/travel.js
@@ -16,7 +16,7 @@
 
 export default function (imageBaseUrl) {
   return {
-    version: 17,
+    version: 19,
     pages: [
       {
         elements: [
@@ -168,48 +168,60 @@ export default function (imageBaseUrl) {
             id: '7de325ef-2490-4e19-9c9c-7031bffa4b05',
           },
           {
-            type: 'image',
             opacity: 100,
             flip: {
               vertical: false,
               horizontal: false,
             },
             rotationAngle: 0,
-            scale: 100,
-            focalX: 50,
-            focalY: 50,
-            isFill: false,
-            resource: {
-              type: 'image',
-              mimeType: 'image/png',
-              src: `${imageBaseUrl}/images/templates/travel/travel_page1_logo.png`,
-              width: 47,
-              height: 15,
-              poster: '',
-              posterId: 0,
-              id: 221,
-              title: 'travel_page1_logo',
-              alt: '',
-              local: false,
-              sizes: {},
+            lockAspectRatio: false,
+            backgroundColor: {
+              color: {
+                r: 255,
+                g: 255,
+                b: 255,
+              },
             },
-            x: 29,
+            isFill: false,
+            type: 'shape',
+            x: 28,
             y: 605,
             width: 94,
             height: 30,
+            scale: 100,
+            focalX: 50,
+            focalY: 50,
             mask: {
               type: 'rectangle',
-              name: 'Rectangle',
-              path: 'M 0,0 1,0 1,1 0,1 0,0 Z',
-              ratio: 1,
             },
-            id: 'd0b3b0de-e60d-4f1d-baa6-b72fe5d4daae',
+            id: '3eada2b4-499c-4964-ad82-deadabe8ae94',
           },
         ],
         type: 'page',
         id: 'fca5c47a-e26f-4feb-b2a3-f6d8b6c68996',
-        backgroundElementId: 'ca140433-52d1-4423-896f-2e5c856cb22f',
         backgroundOverlay: 'none',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: 'e36e376f-3cdb-43f8-b1c7-cdf3a0098132',
+        },
       },
       {
         elements: [
@@ -238,6 +250,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: '143182cf-804b-4d71-93d8-d4a53c9e6ed6',
+            isDefaultBackground: true,
           },
           {
             type: 'shape',
@@ -430,7 +443,6 @@ export default function (imageBaseUrl) {
             },
           },
         ],
-        backgroundElementId: '143182cf-804b-4d71-93d8-d4a53c9e6ed6',
         backgroundOverlay: 'none',
         type: 'page',
         id: '3cdf0fde-f515-477d-8688-472c4cc5a8b3',
@@ -462,6 +474,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: 'b39e1373-e1d4-40ee-bd0c-298924b61a3e',
+            isDefaultBackground: true,
           },
           {
             type: 'shape',
@@ -654,7 +667,6 @@ export default function (imageBaseUrl) {
             },
           },
         ],
-        backgroundElementId: 'b39e1373-e1d4-40ee-bd0c-298924b61a3e',
         backgroundOverlay: 'none',
         type: 'page',
         id: '80b4f7b3-c54a-4e40-9a75-c937cedfed4b',
@@ -917,10 +929,31 @@ export default function (imageBaseUrl) {
             id: '3e017006-465b-461c-ae74-2c57c891f67a',
           },
         ],
-        backgroundElementId: 'a920881d-6fab-4d96-8884-0df9f0b6a8fd',
         backgroundOverlay: 'none',
         type: 'page',
         id: '6302fb0d-8f99-4498-91eb-bca15d67ae84',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: '3769638a-e9e5-4ff0-96dc-9b3df5d78215',
+        },
       },
       {
         elements: [
@@ -1232,10 +1265,31 @@ export default function (imageBaseUrl) {
             y: 591.5,
           },
         ],
-        backgroundElementId: '3b0ede46-334e-4bc5-abb7-f09dec3d6d48',
         backgroundOverlay: 'none',
         type: 'page',
         id: '22081c00-a02f-4085-84de-0f4a31253222',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: '4d03120b-e736-4b71-b5bc-81159357f030',
+        },
       },
       {
         elements: [
@@ -1453,10 +1507,31 @@ export default function (imageBaseUrl) {
             id: 'a518c941-56a4-4e2d-afcd-893c88dc31ae',
           },
         ],
-        backgroundElementId: '117a9caa-d0cc-47d0-b00e-ee623bbcd5fc',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'c2d56aca-cb1a-41eb-bbdc-41dc2c4f597c',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: '64ea1430-5f03-4155-be5d-16faaa4b098e',
+        },
       },
       {
         elements: [
@@ -1485,6 +1560,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: '9012bef0-e5e3-4910-8412-a10ce18e23a6',
+            isDefaultBackground: true,
           },
           {
             type: 'shape',
@@ -1679,7 +1755,6 @@ export default function (imageBaseUrl) {
             },
           },
         ],
-        backgroundElementId: '9012bef0-e5e3-4910-8412-a10ce18e23a6',
         backgroundOverlay: 'none',
         type: 'page',
         id: '7b7d7662-fb1f-46b5-94e0-b01029a666a5',
@@ -1907,10 +1982,31 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(255, 255, 255, 1)">The main island hopping hubs are Phuket, Krabi, Koh Phi Phi, and Koh Lipe. Other favorites include Ko Tao, Ko Pha-Ngan, Ko Samui and Surat Thani.</span>',
           },
         ],
-        backgroundElementId: '3f23fce9-2fb5-4f17-acec-f0f6f524967d',
         backgroundOverlay: 'none',
         type: 'page',
         id: '1659f169-eb29-498a-bd00-6aea80d7ace7',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: '6f8d6dec-a10b-43d5-a74f-0bac45722dab',
+        },
       },
       {
         elements: [
@@ -1939,6 +2035,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: '55fcd4fb-1af4-4540-ac57-a783f94f6864',
+            isDefaultBackground: true,
           },
           {
             font: {
@@ -2679,7 +2776,6 @@ export default function (imageBaseUrl) {
             },
           },
         ],
-        backgroundElementId: '55fcd4fb-1af4-4540-ac57-a783f94f6864',
         backgroundOverlay: 'none',
         type: 'page',
         id: '78da0e6c-6bc7-4680-90a8-2b6bf6e98aaa',
@@ -2711,6 +2807,7 @@ export default function (imageBaseUrl) {
             },
             isBackground: true,
             id: '282588c3-fbc2-4b63-8260-2e58d0e63294',
+            isDefaultBackground: true,
           },
           {
             type: 'shape',
@@ -3214,7 +3311,6 @@ export default function (imageBaseUrl) {
             id: '675e2caa-2276-4b8b-9d80-0fcffd623d62',
           },
         ],
-        backgroundElementId: '282588c3-fbc2-4b63-8260-2e58d0e63294',
         backgroundOverlay: 'none',
         type: 'page',
         id: '9a45a0b2-0261-4298-aef7-c08b99771787',

--- a/assets/src/dashboard/templates/data/wellbeing.js
+++ b/assets/src/dashboard/templates/data/wellbeing.js
@@ -16,7 +16,7 @@
 
 export default function (imageBaseUrl) {
   return {
-    version: 17,
+    version: 19,
     pages: [
       {
         elements: [
@@ -46,6 +46,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: 'df765066-cd07-49bf-8ef7-02ae6f2b3330',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -227,7 +228,6 @@ export default function (imageBaseUrl) {
             content: '<span style="color: rgba(251, 235, 186, 1)">Sleep</span>',
           },
         ],
-        backgroundElementId: 'df765066-cd07-49bf-8ef7-02ae6f2b3330',
         type: 'page',
         id: '80cd76d6-6c52-4892-98d7-f414dbb7619e',
       },
@@ -259,6 +259,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '56248b21-6e15-48fa-bc4b-ebd2163c4b6c',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -481,7 +482,6 @@ export default function (imageBaseUrl) {
             content: '<span style="color: rgba(43, 57, 62, 1)">“</span>',
           },
         ],
-        backgroundElementId: '56248b21-6e15-48fa-bc4b-ebd2163c4b6c',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'e96638f8-1f19-4f34-b7e6-963329aa12fd',
@@ -514,6 +514,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: 'c6e37b7e-ddb8-4028-a66f-dd280351af00',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -862,7 +863,6 @@ export default function (imageBaseUrl) {
             id: '74d501d3-4f54-4348-b718-fef474c789f2',
           },
         ],
-        backgroundElementId: 'c6e37b7e-ddb8-4028-a66f-dd280351af00',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'e6b3eacb-1032-4965-8e57-efe5dbe8b1b7',
@@ -967,7 +967,7 @@ export default function (imageBaseUrl) {
             type: 'shape',
             id: '3016e5bf-a0d2-4d9d-82f0-cb169b5e9189',
             link: {
-              url: `http://google.com`,
+              url: 'http://google.com',
               icon: null,
               desc: 'Lavendar',
             },
@@ -1032,7 +1032,7 @@ export default function (imageBaseUrl) {
             x: 75,
             y: 506,
             link: {
-              url: `http://google.com`,
+              url: 'http://google.com',
               icon: null,
               desc: null,
             },
@@ -1097,7 +1097,7 @@ export default function (imageBaseUrl) {
             x: 330,
             y: 472,
             link: {
-              url: `http://google.com`,
+              url: 'http://google.com',
               icon: null,
               desc: 'Vase',
             },
@@ -1182,10 +1182,31 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(253, 245, 220, 1)">Aroma Therapy</span>',
           },
         ],
-        backgroundElementId: '7744e075-8030-462f-bdd5-15dc4f1ab97d',
         backgroundOverlay: 'solid',
         type: 'page',
         id: '0fd64689-3e15-4e91-b9b3-d991204703b1',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: 'e4224ca8-e130-44df-a647-57d7a6dba4f4',
+        },
       },
       {
         elements: [
@@ -1215,6 +1236,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '970e7f88-c07d-4a78-81f9-e66bd4b2bebe',
+            isDefaultBackground: true,
           },
           {
             opacity: 50,
@@ -1537,7 +1559,6 @@ export default function (imageBaseUrl) {
             id: '49416c51-ae2e-4b5c-bad0-66da4b9247b4',
           },
         ],
-        backgroundElementId: '970e7f88-c07d-4a78-81f9-e66bd4b2bebe',
         backgroundOverlay: 'none',
         type: 'page',
         id: '1a57cf2b-d1d0-432c-8b97-3794c41e2098',
@@ -1757,10 +1778,31 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(31, 42, 46, 1)">A study found that taking a hot bath about 90 minutes before bed could help people fall asleep more quickly.</span>',
           },
         ],
-        backgroundElementId: '4aac4002-7c41-434c-ab44-7bc43f6e863c',
         backgroundOverlay: 'none',
         type: 'page',
         id: '41d961c4-f7af-4d93-a9a1-94bc28287078',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: 'aceee55e-9440-4b53-90b7-4480bb1722ee',
+        },
       },
       {
         elements: [
@@ -2055,10 +2097,31 @@ export default function (imageBaseUrl) {
               '<span style="color: rgba(251, 235, 186, 1)">Bedtime\nRoutine Tips</span>',
           },
         ],
-        backgroundElementId: 'f8dca448-520e-4b47-a0ee-f3aea1cd2e3d',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'b96f282e-4b4e-465d-a2ec-a7c904c3e5d8',
+        defaultBackgroundElement: {
+          type: 'shape',
+          x: 1,
+          y: 1,
+          width: 1,
+          height: 1,
+          rotationAngle: 0,
+          mask: {
+            type: 'rectangle',
+          },
+          backgroundColor: {
+            color: {
+              r: 255,
+              g: 255,
+              b: 255,
+              a: 1,
+            },
+          },
+          isBackground: true,
+          isDefaultBackground: true,
+          id: 'fadc0093-2969-4c68-a93a-443622c08d81',
+        },
       },
       {
         elements: [
@@ -2088,6 +2151,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: '18d986e5-e023-466d-b8fc-fce0393071b0',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -2322,7 +2386,7 @@ export default function (imageBaseUrl) {
             x: 120,
             y: 506,
             content:
-              '<span style="color: rgba(255, 255, 255, 1)">Lorem ipsum dolor sit amet, consectetur adipiscing elit nula vel dui erat. Curabitur sit amet venenatis felis lorem.</span>',
+              '<span style="color: rgba(255, 255, 255, 1)">Lorem ipsum dolor sit amet, consectetur adipiscing elit nula vel dui erat. Curabitur sit amet venenatis felis lorem.</span>',
           },
           {
             opacity: 100,
@@ -2488,7 +2552,6 @@ export default function (imageBaseUrl) {
             id: 'b2a8e955-e246-47af-ac4e-dca6161dd703',
           },
         ],
-        backgroundElementId: '18d986e5-e023-466d-b8fc-fce0393071b0',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'a3dd6d21-4f75-4d8a-bacb-ef9d14f61503',
@@ -2521,6 +2584,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: 'd982e67d-6773-46a8-81db-fb99f0ee69a1',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -2974,7 +3038,7 @@ export default function (imageBaseUrl) {
             x: 142,
             y: 313,
             content:
-              '<span style="color: rgba(43, 57, 62, 1)">Aro Ha, Glenorchy,\n New Zealand</span>',
+              '<span style="color: rgba(43, 57, 62, 1)">Aro Ha, Glenorchy,\nNew Zealand</span>',
           },
           {
             opacity: 100,
@@ -3201,7 +3265,6 @@ export default function (imageBaseUrl) {
             id: '045e16e6-0389-46fd-989c-ac9350b5054e',
           },
         ],
-        backgroundElementId: 'd982e67d-6773-46a8-81db-fb99f0ee69a1',
         backgroundOverlay: 'none',
         type: 'page',
         id: 'd17e5002-9a42-41ea-a7fc-c2fddc7b58e6',
@@ -3234,6 +3297,7 @@ export default function (imageBaseUrl) {
             isBackground: true,
             type: 'shape',
             id: 'fd455062-8efd-4332-ab36-5b66742ce5a1',
+            isDefaultBackground: true,
           },
           {
             opacity: 100,
@@ -3868,7 +3932,6 @@ export default function (imageBaseUrl) {
             id: 'ab69ec53-ab30-4a7a-861e-92444112f983',
           },
         ],
-        backgroundElementId: 'fd455062-8efd-4332-ab36-5b66742ce5a1',
         backgroundOverlay: 'none',
         type: 'page',
         id: '47783f6c-471c-427c-804e-532ace8261d1',


### PR DESCRIPTION
## Summary

This PR does two things:

1.)  It updates the data structure of the following templates to the latest version (v19):
- `DIY`
- `Cooking`
- `Entertainment`
- `Travel`
- `Wellbeing`

2.)  It removes the Bon Appetit logo from the `Cooking` template, and the Travel + Leisure logo from the `Travel` template.

## User-facing changes

`Cooking`: The first page of the Cooking template should have a white box instead of the "Bon Appetit" logo.
![image](https://user-images.githubusercontent.com/40646372/83443014-ec049c80-a3fd-11ea-9da7-cce2ab744c33.png)

`Travel`: The first page of the Travel template should have a white box instead of the "Travel+Leisure" logo.
![image](https://user-images.githubusercontent.com/40646372/83443092-0a6a9800-a3fe-11ea-91c0-795b51a5f5cb.png)


## Testing Instructions

Go to "Explore Templates" and make sure that the "Cooking" and "Travel" templates appear as pictured above.  And make sure that "DIY", "Entertainment", and "Wellbeing" appear without visual bugs (basically, they should look like they looked before, nothing changed on them but their underlying data structure).

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2159 
