### PR TITLE
Make selection lines visible and fix safezone offset

### DIFF
--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -41,6 +41,7 @@ const FramesPageArea = withOverlay(
   styled(PageArea).attrs({
     className: 'container web-stories-content',
     pointerEvents: 'initial',
+    showOverflow: true,
   })``
 );
 
@@ -89,7 +90,6 @@ function FramesLayer() {
       tabIndex="-1"
     >
       <FramesPageArea
-        showOverflow
         overlay={
           Boolean(draggingResource) &&
           isDropSource(draggingResource.type) &&

--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -89,6 +89,7 @@ function FramesLayer() {
       tabIndex="-1"
     >
       <FramesPageArea
+        showOverflow
         overlay={
           Boolean(draggingResource) &&
           isDropSource(draggingResource.type) &&
@@ -100,15 +101,17 @@ function FramesLayer() {
             </FrameSidebar>
           )
         }
+        fullbleed={<Selection />}
       >
         {currentPage &&
           currentPage.elements.map(({ id, ...rest }) => {
             return <FrameElement key={id} element={{ id, ...rest }} />;
           })}
-        <Selection />
       </FramesPageArea>
       <MenuArea
         pointerEvents="initial"
+        // Make its own stacking context.
+        zIndex={1}
         // Cancel lasso.
         onMouseDown={(evt) => evt.stopPropagation()}
       >

--- a/assets/src/edit-story/components/canvas/karma/lasso.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/lasso.karma.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+import { useStory } from '../../../app/story';
+import { useInsertElement } from '..';
+import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
+
+describe('Lasso integration', () => {
+  let fixture;
+  let element1, element2;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+
+    const insertElement = await fixture.renderHook(() => useInsertElement());
+    element1 = await fixture.act(() =>
+      insertElement('text', {
+        font: TEXT_ELEMENT_DEFAULT_FONT,
+        content: 'hello world!',
+        x: 40,
+        y: -40,
+        width: 250,
+      })
+    );
+    element2 = await fixture.act(() =>
+      insertElement('text', {
+        font: TEXT_ELEMENT_DEFAULT_FONT,
+        content: 'hello world!',
+        x: 40,
+        y: 80,
+        width: 250,
+      })
+    );
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  function getFrame(elementId) {
+    return fixture.querySelector(
+      `[data-element-id="${elementId}"] [data-testid="textFrame"]`
+    );
+  }
+
+  async function getSelection() {
+    const storyContext = await fixture.renderHook(() => useStory());
+    return storyContext.state.selectedElementIds;
+  }
+
+  it('should have the last element selected by default', async () => {
+    expect(await getSelection()).toEqual([element2.id]);
+  });
+
+  it('should select right on the top-left corner', async () => {
+    const frame1 = getFrame(element1.id);
+    await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
+      moveRel(frame1, -20, -20),
+      down(),
+      moveBy(22, 22, { steps: 5 }),
+      up(),
+    ]);
+    expect(await getSelection()).toEqual([element1.id]);
+  });
+
+  it('should select right on the bottom-right corner', async () => {
+    const frame1 = getFrame(element1.id);
+    await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
+      moveRel(frame1, '100%', '100%'),
+      moveBy(20, 20),
+      down(),
+      moveBy(-22, -22, { steps: 5 }),
+      up(),
+    ]);
+    expect(await getSelection()).toEqual([element1.id]);
+  });
+
+  it('should select two elements', async () => {
+    const frame1 = getFrame(element1.id);
+    const frame2 = getFrame(element2.id);
+    await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
+      moveRel(frame1, '100%', '100%'),
+      moveBy(2, -2),
+      down(),
+      moveRel(frame2, '100%', 0, { steps: 5 }),
+      moveBy(-2, 2),
+      up(),
+    ]);
+    expect(await getSelection()).toEqual([element1.id, element2.id]);
+  });
+});

