### PR TITLE
Dashboard: Create story from template

### DIFF
--- a/assets/src/dashboard/app/api/test/__snapshots__/useTemplateApi.js.snap
+++ b/assets/src/dashboard/app/api/test/__snapshots__/useTemplateApi.js.snap
@@ -2,7 +2,6 @@
 
 exports[`reshapeTemplateObject should reshape object to match snapshot 1`] = `
 Object {
-  "bottomTargetAction": [Function],
   "centerTargetAction": "template-detail?id=1&isLocal=true",
   "colors": Array [
     Object {
@@ -36,5 +35,6 @@ Object {
     "Joy",
   ],
   "title": "Beauty",
+  "version": 17,
 }
 `;

--- a/assets/src/dashboard/app/api/test/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/test/useTemplateApi.js
@@ -38,6 +38,7 @@ describe('reshapeTemplateObject', () => {
     ],
     description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
     pages: [{ id: 0, elements: [] }],
+    version: 17,
   };
 
   it('should reshape object to match snapshot', () => {

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -17,7 +17,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -213,7 +213,11 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
             style_presets,
             publisher_logo,
             title: {
-              raw: `${title.raw} ${__('(Copy)', 'web-stories')}`,
+              raw: sprintf(
+                /* translators: %s: story title */
+                __('%s (Copy)', 'web-stories'),
+                title.raw
+              ),
             },
             status: 'draft',
           },

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -193,26 +193,8 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
     },
     [wpApi, dataAdapter]
   );
