### PR TITLE
Templates: Add base animations to fashion template

### DIFF
--- a/assets/src/dashboard/animations/parts/components/fullSizeAbsolute.js
+++ b/assets/src/dashboard/animations/parts/components/fullSizeAbsolute.js
@@ -24,6 +24,8 @@ export default styled.div`
   right: 0;
   bottom: 0;
   left: 0;
+  transform-origin: 50% 50%;
+
   ${({ overflowHidden }) =>
     overflowHidden &&
     css`

--- a/assets/src/dashboard/templates/raw/fashion.json
+++ b/assets/src/dashboard/templates/raw/fashion.json
@@ -1,9 +1,13 @@
 {
-  "version": 21,
+  "version": 23,
   "pages": [
     {
       "elements": [
         {
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
           "type": "shape",
           "opacity": 100,
           "flip": {
@@ -19,10 +23,6 @@
               "b": 227
             }
           },
-          "x": 1,
-          "y": 1,
-          "width": 1,
-          "height": 1,
           "mask": {
             "type": "rectangle"
           },
@@ -31,6 +31,10 @@
           "isDefaultBackground": true
         },
         {
+          "x": 60,
+          "y": 58,
+          "width": 353,
+          "height": 456,
           "type": "image",
           "opacity": 100,
           "flip": {
@@ -47,10 +51,6 @@
               "a": 0
             }
           },
-          "x": 73,
-          "y": 71,
-          "width": 367,
-          "height": 474,
           "scale": 170,
           "focalX": 50,
           "focalY": 50,
@@ -130,6 +130,10 @@
           }
         },
         {
+          "x": -145,
+          "y": 269,
+          "width": 501,
+          "height": 155,
           "font": {
             "service": "fonts.google.com",
             "family": "Playfair Display",
@@ -144,7 +148,6 @@
           "rotationAngle": -90,
           "lockAspectRatio": true,
           "backgroundTextMode": "NONE",
-          "fontSize": 99,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -154,22 +157,22 @@
           },
           "lineHeight": 0.95,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": -190,
-          "y": 251,
-          "width": 610,
-          "height": 188,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "id": "a32c17e0-a46b-4821-bbdb-8dc064ac097d",
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">FASHION\nON THE GO</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">FASHION\nON THE GO</span></span>",
+          "fontSize": 81,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 27,
+          "y": 25,
+          "width": 83,
+          "height": 21,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -185,10 +188,6 @@
             }
           },
           "type": "shape",
-          "x": 33,
-          "y": 31,
-          "width": 101,
-          "height": 26,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -336,6 +335,10 @@
     {
       "elements": [
         {
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
           "type": "shape",
           "opacity": 100,
           "flip": {
@@ -351,10 +354,6 @@
               "b": 227
             }
           },
-          "x": 1,
-          "y": 1,
-          "width": 1,
-          "height": 1,
           "mask": {
             "type": "rectangle"
           },
@@ -363,6 +362,10 @@
           "isDefaultBackground": true
         },
         {
+          "x": 18,
+          "y": 21,
+          "width": 334,
+          "height": 267,
           "font": {
             "service": "fonts.google.com",
             "family": "Playfair Display",
@@ -377,7 +380,6 @@
           "rotationAngle": 0,
           "lockAspectRatio": true,
           "backgroundTextMode": "NONE",
-          "fontSize": 46,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -387,22 +389,22 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 21,
-          "y": 11,
-          "width": 347,
-          "height": 276,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "id": "d773925c-2f95-44c0-9b0e-0743d45476f2",
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(0, 0, 0, 1)\">“IF YOU CAN'T BE BETTER THAN YOUR COMPETITION, JUST DRESS BETTER”</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(0, 0, 0, 1)\">“IF YOU CAN'T BE BETTER THAN YOUR COMPETITION, JUST DRESS BETTER”</span></span>",
+          "fontSize": 45,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 19,
+          "y": 503,
+          "width": 354,
+          "height": 90,
           "font": {
             "service": "fonts.google.com",
             "family": "Playfair Display",
@@ -417,7 +419,6 @@
           "rotationAngle": 0,
           "lockAspectRatio": true,
           "backgroundTextMode": "NONE",
-          "fontSize": 46,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -427,23 +428,23 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 347,
-          "height": 91,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "d773925c-2f95-44c0-9b0e-0743d45476f2",
           "id": "61d23551-31e3-4aad-ac15-b8fc5e4be2ec",
-          "x": 22,
-          "y": 543,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(0, 0, 0, 1)\">— ANNA\nWINTOUR</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(0, 0, 0, 1)\">— ANNA\nWINTOUR</span></span>",
+          "fontSize": 45,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 228,
+          "y": 298,
+          "width": 223,
+          "height": 223,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -496,10 +497,6 @@
               }
             }
           },
-          "x": 220,
-          "y": 281,
-          "width": 271,
-          "height": 271,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -510,6 +507,10 @@
           "id": "d6798f2f-b78d-4a5a-9d83-13b84c950394"
         },
         {
+          "x": 320,
+          "y": 396,
+          "width": 37,
+          "height": 29,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -533,10 +534,6 @@
             "local": false,
             "sizes": []
           },
-          "x": 333,
-          "y": 399,
-          "width": 45,
-          "height": 35,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -547,7 +544,6 @@
           "id": "99696270-286f-4c14-b062-aad2a021672a"
         }
       ],
-      "backgroundOverlay": "none",
       "type": "page",
       "id": "cda99980-6722-4141-9616-25e523a98722",
       "animations": [
@@ -675,6 +671,10 @@
     {
       "elements": [
         {
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
           "type": "shape",
           "opacity": 100,
           "flip": {
@@ -690,10 +690,6 @@
               "b": 33
             }
           },
-          "x": 1,
-          "y": 1,
-          "width": 1,
-          "height": 1,
           "mask": {
             "type": "rectangle"
           },
@@ -702,6 +698,10 @@
           "isDefaultBackground": true
         },
         {
+          "x": 1,
+          "y": 1,
+          "width": 336,
+          "height": 486,
           "type": "image",
           "opacity": 95,
           "flip": {
@@ -717,10 +717,6 @@
               "b": 51
             }
           },
-          "x": 1,
-          "y": 1,
-          "width": 409,
-          "height": 592,
           "scale": 170,
           "focalX": 50,
           "focalY": 50,
@@ -800,6 +796,10 @@
           }
         },
         {
+          "x": 2,
+          "y": 295,
+          "width": 335,
+          "height": 192,
           "type": "shape",
           "opacity": 100,
           "flip": {
@@ -832,10 +832,6 @@
             ],
             "rotation": 0.5
           },
-          "x": 2,
-          "y": 359,
-          "width": 408,
-          "height": 234,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -845,6 +841,10 @@
           "id": "6fc327a4-8e5d-48e8-8285-899267ec1183"
         },
         {
+          "x": 43,
+          "y": 1,
+          "width": 405,
+          "height": 393,
           "font": {
             "service": "fonts.google.com",
             "family": "Playfair Display",
@@ -859,7 +859,6 @@
           "rotationAngle": 0,
           "lockAspectRatio": true,
           "backgroundTextMode": "NONE",
-          "fontSize": 173,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -869,22 +868,22 @@
           },
           "lineHeight": 0.93,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 52,
-          "y": 1,
-          "width": 493,
-          "height": 480,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "id": "792955f1-699b-499a-bf65-d88b60d613af",
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 236, 227, 1)\">S/S PREV\nIEW</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 236, 227, 1)\">S/S PREV\nIEW</span></span>",
+          "fontSize": 142,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 50,
+          "y": 419,
+          "width": 198,
+          "height": 35,
           "font": {
             "service": "fonts.google.com",
             "family": "DM Sans",
@@ -899,7 +898,6 @@
           "rotationAngle": 0,
           "lockAspectRatio": true,
           "backgroundTextMode": "NONE",
-          "fontSize": 18,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -909,22 +907,22 @@
           },
           "lineHeight": 1.22,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 61,
-          "y": 509,
-          "width": 240,
-          "height": 42,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "id": "9bd1600f-5d9d-4beb-bdfb-817b118a8852",
-          "content": "<span style=\"letter-spacing: 0.0002em\"><span style=\"color: rgba(255, 236, 227, 1)\">PREVIEW THE LATEST LOOKS OF THE SEASON</span></span>"
+          "content": "<span style=\"letter-spacing: 0.0002em\"><span style=\"color: rgba(255, 236, 227, 1)\">PREVIEW THE LATEST LOOKS OF THE SEASON</span></span>",
+          "fontSize": 15,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 115,
+          "y": 507,
+          "width": 131,
+          "height": 16,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -954,7 +952,6 @@
             "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
             "service": "fonts.google.com"
           },
-          "fontSize": 15,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -964,23 +961,23 @@
           },
           "lineHeight": 1.3,
           "textAlign": "center",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 140,
-          "y": 617,
-          "width": 160,
-          "height": 19,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "d27e267e-5ee5-4b60-8c79-a9e3afa92d52",
-          "content": "<span style=\"color: rgba(255, 255, 255, 1)\"><span style=\"font-weight: 700\">See Full Story</span></span>"
+          "content": "<span style=\"color: rgba(255, 255, 255, 1)\"><span style=\"font-weight: 700\">See Full Story</span></span>",
+          "fontSize": 12,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 169,
+          "y": 476,
+          "width": 23,
+          "height": 23,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -995,10 +992,6 @@
               "b": 255
             }
           },
-          "x": 206,
-          "y": 579,
-          "width": 29,
-          "height": 29,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -1009,6 +1002,10 @@
           "id": "a2240997-ab2a-49ec-bafb-503d778122ca"
         },
         {
+          "x": 177,
+          "y": 486,
+          "width": 7,
+          "height": 4,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1032,10 +1029,6 @@
             "local": false,
             "sizes": []
           },
-          "x": 215.5,
-          "y": 591.5,
-          "width": 10,
-          "height": 4,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -1046,7 +1039,6 @@
           "id": "504deaac-9943-4878-984a-c22cc3efd7cd"
         }
       ],
