### PR TITLE
Add animation controls to story-anim-tool

### DIFF
--- a/assets/src/dashboard/animations/parts/simpleAnimation.js
+++ b/assets/src/dashboard/animations/parts/simpleAnimation.js
@@ -29,6 +29,11 @@ import createKeyframeEffect from '../utils/createKeyframeEffect';
 import { WAAPIAnimationProps, AMPAnimationProps } from './types';
 import FullSizeAbsolute from './components/fullSizeAbsolute';
 
+const sanitizeTimings = (timings) => ({
+  ...timings,
+  easing: timings.easing || 'linear',
+});
+
 function SimpleAnimation(
   animationName,
   keyframes,
@@ -44,7 +49,11 @@ function SimpleAnimation(
       if (!target.current) {
         return () => {};
       }
-      const effect = createKeyframeEffect(target.current, keyframes, timings);
+      const effect = createKeyframeEffect(
+        target.current,
+        keyframes,
+        sanitizeTimings(timings)
+      );
       return hoistAnimation(new Animation(effect, document.timeline));
     }, [hoistAnimation]);
 

--- a/assets/src/dashboard/app/views/storyAnimTool/emitter.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/emitter.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const emitter = () => {
+  const subscriptions = new Map();
+  return {
+    emit: (v) => subscriptions.forEach((subscriber) => subscriber(v)),
+    subscribe: (subscriber) => {
+      const key = Symbol();
+      subscriptions.set(key, subscriber);
+      return () => subscriptions.delete(key);
+    },
+  };
+};

--- a/assets/src/dashboard/app/views/storyAnimTool/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/index.js
@@ -31,6 +31,7 @@ import {
   SORT_DIRECTION,
   STORY_SORT_OPTIONS,
   STORY_STATUS,
+  STORY_PAGE_STATE,
 } from '../../../constants';
 import { PAGE_RATIO } from '../../../constants/pageStructure';
 import { PreviewPage } from '../../../components';
@@ -50,14 +51,19 @@ import {
   Text,
   STORY_WIDTH,
 } from './components';
