### PR TITLE
Nest page menu inside the canvas and support more return-to-canvas scenarios

### DIFF
--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -31,7 +31,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { useStory, useDropTargets } from '../../app';
 import withOverlay from '../overlay/withOverlay';
-import { Layer, PageArea } from './layout';
+import PageMenu from './pagemenu';
+import { Layer, MenuArea, PageArea } from './layout';
 import FrameElement from './frameElement';
 import Selection from './selection';
 import useCanvasKeys from './useCanvasKeys';
@@ -106,6 +107,13 @@ function FramesLayer() {
           })}
         <Selection />
       </FramesPageArea>
+      <MenuArea
+        pointerEvents="initial"
+        // Cancel lasso.
+        onMouseDown={(evt) => evt.stopPropagation()}
+      >
+        <PageMenu />
+      </MenuArea>
     </Layer>
   );
 }

--- a/assets/src/edit-story/components/canvas/karma/pageMenuActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/pageMenuActions.karma.js
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+import { useStory } from '../../../app/story';
+import { useInsertElement } from '../../../components/canvas';
+import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
+
+describe('PageMenu integration', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  describe('add a text', () => {
+    let element;
+
+    beforeEach(async () => {
+      const insertElement = await fixture.renderHook(() => useInsertElement());
+      element = await fixture.act(() =>
+        insertElement('text', {
+          font: TEXT_ELEMENT_DEFAULT_FONT,
+          content: 'hello world!',
+          x: 40,
+          y: 40,
+          width: 250,
+        })
+      );
+      // @todo: The focusing is currently done via timeout. Find a way to
+      // make this nicer.
+      const framesLayer = fixture.querySelector('[data-testid="FramesLayer"]');
+      await waitFor(() => {
+        if (!framesLayer.contains(document.activeElement)) {
+          throw new Error('Focus is not set on the canvas yet');
+        }
+      });
+    });
+
+    function getFrame() {
+      return fixture.querySelector(
+        `[data-element-id="${element.id}"] [data-testid="textFrame"]`
+      );
+    }
+
+    async function getSelection() {
+      const storyContext = await fixture.renderHook(() => useStory());
+      return storyContext.state.selectedElementIds;
+    }
+
+    it('should render initial content and make it selected', async () => {
+      expect(getFrame().textContent).toEqual('hello world!');
+      expect(await getSelection()).toEqual([element.id]);
+    });
+
+    describe('delete the element, restore, and delete again', () => {
+      it('using shortcuts', async () => {
+        // Delete.
+        await fixture.events.keyboard.shortcut('del');
+        expect(getFrame()).toBeNull();
+        expect(await getSelection()).toEqual([]);
+
+        // Restore.
+        await fixture.events.keyboard.shortcut('mod+z');
+        expect(getFrame()).toBeTruthy();
+        expect(await getSelection()).toEqual([element.id]);
+
+        // Delete again.
+        await fixture.events.keyboard.shortcut('del');
+        expect(getFrame()).toBeNull();
+        expect(await getSelection()).toEqual([]);
+      });
+
+      it('using page menu', async () => {
+        // Delete.
+        await fixture.events.keyboard.shortcut('del');
+        expect(getFrame()).toBeNull();
+        expect(await getSelection()).toEqual([]);
+
+        // Restore.
+        // @todo: Use either `workspace.pageMenu.undoButton` or
+        // `byRole('button', {name: 'Undo Changes'})` APIs.
+        const undoButton = fixture.querySelector(
+          'button[aria-label="Undo Changes"]'
+        );
+        await fixture.events.click(undoButton);
+        expect(getFrame()).toBeTruthy();
+        expect(await getSelection()).toEqual([element.id]);
+
+        // Delete again.
+        await fixture.events.keyboard.shortcut('del');
+        expect(getFrame()).toBeNull();
+        expect(await getSelection()).toEqual([]);
+      });
+    });
+  });
+});

--- a/assets/src/edit-story/components/canvas/navLayer.js
+++ b/assets/src/edit-story/components/canvas/navLayer.js
@@ -23,13 +23,11 @@ import { memo } from 'react';
  * Internal dependencies
  */
 import Header from '../header';
