### PR TITLE
Block Editor: Add default title when rendering story block on the frontend

### DIFF
--- a/includes/Embed_Block.php
+++ b/includes/Embed_Block.php
@@ -88,7 +88,8 @@ class Embed_Block {
 						'type' => 'url',
 					],
 					'title'  => [
-						'type' => 'string',
+						'type'    => 'string',
+						'default' => __( 'Web Story', 'web-stories' ),
 					],
 					'poster' => [
 						'type' => 'string',
@@ -145,9 +146,13 @@ class Embed_Block {
 	 * @return string Rendered block type output.
 	 */
 	public function render_block( array $attributes, $content ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// The only 2 mandatory attributes.
-		if ( empty( $attributes['url'] ) || empty( $attributes['title'] ) ) {
+		// The only mandatory attribute.
+		if ( empty( $attributes['url'] ) ) {
 			return '';
+		}
+
+		if ( empty( $attributes['title'] ) ) {
+			$attributes['title'] = __( 'Web Story', 'web-stories' );
 		}
 
 		if ( is_feed() ) {

--- a/tests/phpunit/tests/Embed_Block.php
+++ b/tests/phpunit/tests/Embed_Block.php
@@ -87,7 +87,7 @@ class Embed_Block extends \WP_UnitTestCase {
 			''
 		);
 
-		$this->assertEmpty( $actual );
+		$this->assertContains( __( 'Web Story', 'web-stories' ), $actual );
 	}
 
 	public function test_render_block_feed_no_poster() {


### PR DESCRIPTION
## Summary

Adds default title when rendering story block on the frontend

## Relevant Technical Choices

Adds the default title both in the `register_block_type` call and the `render_block` callback, because the former doesn't work if the title is an empty string.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None

## Testing Instructions

1. Create a new blog post and embed a web story (e.g. https://www.bbc.co.uk/news/ampstories/carnival/index.html) using the story embed block
1. Leave story title empty in block sidebar
1. Preview post and find `<amp-story-player>` markup
1. Verify that `Web Story` is used as anchor text

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2376
