### PR TITLE
Remove unnecessary useCallback from useContextSelector

### DIFF
--- a/assets/src/edit-story/utils/context.js
+++ b/assets/src/edit-story/utils/context.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { shallowEqual } from 'react-pure-render';
-import { useCallback, useRef } from 'react';
+import { useRef } from 'react';
 import { useContextSelector as useContextSelectorOrig } from 'use-context-selector';
 
 export { createContext, useContext } from 'use-context-selector';
@@ -45,17 +45,14 @@ export const useContextSelector = (
 ) => {
   const ref = useRef();
 
-  const equalityFnCallback = useCallback(
-    (state) => {
-      const selected = selector(state);
-      if (equalityFn(ref.current, selected)) {
-        return ref.current;
-      }
-      ref.current = selected;
-      return selected;
-    },
-    [selector, equalityFn]
-  );
+  const equalityFnCallback = (state) => {
+    const selected = selector(state);
+    if (equalityFn(ref.current, selected)) {
+      return ref.current;
+    }
+    ref.current = selected;
+    return selected;
+  };
 
   // Update the selector fn to memoize the selected value by [equalityFn].
   const patchedSelector = equalityFn ? equalityFnCallback : selector;


### PR DESCRIPTION
## Summary

`useCallback` isn't needed at all, since `useContextSelector` uses the selector without re-rendering when the fn changes:
https://github.com/dai-shi/use-context-selector/blob/master/src/index.js#L69

Creating the `equalityFnCallback` lambda is cheap, as it only creates a temporary object to wrap `equalityFn` and selector.

See #1705.
Fixes #1938.
