### PR TITLE
Fix keyboard navigation on library tabs

### DIFF
--- a/assets/src/edit-story/components/library/karma/libraryTabs.karma.js
+++ b/assets/src/edit-story/components/library/karma/libraryTabs.karma.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+
+describe('LibraryTabs integration', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  describe('keyboad navigation', () => {
+    beforeEach(async () => {
+      const textTab = fixture.container.querySelector('#library-tab-media');
+      await fixture.events.focus(textTab);
+    });
+
+    it('should be on the media tab', async () => {
+      await fixture.waitOnScreen(
+        fixture.container.querySelector('#library-pane-media')
+      );
+      await fixture.snapshot();
+    });
+
+    fit('should switch tabs on left and right keys', async () => {
+      await fixture.events.keyboard.press('ArrowRight');
+
+      // @todo: what's the best way to confirm switching of a tab?
+      await fixture.waitOnScreen(
+        fixture.container.querySelector('#library-pane-text')
+      );
+      await fixture.snapshot('on text pane');
+
+      await fixture.events.keyboard.press('ArrowRight');
+
+      await fixture.waitOnScreen(
+        fixture.container.querySelector('#library-pane-shapes')
+      );
+      await fixture.snapshot('on text pane');
+
+      await fixture.events.keyboard.press('ArrowLeft');
+
+      await fixture.waitOnScreen(
+        fixture.container.querySelector('#library-pane-text')
+      );
+
+      await fixture.events.keyboard.press('ArrowLeft');
+      await fixture.waitOnScreen(
+        fixture.container.querySelector('#library-pane-media')
+      );
+    });
+  });
+});

--- a/assets/src/edit-story/components/library/karma/libraryTabs.karma.js
+++ b/assets/src/edit-story/components/library/karma/libraryTabs.karma.js
@@ -21,10 +21,14 @@ import { Fixture } from '../../../karma';
 
 describe('LibraryTabs integration', () => {
   let fixture;
+  let libraryLayout;
 
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    libraryLayout = fixture.container.querySelector(
+      '[data-testid="libraryLayout"]'
+    );
   });
 
   afterEach(() => {
@@ -37,39 +41,49 @@ describe('LibraryTabs integration', () => {
       await fixture.events.focus(textTab);
     });
 
-    it('should be on the media tab', async () => {
-      await fixture.waitOnScreen(
-        fixture.container.querySelector('#library-pane-media')
+    function getExpandedPanes() {
+      return Array.from(
+        libraryLayout.querySelectorAll('[aria-expanded="true"]')
       );
+    }
+
+    it('should be on the media tab', async () => {
+      const mediaPane = fixture.container.querySelector('#library-pane-media');
+      expect(getExpandedPanes()).toEqual([mediaPane]);
+      await fixture.waitOnScreen(mediaPane);
       await fixture.snapshot();
     });
 
-    fit('should switch tabs on left and right keys', async () => {
+    it('should switch tabs on left and right keys', async () => {
+      // Next: text pane.
       await fixture.events.keyboard.press('ArrowRight');
-
       // @todo: what's the best way to confirm switching of a tab?
-      await fixture.waitOnScreen(
-        fixture.container.querySelector('#library-pane-text')
-      );
+      const textPane = fixture.container.querySelector('#library-pane-text');
+      expect(getExpandedPanes()).toEqual([textPane]);
+      await fixture.waitOnScreen(textPane);
       await fixture.snapshot('on text pane');
 
+      // Next: shapes pane.
       await fixture.events.keyboard.press('ArrowRight');
-
-      await fixture.waitOnScreen(
-        fixture.container.querySelector('#library-pane-shapes')
+      const shapesPane = fixture.container.querySelector(
+        '#library-pane-shapes'
       );
+      expect(getExpandedPanes()).toEqual([shapesPane]);
+      await fixture.waitOnScreen(shapesPane);
       await fixture.snapshot('on text pane');
 
+      // Back: text pane.
       await fixture.events.keyboard.press('ArrowLeft');
-
+      expect(getExpandedPanes()).toEqual([textPane]);
       await fixture.waitOnScreen(
         fixture.container.querySelector('#library-pane-text')
       );
 
+      // Back: media pane.
       await fixture.events.keyboard.press('ArrowLeft');
-      await fixture.waitOnScreen(
-        fixture.container.querySelector('#library-pane-media')
-      );
+      const mediaPane = fixture.container.querySelector('#library-pane-media');
+      expect(getExpandedPanes()).toEqual([mediaPane]);
+      await fixture.waitOnScreen(mediaPane);
     });
   });
 });

--- a/assets/src/edit-story/components/library/libraryLayout.js
+++ b/assets/src/edit-story/components/library/libraryLayout.js
@@ -56,7 +56,7 @@ const LibraryBackground = styled.div`
 
 function LibraryLayout() {
   return (
-    <Layout>
+    <Layout data-testid="libraryLayout">
       <TabsArea>
         <LibraryTabs />
       </TabsArea>

--- a/assets/src/edit-story/components/library/libraryTabs.js
+++ b/assets/src/edit-story/components/library/libraryTabs.js
@@ -38,7 +38,7 @@ function LibraryTabs() {
   const panes = useMemo(() => getPanes(tabs), [tabs]);
   const ref = useRef();
   const handleNavigation = useCallback(
-    (direction) => () => {
+    (direction) => {
       const currentIndex = panes.findIndex(({ id }) => id === tab);
       const nextPane = panes[currentIndex + direction];
       if (!nextPane) {

--- a/assets/src/edit-story/karma/fixture/fixture.js
+++ b/assets/src/edit-story/karma/fixture/fixture.js
@@ -236,6 +236,24 @@ export class Fixture {
   }
 
   /**
+   * @param {Element} element
+   * @return {Promise} Yields when the element is displayed on the screen.
+   */
+  waitOnScreen(element) {
+    return new Promise((resolve) => {
+      const io = new IntersectionObserver((records) => {
+        records.forEach((record) => {
+          if (record.isIntersecting) {
+            resolve();
+            io.disconnect();
+          }
+        });
+      });
+      io.observe(element);
+    });
+  }
+
+  /**
    * Makes a DOM snapshot of the current editor state. Karma must be run
    * with the `--snapshots` option for the snapshotting to be enabled. When
    * enabled, all snapshots are stored in the `/.test_artifacts/karma_snapshots`


### PR DESCRIPTION
## Summary

A simple oversight: instead of passing a key handler, it passes a closure resolving to a handler.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

n/a

## User-facing changes

User can navigate library tabs using arrows left and right.

## Testing Instructions

See #2272

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2272