+import { emitter } from './emitter';
 
 function StoryAnimTool() {
   const [activeStory, setActiveStory] = useState(null);
   const [activeAnimation, setActiveAnimation] = useState({});
   const [activePageIndex, setActivePageIndex] = useState(0);
+  const [pageAnimationState, setPageAnimationState] = useState(
+    STORY_PAGE_STATE.RESET
+  );
 
   const [selectedElementIds, setSelectedElementIds] = useState({});
   const [isElementSelectable, setIsElementSelectable] = useState(false);
+  const globalTimeSubscription = useMemo(() => emitter(), []);
 
   const {
     actions: {
@@ -279,7 +285,14 @@ function StoryAnimTool() {
                       height={STORY_WIDTH / PAGE_RATIO}
                       selectedElementIds={selectedElementIds}
                     >
-                      <PreviewPage page={activeStory.pages[activePageIndex]} />
+                      <PreviewPage
+                        page={activeStory.pages[activePageIndex]}
+                        animationState={pageAnimationState}
+                        subscribeGlobalTime={globalTimeSubscription.subscribe}
+                        onAnimationComplete={() =>
+                          setPageAnimationState(STORY_PAGE_STATE.RESET)
+                        }
+                      />
                     </ActiveCard>
                   </UnitsProvider>
                 </TransformProvider>
@@ -299,6 +312,28 @@ function StoryAnimTool() {
                 }
               >
                 {'Next Page'}
+              </button>
+              <button
+                onClick={() => setPageAnimationState(STORY_PAGE_STATE.PLAYING)}
+              >
+                {'Play'}
+              </button>
+              <button
+                onClick={() => setPageAnimationState(STORY_PAGE_STATE.PAUSED)}
+              >
+                {'Pause'}
+              </button>
+              <button
+                onClick={() => setPageAnimationState(STORY_PAGE_STATE.RESET)}
+              >
+                {'Reset'}
+              </button>
+              <button
+                onClick={() =>
+                  setPageAnimationState(STORY_PAGE_STATE.SCRUBBING)
+                }
+              >
+                {'Scrub'}
               </button>
             </div>
             <ElementsContainer>
@@ -327,6 +362,8 @@ function StoryAnimTool() {
             onAnimationSelect={handleAnimationSelect}
             onAnimationDelete={handleAnimationDelete}
             onToggleTargetSelect={setIsElementSelectable}
+            emitGlobalTime={globalTimeSubscription.emit}
+            canScrub={pageAnimationState === STORY_PAGE_STATE.SCRUBBING}
           />
         </>
       )}

--- a/assets/src/dashboard/app/views/storyAnimTool/timeline/components.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/timeline/components.js
@@ -91,12 +91,11 @@ export const LabelButton = styled.button(
     cursor: pointer;
 
     ${
-      isActive
-        ? `
-      color: ${theme.colors.bluePrimary};
-      font-weight: 700;
-    `
-        : ``
+      isActive &&
+      `
+        color: ${theme.colors.bluePrimary};
+        font-weight: 700;
+      `
     }
   `
 );

--- a/assets/src/dashboard/app/views/storyAnimTool/timeline/components.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/timeline/components.js
@@ -32,12 +32,39 @@ export const Container = styled.div`
 
 export const AnimationList = styled.div(
   ({ theme }) => `
+    position: relative;
     width: 100%;
     height: 100%;
     overflow: scroll;
     background-color: ${theme.colors.gray25};
   `
 );
+
+export const ScrubBarContainer = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 90px;
+  z-index: 10;
+  pointer-events: none;
+`;
+
+export const ScrubBar = styled.div`
+  position: absolute;
+  background-color: red;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: ${({ width }) => width}px;
+  z-index: 10;
+  transform-origin: 0% 0%;
+  pointer-events: auto;
+  cursor: ${({ isDragging }) => (isDragging ? 'grabbing' : 'grab')};
+  opacity: ${({ opacity }) => opacity};
+  transform: translateX(calc(var(--scrub-offset, 0) * 1px));
+  transition: opacity 0.2s linear;
+`;
 
 export const DeleteButton = styled.button`
   display: flex;

--- a/assets/src/dashboard/app/views/storyAnimTool/timeline/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/timeline/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -25,6 +25,7 @@ import { v4 as uuidv4 } from 'uuid';
  * Internal dependencies
  */
 import { StoryPropType } from '../../../../types';
+import { clamp } from '../../../../utils';
 import { ANIMATION_TYPES, FIELD_TYPES } from '../../../../animations/constants';
 import { AnimationProps } from '../../../../animations/parts';
 import {
@@ -40,6 +41,8 @@ import {
   TimelineLabel,
   TimelineBarContainer,
   TimelineBar,
+  ScrubBarContainer,
+  ScrubBar,
 } from './components';
 
 function handleInputFocus(e) {
@@ -98,6 +101,7 @@ function renderFormField(name, type, value, options, onChange) {
 }
 
 const animationTypes = Object.values(ANIMATION_TYPES);
+const scrubBarWidth = 10;
 
 function Timeline({
   story,
@@ -109,7 +113,11 @@ function Timeline({
   onAnimationSelect,
   onAnimationDelete,
   onToggleTargetSelect,
+  emitGlobalTime,
+  canScrub,
 }) {
+  const scrubContainerRef = useRef(null);
+  const [isDragging, setIsDragging] = useState(false);
   const [formFields, setFormFields] = useState({});
 
   const { type: selectedAnimationType, props: animationProps } = useMemo(
@@ -145,6 +153,28 @@ function Timeline({
       ),
     [animations]
   );
+
+  useEffect(() => {
+    if (!(canScrub && isDragging && scrubContainerRef.current)) {
+      return () => {};
+    }
+    const containerBoundingBox = scrubContainerRef.current.getBoundingClientRect();
+    const handleMouseMove = (e) => {
+      const delta = clamp(e.clientX - containerBoundingBox.left, [
+        0,
+        containerBoundingBox.width - scrubBarWidth,
+      ]);
+      emitGlobalTime((delta / containerBoundingBox.width) * totalDuration);
+      scrubContainerRef.current.style.setProperty('--scrub-offset', delta);
+    };
+    const handleMouseUp = () => setIsDragging(false);
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging, emitGlobalTime, totalDuration, canScrub]);
 
   const handleAnimationSubmit = useCallback(
     (e) => {
@@ -295,6 +325,14 @@ function Timeline({
               </TimelineBarContainer>
             </TimelineAnimation>
           ))}
+          <ScrubBarContainer ref={scrubContainerRef}>
+            <ScrubBar
+              opacity={canScrub ? 1 : 0}
+              width={scrubBarWidth}
+              onMouseDown={() => setIsDragging(true)}
+              isDragging={isDragging}
+            />
+          </ScrubBarContainer>
         </AnimationList>
         <AnimationPanel>
           {Object.keys(formFields).length > 0 && (
@@ -353,6 +391,8 @@ Timeline.propTypes = {
   onAnimationSelect: PropTypes.func.isRequired,
   onAnimationDelete: PropTypes.func.isRequired,
   onToggleTargetSelect: PropTypes.func.isRequired,
+  emitGlobalTime: PropTypes.func,
+  canScrub: PropTypes.bool,
 };
 
 export default Timeline;

--- a/assets/src/dashboard/app/views/storyAnimTool/updateTemplateForm.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/updateTemplateForm.js
@@ -95,8 +95,8 @@ function UpdateTemplateForm({ story }) {
           <input
             id="animation"
             type="checkbox"
-            onClick={toggleIncludeAnimations}
-            checked={includeAnimations}
+            onChange={toggleIncludeAnimations}
+            defaultChecked={includeAnimations}
           />
         </div>
 
@@ -107,8 +107,8 @@ function UpdateTemplateForm({ story }) {
           <input
             id="auto-migrate"
             type="checkbox"
-            onClick={toggleAutoMigrateTemplate}
-            checked={autoMigrateTemplate}
+            onChange={toggleAutoMigrateTemplate}
+            defaultChecked={autoMigrateTemplate}
           />
         </div>
         <Submit type="submit" value="Log Story Data to Console" />

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -130,7 +130,7 @@ function CardGallery({ story }) {
           <ActiveCard {...metrics.activeCardSize}>
             <PreviewPage
               page={pages[activePageIndex]}
-              animationState={STORY_PAGE_STATE.ANIMATE}
+              animationState={STORY_PAGE_STATE.PLAY}
             />
           </ActiveCard>
         </UnitsProvider>

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -162,7 +162,7 @@ const CardPreviewContainer = ({
             page={storyPages[pageIndex]}
             animationState={
               CARD_STATE.ACTIVE === cardState
-                ? STORY_PAGE_STATE.PLAY
+                ? STORY_PAGE_STATE.PLAYING
                 : STORY_PAGE_STATE.RESET
             }
           />

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -162,8 +162,8 @@ const CardPreviewContainer = ({
             page={storyPages[pageIndex]}
             animationState={
               CARD_STATE.ACTIVE === cardState
-                ? STORY_PAGE_STATE.ANIMATE
-                : STORY_PAGE_STATE.IDLE
+                ? STORY_PAGE_STATE.PLAY
+                : STORY_PAGE_STATE.RESET
             }
           />
         </PreviewErrorBoundary>

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -33,20 +33,22 @@ function PreviewPageController({ page, animationState, subscribeGlobalTime }) {
   } = useStoryAnimationContext();
 
   useEffect(() => {
-    if (STORY_PAGE_STATE.PLAYING === animationState) {
-      WAAPIAnimationMethods.play();
+    switch (animationState) {
+      case STORY_PAGE_STATE.PLAYING:
+        WAAPIAnimationMethods.play();
+        return () => {};
+      case STORY_PAGE_STATE.RESET:
+        WAAPIAnimationMethods.reset();
+        return () => {};
+      case STORY_PAGE_STATE.SCRUBBING:
+        WAAPIAnimationMethods.pause();
+        return subscribeGlobalTime?.(WAAPIAnimationMethods.setCurrentTime);
+      case STORY_PAGE_STATE.PAUSED:
+        WAAPIAnimationMethods.pause();
+        return () => {};
+      default:
+        return () => {};
     }
-    if (STORY_PAGE_STATE.RESET === animationState) {
-      WAAPIAnimationMethods.reset();
-    }
-    if (STORY_PAGE_STATE.SCRUBBING === animationState) {
-      WAAPIAnimationMethods.pause();
-      return subscribeGlobalTime?.(WAAPIAnimationMethods.setCurrentTime);
-    }
-    if (STORY_PAGE_STATE.PAUSED === animationState) {
-      WAAPIAnimationMethods.pause();
-    }
-    return () => {};
   }, [animationState, WAAPIAnimationMethods, subscribeGlobalTime]);
 
   /**

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -27,26 +27,27 @@ import StoryPropTypes from '../../edit-story/types';
 import { STORY_PAGE_STATE } from '../constants';
 import StoryAnimation, { useStoryAnimationContext } from './storyAnimation';
 
-function PreviewPageController({ page, animationState, scrubSubscription }) {
+function PreviewPageController({ page, animationState, subscribeGlobalTime }) {
   const {
     actions: { WAAPIAnimationMethods },
   } = useStoryAnimationContext();
 
   useEffect(() => {
-    if (STORY_PAGE_STATE.PLAY === animationState) {
+    if (STORY_PAGE_STATE.PLAYING === animationState) {
       WAAPIAnimationMethods.play();
     }
     if (STORY_PAGE_STATE.RESET === animationState) {
       WAAPIAnimationMethods.reset();
     }
     if (STORY_PAGE_STATE.SCRUBBING === animationState) {
-      return scrubSubscription?.subscribe(WAAPIAnimationMethods.setCurrentTime);
+      WAAPIAnimationMethods.pause();
+      return subscribeGlobalTime?.(WAAPIAnimationMethods.setCurrentTime);
     }
     if (STORY_PAGE_STATE.PAUSED === animationState) {
       WAAPIAnimationMethods.pause();
     }
     return () => {};
-  }, [animationState, WAAPIAnimationMethods, scrubSubscription]);
+  }, [animationState, WAAPIAnimationMethods, subscribeGlobalTime]);
 
   /**
    * Reset everything on unmount;
@@ -65,9 +66,9 @@ function PreviewPageController({ page, animationState, scrubSubscription }) {
 
 function PreviewPage({
   page,
-  animationState = STORY_PAGE_STATE.PAUSED,
+  animationState = STORY_PAGE_STATE.RESET,
   onAnimationComplete,
-  scrubSubscription,
+  subscribeGlobalTime,
 }) {
   return (
     <StoryAnimation.Provider
@@ -78,7 +79,7 @@ function PreviewPage({
         page={page}
         animationState={animationState}
         onAnimationComplete={onAnimationComplete}
-        scrubSubscription={scrubSubscription}
+        subscribeGlobalTime={subscribeGlobalTime}
       />
     </StoryAnimation.Provider>
   );
@@ -88,7 +89,7 @@ PreviewPage.propTypes = {
   page: StoryPropTypes.page.isRequired,
   animationState: PropTypes.oneOf(Object.values(STORY_PAGE_STATE)),
   onAnimationComplete: PropTypes.func,
-  scrubSubscription: PropTypes.func,
+  subscribeGlobalTime: PropTypes.func,
 };
 
 export default PreviewPage;

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -27,19 +27,26 @@ import StoryPropTypes from '../../edit-story/types';
 import { STORY_PAGE_STATE } from '../constants';
 import StoryAnimation, { useStoryAnimationContext } from './storyAnimation';
 
-function PreviewPageController({ page, animationState }) {
+function PreviewPageController({ page, animationState, scrubSubscription }) {
   const {
     actions: { WAAPIAnimationMethods },
   } = useStoryAnimationContext();
 
   useEffect(() => {
-    if (STORY_PAGE_STATE.ANIMATE === animationState) {
+    if (STORY_PAGE_STATE.PLAY === animationState) {
       WAAPIAnimationMethods.play();
     }
-    if (STORY_PAGE_STATE.IDLE === animationState) {
+    if (STORY_PAGE_STATE.RESET === animationState) {
       WAAPIAnimationMethods.reset();
     }
-  }, [animationState, WAAPIAnimationMethods]);
+    if (STORY_PAGE_STATE.SCRUBBING === animationState) {
+      return scrubSubscription?.subscribe(WAAPIAnimationMethods.setCurrentTime);
+    }
+    if (STORY_PAGE_STATE.PAUSED === animationState) {
+      WAAPIAnimationMethods.pause();
+    }
+    return () => {};
+  }, [animationState, WAAPIAnimationMethods, scrubSubscription]);
 
   /**
    * Reset everything on unmount;
@@ -58,8 +65,9 @@ function PreviewPageController({ page, animationState }) {
 
 function PreviewPage({
   page,
-  animationState = STORY_PAGE_STATE.IDLE,
+  animationState = STORY_PAGE_STATE.PAUSED,
   onAnimationComplete,
+  scrubSubscription,
 }) {
   return (
     <StoryAnimation.Provider
@@ -70,6 +78,7 @@ function PreviewPage({
         page={page}
         animationState={animationState}
         onAnimationComplete={onAnimationComplete}
+        scrubSubscription={scrubSubscription}
       />
     </StoryAnimation.Provider>
   );
@@ -79,6 +88,7 @@ PreviewPage.propTypes = {
   page: StoryPropTypes.page.isRequired,
   animationState: PropTypes.oneOf(Object.values(STORY_PAGE_STATE)),
   onAnimationComplete: PropTypes.func,
+  scrubSubscription: PropTypes.func,
 };
 
 export default PreviewPage;

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -34,6 +34,7 @@ import { useFeature } from 'flagged';
  * Internal dependencies
  */
 import { AnimationPart, throughput } from '../../animations/parts';
+import { clamp } from '../../utils';
 
 const Context = createContext(null);
 
@@ -119,7 +120,10 @@ function Provider({ animations, children, onWAAPIFinish }) {
       WAAPIAnimations.forEach((animation) => {
         const { duration, delay } = animation.effect.timing;
         const animationEndTime = (delay || 0) + (duration || 0);
-        animation.currentTime = time === 'end' ? animationEndTime : time;
+        animation.currentTime =
+          time === 'end'
+            ? animationEndTime
+            : clamp(time, [0, animationEndTime]);
       });
 
     return {

--- a/assets/src/dashboard/components/storyAnimation/test/WAAPIWrapper.js
+++ b/assets/src/dashboard/components/storyAnimation/test/WAAPIWrapper.js
@@ -25,7 +25,8 @@ import { useFeature } from 'flagged';
  * Internal dependencies
  */
 import * as useStoryAnimationContext from '../useStoryAnimationContext';
-import StoryAnimation from '..';
+import Provider from '../provider';
+import WAAPIWrapper from '../WAAPIWrapper';
 
 describe('StoryAnimation.WAAPIWrapper', () => {
   useFeature.mockImplementation(() => true);
@@ -52,13 +53,13 @@ describe('StoryAnimation.WAAPIWrapper', () => {
     }));
 
     const { container } = render(
-      <StoryAnimation.Provider animations={[]}>
+      <Provider animations={[]}>
         <div data-testid="story-element-wrapper">
-          <StoryAnimation.WAAPIWrapper target="_">
+          <WAAPIWrapper target="_">
             <div data-testid="inner-content" />
-          </StoryAnimation.WAAPIWrapper>
+          </WAAPIWrapper>
         </div>
-      </StoryAnimation.Provider>
+      </Provider>
     );
 
     expect(container.firstChild).toMatchInlineSnapshot(`

--- a/assets/src/dashboard/components/storyAnimation/test/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/test/provider.js
@@ -204,7 +204,17 @@ describe('StoryAnimation.Provider', () => {
       const play = jest.fn();
       const pause = jest.fn();
       const animations = Array.from({ length: numCalls }, () => {
-        const animation = mockWAAPIAnimation({ play, pause, currentTime: 0 });
+        const animation = mockWAAPIAnimation({
+          play,
+          pause,
+          currentTime: 0,
+          effect: {
+            timing: {
+              duration: 300,
+              delay: 0,
+            },
+          },
+        });
         act(() => {
           result.current.actions.hoistWAAPIAnimation(animation);
         });
@@ -241,6 +251,12 @@ describe('StoryAnimation.Provider', () => {
           play: jest.fn(),
           pause: jest.fn(),
           currentTime: initialTime,
+          effect: {
+            timing: {
+              duration: 300,
+              delay: 0,
+            },
+          },
         })
       );
 

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -133,6 +133,8 @@ export const STORY_VIEWING_LABELS = {
 };
 
 export const STORY_PAGE_STATE = {
-  IDLE: 'idle',
-  ANIMATE: 'animate',
+  RESET: 'reset',
+  PAUSED: 'paused',
+  SCRUBBING: 'scrubbing',
+  PLAYING: 'playing',
 };

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -178,7 +178,7 @@ class Dashboard {
 					 * Issue: 1897
 					 * Creation date: 2020-05-21
 					 */
-					'enableAnimation'       => false,
+					'enableAnimation'       => true,
 					/**
 					 * Description: Enables in-progress views to be accessed.
 					 * Author: @carlos-kelly

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -178,7 +178,7 @@ class Dashboard {
 					 * Issue: 1897
 					 * Creation date: 2020-05-21
 					 */
-					'enableAnimation'       => true,
+					'enableAnimation'       => false,
 					/**
 					 * Description: Enables in-progress views to be accessed.
 					 * Author: @carlos-kelly


### PR DESCRIPTION
## Summary
This should just help us assess how animations are looking while we're building them

## Relevant Technical Choices
Just tried to get this working as quick as possible cus it's a temporary internal tool. So may be a little messy.

## To-do
NA

## User-facing changes
none

## Testing Instructions
Update `enableAnimation` feature flag to be true, then:

Go to `/story-anim-tool` and add animations to your story and use the animation method buttons: `play`, `pause`, `reset` & `scrub`

---

Fixes #
Helps all template animation tickets

## Screenshots
![scrub_functionality](https://user-images.githubusercontent.com/35983235/83810636-b5d15200-a675-11ea-8668-02211dd4d27e.gif)