-      "backgroundOverlay": "none",
       "type": "page",
       "id": "99ae5466-855b-4d84-9379-c401969ade38",
       "backgroundColor": {
@@ -1055,11 +1047,142 @@
           "g": 33,
           "b": 33
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-100%",
+          "offsetY": "-100%",
+          "id": "8eb55f90-5f97-4cd4-90de-38e91bfc506e",
+          "duration": 1300,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": ["6cca5fcd-80d5-4181-b9e6-2979b80c2b99"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": "100%",
+          "offsetY": "100%",
+          "id": "b65f580e-7620-4aba-bb87-04eedaf7dea8",
+          "duration": 1300,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": ["6cca5fcd-80d5-4181-b9e6-2979b80c2b99"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 2,
+          "zoomTo": 1,
+          "id": "22189d99-3a6b-43fd-9312-a2a122f840de",
+          "duration": 800,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": ["6cca5fcd-80d5-4181-b9e6-2979b80c2b99"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 1.2,
+          "zoomTo": 1,
+          "id": "75391b56-7cad-415e-8b87-eb1d760c2517",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": ["6cca5fcd-80d5-4181-b9e6-2979b80c2b99"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": "30%",
+          "offsetY": "30%",
+          "id": "de610d8b-69ec-4297-852a-416a6bc8f14e",
+          "duration": 1500,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": ["792955f1-699b-499a-bf65-d88b60d613af"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "a64a3c49-2ec4-44da-976a-00c0b24fd354",
+          "duration": 400,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": ["792955f1-699b-499a-bf65-d88b60d613af"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "-40%",
+          "id": "c401c972-4cb3-4454-8eba-1a01625c02c0",
+          "duration": 600,
+          "delay": 700,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": ["9bd1600f-5d9d-4beb-bdfb-817b118a8852"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "35f48ff1-030b-4ba3-bc60-e1299a8817a0",
+          "duration": 400,
+          "delay": 700,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": ["9bd1600f-5d9d-4beb-bdfb-817b118a8852"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "af78ffa4-4115-4ac7-8d16-495af9919922",
+          "duration": 1000,
+          "delay": 800,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "504deaac-9943-4878-984a-c22cc3efd7cd",
+            "a2240997-ab2a-49ec-bafb-503d778122ca",
+            "d27e267e-5ee5-4b60-8c79-a9e3afa92d52"
+          ]
+        }
+      ]
     },
     {
       "elements": [
         {
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1074,10 +1197,6 @@
               "b": 227
             }
           },
-          "x": 1,
-          "y": 1,
-          "width": 1,
-          "height": 1,
           "mask": {
             "type": "rectangle"
           },
@@ -1087,6 +1206,10 @@
           "isDefaultBackground": true
         },
         {
+          "x": 20,
+          "y": 26,
+          "width": 174,
+          "height": 76,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1116,7 +1239,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 46,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1126,23 +1248,23 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 24,
-          "y": 32,
-          "width": 213,
-          "height": 92,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "64b41c08-0817-4b98-aa55-0aaa9ea205e8",
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">LOUIS\nVUITTON</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">LOUIS\nVUITTON</span></span>",
+          "fontSize": 37,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 20,
+          "y": 110,
+          "width": 143,
+          "height": 13,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1166,7 +1288,6 @@
               [1, 700]
             ]
           },
-          "fontSize": 16,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1176,23 +1297,23 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 24,
-          "y": 134,
-          "width": 174,
-          "height": 16,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "a2a90d9e-2bce-44d3-95cd-77f33c55e144",
-          "content": "<span style=\"letter-spacing: 0.0002em\"><span style=\"color: rgba(33, 33, 33, 1)\">A RICH HISTORY</span></span>"
+          "content": "<span style=\"letter-spacing: 0.0002em\"><span style=\"color: rgba(33, 33, 33, 1)\">A RICH HISTORY</span></span>",
+          "fontSize": 13,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 107,
+          "y": 199,
+          "width": 230,
+          "height": 25,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1222,7 +1343,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 24,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1232,23 +1352,23 @@
           },
           "lineHeight": 1.3,
           "textAlign": "right",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 130,
-          "y": 243,
-          "width": 281,
-          "height": 31,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "8c45242f-9941-4fdc-b5de-3339a36585bf",
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">LV MONOGRAM CANVAS</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">LV MONOGRAM CANVAS</span></span>",
+          "fontSize": 20,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 148,
+          "y": 92,
+          "width": 195,
+          "height": 128,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1262,7 +1382,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 120,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1272,23 +1391,23 @@
           },
           "lineHeight": 1.3,
           "textAlign": "right",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 181,
-          "y": 112,
-          "width": 237,
-          "height": 156,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "acb2ccae-1faf-4192-bf28-19614324ed25",
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1896</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1896</span></span>",
+          "fontSize": 98,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 21,
+          "y": 213,
+          "width": 131,
+          "height": 64,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1302,7 +1421,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 60,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1312,23 +1430,23 @@
           },
           "lineHeight": 1.3,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 25,
-          "y": 261,
-          "width": 160,
-          "height": 78,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "e6ee6ead-43e0-45a4-aeef-1bcb7c914fcd",
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1901</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1901</span></span>",
+          "fontSize": 49,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 22,
+          "y": 269,
+          "width": 195,
+          "height": 25,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1358,7 +1476,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 24,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1368,23 +1485,23 @@
           },
           "lineHeight": 1.3,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 28,
-          "y": 328,
-          "width": 237,
-          "height": 31,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "2c548d81-abe2-4f74-9292-9910382fb293",
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">THE STEAMER BAG</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">THE STEAMER BAG</span></span>",
+          "fontSize": 20,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 206,
+          "y": 275,
+          "width": 131,
+          "height": 63,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1398,7 +1515,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 60,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1408,24 +1524,24 @@
           },
           "lineHeight": 1.3,
           "textAlign": "right",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 160,
-          "height": 77,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "e6ee6ead-43e0-45a4-aeef-1bcb7c914fcd",
           "id": "9156bf8e-3cdd-41fb-99c2-f6206f95ec1b",
-          "x": 251,
-          "y": 335,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1930</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1930</span></span>",
+          "fontSize": 49,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 143,
+          "y": 330,
+          "width": 195,
+          "height": 24,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1455,7 +1571,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 24,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1465,24 +1580,24 @@
           },
           "lineHeight": 1.3,
           "textAlign": "right",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 237,
-          "height": 30,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "2c548d81-abe2-4f74-9292-9910382fb293",
           "id": "78ef1efb-0ca7-4067-9a38-a646987fd096",
-          "x": 174,
-          "y": 402,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">THE KEEPALL BAG</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">THE KEEPALL BAG</span></span>",
+          "fontSize": 20,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 21,
+          "y": 440,
+          "width": 230,
+          "height": 24,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1512,7 +1627,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 24,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1522,24 +1636,24 @@
           },
           "lineHeight": 1.3,
           "textAlign": "left",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 281,
-          "height": 30,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "8c45242f-9941-4fdc-b5de-3339a36585bf",
           "id": "f5593520-3bb3-49d6-bfbd-c9fe2af7ee51",
-          "x": 25,
-          "y": 536,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">THE PAPILLION BAG</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">THE PAPILLION BAG</span></span>",
+          "fontSize": 20,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 21,
+          "y": 332,
+          "width": 195,
+          "height": 128,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1553,7 +1667,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 120,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1563,24 +1676,24 @@
           },
           "lineHeight": 1.3,
           "textAlign": "left",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 237,
-          "height": 156,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "acb2ccae-1faf-4192-bf28-19614324ed25",
           "id": "a10cc4c5-ee6f-43dd-a391-ce72a14a43b7",
-          "x": 25,
-          "y": 405,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1966</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1966</span></span>",
+          "fontSize": 98,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 206,
+          "y": 438,
+          "width": 131,
+          "height": 63,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1594,7 +1707,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 60,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1604,24 +1716,24 @@
           },
           "lineHeight": 1.3,
           "textAlign": "right",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 160,
-          "height": 77,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "9156bf8e-3cdd-41fb-99c2-f6206f95ec1b",
           "id": "8c739a98-8a17-45f2-988a-935fc4e5ec33",
-          "x": 251,
-          "y": 534,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1985</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1985</span></span>",
+          "fontSize": 49,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 143,
+          "y": 493,
+          "width": 195,
+          "height": 24,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1651,7 +1763,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 24,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1661,25 +1772,20 @@
           },
           "lineHeight": 1.3,
           "textAlign": "right",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 237,
-          "height": 30,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "78ef1efb-0ca7-4067-9a38-a646987fd096",
           "id": "f17ac170-7428-4788-9f02-0a8704c1b8bf",
-          "x": 174,
-          "y": 601,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">EPI LEATHER</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">EPI LEATHER</span></span>",
+          "fontSize": 20,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         }
       ],
