### PR TITLE
Dashboard: Temporarily remove story actions that aren't ready yet

### DIFF
--- a/assets/src/dashboard/app/views/myStories/content/stories/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/stories/index.js
@@ -20,6 +20,8 @@
 import { text } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import styled from 'styled-components';
+import { FlagsProvider } from 'flagged';
+
 /**
  * Internal dependencies
  */
@@ -97,11 +99,13 @@ export const _default = () => {
   });
 
   return (
-    <Layout.Provider>
-      <StorybookLayoutContainer>
-        <Content {...defaultProps} view={{ ...view, pageSize }} />
-      </StorybookLayoutContainer>
-    </Layout.Provider>
+    <FlagsProvider features={{ enableInProgressStoryActions: false }}>
+      <Layout.Provider>
+        <StorybookLayoutContainer>
+          <Content {...defaultProps} view={{ ...view, pageSize }} />
+        </StorybookLayoutContainer>
+      </Layout.Provider>
+    </FlagsProvider>
   );
 };
 
@@ -118,15 +122,17 @@ export const AllDataFetched = () => {
     isGrid: true,
   });
   return (
-    <Layout.Provider>
-      <StorybookLayoutContainer>
-        <Content
-          {...defaultProps}
-          allPagesFetched={true}
-          view={{ ...view, pageSize }}
-        />
-      </StorybookLayoutContainer>
-    </Layout.Provider>
+    <FlagsProvider features={{ enableInProgressStoryActions: false }}>
+      <Layout.Provider>
+        <StorybookLayoutContainer>
+          <Content
+            {...defaultProps}
+            allPagesFetched={true}
+            view={{ ...view, pageSize }}
+          />
+        </StorybookLayoutContainer>
+      </Layout.Provider>
+    </FlagsProvider>
   );
 };
 