--- a/assets/src/edit-story/components/canvas/karma/selection.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/selection.karma.js
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+import { useStory } from '../../../app/story';
+import { useInsertElement } from '..';
+import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
+
+describe('Selection integration', () => {
+  let fixture;
+  let element1;
+  let fullbleed;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+
+    fullbleed = fixture.container.querySelector('[data-testid="fullbleed"]');
+
+    const insertElement = await fixture.renderHook(() => useInsertElement());
+    element1 = await fixture.act(() =>
+      insertElement('text', {
+        font: TEXT_ELEMENT_DEFAULT_FONT,
+        content: 'hello world!',
+        x: 0,
+        y: 40,
+        width: 250,
+      })
+    );
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  function getFrame(elementId) {
+    return fixture.querySelector(
+      `[data-element-id="${elementId}"] [data-testid="textFrame"]`
+    );
+  }
+
+  async function getSelection() {
+    const storyContext = await fixture.renderHook(() => useStory());
+    return storyContext.state.selectedElementIds;
+  }
+
+  it('should have the last element selected by default', async () => {
+    expect(await getSelection()).toEqual([element1.id]);
+  });
+
+  it('should show the selection lines when out of page area', async () => {
+    const frame1 = getFrame(element1.id);
+    await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
+      moveRel(frame1, 5, 5),
+      down(),
+      moveBy(-20, 0, { steps: 5 }),
+      up(),
+    ]);
+    expect(await getSelection()).toEqual([element1.id]);
+    await fixture.snapshot();
+  });
+
+  it('should show the selection under the page menu', async () => {
+    const frame1 = getFrame(element1.id);
+    const fbcr = frame1.getBoundingClientRect();
+    await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
+      moveRel(frame1, 5, 5),
+      down(),
+      moveBy(
+        0,
+        fullbleed.getBoundingClientRect().bottom -
+          fbcr.bottom +
+          fbcr.height -
+          5,
+        { steps: 5 }
+      ),
+      up(),
+    ]);
+    expect(await getSelection()).toEqual([element1.id]);
+    await fixture.snapshot();
+  });
+});

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -99,6 +99,7 @@ const Area = styled.div`
   position: relative;
   width: 100%;
   height: 100%;
+  ${({ zIndex }) => (zIndex !== undefined ? `z-index: ${zIndex}` : null)};
 `;
 
 // Page area is not `overflow:hidden` by default to allow different clipping
@@ -215,6 +216,7 @@ const PageArea = forwardRef(
       showOverflow = false,
       fullbleedRef = createRef(),
       overlay = [],
+      fullbleed = [],
     },
     ref
   ) => {
@@ -230,6 +232,7 @@ const PageArea = forwardRef(
               <PageAreaDangerZoneBottom />
             </>
           )}
+          {fullbleed}
         </PageAreaWithOverflow>
         {overlay}
       </PageAreaFullbleedContainer>
@@ -240,6 +243,7 @@ const PageArea = forwardRef(
 PageArea.propTypes = {
   children: PropTypes.node,
   overlay: PropTypes.node,
+  fullbleed: PropTypes.node,
   showDangerZone: PropTypes.bool,
   showOverflow: PropTypes.bool,
 };

--- a/assets/src/edit-story/components/canvas/selectionCanvas.js
+++ b/assets/src/edit-story/components/canvas/selectionCanvas.js
@@ -28,6 +28,7 @@ import { useStory } from '../../app';
 import withOverlay from '../overlay/withOverlay';
 import InOverlay from '../overlay';
 import { useUnits } from '../../units';
+import { PAGE_RATIO } from '../../constants';
 import useCanvas from './useCanvas';
 
 const LASSO_ACTIVE_THRESHOLD = 10;
@@ -150,8 +151,17 @@ function SelectionCanvas({ children }) {
   const onMouseUp = () => {
     if (lassoModeRef.current === LassoMode.ON) {
       const [lx, ly, lwidth, lheight] = getLassoBox();
-      const x = editorToDataX(lx - fullbleedContainer.offsetLeft);
-      const y = editorToDataY(ly - fullbleedContainer.offsetTop);
+      const {
+        offsetLeft,
+        offsetTop,
+        offsetHeight,
+        offsetWidth,
+      } = fullbleedContainer;
+      // Offset from the fullbleed to the safe zone.
+      const dx = offsetLeft;
+      const dy = offsetTop + (offsetHeight - offsetWidth / PAGE_RATIO) / 2;
+      const x = editorToDataX(lx - dx);
+      const y = editorToDataY(ly - dy);
       const width = editorToDataX(lwidth);
       const height = editorToDataY(lheight);
       clearSelection();


### PR DESCRIPTION
## Summary

Fixes the following issues:
1. The selection lines are now visible when they overflow the page area. However, they are placed behind page menu and other nav controls.
2. The safezone offset is fixed when an overflowing element is selected.

The best I can tell the bug arises due to Chrome bug. Simply doing `$0.style.position = 'relative'; $0.style.position = 'absolute'` (i.e. resetting the position style) fixes the issue.

## Relevant Technical Choices

The solution is to move the moveable and selection lines to the fullbleed zone, out of safezone.

## To-do

- [x] Check how this behaves with lasso
- [x] Karma tests

## User-facing changes

The selection lines are visible for overflowing elements.

## Testing Instructions

See #1787

---

Fixes #1787
Fixes #1545