### PR TITLE
Dashboard: Confirm Delete Dialog UI

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -36,6 +36,7 @@ import { GlobalStyle as ModalGlobalStyle } from '../assets/src/edit-story/compon
 import dashboardTheme, {
   GlobalStyle as DashboardGlobalStyle,
 } from '../assets/src/dashboard/theme';
+import { GlobalStyle as DashboardModalGlobalStyle } from '../assets/src/dashboard/components/modal';
 import DashboardKeyboardOnlyOutline from '../assets/src/dashboard/utils/keyboardOnlyOutline';
 import { ConfigProvider } from '../assets/src/dashboard/app/config';
 import ApiProvider from '../assets/src/dashboard/app/api/apiProvider';
@@ -87,6 +88,7 @@ addDecorator((story, { id }) => {
           >
             <ApiProvider>
               <DashboardGlobalStyle />
+              <DashboardModalGlobalStyle />
               <DashboardKeyboardOnlyOutline />
               {story()}
             </ApiProvider>

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -65,6 +65,11 @@ function StoriesView({
   const [activeDialog, setActiveDialog] = useState('');
   const [activeStory, setActiveStory] = useState(null);
 
+  const isActiveDeleteStoryDialog = useMemo(
+    () => activeDialog === ACTIVE_DIALOG_DELETE_STORY && activeStory,
+    [activeDialog, activeStory]
+  );
+
   useEffect(() => {
     if (!activeDialog) {
       setActiveStory(null);
@@ -169,7 +174,7 @@ function StoriesView({
   return (
     <>
       {ActiveView}
-      {activeDialog === ACTIVE_DIALOG_DELETE_STORY && activeStory && (
+      {isActiveDeleteStoryDialog && (
         <Dialog
           isOpen={true}
           contentLabel={__('Dialog to confirm deleting a story', 'web-stories')}

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -65,10 +65,8 @@ function StoriesView({
   const [activeDialog, setActiveDialog] = useState('');
   const [activeStory, setActiveStory] = useState(null);
 
-  const isActiveDeleteStoryDialog = useMemo(
-    () => activeDialog === ACTIVE_DIALOG_DELETE_STORY && activeStory,
-    [activeDialog, activeStory]
-  );
+  const isActiveDeleteStoryDialog =
+    activeDialog === ACTIVE_DIALOG_DELETE_STORY && activeStory;
 
   useEffect(() => {
     if (!activeDialog) {

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -48,6 +48,7 @@ import {
 } from '../../../../../constants';
 import { StoryGridView, StoryListView } from '../../../shared';
 
+const ACTIVE_DIALOG_DELETE_STORY = 'DELETE_STORY';
 function StoriesView({
   filterValue,
   sort,
@@ -61,14 +62,14 @@ function StoriesView({
   const enableInProgressStoryActions = useFeature(
     'enableInProgressStoryActions'
   );
-  const [activeModal, setActiveModal] = useState('');
+  const [activeDialog, setActiveDialog] = useState('');
   const [activeStory, setActiveStory] = useState(null);
 
   useEffect(() => {
-    if (!activeModal) {
+    if (!activeDialog) {
       setActiveStory(null);
     }
-  }, [activeModal, setActiveStory]);
+  }, [activeDialog, setActiveStory]);
 
   const handleOnRenameStory = useCallback(
     (story, newTitle) => {
@@ -98,8 +99,8 @@ function StoriesView({
           break;
 
         case STORY_CONTEXT_MENU_ACTIONS.DELETE:
-          setActiveModal('DELETE_STORY');
           setActiveStory(story);
+          setActiveDialog(ACTIVE_DIALOG_DELETE_STORY);
           break;
 
         default:
@@ -168,17 +169,17 @@ function StoriesView({
   return (
     <>
       {ActiveView}
-      {activeModal === 'DELETE_STORY' && (
+      {activeDialog === ACTIVE_DIALOG_DELETE_STORY && activeStory && (
         <Dialog
           isOpen={true}
-          contentLabel={__('Modal to confirm deleting a story', 'web-stories')}
+          contentLabel={__('Dialog to confirm deleting a story', 'web-stories')}
           title={__('Delete Story', 'web-stories')}
-          onClose={() => setActiveModal('')}
+          onClose={() => setActiveDialog('')}
           actions={
             <>
               <Button
                 type={BUTTON_TYPES.DEFAULT}
-                onClick={() => setActiveModal('')}
+                onClick={() => setActiveDialog('')}
               >
                 {__('Cancel', 'web-stories')}
               </Button>
@@ -186,7 +187,7 @@ function StoriesView({
                 type={BUTTON_TYPES.CTA}
                 onClick={() => {
                   storyActions.trashStory(activeStory);
-                  setActiveModal('');
+                  setActiveDialog('');
                 }}
               >
                 {__('Delete', 'web-stories')}

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -23,7 +23,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { useFeature } from 'flagged';
 
 /**
@@ -38,11 +38,13 @@ import {
   SortPropTypes,
   ViewPropTypes,
 } from '../../../../../utils/useStoryView';
+import { Button, Dialog } from '../../../../../components';
 import {
   VIEW_STYLE,
   STORY_ITEM_CENTER_ACTION_LABELS,
   STORY_CONTEXT_MENU_ACTIONS,
   STORY_CONTEXT_MENU_ITEMS,
+  BUTTON_TYPES,
 } from '../../../../../constants';
 import { StoryGridView, StoryListView } from '../../../shared';
 
@@ -59,6 +61,15 @@ function StoriesView({
   const enableInProgressStoryActions = useFeature(
     'enableInProgressStoryActions'
   );
+  const [activeModal, setActiveModal] = useState('');
+  const [activeStory, setActiveStory] = useState(null);
+
+  useEffect(() => {
+    if (!activeModal) {
+      setActiveStory(null);
+    }
+  }, [activeModal, setActiveStory]);
+
   const handleOnRenameStory = useCallback(
     (story, newTitle) => {
       setTitleRenameId(-1);
@@ -87,17 +98,8 @@ function StoriesView({
           break;
 
         case STORY_CONTEXT_MENU_ACTIONS.DELETE:
-          if (
-            window.confirm(
-              sprintf(
-                /* translators: %s: story title. */
-                __('Are you sure you want to delete "%s"?', 'web-stories'),
-                story.title
-              )
-            )
-          ) {
-            storyActions.trashStory(story);
-          }
+          setActiveModal('DELETE_STORY');
+          setActiveStory(story);
           break;
 
         default:
@@ -136,30 +138,70 @@ function StoriesView({
     };
   }, [handleOnRenameStory, setTitleRenameId, titleRenameId]);
 
-  return view.style === VIEW_STYLE.LIST ? (
-    <StoryListView
-      handleSortChange={sort.set}
-      handleSortDirectionChange={sort.setDirection}
-      renameStory={renameStory}
-      sortDirection={sort.direction}
-      stories={stories}
-      storyMenu={storyMenu}
-      storySort={sort.value}
-      storyStatus={filterValue}
-      users={users}
-    />
-  ) : (
-    <StoryGridView
-      bottomActionLabel={__('Open in editor', 'web-stories')}
-      centerActionLabelByStatus={
-        enableInProgressStoryActions && STORY_ITEM_CENTER_ACTION_LABELS
-      }
-      pageSize={view.pageSize}
-      renameStory={renameStory}
-      storyMenu={storyMenu}
-      stories={stories}
-      users={users}
-    />
+  const ActiveView =
+    view.style === VIEW_STYLE.LIST ? (
+      <StoryListView
+        handleSortChange={sort.set}
+        handleSortDirectionChange={sort.setDirection}
+        renameStory={renameStory}
+        sortDirection={sort.direction}
+        stories={stories}
+        storyMenu={storyMenu}
+        storySort={sort.value}
+        storyStatus={filterValue}
+        users={users}
+      />
+    ) : (
+      <StoryGridView
+        bottomActionLabel={__('Open in editor', 'web-stories')}
+        centerActionLabelByStatus={
+          enableInProgressStoryActions && STORY_ITEM_CENTER_ACTION_LABELS
+        }
+        pageSize={view.pageSize}
+        renameStory={renameStory}
+        storyMenu={storyMenu}
+        stories={stories}
+        users={users}
+      />
+    );
+
+  return (
+    <>
+      {ActiveView}
+      {activeModal === 'DELETE_STORY' && (
+        <Dialog
+          isOpen={true}
+          contentLabel={__('Modal to confirm deleting a story', 'web-stories')}
+          title={__('Delete Story', 'web-stories')}
+          onClose={() => setActiveModal('')}
+          actions={
+            <>
+              <Button
+                type={BUTTON_TYPES.DEFAULT}
+                onClick={() => setActiveModal('')}
+              >
+                {__('Cancel', 'web-stories')}
+              </Button>
+              <Button
+                type={BUTTON_TYPES.CTA}
+                onClick={() => {
+                  storyActions.trashStory(activeStory);
+                  setActiveModal('');
+                }}
+              >
+                {__('Delete', 'web-stories')}
+              </Button>
+            </>
+          }
+        >
+          {sprintf(
+            /* translators: %s: story title. */
+            __('Are you sure you want to delete "%s"?', 'web-stories'),
+            activeStory.title
+          )}
+        </Dialog>
+      )}
+    </>
   );
 }
 

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -66,6 +66,20 @@ const PrimaryButton = styled(StyledButton)`
   background-color: ${({ theme }) => theme.colors.bluePrimary};
 `;
 
+const DefaultButton = styled(StyledButton)(
+  ({ theme }) => `
+    background-color: ${theme.colors.white};
+    color: ${theme.colors.gray800};
+    border: ${theme.borders.gray800};
+    &:focus,
+    &:active,
+    &:hover {
+      color: ${theme.colors.gray900};
+      border-color: ${theme.colors.gray900};
+    }
+  `
+);
+
 // TODO: address CTA active styling
 const CtaButton = styled(StyledButton)`
   background-color: ${({ theme }) => theme.colors.bluePrimary};
@@ -110,6 +124,7 @@ const Button = ({
     [BUTTON_TYPES.PRIMARY]: PrimaryButton,
     [BUTTON_TYPES.SECONDARY]: SecondaryButton,
     [BUTTON_TYPES.CTA]: CtaButton,
+    [BUTTON_TYPES.DEFAULT]: DefaultButton,
   };
 
   const StyledButtonByType = ButtonOptions[type];

--- a/assets/src/dashboard/components/button/stories/index.js
+++ b/assets/src/dashboard/components/button/stories/index.js
@@ -50,6 +50,7 @@ export const _default = () => {
             cta: BUTTON_TYPES.CTA,
             primary: BUTTON_TYPES.PRIMARY,
             secondary: BUTTON_TYPES.SECONDARY,
+            default: BUTTON_TYPES.DEFAULT,
           },
           BUTTON_TYPES.PRIMARY
         )}

--- a/assets/src/dashboard/components/cardGridItem/index.js
+++ b/assets/src/dashboard/components/cardGridItem/index.js
@@ -35,7 +35,12 @@ const CardGridItem = styled.div`
     margin: 12px 0;
   }
 
-  &:hover ${MoreVerticalButton}, &:active ${MoreVerticalButton} {
+  &:hover
+    ${MoreVerticalButton},
+    &:active
+    ${MoreVerticalButton},
+    &:focus-within
+    ${MoreVerticalButton} {
     opacity: 1;
   }
 `;

--- a/assets/src/dashboard/components/dialog/index.js
+++ b/assets/src/dashboard/components/dialog/index.js
@@ -29,26 +29,26 @@ import Modal from '../modal';
 // Shadow styles ported from @material-ui/Dialog
 const DialogBox = styled.div(
   ({ theme: { colors } }) => `
-  display: flex;
-  position: relative;
-  overflow-y: auto;
-  max-width: 920px;
-  max-height: calc(100% - 64px);
-  margin: 32px;
-  padding: 24px;
-  flex-direction: column;
-  background-color: ${colors.white};
-  border-radius: 4px;
-  box-shadow: ${`0px 11px 15px -7px ${rgba(
-    colors.gray900,
-    0.2
-  )}, 0px 24px 38px 3px ${rgba(colors.gray900, 0.14)}, 0px 9px 46px 8px ${rgba(
-    colors.gray900,
-    0.12
-  )}`};
-  color: ${colors.gray800};
-  transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
-`
+    display: flex;
+    position: relative;
+    overflow-y: auto;
+    max-width: 920px;
+    max-height: calc(100% - 64px);
+    margin: 32px;
+    padding: 24px;
+    flex-direction: column;
+    background-color: ${colors.white};
+    border-radius: 4px;
+    box-shadow: ${`0px 11px 15px -7px ${rgba(
+      colors.gray900,
+      0.2
+    )}, 0px 24px 38px 3px ${rgba(
+      colors.gray900,
+      0.14
+    )}, 0px 9px 46px 8px ${rgba(colors.gray900, 0.12)}`};
+    color: ${colors.gray800};
+    transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+  `
 );
 
 const DialogTitle = styled.h1`

--- a/assets/src/dashboard/components/dialog/index.js
+++ b/assets/src/dashboard/components/dialog/index.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { rgba } from 'polished';
+/**
+ * Internal dependencies
+ */
+import { TypographyPresets } from '../typography';
+import Modal from '../modal';
+
+// Shadow styles ported from @material-ui/Dialog
+const DialogBox = styled.div(
+  ({ theme: { colors } }) => `
+  display: flex;
+  position: relative;
+  overflow-y: auto;
+  max-width: 920px;
+  max-height: calc(100% - 64px);
+  margin: 32px;
+  padding: 24px;
+  flex-direction: column;
+  background-color: ${colors.white};
+  border-radius: 4px;
+  box-shadow: ${`0px 11px 15px -7px ${rgba(
+    colors.gray900,
+    0.2
+  )}, 0px 24px 38px 3px ${rgba(colors.gray900, 0.14)}, 0px 9px 46px 8px ${rgba(
+    colors.gray900,
+    0.12
+  )}`};
+  color: ${colors.gray800};
+  transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
+`
+);
+
+const DialogTitle = styled.h1`
+  ${TypographyPresets.Large};
+  flex: 0 0 auto;
+  margin: 0;
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
+`;
+const DialogContent = styled.div`
+  ${TypographyPresets.Medium};
+  flex: 1 1 auto;
+  padding: 16px 0;
+  overflow-y: auto;
+  color: ${({ theme }) => theme.colors.gray700};
+`;
+
+const DialogActions = styled.div`
+  display: flex;
+  align-items: flex-end;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0;
+
+  & > button {
+    margin: 0 10px;
+    &:last-of-type {
+      margin-right: 0;
+    }
+  }
+`;
+
+function Dialog({ children, title, actions, isOpen, onClose, ...props }) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} {...props}>
+      <DialogBox>
+        {Boolean(title) && <DialogTitle>{title}</DialogTitle>}
+        <DialogContent>{children}</DialogContent>
+        {Boolean(actions) && <DialogActions>{actions}</DialogActions>}
+      </DialogBox>
+    </Modal>
+  );
+}
+
+Dialog.propTypes = {
+  actions: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+  children: PropTypes.node.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  title: PropTypes.string,
+  contentLabel: PropTypes.string,
+};
+
+export default Dialog;

--- a/assets/src/dashboard/components/dialog/index.js
+++ b/assets/src/dashboard/components/dialog/index.js
@@ -73,7 +73,7 @@ const DialogActions = styled.div`
   padding: 0;
 
   & > button {
-    margin: 0 10px;
+    margin-right: 10px;
     &:last-of-type {
       margin-right: 0;
     }

--- a/assets/src/dashboard/components/dialog/stories/index.js
+++ b/assets/src/dashboard/components/dialog/stories/index.js
@@ -24,8 +24,8 @@ import { text } from '@storybook/addon-knobs';
 /**
  * Internal dependencies
  */
-import Dialog from '..';
 import Button from '../../button';
+import Dialog from '..';
 
 export default {
   title: 'Dashboard/Components/Dialog',
@@ -35,7 +35,7 @@ export default {
 export const _default = () => {
   const [toggleDialog, setToggleDialog] = useState(false);
 
-  const ActionNode = (
+  const ActionsNode = (
     <Button
       onClick={() => {
         action('button clicked');
@@ -58,7 +58,7 @@ export const _default = () => {
         isOpen={toggleDialog}
         title={text('title', 'Dialog title')}
         contentLabel={'Dialog content Label for modal'}
-        actions={ActionNode}
+        actions={ActionsNode}
       >
         <p>
           {text(
@@ -74,7 +74,7 @@ export const _default = () => {
 export const With2Actions = () => {
   const [toggleDialog, setToggleDialog] = useState(false);
 
-  const ActionNode = (
+  const ActionsNode = (
     <>
       <Button
         onClick={() => {
@@ -106,7 +106,7 @@ export const With2Actions = () => {
         isOpen={toggleDialog}
         title={text('title', 'Dialog title')}
         contentLabel={'Dialog content Label for modal'}
-        actions={ActionNode}
+        actions={ActionsNode}
       >
         <p>
           {text(

--- a/assets/src/dashboard/components/dialog/stories/index.js
+++ b/assets/src/dashboard/components/dialog/stories/index.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from '..';
+import Button from '../../button';
+
+export default {
+  title: 'Dashboard/Components/Dialog',
+  component: Dialog,
+};
+
+export const _default = () => {
+  const [toggleDialog, setToggleDialog] = useState(false);
+
+  const ActionNode = (
+    <Button
+      onClick={() => {
+        action('button clicked');
+        setToggleDialog(!toggleDialog);
+      }}
+    >
+      {'Button Text'}
+    </Button>
+  );
+  return (
+    <>
+      <Button onClick={() => setToggleDialog(!toggleDialog)}>
+        {'Toggle Dialog'}
+      </Button>
+      <Dialog
+        onClose={() => {
+          action('close dialog clicked');
+          setToggleDialog(!toggleDialog);
+        }}
+        isOpen={toggleDialog}
+        title={text('title', 'Dialog title')}
+        contentLabel={'Dialog content Label for modal'}
+        actions={ActionNode}
+      >
+        <p>
+          {text(
+            'body text',
+            'Are you sure you want to do this action? It cannot be reversed.'
+          )}
+        </p>
+      </Dialog>
+    </>
+  );
+};
+
+export const With2Actions = () => {
+  const [toggleDialog, setToggleDialog] = useState(false);
+
+  const ActionNode = (
+    <>
+      <Button
+        onClick={() => {
+          action('cancel button clicked');
+          setToggleDialog(!toggleDialog);
+        }}
+      >
+        {'cancel'}
+      </Button>
+      <Button
+        onClick={() => {
+          action('button clicked');
+        }}
+      >
+        {'an action'}
+      </Button>
+    </>
+  );
+  return (
+    <>
+      <Button onClick={() => setToggleDialog(!toggleDialog)}>
+        {'Toggle Dialog'}
+      </Button>
+      <Dialog
+        onClose={() => {
+          action('close dialog clicked');
+          setToggleDialog(!toggleDialog);
+        }}
+        isOpen={toggleDialog}
+        title={text('title', 'Dialog title')}
+        contentLabel={'Dialog content Label for modal'}
+        actions={ActionNode}
+      >
+        <p>
+          {text(
+            'body text',
+            'Are you sure you want to do this action? It cannot be reversed.'
+          )}
+        </p>
+      </Dialog>
+    </>
+  );
+};

--- a/assets/src/dashboard/components/dialog/test/dialog.js
+++ b/assets/src/dashboard/components/dialog/test/dialog.js
@@ -15,29 +15,48 @@
  */
 
 /**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
 import { renderWithTheme } from '../../../testUtils/';
-import Modal from '../';
+import Dialog from '../';
 
-describe('Modal', () => {
-  it('should not render a modal by default', () => {
+describe('Dialog', () => {
+  it('should not render a dialog by default', () => {
     const { queryAllByRole } = renderWithTheme(
-      <Modal onClose={jest.fn}>
-        <p>{'modal child'}</p>
-      </Modal>
+      <Dialog onClose={jest.fn}>
+        <p>{'dialog child'}</p>
+      </Dialog>
     );
 
     expect(queryAllByRole('dialog', { hidden: true })).toHaveLength(0);
   });
 
-  it('should render a modal when isOpen is true', () => {
-    const { getByRole } = renderWithTheme(
-      <Modal onClose={jest.fn} isOpen={true}>
-        <p>{'modal child'}</p>
-      </Modal>
+  it('should render a dialog when isOpen is true', () => {
+    const mockButtonClick = jest.fn();
+    const ActionsNode = (
+      <button onClick={mockButtonClick}>{'dialog button'}</button>
+    );
+
+    const { getByRole, getByText } = renderWithTheme(
+      <Dialog
+        onClose={jest.fn}
+        isOpen={true}
+        title="dialog title"
+        actions={ActionsNode}
+      >
+        <p>{'dialog child'}</p>
+      </Dialog>
     );
 
     expect(getByRole('dialog')).toBeInTheDocument();
+    const dialogButton = getByText('dialog button');
+
+    fireEvent.click(dialogButton);
+    expect(mockButtonClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -24,21 +24,20 @@ export {
   CardTitle,
   default as CardGridItem,
 } from './cardGridItem';
-export {
-  default as NavProvider,
-  useNavContext,
-} from '../components/navProvider';
 export { default as ColorList } from './colorList';
 export {
   DetailViewContentGutter,
   StandardViewContentGutter,
 } from './contentGutter';
+export { default as Dialog } from './dialog';
 export { default as Dropdown } from './dropdown';
 export { default as InfiniteScroller } from './infiniteScroller';
 export { default as InlineInputForm } from './inlineInputForm';
 export { TextInput } from './input';
 export { default as Layout, useLayoutContext } from './layout';
+export { default as Modal } from './modal';
 export { default as MultiPartPill } from './multiPartPill';
+export { default as NavProvider, useNavContext } from './navProvider';
 export {
   AppFrame,
   LeftRail,

--- a/assets/src/dashboard/components/modal/index.js
+++ b/assets/src/dashboard/components/modal/index.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import ReactModal from 'react-modal';
+import PropTypes from 'prop-types';
+import { createGlobalStyle } from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import theme from '../../theme';
+
+const CONTENT_CLASS = 'WebStories_ReactModal__Content';
+const OVERLAY_CLASS = 'WebStories_ReactModal__Overlay';
+
+export const GlobalStyle = createGlobalStyle`
+  .${OVERLAY_CLASS} {
+    opacity: 0;
+    transition: opacity 0.1s ease-out;
+  }
+
+  .${OVERLAY_CLASS}.ReactModal__Overlay--after-open {
+    opacity: 1;
+  }
+
+  .${OVERLAY_CLASS}.ReactModal__Overlay--before-close {
+    opacity: 0;
+  }
+`;
+
+const customStyles = {
+  overlay: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 10,
+    backgroundColor: theme.colors.gray900,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  content: {
+    overflow: 'auto',
+    outline: 'none',
+    display: 'flex',
+    backgroundColor: theme.colors.white,
+    maxHeight: '100%',
+    justifyContent: 'center',
+  },
+};
+
+export default function Modal({
+  children,
+  contentLabel = __('modal', 'web-stories'),
+  contentStyles,
+  isOpen,
+  modalStyles = {},
+  onClose,
+  overlayStyles,
+  ...props
+}) {
+  return (
+    <ReactModal
+      className={CONTENT_CLASS}
+      closeTimeoutMS={100}
+      contentLabel={contentLabel}
+      isOpen={isOpen}
+      onRequestClose={onClose}
+      overlayClassName={OVERLAY_CLASS}
+      style={{
+        maxHeight: '100vh',
+        ...modalStyles,
+        overlay: { ...customStyles.overlay, ...overlayStyles },
+        content: { ...customStyles.content, ...contentStyles },
+      }}
+      {...props}
+    >
+      {children}
+    </ReactModal>
+  );
+}
+
+Modal.propTypes = {
+  children: PropTypes.node.isRequired,
+  onClose: PropTypes.func.isRequired,
+  contentLabel: PropTypes.string,
+  contentStyles: PropTypes.object,
+  isOpen: PropTypes.bool,
+  modalStyles: PropTypes.object,
+  overlayStyles: PropTypes.object,
+};

--- a/assets/src/dashboard/components/modal/index.js
+++ b/assets/src/dashboard/components/modal/index.js
@@ -25,6 +25,7 @@ import { __ } from '@wordpress/i18n';
 import ReactModal from 'react-modal';
 import PropTypes from 'prop-types';
 import { createGlobalStyle } from 'styled-components';
+import { rgba } from 'polished';
 
 /**
  * Internal dependencies
@@ -57,7 +58,7 @@ const customStyles = {
     right: 0,
     bottom: 0,
     zIndex: 10,
-    backgroundColor: theme.colors.gray900,
+    backgroundColor: rgba(theme.colors.gray900, 0.96),
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -66,7 +67,6 @@ const customStyles = {
     overflow: 'auto',
     outline: 'none',
     display: 'flex',
-    backgroundColor: theme.colors.white,
     maxHeight: '100%',
     justifyContent: 'center',
   },

--- a/assets/src/dashboard/components/modal/stories/index.js
+++ b/assets/src/dashboard/components/modal/stories/index.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+
+/**
+ * Internal dependencies
+ */
+import Modal from '..';
+
+export default {
+  title: 'Dashboard/Components/Modal',
+  component: Modal,
+};
+
+export const _default = () => {
+  const [toggleModal, setToggleModal] = useState(false);
+  return (
+    <>
+      <h1>{'Dummy header for modal context'}</h1>
+      <p>
+        {
+          "I can afford more glasses! White rabbit object: whatever it did, it did it all. Don't get cheap on me, Dodgson. Because we're being hunted. Bloody move! I told you, how many times, we needed locking mechanisms on the vehicle doors!"
+        }
+      </p>
+      <button onClick={() => setToggleModal(!toggleModal)}>
+        {'Toggle Modal'}
+      </button>
+
+      <Modal
+        ariaHideApp={false} // this is ONLY for storybook to eliminate a warning, we set the app id in the root index of dashboard
+        contentLabel={'my storybook modal label'}
+        aria={{
+          labelledby: 'additional heading for aria - optional',
+          describedby: 'additional described by for aria - optional',
+        }}
+        isOpen={toggleModal}
+        onClose={() => {
+          action('close modal clicked');
+          setToggleModal(!toggleModal);
+        }}
+      >
+        <div>
+          <h1>{'Modal Content Goes Here!'}</h1>
+          <p>{'kjalskdjfalkdfjlkafjdlakdfj'}</p>
+          <button>{'a button'}</button>
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export const OverriddenStyles = () => {
+  const [toggleModal, setToggleModal] = useState(false);
+
+  return (
+    <>
+      <h1>{'Dummy header for modal context'}</h1>
+      <p>
+        {
+          "Don't get cheap on me, Dodgson. I told you, how many times, we needed locking mechanisms on the vehicle doors!"
+        }
+      </p>
+      <button onClick={() => setToggleModal(!toggleModal)}>
+        {'Toggle Modal'}
+      </button>
+
+      <Modal
+        ariaHideApp={false} // this is ONLY for storybook to eliminate a warning, we set the app id in the root index of dashboard
+        isOpen={toggleModal}
+        onClose={() => {
+          action('close modal clicked');
+          setToggleModal(!toggleModal);
+        }}
+        contentStyles={{
+          backgroundColor: 'salmon',
+          borderRadius: '5px',
+          padding: '10px 20px',
+        }}
+        overlayStyles={{
+          backgroundColor: 'rgba(255, 255, 255, 0.75)',
+        }}
+      >
+        <div>
+          <h1>{'Modal Content Goes Here!'}</h1>
+          <p>{'kjalskdjfalkdfjlkafjdlakdfj'}</p>
+          <button>{'a button'}</button>
+        </div>
+      </Modal>
+    </>
+  );
+};

--- a/assets/src/dashboard/components/modal/test/modal.js
+++ b/assets/src/dashboard/components/modal/test/modal.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { renderWithTheme } from '../../../testUtils/';
+import Modal from '../';
+
+describe('Modal', () => {
+  const onCloseMock = jest.fn;
+
+  it('should not render a modal by default', () => {
+    const { queryAllByRole } = renderWithTheme(
+      <Modal onClose={onCloseMock}>
+        <p>{'modal child'}</p>
+      </Modal>
+    );
+
+    expect(queryAllByRole('dialog', { hidden: true })).toHaveLength(0);
+  });
+
+  it('should render a modal when isOpen is true', () => {
+    const { getByRole } = renderWithTheme(
+      <Modal onClose={onCloseMock} isOpen={true}>
+        <p>{'modal child'}</p>
+      </Modal>
+    );
+
+    expect(getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/assets/src/dashboard/constants/components.js
+++ b/assets/src/dashboard/constants/components.js
@@ -22,3 +22,27 @@ export const PILL_INPUT_TYPES = {
   CHECKBOX: 'checkbox',
   RADIO: 'radio',
 };
+
+export const BUTTON_TYPES = {
+  CTA: 'cta',
+  DEFAULT: 'default',
+  PRIMARY: 'primary',
+  SECONDARY: 'secondary',
+};
+
+export const CHIP_TYPES = {
+  STANDARD: 'standard',
+  SMALL: 'small',
+};
+
+export const DROPDOWN_TYPES = {
+  MENU: 'menu',
+  PANEL: 'panel',
+  COLOR_PANEL: 'color_panel',
+};
+
+export const KEYS = {
+  ENTER: 'Enter',
+  UP: 'ArrowUp',
+  DOWN: 'ArrowDown',
+};

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -25,29 +25,6 @@ import { STORY_VIEWING_LABELS } from './stories';
 import { SAVED_TEMPLATES_VIEWING_LABELS } from './savedTemplates';
 import { TEMPLATES_GALLERY_VIEWING_LABELS } from './templates';
 
-export const BUTTON_TYPES = {
-  CTA: 'cta',
-  PRIMARY: 'primary',
-  SECONDARY: 'secondary',
-};
-
-export const CHIP_TYPES = {
-  STANDARD: 'standard',
-  SMALL: 'small',
-};
-
-export const DROPDOWN_TYPES = {
-  MENU: 'menu',
-  PANEL: 'panel',
-  COLOR_PANEL: 'color_panel',
-};
-
-export const KEYS = {
-  ENTER: 'Enter',
-  UP: 'ArrowUp',
-  DOWN: 'ArrowDown',
-};
-
 export const KEYBOARD_USER_CLASS = `useskeyboard`;
 export const KEYBOARD_USER_SELECTOR = `.${KEYBOARD_USER_CLASS}`;
 
@@ -130,6 +107,7 @@ export const RESULT_LABELS = {
 };
 
 export * from './animation';
+export * from './components';
 export * from './direction';
 export * from './pageStructure';
 export * from './savedTemplates';

--- a/assets/src/dashboard/index.js
+++ b/assets/src/dashboard/index.js
@@ -19,6 +19,7 @@
  */
 import { render } from 'react-dom';
 import { FlagsProvider } from 'flagged';
+import Modal from 'react-modal';
 import 'web-animations-js/web-animations-next-lite.min.js';
 
 /**
@@ -37,6 +38,8 @@ import './style.css'; // This way the general dashboard styles are loaded before
 const initialize = (id, config, flags) => {
   const appElement = document.getElementById(id);
 
+  // see http://reactcommunity.org/react-modal/accessibility/
+  Modal.setAppElement(appElement);
   render(
     <FlagsProvider features={flags}>
       <App config={config} />

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -75,6 +75,7 @@ const colors = {
 const borders = {
   gray50: `1px solid ${colors.gray50}`,
   gray100: `1px solid ${colors.gray100}`,
+  gray800: `1px solid ${colors.gray800}`,
   transparent: '1px solid transparent',
   bluePrimary: `1px solid ${colors.bluePrimary}`,
   action: `1px solid ${colors.action}`,


### PR DESCRIPTION
## Summary
We needed a dialog on the dashboard side of the app to replace the browser default alert for deleting a story. Leveraged technical choices and react modal that are already in play within the story editor.

<img width="432" alt="Screen Shot 2020-06-09 at 4 49 46 PM" src="https://user-images.githubusercontent.com/10720454/84210088-12b57980-aa75-11ea-9c8c-d352bc27dedb.png">

![cancel delete story](https://user-images.githubusercontent.com/10720454/84210090-134e1000-aa75-11ea-9757-db60b950955a.gif)

![complete delete story](https://user-images.githubusercontent.com/10720454/84210094-177a2d80-aa75-11ea-896c-eae18607a56c.gif)

## Relevant Technical Choices
- Modal 
  - Leverages reactModal. Creates a new `Modal` for the dashboard to use, kept the API mostly the same as the story editor so that creating a library eventually that can replace the duplicate modals in the editor and dashboard is more streamlines. 
  - Chose to rename `open` to `isOpen` to comply with boolean best practices in props 
  - removed references to wordPress to make it easier to pull out when ready.  
- Dialog
  - Leverages dialog from story editor too. Minor updates, making the title an `h1` instead of a `div` and tweaking spacing so that things stay consistent regardless of different props existing 
- Delete story dialog 
  - added 2 pieces of state to the storyView component - 1 for active dialog and 1 for the active story
  - My thought process here is that if we notice ourselves having _any more_ active dialogs that the state `setActiveDialog` can easily become a state machine and we can have a 1 stop shop for the different kinds. I opted to just use the `Dialog` component straight here to avoid unnecessary complexity at the moment. 

## To-do
- Potentially extracting the confirm action dialog as a shared dialog type and creating some sort of state machine to manage dialogs easily. 

## User-facing changes
- Now when you select 'delete story' from the story context menu (three vertical dots) you will get a confirmation dialog that looks like the screenshots attached. 
- If you click 'cancel' it will not delete and it will close the dialog 
- If you click 'Delete' it will delete your story, close the dialog. 

## Testing Instructions
- Modal and Dialog can be found by themselves in storybook: 
  - modal: Dashboard/Components/Modal
  - dialog: Dashboard/Components/Dialog
- You can also test the delete interaction in storybook! Dashboard/Views/MyStories/Content 
- Try deleting a story and cancelling deleting a story on the branch in the my stories view in both grid and list form. 
- Also try using the keyboard. The modal should focus and be super easy to key through.

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2263 