@@ -135,38 +141,44 @@ export const AllDataFetchedAsList = () => {
     thumbnailMode: true,
   });
   return (
-    <Layout.Provider>
-      <StorybookLayoutContainer>
-        <Content
-          {...defaultProps}
-          allPagesFetched={true}
-          view={{ ...view, style: VIEW_STYLE.LIST, pageSize }}
-        />
-      </StorybookLayoutContainer>
-    </Layout.Provider>
+    <FlagsProvider features={{ enableInProgressStoryActions: false }}>
+      <Layout.Provider>
+        <StorybookLayoutContainer>
+          <Content
+            {...defaultProps}
+            allPagesFetched={true}
+            view={{ ...view, style: VIEW_STYLE.LIST, pageSize }}
+          />
+        </StorybookLayoutContainer>
+      </Layout.Provider>
+    </FlagsProvider>
   );
 };
 
 export const _StoriesViewGrid = () => (
-  <StoriesView
-    filterValue={STORY_STATUS.ALL}
-    sort={sort}
-    storyActions={storyActions}
-    stories={formattedStoriesArray}
-    users={formattedUsersObject}
-    view={view}
-  />
+  <FlagsProvider features={{ enableInProgressStoryActions: false }}>
+    <StoriesView
+      filterValue={STORY_STATUS.ALL}
+      sort={sort}
+      storyActions={storyActions}
+      stories={formattedStoriesArray}
+      users={formattedUsersObject}
+      view={view}
+    />
+  </FlagsProvider>
 );
 
 export const _StoriesViewList = () => (
-  <StoriesView
-    filterValue={STORY_STATUS.ALL}
-    sort={sort}
-    storyActions={storyActions}
-    stories={formattedStoriesArray}
-    users={formattedUsersObject}
-    view={{ ...view, style: VIEW_STYLE.LIST }}
-  />
+  <FlagsProvider features={{ enableInProgressStoryActions: false }}>
+    <StoriesView
+      filterValue={STORY_STATUS.ALL}
+      sort={sort}
+      storyActions={storyActions}
+      stories={formattedStoriesArray}
+      users={formattedUsersObject}
+      view={{ ...view, style: VIEW_STYLE.LIST }}
+    />
+  </FlagsProvider>
 );
 
 export const _EmptyView = () => (

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -25,6 +25,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import PropTypes from 'prop-types';
 import { useState, useCallback, useMemo } from 'react';
 import { useFeature } from 'flagged';
+
 /**
  * Internal dependencies
  */

--- a/assets/src/dashboard/app/views/myStories/content/test/content.js
+++ b/assets/src/dashboard/app/views/myStories/content/test/content.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { renderWithTheme } from '../../../../../testUtils';
+import { renderWithThemeAndFlagsProvider } from '../../../../../testUtils';
 import formattedUsersObject from '../../../../../storybookUtils/formattedUsersObject';
 
 import { VIEW_STYLE, STORY_STATUSES } from '../../../../../constants';
@@ -65,7 +65,7 @@ describe('My Stories <Content />', function () {
   });
 
   it('should render the content grid with the correct story count.', function () {
-    const { getAllByTestId } = renderWithTheme(
+    const { getAllByTestId } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <Content
           filter={STORY_STATUSES[0]}
@@ -86,14 +86,15 @@ describe('My Stories <Content />', function () {
             updateStory: jest.fn,
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressStoryActions: false }
     );
 
     expect(getAllByTestId(/^story-grid-item/)).toHaveLength(fakeStories.length);
   });
 
   it('should show "Create a story to get started!" if no stories are present.', function () {
-    const { getByText } = renderWithTheme(
+    const { getByText } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <Content
           filter={STORY_STATUSES[0]}
@@ -114,14 +115,15 @@ describe('My Stories <Content />', function () {
             updateStory: jest.fn,
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressStoryActions: false }
     );
 
     expect(getByText('Create a story to get started!')).toBeInTheDocument();
   });
 
   it('should show "Sorry, we couldn\'t find any results matching "scooby dooby doo" if no stories are found for a search query are present.', function () {
-    const { getByText } = renderWithTheme(
+    const { getByText } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <Content
           filter={STORY_STATUSES[0]}
@@ -142,7 +144,8 @@ describe('My Stories <Content />', function () {
             updateStory: jest.fn,
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressStoryActions: false }
     );
 
     expect(

--- a/assets/src/dashboard/app/views/myStories/content/test/storiesView.js
+++ b/assets/src/dashboard/app/views/myStories/content/test/storiesView.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { renderWithTheme } from '../../../../../testUtils';
+import { renderWithThemeAndFlagsProvider } from '../../../../../testUtils';
 
 import {
   STORY_SORT_OPTIONS,
@@ -58,7 +58,7 @@ const fakeStories = [
 
 describe('My Stories <StoriesView />', function () {
   it(`should render stories as a grid when view is ${VIEW_STYLE.GRID}`, function () {
-    const { getAllByTestId } = renderWithTheme(
+    const { getAllByTestId } = renderWithThemeAndFlagsProvider(
       <StoriesView
         filterValue="all"
         sort={{
@@ -77,7 +77,8 @@ describe('My Stories <StoriesView />', function () {
           style: VIEW_STYLE.GRID,
           pageSize: { width: 210, height: 316 },
         }}
-      />
+      />,
+      { enableInProgressStoryActions: false }
     );
 
     expect(getAllByTestId(/^story-grid-item/)).toHaveLength(fakeStories.length);

--- a/assets/src/dashboard/app/views/savedTemplates/savedTemplatesGridView/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/savedTemplatesGridView/index.js
@@ -23,29 +23,48 @@ import { __ } from '@wordpress/i18n';
  * External dependencies
  */
 import { useState, useCallback, useMemo } from 'react';
-
+import { useFeature } from 'flagged';
 /**
  * Internal dependencies
  */
-import { TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS } from '../../../../constants';
+import {
+  TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS,
+  STORY_CONTEXT_MENU_ITEMS,
+} from '../../../../constants';
 import { ViewPropTypes } from '../../../../utils/useStoryView';
 import { StoriesPropType } from '../../../../types';
 import { StoryGridView } from '../../shared';
 
 function SavedTemplatesGridView({ stories, view }) {
   const [contextMenuId, setContextMenuId] = useState(-1);
+  const enableInProgressStoryActions = useFeature(
+    'enableInProgressStoryActions'
+  );
 
   const handleMenuItemSelected = useCallback(() => {
     setContextMenuId(-1);
   }, []);
+
+  const enabledMenuItems = useMemo(() => {
+    if (enableInProgressStoryActions) {
+      return STORY_CONTEXT_MENU_ITEMS;
+    }
+    return STORY_CONTEXT_MENU_ITEMS.filter((item) => !item.inProgress);
+  }, [enableInProgressStoryActions]);
 
   const storyMenu = useMemo(() => {
     return {
       handleMenuToggle: setContextMenuId,
       contextMenuId,
       handleMenuItemSelected,
+      menuItems: enabledMenuItems,
     };
-  }, [setContextMenuId, contextMenuId, handleMenuItemSelected]);
+  }, [
+    setContextMenuId,
+    contextMenuId,
+    handleMenuItemSelected,
+    enabledMenuItems,
+  ]);
 
   return (
     <StoryGridView

--- a/assets/src/dashboard/app/views/savedTemplates/savedTemplatesGridView/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/savedTemplatesGridView/index.js
@@ -24,6 +24,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { useState, useCallback, useMemo } from 'react';
 import { useFeature } from 'flagged';
+
 /**
  * Internal dependencies
  */

--- a/assets/src/dashboard/app/views/savedTemplates/test/savedTemplates.js
+++ b/assets/src/dashboard/app/views/savedTemplates/test/savedTemplates.js
@@ -22,7 +22,7 @@
  */
 import { fireEvent } from '@testing-library/react';
 import { SavedTemplatesContent, SavedTemplatesHeader } from '../index';
-import { renderWithTheme } from '../../../../testUtils';
+import { renderWithThemeAndFlagsProvider } from '../../../../testUtils';
 import {
   STORY_SORT_OPTIONS,
   VIEW_STYLE,
@@ -68,7 +68,7 @@ describe('<SavedTemplates />', function () {
   });
 
   it('should render with the correct count label and search keyword.', function () {
-    const { getByPlaceholderText, getByText } = renderWithTheme(
+    const { getByPlaceholderText, getByText } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <SavedTemplatesHeader
           filter={{ value: SAVED_TEMPLATES_STATUSES.ALL }}
@@ -80,7 +80,8 @@ describe('<SavedTemplates />', function () {
             pageSize: { width: 200, height: 300 },
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressStoryActions: false }
     );
     expect(getByPlaceholderText('Search Templates').value).toBe('Harry Potter');
     expect(getByText('3 results')).toBeInTheDocument();
@@ -88,7 +89,7 @@ describe('<SavedTemplates />', function () {
 
   it('should call the set keyword function when new text is searched', function () {
     const setKeywordFn = jest.fn();
-    const { getByPlaceholderText } = renderWithTheme(
+    const { getByPlaceholderText } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <SavedTemplatesHeader
           filter={{ value: SAVED_TEMPLATES_STATUSES.ALL }}
@@ -100,7 +101,8 @@ describe('<SavedTemplates />', function () {
             pageSize: { width: 200, height: 300 },
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressStoryActions: false }
     );
     fireEvent.change(getByPlaceholderText('Search Templates'), {
       target: { value: 'Hermione Granger' },
@@ -110,7 +112,7 @@ describe('<SavedTemplates />', function () {
 
   it('should call the set sort function when a new sort is selected', function () {
     const setSortFn = jest.fn();
-    const { getAllByText, getByText } = renderWithTheme(
+    const { getAllByText, getByText } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <SavedTemplatesHeader
           filter={{ value: SAVED_TEMPLATES_STATUSES.ALL }}
@@ -122,7 +124,8 @@ describe('<SavedTemplates />', function () {
             pageSize: { width: 200, height: 300 },
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressStoryActions: false }
     );
     fireEvent.click(getAllByText('Created by')[0].parentElement);
     fireEvent.click(getByText('Last modified'));
@@ -131,7 +134,7 @@ describe('<SavedTemplates />', function () {
   });
 
   it('should render the content grid with the correct story count.', function () {
-    const { getAllByText } = renderWithTheme(
+    const { getAllByText } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <SavedTemplatesContent
           stories={fakeStories}
@@ -143,7 +146,8 @@ describe('<SavedTemplates />', function () {
             pageSize: { width: 200, height: 300 },
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressStoryActions: false }
     );
 
     expect(getAllByText('Use template')).toHaveLength(fakeStories.length);

--- a/assets/src/dashboard/app/views/shared/stories/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/storyGridView.js
@@ -26,7 +26,10 @@ import { action } from '@storybook/addon-actions';
 
 import formattedStoriesArray from '../../../../storybookUtils/formattedStoriesArray';
 import formattedUsersObject from '../../../../storybookUtils/formattedUsersObject';
-import { STORY_ITEM_CENTER_ACTION_LABELS } from '../../../../constants';
+import {
+  STORY_ITEM_CENTER_ACTION_LABELS,
+  STORY_CONTEXT_MENU_ITEMS,
+} from '../../../../constants';
 import StoryGridView from '../storyGridView';
 
 export default {
@@ -44,6 +47,7 @@ export const _default = () => {
       storyMenu={{
         handleMenuToggle: action('handleMenuToggle'),
         contextMenuId: -1,
+        menuItems: STORY_CONTEXT_MENU_ITEMS,
         handleMenuItemSelected: action('handleMenuItemSelected'),
       }}
       isTemplate={boolean('isTemplate')}

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -61,7 +61,7 @@ const StoryGrid = styled(CardGrid)`
 const StoryGridView = ({
   stories,
   users,
-  centerActionLabelByStatus,
+  // centerActionLabelByStatus,
   bottomActionLabel,
   isSavedTemplate,
   pageSize,
@@ -88,10 +88,10 @@ const StoryGridView = ({
             <CardPreviewContainer
               pageSize={pageSize}
               story={story}
-              centerAction={{
-                targetAction: story.centerTargetAction,
-                label: centerActionLabelByStatus[story.status],
-              }}
+              // centerAction={{
+              //   targetAction: story.centerTargetAction,
+              //   label: centerActionLabelByStatus[story.status],
+              // }}
               bottomAction={{
                 targetAction: story.bottomTargetAction,
                 label: bottomActionLabel,

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -118,6 +118,7 @@ const StoryGridView = ({
                 contextMenuId={storyMenu.contextMenuId}
                 onMenuItemSelected={storyMenu.handleMenuItemSelected}
                 story={story}
+                menuItems={storyMenu.menuItems}
               />
             </DetailRow>
           </CardGridItem>
@@ -132,7 +133,10 @@ StoryGridView.propTypes = {
   isSavedTemplate: PropTypes.bool,
   stories: StoriesPropType,
   users: UsersPropType,
-  centerActionLabelByStatus: PropTypes.objectOf(PropTypes.string),
+  centerActionLabelByStatus: PropTypes.oneOfType([
+    PropTypes.objectOf(PropTypes.string),
+    PropTypes.bool,
+  ]),
   bottomActionLabel: ActionLabel,
   pageSize: PageSizePropType.isRequired,
   storyMenu: StoryMenuPropType,

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -91,7 +91,6 @@ const StoryGridView = ({
               centerAction={{
                 targetAction: story.centerTargetAction,
                 label: centerActionLabelByStatus[story.status],
-                inProgress: true,
               }}
               bottomAction={{
                 targetAction: story.bottomTargetAction,

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -61,7 +61,7 @@ const StoryGrid = styled(CardGrid)`
 const StoryGridView = ({
   stories,
   users,
-  // centerActionLabelByStatus,
+  centerActionLabelByStatus,
   bottomActionLabel,
   isSavedTemplate,
   pageSize,
@@ -88,10 +88,11 @@ const StoryGridView = ({
             <CardPreviewContainer
               pageSize={pageSize}
               story={story}
-              // centerAction={{
-              //   targetAction: story.centerTargetAction,
-              //   label: centerActionLabelByStatus[story.status],
-              // }}
+              centerAction={{
+                targetAction: story.centerTargetAction,
+                label: centerActionLabelByStatus[story.status],
+                inProgress: true,
+              }}
               bottomAction={{
                 targetAction: story.bottomTargetAction,
                 label: bottomActionLabel,

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -257,6 +257,7 @@ export default function StoryListView({
                         contextMenuId={storyMenu.contextMenuId}
                         onMenuItemSelected={storyMenu.handleMenuItemSelected}
                         story={story}
+                        menuItems={storyMenu.menuItems}
                         verticalAlign="center"
                       />
                     </>

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -178,7 +178,7 @@ const CardPreviewContainer = ({
         onMouseLeave={() => dispatch(CARD_ACTION.DEACTIVATE)}
       >
         <EmptyActionContainer />
-        {centerAction && !centerAction.inProgress && (
+        {centerAction?.label && (
           <ActionContainer>
             <Button
               type={BUTTON_TYPES.SECONDARY}
@@ -201,7 +201,7 @@ const CardPreviewContainer = ({
 const ActionButtonPropType = PropTypes.shape({
   targetAction: PropTypes.oneOfType([PropTypes.func, PropTypes.string])
     .isRequired,
-  label: ActionLabel.isRequired,
+  label: ActionLabel,
 });
 
 CardPreviewContainer.propTypes = {

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -178,7 +178,7 @@ const CardPreviewContainer = ({
         onMouseLeave={() => dispatch(CARD_ACTION.DEACTIVATE)}
       >
         <EmptyActionContainer />
-        {centerAction && (
+        {centerAction && !centerAction.inProgress && (
           <ActionContainer>
             <Button
               type={BUTTON_TYPES.SECONDARY}

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -127,7 +127,8 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
 
   const renderMenuItem = useCallback(
     (item, index) => {
-      const itemIsDisabled = !item.value && item.value !== 0;
+      const itemIsDisabled =
+        (!item.value && item.value !== 0) || item.inProgress;
       return (
         <MenuItem
           key={`${item.value}_${index}`}

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -127,8 +127,7 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
 
   const renderMenuItem = useCallback(
     (item, index) => {
-      const itemIsDisabled =
-        (!item.value && item.value !== 0) || item.inProgress;
+      const itemIsDisabled = !item.value && item.value !== 0;
       return (
         <MenuItem
           key={`${item.value}_${index}`}

--- a/assets/src/dashboard/components/storyMenu/index.js
+++ b/assets/src/dashboard/components/storyMenu/index.js
@@ -24,11 +24,11 @@ import { useCallback, useRef } from 'react';
 /**
  * Internal dependencies
  */
-import { STORY_CONTEXT_MENU_ITEMS } from '../../constants';
 import { StoryPropType } from '../../types';
 import { MoreVertical as MoreVerticalSvg } from '../../icons';
 import useFocusOut from '../../utils/useFocusOut';
 import { PopoverMenuCard } from '../popoverMenu';
+import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
 
 export const MoreVerticalButton = styled.button`
   display: flex;
@@ -69,8 +69,10 @@ export default function StoryMenu({
   onMenuItemSelected,
   story,
   verticalAlign,
+  menuItems,
 }) {
   const containerRef = useRef(null);
+
   const handleFocusOut = useCallback(() => {
     if (contextMenuId === story.id) {
       onMoreButtonSelected(-1);
@@ -92,7 +94,7 @@ export default function StoryMenu({
       <PopoverMenuCard
         isOpen={isPopoverMenuOpen}
         onSelect={(menuItem) => onMenuItemSelected(menuItem, story)}
-        items={STORY_CONTEXT_MENU_ITEMS}
+        items={menuItems}
       />
     </MenuContainer>
   );
@@ -103,5 +105,6 @@ StoryMenu.propTypes = {
   onMoreButtonSelected: PropTypes.func.isRequired,
   onMenuItemSelected: PropTypes.func.isRequired,
   contextMenuId: PropTypes.number.isRequired,
+  menuItems: PropTypes.arrayOf(DROPDOWN_ITEM_PROP_TYPE).isRequired,
   verticalAlign: PropTypes.oneOf(['center', 'flex-start', 'flex-end']),
 };

--- a/assets/src/dashboard/components/storyMenu/stories/index.js
+++ b/assets/src/dashboard/components/storyMenu/stories/index.js
@@ -24,6 +24,7 @@ import { actions } from '@storybook/addon-actions';
  */
 import { useState } from 'react';
 import StoryMenu, { MoreVerticalButton } from '..';
+import { STORY_CONTEXT_MENU_ITEMS } from '../../../constants';
 
 const Container = styled.div`
   margin: 200px 0 0 50px;
@@ -54,6 +55,7 @@ export const _default = () => {
           actions('onClick ', item.label, story.id);
           setContextMenuId(-1);
         }}
+        menuItems={STORY_CONTEXT_MENU_ITEMS}
         story={{ id: 1, status: 'publish', title: 'Sample Story' }}
       />
     </Container>

--- a/assets/src/dashboard/components/storyMenu/test/storyMenu.js
+++ b/assets/src/dashboard/components/storyMenu/test/storyMenu.js
@@ -22,6 +22,7 @@ import { fireEvent } from '@testing-library/react';
  */
 import { renderWithTheme } from '../../../testUtils';
 import StoryMenu from '../';
+import { STORY_CONTEXT_MENU_ITEMS } from '../../../constants';
 
 describe('StoryMenu', () => {
   it('should render a button by default', () => {
@@ -30,6 +31,7 @@ describe('StoryMenu', () => {
         onMoreButtonSelected={jest.fn}
         contextMenuId={1}
         onMenuItemSelected={jest.fn}
+        menuItems={STORY_CONTEXT_MENU_ITEMS}
         story={{ id: 1, status: 'publish', title: 'Sample Story' }}
       />
     );
@@ -46,6 +48,7 @@ describe('StoryMenu', () => {
         onMoreButtonSelected={mockOnMoreButtonSelected}
         contextMenuId={1}
         onMenuItemSelected={jest.fn}
+        menuItems={STORY_CONTEXT_MENU_ITEMS}
         story={{ id: 1, status: 'publish', title: 'Sample Story' }}
       />
     );
@@ -63,6 +66,7 @@ describe('StoryMenu', () => {
         onMoreButtonSelected={jest.fn}
         contextMenuId={1}
         onMenuItemSelected={mockMenuItemSelected}
+        menuItems={STORY_CONTEXT_MENU_ITEMS}
         story={{ id: 1, status: 'publish', title: 'Sample Story' }}
       />
     );

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -37,7 +37,7 @@ export const STORY_CONTEXT_MENU_ITEMS = [
   },
   {
     label: __('Preview', 'web-stories'),
-    value: STORY_CONTEXT_MENU_ACTIONS.PREVIEW,
+    value: false, // STORY_CONTEXT_MENU_ACTIONS.PREVIEW,
   },
   { label: null, value: false, separator: true },
   {
@@ -50,7 +50,7 @@ export const STORY_CONTEXT_MENU_ITEMS = [
   },
   {
     label: __('Create Template', 'web-stories'),
-    value: STORY_CONTEXT_MENU_ACTIONS.CREATE_TEMPLATE,
+    value: false, // STORY_CONTEXT_MENU_ACTIONS.CREATE_TEMPLATE,
   },
   { label: null, value: false, separator: true },
   {

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -37,7 +37,8 @@ export const STORY_CONTEXT_MENU_ITEMS = [
   },
   {
     label: __('Preview', 'web-stories'),
-    value: false, // STORY_CONTEXT_MENU_ACTIONS.PREVIEW,
+    value: STORY_CONTEXT_MENU_ACTIONS.PREVIEW,
+    inProgress: true,
   },
   { label: null, value: false, separator: true },
   {
@@ -50,7 +51,8 @@ export const STORY_CONTEXT_MENU_ITEMS = [
   },
   {
     label: __('Create Template', 'web-stories'),
-    value: false, // STORY_CONTEXT_MENU_ACTIONS.CREATE_TEMPLATE,
+    value: STORY_CONTEXT_MENU_ACTIONS.CREATE_TEMPLATE,
+    inProgress: true,
   },
   { label: null, value: false, separator: true },
   {

--- a/assets/src/dashboard/testUtils/index.js
+++ b/assets/src/dashboard/testUtils/index.js
@@ -14,5 +14,8 @@
  * limitations under the License.
  */
 export { default as flushPromiseQueue } from './flushPromiseQueue';
-export { default as renderWithTheme } from './renderWithTheme';
+export {
+  default as renderWithTheme,
+  renderWithThemeAndFlagsProvider,
+} from './renderWithTheme';
 export { default as createWrapperWithProps } from './createWrapperWithProps';

--- a/assets/src/dashboard/testUtils/renderWithTheme.js
+++ b/assets/src/dashboard/testUtils/renderWithTheme.js
@@ -19,6 +19,7 @@
  */
 import { render } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
+import { FlagsProvider } from 'flagged';
 
 /**
  * Internal dependencies
@@ -34,3 +35,9 @@ const renderWithTheme = (ui, options) =>
   render(ui, { wrapper: WithThemeProvider, ...options });
 
 export default renderWithTheme;
+
+export const renderWithThemeAndFlagsProvider = (ui, featureFlags = {}) => {
+  return renderWithTheme(
+    <FlagsProvider features={featureFlags}>{ui}</FlagsProvider>
+  );
+};

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -95,6 +95,12 @@ export const StoryMenuPropType = PropTypes.shape({
   handleMenuToggle: PropTypes.func.isRequired,
   contextMenuId: PropTypes.number.isRequired,
   handleMenuItemSelected: PropTypes.func.isRequired,
+  menuItems: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.oneOfType[(PropTypes.string, PropTypes.bool)],
+    })
+  ),
 });
 
 export const RenameStoryPropType = PropTypes.shape({

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -178,14 +178,21 @@ class Dashboard {
 					 * Issue: 1897
 					 * Creation date: 2020-05-21
 					 */
-					'enableAnimation'       => false,
+					'enableAnimation'              => false,
 					/**
 					 * Description: Enables in-progress views to be accessed.
 					 * Author: @carlos-kelly
 					 * Issue: 2081
 					 * Creation date: 2020-05-28
 					 */
-					'enableInProgressViews' => false,
+					'enableInProgressViews'        => false,
+					/**
+					 * Description: Enables in-progress story actions.
+					 * Author: @brittanyirl
+					 * Issue: 2344
+					 * Creation date: 2020-06-10
+					 */
+					'enableInProgressStoryActions' => false,
 				],
 			]
 		);


### PR DESCRIPTION
## Summary
Ahead of beta release disabling story actions that aren't done yet to prevent users from trying to interact with them and getting confused. These are the ability to preview a story and create a template from a story.

## Relevant Technical Choices
- Setting up new feature flag for `enableInProgressStoryActions` to control when story actions that are not done yet are exposed. 
- To get this to be more streamlines I moved the menu options that are rendered for each story up to the view level, getting passed in with the rest of the context menu values that are necessary for it to work. 
- Created a new test util to add a feature flag provider to the theme wrapper to avoid extraneous imports on tests 


## To-do
None

## User-facing changes
- the 'preview' button on hover of a story should be gone 
<img width="221" alt="Screen Shot 2020-06-10 at 11 04 08 AM" src="https://user-images.githubusercontent.com/10720454/84297015-219a3b80-ab0a-11ea-81f9-e3a8222ed03a.png">

- when you expand a story's context menu the 'preview' and 'create template' items should not be rendered. 
<img width="407" alt="Screen Shot 2020-06-10 at 2 21 12 PM" src="https://user-images.githubusercontent.com/10720454/84314656-a8104680-ab25-11ea-9f39-7aa306abacda.png">


## Testing Instructions
- See that the above user facing changes are present.

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2344 
