### PR TITLE
Fix: Adding text presets crashes editor

### DIFF
--- a/assets/src/edit-story/components/panels/stylePreset/utils.js
+++ b/assets/src/edit-story/components/panels/stylePreset/utils.js
@@ -49,7 +49,7 @@ export function findMatchingStylePreset(preset, stylePresets) {
 export function generatePresetStyle(preset, prepareForCSS) {
   const { color, backgroundColor, font, backgroundTextMode } = preset;
   let style = {
-    ...(font && { fontFamily: generateFontFamily(font) }),
+    fontFamily: generateFontFamily(font),
     ...generatePatternStyles(color, 'color'),
   };
 

--- a/assets/src/edit-story/components/panels/stylePreset/utils.js
+++ b/assets/src/edit-story/components/panels/stylePreset/utils.js
@@ -49,7 +49,7 @@ export function findMatchingStylePreset(preset, stylePresets) {
 export function generatePresetStyle(preset, prepareForCSS) {
   const { color, backgroundColor, font, backgroundTextMode } = preset;
   let style = {
-    fontFamily: generateFontFamily(font),
+    ...(font && { fontFamily: generateFontFamily(font) }),
     ...generatePatternStyles(color, 'color'),
   };
 

--- a/includes/Database_Upgrader.php
+++ b/includes/Database_Upgrader.php
@@ -59,6 +59,7 @@ class Database_Upgrader {
 			'1.0.0' => 'upgrade_1',
 			'2.0.0' => 'v_2_replace_conic_style_presets',
 			'2.0.1' => 'v_2_add_term',
+			'2.0.2' => 'remove_broken_text_styles',
 		];
 
 		$version = get_option( self::OPTION, '0.0.0' );
@@ -153,6 +154,36 @@ class Database_Upgrader {
 	 */
 	protected function v_2_add_term() {
 		wp_insert_term( 'editor', Media::STORY_MEDIA_TAXONOMY );
+	}
+
+	/**
+	 * Removes broken text styles (with color.r|g|b structure).
+	 *
+	 * @return void
+	 */
+	protected function remove_broken_text_styles() {
+		$style_presets = get_option( Stories_Controller::STYLE_PRESETS_OPTION, false );
+		// Nothing to do if style presets don't exist.
+		if ( ! $style_presets || ! is_array( $style_presets ) ) {
+			return;
+		}
+
+		$text_styles = [];
+		if ( ! empty( $style_presets['textStyles'] ) ) {
+			foreach ( $style_presets['textStyles'] as $preset ) {
+				if ( isset( $preset['color']['r'] ) ) {
+					continue;
+				}
+				$text_styles[] = $preset;
+			}
+		}
+
+		$updated_style_presets = [
+			'fillColors' => $style_presets['fillColors'],
+			'textColors' => $style_presets['textColors'],
+			'textStyles' => $text_styles,
+		];
+		update_option( Stories_Controller::STYLE_PRESETS_OPTION, $updated_style_presets );
 	}
 
 	/**

--- a/tests/phpunit/tests/Database_Upgrader.php
+++ b/tests/phpunit/tests/Database_Upgrader.php
@@ -115,7 +115,7 @@ class Database_Upgrader extends \WP_UnitTestCase {
 		delete_option( Stories_Controller::STYLE_PRESETS_OPTION );
 	}
 
-	public function test_v_3_remove_old_text_styles() {
+	public function test_remove_broken_text_styles() {
 		$presets = [
 			'textStyles' => [
 				[

--- a/tests/phpunit/tests/Database_Upgrader.php
+++ b/tests/phpunit/tests/Database_Upgrader.php
@@ -114,4 +114,56 @@ class Database_Upgrader extends \WP_UnitTestCase {
 
 		delete_option( Stories_Controller::STYLE_PRESETS_OPTION );
 	}
+
+	public function test_v_3_remove_old_text_styles() {
+		$presets = [
+			'textStyles' => [
+				[
+					'color' => [
+						'r' => 255,
+						'g' => 255,
+						'b' => 255,
+					],
+					'font'  => [],
+				],
+				[
+					'color' => [
+						'type'  => 'solid',
+						'color' => [
+							'r' => 255,
+							'g' => 255,
+							'b' => 255,
+						],
+					],
+					'font'  => [],
+				],
+			],
+			'textColors' => [],
+			'fillColors' => [],
+		];
+		add_option( Stories_Controller::STYLE_PRESETS_OPTION, $presets );
+
+		$object = new \Google\Web_Stories\Database_Upgrader();
+		$object->init();
+
+		$style_presets = get_option( Stories_Controller::STYLE_PRESETS_OPTION );
+		$this->assertSame(
+			$style_presets['textStyles'],
+			[
+				[
+					'color' => [
+						'type'  => 'solid',
+						'color' => [
+							'r' => 255,
+							'g' => 255,
+							'b' => 255,
+						],
+					],
+					'font'  => [],
+				],
+			]
+		);
+
+		delete_option( Stories_Controller::STYLE_PRESETS_OPTION );
+	}
 }

--- a/web-stories.php
+++ b/web-stories.php
@@ -41,7 +41,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'WEBSTORIES_VERSION', '1.0.0-alpha' );
-define( 'WEBSTORIES_DB_VERSION', '2.0.1' );
+define( 'WEBSTORIES_DB_VERSION', '2.0.2' );
 define( 'WEBSTORIES_PLUGIN_FILE', __FILE__ );
 define( 'WEBSTORIES_PLUGIN_DIR_PATH', plugin_dir_path( WEBSTORIES_PLUGIN_FILE ) );
 define( 'WEBSTORIES_PLUGIN_DIR_URL', plugin_dir_url( WEBSTORIES_PLUGIN_FILE ) );


### PR DESCRIPTION
Fixes #1990

What's causing the issue is data that "shouldn’t belong to textStyles at all. That’s the format for textColors and fillColors only".

It's just affecting the QA env.