-      "backgroundOverlay": "none",
       "type": "page",
       "id": "22e2ed54-fa70-43c5-81e8-81ad672bd6ad",
       "backgroundColor": {
@@ -1688,11 +1794,198 @@
           "g": 236,
           "b": 227
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "250px",
+          "id": "cd496dbb-da8b-41f2-93d9-1badcdb81289",
+          "duration": 1300,
+          "delay": 900,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "8c45242f-9941-4fdc-b5de-3339a36585bf",
+            "acb2ccae-1faf-4192-bf28-19614324ed25"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "09ce1552-0cba-4d00-a876-0e312929f745",
+          "duration": 400,
+          "delay": 900,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "acb2ccae-1faf-4192-bf28-19614324ed25",
+            "8c45242f-9941-4fdc-b5de-3339a36585bf"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "250px",
+          "id": "aaed8507-4949-46fe-a2c6-040442843271",
+          "duration": 1300,
+          "delay": 950,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": [
+            "e6ee6ead-43e0-45a4-aeef-1bcb7c914fcd",
+            "2c548d81-abe2-4f74-9292-9910382fb293"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "cac577f7-83f7-4b57-875b-768541bd3e58",
+          "duration": 400,
+          "delay": 950,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "e6ee6ead-43e0-45a4-aeef-1bcb7c914fcd",
+            "2c548d81-abe2-4f74-9292-9910382fb293"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "250px",
+          "id": "d7d3b994-53ca-4e62-9cd2-cc9379486e72",
+          "duration": 1300,
+          "delay": 1000,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "9156bf8e-3cdd-41fb-99c2-f6206f95ec1b",
+            "78ef1efb-0ca7-4067-9a38-a646987fd096"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "57b3f4e4-eb48-4ad3-998a-94e8bd861e01",
+          "duration": 400,
+          "delay": 1000,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": [
+            "78ef1efb-0ca7-4067-9a38-a646987fd096",
+            "9156bf8e-3cdd-41fb-99c2-f6206f95ec1b"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "250px",
+          "id": "1acd64af-465c-445a-991f-6174765f5ffc",
+          "duration": 1300,
+          "delay": 1050,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "a10cc4c5-ee6f-43dd-a391-ce72a14a43b7",
+            "f5593520-3bb3-49d6-bfbd-c9fe2af7ee51"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "aa687737-f403-43c3-9922-7639e4fca2ce",
+          "duration": 400,
+          "delay": 1050,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "a10cc4c5-ee6f-43dd-a391-ce72a14a43b7",
+            "f5593520-3bb3-49d6-bfbd-c9fe2af7ee51"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "250px",
+          "id": "3866e5d4-d92a-444f-a878-cf78c4c612b0",
+          "duration": 1500,
+          "delay": 1100,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "8c739a98-8a17-45f2-988a-935fc4e5ec33",
+            "f17ac170-7428-4788-9f02-0a8704c1b8bf"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "6957863e-9946-4a9e-86cd-6854041cf267",
+          "duration": 400,
+          "delay": 1100,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "8c739a98-8a17-45f2-988a-935fc4e5ec33",
+            "f17ac170-7428-4788-9f02-0a8704c1b8bf"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "290",
+          "id": "7a7f69b6-b7d3-407b-b048-53f838ed2f47",
+          "duration": 1400,
+          "delay": 200,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": [
+            "64b41c08-0817-4b98-aa55-0aaa9ea205e8",
+            "a2a90d9e-2bce-44d3-95cd-77f33c55e144"
+          ]
+        }
+      ]
     },
     {
       "elements": [
         {
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1707,10 +2000,6 @@
               "b": 33
             }
           },
-          "x": 1,
-          "y": 1,
-          "width": 1,
-          "height": 1,
           "mask": {
             "type": "rectangle"
           },
@@ -1720,6 +2009,10 @@
           "isDefaultBackground": true
         },
         {
+          "x": -212,
+          "y": 262,
+          "width": 512,
+          "height": 128,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1733,7 +2026,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 120,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1743,23 +2035,23 @@
           },
           "lineHeight": 1.3,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": -257,
-          "y": 319,
-          "width": 624,
-          "height": 156,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "bad4432f-b82b-4579-bb2d-d9858f7feec2",
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 236, 227, 1)\">CARDIN —</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 236, 227, 1)\">CARDIN —</span></span>",
+          "fontSize": 98,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": -302,
+          "y": -309,
+          "width": 693,
+          "height": 128,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1773,7 +2065,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 120,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1783,24 +2074,24 @@
           },
           "lineHeight": 1.3,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 844,
-          "height": 156,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "bad4432f-b82b-4579-bb2d-d9858f7feec2",
           "id": "875e2b60-1738-425a-8d7d-95f648bb3af6",
-          "x": -367,
-          "y": -376,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 236, 227, 0.35)\">THE HANDBAG</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 236, 227, 0.35)\">THE HANDBAG</span></span>",
+          "fontSize": 98,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 11,
+          "y": 94,
+          "width": 349,
+          "height": 308,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1860,10 +2151,6 @@
               }
             }
           },
-          "x": 14,
-          "y": 114,
-          "width": 425,
-          "height": 375,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -1874,6 +2161,10 @@
           "id": "b5631bd3-6a40-4d43-b4b8-9f0b7c76a742"
         },
         {
+          "x": 132,
+          "y": 34,
+          "width": 24,
+          "height": 24,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1888,10 +2179,6 @@
               "b": 74
             }
           },
-          "x": 161,
-          "y": 41,
-          "width": 30,
-          "height": 30,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -1902,6 +2189,10 @@
           "id": "ba9ff730-74e6-478a-943e-8aa33851048d"
         },
         {
+          "x": 133,
+          "y": 415,
+          "width": 131,
+          "height": 22,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1915,7 +2206,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 22,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1925,23 +2215,23 @@
           },
           "lineHeight": 1.3,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 162,
-          "y": 505,
-          "width": 160,
-          "height": 28,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "f19846b4-b351-4607-a8f9-c7e69ff7a6f3",
-          "content": "<span style=\"letter-spacing: 0.0002em\"><span style=\"color: rgba(255, 108, 74, 1)\">CARDIN</span></span>"
+          "content": "<span style=\"letter-spacing: 0.0002em\"><span style=\"color: rgba(255, 108, 74, 1)\">CARDIN</span></span>",
+          "fontSize": 19,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 133,
+          "y": 436,
+          "width": 131,
+          "height": 45,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -1965,7 +2255,6 @@
               [1, 700]
             ]
           },
-          "fontSize": 22,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1975,24 +2264,24 @@
           },
           "lineHeight": 1.25,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 160,
-          "height": 54,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "f19846b4-b351-4607-a8f9-c7e69ff7a6f3",
           "id": "61b42950-25ca-46cf-83bf-1e04cdc0cd94",
-          "x": 162,
-          "y": 532,
-          "content": "<span style=\"letter-spacing: 0.0002em\"><span style=\"color: rgba(255, 236, 227, 1)\">THE HANDBAG\n$450</span></span>"
+          "content": "<span style=\"letter-spacing: 0.0002em\"><span style=\"color: rgba(255, 236, 227, 1)\">THE HANDBAG\n$450</span></span>",
+          "fontSize": 19,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 133,
+          "y": 513,
+          "width": 131,
+          "height": 14,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2016,7 +2305,6 @@
               [1, 700]
             ]
           },
-          "fontSize": 14,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2026,24 +2314,24 @@
           },
           "lineHeight": 1.25,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 160,
-          "height": 17,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "61b42950-25ca-46cf-83bf-1e04cdc0cd94",
           "id": "67777589-1517-4a00-9e95-11e262bf02dd",
-          "x": 162,
-          "y": 625,
-          "content": "<span style=\"letter-spacing: 0.0008em\"><span style=\"color: rgba(255, 236, 227, 1)\">LEARN MORE</span></span>"
+          "content": "<span style=\"letter-spacing: 0.0008em\"><span style=\"color: rgba(255, 236, 227, 1)\">LEARN MORE</span></span>",
+          "fontSize": 11,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 224,
+          "y": 517,
+          "width": 11,
+          "height": 7,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2067,10 +2355,6 @@
             "local": false,
             "sizes": []
           },
-          "x": 272,
-          "y": 628.5,
-          "width": 14,
-          "height": 7,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -2081,7 +2365,6 @@
           "id": "87ae3605-e8e2-4d0f-8700-f84de19e4f01"
         }
       ],
-      "backgroundOverlay": "none",
       "type": "page",
       "id": "06f93f32-41a9-4fcd-9d03-08ea29f591e4",
       "backgroundColor": {
@@ -2095,6 +2378,10 @@
     {
       "elements": [
         {
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2109,10 +2396,6 @@
               "b": 227
             }
           },
-          "x": 1,
-          "y": 1,
-          "width": 1,
-          "height": 1,
           "mask": {
             "type": "rectangle"
           },
@@ -2122,6 +2405,10 @@
           "isDefaultBackground": true
         },
         {
+          "x": 17,
+          "y": 7,
+          "width": 283,
+          "height": 113,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2135,7 +2422,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 46,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2145,23 +2431,23 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 20,
-          "y": 10,
-          "width": 344,
-          "height": 138,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "735394cc-0da6-479c-951d-14579f0766ef",
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">TOP 5\nCOLLECTIONS\nTHIS SEASON</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">TOP 5\nCOLLECTIONS\nTHIS SEASON</span></span>",
+          "fontSize": 37,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 43,
+          "y": 193,
+          "width": 187,
+          "height": 37,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2191,7 +2477,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 46,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2201,24 +2486,24 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 229,
-          "height": 46,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "735394cc-0da6-479c-951d-14579f0766ef",
           "id": "ecfb31af-00a8-4533-b86a-e268e7b2a573",
-          "x": 52,
-          "y": 235,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">RODARTE</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">RODARTE</span></span>",
+          "fontSize": 37,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 131,
+          "y": 258,
+          "width": 187,
+          "height": 37,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2248,7 +2533,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 46,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2258,24 +2542,24 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 229,
-          "height": 46,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "ecfb31af-00a8-4533-b86a-e268e7b2a573",
           "id": "f40e6fac-12c9-4259-a5af-8de9d1fd1c64",
-          "x": 160,
-          "y": 314,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">CHANEL</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">CHANEL</span></span>",
+          "fontSize": 37,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 24,
+          "y": 327,
+          "width": 227,
+          "height": 37,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2305,7 +2589,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 46,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2315,24 +2598,24 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 275,
-          "height": 46,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "f40e6fac-12c9-4259-a5af-8de9d1fd1c64",
           "id": "dc565020-6358-44d9-9aac-a8eb90e76415",
-          "x": 30,
-          "y": 398,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">RICK OWENS</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">RICK OWENS</span></span>",
+          "fontSize": 37,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 110,
+          "y": 395,
+          "width": 131,
+          "height": 37,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2362,7 +2645,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 46,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2372,24 +2654,24 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 159,
-          "height": 46,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "dc565020-6358-44d9-9aac-a8eb90e76415",
           "id": "d6fea8bd-8f0a-414b-a845-722d436a6d43",
-          "x": 134,
-          "y": 482,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">PRADA</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">PRADA</span></span>",
+          "fontSize": 37,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 72,
+          "y": 461,
+          "width": 246,
+          "height": 37,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2419,7 +2701,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 46,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2429,24 +2710,24 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 300,
-          "height": 46,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "d6fea8bd-8f0a-414b-a845-722d436a6d43",
           "id": "7726e175-d97f-42ed-bb2e-a581f4135332",
-          "x": 88,
-          "y": 561,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">BALENCIAGA</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">BALENCIAGA</span></span>",
+          "fontSize": 37,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 196,
+          "y": 170,
+          "width": 46,
+          "height": 46,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2470,10 +2751,6 @@
             "local": false,
             "sizes": []
           },
-          "x": 238.5,
-          "y": 207,
-          "width": 55,
-          "height": 55,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -2484,6 +2761,10 @@
           "id": "b9736281-90de-4a2e-b813-7faddcba9dd9"
         },
         {
+          "x": 200,
+          "y": 176,
+          "width": 35,
+          "height": 26,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2497,7 +2778,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 32,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2507,24 +2787,24 @@
           },
           "lineHeight": 1,
           "textAlign": "center",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 43,
