### PR TITLE
Dashboard: Hide in progress template actions 

### DIFF
--- a/assets/src/dashboard/app/views/exploreTemplates/header/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/header/index.js
@@ -125,7 +125,7 @@ function Header({ filter, totalTemplates, search, templates, sort, view }) {
         searchPlaceholder={__('Search Templates', 'web-stories')}
         stories={templates}
         handleTypeaheadChange={
-          enableInProgressTemplateActions && search.setKeyword
+          enableInProgressTemplateActions ? search.setKeyword : undefined
         }
         typeaheadValue={search.keyword}
       >
@@ -137,7 +137,9 @@ function Header({ filter, totalTemplates, search, templates, sort, view }) {
         handleLayoutSelect={view.toggleStyle}
         currentSort={sort.value}
         pageSortOptions={TEMPLATES_GALLERY_SORT_MENU_ITEMS}
-        handleSortChange={enableInProgressTemplateActions && sort.set}
+        handleSortChange={
+          enableInProgressTemplateActions ? sort.set : undefined
+        }
         sortDropdownAriaLabel={__(
           'Choose sort option for display',
           'web-stories'

--- a/assets/src/dashboard/app/views/exploreTemplates/header/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/header/index.js
@@ -25,7 +25,6 @@ import { __ } from '@wordpress/i18n';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useFeature } from 'flagged';
-import { useMemo } from 'react';
 
 /**
  * Internal dependencies
@@ -83,39 +82,26 @@ function Header({ filter, totalTemplates, search, templates, sort, view }) {
     clearAllColors,
   } = useTemplateFilters();
 
-  const TemplateFilters = useMemo(() => {
-    if (enableInProgressTemplateActions) {
-      return (
-        <HeadingDropdownsContainer>
-          <Dropdown
-            ariaLabel={__('Category Dropdown', 'web-stories')}
-            type={DROPDOWN_TYPES.PANEL}
-            placeholder={__('Category', 'web-stories')}
-            items={selectedCategories}
-            onClear={clearAllCategories}
-            onChange={onNewCategorySelected}
-          />
-          <Dropdown
-            ariaLabel={__('Color Dropdown', 'web-stories')}
-            type={DROPDOWN_TYPES.COLOR_PANEL}
-            placeholder={__('Color', 'web-stories')}
-            items={selectedColors}
-            onClear={clearAllColors}
-            onChange={onNewColorSelected}
-          />
-        </HeadingDropdownsContainer>
-      );
-    }
-    return null;
-  }, [
-    enableInProgressTemplateActions,
-    selectedCategories,
-    clearAllCategories,
-    onNewCategorySelected,
-    selectedColors,
-    clearAllColors,
-    onNewColorSelected,
-  ]);
+  const TemplateFilters = enableInProgressTemplateActions ? (
+    <HeadingDropdownsContainer>
+      <Dropdown
+        ariaLabel={__('Category Dropdown', 'web-stories')}
+        type={DROPDOWN_TYPES.PANEL}
+        placeholder={__('Category', 'web-stories')}
+        items={selectedCategories}
+        onClear={clearAllCategories}
+        onChange={onNewCategorySelected}
+      />
+      <Dropdown
+        ariaLabel={__('Color Dropdown', 'web-stories')}
+        type={DROPDOWN_TYPES.COLOR_PANEL}
+        placeholder={__('Color', 'web-stories')}
+        items={selectedColors}
+        onClear={clearAllColors}
+        onChange={onNewColorSelected}
+      />
+    </HeadingDropdownsContainer>
+  ) : null;
 
   return (
     <Layout.Squishable>
@@ -124,8 +110,9 @@ function Header({ filter, totalTemplates, search, templates, sort, view }) {
         defaultTitle={__('Templates', 'web-stories')}
         searchPlaceholder={__('Search Templates', 'web-stories')}
         stories={templates}
+        showTypeahead={enableInProgressTemplateActions}
         handleTypeaheadChange={
-          enableInProgressTemplateActions ? search.setKeyword : undefined
+          enableInProgressTemplateActions ? search.setKeyword : () => {}
         }
         typeaheadValue={search.keyword}
       >
@@ -137,9 +124,7 @@ function Header({ filter, totalTemplates, search, templates, sort, view }) {
         handleLayoutSelect={view.toggleStyle}
         currentSort={sort.value}
         pageSortOptions={TEMPLATES_GALLERY_SORT_MENU_ITEMS}
-        handleSortChange={
-          enableInProgressTemplateActions ? sort.set : undefined
-        }
+        handleSortChange={enableInProgressTemplateActions ? sort.set : () => {}}
         sortDropdownAriaLabel={__(
           'Choose sort option for display',
           'web-stories'

--- a/assets/src/dashboard/app/views/exploreTemplates/header/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/header/index.js
@@ -24,6 +24,8 @@ import { __ } from '@wordpress/i18n';
  */
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import { useFeature } from 'flagged';
+import { useMemo } from 'react';
 
 /**
  * Internal dependencies
@@ -61,6 +63,10 @@ const HeadingDropdownsContainer = styled.div`
   }
 `;
 function Header({ filter, totalTemplates, search, templates, sort, view }) {
+  const enableInProgressTemplateActions = useFeature(
+    'enableInProgressTemplateActions'
+  );
+
   const resultsLabel = useDashboardResultsLabel({
     isActiveSearch: Boolean(search.keyword),
     totalResults: totalTemplates,
@@ -77,16 +83,9 @@ function Header({ filter, totalTemplates, search, templates, sort, view }) {
     clearAllColors,
   } = useTemplateFilters();
 
-  return (
-    <Layout.Squishable>
-      <PageHeading
-        centerContent
-        defaultTitle={__('Templates', 'web-stories')}
-        searchPlaceholder={__('Search Templates', 'web-stories')}
-        stories={templates}
-        handleTypeaheadChange={search.setKeyword}
-        typeaheadValue={search.keyword}
-      >
+  const TemplateFilters = useMemo(() => {
+    if (enableInProgressTemplateActions) {
+      return (
         <HeadingDropdownsContainer>
           <Dropdown
             ariaLabel={__('Category Dropdown', 'web-stories')}
@@ -105,6 +104,32 @@ function Header({ filter, totalTemplates, search, templates, sort, view }) {
             onChange={onNewColorSelected}
           />
         </HeadingDropdownsContainer>
+      );
+    }
+    return null;
+  }, [
+    enableInProgressTemplateActions,
+    selectedCategories,
+    clearAllCategories,
+    onNewCategorySelected,
+    selectedColors,
+    clearAllColors,
+    onNewColorSelected,
+  ]);
+
+  return (
+    <Layout.Squishable>
+      <PageHeading
+        centerContent
+        defaultTitle={__('Templates', 'web-stories')}
+        searchPlaceholder={__('Search Templates', 'web-stories')}
+        stories={templates}
+        handleTypeaheadChange={
+          enableInProgressTemplateActions && search.setKeyword
+        }
+        typeaheadValue={search.keyword}
+      >
+        {TemplateFilters}
       </PageHeading>
       <BodyViewOptions
         resultsLabel={resultsLabel}
@@ -112,7 +137,7 @@ function Header({ filter, totalTemplates, search, templates, sort, view }) {
         handleLayoutSelect={view.toggleStyle}
         currentSort={sort.value}
         pageSortOptions={TEMPLATES_GALLERY_SORT_MENU_ITEMS}
-        handleSortChange={sort.set}
+        handleSortChange={enableInProgressTemplateActions && sort.set}
         sortDropdownAriaLabel={__(
           'Choose sort option for display',
           'web-stories'

--- a/assets/src/dashboard/app/views/exploreTemplates/header/stories/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/header/stories/index.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { action } from '@storybook/addon-actions';
+import { FlagsProvider } from 'flagged';
 
 /**
  * Internal dependencies
@@ -70,19 +71,23 @@ export default {
 };
 
 export const _default = () => (
-  <Layout.Provider>
-    <Header {...defaultProps} />
-  </Layout.Provider>
+  <FlagsProvider features={{ enableInProgressTemplateActions: false }}>
+    <Layout.Provider>
+      <Header {...defaultProps} />
+    </Layout.Provider>
+  </FlagsProvider>
 );
 
 export const ActiveSearch = () => (
-  <Layout.Provider>
-    <Header
-      {...defaultProps}
-      search={{
-        ...search,
-        keyword: 'demo search',
-      }}
-    />
-  </Layout.Provider>
+  <FlagsProvider features={{ enableInProgressTemplateActions: true }}>
+    <Layout.Provider>
+      <Header
+        {...defaultProps}
+        search={{
+          ...search,
+          keyword: 'demo search',
+        }}
+      />
+    </Layout.Provider>
+  </FlagsProvider>
 );

--- a/assets/src/dashboard/app/views/exploreTemplates/header/test/header.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/header/test/header.js
@@ -27,7 +27,7 @@ import {
   VIEW_STYLE,
   TEMPLATES_GALLERY_SORT_OPTIONS,
 } from '../../../../../constants';
-import { renderWithTheme } from '../../../../../testUtils';
+import { renderWithThemeAndFlagsProvider } from '../../../../../testUtils';
 import LayoutProvider from '../../../../../components/layout/provider';
 import Header from '../';
 
@@ -69,7 +69,7 @@ const fakeTemplates = [
 
 describe('Explore Templates <Header />', function () {
   it('should have results label that says "Viewing all templates" on initial page view', function () {
-    const { getByText } = renderWithTheme(
+    const { getByText } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <Header
           filter={{ value: TEMPLATES_GALLERY_STATUS.ALL }}
@@ -85,14 +85,15 @@ describe('Explore Templates <Header />', function () {
             pageSize: { width: 200, height: 300 },
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressTemplateActions: false }
     );
 
     expect(getByText('Viewing all templates')).toBeInTheDocument();
   });
 
   it('should render with the correct count label and search keyword.', function () {
-    const { getByPlaceholderText, getByText } = renderWithTheme(
+    const { getByPlaceholderText, getByText } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <Header
           filter={{ value: TEMPLATES_GALLERY_STATUS.ALL }}
@@ -108,7 +109,8 @@ describe('Explore Templates <Header />', function () {
             pageSize: { width: 200, height: 300 },
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressTemplateActions: true }
     );
     expect(getByPlaceholderText('Search Templates').value).toBe('Harry Potter');
     expect(getByText('8 results')).toBeInTheDocument();
@@ -116,7 +118,7 @@ describe('Explore Templates <Header />', function () {
 
   it('should call the set keyword function when new text is searched', function () {
     const setKeywordFn = jest.fn();
-    const { getByPlaceholderText } = renderWithTheme(
+    const { getByPlaceholderText } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <Header
           filter={{ value: TEMPLATES_GALLERY_STATUS.ALL }}
@@ -132,7 +134,8 @@ describe('Explore Templates <Header />', function () {
             pageSize: { width: 200, height: 300 },
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressTemplateActions: true }
     );
     fireEvent.change(getByPlaceholderText('Search Templates'), {
       target: { value: 'Hermione Granger' },
@@ -142,7 +145,7 @@ describe('Explore Templates <Header />', function () {
 
   it('should call the set sort function when a new sort is selected', function () {
     const setSortFn = jest.fn();
-    const { getAllByText, getByText } = renderWithTheme(
+    const { getAllByText, getByText } = renderWithThemeAndFlagsProvider(
       <LayoutProvider>
         <Header
           filter={{ value: TEMPLATES_GALLERY_STATUS.ALL }}
@@ -158,11 +161,35 @@ describe('Explore Templates <Header />', function () {
             pageSize: { width: 200, height: 300 },
           }}
         />
-      </LayoutProvider>
+      </LayoutProvider>,
+      { enableInProgressTemplateActions: true }
     );
     fireEvent.click(getAllByText('Popular')[0].parentElement);
     fireEvent.click(getByText('Recent'));
 
     expect(setSortFn).toHaveBeenCalledWith('recent');
+  });
+
+  it('should not render with search when enableInProgressTemplateActions is false', function () {
+    const { queryAllByRole } = renderWithThemeAndFlagsProvider(
+      <LayoutProvider>
+        <Header
+          filter={{ value: TEMPLATES_GALLERY_STATUS.ALL }}
+          totalTemplates={8}
+          search={{ keyword: '', setKeyword: jest.fn }}
+          templates={fakeTemplates}
+          sort={{
+            value: TEMPLATES_GALLERY_SORT_OPTIONS.POPULAR,
+            set: jest.fn,
+          }}
+          view={{
+            style: VIEW_STYLE.GRID,
+            pageSize: { width: 200, height: 300 },
+          }}
+        />
+      </LayoutProvider>,
+      { enableInProgressTemplateActions: false }
+    );
+    expect(queryAllByRole('input')).toHaveLength(0);
   });
 });

--- a/assets/src/dashboard/app/views/exploreTemplates/header/test/header.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/header/test/header.js
@@ -190,6 +190,6 @@ describe('Explore Templates <Header />', function () {
       </LayoutProvider>,
       { enableInProgressTemplateActions: false }
     );
-    expect(queryAllByRole('input')).toHaveLength(0);
+    expect(queryAllByRole('textbox')).toHaveLength(0);
   });
 });

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -123,7 +123,7 @@ export default function BodyViewOptions({
 BodyViewOptions.propTypes = {
   currentSort: PropTypes.string.isRequired,
   handleLayoutSelect: PropTypes.func,
-  handleSortChange: PropTypes.func.isRequired,
+  handleSortChange: PropTypes.func,
   layoutStyle: PropTypes.string.isRequired,
   resultsLabel: PropTypes.string.isRequired,
   wpListURL: PropTypes.string,

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -88,7 +88,7 @@ export default function BodyViewOptions({
       <DisplayFormatContainer>
         <Label>{resultsLabel}</Label>
         <ControlsContainer>
-          {layoutStyle === VIEW_STYLE.GRID && (
+          {layoutStyle === VIEW_STYLE.GRID && Boolean(handleSortChange) && (
             <StorySortDropdownContainer>
               <SortDropdown
                 alignment="flex-end"

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -112,16 +112,18 @@ const PageHeading = ({
           {defaultTitle}
         </StyledHeader>
         <Content centerContent={centerContent}>{children}</Content>
-        <SearchContainer>
-          <SearchInner>
-            <TypeaheadSearch
-              placeholder={searchPlaceholder}
-              currentValue={typeaheadValue}
-              stories={stories}
-              handleChange={handleTypeaheadChange}
-            />
-          </SearchInner>
-        </SearchContainer>
+        {Boolean(handleTypeaheadChange) && (
+          <SearchContainer>
+            <SearchInner>
+              <TypeaheadSearch
+                placeholder={searchPlaceholder}
+                currentValue={typeaheadValue}
+                stories={stories}
+                handleChange={handleTypeaheadChange}
+              />
+            </SearchInner>
+          </SearchContainer>
+        )}
       </HeadingBodyWrapper>
     </Container>
   );

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -101,6 +101,7 @@ const PageHeading = ({
   searchPlaceholder,
   centerContent = false,
   stories = [],
+  showTypeahead = true,
   handleTypeaheadChange,
   typeaheadValue = '',
 }) => {
@@ -112,7 +113,7 @@ const PageHeading = ({
           {defaultTitle}
         </StyledHeader>
         <Content centerContent={centerContent}>{children}</Content>
-        {Boolean(handleTypeaheadChange) && (
+        {showTypeahead && (
           <SearchContainer>
             <SearchInner>
               <TypeaheadSearch
@@ -138,6 +139,7 @@ PageHeading.propTypes = {
   defaultTitle: PropTypes.string.isRequired,
   searchPlaceholder: PropTypes.string,
   stories: StoriesPropType,
+  showTypeahead: PropTypes.bool,
   handleTypeaheadChange: PropTypes.func,
   typeaheadValue: PropTypes.string,
 };

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -178,21 +178,28 @@ class Dashboard {
 					 * Issue: 1897
 					 * Creation date: 2020-05-21
 					 */
-					'enableAnimation'              => false,
+					'enableAnimation'                 => false,
 					/**
 					 * Description: Enables in-progress views to be accessed.
 					 * Author: @carlos-kelly
 					 * Issue: 2081
 					 * Creation date: 2020-05-28
 					 */
-					'enableInProgressViews'        => false,
+					'enableInProgressViews'           => false,
 					/**
 					 * Description: Enables in-progress story actions.
 					 * Author: @brittanyirl
 					 * Issue: 2344
 					 * Creation date: 2020-06-10
 					 */
-					'enableInProgressStoryActions' => false,
+					'enableInProgressStoryActions'    => false,
+					/**
+					 * Description: Enables in-progress template actions.
+					 * Author: @brittanyirl
+					 * Issue: 2381
+					 * Creation date: 2020-06-11
+					 */
+					'enableInProgressTemplateActions' => false,
 				],
 			]
 		);


### PR DESCRIPTION
## Summary
Hide template actions that are still in progress with a flag. This includes the template filters, sort, and search.

<img width="1101" alt="Screen Shot 2020-06-11 at 2 41 51 PM" src="https://user-images.githubusercontent.com/10720454/84439202-01937680-abf5-11ea-999c-e2d778412fa3.png">

## Relevant Technical Choices
- adds a new flag called `enableInProgressTemplateActions` that hides actions on explore templates that are not connected to an API yet. 
- Used the `onClick` prop that gets passed to the Header and Body Options (respectively) to check if that UI should be rendered. So when `enableInProgressTemplateActions` is false, that prop is `false` instead of passing in a function. I chose this because if that function isn't there the UI to trigger that function is useless anyways. It seemed streamlined to me. 

## User-facing changes
- You should no longer see the following UI on explore templates: 
  - Search Input
  - Filter Dropdowns  
  - Sort Dropdown 

## Testing Instructions
- See that the above UI is not showing up in the explore templates view (and storybook Dashboard/Views/ExploreTemplates/Header/Default
- Flip the `enableInProgressTemplateActions` to true and see that the UI is back to "normal" with nothing hidden. 

---


Addresses #2381 
