### PR TITLE
Updates: Add beta updater class

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -2,6 +2,7 @@
 .github
 .idea
 .storybook
+__cdn__
 __mocks__
 __static__
 assets/src

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
 before_deploy:
   - npm run storybook:build
   - npm run workflow:copy-template-assets
+  - npm run workflow:copy-cdn-files
 
 deploy:
   - provider: pages

--- a/__cdn__/service/plugin-updates.json
+++ b/__cdn__/service/plugin-updates.json
@@ -1,0 +1,17 @@
+{
+  "name": "Web Stories",
+  "slug": "web-stories",
+  "version": "1.0.0-alpha.9+2ce347d",
+  "last_updated": "2020-06-15 15:06:13",
+  "url": "https://github.com/google/web-stories-wp",
+  "download_url": "https://github.com/google/web-stories-wp/releases/download/v1.0.0-alpha.9%2B2ce347d/web-stories.zip",
+  "tested": "5.4",
+  "requires": "5.3",
+  "requires_php": "5.6",
+  "icons": {
+    "svg": "",
+    "2x": "",
+    "1x": "",
+    "default": ""
+  }
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -48,6 +48,10 @@ class Plugin {
 		add_action( 'init', [ Story_Post_Type::class, 'init' ] );
 		add_action( 'init', [ Template_Post_Type::class, 'init' ] );
 
+		// Beta version updater.
+		$updater = new Updater();
+		add_action( 'init', [ $updater, 'init' ], 9 );
+
 		// REST API endpoints.
 		// High priority so it runs after create_initial_rest_routes().
 		add_action( 'rest_api_init', [ $this, 'register_rest_routes' ], 100 );

--- a/includes/Updater.php
+++ b/includes/Updater.php
@@ -170,7 +170,7 @@ class Updater {
 	 * Callback for when updates are finished.
 	 *
 	 * @param \WP_Upgrader $upgrader Upgrader instance.
-	 * @param array $options Upgrader event data.
+	 * @param array        $options  Upgrader event data.
 	 */
 	public function upgrader_process_complete( $upgrader, $options ) {
 		if (

--- a/includes/Updater.php
+++ b/includes/Updater.php
@@ -171,6 +171,7 @@ class Updater {
 	 *
 	 * @param \WP_Upgrader $upgrader Upgrader instance.
 	 * @param array        $options  Upgrader event data.
+	 * @return void
 	 */
 	public function upgrader_process_complete( $upgrader, $options ) {
 		if (

--- a/includes/Updater.php
+++ b/includes/Updater.php
@@ -40,26 +40,9 @@ class Updater {
 	 * @return void
 	 */
 	public function init() {
-		add_filter(
-			'plugins_api',
-			function( $value, $action, $args ) {
-				return $this->plugin_info( $value, $action, $args );
-			},
-			10,
-			3
-		);
-		add_filter(
-			'pre_set_site_transient_update_plugins',
-			function( $value ) {
-				return $this->updater_data( $value );
-			}
-		);
-		add_action(
-			'load-update-core.php',
-			function() {
-				$this->clear_plugin_data();
-			}
-		);
+		add_filter( 'plugins_api', [ $this, 'plugin_info' ], 10, 3 );
+		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'updater_data' ] );
+		add_action( 'load-update-core.php', [ $this, 'clear_plugin_data' ] );
 		add_action(
 			'upgrader_process_complete',
 			function( $upgrader, $options ) {

--- a/includes/Updater.php
+++ b/includes/Updater.php
@@ -123,8 +123,11 @@ class Updater {
 		if ( ! empty( $data['banners_rtl'] ) ) {
 			$new_data['banners_rtl'] = $data['banners_rtl'];
 		}
+
+		$is_plugin_outdated = version_compare( WEBSTORIES_VERSION, $data['version'], '<' );
+
 		// Return data if Web Stories plugin is not up to date.
-		if ( version_compare( WEBSTORIES_VERSION, $data['version'], '<' ) ) {
+		if ( $is_plugin_outdated && is_wp_version_compatible( $data['requires'] ) && is_php_version_compatible( $data['requires_php'] ) ) {
 			$value->response[ plugin_basename( WEBSTORIES_PLUGIN_FILE ) ] = (object) $new_data;
 		} else {
 			$value->no_update[ plugin_basename( WEBSTORIES_PLUGIN_FILE ) ] = (object) $new_data;

--- a/includes/Updater.php
+++ b/includes/Updater.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Class Updater
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories;
+
+/**
+ * Plugin updater class.
+ *
+ * Allows updating from beta releases to the most current version.
+ *
+ * @todo Remove for stable release.
+ */
+class Updater {
+	/**
+	 * Registers functionality through WordPress hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_filter(
+			'plugins_api',
+			function( $value, $action, $args ) {
+				return $this->plugin_info( $value, $action, $args );
+			},
+			10,
+			3
+		);
+		add_filter(
+			'pre_set_site_transient_update_plugins',
+			function( $value ) {
+				return $this->updater_data( $value );
+			}
+		);
+		add_action(
+			'load-update-core.php',
+			function() {
+				$this->clear_plugin_data();
+			}
+		);
+		add_action(
+			'upgrader_process_complete',
+			function( $upgrader, $options ) {
+				if (
+					'update' !== $options['action'] ||
+					'plugin' !== $options['type'] ||
+					! isset( $options['plugins'] ) ||
+					! in_array( plugin_basename( WEBSTORIES_PLUGIN_FILE ), $options['plugins'], true )
+				) {
+					return;
+				}
+				$this->clear_plugin_data();
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Retrieves plugin information data from custom API endpoint.
+	 *
+	 * @param false|object|array $value  The result object or array. Default false.
+	 * @param string             $action The type of information being requested from the Plugin Installation API.
+	 * @param mixed              $args   Plugin API arguments.
+	 * @return false|object|array Updated $value, or passed-through $value on failure.
+	 */
+	private function plugin_info( $value, $action, $args ) {
+		list( $plugin_slug ) = explode( '/', plugin_basename( WEBSTORIES_PLUGIN_FILE ) );
+		if ( 'plugin_information' !== $action || $plugin_slug !== $args->slug ) {
+			return $value;
+		}
+		$data = $this->fetch_plugin_data();
+		if ( ! $data ) {
+			return $value;
+		}
+		$new_data = [
+			'slug'          => $plugin_slug,
+			'name'          => $data['name'],
+			'version'       => $data['version'],
+			'author'        => '<a href="https://opensource.google.com">Google</a>',
+			'download_link' => $data['download_url'],
+			'trunk'         => $data['download_url'],
+			'tested'        => $data['tested'],
+			'requires'      => $data['requires'],
+			'requires_php'  => $data['requires_php'],
+			'last_updated'  => $data['last_updated'],
+		];
+		if ( ! empty( $data['icons'] ) ) {
+			$new_data['icons'] = $data['icons'];
+		}
+		if ( ! empty( $data['banners'] ) ) {
+			$new_data['banners'] = $data['banners'];
+		}
+		if ( ! empty( $data['banners_rtl'] ) ) {
+			$new_data['banners_rtl'] = $data['banners_rtl'];
+		}
+		return (object) $new_data;
+	}
+	/**
+	 * Retrieves plugin update data from custom API endpoint.
+	 *
+	 * @param mixed $value Update check object.
+	 * @return object Modified update check object.
+	 */
+	private function updater_data( $value ) {
+		// Stop here if the current user does not have sufficient capabilities.
+		if ( ! current_user_can( 'update_plugins' ) ) {
+			return $value;
+		}
+		$data = $this->fetch_plugin_data();
+		if ( ! $data || ! isset( $data['download_url'] ) ) {
+			return $value;
+		}
+		list( $plugin_slug ) = explode( '/', plugin_basename( WEBSTORIES_PLUGIN_FILE ) );
+		$new_data            = [
+			'id'           => 'https://github.com/google/web-stories-wp',
+			'slug'         => $plugin_slug,
+			'plugin'       => plugin_basename( WEBSTORIES_PLUGIN_FILE ),
+			'new_version'  => $data['version'],
+			'url'          => $data['url'],
+			'package'      => $data['download_url'],
+			'tested'       => $data['tested'],
+			'requires'     => $data['requires'],
+			'requires_php' => $data['requires_php'],
+		];
+		if ( ! empty( $data['icons'] ) ) {
+			$new_data['icons'] = $data['icons'];
+		}
+		if ( ! empty( $data['banners'] ) ) {
+			$new_data['banners'] = $data['banners'];
+		}
+		if ( ! empty( $data['banners_rtl'] ) ) {
+			$new_data['banners_rtl'] = $data['banners_rtl'];
+		}
+		// Return data if Web Stories plugin is not up to date.
+		if ( version_compare( WEBSTORIES_VERSION, $data['version'], '<' ) ) {
+			$value->response[ plugin_basename( WEBSTORIES_PLUGIN_FILE ) ] = (object) $new_data;
+		} else {
+			$value->no_update[ plugin_basename( WEBSTORIES_PLUGIN_FILE ) ] = (object) $new_data;
+		}
+		return $value;
+	}
+	/**
+	 * Gets plugin data from the API.
+	 *
+	 * @return array|false Associative array of plugin data, or false on failure.
+	 */
+	private function fetch_plugin_data() {
+		$data = get_site_transient( 'web_stories_updater' );
+		// Query our custom endpoint if the transient is expired.
+		if ( empty( $data ) ) {
+			$response = wp_remote_get( 'https://google.github.io/web-stories-wp/service/plugin-updates.json' ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+			// Retrieve data from the body and decode json format.
+			$data = json_decode( wp_remote_retrieve_body( $response ), true );
+			// Stop here if there is an error, set a temporary transient and bail out.
+			if ( is_wp_error( $response ) || isset( $data['error'] ) || ! isset( $data['version'] ) ) {
+				set_site_transient( 'web_stories_updater', [ 'version' => WEBSTORIES_VERSION ], 30 * MINUTE_IN_SECONDS );
+				return false;
+			}
+			set_site_transient( 'web_stories_updater', $data, DAY_IN_SECONDS );
+		}
+		return $data;
+	}
+
+	/**
+	 * Clears plugin data transient.
+	 *
+	 * @return void
+	 */
+	private function clear_plugin_data() {
+		delete_site_transient( 'web_stories_updater' );
+	}
+}

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "test:e2e:firefox:debug": "PUPPETEER_PRODUCT=firefox PUPPETEER_HEADLESS=false PUPPETEER_DEVTOOLS=true node --inspect-brk node_modules/.bin/jest --runInBand --config=tests/e2e/jest.config.js",
     "percy": "percy snapshot --config=percy.config.yml .test_artifacts/karma_snapshots/",
     "preworkflow:copy-template-assets": "mkdir -p build/storybook/plugin-assets/images",
+    "workflow:copy-cdn-files": "cp -R __cdn__/ build/storybook",
     "workflow:copy-template-assets": "cp -R assets/images/templates build/storybook/plugin-assets/images/templates",
     "workflow:version": "./bin/commander.js version",
     "workflow:build-plugin": "./bin/commander.js build-plugin",


### PR DESCRIPTION
## Summary

Adds a simple updater class to override WordPress default behavior.

Allows users to update from one beta version to the next

## Relevant Technical Choices

Hosts a static JSON file at https://google.github.io/web-stories-wp/service/plugin-updates.json that we can use to list the most up-to-date version.

This code will be removed again for the stable release, so it doesn't have to be perfect.

Code is taken from Site Kit Tester plugin..

## To-do

* [ ] Remove for stable release

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Manually change `WEBSTORIES_VERSION` to `1.0.0-alpha.8` or lower.
1. Check for Updates in WordPress
1. See update notification:

<img width="942" alt="Screenshot 2020-06-16 at 14 30 11" src="https://user-images.githubusercontent.com/841956/84776186-4c8c0000-afe0-11ea-956e-298d88377bc7.png">


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2478