-import PageMenu from './pagemenu';
 import PageNav from './pagenav';
 import Carousel from './carousel';
 import {
   Layer,
   HeadArea,
-  MenuArea,
   NavPrevArea,
   NavNextArea,
   CarouselArea,
@@ -46,9 +44,6 @@ function NavLayer() {
       <HeadArea pointerEvents="initial">
         <Header />
       </HeadArea>
-      <MenuArea pointerEvents="initial">
-        <PageMenu />
-      </MenuArea>
       <NavPrevArea>
         <PageNav isNext={false} />
       </NavPrevArea>

--- a/assets/src/edit-story/components/canvas/useCanvasKeys.js
+++ b/assets/src/edit-story/components/canvas/useCanvasKeys.js
@@ -54,16 +54,15 @@ function useCanvasKeys(ref) {
 
     const doc = container.ownerDocument;
 
-    const handler = (evt) => {
-      if (!container.contains(evt.target)) {
-        // Make sure that no other component is trying to get the focus
-        // at this time.
-        setTimeout(() => {
-          if (doc.activeElement === doc.body) {
-            container.focus();
-          }
-        }, 300);
-      }
+    const handler = () => {
+      // Make sure that no other component is trying to get the focus
+      // at this time. We have to check all "focusout" events here because
+      // after DOM removal, the "focusout" events are all over the place.
+      setTimeout(() => {
+        if (doc.activeElement === doc.body) {
+          container.focus();
+        }
+      }, 300);
     };
     doc.addEventListener('focusout', handler, true);
     return () => {

--- a/assets/src/edit-story/karma/_init.js
+++ b/assets/src/edit-story/karma/_init.js
@@ -155,31 +155,25 @@ afterAll(() => {
 });
 
 beforeEach(() => {
-  rootEl = document.createElement('test-root');
-  rootEl.innerHTML = `
-    <style>
-      test-root, test-body {
-        display: block;
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        margin: 0;
-      }
-    </style>
-    <test-body>
-    </test-body>
-  `;
-  document.body.appendChild(rootEl);
-  const body = rootEl.querySelector('test-body');
+  // @todo: ideally we can find a way to use a new <body> for each test, but
+  // there are too many browser APIs to patch to make it consistent.
 
-  spyOnProperty(document, 'documentElement', 'get').and.returnValue(rootEl);
-  spyOnProperty(document, 'body', 'get').and.returnValue(body);
   // @todo: ideally we can find a way to use a new <head> for each test, but
   // styled-components uses some side-effect-y global constants to manage
   // the stylesheet state, e.g. `masterSheet`.
   // See https://github.com/styled-components/styled-components/blob/4add697ac770634300f7775fc880882b5497bdf4/packages/styled-components/src/models/StyleSheetManager.js#L25
+
+  rootEl = document.createElement('test-root');
+  rootEl.style.cssText = `
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+  `;
+  document.body.appendChild(rootEl);
 });
 
 afterEach(() => {

--- a/assets/src/edit-story/karma/fixture.js
+++ b/assets/src/edit-story/karma/fixture.js
@@ -166,10 +166,14 @@ export class Fixture {
    * @return {Promise} Yields when the editor rendering is complete.
    */
   render() {
+    const root = document.querySelector('test-root');
     const { container } = render(
       <FlagsProvider features={this._flags}>
         <App key={Math.random()} config={this._config} />
-      </FlagsProvider>
+      </FlagsProvider>,
+      {
+        container: root,
+      }
     );
     // The editor should always be given 100%:100% size. The testing-library
     // renders an extra container so it should be given the same size.
@@ -303,9 +307,10 @@ class ComponentStub {
       );
 
       return (
-        <HookExecutor key={refresher} hooks={hooks}>
+        <>
+          <HookExecutor key={refresher} hooks={hooks} />
           <Impl _wrapped={true} ref={ref} {...props} />
-        </HookExecutor>
+        </>
       );
     });
     Wrapper.displayName = `Mock(${
@@ -337,10 +342,12 @@ class ComponentStub {
   }
 }
 
-function HookExecutor({ hooks, children }) {
+/* eslint-disable react/prop-types, react/jsx-no-useless-fragment */
+function HookExecutor({ hooks }) {
   hooks.forEach((func) => func());
-  return children;
+  return <></>;
 }
+/* eslint-enable react/prop-types, react/jsx-no-useless-fragment */
 
 class APIProviderFixture {
   constructor() {

--- a/assets/src/edit-story/karma/fixtureEvents.js
+++ b/assets/src/edit-story/karma/fixtureEvents.js
@@ -142,7 +142,8 @@ class Keyboard {
       typeof arrayOrGenerator === 'function'
         ? arrayOrGenerator(this._events)
         : arrayOrGenerator;
-    return this._act(() => karmaPuppeteer.keyboard.seq(cleanupKeys(array)));
+    const keys = cleanupKeys(array);
+    return this._act(() => karmaPuppeteer.keyboard.seq(keys));
   }
 
   /**
@@ -478,7 +479,7 @@ function cleanupKey(key) {
     return isApple ? 'Meta' : 'Control';
   }
   if (upperKey === 'DEL') {
-    return isApple ? 'Delete' : 'Backspace';
+    return isApple ? 'Backspace' : 'Delete';
   }
   if (upperKey.length === 1 && /[A-Z]/.test(upperKey)) {
     return `Key${upperKey}`;


### PR DESCRIPTION
Fixes #1852

Possibly an alternative to #2189 for #1781 (TBD).

Two main changes:
1. I moved page menu inside the frames layer. I judged that the affinity of the page menu is closer to the canvas, e.g. comparing to carousel.
2. The focus trapping code is a bit more aggressive now. The main reason for that is that DOM removals often result in somewhat unstable "focusout" events.

Notes on tests:
1. I had to remove "faux" body from the test. It was nice to have it, but with focus work, too many DOM APIs would need to be patched to keep it up.
2. There's an added nuance on `waitFor` in the test. This is necessary because a lot of our focusing logic is timer based. I don't see a way around this yet.
3. I noticed that the `fixture.renderHook` was unmounting/remounting the components it was rendering the hook for. It's completely unnecessary (and likely harmful), so I fixed that here as well.