### PR TITLE
Remove slash after imageBaseUrl

### DIFF
--- a/assets/src/dashboard/templates/getTemplates.js
+++ b/assets/src/dashboard/templates/getTemplates.js
@@ -43,7 +43,7 @@ export function loadTemplate(title, data, imageBaseUrl) {
           elem.resource.sizes = [];
         }
         if (elem.resource && elem.resource.src) {
-          elem.resource.src = `${imageBaseUrl}/images/templates/${title}/${getImageFile(
+          elem.resource.src = `${imageBaseUrl}images/templates/${title}/${getImageFile(
             elem.resource.src
           )}`;
         }

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -198,7 +198,7 @@ class Dashboard {
 					'newStoryURL'  => $new_story_url,
 					'editStoryURL' => $edit_story_url,
 					'wpListURL'    => $classic_wp_list_url,
-					'assetsURL'    => WEBSTORIES_ASSETS_URL,
+					'assetsURL'    => trailingslashit( WEBSTORIES_ASSETS_URL ),
 					'version'      => WEBSTORIES_VERSION,
 					'api'          => [
 						'stories' => sprintf( '/wp/v2/%s', $rest_base ),


### PR DESCRIPTION
`imageBaseUrl` already contains a trailing slash.

Now all the template assets URLs look like this `https://google.github.io/web-stories-wp/plugin-assets//images/templates/beauty/beauty_page1_bg.png`