### PR TITLE
Dashboard: Save Story as Template

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -41,6 +41,7 @@ export default function ApiProvider({ children }) {
 
   const { templates, api: templateApi } = useTemplateApi(dataAdapter, {
     assetsURL,
+    wpApi: api.templates,
   });
 
   const { stories, api: storyApi } = useStoryApi(dataAdapter, {

--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -49,7 +49,7 @@ export default function ApiProvider({ children }) {
     storyApi: api.stories,
   });
 
-  const { api: fontApi } = useFontApi(dataAdapter, { wpApi: api.fonts });
+  const { api: fontApi } = useFontApi(dataAdapter, { fontApi: api.fonts });
 
   const value = useMemo(
     () => ({

--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -36,17 +36,17 @@ export default function ApiProvider({ children }) {
   const { api, editStoryURL, assetsURL } = useConfig();
 
   const { users, api: usersApi } = useUsersApi(dataAdapter, {
-    wpApi: api.users,
+    userApi: api.users,
   });
 
   const { templates, api: templateApi } = useTemplateApi(dataAdapter, {
     assetsURL,
-    wpApi: api.templates,
+    templateApi: api.templates,
   });
 
   const { stories, api: storyApi } = useStoryApi(dataAdapter, {
     editStoryURL,
-    wpApi: api.stories,
+    storyApi: api.stories,
   });
 
   const { api: fontApi } = useFontApi(dataAdapter, { wpApi: api.fonts });

--- a/assets/src/dashboard/app/api/fetchAllFromPages.js
+++ b/assets/src/dashboard/app/api/fetchAllFromPages.js
@@ -26,14 +26,14 @@ import queryString from 'query-string';
  *
  * @param response The response from the initial wpFetch call
  * @param dataAdapter The WP Data Adapter that will make the additional page fetch requests
- * @param wpApi The base url for the fetch calls
+ * @param apiString The base url for the fetch calls
  * @return Promise<any[]> A flattened array with all the entities
  */
 
 export default async function fetchAllFromTotalPages(
   response,
   dataAdapter,
-  wpApi
+  apiString
 ) {
   const totalPages = parseInt(response.headers.get('X-WP-TotalPages'));
   const additionalRequests = [];
@@ -43,7 +43,7 @@ export default async function fetchAllFromTotalPages(
       additionalRequests.push(
         dataAdapter.get(
           queryString.stringifyUrl({
-            url: wpApi,
+            url: apiString,
             query: { page: i },
           })
         )

--- a/assets/src/dashboard/app/api/test/useCategoryApi.js
+++ b/assets/src/dashboard/app/api/test/useCategoryApi.js
@@ -47,7 +47,7 @@ jest.mock('../wpAdapter', () => ({
 describe('useCategoryApi', () => {
   it('should return categories in state data when the API request is fired', async () => {
     const { result } = renderHook(() =>
-      useCategoriesApi(wpAdapter, { wpApi: 'categories' })
+      useCategoriesApi(wpAdapter, { categoryApi: 'categories' })
     );
 
     await act(async () => {

--- a/assets/src/dashboard/app/api/test/useTagsApi.js
+++ b/assets/src/dashboard/app/api/test/useTagsApi.js
@@ -44,7 +44,7 @@ jest.mock('../wpAdapter', () => ({
 describe('useTagsApi', () => {
   it('should return tags in state data when the API request is fired', async () => {
     const { result } = renderHook(() =>
-      useTagsApi(wpAdapter, { wpApi: 'tags' })
+      useTagsApi(wpAdapter, { tagsApi: 'tags' })
     );
 
     await act(async () => {

--- a/assets/src/dashboard/app/api/test/useUserApi.js
+++ b/assets/src/dashboard/app/api/test/useUserApi.js
@@ -43,7 +43,7 @@ jest.mock('../wpAdapter', () => ({
 describe('useUserApi', () => {
   it('should return user in state data when the API request is fired', async () => {
     const { result } = renderHook(() =>
-      useUserApi(wpAdapter, { wpApi: 'user' })
+      useUserApi(wpAdapter, { userApi: 'user' })
     );
 
     await act(async () => {

--- a/assets/src/dashboard/app/api/useCategoriesApi.js
+++ b/assets/src/dashboard/app/api/useCategoriesApi.js
@@ -26,13 +26,13 @@ import queryString from 'query-string';
 import groupBy from '../../utils/groupBy';
 import fetchAllFromTotalPages from './fetchAllFromPages';
 
-export default function useCategoriesApi(dataAdapter, { wpApi }) {
+export default function useCategoriesApi(dataAdapter, { categoryApi }) {
   const [categories, setCategories] = useState({});
   const fetchCategories = useCallback(async () => {
     try {
       const response = await dataAdapter.get(
         queryString.stringifyUrl({
-          url: wpApi,
+          url: categoryApi,
           query: { per_page: 100 },
         }),
         {
@@ -43,7 +43,7 @@ export default function useCategoriesApi(dataAdapter, { wpApi }) {
       const categoriesJson = await fetchAllFromTotalPages(
         response,
         dataAdapter,
-        wpApi
+        categoryApi
       );
 
       setCategories(
@@ -55,7 +55,7 @@ export default function useCategoriesApi(dataAdapter, { wpApi }) {
     } catch (e) {
       setCategories({});
     }
-  }, [dataAdapter, wpApi]);
+  }, [dataAdapter, categoryApi]);
 
   useEffect(() => {
     fetchCategories();

--- a/assets/src/dashboard/app/api/useFontApi.js
+++ b/assets/src/dashboard/app/api/useFontApi.js
@@ -19,20 +19,20 @@
  */
 import { useCallback, useMemo } from 'react';
 
-const useFontApi = (dataAdapter, { wpApi }) => {
+const useFontApi = (dataAdapter, { fontApi }) => {
   const getAllFonts = useCallback(() => {
-    if (!wpApi) {
+    if (!fontApi) {
       return Promise.resolve([]);
     }
 
-    return dataAdapter.get(wpApi).then((data) =>
+    return dataAdapter.get(fontApi).then((data) =>
       data.map((font) => ({
         value: font.family,
         name: font.family,
         ...font,
       }))
     );
-  }, [dataAdapter, wpApi]);
+  }, [dataAdapter, fontApi]);
 
   const api = useMemo(
     () => ({

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -83,7 +83,7 @@ export function reshapeStoryObject(editStoryURL) {
   };
 }
 
-const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
+const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
   const [state, dispatch] = useReducer(storyReducer, defaultStoriesState);
 
   const fetchStories = useCallback(
@@ -100,7 +100,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
         payload: true,
       });
 
-      if (!wpApi) {
+      if (!storyApi) {
         dispatch({
           type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
           payload: true,
@@ -120,7 +120,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
 
       try {
         const path = queryString.stringifyUrl({
-          url: wpApi,
+          url: storyApi,
           query,
         });
 
@@ -163,13 +163,13 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
         });
       }
     },
-    [wpApi, dataAdapter, editStoryURL]
+    [storyApi, dataAdapter, editStoryURL]
   );
 
   const updateStory = useCallback(
     async (story) => {
       try {
-        const response = await dataAdapter.post(`${wpApi}/${story.id}`, {
+        const response = await dataAdapter.post(`${storyApi}/${story.id}`, {
           data: story,
         });
         dispatch({
@@ -181,13 +181,13 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
         console.error(e);
       }
     },
-    [wpApi, dataAdapter, editStoryURL]
+    [storyApi, dataAdapter, editStoryURL]
   );
 
   const trashStory = useCallback(
     async (story) => {
       try {
-        await dataAdapter.deleteRequest(`${wpApi}/${story.id}`, {
+        await dataAdapter.deleteRequest(`${storyApi}/${story.id}`, {
           data: story,
         });
         dispatch({
@@ -199,7 +199,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
         console.error(e);
       }
     },
-    [wpApi, dataAdapter]
+    [storyApi, dataAdapter]
   );
 
   const createStoryFromTemplate = useCallback(
@@ -222,7 +222,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
             },
           },
         });
-        const response = await dataAdapter.post(wpApi, {
+        const response = await dataAdapter.post(storyApi, {
           data: {
             ...storyPropsToSave,
             story_data: {
@@ -253,7 +253,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
         });
       }
     },
-    [dataAdapter, editStoryURL, wpApi]
+    [dataAdapter, editStoryURL, storyApi]
   );
 
   const duplicateStory = useCallback(
@@ -268,7 +268,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
           title,
         } = story.originalStoryData;
 
-        const response = await dataAdapter.post(wpApi, {
+        const response = await dataAdapter.post(storyApi, {
           data: {
             content,
             story_data,
@@ -294,7 +294,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, wpApi }) => {
         console.error(e);
       }
     },
-    [wpApi, dataAdapter, editStoryURL]
+    [storyApi, dataAdapter, editStoryURL]
   );
 
   const api = useMemo(

--- a/assets/src/dashboard/app/api/useTagsApi.js
+++ b/assets/src/dashboard/app/api/useTagsApi.js
@@ -26,13 +26,13 @@ import queryString from 'query-string';
 import groupBy from '../../utils/groupBy';
 import fetchAllFromTotalPages from './fetchAllFromPages';
 
-export default function useTagsApi(dataAdapter, { wpApi }) {
+export default function useTagsApi(dataAdapter, { tagsApi }) {
   const [tags, setTags] = useState({});
   const fetchTags = useCallback(async () => {
     try {
       const response = await dataAdapter.get(
         queryString.stringifyUrl({
-          url: wpApi,
+          url: tagsApi,
           query: { per_page: 100 },
         }),
         {
@@ -43,7 +43,7 @@ export default function useTagsApi(dataAdapter, { wpApi }) {
       const tagsJson = await fetchAllFromTotalPages(
         response,
         dataAdapter,
-        wpApi
+        tagsApi
       );
 
       setTags(
@@ -55,7 +55,7 @@ export default function useTagsApi(dataAdapter, { wpApi }) {
     } catch (e) {
       setTags({});
     }
-  }, [dataAdapter, wpApi]);
+  }, [dataAdapter, tagsApi]);
 
   useEffect(() => {
     fetchTags();

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -92,9 +92,9 @@ export function reshapeSavedTemplates({
 const useTemplateApi = (dataAdapter, config) => {
   const [state, dispatch] = useReducer(templateReducer, defaultTemplatesState);
 
-  const { assetsURL, wpApi } = config;
+  const { assetsURL, templateApi } = config;
 
-  const fetchSavedTemplates = useCallback((filters) => {
+  const fetchSavedTemplates = useCallback(() => {
     // Saved Templates = Bookmarked Templates + My Templates
     dispatch({
       type: TEMPLATE_ACTION_TYPES.PLACEHOLDER,
@@ -127,7 +127,7 @@ const useTemplateApi = (dataAdapter, config) => {
         payload: true,
       });
 
-      if (!wpApi) {
+      if (!templateApi) {
         dispatch({
           type: TEMPLATE_ACTION_TYPES.FETCH_MY_TEMPLATES_FAILURE,
           payload: { message: 'unable to connect to data', code: '' },
@@ -142,7 +142,7 @@ const useTemplateApi = (dataAdapter, config) => {
 
       try {
         const path = queryString.stringifyUrl({
-          url: wpApi,
+          url: templateApi,
           query,
         });
         const response = await dataAdapter.get(path, {
@@ -183,7 +183,7 @@ const useTemplateApi = (dataAdapter, config) => {
         });
       }
     },
-    [dataAdapter, wpApi]
+    [dataAdapter, templateApi]
   );
 
   const fetchMyTemplateById = useCallback((templateId) => {
@@ -257,7 +257,7 @@ const useTemplateApi = (dataAdapter, config) => {
           title,
         } = story.originalStoryData;
 
-        await dataAdapter.post(wpApi, {
+        await dataAdapter.post(templateApi, {
           data: {
             content,
             story_data,
@@ -283,7 +283,7 @@ const useTemplateApi = (dataAdapter, config) => {
         });
       }
     },
-    [dataAdapter, wpApi]
+    [dataAdapter, templateApi]
   );
 
   const fetchRelatedTemplates = useCallback(() => {

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -244,6 +244,7 @@ const useTemplateApi = (dataAdapter, config) => {
     async (story) => {
       await dispatch({
         type: TEMPLATE_ACTION_TYPES.CREATING_TEMPLATE_FROM_STORY,
+        payload: true,
       });
 
       try {
@@ -274,6 +275,11 @@ const useTemplateApi = (dataAdapter, config) => {
         dispatch({
           type: TEMPLATE_ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_FAILURE,
           payload: { message: err.message, code: err.code },
+        });
+      } finally {
+        dispatch({
+          type: TEMPLATE_ACTION_TYPES.CREATING_TEMPLATE_FROM_STORY,
+          payload: false,
         });
       }
     },

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -19,6 +19,7 @@
  */
 import { useCallback, useMemo, useReducer } from 'react';
 import moment from 'moment';
+import queryString from 'query-string';
 
 /**
  * Internal dependencies
@@ -57,12 +58,41 @@ export function reshapeTemplateObject(isLocal) {
   });
 }
 
+// TODO once templates are all connected to an API this and the above reshapeTemplateObject should be able to be one and the same
+// Connecting the ability to create a template from a story I wanted to be able to see the results on saved templates, this endpoint is still missing some template related data.
+export function reshapeSavedTemplates({
+  author,
+  isLocal = true,
+  id,
+  title,
+  modified,
+  tags = [],
+  colors = [],
+  createdBy = 'N/A',
+  description,
+  pages,
+}) {
+  return {
+    author,
+    isLocal,
+    id,
+    title: title.rendered,
+    createdBy,
+    description,
+    status: 'template',
+    modified: moment(modified),
+    tags,
+    colors,
+    pages,
+    centerTargetAction: false, // `${APP_ROUTES.TEMPLATE_DETAIL}?id=${id}&isLocal=${isLocal}`,
+  };
+}
 // TODO: Remove this eslint rule once endpoints are working
 /* eslint-disable no-unused-vars */
 const useTemplateApi = (dataAdapter, config) => {
   const [state, dispatch] = useReducer(templateReducer, defaultTemplatesState);
 
-  const { assetsURL } = config;
+  const { assetsURL, wpApi } = config;
 
   const fetchSavedTemplates = useCallback((filters) => {
     // Saved Templates = Bookmarked Templates + My Templates
@@ -90,17 +120,71 @@ const useTemplateApi = (dataAdapter, config) => {
     });
   }, []);
 
-  const fetchMyTemplates = useCallback((filters) => {
-    dispatch({
-      type: TEMPLATE_ACTION_TYPES.PLACEHOLDER,
-      paylod: {
-        templates: [],
-        totalPages: 0,
-        totalTemplates: 0,
-        page: 1,
-      },
-    });
-  }, []);
+  const fetchMyTemplates = useCallback(
+    async ({ page = 1 }) => {
+      dispatch({
+        type: TEMPLATE_ACTION_TYPES.LOADING_TEMPLATES,
+        payload: true,
+      });
+
+      if (!wpApi) {
+        dispatch({
+          type: TEMPLATE_ACTION_TYPES.FETCH_MY_TEMPLATES_FAILURE,
+          payload: { message: 'unable to connect to data', code: '' },
+        });
+      }
+
+      const query = {
+        page,
+        per_page: 100,
+        status: 'publish,draft,pending',
+      };
+
+      try {
+        const path = queryString.stringifyUrl({
+          url: wpApi,
+          query,
+        });
+        const response = await dataAdapter.get(path, {
+          parse: false,
+          cache: 'no-cache',
+        });
+
+        const totalPages =
+          response.headers && parseInt(response.headers.get('X-WP-TotalPages'));
+
+        const totalTemplates =
+          response.headers && parseInt(response.headers.get('X-WP-Total'));
+
+        const serverTemplateResponse = await response.json();
+
+        const reshapedTemplates = serverTemplateResponse.map(
+          reshapeSavedTemplates
+        );
+
+        dispatch({
+          type: TEMPLATE_ACTION_TYPES.FETCH_MY_TEMPLATES_SUCCESS,
+          payload: {
+            savedTemplates: reshapedTemplates,
+            totalPages,
+            totalTemplates,
+            page,
+          },
+        });
+      } catch (err) {
+        dispatch({
+          type: TEMPLATE_ACTION_TYPES.FETCH_MY_TEMPLATES_FAILURE,
+          payload: { message: err.message, code: err.code },
+        });
+      } finally {
+        dispatch({
+          type: TEMPLATE_ACTION_TYPES.LOADING_TEMPLATES,
+          payload: false,
+        });
+      }
+    },
+    [dataAdapter, wpApi]
+  );
 
   const fetchMyTemplateById = useCallback((templateId) => {
     return Promise.resolve({});
@@ -156,12 +240,45 @@ const useTemplateApi = (dataAdapter, config) => {
     }
   }, []);
 
-  const createTemplateFromStory = useCallback(async (story) => {
-    // api call to create a template from a story
-    await dispatch({
-      type: TEMPLATE_ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY,
-    });
-  }, []);
+  const createTemplateFromStory = useCallback(
+    async (story) => {
+      await dispatch({
+        type: TEMPLATE_ACTION_TYPES.CREATING_TEMPLATE_FROM_STORY,
+      });
+
+      try {
+        const {
+          content,
+          story_data,
+          style_presets,
+          publisher_logo,
+          featured_media,
+          title,
+        } = story.originalStoryData;
+
+        await dataAdapter.post(wpApi, {
+          data: {
+            content,
+            story_data,
+            featured_media,
+            style_presets,
+            publisher_logo,
+            title,
+          },
+        });
+
+        dispatch({
+          type: TEMPLATE_ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_SUCCESS,
+        });
+      } catch (err) {
+        dispatch({
+          type: TEMPLATE_ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_FAILURE,
+          payload: { message: err.message, code: err.code },
+        });
+      }
+    },
+    [dataAdapter, wpApi]
+  );
 
   const fetchRelatedTemplates = useCallback(() => {
     if (!state.templates) {

--- a/assets/src/dashboard/app/api/useUserApi.js
+++ b/assets/src/dashboard/app/api/useUserApi.js
@@ -26,13 +26,13 @@ import queryString from 'query-string';
 import groupBy from '../../utils/groupBy';
 import fetchAllFromTotalPages from './fetchAllFromPages';
 
-export default function useUsersApi(dataAdapter, { wpApi }) {
+export default function useUserApi(dataAdapter, { userApi }) {
   const [users, setUsers] = useState({});
   const fetchUsers = useCallback(async () => {
     try {
       const response = await dataAdapter.get(
         queryString.stringifyUrl({
-          url: wpApi,
+          url: userApi,
           query: { per_page: 100 },
         }),
         {
@@ -43,7 +43,7 @@ export default function useUsersApi(dataAdapter, { wpApi }) {
       const usersJson = await fetchAllFromTotalPages(
         response,
         dataAdapter,
-        wpApi
+        userApi
       );
 
       setUsers(
@@ -55,7 +55,7 @@ export default function useUsersApi(dataAdapter, { wpApi }) {
     } catch (e) {
       setUsers({});
     }
-  }, [dataAdapter, wpApi]);
+  }, [dataAdapter, userApi]);
 
   useEffect(() => {
     fetchUsers();

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -118,15 +118,7 @@ function storyReducer(state, action) {
           ? fetchedStoriesById
           : [...state.storiesOrderById, ...fetchedStoriesById];
 
-      // we want to make sure that pagination is kept intact regardless of page number.
-      // we are using infinite scroll, not traditional pagination.
-      // this means we need to append our new stories to the bottom of our already existing stories.
-      // when we combine existing stories with the new ones we need to make sure we're not duplicating anything.
-      const uniqueStoryIds = combinedStoryIds.filter(
-        (storyId, index, storyIdsArray) => {
-          return storyIdsArray.indexOf(storyId) === index;
-        }
-      );
+      const uniqueStoryIds = [...new Set(combinedStoryIds)];
 
       return {
         ...state,

--- a/assets/src/dashboard/app/reducer/templates.js
+++ b/assets/src/dashboard/app/reducer/templates.js
@@ -35,7 +35,7 @@ export const defaultTemplatesState = {
   allPagesFetched: false,
   error: {},
   isLoading: false,
-  savedTemplate: {},
+  savedTemplates: {},
   savedTemplatesOrderById: [],
   templates: {},
   templatesOrderById: [],

--- a/assets/src/dashboard/app/reducer/templates.js
+++ b/assets/src/dashboard/app/reducer/templates.js
@@ -20,7 +20,9 @@
 import groupBy from '../../utils/groupBy';
 
 export const ACTION_TYPES = {
-  CREATE_TEMPLATE_FROM_STORY: 'create_template_from_story',
+  CREATING_TEMPLATE_FROM_STORY: 'create_template_from_story',
+  CREATE_TEMPLATE_FROM_STORY_FAILURE: 'create_template_from_story_failure',
+  CREATE_TEMPLATE_FROM_STORY_SUCCESS: 'create_template_from_story_success',
   LOADING_TEMPLATES: 'loading_templates',
   FETCH_TEMPLATES_SUCCESS: 'fetch_templates_success',
   FETCH_TEMPLATES_FAILURE: 'fetch_templates_failure',
@@ -31,7 +33,7 @@ export const ACTION_TYPES = {
 
 export const defaultTemplatesState = {
   allPagesFetched: false,
-  isError: false,
+  error: {},
   isLoading: false,
   savedTemplate: {},
   savedTemplatesOrderById: [],
@@ -43,21 +45,26 @@ export const defaultTemplatesState = {
 
 function templateReducer(state, action) {
   switch (action.type) {
-    case ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY: {
-      return state;
-    }
-    case ACTION_TYPES.LOADING_TEMPLATES: {
+    case ACTION_TYPES.LOADING_TEMPLATES:
+    case ACTION_TYPES.CREATING_TEMPLATE_FROM_STORY: {
       return {
         ...state,
         isLoading: action.payload,
       };
     }
 
-    case ACTION_TYPES.FETCH_MY_TEMPLATES_FAILURE:
-    case ACTION_TYPES.FETCH_TEMPLATES_FAILURE:
+    case ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_SUCCESS: {
       return {
         ...state,
-        isError: action.payload,
+      };
+    }
+
+    case ACTION_TYPES.FETCH_MY_TEMPLATES_FAILURE:
+    case ACTION_TYPES.FETCH_TEMPLATES_FAILURE:
+    case ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_FAILURE:
+      return {
+        ...state,
+        error: action.payload,
       };
 
     case ACTION_TYPES.FETCH_MY_TEMPLATES_SUCCESS: {
@@ -112,7 +119,7 @@ function templateReducer(state, action) {
 
       return {
         ...state,
-        isError: false,
+        error: {},
         templatesOrderById: uniqueTemplateIds,
         templates: {
           ...state.templates,

--- a/assets/src/dashboard/app/reducer/templates.js
+++ b/assets/src/dashboard/app/reducer/templates.js
@@ -20,7 +20,7 @@
 import groupBy from '../../utils/groupBy';
 
 export const ACTION_TYPES = {
-  CREATING_TEMPLATE_FROM_STORY: 'create_template_from_story',
+  CREATING_TEMPLATE_FROM_STORY: 'creating_template_from_story',
   CREATE_TEMPLATE_FROM_STORY_FAILURE: 'create_template_from_story_failure',
   CREATE_TEMPLATE_FROM_STORY_SUCCESS: 'create_template_from_story_success',
   LOADING_TEMPLATES: 'loading_templates',

--- a/assets/src/dashboard/app/reducer/templates.js
+++ b/assets/src/dashboard/app/reducer/templates.js
@@ -94,7 +94,7 @@ function templateReducer(state, action) {
           ...groupBy(action.payload.savedTemplates, 'id'),
         },
         savedTemplatesOrderById: uniqueTemplateIds,
-        page: action.payload.page,
+        totalTemplates: action.payload.totalTemplates,
         totalPages: action.payload.totalPages,
       };
     }

--- a/assets/src/dashboard/app/reducer/templates.js
+++ b/assets/src/dashboard/app/reducer/templates.js
@@ -77,15 +77,7 @@ function templateReducer(state, action) {
           ? fetchedTemplatesById
           : [...state.savedTemplatesById, ...fetchedTemplatesById];
 
-      // we want to make sure that pagination is kept intact regardless of page number.
-      // we are using infinite scroll, not traditional pagination.
-      // this means we need to append our new templates to the bottom of our already existing templates.
-      // when we combine existing templates with the new ones we need to make sure we're not duplicating anything.
-      const uniqueTemplateIds = combinedTemplateIds.filter(
-        (templateId, index, templateIdsArray) => {
-          return templateIdsArray.indexOf(templateId) === index;
-        }
-      );
+      const uniqueTemplateIds = [...new Set(combinedTemplateIds)];
 
       return {
         ...state,
@@ -107,15 +99,7 @@ function templateReducer(state, action) {
           ? fetchedTemplatesById
           : [...state.templatesOrderById, ...fetchedTemplatesById];
 
-      // we want to make sure that pagination is kept intact regardless of page number.
-      // we are using infinite scroll, not traditional pagination.
-      // this means we need to append our new templates to the bottom of our already existing templates.
-      // when we combine existing templates with the new ones we need to make sure we're not duplicating anything.
-      const uniqueTemplateIds = combinedTemplateIds.filter(
-        (templateId, index, templateIdsArray) => {
-          return templateIdsArray.indexOf(templateId) === index;
-        }
-      );
+      const uniqueTemplateIds = [...new Set(combinedTemplateIds)];
 
       return {
         ...state,

--- a/assets/src/dashboard/app/reducer/test/templates.js
+++ b/assets/src/dashboard/app/reducer/test/templates.js
@@ -23,7 +23,7 @@ import templateReducer, {
 } from '../templates';
 
 describe('templateReducer', () => {
-  it(`should update stories state when ${ACTION_TYPES.FETCH_TEMPLATES_SUCCESS} is called`, () => {
+  it(`should update templates state when ${ACTION_TYPES.FETCH_TEMPLATES_SUCCESS} is called`, () => {
     const result = templateReducer(initialState, {
       type: ACTION_TYPES.FETCH_TEMPLATES_SUCCESS,
       payload: {
@@ -57,7 +57,7 @@ describe('templateReducer', () => {
 
     expect(result).toMatchObject({
       ...initialState,
-      isError: false,
+      error: {},
       templatesOrderById: [1, 2, 3, 4, 5],
       templates: {
         1: {
@@ -87,7 +87,7 @@ describe('templateReducer', () => {
     });
   });
 
-  it(`should update stories state when ${ACTION_TYPES.FETCH_TEMPLATES_SUCCESS} is called and maintain order from existing state`, () => {
+  it(`should update templates state when ${ACTION_TYPES.FETCH_TEMPLATES_SUCCESS} is called and maintain order from existing state`, () => {
     const result = templateReducer(
       { ...initialState, templatesOrderById: [1, 2, 3, 8, 9] },
       {
@@ -168,27 +168,121 @@ describe('templateReducer', () => {
     });
   });
 
-  it(`should update isError when ${ACTION_TYPES.FETCH_TEMPLATES_FAILURE} is called`, () => {
+  it(`should update isLoading when ${ACTION_TYPES.CREATING_TEMPLATE_FROM_STORY} is called`, () => {
     const result = templateReducer(
       { ...initialState },
       {
-        type: ACTION_TYPES.FETCH_TEMPLATES_FAILURE,
+        type: ACTION_TYPES.CREATING_TEMPLATE_FROM_STORY,
         payload: true,
       }
     );
 
     expect(result).toMatchObject({
       ...initialState,
-      isError: true,
+      isLoading: true,
     });
   });
 
-  it(`should return the existing state when ${ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY} is called`, () => {
+  it(`should update error when ${ACTION_TYPES.FETCH_TEMPLATES_FAILURE} is called`, () => {
+    const result = templateReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.FETCH_TEMPLATES_FAILURE,
+        payload: { message: 'test error message', code: 'test-error-code' },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      error: { message: 'test error message', code: 'test-error-code' },
+    });
+  });
+
+  it(`should update error when ${ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_FAILURE} is called`, () => {
+    const result = templateReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_FAILURE,
+        payload: { message: 'test error message', code: 'test-error-code' },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      error: { message: 'test error message', code: 'test-error-code' },
+    });
+  });
+
+  it(`should return the existing state when ${ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_SUCCESS} is called`, () => {
     const result = templateReducer(
       { ...initialState },
       { type: ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY }
     );
 
     expect(result).toMatchObject(initialState);
+  });
+
+  it(`should update savedTemplates state when ${ACTION_TYPES.FETCH_MY_TEMPLATES_SUCCESS} is called`, () => {
+    const result = templateReducer(initialState, {
+      type: ACTION_TYPES.FETCH_MY_TEMPLATES_SUCCESS,
+      payload: {
+        page: 1,
+        savedTemplates: [
+          {
+            id: 1,
+            title: 'Beauty',
+          },
+          {
+            id: 2,
+            title: 'Cooking',
+          },
+          {
+            id: 3,
+            title: 'DIY',
+          },
+          {
+            id: 4,
+            title: 'Cooking',
+          },
+          {
+            id: 5,
+            title: 'Entertainment',
+          },
+        ],
+        totalTemplates: 12,
+        totalPages: 2,
+      },
+    });
+
+    expect(result).toMatchObject({
+      ...initialState,
+      error: {},
+      savedTemplatesOrderById: [1, 2, 3, 4, 5],
+      savedTemplates: {
+        1: {
+          id: 1,
+          title: 'Beauty',
+        },
+        2: {
+          id: 2,
+          title: 'Cooking',
+        },
+        3: {
+          id: 3,
+          title: 'DIY',
+        },
+        4: {
+          id: 4,
+          title: 'Cooking',
+        },
+        5: {
+          id: 5,
+          title: 'Entertainment',
+        },
+      },
+      totalTemplates: 12,
+      totalPages: 2,
+      allPagesFetched: false,
+    });
   });
 });

--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useContext } from 'react';
 
 /**
  * Internal dependencies
@@ -47,12 +47,10 @@ import useStoryView, {
   SortPropTypes,
   ViewPropTypes,
 } from '../../../utils/useStoryView';
-import getAllTemplates from '../../../templates';
 import { StoriesPropType } from '../../../types';
-import { reshapeTemplateObject } from '../../api/useTemplateApi';
-import { useConfig } from '../../config';
 import FontProvider from '../../font/fontProvider';
 import { BodyViewOptions, PageHeading } from '../shared';
+import { ApiContext } from '../../api/apiProvider';
 import SavedTemplatesGridView from './savedTemplatesGridView';
 
 function Header({ filter, search, sort, stories, view }) {
@@ -110,18 +108,29 @@ function Content({ stories, view, page }) {
 }
 
 function SavedTemplates() {
-  const config = useConfig();
+  const {
+    actions: {
+      templateApi: { fetchMyTemplates },
+    },
+    state: {
+      templates: { savedTemplates, savedTemplatesOrderById },
+    },
+  } = useContext(ApiContext);
+
   const { filter, page, sort, search, view } = useStoryView({
     filters: SAVED_TEMPLATES_STATUSES,
     totalPages: 1,
   });
 
-  const [mockTemplates, setMockTemplates] = useState([]);
+  const orderedSavedTemplates = useMemo(() => {
+    return savedTemplatesOrderById.map((templateId) => {
+      return savedTemplates[templateId];
+    });
+  }, [savedTemplates, savedTemplatesOrderById]);
 
   useEffect(() => {
-    const templates = getAllTemplates(config).map(reshapeTemplateObject(false));
-    setMockTemplates(templates);
-  }, [config]);
+    fetchMyTemplates({ page: 1 });
+  }, [fetchMyTemplates]);
 
   return (
     <Layout.Provider>
@@ -129,10 +138,15 @@ function SavedTemplates() {
         filter={filter}
         view={view}
         search={search}
-        stories={mockTemplates}
+        stories={orderedSavedTemplates}
         sort={sort}
       />
-      <Content view={view} page={page} sort={sort} stories={mockTemplates} />
+      <Content
+        view={view}
+        page={page}
+        sort={sort}
+        stories={orderedSavedTemplates}
+      />
     </Layout.Provider>
   );
 }

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -201,9 +201,10 @@ class Dashboard {
 					'assetsURL'    => trailingslashit( WEBSTORIES_ASSETS_URL ),
 					'version'      => WEBSTORIES_VERSION,
 					'api'          => [
-						'stories' => sprintf( '/wp/v2/%s', $rest_base ),
-						'users'   => '/wp/v2/users',
-						'fonts'   => '/web-stories/v1/fonts',
+						'stories'   => sprintf( '/wp/v2/%s', $rest_base ),
+						'users'     => '/wp/v2/users',
+						'fonts'     => '/web-stories/v1/fonts',
+						'templates' => '/wp/v2/web-story-template',
 					],
 				],
 				'flags'  => [


### PR DESCRIPTION
## Summary
Adds ability to 'create template' on my stories story context menu

## Relevant Technical Choices
- Adds new endpoint `/wp/v2/web-story-template` to access templates created from stories (https://github.com/google/web-stories-wp/pull/1997) 
- Separates out `savedTemplates` from `templates` in template reducer because it seems like we're going to have several places to aggregate templates from (at least at first) and this seems like an ok way to keep things separated. 
- I did not address separating out totals yet, tried to only touch parts of savedTemplates necessary to make this PR easily testable. 

## To-do
- After saving as a template, the publish button and related areas will disappear, as you’re now editing an unpublishable template
- After saving as a template, the saved template will not appear in the Dashboard under drafts,, and will instead appear under “My templates” in the templates gallery
- “Save as template” keyboard shortcut: ⌘ + ⌥ + S
- Saved templates pagination (not really part of this but it's noticeably missing when you look at the code) 
- More tests

## User-facing changes
- None are exposed atm 


## Testing Instructions
- Click on a context menu for a story and select 'create template'. See a POST for `http://localhost:8899/wp-json/wp/v2/web-story-template?_locale=user` with a response status of `201 Created`
- If you pull the branch down and comment out the `APP_ROUTES.SAVED_TEMPLATES,` `inProgress` after creating a template or two from stories you will see them show up in saved templates if you click on that view too. This view is broken though, not all the necessary data is getting returned to us at this route to form previews. I figure this is helpful to finding the missing pieces on the api though. 

![create template from story response](https://user-images.githubusercontent.com/10720454/84069067-2b476600-a987-11ea-9673-3bbab52915f8.gif)

<img width="396" alt="Screen Shot 2020-06-08 at 1 36 33 PM" src="https://user-images.githubusercontent.com/10720454/84072939-32717280-a98d-11ea-85fc-843fd26ccdee.png">

<img width="701" alt="Screen Shot 2020-06-08 at 1 37 12 PM" src="https://user-images.githubusercontent.com/10720454/84072935-31404580-a98d-11ea-9c88-5bd9352d5942.png">


---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #223 
