### PR TITLE
Make delete work globally.

### DIFF
--- a/assets/src/edit-story/components/canvas/useCanvasKeys.js
+++ b/assets/src/edit-story/components/canvas/useCanvasKeys.js
@@ -27,6 +27,7 @@ import { useGlobalKeyDownEffect, useKeyDownEffect } from '../keyboard';
 import { useStory } from '../../app';
 import { LAYER_DIRECTIONS } from '../../constants';
 import { getPastedCoordinates } from '../../utils/copyPaste';
+import nativeEventHandlingExpected from '../../utils/nativeEventHandlingExpected';
 
 const MOVE_COARSE_STEP = 10;
 
@@ -71,9 +72,15 @@ function useCanvasKeys(ref) {
     };
   }, [ref]);
 
-  useKeyDownEffect(ref, 'delete', () => deleteSelectedElements(), [
-    deleteSelectedElements,
-  ]);
+  useGlobalKeyDownEffect(
+    'delete',
+    () => {
+      if (!nativeEventHandlingExpected()) {
+        deleteSelectedElements();
+      }
+    },
+    [deleteSelectedElements]
+  );
   useKeyDownEffect(ref, 'esc', () => clearSelection(), [clearSelection]);
 
   // Position (x/y) key handler.

--- a/assets/src/edit-story/utils/nativeEventHandlingExpected.js
+++ b/assets/src/edit-story/utils/nativeEventHandlingExpected.js
@@ -20,7 +20,7 @@
  *
  * @return {boolean} If native handling is expected.
  */
-function nativeCopyPasteExpected() {
+function nativeEventHandlingExpected() {
   const { activeElement } = document;
   const { tagName, type, isContentEditable } = activeElement;
 
@@ -39,4 +39,4 @@ function nativeCopyPasteExpected() {
   return Boolean(range && !range.collapsed);
 }
 
-export default nativeCopyPasteExpected;
+export default nativeEventHandlingExpected;

--- a/assets/src/edit-story/utils/test/nativeEventHandlingExpected.js
+++ b/assets/src/edit-story/utils/test/nativeEventHandlingExpected.js
@@ -17,26 +17,26 @@
 /**
  * Internal dependencies
  */
-import nativeCopyPasteExpected from '../nativeCopyPasteExpected';
+import nativeEventHandlingExpected from '../nativeEventHandlingExpected';
 
-describe('nativeCopyPasteExpected', () => {
+describe('nativeEventHandlingExpected', () => {
   it('should detect selection correctly for different inputs', () => {
     const textArea = document.createElement('textarea');
     document.body.appendChild(textArea);
     textArea.focus();
-    expect(nativeCopyPasteExpected()).toBe(true);
+    expect(nativeEventHandlingExpected()).toBe(true);
 
     const textInput = document.createElement('input');
     textInput.type = 'text';
     document.body.appendChild(textInput);
     textInput.focus();
-    expect(nativeCopyPasteExpected()).toBe(true);
+    expect(nativeEventHandlingExpected()).toBe(true);
 
     const numberInput = document.createElement('input');
     numberInput.type = 'number';
     document.body.appendChild(numberInput);
     numberInput.focus();
-    expect(nativeCopyPasteExpected()).toBe(true);
+    expect(nativeEventHandlingExpected()).toBe(true);
 
     const originalWindow = { ...window };
     const windowSpy = jest.spyOn(global, 'window', 'get');
@@ -49,7 +49,7 @@ describe('nativeCopyPasteExpected', () => {
     incorrectInput.type = 'test';
     document.body.appendChild(incorrectInput);
     incorrectInput.focus();
-    expect(nativeCopyPasteExpected()).toBe(false);
+    expect(nativeEventHandlingExpected()).toBe(false);
 
     windowSpy.mockRestore();
   });
@@ -68,7 +68,7 @@ describe('nativeCopyPasteExpected', () => {
       },
     }));
 
-    expect(nativeCopyPasteExpected()).toBe(true);
+    expect(nativeEventHandlingExpected()).toBe(true);
 
     windowSpy.mockRestore();
   });

--- a/assets/src/edit-story/utils/useGlobalClipboardHandlers.js
+++ b/assets/src/edit-story/utils/useGlobalClipboardHandlers.js
@@ -22,7 +22,7 @@ import { useEffect } from 'react';
 /**
  * Internal dependencies
  */
-import nativeCopyPasteExpected from './nativeCopyPasteExpected';
+import nativeEventHandlingExpected from './nativeEventHandlingExpected';
 
 /**
  * @param {function(!ClipboardEvent)} copyCutHandler
@@ -34,7 +34,7 @@ function useGlobalClipboardHandlers(copyCutHandler, pasteHandler) {
       const { clipboardData } = evt;
 
       // Elements that either handle their own clipboard or have selection.
-      if (nativeCopyPasteExpected()) {
+      if (nativeEventHandlingExpected()) {
         return;
       }
 
@@ -48,7 +48,7 @@ function useGlobalClipboardHandlers(copyCutHandler, pasteHandler) {
 
     // We always use global handler for pasting.
     const pasteHandlerWrapper = (evt) => {
-      if (!nativeCopyPasteExpected()) {
+      if (!nativeEventHandlingExpected()) {
         pasteHandler(evt);
       }
     };


### PR DESCRIPTION
## Summary

Makes 'delete' work globally, ignoring the cases (falling back to default) where input is in focus or text selected.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

Currently, this makes 'Delete' work globally, however, this might change in the future if we decide to force focus to the canvas instead where relevant.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- Delete key works now globally, meaning that the user can click "Undo" or switch between the Library tabs, then hit "Delete" and still delete the selected elements.
<!-- Please describe your changes. -->

## Testing Instructions
1. Add an element or some elements
2. While keeping the elements selected, focus somewhere else, e.g. click "Redo" or switch between the Library tabs or Design Panel tabs
3. Click "Delete" / "Backspace"
4. Verify the elements still get deleted.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1781 
