### PR TITLE
Dashboard: Update router for new history version.

### DIFF
--- a/assets/src/dashboard/app/router/routerProvider.js
+++ b/assets/src/dashboard/app/router/routerProvider.js
@@ -35,7 +35,7 @@ function RouterProvider({ children, ...props }) {
   );
 
   useEffect(() => {
-    return history.current.listen((location) => {
+    return history.current.listen(({ location }) => {
       setQueryParams(queryString.parse(location.search));
       setCurrentPath(location.pathname);
     });

--- a/assets/src/dashboard/app/router/test/router.js
+++ b/assets/src/dashboard/app/router/test/router.js
@@ -49,7 +49,7 @@ describe('RouterProvider', () => {
 
     jest.spyOn(history, 'push').mockImplementation((sender) => {
       listeners.forEach((l) => {
-        l({ search: '', pathname: sender });
+        l({ location: { search: '', pathname: sender } });
       });
     });
 
@@ -84,7 +84,7 @@ describe('RouterProvider', () => {
 
     jest.spyOn(history, 'push').mockImplementation((sender) => {
       listeners.forEach((l) => {
-        l({ search: '', pathname: sender });
+        l({ location: { search: '', pathname: sender } });
       });
     });
 


### PR DESCRIPTION
## Summary

Dependabot merged in v5 of history which introduced a breaking change with how we get the location on event change. This updates our code to use the new API.


## Testing Instructions

- Visit the dashboard and npm install
- Navigation via the left rail should work again