-          "height": 32,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "735394cc-0da6-479c-951d-14579f0766ef",
           "id": "3873fcaf-3c89-43dd-ba61-47bfed747b3e",
-          "x": 244.5,
-          "y": 215,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1</span></span>",
+          "fontSize": 26,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 103,
+          "y": 239,
+          "width": 46,
+          "height": 46,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2548,8 +2828,6 @@
             "local": false,
             "sizes": []
           },
-          "width": 55,
-          "height": 55,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -2558,11 +2836,13 @@
           },
           "type": "image",
           "basedOn": "b9736281-90de-4a2e-b813-7faddcba9dd9",
-          "id": "9cc65a3f-90c8-4a6b-8994-2db0da03e2aa",
-          "x": 125.5,
-          "y": 290
+          "id": "9cc65a3f-90c8-4a6b-8994-2db0da03e2aa"
         },
         {
+          "x": 116,
+          "y": 244,
+          "width": 21,
+          "height": 26,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2576,7 +2856,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 32,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2586,24 +2865,24 @@
           },
           "lineHeight": 1,
           "textAlign": "center",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 25,
-          "height": 32,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "3873fcaf-3c89-43dd-ba61-47bfed747b3e",
           "id": "e614554a-4201-4bdd-9ced-c5fe97c758c8",
-          "x": 140.5,
-          "y": 297.5,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">2</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">2</span></span>",
+          "fontSize": 26,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 234,
+          "y": 304,
+          "width": 46,
+          "height": 46,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2627,8 +2906,6 @@
             "local": false,
             "sizes": []
           },
-          "width": 55,
-          "height": 55,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -2637,11 +2914,13 @@
           },
           "type": "image",
           "basedOn": "9cc65a3f-90c8-4a6b-8994-2db0da03e2aa",
-          "id": "1995d229-c3c4-4f57-8e19-dc65b333e87a",
-          "x": 284.75,
-          "y": 370.5
+          "id": "1995d229-c3c4-4f57-8e19-dc65b333e87a"
         },
         {
+          "x": 239,
+          "y": 310,
+          "width": 34,
+          "height": 26,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2655,7 +2934,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 32,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2665,24 +2943,24 @@
           },
           "lineHeight": 1,
           "textAlign": "center",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 41,
-          "height": 32,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "e614554a-4201-4bdd-9ced-c5fe97c758c8",
           "id": "53f8e685-93b5-4971-bb76-03d52602eb47",
-          "x": 291,
-          "y": 378,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">3</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">3</span></span>",
+          "fontSize": 26,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 82,
+          "y": 375,
+          "width": 46,
+          "height": 46,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2706,8 +2984,6 @@
             "local": false,
             "sizes": []
           },
-          "width": 55,
-          "height": 55,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -2716,11 +2992,13 @@
           },
           "type": "image",
           "basedOn": "1995d229-c3c4-4f57-8e19-dc65b333e87a",
-          "id": "8368daee-25c0-47fa-a3f8-f1d087aff0ea",
-          "x": 100.875,
-          "y": 457.5
+          "id": "8368daee-25c0-47fa-a3f8-f1d087aff0ea"
         },
         {
+          "x": 89,
+          "y": 381,
+          "width": 34,
+          "height": 26,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2734,7 +3012,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 32,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2744,24 +3021,24 @@
           },
           "lineHeight": 1,
           "textAlign": "center",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 41,
-          "height": 32,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "53f8e685-93b5-4971-bb76-03d52602eb47",
           "id": "c8f479d6-429d-4ea4-93e8-ce8dfb37a5d5",
-          "x": 107.875,
-          "y": 465,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">4</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">4</span></span>",
+          "fontSize": 26,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 276,
+          "y": 439,
+          "width": 46,
+          "height": 46,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2785,8 +3062,6 @@
             "local": false,
             "sizes": []
           },
-          "width": 55,
-          "height": 55,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -2795,11 +3070,13 @@
           },
           "type": "image",
           "basedOn": "8368daee-25c0-47fa-a3f8-f1d087aff0ea",
-          "id": "797bc565-14f8-4635-aef9-d3aaa1d4f61f",
-          "x": 335.9375,
-          "y": 535.5
+          "id": "797bc565-14f8-4635-aef9-d3aaa1d4f61f"
         },
         {
+          "x": 282,
+          "y": 447,
+          "width": 34,
+          "height": 26,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2813,7 +3090,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 32,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -2823,25 +3099,20 @@
           },
           "lineHeight": 1,
           "textAlign": "center",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 41,
-          "height": 32,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "53f8e685-93b5-4971-bb76-03d52602eb47",
           "id": "175d2727-d683-4601-8405-f0a2ee56a654",
-          "x": 343,
-          "y": 544,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">5</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">5</span></span>",
+          "fontSize": 26,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         }
       ],
-      "backgroundOverlay": "none",
       "type": "page",
       "id": "e39c480a-e017-4c6e-b48c-4dc1ef00f6ab",
       "backgroundColor": {
@@ -2855,6 +3126,10 @@
     {
       "elements": [
         {
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -2869,10 +3144,6 @@
               "b": 227
             }
           },
-          "x": 1,
-          "y": 1,
-          "width": 1,
-          "height": 1,
           "mask": {
             "type": "rectangle"
           },
@@ -2882,6 +3153,10 @@
           "isDefaultBackground": true
         },
         {
+          "x": 1,
+          "y": 0,
+          "width": 348,
+          "height": 318,
           "opacity": 90,
           "flip": {
             "vertical": false,
@@ -2896,10 +3171,6 @@
               "b": 51
             }
           },
-          "x": 1,
-          "y": 0,
-          "width": 424,
-          "height": 388,
           "scale": 230,
           "focalX": 46.85572257958338,
           "focalY": 44.20206702632711,
@@ -2980,6 +3251,10 @@
           }
         },
         {
+          "x": 19,
+          "y": 342,
+          "width": 187,
+          "height": 37,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3009,7 +3284,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 46,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -3019,24 +3293,24 @@
           },
           "lineHeight": 1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 229,
-          "height": 46,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "ecfb31af-00a8-4533-b86a-e268e7b2a573",
           "id": "9ce78e9e-7568-45de-bef3-1f9438a11568",
-          "x": 22,
-          "y": 417,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">CARDIN</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">CARDIN</span></span>",
+          "fontSize": 37,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 23,
+          "y": 260,
+          "width": 101,
+          "height": 101,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3082,10 +3356,6 @@
               }
             }
           },
-          "x": 28.75,
-          "y": 317,
-          "width": 123,
-          "height": 123,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -3096,6 +3366,10 @@
           "id": "e03c6326-6b3a-4a11-b7f1-80decd115e08"
         },
         {
+          "x": 37,
+          "y": 274,
+          "width": 75,
+          "height": 59,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3109,7 +3383,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 72,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -3119,24 +3392,24 @@
           },
           "lineHeight": 1,
           "textAlign": "center",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 91,
-          "height": 72,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "735394cc-0da6-479c-951d-14579f0766ef",
           "id": "8c86903b-0df0-4c1e-a75a-23f1e79522b3",
-          "x": 44.75,
-          "y": 334.5,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(255, 108, 74, 1)\">1</span></span>",
+          "fontSize": 59,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 22,
+          "y": 397,
+          "width": 328,
+          "height": 82,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3160,7 +3433,6 @@
               [1, 700]
             ]
           },
-          "fontSize": 16,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -3170,23 +3442,23 @@
           },
           "lineHeight": 1.25,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 28,
-          "y": 484,
-          "width": 399,
-          "height": 100,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "43b205d1-376b-4eaf-b493-e55d70f8703e",
-          "content": "<span style=\"color: rgba(133, 130, 128, 1)\">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam vel dui erat. Curabitur sit amet venenatis felis. In ac ornare lacus. Integer vitae lacus a lectus eleifend finibus. Proin malesuada maximus felis, non lacinia est porttitor ante eget scelerisque.</span>"
+          "content": "<span style=\"color: rgba(133, 130, 128, 1)\">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam vel dui erat. Curabitur sit amet venenatis felis. In ac ornare lacus. Integer vitae lacus a lectus eleifend finibus. Proin malesuada maximus felis, non lacinia est porttitor ante eget scelerisque.</span>",
+          "fontSize": 13,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 23,
+          "y": 510,
+          "width": 131,
+          "height": 14,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3210,7 +3482,6 @@
               [1, 700]
             ]
           },
-          "fontSize": 14,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -3220,24 +3491,24 @@
           },
           "lineHeight": 1.25,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 160,
