### PR TITLE
Embed Block: Fix center alignment 

### DIFF
--- a/assets/src/story-embed-block/block/edit.css
+++ b/assets/src/story-embed-block/block/edit.css
@@ -31,7 +31,9 @@
   width: inherit;
   height: inherit;
 }
-
+.wp-block-web-stories-embed.aligncenter .components-resizable-box__container {
+  margin: auto;
+}
 /* Embed Preview Component */
 
 .web-stories-embed-preview {

--- a/includes/Embed_Block.php
+++ b/includes/Embed_Block.php
@@ -169,7 +169,8 @@ class Embed_Block {
 		$title        = (string) $attributes['title'];
 		$poster       = ! empty( $attributes['poster'] ) ? esc_url( $attributes['poster'] ) : '';
 		$align        = sprintf( 'align%s', $attributes['align'] );
-		$player_style = sprintf( 'width: %dpx; height: %dpx', absint( $attributes['width'] ), absint( $attributes['height'] ) );
+		$margin       = ( 'center' === $attributes['align'] ) ? 'auto' : '0';
+		$player_style = sprintf( 'width: %dpx; height: %dpx; margin: %s', absint( $attributes['width'] ), absint( $attributes['height'] ), esc_attr( $margin ) );
 		$poster_style = ! empty( $poster ) ? sprintf( '--story-player-poster: url(%s)', $poster ) : '';
 
 		wp_enqueue_style( 'amp-story-player' );


### PR DESCRIPTION
## Summary
Super simple fix, using `margin: auto`.

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Insert block to embed a story
1. Align block centered
1. Verify block is centered both on the frontend and in the editor

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2374
