### PR TITLE
Remove dependency on state changes of uploading video id(s)

### DIFF
--- a/assets/src/edit-story/app/media/mediaProvider.js
+++ b/assets/src/edit-story/app/media/mediaProvider.js
@@ -121,6 +121,9 @@ function MediaProvider({ children }) {
 
   const uploadVideoPoster = useCallback(
     (id, src) => {
+      // eslint-disable-next-line no-shadow
+      const { processed, processing } = stateRef.current;
+
       const process = async () => {
         if (processed.includes(id) || processing.includes(id)) {
           return;
@@ -131,7 +134,7 @@ function MediaProvider({ children }) {
       };
       process();
     },
-    [processed, processing, setProcessing, uploadVideoFrame, removeProcessing]
+    [setProcessing, uploadVideoFrame, removeProcessing]
   );
 
   const processor = useCallback(


### PR DESCRIPTION
## Summary

Remove dependency on 'processing' and 'processed' state changes from uploadVideoPoster by using useRef.

As per go/story-editor-context-perf:
docs.google.com/document/d/18m9HamHkOvvTrv-mSOJawha0K4KTdn49HrnfXShULDI/edit#heading=h.khdu6hi94lhl

This will allow ‘uploadMedia’ and ‘uploadWithPreview’ action functions to refer to state without causing unnecessary re-renderings of CanvasUploadDropTarget, LibraryUploadDropTarget and their children.

React profiler of scrolling through media after this series of changes:
share.getcloudapp.com/YEu14qDg

Fixes #1466
