### PR TITLE
Dashboard: Refresh stories preview after workspace changes

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -117,6 +117,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
 
         const response = await dataAdapter.get(path, {
           parse: false,
+          cache: 'no-cache',
         });
 
         const totalPages =


### PR DESCRIPTION
## Summary
Story previews were not previously being updated after navigating to the workspace editor, making changes, and then navigating back due to http cacheing.  

## Relevant Technical Choices

In the `useStoryApi` hook I updated the call to `dataAdapter.get` to include the following option `{ cache: 'no-cache' }` which will be passed through to wordpress' `apiFetch` library.  


## User-facing changes

Story previews will now reflect changes made in the workspace editor when navigating back and forth between the two apps.

## Testing Instructions

1. Launch into the dashboard and create or edit a story to open the workspace editor
2. Make changes to your story and Save as a draft
3. Navigate back to the dashboard and validate that your story preview has updated2

**Before**

![2188-before](https://user-images.githubusercontent.com/2755722/83572007-cd360100-a4f6-11ea-813f-227c47726533.gif)


**After**

![2188-after](https://user-images.githubusercontent.com/2755722/83571815-7b8d7680-a4f6-11ea-90a2-47c96e011d02.gif)


<!-- Please reference the issue(s) this PR addresses. -->

#2188
