### PR TITLE
Steal focus from _some_ pointer-activated buttons

### DIFF
--- a/assets/src/edit-story/components/library/libraryProvider.js
+++ b/assets/src/edit-story/components/library/libraryProvider.js
@@ -18,12 +18,13 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 /**
  * Internal dependencies
  */
 import { useInsertElement } from '../canvas';
+import isPointerClickEvent from '../../utils/isPointerClickEvent';
 import Context from './context';
 
 const MEDIA = 'media';
@@ -41,8 +42,15 @@ const TABS = {
 };
 
 function LibraryProvider({ children }) {
-  const [tab, setTab] = useState(MEDIA);
+  const [tab, setTabState] = useState(MEDIA);
   const insertElement = useInsertElement();
+
+  const setTab = useCallback((tabId, evt) => {
+    setTabState(tabId);
+    if (evt && isPointerClickEvent(evt)) {
+      evt.currentTarget.blur();
+    }
+  }, []);
 
   const state = useMemo(
     () => ({
@@ -57,7 +65,7 @@ function LibraryProvider({ children }) {
         tabs: TABS,
       },
     }),
-    [tab, insertElement]
+    [tab, insertElement, setTab]
   );
 
   return <Context.Provider value={state}>{children}</Context.Provider>;

--- a/assets/src/edit-story/components/library/libraryProvider.js
+++ b/assets/src/edit-story/components/library/libraryProvider.js
@@ -24,7 +24,7 @@ import { useCallback, useMemo, useState } from 'react';
  * Internal dependencies
  */
 import { useInsertElement } from '../canvas';
-import isPointerClickEvent from '../../utils/isPointerClickEvent';
+import { blurOnPointerClick } from '../../utils/clickEvent';
 import Context from './context';
 
 const MEDIA = 'media';
@@ -47,8 +47,8 @@ function LibraryProvider({ children }) {
 
   const setTab = useCallback((tabId, evt) => {
     setTabState(tabId);
-    if (evt && isPointerClickEvent(evt)) {
-      evt.currentTarget.blur();
+    if (evt) {
+      blurOnPointerClick(evt);
     }
   }, []);
 

--- a/assets/src/edit-story/components/library/libraryTabs.js
+++ b/assets/src/edit-story/components/library/libraryTabs.js
@@ -68,7 +68,7 @@ function LibraryTabs() {
           key={id}
           id={getTabId(id)}
           isActive={tab === id}
-          onClick={() => setTab(id)}
+          onClick={(evt) => setTab(id, evt)}
         />
       ))}
     </Tabs>

--- a/assets/src/edit-story/utils/clickEvent.js
+++ b/assets/src/edit-story/utils/clickEvent.js
@@ -15,12 +15,23 @@
  */
 
 /**
- * @param {ClickEvent} evt
+ * @param {Event} evt
  * @return {boolean} True means that this event is triggered by a pointer, and
  * false means the click was triggered by the keyboard.
  */
-function isPointerClickEvent(evt) {
+export function isPointerClickEvent(evt) {
   return evt.detail > 0;
 }
 
-export default isPointerClickEvent;
+/**
+ * @param {Event} evt
+ */
+export function blurOnPointerClick(evt) {
+  if (
+    evt &&
+    isPointerClickEvent(evt) &&
+    document.activeElement === evt.currentTarget
+  ) {
+    evt.currentTarget.blur();
+  }
+}

--- a/assets/src/edit-story/utils/isPointerClickEvent.js
+++ b/assets/src/edit-story/utils/isPointerClickEvent.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @param {ClickEvent} evt
+ * @return {boolean} True means that this event is triggered by a pointer, and
+ * false means the click was triggered by the keyboard.
+ */
+function isPointerClickEvent(evt) {
+  return evt.detail > 0;
+}
+
+export default isPointerClickEvent;


### PR DESCRIPTION
## Summary

A follow up on #2261. A possible alternative to #2189 for #1781 (TBD).

## Relevant Technical Choices

This pull request proposes to auto-blur buttons activated by a pointer, such as a mouse or a touch. The behavior for keyboard activations is unchanged.

This feature can be considered as an extension of keyboard-only-outlines feature. E.g. "if we are not willing to highlight focus on pointer events, then maybe we shouldn't move focus"

Key notes:
- This works by blurring the clicked button if event is determined to have come from a pointer. Once a button is blurred, our `useCanvasKey` catches the "focusout" and returns focus back to the canvas.
- I confirmed on all browsers that `isPointerClickEvent` works as expected. Slightly under-documented feature, but it flows logically from the definition of the `ClickEvent.detail`.
- We would not immediately apply it to all possible buttons, but will instead move in groups: library tabs, design panel toggles, etc. But to a big extent it is a case-by-case/group-by-group decision.

## To-do

- [ ] Discuss and confirm this approach
- [ ] Support more buttons
- [ ] Add unit tests
- [ ] Add Karma tests

## User-facing changes

The most noticeable change to a user would click a button and then press <kbd>tab</kbd>. However, this would seem to be an outlier for user expectations.

## Testing Instructions

See #1781.

---

Fixes #1781
