### PR TITLE
Karma: test containers for DOM lookup

### DIFF
--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -20,6 +20,11 @@
 import styled from 'styled-components';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import Library from '../../components/library';
@@ -58,7 +63,7 @@ const Area = styled.div`
 
 function Layout() {
   return (
-    <Editor>
+    <Editor role="main" aria-label={__('Web Stories Editor', 'web-stories')}>
       <Area area="lib">
         <Library />
       </Area>

--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -63,7 +63,7 @@ const Area = styled.div`
 
 function Layout() {
   return (
-    <Editor role="main" aria-label={__('Web Stories Editor', 'web-stories')}>
+    <Editor role="region" aria-label={__('Web Stories Editor', 'web-stories')}>
       <Area area="lib">
         <Library />
       </Area>

--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -36,7 +36,9 @@ import {
   INSPECTOR_MIN_WIDTH,
 } from '../../constants';
 
-const Editor = styled.div`
+const Editor = styled.section.attrs({
+  'aria-label': __('Web Stories Editor', 'web-stories'),
+})`
   font-family: ${({ theme }) => theme.fonts.body1.family};
   font-size: ${({ theme }) => theme.fonts.body1.size};
   line-height: ${({ theme }) => theme.fonts.body1.lineHeight};
@@ -63,7 +65,7 @@ const Area = styled.div`
 
 function Layout() {
   return (
-    <Editor role="region" aria-label={__('Web Stories Editor', 'web-stories')}>
+    <Editor>
       <Area area="lib">
         <Library />
       </Area>

--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -21,6 +21,11 @@ import styled from 'styled-components';
 import { memo, useRef } from 'react';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import EditLayer from './editLayer';
@@ -47,7 +52,12 @@ function CanvasLayout() {
   const layoutParamsCss = useLayoutParamsCssVars();
 
   return (
-    <Background ref={backgroundRef} style={layoutParamsCss}>
+    <Background
+      ref={backgroundRef}
+      style={layoutParamsCss}
+      role="region"
+      aria-label={__('Canvas', 'web-stories')}
+    >
       <CanvasUploadDropTarget>
         <CanvasElementDropzone>
           <SelectionCanvas>

--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -37,7 +37,9 @@ import { useLayoutParams, useLayoutParamsCssVars } from './layout';
 import CanvasUploadDropTarget from './canvasUploadDropTarget';
 import CanvasElementDropzone from './canvasElementDropzone';
 
-const Background = styled.div`
+const Background = styled.section.attrs({
+  'aria-label': __('Canvas', 'web-stories'),
+})`
   background-color: ${({ theme }) => theme.colors.bg.v1};
   width: 100%;
   height: 100%;
@@ -52,12 +54,7 @@ function CanvasLayout() {
   const layoutParamsCss = useLayoutParamsCssVars();
 
   return (
-    <Background
-      ref={backgroundRef}
-      style={layoutParamsCss}
-      role="region"
-      aria-label={__('Canvas', 'web-stories')}
-    >
+    <Background ref={backgroundRef} style={layoutParamsCss}>
       <CanvasUploadDropTarget>
         <CanvasElementDropzone>
           <SelectionCanvas>

--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -86,6 +86,8 @@ function FramesLayer() {
       // there's no selection, but it's not reacheable by keyboard
       // otherwise.
       tabIndex="-1"
+      role="region"
+      aria-label={__('Frames', 'web-stories')}
     >
       <FramesPageArea
         overlay={

--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -86,7 +86,6 @@ function FramesLayer() {
       // there's no selection, but it's not reacheable by keyboard
       // otherwise.
       tabIndex="-1"
-      role="region"
       aria-label={__('Frames', 'web-stories')}
     >
       <FramesPageArea

--- a/assets/src/edit-story/components/canvas/karma/lasso.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/lasso.karma.js
@@ -55,12 +55,6 @@ describe('Lasso integration', () => {
     fixture.restore();
   });
 
-  function getFrame(elementId) {
-    return fixture.querySelector(
-      `[data-element-id="${elementId}"] [data-testid="textFrame"]`
-    );
-  }
-
   async function getSelection() {
     const storyContext = await fixture.renderHook(() => useStory());
     return storyContext.state.selectedElementIds;
@@ -71,9 +65,9 @@ describe('Lasso integration', () => {
   });
 
   it('should select right on the top-left corner', async () => {
-    const frame1 = getFrame(element1.id);
+    const frame1 = fixture.editor.canvas.framesLayer.frame(element1.id);
     await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
-      moveRel(frame1, -20, -20),
+      moveRel(frame1.node, -20, -20),
       down(),
       moveBy(22, 22, { steps: 5 }),
       up(),
@@ -82,9 +76,9 @@ describe('Lasso integration', () => {
   });
 
   it('should select right on the bottom-right corner', async () => {
-    const frame1 = getFrame(element1.id);
+    const frame1 = fixture.editor.canvas.framesLayer.frame(element1.id);
     await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
-      moveRel(frame1, '100%', '100%'),
+      moveRel(frame1.node, '100%', '100%'),
       moveBy(20, 20),
       down(),
       moveBy(-22, -22, { steps: 5 }),
@@ -94,13 +88,13 @@ describe('Lasso integration', () => {
   });
 
   it('should select two elements', async () => {
-    const frame1 = getFrame(element1.id);
-    const frame2 = getFrame(element2.id);
+    const frame1 = fixture.editor.canvas.framesLayer.frame(element1.id);
+    const frame2 = fixture.editor.canvas.framesLayer.frame(element2.id);
     await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
-      moveRel(frame1, '100%', '100%'),
+      moveRel(frame1.node, '100%', '100%'),
       moveBy(2, -2),
       down(),
-      moveRel(frame2, '100%', 0, { steps: 5 }),
+      moveRel(frame2.node, '100%', 0, { steps: 5 }),
       moveBy(-2, 2),
       up(),
     ]);

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -63,7 +63,7 @@ const MAX_CAROUSEL_HEIGHT =
   MAX_CAROUSEL_THUMB_HEIGHT + CAROUSEL_VERTICAL_PADDING * 2;
 
 // @todo: the menu height is not responsive
-const Layer = styled.div`
+const Layer = styled.section`
   ${pointerEventsCss}
 
   position: absolute;

--- a/assets/src/edit-story/karma/fixture/containers/canvas.js
+++ b/assets/src/edit-story/karma/fixture/containers/canvas.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Container } from './container';
+
+/**
+ * The editor's canvas. Includes: display, frames, editor layers, carousel,
+ * navigation buttons, page menu.
+ */
+export class Canvas extends Container {
+  constructor(node, path) {
+    super(node, path);
+  }
+
+  get displayLayer() {
+    // @todo: display layer.
+    return null;
+  }
+
+  get framesLayer() {
+    return this._get(
+      this.getByRole('region', { name: 'Frames' }),
+      'framesLayer',
+      FramesLayer
+    );
+  }
+
+  get editLayer() {
+    return null;
+  }
+}
+
+/**
+ * Contains element frames.
+ */
+class FramesLayer extends Container {
+  constructor(node, path) {
+    super(node, path);
+  }
+
+  get frames() {
+    return this._getAll(
+      // @todo: improve query.
+      this.node.querySelectorAll('[data-testid="frameElement"]'),
+      (node) => `frames[${node.getAttribute('data-element-id')}]`,
+      Frame
+    );
+  }
+
+  frame(elementId) {
+    return this._get(
+      // @todo: improve query.
+      this.node.querySelector(
+        `[data-testid="frameElement"][data-element-id="${elementId}"]`
+      ),
+      `frames[${elementId}]`,
+      Frame
+    );
+  }
+}
+
+/**
+ * An element's frame.
+ */
+class Frame extends Container {
+  constructor(node, path) {
+    super(node, path);
+  }
+}

--- a/assets/src/edit-story/karma/fixture/containers/container.js
+++ b/assets/src/edit-story/karma/fixture/containers/container.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { getByRole, queryByRole } from '@testing-library/react';
+
+export class Container {
+  /**
+   * @param {Element} node
+   * @param {string} path
+   */
+  constructor(node, path) {
+    this._node = node;
+    this._path = path;
+  }
+
+  get node() {
+    return this._node;
+  }
+
+  get path() {
+    return this._path;
+  }
+
+  /**
+   * See https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+   *
+   * @param {string} role
+   * @param {Object} options
+   */
+  getByRole(role, options) {
+    return getByRole(this._node, role, options);
+  }
+
+  /**
+   * See https://testing-library.com/docs/dom-testing-library/api-queries#byrole
+   *
+   * @param {string} role
+   * @param {Object} options
+   */
+  queryByRole(role, options) {
+    return queryByRole(this._node, role, options);
+  }
+
+  _get(node, name, constr) {
+    if (!node) {
+      return null;
+    }
+    const path = `${this._path}.${name}`;
+    const key = `FixturePath(${path})`;
+    if (!node[key]) {
+      node[key] = new constr(node, path);
+    }
+    return node[key];
+  }
+
+  _getAll(nodeList, nameFn, constr) {
+    return Array.from(nodeList).map((node) =>
+      this._get(node, nameFn(node), constr)
+    );
+  }
+}

--- a/assets/src/edit-story/karma/fixture/containers/editor.js
+++ b/assets/src/edit-story/karma/fixture/containers/editor.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Container } from './container';
+import { Canvas } from './canvas';
+
+/**
+ * The complete editor container, including library, canvas, inspector, etc.
+ */
+export class Editor extends Container {
+  constructor(node, path) {
+    super(node, path);
+  }
+
+  get canvas() {
+    return this._get(
+      this.getByRole('region', { name: 'Canvas' }),
+      'canvas',
+      Canvas
+    );
+  }
+
+  get titleBar() {
+    // @todo: title bar container.
+    return null;
+  }
+
+  get library() {
+    // @todo: library container.
+    return null;
+  }
+}

--- a/assets/src/edit-story/karma/fixture/containers/index.js
+++ b/assets/src/edit-story/karma/fixture/containers/index.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { Editor } from './editor';

--- a/assets/src/edit-story/karma/fixture/fixture.js
+++ b/assets/src/edit-story/karma/fixture/fixture.js
@@ -204,7 +204,7 @@ export class Fixture {
     this._screen = screen;
 
     this._editor = new EditorContainer(
-      getByRole('main', { name: 'Web Stories Editor' }),
+      getByRole('region', { name: 'Web Stories Editor' }),
       'editor'
     );
 

--- a/assets/src/edit-story/karma/fixture/fixture.js
+++ b/assets/src/edit-story/karma/fixture/fixture.js
@@ -33,6 +33,7 @@ import { DATA_VERSION } from '../../migration';
 import { createPage } from '../../elements';
 import FixtureEvents from './events';
 import getMediaResponse from './db/getMediaResponse';
+import { Editor as EditorContainer } from './containers';
 
 const DEFAULT_CONFIG = {
   storyId: 1,
@@ -101,6 +102,8 @@ export class Fixture {
     this._events = new FixtureEvents(this.act.bind(this));
 
     this._container = null;
+
+    this._editor = null;
   }
 
   restore() {}
@@ -111,6 +114,10 @@ export class Fixture {
 
   get screen() {
     return this._screen;
+  }
+
+  get editor() {
+    return this._editor;
   }
 
   /**
@@ -181,7 +188,7 @@ export class Fixture {
    */
   render() {
     const root = document.querySelector('test-root');
-    const { container } = render(
+    const { container, getByRole } = render(
       <FlagsProvider features={this._flags}>
         <App key={Math.random()} config={this._config} />
       </FlagsProvider>,
@@ -195,6 +202,11 @@ export class Fixture {
     container.style.height = '100%';
     this._container = container;
     this._screen = screen;
+
+    this._editor = new EditorContainer(
+      getByRole('main', { name: 'Web Stories Editor' }),
+      'editor'
+    );
 
     // @todo: find a stable way to wait for the story to fully render. Can be
     // implemented via `waitFor`.


### PR DESCRIPTION
## Summary

A lazy-resolved DOM navigation mechanism for fixture tests.

## Relevant Technical Choices

1. A property-based API for convenience. E.g. `editor.canvas.framesLayer....`.
2. Both singular and array-style properties. E.g. `framesLayer.frames` and `framesLayer.frame(elementId)`.
3. a11y information is used as much as possible for all lookups.
4. Non-property API is also available, e.g. `editor.canvas.getByRole(...)`.
5. All queries are repeated each type. This is so that the caching doesn't "corrupt" test.

## To-do

- [ ] More nav properties

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
