### PR TITLE
Dashboard: Integrating amp-animations into a generated amp-story

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -24,7 +24,6 @@
 />
 
 <script async src="https://cdn.ampproject.org/v0.js"></script>
-<script async custom-element="amp-animation" src="https://cdn.ampproject.org/v0/amp-animation-0.1.js"></script>
 <script
   async
   custom-element="amp-story"

--- a/assets/src/dashboard/animations/outputs/animationOutput.js
+++ b/assets/src/dashboard/animations/outputs/animationOutput.js
@@ -22,19 +22,18 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { GeneralAnimationPropTypes } from './types';
+import { GeneralAnimationPropTypes, KeyframesPropTypes } from './types';
 
-function AnimationOutput({ animation, config }) {
+function AnimationOutput({ config }) {
   const configs = Array.isArray(config) ? config : [config];
 
   return (
-    <amp-story-animation layout="nodisplay">
+    <amp-story-animation layout="nodisplay" trigger="visibility">
       <script
         type="application/json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(
             configs.map((conf) => ({
-              animation,
               ...conf,
             }))
           ),
@@ -47,11 +46,11 @@ function AnimationOutput({ animation, config }) {
 const AnimationConfigPropTypes = PropTypes.shape({
   selector: PropTypes.string.isRequired,
   animation: PropTypes.string,
+  keyframes: KeyframesPropTypes,
   ...GeneralAnimationPropTypes,
 });
 
 AnimationOutput.propTypes = {
-  animation: PropTypes.string,
   config: PropTypes.oneOfType([
     AnimationConfigPropTypes,
     PropTypes.arrayOf(AnimationConfigPropTypes),

--- a/assets/src/dashboard/animations/outputs/types.js
+++ b/assets/src/dashboard/animations/outputs/types.js
@@ -35,6 +35,7 @@ export const GeneralAnimationPropTypes = {
   ]),
   duration: PropTypes.number,
   easing: PropTypes.string,
+  easingPreset: PropTypes.string,
   endDelay: PropTypes.number,
   fill: PropTypes.oneOf(['backwards', 'forwards', 'both', 'none']),
   iterationStart: PropTypes.number,

--- a/assets/src/dashboard/animations/parts/blinkOn/stories/index.js
+++ b/assets/src/dashboard/animations/parts/blinkOn/stories/index.js
@@ -78,7 +78,6 @@ export const AMPStory = () => {
       {[1, 2].map((pageId) => (
         <amp-story-page key={pageId} id={`page-${pageId}`}>
           <StoryAnimation.Provider animations={animations}>
-            <StoryAnimation.AMPKeyframes />
             <StoryAnimation.AMPAnimations />
 
             <amp-story-grid-layer template="horizontal">

--- a/assets/src/dashboard/animations/parts/bounce/stories/index.js
+++ b/assets/src/dashboard/animations/parts/bounce/stories/index.js
@@ -66,7 +66,6 @@ export const AMPStory = () => {
       {[1, 2].map((pageId) => (
         <amp-story-page key={pageId} id={`page-${pageId}`}>
           <StoryAnimation.Provider animations={animations}>
-            <StoryAnimation.AMPKeyframes />
             <StoryAnimation.AMPAnimations />
 
             <amp-story-grid-layer template="vertical">

--- a/assets/src/dashboard/animations/parts/components/fullSizeAbsolute.js
+++ b/assets/src/dashboard/animations/parts/components/fullSizeAbsolute.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * External dependencies
  */

--- a/assets/src/dashboard/animations/parts/fade/stories/index.js
+++ b/assets/src/dashboard/animations/parts/fade/stories/index.js
@@ -73,7 +73,6 @@ export const AMPStory = () => {
       {[1, 2].map((pageId) => (
         <amp-story-page key={pageId} id={`page-${pageId}`}>
           <StoryAnimation.Provider animations={animations}>
-            <StoryAnimation.AMPKeyframes />
             <StoryAnimation.AMPAnimations />
 
             <amp-story-grid-layer template="horizontal">

--- a/assets/src/dashboard/animations/parts/flip/stories/index.js
+++ b/assets/src/dashboard/animations/parts/flip/stories/index.js
@@ -101,7 +101,6 @@ export const AMPStory = () => {
       {[1, 2].map((pageId) => (
         <amp-story-page key={pageId} id={`page-${pageId}`}>
           <StoryAnimation.Provider animations={animations}>
-            <StoryAnimation.AMPKeyframes />
             <StoryAnimation.AMPAnimations />
 
             <amp-story-grid-layer template="vertical">

--- a/assets/src/dashboard/animations/parts/floatOn/stories/index.js
+++ b/assets/src/dashboard/animations/parts/floatOn/stories/index.js
@@ -97,7 +97,6 @@ export const AMPStory = () => {
       {[1, 2].map((pageId) => (
         <amp-story-page key={pageId} id={`page-${pageId}`}>
           <StoryAnimation.Provider animations={animations}>
-            <StoryAnimation.AMPKeyframes />
             <StoryAnimation.AMPAnimations />
 
             <amp-story-grid-layer template="vertical">

--- a/assets/src/dashboard/animations/parts/index.js
+++ b/assets/src/dashboard/animations/parts/index.js
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
 /**
  * Internal dependencies
  */
@@ -35,13 +41,21 @@ import moveProps from './move/animationProps';
 import spinProps from './spin/animationProps';
 import zoomProps from './zoom/animationProps';
 
+function EmptyAMPTarget({ children, ...rest }) {
+  return <div {...rest}>{children}</div>;
+}
+
+EmptyAMPTarget.propTypes = {
+  children: PropTypes.node,
+};
+
 export function throughput() {
   return {
     id: -1,
     generatedKeyframes: {},
     WAAPIAnimation: ({ children }) => children,
-    AMPTarget: ({ children }) => children,
-    AMPAnimation: () => {},
+    AMPTarget: EmptyAMPTarget,
+    AMPAnimation: () => null,
   };
 }
 

--- a/assets/src/dashboard/animations/parts/move/stories/index.js
+++ b/assets/src/dashboard/animations/parts/move/stories/index.js
@@ -88,7 +88,6 @@ export const AMPStory = () => {
       {[1, 2].map((pageId) => (
         <amp-story-page key={pageId} id={`page-${pageId}`}>
           <StoryAnimation.Provider animations={animations}>
-            <StoryAnimation.AMPKeyframes />
             <StoryAnimation.AMPAnimations />
             {elements.map(({ id, color, ...styles }) => (
               <StoryAnimation.AMPWrapper

--- a/assets/src/dashboard/animations/parts/simpleAnimation.js
+++ b/assets/src/dashboard/animations/parts/simpleAnimation.js
@@ -68,7 +68,7 @@ function SimpleAnimation(
 
   WAAPIAnimation.propTypes = WAAPIAnimationProps;
 
-  const AMPTarget = function ({ children, style }) {
+  const AMPTarget = function ({ children, style = {} }) {
     const options = useClippingContainer
       ? {
           useClippingContainer: useClippingContainer,
@@ -91,11 +91,10 @@ function SimpleAnimation(
 
   AMPTarget.propTypes = AMPAnimationProps;
 
-  const AMPAnimation = function ({ prefixId }) {
+  const AMPAnimation = function () {
     return (
       <AnimationOutput
-        animation={`${prefixId}-${animationName}`}
-        config={{ selector: `#anim-${id}`, ...timings }}
+        config={{ selector: `#anim-${id}`, keyframes, ...timings }}
       />
     );
   };

--- a/assets/src/dashboard/animations/parts/spin/stories/index.js
+++ b/assets/src/dashboard/animations/parts/spin/stories/index.js
@@ -134,7 +134,6 @@ export const AMPStory = () => {
       {[1, 2].map((pageId) => (
         <amp-story-page key={pageId} id={`page-${pageId}`}>
           <StoryAnimation.Provider animations={animations}>
-            <StoryAnimation.AMPKeyframes />
             <StoryAnimation.AMPAnimations />
             <amp-story-grid-layer template="vertical">
               {elements.map(({ id, color }) => (

--- a/assets/src/dashboard/animations/parts/types.js
+++ b/assets/src/dashboard/animations/parts/types.js
@@ -13,10 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * External dependencies
  */
 import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { ANIMATION_TYPES } from '../constants';
+import { GeneralAnimationPropTypes } from '../outputs/types';
 
 export const WAAPIAnimationProps = {
   children: PropTypes.node.isRequired,
@@ -24,7 +31,15 @@ export const WAAPIAnimationProps = {
 };
 
 export const AMPAnimationProps = {
+  className: PropTypes.string,
   children: PropTypes.node,
   style: PropTypes.object,
   prefixId: PropTypes.string,
+};
+
+export const AnimationProps = {
+  id: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(Object.values(ANIMATION_TYPES)),
+  targets: PropTypes.arrayOf(PropTypes.string),
+  ...GeneralAnimationPropTypes,
 };

--- a/assets/src/dashboard/animations/parts/zoom/stories/index.js
+++ b/assets/src/dashboard/animations/parts/zoom/stories/index.js
@@ -95,7 +95,6 @@ export const AMPStory = () => {
       {[1, 2].map((pageId) => (
         <amp-story-page key={pageId} id={`page-${pageId}`}>
           <StoryAnimation.Provider animations={animations}>
-            <StoryAnimation.AMPKeyframes />
             <StoryAnimation.AMPAnimations />
 
             <amp-story-grid-layer template="vertical">

--- a/assets/src/dashboard/components/storyAnimation/AMPWrapper.js
+++ b/assets/src/dashboard/components/storyAnimation/AMPWrapper.js
@@ -25,7 +25,17 @@ import PropTypes from 'prop-types';
  */
 import useStoryAnimationContext from './useStoryAnimationContext';
 
-function ComposableWrapper({ animationParts, children, style }) {
+const fullSizeAbsoluteStyles = {
+  width: '100%',
+  height: '100%',
+  display: 'block',
+  position: 'absolute',
+  pointerEvents: 'none',
+  top: 0,
+  left: 0,
+};
+
+function ComposableWrapper({ animationParts, children }) {
   const ComposedWrapper = useMemo(
     () =>
       animationParts.reduce(
@@ -34,7 +44,9 @@ function ComposableWrapper({ animationParts, children, style }) {
           const Composed = function (props) {
             return (
               <Composable>
-                <AMPTarget style={style}>{props.children}</AMPTarget>
+                <AMPTarget style={fullSizeAbsoluteStyles}>
+                  {props.children}
+                </AMPTarget>
               </Composable>
             );
           };
@@ -43,7 +55,7 @@ function ComposableWrapper({ animationParts, children, style }) {
         },
         (props) => props.children
       ),
-    [animationParts, style]
+    [animationParts]
   );
 
   return <ComposedWrapper>{children}</ComposedWrapper>;
@@ -52,16 +64,15 @@ function ComposableWrapper({ animationParts, children, style }) {
 ComposableWrapper.propTypes = {
   animationParts: PropTypes.arrayOf(PropTypes.object),
   children: PropTypes.node.isRequired,
-  style: PropTypes.object,
 };
 
-function AMPWrapper({ target, children, style }) {
+function AMPWrapper({ target, children }) {
   const {
     actions: { getAnimationParts },
   } = useStoryAnimationContext();
 
   return (
-    <ComposableWrapper style={style} animationParts={getAnimationParts(target)}>
+    <ComposableWrapper animationParts={getAnimationParts(target)}>
       {children}
     </ComposableWrapper>
   );
@@ -70,7 +81,6 @@ function AMPWrapper({ target, children, style }) {
 AMPWrapper.propTypes = {
   target: PropTypes.string,
   children: PropTypes.node,
-  style: PropTypes.object,
 };
 
 export default AMPWrapper;

--- a/assets/src/dashboard/components/storyAnimation/AMPWrapper.js
+++ b/assets/src/dashboard/components/storyAnimation/AMPWrapper.js
@@ -30,7 +30,6 @@ const fullSizeAbsoluteStyles = {
   height: '100%',
   display: 'block',
   position: 'absolute',
-  pointerEvents: 'none',
   top: 0,
   left: 0,
 };

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -34,6 +34,7 @@ import { useFeature } from 'flagged';
  * Internal dependencies
  */
 import { AnimationPart, throughput } from '../../animations/parts';
+import { AnimationProps } from '../../animations/parts/types';
 import { clamp } from '../../utils';
 
 const Context = createContext(null);
@@ -196,7 +197,7 @@ function Provider({ animations, children, onWAAPIFinish }) {
 }
 
 Provider.propTypes = {
-  animations: PropTypes.arrayOf(PropTypes.object),
+  animations: PropTypes.arrayOf(PropTypes.shape(AnimationProps)),
   children: PropTypes.node.isRequired,
   onWAAPIFinish: PropTypes.func,
 };

--- a/assets/src/edit-story/output/element.js
+++ b/assets/src/edit-story/output/element.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import StoryAnimation from '../../dashboard/components/storyAnimation';
 import StoryPropTypes from '../types';
 import WithMask from '../masks/output';
 import { getDefinitionForType } from '../elements';
@@ -25,7 +26,6 @@ import WithLink from '../components/link/output';
 
 function OutputElement({ element }) {
   const { id, opacity, type } = element;
-
   const { Output } = getDefinitionForType(type);
 
   // Box is calculated based on the 100%:100% basis for width and height
@@ -33,12 +33,10 @@ function OutputElement({ element }) {
   const { x, y, width, height, rotationAngle } = box;
 
   return (
-    <WithMask
-      element={element}
-      box={box}
-      id={'el-' + id}
-      className="wrapper"
+    <div
       style={{
+        position: 'absolute',
+        pointerEvents: 'none',
         left: `${x}%`,
         top: `${y}%`,
         width: `${width}%`,
@@ -46,22 +44,40 @@ function OutputElement({ element }) {
         transform: rotationAngle ? `rotate(${rotationAngle}deg)` : null,
         opacity: opacity ? opacity / 100 : null,
       }}
-      skipDefaultMask
     >
-      <WithLink
-        element={element}
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'block',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-        }}
-      >
-        <Output element={element} box={box} />
-      </WithLink>
-    </WithMask>
+      <StoryAnimation.AMPWrapper target={id}>
+        <WithMask
+          className="mask"
+          element={element}
+          box={box}
+          id={'el-' + id}
+          style={{
+            pointerEvents: 'initial',
+            width: '100%',
+            height: '100%',
+            display: 'block',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+          }}
+          skipDefaultMask
+        >
+          <WithLink
+            element={element}
+            style={{
+              width: '100%',
+              height: '100%',
+              display: 'block',
+              position: 'absolute',
+              top: 0,
+              left: 0,
+            }}
+          >
+            <Output element={element} box={box} />
+          </WithLink>
+        </WithMask>
+      </StoryAnimation.AMPWrapper>
+    </div>
   );
 }
 

--- a/assets/src/edit-story/output/page.js
+++ b/assets/src/edit-story/output/page.js
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import StoryAnimation from '../../dashboard/components/storyAnimation';
 import StoryPropTypes from '../types';
 import { PAGE_WIDTH, PAGE_HEIGHT } from '../constants';
 import generatePatternStyles from '../utils/generatePatternStyles';
@@ -31,7 +32,7 @@ import getLongestMediaElement from './utils/getLongestMediaElement';
 const ASPECT_RATIO = `${PAGE_WIDTH}:${PAGE_HEIGHT}`;
 
 function OutputPage({ page, autoAdvance, defaultPageDuration }) {
-  const { id, elements, backgroundColor } = page;
+  const { id, animations, elements, backgroundColor } = page;
   const backgroundStyles = {
     backgroundColor: 'white',
     ...generatePatternStyles(backgroundColor),
@@ -48,33 +49,37 @@ function OutputPage({ page, autoAdvance, defaultPageDuration }) {
       id={id}
       auto-advance-after={autoAdvance ? autoAdvanceAfter : undefined}
     >
-      {backgroundElement && (
+      <StoryAnimation.Provider animations={animations}>
+        <StoryAnimation.AMPAnimations />
+
+        {backgroundElement && (
+          <amp-story-grid-layer template="vertical" aspect-ratio={ASPECT_RATIO}>
+            <div className="page-fullbleed-area" style={backgroundStyles}>
+              <div className="page-safe-area">
+                <OutputElement element={backgroundElement} />
+                {backgroundElement.backgroundOverlay && (
+                  <div
+                    className="page-background-overlay-area"
+                    style={generatePatternStyles(
+                      backgroundElement.backgroundOverlay
+                    )}
+                  />
+                )}
+              </div>
+            </div>
+          </amp-story-grid-layer>
+        )}
+
         <amp-story-grid-layer template="vertical" aspect-ratio={ASPECT_RATIO}>
-          <div className="page-fullbleed-area" style={backgroundStyles}>
+          <div className="page-fullbleed-area">
             <div className="page-safe-area">
-              <OutputElement element={backgroundElement} />
-              {backgroundElement.backgroundOverlay && (
-                <div
-                  className="page-background-overlay-area"
-                  style={generatePatternStyles(
-                    backgroundElement.backgroundOverlay
-                  )}
-                />
-              )}
+              {regularElements.map((element) => (
+                <OutputElement key={'el-' + element.id} element={element} />
+              ))}
             </div>
           </div>
         </amp-story-grid-layer>
-      )}
-
-      <amp-story-grid-layer template="vertical" aspect-ratio={ASPECT_RATIO}>
-        <div className="page-fullbleed-area">
-          <div className="page-safe-area">
-            {regularElements.map((element) => (
-              <OutputElement key={'el-' + element.id} element={element} />
-            ))}
-          </div>
-        </div>
-      </amp-story-grid-layer>
+      </StoryAnimation.Provider>
     </amp-story-page>
   );
 }

--- a/assets/src/edit-story/output/story.js
+++ b/assets/src/edit-story/output/story.js
@@ -36,6 +36,7 @@ function OutputStory({
 }) {
   const ampExtensions = getUsedAmpExtensions(pages);
   const fontDeclarations = getFontDeclarations(pages);
+
   return (
     <html amp="" lang="en">
       <head>

--- a/assets/src/edit-story/output/test/page.js
+++ b/assets/src/edit-story/output/test/page.js
@@ -22,11 +22,21 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+jest.mock('flagged');
+import { useFeature } from 'flagged';
 import PageOutput from '../page';
 import { queryByAutoAdvanceAfter, queryById } from '../../testUtils';
 import { PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
 
 describe('Page output', () => {
+  useFeature.mockImplementation((feature) => {
+    const config = {
+      enableAnimation: true,
+    };
+
+    return config[feature];
+  });
+
   describe('aspect-ratio markup', () => {
     let backgroundElement;
 
@@ -135,6 +145,83 @@ describe('Page output', () => {
         '.page-background-overlay-area'
       );
       expect(overlayLayer).toBeInTheDocument();
+    });
+  });
+
+  describe('animation markup', () => {
+    it('should render animation tags for animations', () => {
+      const props = {
+        id: '123',
+        backgroundColor: { type: 'solid', color: { r: 255, g: 255, b: 255 } },
+        page: {
+          id: '123',
+          animations: [
+            { targets: ['123', '124'], type: 'bounce', duration: 1000 },
+            { targets: ['123'], type: 'spin', duration: 1000 },
+          ],
+          elements: [
+            {
+              id: '123',
+              type: 'video',
+              mimeType: 'video/mp4',
+              scale: 1,
+              origRatio: 9 / 16,
+              x: 50,
+              y: 100,
+              height: 1920,
+              width: 1080,
+              rotationAngle: 0,
+              loop: true,
+              resource: {
+                type: 'video',
+                mimeType: 'video/mp4',
+                id: 123,
+                src: 'https://example.com/image.png',
+                poster: 'https://example.com/poster.png',
+                height: 1920,
+                width: 1080,
+                length: 99,
+              },
+            },
+            {
+              id: '124',
+              type: 'shape',
+              opacity: 100,
+              flip: {
+                vertical: false,
+                horizontal: false,
+              },
+              rotationAngle: 0,
+              lockAspectRatio: true,
+              backgroundColor: {
+                color: {
+                  r: 51,
+                  g: 51,
+                  b: 51,
+                },
+              },
+              x: 249,
+              y: 67,
+              width: 147,
+              height: 147,
+              scale: 100,
+              focalX: 50,
+              focalY: 50,
+              mask: {
+                type: 'circle',
+              },
+            },
+          ],
+        },
+        autoAdvance: true,
+        defaultPageDuration: 11,
+      };
+
+      const { container } = render(<PageOutput {...props} />);
+
+      const storyAnimations = container.querySelectorAll('amp-story-animation');
+      expect(storyAnimations).toHaveLength(3);
+      expect(storyAnimations[0]).toHaveAttribute('trigger', `visibility`);
     });
   });
 
@@ -376,6 +463,42 @@ describe('Page output', () => {
                   height: 1920,
                   width: 1080,
                   length: 99,
+                },
+              },
+            ],
+          },
+          autoAdvance: true,
+          defaultPageDuration: 11,
+        };
+
+        await expect(<PageOutput {...props} />).toBeValidAMPStoryPage();
+      });
+
+      it('should produce valid output with animations', async () => {
+        const props = {
+          id: '123',
+          backgroundColor: { type: 'solid', color: { r: 255, g: 255, b: 255 } },
+          page: {
+            id: '123',
+            animations: [{ targets: ['123'], type: 'bounce', duration: 1000 }],
+            elements: [
+              {
+                type: 'text',
+                id: '123',
+                x: 50,
+                y: 100,
+                height: 1920,
+                width: 1080,
+                rotationAngle: 0,
+                content: 'Hello World',
+                color: { type: 'solid', color: { r: 255, g: 255, b: 255 } },
+                padding: {
+                  horizontal: 0,
+                  vertical: 0,
+                },
+                font: {
+                  family: 'Roboto',
+                  service: 'fonts.google.com',
                 },
               },
             ],

--- a/assets/src/edit-story/output/test/story.js
+++ b/assets/src/edit-story/output/test/story.js
@@ -17,6 +17,8 @@
 /**
  * External dependencies
  */
+jest.mock('flagged');
+import { useFeature } from 'flagged';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 /**
@@ -25,6 +27,14 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import StoryOutput from '../story';
 
 describe('Story output', () => {
+  useFeature.mockImplementation((feature) => {
+    const config = {
+      enableAnimation: true,
+    };
+
+    return config[feature];
+  });
+
   it('should include Google Fonts stylesheet', () => {
     const props = {
       id: '123',
@@ -46,6 +56,10 @@ describe('Story output', () => {
       pages: [
         {
           id: '123',
+          animations: [
+            { targets: ['123'], type: 'bounce', duration: 1000 },
+            { targets: ['124'], type: 'spin', duration: 500 },
+          ],
           backgroundColor: {
             type: 'solid',
             color: { r: 255, g: 255, b: 255 },
@@ -80,7 +94,7 @@ describe('Story output', () => {
             },
             {
               type: 'text',
-              id: '123',
+              id: '124',
               x: 50,
               y: 100,
               height: 1920,
@@ -220,6 +234,71 @@ describe('Story output', () => {
         pages: [
           {
             id: '123',
+            backgroundColor: {
+              type: 'solid',
+              color: { r: 255, g: 255, b: 255 },
+            },
+            page: {
+              id: '123',
+            },
+            elements: [
+              {
+                type: 'text',
+                id: '123',
+                x: 50,
+                y: 100,
+                height: 1920,
+                width: 1080,
+                rotationAngle: 0,
+                content: 'Hello World',
+                color: { type: 'solid', color: { r: 255, g: 255, b: 255 } },
+                padding: {
+                  horizontal: 0,
+                  vertical: 0,
+                },
+                font: {
+                  family: 'Roboto',
+                  service: 'fonts.google.com',
+                },
+              },
+            ],
+          },
+        ],
+        metadata: {
+          publisher: {
+            name: 'Publisher Name',
+            logo: 'https://example.com/logo.png',
+          },
+          fallbackPoster: 'https://example.com/logo.png',
+          logoPlaceholder: 'https://example.com/logo.png',
+        },
+      };
+
+      await expect(<StoryOutput {...props} />).toBeValidAMP();
+    });
+
+    it('should produce valid AMP output when using animations', async () => {
+      const props = {
+        id: '123',
+        backgroundColor: { type: 'solid', color: { r: 255, g: 255, b: 255 } },
+        story: {
+          title: 'Example',
+          slug: 'example',
+          status: 'publish',
+          author: 123,
+          date: '123',
+          modified: '123',
+          excerpt: '123',
+          featuredMedia: 123,
+          publisherLogoUrl: 'https://example.com/logo.png',
+          password: '123',
+          link: 'https://example.com/story',
+          autoAdvance: false,
+        },
+        pages: [
+          {
+            id: '123',
+            animations: [{ targets: ['123'], type: 'bounce', duration: 1000 }],
             backgroundColor: {
               type: 'solid',
               color: { r: 255, g: 255, b: 255 },

--- a/assets/src/edit-story/output/utils/getStoryMarkup.js
+++ b/assets/src/edit-story/output/utils/getStoryMarkup.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { renderToStaticMarkup } from 'react-dom/server';
+import { FlagsProvider } from 'flagged';
 
 /**
  * Internal dependencies
@@ -33,7 +34,11 @@ import OutputStory from '../story';
  * @return {string} Story markup.
  */
 export default function getStoryMarkup(story, pages, metadata) {
+  const { flags } = window.webStoriesEditorSettings;
+
   return renderToStaticMarkup(
-    <OutputStory story={story} pages={pages} metadata={metadata} />
+    <FlagsProvider features={flags}>
+      <OutputStory story={story} pages={pages} metadata={metadata} />
+    </FlagsProvider>
   );
 }

--- a/assets/src/edit-story/output/utils/styles.js
+++ b/assets/src/edit-story/output/utils/styles.js
@@ -53,7 +53,7 @@ function CustomStyles() {
                 margin: auto 0;
               }
 
-              .wrapper {
+              .mask {
                 position: absolute;
                 overflow: hidden;
               }

--- a/assets/src/edit-story/output/utils/test/getStoryMarkup.js
+++ b/assets/src/edit-story/output/utils/test/getStoryMarkup.js
@@ -15,11 +15,20 @@
  */
 
 /**
+ * External dependencies
+ */
+jest.mock('flagged');
+import { useFeature, FlagsProvider } from 'flagged';
+
+/**
  * Internal dependencies
  */
 import getStoryMarkup from '../getStoryMarkup';
 
 describe('getStoryMarkup', () => {
+  useFeature.mockImplementation(() => true);
+  FlagsProvider.mockImplementation(({ children }) => children);
+
   it('should generate expected story markup', () => {
     const story = {
       storyId: 1,
@@ -49,6 +58,10 @@ describe('getStoryMarkup', () => {
       {
         type: 'page',
         id: '2',
+        animations: [
+          { targets: ['2'], type: 'bounce', duration: 1000 },
+          { targets: ['2'], type: 'spin', duration: 1000 },
+        ],
         elements: [
           {
             id: '2',
@@ -88,5 +101,7 @@ describe('getStoryMarkup', () => {
     expect(markup).toContain(
       'poster-portrait-src="https://example.com/fallback-poster.jpg"'
     );
+
+    expect(markup).toContain('<amp-story-animation');
   });
 });

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import { AnimationProps } from '../dashboard/animations/parts/types';
 import { OverlayType } from './utils/backgroundOverlay';
 import { BACKGROUND_TEXT_MODE } from './constants';
 import MULTIPLE_VALUE from './components/form/multipleValue';
@@ -101,6 +102,7 @@ StoryPropTypes.box = PropTypes.exact({
 
 StoryPropTypes.page = PropTypes.shape({
   id: PropTypes.string.isRequired,
+  animations: PropTypes.arrayOf(PropTypes.shape(AnimationProps)),
   elements: PropTypes.arrayOf(PropTypes.shape(StoryPropTypes.element)),
   backgroundOverlay: PropTypes.oneOf(Object.values(OverlayType)),
 });

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -366,6 +366,13 @@ class Story_Post_Type {
 			],
 			'flags'  => [
 				/**
+				 * Description: Enables user facing animations.
+				 * Author: @mariano-formidable
+				 * Issue: 1903
+				 * Creation date: 2020-06-08
+				 */
+				'enableAnimation'              => false,
+				/**
 				 * Description: Flag for hover dropdown menu for media element in media library.
 				 * Author: @joannag6
 				 * Issue: #1319 and #354


### PR DESCRIPTION
## Summary

This PR updates the `amp-story` generation logic to include AMP animations if the `edit-story` feature flag `enableAnimation` is set to true.

## To-do

I had to `skip` a couple of the _new_ tests I wrote because they're using `toBeValidAMP` to assert that the generated story is valid, but the validation check fails because we're using `amp-animation` tags in our generated html.  The stories do animation correctly so I'm not sure if we should be using another tag or if the `toBeValidAMP` logic needs to be updated (since amp-animations in amp-stories is a new feature).  Once we figure out what's what, I can go back and update these tests (and our logic) so everything passes.

## User-facing changes

Technically nothing should change, a generated story without animations should generate the same, but because this touches story generation logic this should definitely be QA'd.

## Testing Instructions

**Testing stories without animations**

1.) Edit an existing story, or make a brand new story (and add elements to it).
2.) Click the "Preview" button.
3.) This should open up a window with the generated story and the pages should look just how they looked in the editor.

**Testing stories with animations**

1.) Go to `Story_Post_type.php` and set `enableAnimation` to `true` (and refresh the app).
2.) Go to the animation UI tool (url: `/wp-admin/edit.php?post_type=web-story&page=stories-dashboard#/story-anim-tool`).  
3.) Follow the instructions found [here](https://github.com/google/web-stories-wp/pull/1765) to add an animation to an existing story in your repo.
4.) Go to the dashboard and find that story you edited and open it up in the editor.
5.) Click on "Preview".
6.) The elements you applied animations too should animate appropriately in the preview window.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1903

## Screenshots

Simple story generated with `enableAnimations` set to `false`:
![no_animations](https://user-images.githubusercontent.com/40646372/84178971-22fc3300-aa3a-11ea-96a1-454c444d38e3.gif)

Same story generated with `enableAnimations` set to `true`:
![yes_animation](https://user-images.githubusercontent.com/40646372/84179177-6bb3ec00-aa3a-11ea-8f58-4950858bc16e.gif)