-          "height": 17,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "67777589-1517-4a00-9e95-11e262bf02dd",
           "id": "46ec18b4-8061-467f-88a0-fb2abd494061",
-          "x": 29,
-          "y": 622,
-          "content": "<span style=\"letter-spacing: 0.0008em\"><span style=\"color: rgba(33, 33, 33, 1)\">LEARN MORE</span></span>"
+          "content": "<span style=\"letter-spacing: 0.0008em\"><span style=\"color: rgba(33, 33, 33, 1)\">LEARN MORE</span></span>",
+          "fontSize": 11,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 112,
+          "y": 515,
+          "width": 11,
+          "height": 7,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3261,10 +3532,6 @@
             "local": false,
             "sizes": []
           },
-          "x": 137,
-          "y": 627,
-          "width": 14,
-          "height": 7,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -3275,7 +3542,6 @@
           "id": "08232848-6452-4121-8ffa-724c8e587687"
         }
       ],
-      "backgroundOverlay": "none",
       "type": "page",
       "id": "050444c7-6097-410f-8147-0c195b051a27",
       "backgroundColor": {
@@ -3289,6 +3555,10 @@
     {
       "elements": [
         {
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3303,10 +3573,6 @@
               "b": 255
             }
           },
-          "x": 1,
-          "y": 1,
-          "width": 1,
-          "height": 1,
           "mask": {
             "type": "rectangle"
           },
@@ -3388,6 +3654,10 @@
           "focalY": 58.333333333333336
         },
         {
+          "x": -321,
+          "y": 144,
+          "width": 737,
+          "height": 128,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3401,7 +3671,6 @@
             "family": "Playfair Display",
             "fallbacks": ["serif"]
           },
-          "fontSize": 120,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -3411,24 +3680,24 @@
           },
           "lineHeight": 1.3,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 897,
-          "height": 156,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "bad4432f-b82b-4579-bb2d-d9858f7feec2",
           "id": "faf0a8bb-fa80-40b7-b423-80b8bd4cd7a5",
-          "x": -391,
-          "y": 175,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">GET THE LOOK</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">GET THE LOOK</span></span>",
+          "fontSize": 98,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 142,
+          "y": 468,
+          "width": 19,
+          "height": 19,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3443,8 +3712,6 @@
               "b": 227
             }
           },
-          "width": 22,
-          "height": 22,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -3453,11 +3720,13 @@
           },
           "type": "shape",
           "basedOn": "06b9b1f3-3fdb-49b8-8efa-895081f2a0c6",
-          "id": "833449da-699c-4fac-aa52-cefc6c713423",
-          "x": 173,
-          "y": 570
+          "id": "833449da-699c-4fac-aa52-cefc6c713423"
         },
         {
+          "x": 144,
+          "y": 470,
+          "width": 15,
+          "height": 15,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3472,10 +3741,6 @@
               "b": 74
             }
           },
-          "x": 175,
-          "y": 572,
-          "width": 18,
-          "height": 18,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -3486,6 +3751,10 @@
           "id": "06b9b1f3-3fdb-49b8-8efa-895081f2a0c6"
         },
         {
+          "x": 265,
+          "y": 297,
+          "width": 19,
+          "height": 19,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3500,8 +3769,6 @@
               "b": 227
             }
           },
-          "width": 22,
-          "height": 22,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -3510,11 +3777,13 @@
           },
           "type": "shape",
           "basedOn": "833449da-699c-4fac-aa52-cefc6c713423",
-          "id": "5c3a77a7-f9c2-4bd5-bf8f-9d211c433af3",
-          "x": 323,
-          "y": 362
+          "id": "5c3a77a7-f9c2-4bd5-bf8f-9d211c433af3"
         },
         {
+          "x": 267,
+          "y": 299,
+          "width": 15,
+          "height": 15,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3529,8 +3798,6 @@
               "b": 74
             }
           },
-          "width": 18,
-          "height": 18,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -3539,11 +3806,13 @@
           },
           "type": "shape",
           "basedOn": "06b9b1f3-3fdb-49b8-8efa-895081f2a0c6",
-          "id": "1273a089-3c1f-44e2-a992-ee1c74571ce0",
-          "x": 325,
-          "y": 364
+          "id": "1273a089-3c1f-44e2-a992-ee1c74571ce0"
         },
         {
+          "x": 172,
+          "y": 229,
+          "width": 19,
+          "height": 19,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3558,8 +3827,6 @@
               "b": 227
             }
           },
-          "width": 22,
-          "height": 22,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -3568,11 +3835,13 @@
           },
           "type": "shape",
           "basedOn": "5c3a77a7-f9c2-4bd5-bf8f-9d211c433af3",
-          "id": "67a25f3e-d47f-4b06-97e8-b315ef85e0e2",
-          "x": 209,
-          "y": 280
+          "id": "67a25f3e-d47f-4b06-97e8-b315ef85e0e2"
         },
         {
+          "x": 173,
+          "y": 231,
+          "width": 15,
+          "height": 15,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3587,8 +3856,6 @@
               "b": 74
             }
           },
-          "width": 18,
-          "height": 18,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -3597,11 +3864,13 @@
           },
           "type": "shape",
           "basedOn": "1273a089-3c1f-44e2-a992-ee1c74571ce0",
-          "id": "0ece7509-bf1e-479d-a146-8be2be2f0cee",
-          "x": 211,
-          "y": 282
+          "id": "0ece7509-bf1e-479d-a146-8be2be2f0cee"
         },
         {
+          "x": 135,
+          "y": 111,
+          "width": 19,
+          "height": 19,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3616,8 +3885,6 @@
               "b": 227
             }
           },
-          "width": 22,
-          "height": 22,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -3626,11 +3893,13 @@
           },
           "type": "shape",
           "basedOn": "67a25f3e-d47f-4b06-97e8-b315ef85e0e2",
-          "id": "f6443849-a102-4899-9be1-ba2651204712",
-          "x": 164,
-          "y": 136
+          "id": "f6443849-a102-4899-9be1-ba2651204712"
         },
         {
+          "x": 136,
+          "y": 113,
+          "width": 15,
+          "height": 15,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3645,8 +3914,6 @@
               "b": 74
             }
           },
-          "width": 18,
-          "height": 18,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -3655,11 +3922,13 @@
           },
           "type": "shape",
           "basedOn": "0ece7509-bf1e-479d-a146-8be2be2f0cee",
-          "id": "15da37bf-3d0f-42d6-bce1-c5cd63d92603",
-          "x": 166,
-          "y": 138
+          "id": "15da37bf-3d0f-42d6-bce1-c5cd63d92603"
         },
         {
+          "x": 77,
+          "y": 389,
+          "width": 147,
+          "height": 67,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3674,10 +3943,6 @@
               "b": 227
             }
           },
-          "x": 94,
-          "y": 473,
-          "width": 179,
-          "height": 82,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -3688,6 +3953,10 @@
           "id": "e3507933-d80f-4ed2-b52a-02dea8a0779d"
         },
         {
+          "x": 85,
+          "y": 394,
+          "width": 76,
+          "height": 16,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3717,7 +3986,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 15,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -3727,23 +3995,23 @@
           },
           "lineHeight": 1.3,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "x": 104,
-          "y": 481,
-          "width": 92,
-          "height": 19,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "id": "b141ca71-b4f8-474c-93d0-b2a0b439c83e",
-          "content": "<span style=\"color: rgba(33, 33, 33, 1)\">CARDIN</span>"
+          "content": "<span style=\"color: rgba(33, 33, 33, 1)\">CARDIN</span>",
+          "fontSize": 12,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 85,
+          "y": 411,
+          "width": 111,
+          "height": 14,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3767,7 +4035,6 @@
               [1, 700]
             ]
           },
-          "fontSize": 14,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -3777,24 +4044,24 @@
           },
           "lineHeight": 1.3,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 136,
-          "height": 17,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "b141ca71-b4f8-474c-93d0-b2a0b439c83e",
           "id": "4c1eea44-cac5-45ba-bdc2-c6959c9edd76",
-          "x": 104,
-          "y": 501,
-          "content": "<span style=\"color: rgba(33, 33, 33, 1)\">The Everyday Boots</span>"
+          "content": "<span style=\"color: rgba(33, 33, 33, 1)\">The Everyday Boots</span>",
+          "fontSize": 11,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 85,
+          "y": 435,
+          "width": 111,
+          "height": 14,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3818,7 +4085,6 @@
               [1, 700]
             ]
           },
-          "fontSize": 14,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -3828,24 +4094,24 @@
           },
           "lineHeight": 1.3,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 136,
-          "height": 17,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "4c1eea44-cac5-45ba-bdc2-c6959c9edd76",
           "id": "bed8c7dc-aa6d-4fb9-b87d-b7bcb5911f93",
-          "x": 104,
-          "y": 531,
-          "content": "<span style=\"color: rgba(33, 33, 33, 1)\">$575</span>"
+          "content": "<span style=\"color: rgba(33, 33, 33, 1)\">$575</span>",
+          "fontSize": 11,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 208,
+          "y": 441,
+          "width": 7,
+          "height": 7,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3869,10 +4135,6 @@
             "local": false,
             "sizes": []
           },
-          "x": 253,
-          "y": 537,
-          "width": 10,
-          "height": 10,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -3883,7 +4145,6 @@
           "id": "4446cc97-cd5a-45ea-8232-3a53e1df3d86"
         }
       ],
