### PR TITLE
Dashboard: Bug fixes for color panel translation and detail template capitalization

### DIFF
--- a/assets/src/dashboard/components/dropdown/index.js
+++ b/assets/src/dashboard/components/dropdown/index.js
@@ -17,7 +17,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -244,7 +244,12 @@ const Dropdown = ({
                 {selectedItems.length > 1 &&
                   sprintf(
                     /* translators: %s: number selected */
-                    __(' + %s', 'web-stories'),
+                    _n(
+                      ' + %s',
+                      ' + %s',
+                      (selectedItems.length - 1).toString(10),
+                      'web-stories'
+                    ),
                     (selectedItems.length - 1).toString(10)
                   )}
               </>

--- a/assets/src/dashboard/components/templateNavBar/index.js
+++ b/assets/src/dashboard/components/templateNavBar/index.js
@@ -75,6 +75,9 @@ const CloseLink = styled.a`
     color: ${theme.colors.gray700};
   `}
 `;
+const CapitalizedButton = styled(Button)`
+  text-transform: uppercase;
+`;
 
 export function TemplateNavBar({ handleCta }) {
   return (
@@ -84,9 +87,9 @@ export function TemplateNavBar({ handleCta }) {
       </Container>
       <Container>
         <BookmarkToggle />
-        <Button type={BUTTON_TYPES.CTA} onClick={handleCta}>
-          {__('USE TEMPLATE', 'web-stories')}
-        </Button>
+        <CapitalizedButton type={BUTTON_TYPES.CTA} onClick={handleCta}>
+          {__('use template', 'web-stories')}
+        </CapitalizedButton>
       </Container>
     </Nav>
   );


### PR DESCRIPTION
## Summary
Two small bug fixes to improve internationalization. 
1) Giving the color dropdown that shows `[color 1] + n` a true plural option for if translations need it. 
2) Moving the forced capitalization of a button on the detail template view to css. 

## Relevant Technical Choices
- using _n not __ for plural of numbers in i18n 

## To-do
N/A

## User-facing changes
- None, should appear the exact same to the user 
(Areas to regression test are the color filter on templates and the 'USE TEMPLATE' button on the detail template view) 

## Testing Instructions
- Regression test that the color label updates the same on the template color picker
-  and that the 'USE TEMPLATE' button on the detail view of template is still all caps. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2293
