### PR TITLE
Dashboard: Update story-anim-tool to help update/migrate templates easier

### DIFF
--- a/assets/src/dashboard/app/views/storyAnimTool/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/index.js
@@ -37,6 +37,7 @@ import { PreviewPage } from '../../../components';
 import { clamp } from '../../../utils';
 import { ApiContext } from '../../api/apiProvider';
 import FontProvider from '../../font/fontProvider';
+import UpdateTemplateForm from './updateTemplateForm';
 import Timeline from './timeline';
 import {
   PageContainer,
@@ -314,6 +315,7 @@ function StoryAnimTool() {
                 </ElementInfo>
               ))}
             </ElementsContainer>
+            <UpdateTemplateForm story={activeStory} />
           </Container>
           <Timeline
             story={activeStory}

--- a/assets/src/dashboard/app/views/storyAnimTool/updateTemplateForm.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/updateTemplateForm.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useState, useCallback } from 'react';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { StoryPropType } from '../../../types';
+
+const Title = styled.h2`
+  margin-bottom: 20px;
+`;
+
+const Container = styled.div`
+  padding: 20px;
+`;
+
+const Submit = styled.input`
+  display: block;
+  margin-top: 10px;
+`;
+
+function UpdateTemplateForm({ story }) {
+  const [includeAnimations, setIncludeAnimations] = useState(false);
+
+  const toggleIncludeAnimations = useCallback(() => {
+    setIncludeAnimations((prevIncludeAnimations) => !prevIncludeAnimations);
+  }, []);
+
+  const handleTemplateUpdate = useCallback(
+    (e) => {
+      e.preventDefault();
+
+      const pages = includeAnimations
+        ? story.pages
+        : story.pages.reduce((acc, page) => {
+            const { animations, ...rest } = page;
+            return [...acc, { ...rest }];
+          }, []);
+
+      const { story_data } = story.originalStoryData;
+
+      // eslint-disable-next-line no-console
+      console.log({
+        ...story_data,
+        pages,
+      });
+    },
+    [story, includeAnimations]
+  );
+
+  return (
+    <Container>
+      <form onSubmit={handleTemplateUpdate}>
+        <Title>{story.title}</Title>
+        <label htmlFor="animation">{'Include Animations?'}</label>
+        <input
+          id="animation"
+          type="checkbox"
+          onClick={toggleIncludeAnimations}
+          value={includeAnimations}
+        />
+        <Submit type="submit" value="Log Story Data to Console" />
+      </form>
+    </Container>
+  );
+}
+
+UpdateTemplateForm.propTypes = {
+  story: StoryPropType.isRequired,
+};
+
+export default UpdateTemplateForm;

--- a/assets/src/dashboard/app/views/storyAnimTool/updateTemplateForm.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/updateTemplateForm.js
@@ -23,6 +23,10 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
+import {
+  migrate,
+  DATA_VERSION,
+} from '../../../../edit-story/migration/migrate';
 import { StoryPropType } from '../../../types';
 
 const Title = styled.h2`
@@ -40,9 +44,16 @@ const Submit = styled.input`
 
 function UpdateTemplateForm({ story }) {
   const [includeAnimations, setIncludeAnimations] = useState(false);
+  const [autoMigrateTemplate, setAutoMigrateTemplate] = useState(true);
 
   const toggleIncludeAnimations = useCallback(() => {
     setIncludeAnimations((prevIncludeAnimations) => !prevIncludeAnimations);
+  }, []);
+
+  const toggleAutoMigrateTemplate = useCallback(() => {
+    setAutoMigrateTemplate(
+      (prevAutoMigrateTemplate) => !prevAutoMigrateTemplate
+    );
   }, []);
 
   const handleTemplateUpdate = useCallback(
@@ -57,27 +68,49 @@ function UpdateTemplateForm({ story }) {
           }, []);
 
       const { story_data } = story.originalStoryData;
-
-      // eslint-disable-next-line no-console
-      console.log({
+      const updatedStoryData = {
         ...story_data,
         pages,
-      });
+      };
+
+      const processedStoryData = autoMigrateTemplate
+        ? {
+            ...migrate(updatedStoryData, story_data.version),
+            version: DATA_VERSION,
+          }
+        : updatedStoryData;
+
+      // eslint-disable-next-line no-console
+      console.log(processedStoryData);
     },
-    [story, includeAnimations]
+    [story, includeAnimations, autoMigrateTemplate]
   );
 
   return (
     <Container>
       <form onSubmit={handleTemplateUpdate}>
         <Title>{story.title}</Title>
-        <label htmlFor="animation">{'Include Animations?'}</label>
-        <input
-          id="animation"
-          type="checkbox"
-          onClick={toggleIncludeAnimations}
-          value={includeAnimations}
-        />
+        <div>
+          <label htmlFor="animation">{'Include Animations?'}</label>
+          <input
+            id="animation"
+            type="checkbox"
+            onClick={toggleIncludeAnimations}
+            checked={includeAnimations}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="auto-migrate">
+            {'Migrate Template to latest version?'}
+          </label>
+          <input
+            id="auto-migrate"
+            type="checkbox"
+            onClick={toggleAutoMigrateTemplate}
+            checked={autoMigrateTemplate}
+          />
+        </div>
         <Submit type="submit" value="Log Story Data to Console" />
       </form>
     </Container>

--- a/assets/src/dashboard/app/views/storyAnimTool/updateTemplateForm.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/updateTemplateForm.js
@@ -43,7 +43,7 @@ const Submit = styled.input`
 `;
 
 function UpdateTemplateForm({ story }) {
-  const [includeAnimations, setIncludeAnimations] = useState(false);
+  const [includeAnimations, setIncludeAnimations] = useState(true);
   const [autoMigrateTemplate, setAutoMigrateTemplate] = useState(true);
 
   const toggleIncludeAnimations = useCallback(() => {


### PR DESCRIPTION
## Summary

This PR adds a small form to the `story-anim-tool` that lets us `console.log` the updated (and optionally migrated) JSON for the selected template.

## Relevant Technical Choices

This is just a simple internal dev tool, so I opted to `console.log` the results so we can copy the date using the chrome dev tools instead of doing anything more fancy.

## User-facing changes

None

## Testing Instructions

1. Go to the `story-anim-tool` at the following URL: 
`/wp-admin/admin.php?page=stories-dashboard#/story-anim-tool`

2. Select a template to update.

3. Open up the chrome dev tools and click on "Log Story Data to Console".

If you have "Include Animations?" checked in, the logged out `story_data` will included the added `animations` properties.

If you have "Migrate Template to latest version?" checked in, the logged out `story_data` will be migrated to the latest data version available within the app.

---

Fixes #2220 

## Screenshots

![image](https://user-images.githubusercontent.com/40646372/83690051-ded5e200-a5a4-11ea-9ec3-7260232667be.png)
