### PR TITLE
Add Background Wrapper and Migration to Dashboard Stories.

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -36,6 +36,7 @@ import {
   ORDER_BY_SORT,
   ITEMS_PER_PAGE,
 } from '../../constants';
+import { migrate, DATA_VERSION } from '../../../edit-story/migration/migrate';
 import storyReducer, {
   defaultStoriesState,
   ACTION_TYPES as STORY_ACTION_TYPES,
@@ -60,13 +61,19 @@ export function reshapeStoryObject(editStoryURL) {
     ) {
       return null;
     }
+
+    const updatedStoryData = {
+      ...migrate(storyData, storyData.version),
+      version: DATA_VERSION,
+    };
+
     return {
       id,
       status,
       title: title.raw,
       modified: moment(modified),
       created: moment(date),
-      pages: storyData.pages,
+      pages: updatedStoryData.pages,
       author,
       centerTargetAction: '',
       bottomTargetAction: `${editStoryURL}&post=${id}`,

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -18,6 +18,7 @@
  */
 import { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 /**
  * Internal dependencies
@@ -25,7 +26,16 @@ import PropTypes from 'prop-types';
 import DisplayElement from '../../edit-story/components/canvas/displayElement';
 import StoryPropTypes from '../../edit-story/types';
 import { STORY_PAGE_STATE } from '../constants';
+import generatePatternStyles from '../../edit-story/utils/generatePatternStyles';
 import StoryAnimation, { useStoryAnimationContext } from './storyAnimation';
+
+const PreviewWrapper = styled.div`
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+  background-color: white;
+  ${({ background }) => generatePatternStyles(background)};
+`;
 
 function PreviewPageController({ page, animationState, subscribeGlobalTime }) {
   const {
@@ -56,14 +66,19 @@ function PreviewPageController({ page, animationState, subscribeGlobalTime }) {
    */
   useEffect(() => () => WAAPIAnimationMethods.reset(), [WAAPIAnimationMethods]);
 
-  return page.elements.map(({ id, ...rest }) => (
-    <DisplayElement
-      key={id}
-      page={page}
-      element={{ id, ...rest }}
-      isAnimatable
-    />
-  ));
+  return (
+    <PreviewWrapper background={page.backgroundColor}>
+      {page.elements.map(({ id, ...rest }) => (
+        <DisplayElement
+          previewMode
+          key={id}
+          page={page}
+          element={{ id, ...rest }}
+          isAnimatable
+        />
+      ))}
+    </PreviewWrapper>
+  );
 }
 
 function PreviewPage({
@@ -91,6 +106,12 @@ PreviewPage.propTypes = {
   page: StoryPropTypes.page.isRequired,
   animationState: PropTypes.oneOf(Object.values(STORY_PAGE_STATE)),
   onAnimationComplete: PropTypes.func,
+  subscribeGlobalTime: PropTypes.func,
+};
+
+PreviewPageController.propTypes = {
+  page: StoryPropTypes.page.isRequired,
+  animationState: PropTypes.oneOf(Object.values(STORY_PAGE_STATE)),
   subscribeGlobalTime: PropTypes.func,
 };
 


### PR DESCRIPTION
## Summary

- Fixes backgrounds on older stories and migrates story data for the Dashboard Preview Cards

## Relevant Technical Choices

- Uses the same PreviewWrapper with backgroundColor component as the editor
- Migrates story data on API load

## User-facing changes

- Backgrounds should come through on older stories

## Testing Instructions

- Go to the dashboard and see if backgrounds come through on older stories

---

<!-- Please reference the issue(s) this PR addresses. -->

#2375 
