### PR TITLE
Add Easing Presets

### DIFF
--- a/assets/src/dashboard/animations/constants.js
+++ b/assets/src/dashboard/animations/constants.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+export { BEZIER } from '../constants';
+
 export const ANIMATION_TYPES = {
   BLINK_ON: 'blinkOn',
   BOUNCE: 'bounce',

--- a/assets/src/dashboard/animations/parts/defaultAnimationProps.js
+++ b/assets/src/dashboard/animations/parts/defaultAnimationProps.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { ANIMATION_TYPES, FIELD_TYPES } from '../constants';
+import { ANIMATION_TYPES, FIELD_TYPES, BEZIER } from '../constants';
 
 export default {
   id: {
@@ -42,6 +42,12 @@ export default {
     type: FIELD_TYPES.DROPDOWN,
     values: ['normal', 'reverse', 'alternate', 'alternate-reverse'],
     defaultValue: 'normal',
+  },
+  easingPreset: {
+    label: 'Easing Presets',
+    type: FIELD_TYPES.DROPDOWN,
+    values: Object.keys(BEZIER),
+    defaultValue: Object.keys(BEZIER)[0],
   },
   easing: {
     type: FIELD_TYPES.TEXT,

--- a/assets/src/dashboard/animations/parts/index.js
+++ b/assets/src/dashboard/animations/parts/index.js
@@ -16,7 +16,7 @@
 /**
  * Internal dependencies
  */
-import { ANIMATION_TYPES } from '../constants';
+import { ANIMATION_TYPES, BEZIER } from '../constants';
 import { AnimationBounce } from './bounce';
 import { AnimationBlinkOn } from './blinkOn';
 import { AnimationFade } from './fade';
@@ -57,6 +57,9 @@ export function AnimationPart(type, args) {
       [ANIMATION_TYPES.SPIN]: AnimationSpin,
       [ANIMATION_TYPES.ZOOM]: AnimationZoom,
     }[type] || throughput;
+
+  args.easing = args.easing || BEZIER[args.easingPreset];
+  args.easingPreset = undefined;
 
   return generator(args);
 }

--- a/assets/src/dashboard/constants/animation.js
+++ b/assets/src/dashboard/constants/animation.js
@@ -14,10 +14,26 @@
  * limitations under the License.
  */
 export const BEZIER = {
+  linear: 'linear',
+  inQuad: 'cubic-bezier(0.55, 0.085, 0.68, 0.53)',
   outQuad: 'cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+  inOutQuad: 'cubic-bezier(0.455, 0.03, 0.515, 0.955)',
+  inCubic: 'cubic-bezier(0.55, 0.055, 0.675, 0.19)',
   outCubic: 'cubic-bezier(0.215, 0.61, 0.355, 1)',
+  inOutCubic: 'cubic-bezier(0.645, 0.045, 0.355, 1)',
+  inQuart: 'cubic-bezier(0.895, 0.03, 0.685, 0.22)',
   outQuart: 'cubic-bezier(0.165, 0.84, 0.44, 1)',
+  inOutQuart: 'cubic-bezier(0.77, 0, 0.175, 1)',
+  inQuint: 'cubic-bezier(0.755, 0.05, 0.855, 0.06)',
   outQuint: 'cubic-bezier(0.23, 1, 0.32, 1)',
+  inOutQuint: 'cubic-bezier(0.86, 0, 0.07, 1)',
+  inSine: 'cubic-bezier(0.47, 0, 0.745, 0.715)',
   outSine: 'cubic-bezier(0.39, 0.575, 0.565, 1)',
+  inOutSine: 'cubic-bezier(0.445, 0.05, 0.55, 0.95)',
+  inExpo: 'cubic-bezier(0.95, 0.05, 0.795, 0.035)',
+  outExpo: 'cubic-bezier(0.19, 1, 0.22, 1)',
+  inOutExpo: 'cubic-bezier(1, 0, 0, 1)',
+  inCirc: 'cubic-bezier(0.6, 0.04, 0.98, 0.335)',
   outCirc: 'cubic-bezier(0.075, 0.82, 0.165, 1)',
+  inOutCirc: 'cubic-bezier(0.785, 0.135, 0.15, 0.86)',
 };


### PR DESCRIPTION
## Summary
Adds base easing presets field to `/story-anim-tools` which contains frequently used bezier values found here:
https://easings.net/

Way this works is custom `Easing` field always overrides it, but if nothing found in custom field, it will use the selected preset.

## Relevant Technical Choices
Quick n' Dirty

## To-do
NA

## User-facing changes
NA

## Testing Instructions
Turn `enableAnimation` feature on.

Then go to `/story-anim-tool`. Try out a custom easing & try out a preset. Make sure nothing errors out and it follows spec above.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
2283 - https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/2283

## Screenshots
<img width="390" alt="Screen Shot 2020-06-05 at 12 39 52 PM" src="https://user-images.githubusercontent.com/35983235/83912377-00f96c80-a72b-11ea-85d7-e0f8c8fd35c8.png">
<img width="450" alt="Screen Shot 2020-06-05 at 12 39 40 PM" src="https://user-images.githubusercontent.com/35983235/83912379-022a9980-a72b-11ea-8288-3bee014e003e.png">