-      "backgroundOverlay": "none",
       "type": "page",
       "id": "9e35d123-c307-4474-abd6-bb80a265bb2a",
       "defaultBackgroundElement": {
@@ -3920,6 +4181,10 @@
     {
       "elements": [
         {
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3934,10 +4199,6 @@
               "b": 227
             }
           },
-          "x": 1,
-          "y": 1,
-          "width": 1,
-          "height": 1,
           "mask": {
             "type": "rectangle"
           },
@@ -3947,6 +4208,10 @@
           "isDefaultBackground": true
         },
         {
+          "x": 44,
+          "y": 15,
+          "width": 213,
+          "height": 98,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -3976,7 +4241,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 62,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -3986,24 +4250,24 @@
           },
           "lineHeight": 0.98,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 258,
-          "height": 120,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "64b41c08-0817-4b98-aa55-0aaa9ea205e8",
           "id": "421f76ac-4c4d-4a44-ad77-622facf57db5",
-          "x": 53,
-          "y": 18,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">MORE\nSTORIES</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">MORE\nSTORIES</span></span>",
+          "fontSize": 51,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 132,
+          "y": 169,
+          "width": 195,
+          "height": 32,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4033,7 +4297,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 18,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -4043,24 +4306,24 @@
           },
           "lineHeight": 1.1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 237,
-          "height": 38,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "2c548d81-abe2-4f74-9292-9910382fb293",
           "id": "1043803d-625c-4b7a-a5ad-1cdecfbb1c62",
-          "x": 161,
-          "y": 206,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">HOW TO PULL OFF THE\nALL DENIM LOOK</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">HOW TO PULL OFF THE\nALL DENIM LOOK</span></span>",
+          "fontSize": 15,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 132,
+          "y": 256,
+          "width": 195,
+          "height": 32,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4090,7 +4353,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 18,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -4100,24 +4362,24 @@
           },
           "lineHeight": 1.1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 237,
-          "height": 38,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "1043803d-625c-4b7a-a5ad-1cdecfbb1c62",
           "id": "87b77bd3-8bc3-44ca-af6f-661e45522a7c",
-          "x": 161,
-          "y": 312,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">THE BEST STREET\nSTYLES FROM NYFW</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">THE BEST STREET\nSTYLES FROM NYFW</span></span>",
+          "fontSize": 15,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 131,
+          "y": 339,
+          "width": 195,
+          "height": 32,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4147,7 +4409,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 18,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -4157,24 +4418,24 @@
           },
           "lineHeight": 1.1,
           "textAlign": "initial",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 237,
-          "height": 38,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "87b77bd3-8bc3-44ca-af6f-661e45522a7c",
           "id": "44e7aa5c-3fe0-43db-8d46-c0a4425eeb18",
-          "x": 159,
-          "y": 413,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">THE LATEST TRENDS\nIN SNEAKER LAND</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">THE LATEST TRENDS\nIN SNEAKER LAND</span></span>",
+          "fontSize": 15,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 46,
+          "y": 420,
+          "width": 271,
+          "height": 1,
           "opacity": 10,
           "flip": {
             "vertical": false,
@@ -4189,10 +4450,6 @@
               "b": 33
             }
           },
-          "x": 55,
-          "y": 513,
-          "width": 330,
-          "height": 1,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -4203,6 +4460,10 @@
           "id": "c330044d-44a1-4cee-91b3-51f2147914d7"
         },
         {
+          "x": 45,
+          "y": 150,
+          "width": 71,
+          "height": 71,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4217,10 +4478,6 @@
               "b": 51
             }
           },
-          "x": 54,
-          "y": 183,
-          "width": 86,
-          "height": 86,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -4244,6 +4501,10 @@
           }
         },
         {
+          "x": 45,
+          "y": 237,
+          "width": 71,
+          "height": 71,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4258,8 +4519,6 @@
               "b": 51
             }
           },
-          "width": 86,
-          "height": 86,
           "scale": 130,
           "focalX": 41.611295124593894,
           "focalY": 35.212817670108095,
@@ -4269,8 +4528,6 @@
           "type": "image",
           "basedOn": "d01ae69c-43cc-455e-bb63-250642795201",
           "id": "c77c788b-cba9-421d-8a9a-2e8b604e99b8",
-          "x": 54,
-          "y": 288,
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
@@ -4329,6 +4586,10 @@
           }
         },
         {
+          "x": 44,
+          "y": 323,
+          "width": 71,
+          "height": 71,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4343,8 +4604,6 @@
               "b": 51
             }
           },
-          "width": 86,
-          "height": 86,
           "scale": 220,
           "focalX": 53.074903314458275,
           "focalY": 63.289037207094864,
@@ -4354,8 +4613,6 @@
           "type": "image",
           "basedOn": "c77c788b-cba9-421d-8a9a-2e8b604e99b8",
           "id": "ba68ba92-edcd-4c5c-a4fe-5263fc994e2b",
-          "x": 53,
-          "y": 393,
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
@@ -4463,6 +4720,10 @@
           }
         },
         {
+          "x": 84,
+          "y": 439,
+          "width": 195,
+          "height": 21,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4492,7 +4753,6 @@
               [1, 900]
             ]
           },
-          "fontSize": 24,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -4502,24 +4762,24 @@
           },
           "lineHeight": 1.1,
           "textAlign": "center",
-          "padding": {
-            "vertical": 0,
-            "horizontal": 0,
-            "locked": true
-          },
-          "width": 237,
-          "height": 26,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "type": "text",
           "basedOn": "1043803d-625c-4b7a-a5ad-1cdecfbb1c62",
           "id": "40a6fb22-daa4-4d78-8cdc-5ce6547d1d64",
-          "x": 102,
-          "y": 535,
-          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">FOLLOW US</span></span>"
+          "content": "<span style=\"letter-spacing: -0.0001em\"><span style=\"color: rgba(33, 33, 33, 1)\">FOLLOW US</span></span>",
+          "fontSize": 20,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         },
         {
+          "x": 79,
+          "y": 471,
+          "width": 39,
+          "height": 39,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4543,10 +4803,6 @@
             "local": false,
             "sizes": []
           },
-          "x": 96,
-          "y": 574,
-          "width": 48,
-          "height": 48,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -4557,6 +4813,10 @@
           "id": "38462ba6-4406-458f-8f0e-88fa6558e712"
         },
         {
+          "x": 133,
+          "y": 471,
+          "width": 39,
+          "height": 39,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4580,10 +4840,6 @@
             "local": false,
             "sizes": []
           },
-          "x": 162,
-          "y": 574,
-          "width": 48,
-          "height": 48,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -4594,6 +4850,10 @@
           "id": "d4c4986d-35cf-414c-8047-8697a4e03446"
         },
         {
+          "x": 187,
+          "y": 471,
+          "width": 39,
+          "height": 39,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4617,10 +4877,6 @@
             "local": false,
             "sizes": []
           },
-          "x": 229,
-          "y": 574,
-          "width": 48,
-          "height": 48,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -4631,6 +4887,10 @@
           "id": "e13df6ed-9e36-42f5-a614-54faaf827097"
         },
         {
+          "x": 243,
+          "y": 471,
+          "width": 39,
+          "height": 39,
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -4654,10 +4914,6 @@
             "local": false,
             "sizes": []
           },
-          "x": 296,
-          "y": 573,
-          "width": 48,
-          "height": 48,
           "mask": {
             "type": "rectangle",
             "name": "Rectangle",
@@ -4668,7 +4924,6 @@
           "id": "372a14f4-bc2c-493c-92e7-f7aa5d470289"
         }
       ],