-  const createStoryFromTemplate = useCallback(async (template) => {
-    await template;
-    // try {
-    // const { pages, title } = template;
-    // const response = await dataAdapter.post(wpApi, {
-    //   data: {
-    //     content: {},
-    //     story_data: {
-    //       pages,
-    //     },
-    //     title,
-    //     status: 'draft',
-    //   },
-    // });
-    // console.log(response);
-    // redirect to new id: ${editStoryURL}&post=${id}
-    // } catch (e) {
-    //   // eslint-disable-next-line no-console
-    //   console.error(e);
-    // }
+  const createStoryFromTemplate = useCallback((template) => {
+    return Promise.resolve({ success: true, template });
   }, []);
 
   const duplicateStory = useCallback(

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -204,7 +204,6 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
 
       try {
         const { createdBy, pages, version } = template;
-
         const storyPropsToSave = await getStoryPropsToSave({
           story: {
             status: 'auto-draft',

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -193,6 +193,27 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
     },
     [wpApi, dataAdapter]
   );
+  const createStoryFromTemplate = useCallback(async (template) => {
+    await template;
+    // try {
+    // const { pages, title } = template;
+    // const response = await dataAdapter.post(wpApi, {
+    //   data: {
+    //     content: {},
+    //     story_data: {
+    //       pages,
+    //     },
+    //     title,
+    //     status: 'draft',
+    //   },
+    // });
+    // console.log(response);
+    // redirect to new id: ${editStoryURL}&post=${id}
+    // } catch (e) {
+    //   // eslint-disable-next-line no-console
+    //   console.error(e);
+    // }
+  }, []);
 
   const duplicateStory = useCallback(
     async (story) => {
@@ -236,12 +257,19 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
 
   const api = useMemo(
     () => ({
+      duplicateStory,
+      fetchStories,
+      createStoryFromTemplate,
+      trashStory,
+      updateStory,
+    }),
+    [
+      createStoryFromTemplate,
+      duplicateStory,
+      trashStory,
       updateStory,
       fetchStories,
-      trashStory,
-      duplicateStory,
-    }),
-    [duplicateStory, trashStory, updateStory, fetchStories]
+    ]
   );
 
   return { stories: state, api };

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -198,17 +198,15 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
     async (template) => {
       try {
         const { createdBy, pages, title, version } = template;
-        const copyTemplateTitle = sprintf(
-          /* translators: %s: template title */
-          __('%s (Copy)', 'web-stories'),
-          title
-        );
+        // const copyTemplateTitle = sprintf(
+        //   /* translators: %s: template title */
+        //   __('%s (Copy)', 'web-stories'),
+        //   title
+        // );
 
         const storyPropsToSave = await getStoryPropsToSave({
           story: {
-            title: copyTemplateTitle,
-            status: 'draft',
-            date: new Date(),
+            status: 'auto-draft',
           },
           pages,
           metadata: {

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -63,10 +63,6 @@ const useTemplateApi = (dataAdapter, config) => {
 
   const { assetsURL } = config;
 
-  const createStoryFromTemplatePages = useCallback((pages) => {
-    return Promise.resolve({ success: true, storyId: -1 });
-  }, []);
-
   const fetchSavedTemplates = useCallback((filters) => {
     // Saved Templates = Bookmarked Templates + My Templates
     dispatch({
@@ -184,7 +180,6 @@ const useTemplateApi = (dataAdapter, config) => {
   const api = useMemo(
     () => ({
       bookmarkTemplateById,
-      createStoryFromTemplatePages,
       createTemplateFromStory,
       fetchBookmarkedTemplates,
       fetchExternalTemplates,
@@ -196,7 +191,6 @@ const useTemplateApi = (dataAdapter, config) => {
     }),
     [
       bookmarkTemplateById,
-      createStoryFromTemplatePages,
       createTemplateFromStory,
       fetchBookmarkedTemplates,
       fetchExternalTemplateById,

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -40,6 +40,7 @@ export function reshapeTemplateObject(isLocal) {
     createdBy,
     description,
     pages,
+    version,
   }) => ({
     isLocal,
     id,
@@ -51,8 +52,8 @@ export function reshapeTemplateObject(isLocal) {
     tags,
     colors,
     pages,
+    version,
     centerTargetAction: `${APP_ROUTES.TEMPLATE_DETAIL}?id=${id}&isLocal=${isLocal}`,
-    bottomTargetAction: () => {},
   });
 }
 

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -20,6 +20,9 @@
 import groupBy from '../../utils/groupBy';
 
 export const ACTION_TYPES = {
+  CREATING_STORY_FROM_TEMPLATE: 'creating_story_from_template',
+  CREATE_STORY_FROM_TEMPLATE_SUCCESS: 'create_story_from_template_success',
+  CREATE_STORY_FROM_TEMPLATE_FAILURE: 'create_story_from_template_failure',
   LOADING_STORIES: 'loading_stories',
   FETCH_STORIES_SUCCESS: 'fetch_stories_success',
   FETCH_STORIES_FAILURE: 'fetch_stories_failure',
@@ -29,7 +32,7 @@ export const ACTION_TYPES = {
 };
 
 export const defaultStoriesState = {
-  isError: false,
+  error: {},
   isLoading: false,
   stories: {},
   storiesOrderById: [],
@@ -39,17 +42,28 @@ export const defaultStoriesState = {
 
 function storyReducer(state, action) {
   switch (action.type) {
-    case ACTION_TYPES.LOADING_STORIES: {
+    case ACTION_TYPES.LOADING_STORIES:
+    case ACTION_TYPES.CREATING_STORY_FROM_TEMPLATE: {
       return {
         ...state,
         isLoading: action.payload,
       };
     }
-    case ACTION_TYPES.FETCH_STORIES_FAILURE:
+
+    case ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_FAILURE:
+    case ACTION_TYPES.FETCH_STORIES_FAILURE: {
       return {
         ...state,
-        isError: action.payload,
+        error: action.payload,
       };
+    }
+
+    case ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_SUCCESS: {
+      return {
+        ...state,
+        error: {},
+      };
+    }
 
     case ACTION_TYPES.UPDATE_STORY:
       return {
@@ -116,7 +130,7 @@ function storyReducer(state, action) {
 
       return {
         ...state,
-        isError: false,
+        error: {},
         storiesOrderById: uniqueStoryIds,
         stories: { ...state.stories, ...groupBy(action.payload.stories, 'id') },
         totalPages: action.payload.totalPages,

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -21,7 +21,7 @@ import storyReducer, { ACTION_TYPES } from '../stories';
 
 describe('storyReducer', () => {
   const initialState = {
-    isError: false,
+    error: {},
     isLoading: false,
     stories: {},
     storiesOrderById: [],
@@ -58,7 +58,7 @@ describe('storyReducer', () => {
 
     expect(result).toMatchObject({
       ...initialState,
-      isError: false,
+      error: {},
       storiesOrderById: [94, 78, 12],
       stories: {
         94: { id: 94, status: 'draft', title: 'my test story 1' },
@@ -100,7 +100,7 @@ describe('storyReducer', () => {
 
     expect(result).toMatchObject({
       ...initialState,
-      isError: false,
+      error: {},
       storiesOrderById: [95, 94, 65, 78, 12],
       stories: {
         94: { id: 94, status: 'draft', title: 'my test story 1' },
@@ -140,7 +140,7 @@ describe('storyReducer', () => {
 
     expect(result).toMatchObject({
       ...initialState,
-      isError: false,
+      error: {},
       storiesOrderById: [94, 65, 78, 12],
       stories: {
         94: { id: 94, status: 'draft', title: 'my test story 1' },
@@ -215,18 +215,62 @@ describe('storyReducer', () => {
     });
   });
 
-  it(`should update isError when ${ACTION_TYPES.FETCH_STORIES_FAILURE} is called`, () => {
+  it(`should update isLoading when ${ACTION_TYPES.CREATING_STORY_FROM_TEMPLATE} is called`, () => {
     const result = storyReducer(
       { ...initialState },
       {
-        type: ACTION_TYPES.FETCH_STORIES_FAILURE,
+        type: ACTION_TYPES.CREATING_STORY_FROM_TEMPLATE,
         payload: true,
       }
     );
 
     expect(result).toMatchObject({
       ...initialState,
-      isError: true,
+      isLoading: true,
+    });
+  });
+
+  it(`should update error to empty object when ${ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_SUCCESS} is called`, () => {
+    const result = storyReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_SUCCESS,
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      error: {},
+    });
+  });
+
+  it(`should update error when ${ACTION_TYPES.FETCH_STORIES_FAILURE} is called`, () => {
+    const result = storyReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.FETCH_STORIES_FAILURE,
+        payload: { message: 'my error message', code: 'my_error_code' },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      error: { message: 'my error message', code: 'my_error_code' },
+    });
+  });
+
+  it(`should update error when ${ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_FAILURE} is called`, () => {
+    const result = storyReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_FAILURE,
+        payload: { message: 'my error message', code: 'my_error_code' },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      error: { message: 'my error message', code: 'my_error_code' },
     });
   });
 

--- a/assets/src/dashboard/app/views/exploreTemplates/content/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/index.js
@@ -34,15 +34,14 @@ import {
   Layout,
   StandardViewContentGutter,
 } from '../../../../components';
-import { TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS } from '../../../../constants';
 import {
   ViewPropTypes,
   PagePropTypes,
   SearchPropTypes,
 } from '../../../../utils/useTemplateView';
-import { TemplatesPropType } from '../../../../types';
+import { TemplatesPropType, TemplateActionsPropType } from '../../../../types';
 import FontProvider from '../../../font/fontProvider';
-import { StoryGridView } from '../../shared';
+import { TemplateGridView } from '../../shared';
 import EmptyView from './emptyView';
 
 function Content({
@@ -53,6 +52,7 @@ function Content({
   view,
   totalTemplates,
   search,
+  templateActions,
 }) {
   return (
     <Layout.Scrollable>
@@ -62,14 +62,10 @@ function Content({
             <StandardViewContentGutter>
               {totalTemplates > 0 ? (
                 <>
-                  <StoryGridView
-                    stories={templates}
-                    centerActionLabelByStatus={
-                      TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS
-                    }
-                    bottomActionLabel={__('Use template', 'web-stories')}
-                    isTemplate
+                  <TemplateGridView
+                    templates={templates}
                     pageSize={view.pageSize}
+                    templateActions={templateActions}
                   />
                   <InfiniteScroller
                     canLoadMore={!allPagesFetched}
@@ -99,6 +95,7 @@ Content.propTypes = {
   templates: TemplatesPropType,
   totalTemplates: PropTypes.number,
   search: SearchPropTypes,
+  templateActions: TemplateActionsPropType,
   view: ViewPropTypes,
 };
 export default Content;

--- a/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
@@ -59,7 +59,7 @@ const StorybookLayoutContainer = styled.div`
 `;
 
 export default {
-  title: 'Dashboard/Components/exploreTemplates/Content',
+  title: 'Dashboard/Views/ExploreTemplates/Content',
   component: Content,
 };
 export const _default = () => {

--- a/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
@@ -43,6 +43,9 @@ const page = {
   requestNextPage: action('request next page clicked'),
 };
 
+const templateActions = {
+  createStoryFromTemplate: action('create story from template clicked'),
+};
 const defaultProps = {
   allPagesFetched: false,
   isLoading: false,
@@ -51,6 +54,7 @@ const defaultProps = {
   templates: formattedTemplatesArray,
   view: view,
   totalTemplates: 3,
+  templateActions,
 };
 
 const StorybookLayoutContainer = styled.div`

--- a/assets/src/dashboard/app/views/exploreTemplates/content/test/content.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/test/content.js
@@ -87,8 +87,9 @@ describe('Explore Templates <Content />', function () {
       </LayoutProvider>
     );
 
-    // update this to be regex
-    expect(getAllByTestId('grid-item')).toHaveLength(fakeTemplates.length);
+    const useButtons = getAllByTestId(/^template-grid-item/);
+
+    expect(useButtons).toHaveLength(fakeTemplates.length);
   });
 
   it('should show "No templates currently available" if no templates are present.', function () {

--- a/assets/src/dashboard/app/views/exploreTemplates/header/stories/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/header/stories/index.js
@@ -65,7 +65,7 @@ const defaultProps = {
 };
 
 export default {
-  title: 'Dashboard/Components/exploreTemplates/Header',
+  title: 'Dashboard/Views/ExploreTemplates/Header',
   component: Header,
 };
 

--- a/assets/src/dashboard/app/views/exploreTemplates/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/index.js
@@ -42,7 +42,8 @@ function ExploreTemplates() {
       },
     },
     actions: {
-      templateApi: { fetchExternalTemplates, createStoryFromTemplatePages },
+      storyApi: { createStoryFromTemplate },
+      templateApi: { fetchExternalTemplates },
     },
   } = useContext(ApiContext);
 
@@ -78,7 +79,7 @@ function ExploreTemplates() {
         totalTemplates={totalTemplates}
         search={search}
         view={view}
-        templateActions={{ createStoryFromTemplatePages }}
+        templateActions={{ createStoryFromTemplate }}
       />
       <Layout.Fixed>
         <ScrollToTop />

--- a/assets/src/dashboard/app/views/exploreTemplates/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/index.js
@@ -42,7 +42,7 @@ function ExploreTemplates() {
       },
     },
     actions: {
-      templateApi: { fetchExternalTemplates },
+      templateApi: { fetchExternalTemplates, createStoryFromTemplatePages },
     },
   } = useContext(ApiContext);
 
@@ -78,6 +78,7 @@ function ExploreTemplates() {
         totalTemplates={totalTemplates}
         search={search}
         view={view}
+        templateActions={{ createStoryFromTemplatePages }}
       />
       <Layout.Fixed>
         <ScrollToTop />

--- a/assets/src/dashboard/app/views/myStories/content/stories/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/stories/index.js
@@ -38,7 +38,7 @@ import StoriesView from '../storiesView';
 import EmptyView from '../emptyView';
 
 export default {
-  title: 'Dashboard/Components/myStories/Content',
+  title: 'Dashboard/Views/MyStories/Content',
   component: Content,
 };
 

--- a/assets/src/dashboard/app/views/myStories/content/test/content.js
+++ b/assets/src/dashboard/app/views/myStories/content/test/content.js
@@ -89,7 +89,7 @@ describe('My Stories <Content />', function () {
       </LayoutProvider>
     );
 
-    expect(getAllByTestId('grid-item')).toHaveLength(fakeStories.length);
+    expect(getAllByTestId(/^story-grid-item/)).toHaveLength(fakeStories.length);
   });
 
   it('should show "Create a story to get started!" if no stories are present.', function () {

--- a/assets/src/dashboard/app/views/myStories/content/test/storiesView.js
+++ b/assets/src/dashboard/app/views/myStories/content/test/storiesView.js
@@ -80,6 +80,6 @@ describe('My Stories <StoriesView />', function () {
       />
     );
 
-    expect(getAllByTestId('grid-item')).toHaveLength(fakeStories.length);
+    expect(getAllByTestId(/^story-grid-item/)).toHaveLength(fakeStories.length);
   });
 });

--- a/assets/src/dashboard/app/views/myStories/header/stories/index.js
+++ b/assets/src/dashboard/app/views/myStories/header/stories/index.js
@@ -33,7 +33,7 @@ import formattedStoriesArray from '../../../../../storybookUtils/formattedStorie
 import { Layout } from '../../../../../components';
 
 export default {
-  title: 'Dashboard/Components/myStories/Header',
+  title: 'Dashboard/Views/MyStories/Header',
   component: Header,
 };
 

--- a/assets/src/dashboard/app/views/shared/index.js
+++ b/assets/src/dashboard/app/views/shared/index.js
@@ -22,4 +22,5 @@ export {
 } from './pageHeading';
 export { default as StoryGridView } from './storyGridView';
 export { default as StoryListView } from './storyListView';
+export { default as TemplateGridView } from './templateGridView';
 export { default as TypeaheadSearch } from './typeaheadSearch';

--- a/assets/src/dashboard/app/views/shared/stories/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/storyGridView.js
@@ -24,13 +24,13 @@ import { action } from '@storybook/addon-actions';
  * Internal dependencies
  */
 
-import StoryGridView from '../storyGridView';
 import formattedStoriesArray from '../../../../storybookUtils/formattedStoriesArray';
 import formattedUsersObject from '../../../../storybookUtils/formattedUsersObject';
 import { STORY_ITEM_CENTER_ACTION_LABELS } from '../../../../constants';
+import StoryGridView from '../storyGridView';
 
 export default {
-  title: 'Dashboard/Components/StoryGridView',
+  title: 'Dashboard/Views/Shared/StoryGridView',
   component: StoryGridView,
 };
 

--- a/assets/src/dashboard/app/views/shared/stories/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/templateGridView.js
@@ -17,40 +17,28 @@
 /**
  * External dependencies
  */
-import { boolean, text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
-import styled from 'styled-components';
 
 /**
  * Internal dependencies
  */
-import { PageHeading } from '../';
-import { NavProvider, LeftRail } from '../../../../components';
+
+import formattedTemplatesArray from '../../../../storybookUtils/formattedTemplatesArray';
+import TemplateGridView from '../templateGridView';
 
 export default {
-  title: 'Dashboard/Views/Shared/PageHeading',
-  component: PageHeading,
+  title: 'Dashboard/Views/Shared/TemplateGridView',
+  component: TemplateGridView,
 };
-
-const InnerContent = styled.div`
-  background-color: red;
-  width: 100%;
-  height: 50%;
-`;
 
 export const _default = () => {
   return (
-    <NavProvider>
-      <LeftRail />
-      <PageHeading
-        centerContent={boolean('Center Inner Content', false)}
-        stories={[]}
-        handleTypeaheadChange={(value) => action('Search with value: ', value)}
-        defaultTitle={text('Page Heading', 'My Stories')}
-        searchPlaceholder={text('Search Placeholder', 'Find Stories')}
-      >
-        <InnerContent />
-      </PageHeading>
-    </NavProvider>
+    <TemplateGridView
+      templates={formattedTemplatesArray}
+      pageSize={{ width: 210, height: 316 }}
+      templateActions={{
+        createStoryFromTemplate: action('create story from template clicked'),
+      }}
+    />
   );
 };

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -63,7 +63,6 @@ const StoryGridView = ({
   users,
   centerActionLabelByStatus,
   bottomActionLabel,
-  isTemplate,
   isSavedTemplate,
   pageSize,
   storyMenu,
@@ -82,7 +81,7 @@ const StoryGridView = ({
           : {};
 
         return (
-          <CardGridItem key={story.id} isTemplate={isTemplate}>
+          <CardGridItem key={story.id}>
             <CardPreviewContainer
               pageSize={pageSize}
               story={story}
@@ -95,30 +94,28 @@ const StoryGridView = ({
                 label: bottomActionLabel,
               }}
             />
-            {!isTemplate && (
-              <DetailRow>
-                <CardTitle
-                  title={story.title}
-                  titleLink={story.editStoryLink}
-                  status={story?.status}
-                  id={story.id}
-                  secondaryTitle={
-                    isSavedTemplate
-                      ? __('Google', 'web-stories')
-                      : users[story.author]?.name
-                  }
-                  displayDate={story?.modified}
-                  {...titleRenameProps}
-                />
+            <DetailRow>
+              <CardTitle
+                title={story.title}
+                titleLink={story.editStoryLink}
+                status={story?.status}
+                id={story.id}
+                secondaryTitle={
+                  isSavedTemplate
+                    ? __('Google', 'web-stories')
+                    : users[story.author]?.name
+                }
+                displayDate={story?.modified}
+                {...titleRenameProps}
+              />
 
-                <StoryMenu
-                  onMoreButtonSelected={storyMenu.handleMenuToggle}
-                  contextMenuId={storyMenu.contextMenuId}
-                  onMenuItemSelected={storyMenu.handleMenuItemSelected}
-                  story={story}
-                />
-              </DetailRow>
-            )}
+              <StoryMenu
+                onMoreButtonSelected={storyMenu.handleMenuToggle}
+                contextMenuId={storyMenu.contextMenuId}
+                onMenuItemSelected={storyMenu.handleMenuItemSelected}
+                story={story}
+              />
+            </DetailRow>
           </CardGridItem>
         );
       })}

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -81,7 +81,10 @@ const StoryGridView = ({
           : {};
 
         return (
-          <CardGridItem key={story.id}>
+          <CardGridItem
+            key={story.id}
+            data-testid={`story-grid-item-${story.id}`}
+          >
             <CardPreviewContainer
               pageSize={pageSize}
               story={story}

--- a/assets/src/dashboard/app/views/shared/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/templateGridView.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS } from '../../../constants';
+import {
+  CardGridItem,
+  CardPreviewContainer,
+  CardGrid,
+} from '../../../components';
+import {
+  PageSizePropType,
+  TemplatesPropType,
+  TemplateActionsPropType,
+} from '../../../types';
+
+const GridContainer = styled(CardGrid)`
+  width: ${({ theme }) =>
+    `calc(100% - ${theme.standardViewContentGutter.desktop}px)`};
+
+  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
+    width: ${({ theme }) =>
+      `calc(100% - ${theme.standardViewContentGutter.min}px)`};
+  }
+`;
+
+const TemplateGridView = ({ pageSize, templates, templateActions }) => (
+  <GridContainer pageSize={pageSize}>
+    {templates.map((template) => (
+      <CardGridItem key={template.id}>
+        <CardPreviewContainer
+          pageSize={pageSize}
+          story={template}
+          centerAction={{
+            targetAction: template.centerTargetAction,
+            label: TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS[template.status],
+          }}
+          bottomAction={{
+            targetAction: templateActions.createStoryFromTemplate,
+            label: __('Use template', 'web-stories'),
+          }}
+        />
+      </CardGridItem>
+    ))}
+  </GridContainer>
+);
+
+TemplateGridView.propTypes = {
+  pageSize: PageSizePropType,
+  templates: TemplatesPropType,
+  templateActions: TemplateActionsPropType,
+};
+export default TemplateGridView;

--- a/assets/src/dashboard/app/views/shared/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/templateGridView.js
@@ -51,7 +51,10 @@ const GridContainer = styled(CardGrid)`
 const TemplateGridView = ({ pageSize, templates, templateActions }) => (
   <GridContainer pageSize={pageSize}>
     {templates.map((template) => (
-      <CardGridItem key={template.id}>
+      <CardGridItem
+        key={template.id}
+        data-testid={`template-grid-item-${template.id}`}
+      >
         <CardPreviewContainer
           pageSize={pageSize}
           story={template}

--- a/assets/src/dashboard/app/views/shared/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/templateGridView.js
@@ -60,7 +60,8 @@ const TemplateGridView = ({ pageSize, templates, templateActions }) => (
             label: TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS[template.status],
           }}
           bottomAction={{
-            targetAction: templateActions.createStoryFromTemplate,
+            targetAction: () =>
+              templateActions.createStoryFromTemplate(template),
             label: __('Use template', 'web-stories'),
           }}
         />

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -200,7 +200,9 @@ function TemplateDetails() {
         <TransformProvider>
           <Layout.Provider>
             <Layout.Fixed>
-              <TemplateNavBar />
+              <TemplateNavBar
+                handleCta={() => createStoryFromTemplate(template)}
+              />
             </Layout.Fixed>
             <Layout.Scrollable>
               <DetailViewContentGutter>

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -76,8 +76,8 @@ function TemplateDetails() {
       templates: { templates, templatesOrderById },
     },
     actions: {
+      storyApi: { createStoryFromTemplate },
       templateApi: {
-        createStoryFromTemplate,
         fetchMyTemplateById,
         fetchExternalTemplateById,
         fetchRelatedTemplates,

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -36,14 +36,13 @@ import {
   Pill,
   TemplateNavBar,
 } from '../../../components';
-import { TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS } from '../../../constants';
 import { clamp, usePagePreviewSize } from '../../../utils/';
 import { ApiContext } from '../../api/apiProvider';
 import { useConfig } from '../../config';
 import FontProvider from '../../font/fontProvider';
 import { resolveRelatedTemplateRoute } from '../../router';
 import useRouteHistory from '../../router/useRouteHistory';
-import { StoryGridView } from '../shared';
+import { TemplateGridView } from '../shared';
 import {
   ByLine,
   Column,
@@ -78,6 +77,7 @@ function TemplateDetails() {
     },
     actions: {
       templateApi: {
+        createStoryFromTemplate,
         fetchMyTemplateById,
         fetchExternalTemplateById,
         fetchRelatedTemplates,
@@ -248,14 +248,10 @@ function TemplateDetails() {
                       {__('Related Templates', 'web-stories')}
                     </SubHeading>
                     <UnitsProvider pageSize={pageSize}>
-                      <StoryGridView
-                        stories={relatedTemplates}
-                        centerActionLabelByStatus={
-                          TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS
-                        }
-                        bottomActionLabel={__('Use template', 'web-stories')}
-                        isTemplate
+                      <TemplateGridView
+                        templates={relatedTemplates}
                         pageSize={pageSize}
+                        templateActions={{ createStoryFromTemplate }}
                       />
                     </UnitsProvider>
                   </RowContainer>

--- a/assets/src/dashboard/components/cardGridItem/index.js
+++ b/assets/src/dashboard/components/cardGridItem/index.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -26,7 +25,7 @@ import PropTypes from 'prop-types';
 import { MoreVerticalButton } from '../storyMenu';
 import { ActionLabel } from './types';
 
-const StyledCard = styled.div`
+const CardGridItem = styled.div`
   margin: 0;
   width: 100%;
   display: flex;
@@ -40,17 +39,6 @@ const StyledCard = styled.div`
     opacity: 1;
   }
 `;
-
-const CardGridItem = ({ children, isTemplate }) => (
-  <StyledCard data-testid={'grid-item'} isTemplate={isTemplate}>
-    {children}
-  </StyledCard>
-);
-
-CardGridItem.propTypes = {
-  isTemplate: PropTypes.bool,
-  children: PropTypes.node,
-};
 
 export default CardGridItem;
 export { default as CardPreviewContainer } from './cardPreview';

--- a/assets/src/dashboard/components/templateNavBar/index.js
+++ b/assets/src/dashboard/components/templateNavBar/index.js
@@ -23,6 +23,7 @@ import { __ } from '@wordpress/i18n';
  * External dependencies
  */
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -75,7 +76,7 @@ const CloseLink = styled.a`
   `}
 `;
 
-export function TemplateNavBar() {
+export function TemplateNavBar({ handleCta }) {
   return (
     <Nav>
       <Container>
@@ -83,10 +84,14 @@ export function TemplateNavBar() {
       </Container>
       <Container>
         <BookmarkToggle />
-        <Button type={BUTTON_TYPES.CTA} href={'#'} isLink={true}>
+        <Button type={BUTTON_TYPES.CTA} onClick={handleCta}>
           {__('USE TEMPLATE', 'web-stories')}
         </Button>
       </Container>
     </Nav>
   );
 }
+
+TemplateNavBar.propTypes = {
+  handleCta: PropTypes.func.isRequired,
+};

--- a/assets/src/dashboard/components/templateNavBar/stories/index.js
+++ b/assets/src/dashboard/components/templateNavBar/stories/index.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
 
 /**
  * Internal dependencies
@@ -24,5 +28,5 @@ export default {
 };
 
 export const _default = () => {
-  return <TemplateNavBar />;
+  return <TemplateNavBar handleCta={action('handle cta clicked')} />;
 };

--- a/assets/src/dashboard/storybookUtils/formattedTemplatesArray.js
+++ b/assets/src/dashboard/storybookUtils/formattedTemplatesArray.js
@@ -21,7 +21,7 @@ import moment from 'moment';
 
 const formattedTemplatesArray = [
   {
-    bottomTargetAction: () => {},
+    version: 2,
     centerTargetAction: 'template-detail?id=2&isLocal=false',
     createdBy: 'Google Web Stories',
     description:
@@ -212,7 +212,7 @@ const formattedTemplatesArray = [
     title: 'Cooking',
   },
   {
-    bottomTargetAction: () => {},
+    version: 2,
     centerTargetAction: 'template-detail?id=2&isLocal=false',
     createdBy: 'Google Web Stories',
     description:
@@ -403,7 +403,7 @@ const formattedTemplatesArray = [
     title: 'Cooking',
   },
   {
-    bottomTargetAction: () => {},
+    version: 2,
     centerTargetAction: 'template-detail?id=2&isLocal=false',
     createdBy: 'Google Web Stories',
     description:
@@ -594,7 +594,7 @@ const formattedTemplatesArray = [
     title: 'Cooking',
   },
   {
-    bottomTargetAction: () => {},
+    version: 2,
     centerTargetAction: 'template-detail?id=2&isLocal=false',
     createdBy: 'Google Web Stories',
     description:
@@ -785,7 +785,7 @@ const formattedTemplatesArray = [
     title: 'Cooking',
   },
   {
-    bottomTargetAction: () => {},
+    version: 2,
     centerTargetAction: 'template-detail?id=2&isLocal=false',
     createdBy: 'Google Web Stories',
     description:
@@ -976,7 +976,7 @@ const formattedTemplatesArray = [
     title: 'Cooking',
   },
   {
-    bottomTargetAction: () => {},
+    version: 2,
     centerTargetAction: 'template-detail?id=2&isLocal=false',
     createdBy: 'Google Web Stories',
     description:
@@ -1167,7 +1167,7 @@ const formattedTemplatesArray = [
     title: 'Cooking',
   },
   {
-    bottomTargetAction: () => {},
+    version: 2,
     centerTargetAction: 'template-detail?id=2&isLocal=false',
     createdBy: 'Google Web Stories',
     description:
@@ -1358,7 +1358,7 @@ const formattedTemplatesArray = [
     title: 'Cooking',
   },
   {
-    bottomTargetAction: () => {},
+    version: 2,
     centerTargetAction: 'template-detail?id=2&isLocal=false',
     createdBy: 'Google Web Stories',
     description:

--- a/assets/src/dashboard/templates/index.js
+++ b/assets/src/dashboard/templates/index.js
@@ -43,6 +43,7 @@ export default function ({ assetsURL }) {
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus consectetur mauris sodales magna elementum maximus.',
       pages: templates.beauty.pages,
+      version: templates.beauty.version,
     },
     {
       id: 2,
@@ -59,6 +60,7 @@ export default function ({ assetsURL }) {
       description:
         'Maecenas ultrices tortor nibh, eu consequat magna maximus non. Quisque nec tellus lacus.',
       pages: templates.cooking.pages,
+      version: templates.cooking.version,
     },
     {
       id: 3,
@@ -76,6 +78,7 @@ export default function ({ assetsURL }) {
       description:
         'Mauris placerat velit ut nunc ornare porta. Integer auctor hendrerit aliquam. Proin egestas nisi et nisl commodo.',
       pages: templates.diy.pages,
+      version: templates.diy.version,
     },
     {
       id: 4,
@@ -91,6 +94,7 @@ export default function ({ assetsURL }) {
       description:
         'Nam a tellus tortor. Aenean non mi porta quam feugiat vehicula in a lectus. Suspendisse eget justo ac quam.',
       pages: templates.entertainment.pages,
+      version: templates.entertainment.version,
     },
     {
       id: 5,
@@ -107,6 +111,7 @@ export default function ({ assetsURL }) {
       description:
         'Duis auctor libero vel dui tincidunt, at mattis nisi placerat. Nam id lacinia lectus.',
       pages: templates.fashion.pages,
+      version: templates.fashion.version,
     },
     {
       id: 6,
@@ -121,6 +126,7 @@ export default function ({ assetsURL }) {
       description:
         'Quisque dignissim urna id lectus ultricies blandit. Cras laoreet pharetra lectus. Nunc mollis suscipit feugiat.',
       pages: templates.fitness.pages,
+      version: templates.fitness.version,
     },
     {
       id: 7,
@@ -136,6 +142,7 @@ export default function ({ assetsURL }) {
       description:
         'Vestibulum lobortis quis nunc eget pulvinar. Duis auctor eros quis dignissim iaculis.',
       pages: templates.travel.pages,
+      version: templates.travel.version,
     },
     {
       id: 8,
@@ -153,6 +160,7 @@ export default function ({ assetsURL }) {
       description:
         'In lorem est, aliquam tempus justo nec, tincidunt aliquet diam. Fusce ut nisl ex. Nam mollis dolor non arcu.',
       pages: templates.wellbeing.pages,
+      version: templates.wellbeing.version,
     },
   ];
 }

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -76,6 +76,10 @@ export const StoryActionsPropType = PropTypes.shape({
   updateStory: PropTypes.func,
 });
 
+export const TemplateActionsPropType = PropTypes.shape({
+  createStoryFromTemplate: PropTypes.func,
+});
+
 export const TotalStoriesByStatusPropType = PropTypes.shape({
   all: PropTypes.number,
   draft: PropTypes.number,

--- a/assets/src/dashboard/utils/index.js
+++ b/assets/src/dashboard/utils/index.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-export { default as useResizeEffect } from '../../edit-story/utils/useResizeEffect';
 export { default as clamp } from './clamp';
 export { default as getCurrentYAxis } from './getCurrentYAxis';
 export { default as getFormattedDisplayDate } from './getFormattedDisplayDate';
@@ -27,3 +26,6 @@ export { default as useFocusOut } from './useFocusOut';
 export { default as usePagePreviewSize } from './usePagePreviewSize';
 export { default as useStoryView } from './useStoryView';
 export { default as useTemplateView } from './useTemplateView';
+
+export { default as getStoryPropsToSave } from '../../edit-story/app/story/utils/getStoryPropsToSave';
+export { default as useResizeEffect } from '../../edit-story/utils/useResizeEffect';

--- a/assets/src/dashboard/utils/index.js
+++ b/assets/src/dashboard/utils/index.js
@@ -27,5 +27,6 @@ export { default as usePagePreviewSize } from './usePagePreviewSize';
 export { default as useStoryView } from './useStoryView';
 export { default as useTemplateView } from './useTemplateView';
 
+export { default as addQueryArgs } from '../../edit-story/utils/addQueryArgs';
 export { default as getStoryPropsToSave } from '../../edit-story/app/story/utils/getStoryPropsToSave';
 export { default as useResizeEffect } from '../../edit-story/utils/useResizeEffect';


### PR DESCRIPTION
## Summary
Adds ability to create a story from a template

## Relevant Technical Choices
- Adds new action in useStoryApi that takes template and retrieves rest of story info from `getStoryPropsToSave` and then adds that template as a story
- Exposed template version because without it the new story-template breaks in the editor

(Some clean up)
- New shared view component for template grids (`templateGridView`) to be used in explore templates and template details. The shared storyGrid was just getting so many props and having to handle dueling functionality. Separating this cleaned up the grid components themselves and made the view structure easier. 
- Updating unit tests that rely on `grid-item` to have unique test ids and use regex to grab them all 
- New storybook for templateGridView 
- Move view related storybook content into dashboard/views instead of in components to keep a clear break of content

## User-facing changes
- Ability to create a story from a template. Now when you click 'use template' on 'Explore templates' you get redirected to the editor with an auto-draft copy of that template as a story.

## Testing Instructions
- Regression test explore templates and detail templates, make sure grids still work. 
- See new storybook set up with dashboard/views and new storybook for templateGridView
- Click **'use template'** on any template in the dashboard, you'll see a `post` to `wp-json/wp/v2/web-story?_locale=user` that should return a `201 created` on success. When successful it will redirect to the editor with the new ID created for the auto draft. If you save the draft or publish this template has become a story and is visible in dashboard stories. if you do not save it, it is not available in my stories on dashboard. 
- if you fudge the API and make it error you'll get an error object back that sets in the reducer. We're not handling error states yet in the UI but I did update the reducer to bring back a message instead of a boolean. 
- other places this functionality exists aside from the 'use template' button in the explore templates grid on hover: detail template view (seen when you click 'view') on hover of a template (middle button) x 2 spots. 1) the 'use template' blue CTA in the nav section. 2) the grid of related templates on hover (just like in explore templates) 

---

<!-- Please reference the issue(s) this PR addresses. -->

addresses #2007 