### PR TITLE
Dashboard: Hide bookmarks behind flag

### DIFF
--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -22,6 +22,8 @@ import { sprintf, __ } from '@wordpress/i18n';
  * External dependencies
  */
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useFeature } from 'flagged';
+
 /**
  * Internal dependencies
  */
@@ -63,6 +65,7 @@ function TemplateDetails() {
   const [orderedTemplates, setOrderedTemplates] = useState([]);
   const { pageSize } = usePagePreviewSize({ isGrid: true });
   const { isRTL } = useConfig();
+  const enableBookmarks = useFeature('enableBookmarkActions');
 
   const {
     state: {
@@ -202,6 +205,7 @@ function TemplateDetails() {
             <Layout.Fixed>
               <TemplateNavBar
                 handleCta={() => createStoryFromTemplate(template)}
+                handleBookmarkClick={enableBookmarks}
               />
             </Layout.Fixed>
             <Layout.Scrollable>

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -193,6 +193,8 @@ function TemplateDetails() {
     switchToTemplateByOffset,
   ]);
 
+  const handleBookmarkClickSelected = useCallback(() => {}, []);
+
   if (!template) {
     return null;
   }
@@ -205,7 +207,9 @@ function TemplateDetails() {
             <Layout.Fixed>
               <TemplateNavBar
                 handleCta={() => createStoryFromTemplate(template)}
-                handleBookmarkClick={enableBookmarks}
+                handleBookmarkClick={
+                  enableBookmarks ? handleBookmarkClickSelected : undefined
+                }
               />
             </Layout.Fixed>
             <Layout.Scrollable>

--- a/assets/src/dashboard/components/templateNavBar/index.js
+++ b/assets/src/dashboard/components/templateNavBar/index.js
@@ -96,6 +96,6 @@ export function TemplateNavBar({ handleCta, handleBookmarkClick }) {
 }
 
 TemplateNavBar.propTypes = {
-  handleBookmarkClick: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+  handleBookmarkClick: PropTypes.func,
   handleCta: PropTypes.func.isRequired,
 };

--- a/assets/src/dashboard/components/templateNavBar/index.js
+++ b/assets/src/dashboard/components/templateNavBar/index.js
@@ -79,14 +79,14 @@ const CapitalizedButton = styled(Button)`
   text-transform: uppercase;
 `;
 
-export function TemplateNavBar({ handleCta }) {
+export function TemplateNavBar({ handleCta, handleBookmarkClick }) {
   return (
     <Nav>
       <Container>
         <CloseLink href={parentRoute()}>{__('Close', 'web-stories')}</CloseLink>
       </Container>
       <Container>
-        <BookmarkToggle />
+        {handleBookmarkClick && <BookmarkToggle />}
         <CapitalizedButton type={BUTTON_TYPES.CTA} onClick={handleCta}>
           {__('use template', 'web-stories')}
         </CapitalizedButton>
@@ -96,5 +96,6 @@ export function TemplateNavBar({ handleCta }) {
 }
 
 TemplateNavBar.propTypes = {
+  handleBookmarkClick: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
   handleCta: PropTypes.func.isRequired,
 };

--- a/assets/src/dashboard/components/templateNavBar/stories/index.js
+++ b/assets/src/dashboard/components/templateNavBar/stories/index.js
@@ -28,5 +28,10 @@ export default {
 };
 
 export const _default = () => {
-  return <TemplateNavBar handleCta={action('handle cta clicked')} />;
+  return (
+    <TemplateNavBar
+      handleCta={action('handle cta clicked')}
+      handleBookmarkClick={action('handle bookmark clicked')}
+    />
+  );
 };

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -200,6 +200,13 @@ class Dashboard {
 					 * Creation date: 2020-06-11
 					 */
 					'enableInProgressTemplateActions' => false,
+					/**
+					 * Description: Enables bookmark actions.
+					 * Author: @brittanyirl
+					 * Issue: 2292
+					 * Creation date: 2020-06-11
+					 */
+					'enableBookmarkActions'           => false,
 				],
 			]
 		);


### PR DESCRIPTION
## Summary
Hides bookmarking actions behind a flag. 

<img width="1236" alt="Screen Shot 2020-06-11 at 3 34 59 PM" src="https://user-images.githubusercontent.com/10720454/84441490-238ef800-abf9-11ea-9e62-34dc2fff1a59.png">

## Relevant Technical Choices
- New feature flag for bookmarking actions called `enableBookmarkActions`
- Decided to do this through a click handler prop passed from the view since bookmarking isn't hooked up at all yet and this needs to be there at some point anyway (there's probably going to be some refactor on this view as template APIs get connected) - for now this seemed the most straightforward option. 

## User-facing changes
- You should no longer see the bookmarking icon on the detail template view

## Testing Instructions
- See that the bookmarking button in the nav of the template detail view is hidden 
- Flip the `enableBookmarkActions` flag to `true` and see that the bookmark button is now back on the page. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2292
