### PR TITLE
Workspace: Hide Pre-Publish tab based on feature flag

### DIFF
--- a/assets/src/edit-story/components/inspector/inspectorTabs.js
+++ b/assets/src/edit-story/components/inspector/inspectorTabs.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import { useFeatures } from 'flagged';
 
 /**
  * WordPress dependencies
@@ -87,11 +88,17 @@ function InspectorTabs() {
       tabs: { DESIGN, DOCUMENT, PREPUBLISH },
     },
   } = useInspector();
+  const { showPrePublishTab } = useFeatures();
+
   const tabs = [
     [DESIGN, __('Design', 'web-stories')],
     [DOCUMENT, __('Document', 'web-stories')],
-    [PREPUBLISH, __('Prepublish', 'web-stories')],
   ];
+
+  if (showPrePublishTab) {
+    tabs.push([PREPUBLISH, __('Prepublish', 'web-stories')]);
+  }
+
   return (
     <Tabs>
       {tabs.map(([id, Text]) => (

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -379,6 +379,13 @@ class Story_Post_Type {
 				 * Creation date: 2020-06-02
 				 */
 				'newFontPicker'     => false,
+				/**
+				 * Description: Flag for hiding/enabling the pre publish tab.
+				 * Author: @dmmulroy
+				 * Issue: #2095
+				 * Creation date: 2020-06-04
+				 */
+				'showPrePublishTab' => false,
 			],
 		];
 


### PR DESCRIPTION
## Summary

This hides the Pre Publish tab based on the `showPrePublishTab` feature flag.

## Relevant Technical Choices

The `InpectorTabs` component will conditionally push the Pre Publish tab into the `tabs` state/array which is mapped over to render tab components depending on the feature flag:

```javascript
  const tabs = [
    [DESIGN, __('Design', 'web-stories')],
    [DOCUMENT, __('Document', 'web-stories')],
  ];

  if (showPrePublishTab) {
    tabs.push([PREPUBLISH, __('Prepublish', 'web-stories')]);
  }
```

## User-facing changes
The Pre Publish tab will be hidden from users if the flag is set to false;

## Testing Instructions

When launching into the workspace editor, the Pre Publish tab should not be visible by default. Flipping the `showPrePublishTab` flag in `includes/Story_Post_Type.php` to true and refreshing should make it visible.

![2095-prepub](https://user-images.githubusercontent.com/2755722/83776905-c1f9e700-a656-11ea-815e-56a15113bd80.gif)

---

<!-- Please reference the issue(s) this PR addresses. -->

#2095
