### PR TITLE
Fix PHPCS warnings

### DIFF
--- a/includes/Embed_Block.php
+++ b/includes/Embed_Block.php
@@ -144,28 +144,27 @@ class Embed_Block {
 	 *
 	 * @return string Rendered block type output.
 	 */
-	public function render_block( array $attributes, $content ) {
+	public function render_block( array $attributes, $content ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		// The only 2 mandatory attributes.
 		if ( empty( $attributes['url'] ) || empty( $attributes['title'] ) ) {
 			return '';
 		}
 
 		if ( is_feed() ) {
-			return $this->render_block_feed( $attributes, $content );
+			return $this->render_block_feed( $attributes );
 		}
 
-		return $this->render_block_html( $attributes, $content );
+		return $this->render_block_html( $attributes );
 	}
 
 	/**
 	 * Renders the block type output in default context.
 	 *
-	 * @param array  $attributes Block attributes.
-	 * @param string $content    Block content.
+	 * @param array $attributes Block attributes.
 	 *
 	 * @return string Rendered block type output.
 	 */
-	protected function render_block_html( array $attributes, $content ) {
+	protected function render_block_html( array $attributes ) {
 		$url          = (string) $attributes['url'];
 		$title        = (string) $attributes['title'];
 		$poster       = ! empty( $attributes['poster'] ) ? esc_url( $attributes['poster'] ) : '';
@@ -198,12 +197,11 @@ class Embed_Block {
 	/**
 	 * Renders the block type output in an RSS feed context.
 	 *
-	 * @param array  $attributes Block attributes.
-	 * @param string $content    Block content.
+	 * @param array $attributes Block attributes.
 	 *
 	 * @return string Rendered block type output.
 	 */
-	protected function render_block_feed( array $attributes, $content ) {
+	protected function render_block_feed( array $attributes ) {
 		$url   = (string) $attributes['url'];
 		$title = (string) $attributes['title'];
 

--- a/includes/Media.php
+++ b/includes/Media.php
@@ -213,7 +213,7 @@ class Media {
 			'attachment',
 			'featured_media_src',
 			[
-				'get_callback' => static function ( $prepared, $field_name, $request ) {
+				'get_callback' => static function ( $prepared ) {
 
 					$id    = $prepared['featured_media'];
 					$image = [];

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -416,7 +416,7 @@ class Story_Post_Type {
 		$allowed_mime_types = self::get_allowed_mime_types();
 		$mime_types         = [];
 
-		foreach ( $allowed_mime_types as $type => $mimes ) {
+		foreach ( $allowed_mime_types as $mimes ) {
 			// Otherwise this throws a warning on PHP < 7.3.
 			if ( ! empty( $mimes ) ) {
 				array_push( $mime_types, ...$mimes );


### PR DESCRIPTION
## Summary

Fixes PHPCS warnings by removing unused parameters

## Relevant Technical Choices

Added `phpcs:ignore` comment for `render_block` callback to make it clear what the expected signature is.

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

N/A
