### PR TITLE
Smooth media editor zooming + keyboard user detection refactor

### DIFF
--- a/assets/src/dashboard/utils/keyboardOnlyOutline.js
+++ b/assets/src/dashboard/utils/keyboardOnlyOutline.js
@@ -19,13 +19,14 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { createGlobalStyle } from 'styled-components';
 
 /**
  * Internal dependencies
  */
 import { KEYBOARD_USER_CLASS } from '../constants';
+import useIsUsingKeyboard from './useIsUsingKeyboard';
 
 export const OutlineStyles = createGlobalStyle`
     *:focus {
@@ -33,41 +34,10 @@ export const OutlineStyles = createGlobalStyle`
     }
 `;
 
-const ACCEPTED_KEYS = [
-  'ArrowUp',
-  'ArrowDown',
-  'ArrowLeft',
-  'ArrowRight',
-  'Tab',
-];
-
 const KeyboardOnlyOutline = () => {
-  const [usingKeyboard, setUsingKeyboard] = useState(false);
-  const handleKeydown = (e) => {
-    if (!usingKeyboard && ACCEPTED_KEYS.includes(e.key)) {
-      setUsingKeyboard(true);
-    }
-  };
-
-  const handleMousedown = () => {
-    if (usingKeyboard) {
-      setUsingKeyboard(false);
-    }
-  };
-
-  document.addEventListener('keydown', handleKeydown);
-  document.addEventListener('mousedown', handleMousedown);
-
-  useEffect(() => {
-    return function cleanup() {
-      document.removeEventListener('keydown', handleKeydown);
-      document.removeEventListener('mousedown', handleMousedown);
-    };
+  const usingKeyboard = useIsUsingKeyboard((isUsingKeyboard) => {
+    document.body.classList.toggle(KEYBOARD_USER_CLASS, isUsingKeyboard);
   });
-
-  useEffect(() => {
-    document.body.classList.toggle(KEYBOARD_USER_CLASS, usingKeyboard);
-  }, [usingKeyboard]);
 
   return !usingKeyboard ? <OutlineStyles /> : null;
 };

--- a/assets/src/dashboard/utils/keyboardOnlyOutline.js
+++ b/assets/src/dashboard/utils/keyboardOnlyOutline.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
 /**
@@ -35,9 +35,11 @@ export const OutlineStyles = createGlobalStyle`
 `;
 
 const KeyboardOnlyOutline = () => {
-  const usingKeyboard = useIsUsingKeyboard((isUsingKeyboard) => {
-    document.body.classList.toggle(KEYBOARD_USER_CLASS, isUsingKeyboard);
-  });
+  const usingKeyboard = useIsUsingKeyboard();
+
+  useEffect(() => {
+    document.body.classList.toggle(KEYBOARD_USER_CLASS, usingKeyboard);
+  }, [usingKeyboard]);
 
   return !usingKeyboard ? <OutlineStyles /> : null;
 };

--- a/assets/src/dashboard/utils/useBatchingCallback.js
+++ b/assets/src/dashboard/utils/useBatchingCallback.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+import { unstable_batchedUpdates as batchedUpdates } from 'react-dom';
+
+/**
+ * The same as `useCallback` except that it ensures the updates
+ * are batched. Use anywhere where the native DOM events are handled
+ * or for microtasks.
+ * See https://blog.logrocket.com/simplifying-state-management-in-react-apps-with-batched-updates/.
+ *
+ * @param {function()} callback The callback to be batched and memoized.
+ * @param {!Array|undefined} deps The optional callback dependencies.
+ * @return {function()} The memoized batching function.
+ */
+function useBatchingCallback(callback, deps = undefined) {
+  return useCallback(
+    (...args) => batchedUpdates(() => callback(...args)),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    deps
+  );
+}
+
+export default useBatchingCallback;

--- a/assets/src/dashboard/utils/useIsUsingKeyboard.js
+++ b/assets/src/dashboard/utils/useIsUsingKeyboard.js
@@ -57,8 +57,16 @@ function useIsUsingKeyboard(acceptedKeys = DEFAULT_ACCEPTED_KEYS) {
       true /** useCapture */
     );
     return function cleanup() {
-      document.removeEventListener('keydown', handleKeydown);
-      document.removeEventListener('mousedown', handleMousedown);
+      document.removeEventListener(
+        'keydown',
+        handleKeydown,
+        true /** useCapture */
+      );
+      document.removeEventListener(
+        'mousedown',
+        handleMousedown,
+        true /** useCapture */
+      );
     };
   });
 

--- a/assets/src/dashboard/utils/useIsUsingKeyboard.js
+++ b/assets/src/dashboard/utils/useIsUsingKeyboard.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from 'react';
+
+const DEFAULT_ACCEPTED_KEYS = [
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'Tab',
+];
+
+function useIsUsingKeyboard(callback, acceptedKeys = DEFAULT_ACCEPTED_KEYS) {
+  const [usingKeyboard, setUsingKeyboard] = useState(false);
+  const handleKeydown = (e) => {
+    if (!usingKeyboard && acceptedKeys.includes(e.key)) {
+      setUsingKeyboard(true);
+    }
+  };
+
+  const handleMousedown = () => {
+    if (usingKeyboard) {
+      setUsingKeyboard(false);
+    }
+  };
+
+  document.addEventListener('keydown', handleKeydown);
+  document.addEventListener('mousedown', handleMousedown);
+
+  useEffect(() => {
+    return function cleanup() {
+      document.removeEventListener('keydown', handleKeydown);
+      document.removeEventListener('mousedown', handleMousedown);
+    };
+  });
+
+  useEffect(() => {
+    if (!callback) {
+      return;
+    }
+    callback(usingKeyboard);
+  }, [usingKeyboard, callback]);
+
+  return usingKeyboard;
+}
+
+export default useIsUsingKeyboard;

--- a/assets/src/edit-story/elements/media/scalePanel.js
+++ b/assets/src/edit-story/elements/media/scalePanel.js
@@ -31,6 +31,7 @@ import { __ } from '@wordpress/i18n';
 import InOverlay from '../../components/overlay';
 import RangeInput from '../../components/rangeInput';
 import { Z_INDEX_CANVAS } from '../../constants';
+import useIsUsingKeyboard from '../../utils/useIsUsingKeyboard';
 
 const MIN_WIDTH = 165;
 const HEIGHT = 28;
@@ -71,14 +72,26 @@ const ResetButton = styled.button`
   padding: 1px 8px 0 8px;
 `;
 
+const ACCEPTED_KEYS = [
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'PageUp',
+  'PageDown',
+];
+
 function ScalePanel({ setProperties, width, height, x, y, scale }) {
+  // Handle different step size for mouse and keyboard users
+  const usingKeyboard = useIsUsingKeyboard(null, ACCEPTED_KEYS);
+
   return (
     <InOverlay zIndex={Z_INDEX_CANVAS.FLOAT_PANEL} pointerEvents="initial">
       <Container x={x} y={y} width={width} height={height}>
         <RangeInput
           min={100}
           max={MAX_SCALE}
-          step={10}
+          step={usingKeyboard ? 10 : null}
           value={scale}
           onChange={(evt) => setProperties({ scale: evt.target.valueAsNumber })}
         />

--- a/assets/src/edit-story/elements/media/scalePanel.js
+++ b/assets/src/edit-story/elements/media/scalePanel.js
@@ -83,7 +83,7 @@ const ACCEPTED_KEYS = [
 
 function ScalePanel({ setProperties, width, height, x, y, scale }) {
   // Handle different step size for mouse and keyboard users
-  const usingKeyboard = useIsUsingKeyboard(null, ACCEPTED_KEYS);
+  const usingKeyboard = useIsUsingKeyboard(ACCEPTED_KEYS);
 
   return (
     <InOverlay zIndex={Z_INDEX_CANVAS.FLOAT_PANEL} pointerEvents="initial">
@@ -91,7 +91,7 @@ function ScalePanel({ setProperties, width, height, x, y, scale }) {
         <RangeInput
           min={100}
           max={MAX_SCALE}
-          step={usingKeyboard ? 10 : null}
+          step={usingKeyboard ? 10 : 1}
           value={scale}
           onChange={(evt) => setProperties({ scale: evt.target.valueAsNumber })}
         />

--- a/assets/src/edit-story/utils/keyboardOnlyOutline.js
+++ b/assets/src/edit-story/utils/keyboardOnlyOutline.js
@@ -23,9 +23,6 @@ import React from 'react';
 import { createGlobalStyle } from 'styled-components';
 
 /**
- * Internal depedencies
- */
-/**
  * Internal dependencies
  */
 import useIsUsingKeyboard from './useIsUsingKeyboard';

--- a/assets/src/edit-story/utils/keyboardOnlyOutline.js
+++ b/assets/src/edit-story/utils/keyboardOnlyOutline.js
@@ -19,8 +19,16 @@
 /**
  * External dependencies
  */
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { createGlobalStyle } from 'styled-components';
+
+/**
+ * Internal depedencies
+ */
+/**
+ * Internal dependencies
+ */
+import useIsUsingKeyboard from './useIsUsingKeyboard';
 
 const KEYBOARD_USER_CLASS = `useskeyboard`;
 export const KEYBOARD_USER_SELECTOR = `.${KEYBOARD_USER_CLASS}`;
@@ -31,41 +39,10 @@ const OutlineStyles = createGlobalStyle`
     }
 `;
 
-const ACCEPTED_KEYS = [
-  'ArrowUp',
-  'ArrowDown',
-  'ArrowLeft',
-  'ArrowRight',
-  'Tab',
-];
-
 const KeyboardOnlyOutline = () => {
-  const [usingKeyboard, setUsingKeyboard] = useState(false);
-  const handleKeydown = (e) => {
-    if (!usingKeyboard && ACCEPTED_KEYS.includes(e.key)) {
-      setUsingKeyboard(true);
-    }
-  };
-
-  const handleMousedown = () => {
-    if (usingKeyboard) {
-      setUsingKeyboard(false);
-    }
-  };
-
-  document.addEventListener('keydown', handleKeydown, true);
-  document.addEventListener('mousedown', handleMousedown, true);
-
-  useEffect(() => {
-    return function cleanup() {
-      document.removeEventListener('keydown', handleKeydown);
-      document.removeEventListener('mousedown', handleMousedown);
-    };
-  });
-
-  useEffect(() => {
+  useIsUsingKeyboard((usingKeyboard) => {
     document.body.classList.toggle(KEYBOARD_USER_CLASS, usingKeyboard);
-  }, [usingKeyboard]);
+  });
 
   return <OutlineStyles />;
 };

--- a/assets/src/edit-story/utils/keyboardOnlyOutline.js
+++ b/assets/src/edit-story/utils/keyboardOnlyOutline.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createGlobalStyle } from 'styled-components';
 
 /**
@@ -37,9 +37,11 @@ const OutlineStyles = createGlobalStyle`
 `;
 
 const KeyboardOnlyOutline = () => {
-  useIsUsingKeyboard((usingKeyboard) => {
+  const usingKeyboard = useIsUsingKeyboard();
+
+  useEffect(() => {
     document.body.classList.toggle(KEYBOARD_USER_CLASS, usingKeyboard);
-  });
+  }, [usingKeyboard]);
 
   return <OutlineStyles />;
 };

--- a/assets/src/edit-story/utils/useIsUsingKeyboard.js
+++ b/assets/src/edit-story/utils/useIsUsingKeyboard.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from 'react';
+
+const DEFAULT_ACCEPTED_KEYS = [
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'Tab',
+];
+
+function useIsUsingKeyboard(callback, acceptedKeys = DEFAULT_ACCEPTED_KEYS) {
+  const [usingKeyboard, setUsingKeyboard] = useState(false);
+  const handleKeydown = (e) => {
+    if (!usingKeyboard && acceptedKeys.includes(e.key)) {
+      setUsingKeyboard(true);
+    }
+  };
+
+  const handleMousedown = () => {
+    if (usingKeyboard) {
+      setUsingKeyboard(false);
+    }
+  };
+
+  document.addEventListener('keydown', handleKeydown);
+  document.addEventListener('mousedown', handleMousedown);
+
+  useEffect(() => {
+    return function cleanup() {
+      document.removeEventListener('keydown', handleKeydown);
+      document.removeEventListener('mousedown', handleMousedown);
+    };
+  });
+
+  useEffect(() => {
+    if (!callback) {
+      return;
+    }
+    callback(usingKeyboard);
+  }, [usingKeyboard, callback]);
+
+  return usingKeyboard;
+}
+
+export default useIsUsingKeyboard;


### PR DESCRIPTION
## Summary

Refactors the detection mechanism for whether the user is a keyboard vs mouse user into a react hook that can be re-used by both the image editor and for the focus styles. Removes the need to have predefined steps while dragging the zoom slider for mouse users. 

## User-facing changes

Zooming in and out of images while editing should be smoother for mouse users.

## Testing Instructions

1. Insert a photo into the canvas
2. Double-click to enter edit mode
3. Using the mouse, slide the zoom slider
4. There should no longer be any restriction while dragging
5. Now use the keyboard, the functionality should still work with the arrow keys as well as the page up / page down keys

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #372