-      "backgroundOverlay": "none",
       "type": "page",
       "id": "a9ed1626-720d-4b66-bfbd-40441c83390c",
       "backgroundColor": {

--- a/assets/src/dashboard/templates/raw/fashion.json
+++ b/assets/src/dashboard/templates/raw/fashion.json
@@ -2373,7 +2373,159 @@
           "g": 33,
           "b": 33
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "20px",
+          "id": "31ebab8d-38c2-4fd2-ba40-dcddb6e0b4d1",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["b5631bd3-6a40-4d43-b4b8-9f0b7c76a742"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "50",
+          "id": "e2c389db-d5da-4653-9a4e-4117cc034f01",
+          "duration": 1000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutSine",
+          "fill": "both",
+          "iterations": 1,
+          "targets": ["b5631bd3-6a40-4d43-b4b8-9f0b7c76a742"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "323a436f-f690-4c3e-97c4-6808e98b7a5e",
+          "duration": 1000,
+          "delay": 100,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": ["b5631bd3-6a40-4d43-b4b8-9f0b7c76a742"]
+        },
+        {
+          "type": "bounce",
+          "id": "980b6a01-2aff-4609-abb5-336943dce767",
+          "duration": 800,
+          "delay": 1400,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": ["ba9ff730-74e6-478a-943e-8aa33851048d"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "40px",
+          "id": "9299f52a-5cd7-42d7-a917-adec6d7d04c9",
+          "duration": 1200,
+          "delay": 600,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "f19846b4-b351-4607-a8f9-c7e69ff7a6f3",
+            "61b42950-25ca-46cf-83bf-1e04cdc0cd94"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "44c0d3d9-2783-43e2-a4af-d76df046bd12",
+          "duration": 600,
+          "delay": 700,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": [
+            "f19846b4-b351-4607-a8f9-c7e69ff7a6f3",
+            "61b42950-25ca-46cf-83bf-1e04cdc0cd94"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "20px",
+          "id": "4389565f-c78f-443f-b191-2fbd6892fdb8",
+          "duration": 800,
+          "delay": 1650,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "67777589-1517-4a00-9e95-11e262bf02dd",
+            "87ae3605-e8e2-4d0f-8700-f84de19e4f01"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "ec69713a-9f23-4ac4-8f5e-2ed65e1a0e0a",
+          "duration": 400,
+          "delay": 1750,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "67777589-1517-4a00-9e95-11e262bf02dd",
+            "87ae3605-e8e2-4d0f-8700-f84de19e4f01"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-50px",
+          "offsetY": 0,
+          "id": "d3264120-1ee1-43ab-a462-4ef8dd364394",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "bad4432f-b82b-4579-bb2d-d9858f7feec2",
+            "875e2b60-1738-425a-8d7d-95f648bb3af6"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-750px",
+          "offsetY": 0,
+          "id": "46fd2520-e6f3-4907-b221-9e2e679a0305",
+          "duration": 1500,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "bad4432f-b82b-4579-bb2d-d9858f7feec2",
+            "875e2b60-1738-425a-8d7d-95f648bb3af6"
+          ]
+        }
+      ]
     },
     {
       "elements": [
@@ -3121,7 +3273,255 @@
           "g": 236,
           "b": 227
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "290",
+          "id": "7a7f69b6-b7d3-407b-b048-53f838ed2f47",
+          "duration": 1400,
+          "delay": 200,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "iterations": 1,
+          "targets": ["735394cc-0da6-479c-951d-14579f0766ef"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "250px",
+          "id": "cd496dbb-da8b-41f2-93d9-1badcdb81289",
+          "duration": 1300,
+          "delay": 900,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "ecfb31af-00a8-4533-b86a-e268e7b2a573",
+            "b9736281-90de-4a2e-b813-7faddcba9dd9",
+            "3873fcaf-3c89-43dd-ba61-47bfed747b3e"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "09ce1552-0cba-4d00-a876-0e312929f745",
+          "duration": 400,
+          "delay": 900,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "ecfb31af-00a8-4533-b86a-e268e7b2a573",
+            "b9736281-90de-4a2e-b813-7faddcba9dd9",
+            "3873fcaf-3c89-43dd-ba61-47bfed747b3e"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "250px",
+          "id": "aaed8507-4949-46fe-a2c6-040442843271",
+          "duration": 1300,
+          "delay": 950,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": [
+            "f40e6fac-12c9-4259-a5af-8de9d1fd1c64",
+            "9cc65a3f-90c8-4a6b-8994-2db0da03e2aa",
+            "e614554a-4201-4bdd-9ced-c5fe97c758c8"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "cac577f7-83f7-4b57-875b-768541bd3e58",
+          "duration": 400,
+          "delay": 950,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "f40e6fac-12c9-4259-a5af-8de9d1fd1c64",
+            "9cc65a3f-90c8-4a6b-8994-2db0da03e2aa",
+            "e614554a-4201-4bdd-9ced-c5fe97c758c8"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "250px",
+          "id": "d7d3b994-53ca-4e62-9cd2-cc9379486e72",
+          "duration": 1300,
+          "delay": 1000,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "dc565020-6358-44d9-9aac-a8eb90e76415",
+            "1995d229-c3c4-4f57-8e19-dc65b333e87a",
+            "53f8e685-93b5-4971-bb76-03d52602eb47"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "57b3f4e4-eb48-4ad3-998a-94e8bd861e01",
+          "duration": 400,
+          "delay": 1000,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": [
+            "dc565020-6358-44d9-9aac-a8eb90e76415",
+            "1995d229-c3c4-4f57-8e19-dc65b333e87a",
+            "53f8e685-93b5-4971-bb76-03d52602eb47"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "250px",
+          "id": "1acd64af-465c-445a-991f-6174765f5ffc",
+          "duration": 1300,
+          "delay": 1050,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "d6fea8bd-8f0a-414b-a845-722d436a6d43",
+            "8368daee-25c0-47fa-a3f8-f1d087aff0ea",
+            "c8f479d6-429d-4ea4-93e8-ce8dfb37a5d5"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "aa687737-f403-43c3-9922-7639e4fca2ce",
+          "duration": 400,
+          "delay": 1050,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "d6fea8bd-8f0a-414b-a845-722d436a6d43",
+            "8368daee-25c0-47fa-a3f8-f1d087aff0ea",
+            "c8f479d6-429d-4ea4-93e8-ce8dfb37a5d5"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "250px",
+          "id": "3866e5d4-d92a-444f-a878-cf78c4c612b0",
+          "duration": 1500,
+          "delay": 1100,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "7726e175-d97f-42ed-bb2e-a581f4135332",
+            "797bc565-14f8-4635-aef9-d3aaa1d4f61f",
+            "175d2727-d683-4601-8405-f0a2ee56a654"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "6957863e-9946-4a9e-86cd-6854041cf267",
+          "duration": 400,
+          "delay": 1100,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "797bc565-14f8-4635-aef9-d3aaa1d4f61f",
+            "175d2727-d683-4601-8405-f0a2ee56a654",
+            "7726e175-d97f-42ed-bb2e-a581f4135332"
+          ]
+        },
+        {
+          "type": "spin",
+          "rotation": "-360",
+          "id": "29f27486-6753-4936-a2d9-d123e0541d0b",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": ["b9736281-90de-4a2e-b813-7faddcba9dd9"]
+        },
+        {
+          "type": "spin",
+          "rotation": "-270",
+          "id": "71aafb68-73f7-4147-b96e-b3b2f140c6c0",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": ["797bc565-14f8-4635-aef9-d3aaa1d4f61f"]
+        },
+        {
+          "type": "spin",
+          "rotation": "-300",
+          "id": "7c9a5cae-b02e-4bed-82bb-9917dfd5a04c",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["8368daee-25c0-47fa-a3f8-f1d087aff0ea"]
+        },
+        {
+          "type": "spin",
+          "rotation": "-250",
+          "id": "24cf156d-03ec-43f3-94db-a234e79c2628",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["1995d229-c3c4-4f57-8e19-dc65b333e87a"]
+        },
+        {
+          "type": "spin",
+          "rotation": "-225",
+          "id": "a11853ce-a06f-49c8-8354-c090ad35e575",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["9cc65a3f-90c8-4a6b-8994-2db0da03e2aa"]
+        }
+      ]
     },
     {
       "elements": [
@@ -3550,7 +3950,196 @@
           "g": 236,
           "b": 227
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-100%",
+          "offsetY": "-100%",
+          "id": "127c30e0-7296-4257-b7e9-8382c5576d90",
+          "duration": 1200,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "targets": ["7ecf93c5-2286-495d-86e9-30cdf0bf32b3"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": "100%",
+          "offsetY": "100%",
+          "id": "29a3917d-003b-44f7-8ebc-b0af4b09570d",
+          "duration": 1200,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "forwards",
+          "targets": ["7ecf93c5-2286-495d-86e9-30cdf0bf32b3"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 1.1,
+          "zoomTo": 1,
+          "id": "480dd0ee-dbfe-424a-9514-863c31472b7e",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["7ecf93c5-2286-495d-86e9-30cdf0bf32b3"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 2,
+          "zoomTo": 1,
+          "id": "c96d4ac9-8267-4558-ba03-ad24ecab2392",
+          "duration": 1600,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "targets": ["7ecf93c5-2286-495d-86e9-30cdf0bf32b3"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": 0,
+          "offsetY": "100%",
+          "id": "1e74945b-f871-44cb-b199-4ec20f789579",
+          "duration": 1200,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "targets": ["8c86903b-0df0-4c1e-a75a-23f1e79522b3"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 0.4,
+          "zoomTo": 1,
+          "id": "567331b1-d718-470e-ae4a-707ade4111f1",
+          "duration": 1200,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outSine",
+          "fill": "both",
+          "targets": ["e03c6326-6b3a-4a11-b7f1-80decd115e08"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "80",
+          "id": "9cbb6c39-eae5-41c1-8f4b-d05272d04fa3",
+          "duration": 1300,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "targets": [
+            "9ce78e9e-7568-45de-bef3-1f9438a11568",
+            "e03c6326-6b3a-4a11-b7f1-80decd115e08",
+            "8c86903b-0df0-4c1e-a75a-23f1e79522b3",
+            "43b205d1-376b-4eaf-b493-e55d70f8703e",
+            "46ec18b4-8061-467f-88a0-fb2abd494061",
+            "08232848-6452-4121-8ffa-724c8e587687"
+          ]
+        },
+        {
+          "type": "spin",
+          "rotation": "270",
+          "id": "fd7a01a4-a29e-460e-9fe6-3795a3d989e3",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["e03c6326-6b3a-4a11-b7f1-80decd115e08"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "d8648055-0c1e-4e81-8f0f-25f27278a309",
+          "duration": 1400,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["e03c6326-6b3a-4a11-b7f1-80decd115e08"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": 0,
+          "offsetY": "100%",
+          "id": "fcb128ec-42c1-4a1b-b42f-5fe551e898eb",
+          "duration": 1000,
+          "delay": 100,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "targets": ["9ce78e9e-7568-45de-bef3-1f9438a11568"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "59f6e2bb-18da-4a1c-8a06-6923da201009",
+          "duration": 800,
+          "delay": 200,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["43b205d1-376b-4eaf-b493-e55d70f8703e"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "30px",
+          "id": "883eab15-18c0-4d64-97eb-be2c14415db0",
+          "duration": 1000,
+          "delay": 200,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "targets": ["43b205d1-376b-4eaf-b493-e55d70f8703e"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "20px",
+          "id": "829b24af-5fcc-4167-827f-55175e4441ac",
+          "duration": 1000,
+          "delay": 400,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "both",
+          "targets": [
+            "46ec18b4-8061-467f-88a0-fb2abd494061",
+            "08232848-6452-4121-8ffa-724c8e587687"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "5ffb6f46-6f85-4826-bac8-dfdfd2563e4a",
+          "duration": 400,
+          "delay": 600,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": [
+            "46ec18b4-8061-467f-88a0-fb2abd494061",
+            "08232848-6452-4121-8ffa-724c8e587687"
+          ]
+        }
+      ]
     },
     {
       "elements": [
@@ -4176,7 +4765,159 @@
           "b": 255,
           "a": 1
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "zoom",
+          "zoomFrom": 1.8,
+          "zoomTo": 1,
+          "id": "be590edb-ee8e-4193-a127-207ab9e73571",
+          "duration": 1300,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["a879eb64-3b0f-49f7-93de-e63359e6fb1a"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-30%",
+          "offsetY": 0,
+          "id": "249ac678-3455-41ac-8aef-20df8d8cb551",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["faf0a8bb-fa80-40b7-b423-80b8bd4cd7a5"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-100%",
+          "offsetY": 0,
+          "id": "9641e16f-741c-4c4d-846c-27dbc49d392a",
+          "duration": 1400,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutQuart",
+          "fill": "both",
+          "targets": ["faf0a8bb-fa80-40b7-b423-80b8bd4cd7a5"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 1.1,
+          "zoomTo": 1,
+          "id": "11668a74-2130-4872-8e86-ee78cf035f73",
+          "duration": 6000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["a879eb64-3b0f-49f7-93de-e63359e6fb1a"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 0,
+          "zoomTo": 1,
+          "id": "2864c29c-aee6-440f-bbc3-a1a99916d563",
+          "duration": 600,
+          "delay": 800,
+          "direction": "normal",
+          "easingPreset": "outCubic",
+          "fill": "both",
+          "targets": [
+            "67a25f3e-d47f-4b06-97e8-b315ef85e0e2",
+            "0ece7509-bf1e-479d-a146-8be2be2f0cee"
+          ]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 0,
+          "zoomTo": 1,
+          "id": "1ea88dad-7af1-44c6-b724-72a1605ea84b",
+          "duration": 600,
+          "delay": 900,
+          "direction": "normal",
+          "easingPreset": "outCubic",
+          "fill": "both",
+          "targets": [
+            "15da37bf-3d0f-42d6-bce1-c5cd63d92603",
+            "f6443849-a102-4899-9be1-ba2651204712"
+          ]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 0,
+          "zoomTo": 1,
+          "id": "e466ccdc-70ee-4a95-9529-a83785201b51",
+          "duration": 600,
+          "delay": 1000,
+          "direction": "normal",
+          "easingPreset": "outCubic",
+          "fill": "both",
+          "targets": [
+            "1273a089-3c1f-44e2-a992-ee1c74571ce0",
+            "5c3a77a7-f9c2-4bd5-bf8f-9d211c433af3"
+          ]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 0,
+          "zoomTo": 1,
+          "id": "9c8cff5f-5627-47d5-9df8-7748deaf28fc",
+          "duration": 600,
+          "delay": 1100,
+          "direction": "normal",
+          "easingPreset": "outCubic",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "06b9b1f3-3fdb-49b8-8efa-895081f2a0c6",
+            "833449da-699c-4fac-aa52-cefc6c713423"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "40px",
+          "id": "dcccf0f1-e801-486b-a482-0e8f0d0bc95b",
+          "duration": 800,
+          "delay": 1200,
+          "direction": "normal",
+          "easingPreset": "outCubic",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "4446cc97-cd5a-45ea-8232-3a53e1df3d86",
+            "bed8c7dc-aa6d-4fb9-b87d-b7bcb5911f93",
+            "4c1eea44-cac5-45ba-bdc2-c6959c9edd76",
+            "b141ca71-b4f8-474c-93d0-b2a0b439c83e",
+            "e3507933-d80f-4ed2-b52a-02dea8a0779d"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "23519c9a-00f2-44d5-943d-0a381a69b8d0",
+          "duration": 400,
+          "delay": 1500,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "4446cc97-cd5a-45ea-8232-3a53e1df3d86",
+            "bed8c7dc-aa6d-4fb9-b87d-b7bcb5911f93",
+            "4c1eea44-cac5-45ba-bdc2-c6959c9edd76",
+            "b141ca71-b4f8-474c-93d0-b2a0b439c83e",
+            "e3507933-d80f-4ed2-b52a-02dea8a0779d"
+          ]
+        }
+      ]
     },
     {
       "elements": [
@@ -4932,7 +5673,209 @@
           "g": 236,
           "b": 227
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "100%",
+          "id": "abb31802-bff0-42bc-a6d9-c37b95cd3431",
+          "duration": 1000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutQuart",
+          "fill": "both",
+          "iterations": 1,
+          "targets": ["421f76ac-4c4d-4a44-ad77-622facf57db5"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": 0,
+          "offsetY": "100%",
+          "id": "62938d3c-3f92-4933-b883-b8896616412b",
+          "duration": 900,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "outQuint",
+          "fill": "forwards",
+          "iterations": 1,
+          "targets": ["421f76ac-4c4d-4a44-ad77-622facf57db5"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "80",
+          "id": "ad4a50f7-3a3e-4fd5-8fa2-041c416a93f6",
+          "duration": 800,
+          "delay": 200,
+          "direction": "normal",
+          "easingPreset": "inOutQuart",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "1043803d-625c-4b7a-a5ad-1cdecfbb1c62",
+            "d01ae69c-43cc-455e-bb63-250642795201"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "cd7b7fba-5fc3-4c2c-80a8-b254e0290bd9",
+          "duration": 500,
+          "delay": 350,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "d01ae69c-43cc-455e-bb63-250642795201",
+            "1043803d-625c-4b7a-a5ad-1cdecfbb1c62"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "80",
+          "id": "50986c67-eb26-4526-a774-86df4a030915",
+          "duration": 800,
+          "delay": 250,
+          "direction": "normal",
+          "easingPreset": "inOutQuart",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "87b77bd3-8bc3-44ca-af6f-661e45522a7c",
+            "c77c788b-cba9-421d-8a9a-2e8b604e99b8"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "c2238ade-f962-4582-831a-006a461017ab",
+          "duration": 500,
+          "delay": 400,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": [
+            "87b77bd3-8bc3-44ca-af6f-661e45522a7c",
+            "c77c788b-cba9-421d-8a9a-2e8b604e99b8"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "80",
+          "id": "c368eddd-f19b-4b08-b8e8-3975f4485f19",
+          "duration": 800,
+          "delay": 300,
+          "direction": "normal",
+          "easingPreset": "inOutQuart",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "44e7aa5c-3fe0-43db-8d46-c0a4425eeb18",
+            "ba68ba92-edcd-4c5c-a4fe-5263fc994e2b"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "8067c1c3-1c2b-4610-9e6e-77299aab362e",
+          "duration": 500,
+          "delay": 450,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "44e7aa5c-3fe0-43db-8d46-c0a4425eeb18",
+            "ba68ba92-edcd-4c5c-a4fe-5263fc994e2b"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "80",
+          "id": "77af1bac-5959-4c12-93a1-f098110ff31f",
+          "duration": 800,
+          "delay": 350,
+          "direction": "normal",
+          "easingPreset": "inOutQuart",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "372a14f4-bc2c-493c-92e7-f7aa5d470289",
+            "e13df6ed-9e36-42f5-a614-54faaf827097",
+            "d4c4986d-35cf-414c-8047-8697a4e03446",
+            "38462ba6-4406-458f-8f0e-88fa6558e712",
+            "40a6fb22-daa4-4d78-8cdc-5ce6547d1d64",
+            "c330044d-44a1-4cee-91b3-51f2147914d7"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "7809d1fc-3a75-4e53-bfb8-8fe515f752c5",
+          "duration": 500,
+          "delay": 500,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "c330044d-44a1-4cee-91b3-51f2147914d7",
+            "40a6fb22-daa4-4d78-8cdc-5ce6547d1d64",
+            "38462ba6-4406-458f-8f0e-88fa6558e712",
+            "d4c4986d-35cf-414c-8047-8697a4e03446",
+            "e13df6ed-9e36-42f5-a614-54faaf827097",
+            "372a14f4-bc2c-493c-92e7-f7aa5d470289"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "100%",
+          "id": "672c74fd-39c2-42ee-bfa6-f10faf29aca7",
+          "duration": 900,
+          "delay": 350,
+          "direction": "normal",
+          "easingPreset": "inOutQuart",
+          "fill": "both",
+          "iterations": 1,
+          "targets": ["40a6fb22-daa4-4d78-8cdc-5ce6547d1d64"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "50",
+          "id": "163f0597-fa98-44f1-a300-373213722ef0",
+          "duration": 1000,
+          "delay": 350,
+          "direction": "normal",
+          "easingPreset": "inOutQuart",
+          "fill": "both",
+          "iterations": 1,
+          "targets": [
+            "372a14f4-bc2c-493c-92e7-f7aa5d470289",
+            "e13df6ed-9e36-42f5-a614-54faaf827097",
+            "d4c4986d-35cf-414c-8047-8697a4e03446",
+            "38462ba6-4406-458f-8f0e-88fa6558e712"
+          ]
+        }
+      ]
     }
   ],
   "autoAdvance": true,

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -178,7 +178,7 @@ class Dashboard {
 					 * Issue: 1897
 					 * Creation date: 2020-05-21
 					 */
-					'enableAnimation'                 => true,
+					'enableAnimation'                 => false,
 					/**
 					 * Description: Enables in-progress views to be accessed.
 					 * Author: @carlos-kelly

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -178,7 +178,7 @@ class Dashboard {
 					 * Issue: 1897
 					 * Creation date: 2020-05-21
 					 */
-					'enableAnimation'                 => false,
+					'enableAnimation'                 => true,
 					/**
 					 * Description: Enables in-progress views to be accessed.
 					 * Author: @carlos-kelly


### PR DESCRIPTION
## Summary
Adds the base animations for the fashion template and documents current missing animation parts I ran into in this doc:
https://docs.google.com/spreadsheets/d/1iJ8Adqs4zGWteMoxVCZ2MM4LAza0LQmtPUX6I9qdshY/edit#gid=21496487


## Relevant Technical Choices
All work should just be story data appended to the raw template. Only thing that should have really been changed was origin point to be in the center of an element so scaled elements are anchored in the center.

## To-do
N/A

## User-facing changes
Should be none. All animations behind feature flag

## Testing Instructions
**User Facing**
Only thing to test here is that the animations are still behind a feature flag, so just open up the templates and hover over the fashion story. There should be no Animations.

**Behind Feature Flag**
go to `includes/Dashboard.php` and set `enableAnimations: true` . Then navigate to external templates in the dashboard. Hover over the thumbnail & should see animations on every page.

---

Fixes #2213

## Screenshots
(outputted at 15 fps just so file size isn't too large. To view in high fidelity, open run this branch on your local)
![fashion_base_anims](https://user-images.githubusercontent.com/35983235/84711032-a201d780-af22-11ea-8969-24842d2c4901.gif)

