### PR TITLE
Dashboard: Update aspect ratio to 9:16

### DIFF
--- a/assets/src/dashboard/app/views/exploreTemplates/content/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/index.js
@@ -58,7 +58,12 @@ function Content({
     <Layout.Scrollable>
       <FontProvider>
         <TransformProvider>
-          <UnitsProvider pageSize={view.pageSize}>
+          <UnitsProvider
+            pageSize={{
+              width: view.pageSize.width,
+              height: view.pageSize.height,
+            }}
+          >
             <StandardViewContentGutter>
               {totalTemplates > 0 ? (
                 <>

--- a/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
@@ -25,9 +25,12 @@ import styled from 'styled-components';
  */
 import { Layout } from '../../../../../components';
 import { VIEW_STYLE } from '../../../../../constants';
+import {
+  STORYBOOK_PAGE_SIZE,
+  formattedTemplatesArray,
+} from '../../../../../storybookUtils';
 import { usePagePreviewSize } from '../../../../../utils';
 import Content from '../index';
-import formattedTemplatesArray from '../../../../../storybookUtils/formattedTemplatesArray';
 
 const search = {
   keyword: '',
@@ -35,7 +38,7 @@ const search = {
 };
 const view = {
   style: VIEW_STYLE.GRID,
-  pageSize: { width: 212, height: 318, containerHeight: 376.89 },
+  pageSize: STORYBOOK_PAGE_SIZE,
 };
 const page = {
   value: 1,

--- a/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
@@ -35,7 +35,7 @@ const search = {
 };
 const view = {
   style: VIEW_STYLE.GRID,
-  pageSize: { width: 210, height: 316 },
+  pageSize: { width: 212, height: 377.9, fullBleedHeight: 58.94 },
 };
 const page = {
   value: 1,

--- a/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
@@ -35,7 +35,7 @@ const search = {
 };
 const view = {
   style: VIEW_STYLE.GRID,
-  pageSize: { width: 212, height: 377.9, fullBleedHeight: 58.94 },
+  pageSize: { width: 212, height: 377.9, dangerZoneHeight: 58.94 },
 };
 const page = {
   value: 1,

--- a/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
@@ -35,7 +35,7 @@ const search = {
 };
 const view = {
   style: VIEW_STYLE.GRID,
-  pageSize: { width: 212, height: 377.9, dangerZoneHeight: 58.94 },
+  pageSize: { width: 212, height: 318, containerHeight: 376.89 },
 };
 const page = {
   value: 1,

--- a/assets/src/dashboard/app/views/myStories/content/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/index.js
@@ -65,7 +65,12 @@ function Content({
     <Layout.Scrollable>
       <FontProvider>
         <TransformProvider>
-          <UnitsProvider pageSize={view.pageSize}>
+          <UnitsProvider
+            pageSize={{
+              width: view.pageSize.width,
+              height: view.pageSize.height,
+            }}
+          >
             {stories.length > 0 ? (
               <StandardViewContentGutter>
                 <StoriesView

--- a/assets/src/dashboard/app/views/myStories/content/stories/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/stories/index.js
@@ -62,7 +62,7 @@ const search = {
 const view = {
   style: VIEW_STYLE.GRID,
   toggleStyle: action('toggle view style'),
-  pageSize: { width: 212, height: 377.9, dangerZoneHeight: 58.94 },
+  pageSize: { width: 212, height: 318, containerHeight: 376.89 },
 };
 const page = {
   value: 1,

--- a/assets/src/dashboard/app/views/myStories/content/stories/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/stories/index.js
@@ -32,8 +32,11 @@ import {
   VIEW_STYLE,
   STORY_STATUS,
 } from '../../../../../constants';
-import formattedStoriesArray from '../../../../../storybookUtils/formattedStoriesArray';
-import formattedUsersObject from '../../../../../storybookUtils/formattedUsersObject';
+import {
+  formattedStoriesArray,
+  formattedUsersObject,
+  STORYBOOK_PAGE_SIZE,
+} from '../../../../../storybookUtils';
 import Content from '../';
 import { usePagePreviewSize } from '../../../../../utils';
 import StoriesView from '../storiesView';
@@ -62,7 +65,7 @@ const search = {
 const view = {
   style: VIEW_STYLE.GRID,
   toggleStyle: action('toggle view style'),
-  pageSize: { width: 212, height: 318, containerHeight: 376.89 },
+  pageSize: STORYBOOK_PAGE_SIZE,
 };
 const page = {
   value: 1,

--- a/assets/src/dashboard/app/views/myStories/content/stories/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/stories/index.js
@@ -62,7 +62,7 @@ const search = {
 const view = {
   style: VIEW_STYLE.GRID,
   toggleStyle: action('toggle view style'),
-  pageSize: { width: 210, height: 316 },
+  pageSize: { width: 212, height: 377.9, fullBleedHeight: 58.94 },
 };
 const page = {
   value: 1,

--- a/assets/src/dashboard/app/views/myStories/content/stories/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/stories/index.js
@@ -62,7 +62,7 @@ const search = {
 const view = {
   style: VIEW_STYLE.GRID,
   toggleStyle: action('toggle view style'),
-  pageSize: { width: 212, height: 377.9, fullBleedHeight: 58.94 },
+  pageSize: { width: 212, height: 377.9, dangerZoneHeight: 58.94 },
 };
 const page = {
   value: 1,

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -147,6 +147,7 @@ function StoriesView({
       <StoryListView
         handleSortChange={sort.set}
         handleSortDirectionChange={sort.setDirection}
+        pageSize={view.pageSize}
         renameStory={renameStory}
         sortDirection={sort.direction}
         stories={stories}

--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -91,7 +91,12 @@ function Content({ stories, view, page }) {
     <Layout.Scrollable>
       <FontProvider>
         <TransformProvider>
-          <UnitsProvider pageSize={view.pageSize}>
+          <UnitsProvider
+            pageSize={{
+              width: view.pageSize.width,
+              height: view.pageSize.height,
+            }}
+          >
             <StandardViewContentGutter>
               <SavedTemplatesGridView view={view} stories={stories} />
               <InfiniteScroller

--- a/assets/src/dashboard/app/views/shared/stories/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/storyGridView.js
@@ -52,7 +52,7 @@ export const _default = () => {
       }}
       isTemplate={boolean('isTemplate')}
       isSavedTemplate={boolean('isSavedTemplate')}
-      pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}
+      pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}
     />
   );
 };

--- a/assets/src/dashboard/app/views/shared/stories/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/storyGridView.js
@@ -52,7 +52,7 @@ export const _default = () => {
       }}
       isTemplate={boolean('isTemplate')}
       isSavedTemplate={boolean('isSavedTemplate')}
-      pageSize={{ width: 210, height: 316 }}
+      pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}
     />
   );
 };

--- a/assets/src/dashboard/app/views/shared/stories/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/storyGridView.js
@@ -24,8 +24,11 @@ import { action } from '@storybook/addon-actions';
  * Internal dependencies
  */
 
-import formattedStoriesArray from '../../../../storybookUtils/formattedStoriesArray';
-import formattedUsersObject from '../../../../storybookUtils/formattedUsersObject';
+import {
+  formattedStoriesArray,
+  formattedUsersObject,
+  STORYBOOK_PAGE_SIZE,
+} from '../../../../storybookUtils';
 import {
   STORY_ITEM_CENTER_ACTION_LABELS,
   STORY_CONTEXT_MENU_ITEMS,
@@ -52,7 +55,7 @@ export const _default = () => {
       }}
       isTemplate={boolean('isTemplate')}
       isSavedTemplate={boolean('isSavedTemplate')}
-      pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}
+      pageSize={STORYBOOK_PAGE_SIZE}
     />
   );
 };

--- a/assets/src/dashboard/app/views/shared/stories/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/storyGridView.js
@@ -52,7 +52,7 @@ export const _default = () => {
       }}
       isTemplate={boolean('isTemplate')}
       isSavedTemplate={boolean('isSavedTemplate')}
-      pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}
+      pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}
     />
   );
 };

--- a/assets/src/dashboard/app/views/shared/stories/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/templateGridView.js
@@ -35,7 +35,7 @@ export const _default = () => {
   return (
     <TemplateGridView
       templates={formattedTemplatesArray}
-      pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}
+      pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}
       templateActions={{
         createStoryFromTemplate: action('create story from template clicked'),
       }}

--- a/assets/src/dashboard/app/views/shared/stories/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/templateGridView.js
@@ -23,8 +23,11 @@ import { action } from '@storybook/addon-actions';
  * Internal dependencies
  */
 
-import formattedTemplatesArray from '../../../../storybookUtils/formattedTemplatesArray';
 import TemplateGridView from '../templateGridView';
+import {
+  STORYBOOK_PAGE_SIZE,
+  formattedTemplatesArray,
+} from '../../../../storybookUtils';
 
 export default {
   title: 'Dashboard/Views/Shared/TemplateGridView',
@@ -35,7 +38,7 @@ export const _default = () => {
   return (
     <TemplateGridView
       templates={formattedTemplatesArray}
-      pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}
+      pageSize={STORYBOOK_PAGE_SIZE}
       templateActions={{
         createStoryFromTemplate: action('create story from template clicked'),
       }}

--- a/assets/src/dashboard/app/views/shared/stories/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/templateGridView.js
@@ -35,7 +35,7 @@ export const _default = () => {
   return (
     <TemplateGridView
       templates={formattedTemplatesArray}
-      pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}
+      pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}
       templateActions={{
         createStoryFromTemplate: action('create story from template clicked'),
       }}

--- a/assets/src/dashboard/app/views/shared/stories/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/templateGridView.js
@@ -35,7 +35,7 @@ export const _default = () => {
   return (
     <TemplateGridView
       templates={formattedTemplatesArray}
-      pageSize={{ width: 210, height: 316 }}
+      pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}
       templateActions={{
         createStoryFromTemplate: action('create story from template clicked'),
       }}

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -34,6 +34,7 @@ import {
   UsersPropType,
   RenameStoryPropType,
   StoryMenuPropType,
+  PageSizePropType,
 } from '../../../types';
 import {
   PreviewPage,
@@ -135,6 +136,7 @@ const toggleSortLookup = {
 export default function StoryListView({
   handleSortChange,
   handleSortDirectionChange,
+  pageSize,
   renameStory,
   sortDirection,
   stories,
@@ -233,7 +235,7 @@ export default function StoryListView({
               <TablePreviewCell>
                 <PreviewContainer>
                   <PreviewErrorBoundary>
-                    <PreviewPage page={story.pages[0]} />
+                    <PreviewPage page={story.pages[0]} pageSize={pageSize} />
                   </PreviewErrorBoundary>
                 </PreviewContainer>
               </TablePreviewCell>
@@ -284,6 +286,7 @@ export default function StoryListView({
 StoryListView.propTypes = {
   handleSortChange: PropTypes.func.isRequired,
   handleSortDirectionChange: PropTypes.func.isRequired,
+  pageSize: PageSizePropType,
   renameStory: RenameStoryPropType,
   sortDirection: PropTypes.string.isRequired,
   storyMenu: StoryMenuPropType.isRequired,

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -61,7 +61,7 @@ import {
   STORY_SORT_OPTIONS,
   STORY_STATUS,
 } from '../../../constants';
-import { PAGE_RATIO } from '../../../constants/pageStructure';
+import { FULLBLEED_RATIO } from '../../../constants/pageStructure';
 import PreviewErrorBoundary from '../../../components/previewErrorBoundary';
 import {
   ArrowAlphaAscending as ArrowAlphaAscendingSvg,
@@ -79,7 +79,7 @@ const PreviewContainer = styled.div`
   position: relative;
   overflow: hidden;
   width: ${({ theme }) => theme.previewWidth.thumbnail}px;
-  height: ${({ theme }) => theme.previewWidth.thumbnail / PAGE_RATIO}px;
+  height: ${({ theme }) => theme.previewWidth.thumbnail / FULLBLEED_RATIO}px;
   vertical-align: middle;
   border-radius: ${({ theme }) => theme.storyPreview.borderRadius}px;
   border: ${({ theme }) => theme.storyPreview.border};

--- a/assets/src/dashboard/app/views/storyAnimTool/components.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/components.js
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { PAGE_RATIO } from '../../../constants/pageStructure';
+import { FULLBLEED_RATIO } from '../../../constants/pageStructure';
 
 export const STORY_WIDTH = 275;
 
@@ -63,7 +63,7 @@ export const Container = styled.div`
 
 export const ElementsContainer = styled.div`
   min-width: 300px;
-  height: ${STORY_WIDTH / PAGE_RATIO}px;
+  height: ${STORY_WIDTH / FULLBLEED_RATIO}px;
   overflow: scroll;
 `;
 

--- a/assets/src/dashboard/app/views/storyAnimTool/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/index.js
@@ -35,9 +35,8 @@ import {
   STORY_STATUS,
   STORY_PAGE_STATE,
 } from '../../../constants';
-import { FULLBLEED_RATIO } from '../../../constants/pageStructure';
 import { PreviewPage } from '../../../components';
-import { clamp } from '../../../utils';
+import { clamp, getPagePreviewHeights } from '../../../utils';
 import { ApiContext } from '../../api/apiProvider';
 import FontProvider from '../../font/fontProvider';
 import UpdateTemplateForm from './updateTemplateForm';
@@ -282,6 +281,8 @@ function StoryAnimTool() {
     setActiveAnimation({});
   }, [activePageIndex]);
 
+  const { fullBleedHeight, storyHeight } = getPagePreviewHeights(STORY_WIDTH);
+
   const renderElementContent = useCallback((element) => {
     switch (element.type) {
       case 'image':
@@ -326,15 +327,20 @@ function StoryAnimTool() {
                   <UnitsProvider
                     pageSize={{
                       width: STORY_WIDTH,
-                      height: STORY_WIDTH / FULLBLEED_RATIO,
+                      height: storyHeight,
                     }}
                   >
                     <ActiveCard
                       width={STORY_WIDTH}
-                      height={STORY_WIDTH / FULLBLEED_RATIO}
+                      height={fullBleedHeight}
                       selectedElementIds={selectedElementIds}
                     >
                       <PreviewPage
+                        pageSize={{
+                          width: STORY_WIDTH,
+                          height: storyHeight,
+                          containerHeight: fullBleedHeight,
+                        }}
                         page={activeStory.pages[activePageIndex]}
                         animationState={pageAnimationState}
                         subscribeGlobalTime={globalTimeSubscription.subscribe}

--- a/assets/src/dashboard/app/views/storyAnimTool/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/index.js
@@ -35,7 +35,7 @@ import {
   STORY_STATUS,
   STORY_PAGE_STATE,
 } from '../../../constants';
-import { PAGE_RATIO } from '../../../constants/pageStructure';
+import { FULLBLEED_RATIO } from '../../../constants/pageStructure';
 import { PreviewPage } from '../../../components';
 import { clamp } from '../../../utils';
 import { ApiContext } from '../../api/apiProvider';
@@ -326,12 +326,12 @@ function StoryAnimTool() {
                   <UnitsProvider
                     pageSize={{
                       width: STORY_WIDTH,
-                      height: STORY_WIDTH / PAGE_RATIO,
+                      height: STORY_WIDTH / FULLBLEED_RATIO,
                     }}
                   >
                     <ActiveCard
                       width={STORY_WIDTH}
-                      height={STORY_WIDTH / PAGE_RATIO}
+                      height={STORY_WIDTH / FULLBLEED_RATIO}
                       selectedElementIds={selectedElementIds}
                     >
                       <PreviewPage

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -257,7 +257,12 @@ function TemplateDetails() {
                     <SubHeading>
                       {__('Related Templates', 'web-stories')}
                     </SubHeading>
-                    <UnitsProvider pageSize={pageSize}>
+                    <UnitsProvider
+                      pageSize={{
+                        width: pageSize.width,
+                        height: pageSize.height,
+                      }}
+                    >
                       <TemplateGridView
                         templates={relatedTemplates}
                         pageSize={pageSize}

--- a/assets/src/dashboard/components/cardGallery/components.js
+++ b/assets/src/dashboard/components/cardGallery/components.js
@@ -50,10 +50,10 @@ export const MiniCardWrapper = styled.div`
 `;
 
 export const MiniCard = styled.div(
-  ({ width, height, theme }) => `
+  ({ width, height, dangerZoneHeight, theme }) => `
     position: relative;
     width: ${width}px;
-    height: ${height}px;
+    height: ${height + dangerZoneHeight}px;
     overflow: hidden;
     cursor: pointer;
     border: ${theme.storyPreview.border};
@@ -61,10 +61,10 @@ export const MiniCard = styled.div(
 );
 
 export const ActiveCard = styled.div(
-  ({ height, width, theme }) => `
+  ({ height, width, dangerZoneHeight, theme }) => `
     position: relative;
     width: ${width}px;
-    height: ${height}px;
+    height: ${height + dangerZoneHeight}px;
     overflow: hidden;
     border: ${theme.storyPreview.border};
     box-shadow: ${theme.storyPreview.shadow};

--- a/assets/src/dashboard/components/cardGallery/components.js
+++ b/assets/src/dashboard/components/cardGallery/components.js
@@ -50,22 +50,20 @@ export const MiniCardWrapper = styled.div`
 `;
 
 export const MiniCard = styled.div(
-  ({ width, height, dangerZoneHeight, theme }) => `
+  ({ width, containerHeight, theme }) => `
     position: relative;
     width: ${width}px;
-    height: ${height + dangerZoneHeight}px;
-    overflow: hidden;
+    height: ${containerHeight}px;
     cursor: pointer;
     border: ${theme.storyPreview.border};
   `
 );
 
 export const ActiveCard = styled.div(
-  ({ height, width, dangerZoneHeight, theme }) => `
+  ({ width, containerHeight, theme }) => `
     position: relative;
     width: ${width}px;
-    height: ${height + dangerZoneHeight}px;
-    overflow: hidden;
+    height: ${containerHeight}px;
     border: ${theme.storyPreview.border};
     box-shadow: ${theme.storyPreview.shadow};
   `

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -111,7 +111,12 @@ function CardGallery({ story }) {
   return (
     <GalleryContainer ref={containerRef} maxWidth={MAX_WIDTH}>
       {metrics.miniCardSize && (
-        <UnitsProvider pageSize={metrics.miniCardSize}>
+        <UnitsProvider
+          pageSize={{
+            width: metrics.miniCardSize.width,
+            height: metrics.miniCardSize.height,
+          }}
+        >
           <MiniCardsContainer
             rowHeight={metrics.miniWrapperSize.height}
             gap={metrics.gap}
@@ -132,7 +137,12 @@ function CardGallery({ story }) {
         </UnitsProvider>
       )}
       {metrics.activeCardSize && pages[activePageIndex] && (
-        <UnitsProvider pageSize={metrics.activeCardSize}>
+        <UnitsProvider
+          pageSize={{
+            width: metrics.activeCardSize.width,
+            height: metrics.activeCardSize.height,
+          }}
+        >
           <ActiveCard {...metrics.activeCardSize}>
             <PreviewPage
               page={pages[activePageIndex]}

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -24,7 +24,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { UnitsProvider } from '../../../edit-story/units';
 import { STORY_PAGE_STATE } from '../../constants';
 import { StoryPropType } from '../../types';
-import { getHeightOptions } from '../../utils/usePagePreviewSize';
+import { getPagePreviewHeights } from '../../utils/usePagePreviewSize';
 import PreviewPage from '../previewPage';
 import {
   ActiveCard,
@@ -56,29 +56,28 @@ function CardGallery({ story }) {
     }
     const activeCardWidth = ACTIVE_CARD_WIDTH * dimensionMultiplier;
     const miniCardWidth = MINI_CARD_WIDTH * dimensionMultiplier;
-    const activeHeightOptions = getHeightOptions(activeCardWidth);
-    const miniCardHeightOptions = getHeightOptions(miniCardWidth);
+    const activeHeightOptions = getPagePreviewHeights(activeCardWidth);
+    const miniCardHeightOptions = getPagePreviewHeights(miniCardWidth);
+
     return {
       activeCardSize: {
         width: activeCardWidth,
-        height: activeHeightOptions.fullBleedHeight,
-        dangerZoneHeight: activeHeightOptions.dangerZoneHeight,
+        height: activeHeightOptions.storyHeight,
+        containerHeight: activeHeightOptions.fullBleedHeight,
       },
       miniCardSize: {
         width: miniCardWidth,
-        height: miniCardHeightOptions.fullBleedHeight,
-        dangerZoneHeight: miniCardHeightOptions.dangerZoneHeight,
+        height: miniCardHeightOptions.storyHeight,
+        containerHeight: miniCardHeightOptions.fullBleedHeight,
       },
       miniWrapperSize: {
         width: miniCardWidth + CARD_WRAPPER_BUFFER,
-        height:
-          miniCardHeightOptions.fullBleedHeight +
-          miniCardHeightOptions.dangerZoneHeight +
-          CARD_WRAPPER_BUFFER,
+        height: miniCardHeightOptions.fullBleedHeight + CARD_WRAPPER_BUFFER,
       },
       gap: CARD_GAP * dimensionMultiplier,
     };
   }, [dimensionMultiplier]);
+
   const handleMiniCardClick = useCallback((index) => {
     setActivePageIndex(index);
   }, []);

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -24,7 +24,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { UnitsProvider } from '../../../edit-story/units';
 import { STORY_PAGE_STATE } from '../../constants';
 import { StoryPropType } from '../../types';
-import { getPagePreviewHeights } from '../../utils/usePagePreviewSize';
+import { getPagePreviewHeights } from '../../utils';
 import PreviewPage from '../previewPage';
 import {
   ActiveCard,

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -22,12 +22,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
  * Internal dependencies
  */
 import { UnitsProvider } from '../../../edit-story/units';
-import {
-  PAGE_RATIO,
-  STORY_PAGE_STATE,
-  TWO_THIRDS_RATIO,
-} from '../../constants';
+import { STORY_PAGE_STATE } from '../../constants';
 import { StoryPropType } from '../../types';
+import { getHeightOptions } from '../../utils/usePagePreviewSize';
 import PreviewPage from '../previewPage';
 import {
   ActiveCard,
@@ -59,27 +56,29 @@ function CardGallery({ story }) {
     }
     const activeCardWidth = ACTIVE_CARD_WIDTH * dimensionMultiplier;
     const miniCardWidth = MINI_CARD_WIDTH * dimensionMultiplier;
+    const activeHeightOptions = getHeightOptions(activeCardWidth);
+    const miniCardHeightOptions = getHeightOptions(miniCardWidth);
     return {
       activeCardSize: {
         width: activeCardWidth,
-        height: activeCardWidth / PAGE_RATIO,
-        fullBleedHeight:
-          activeCardWidth / PAGE_RATIO - activeCardWidth / TWO_THIRDS_RATIO,
+        height: activeHeightOptions.fullBleedHeight,
+        dangerZoneHeight: activeHeightOptions.dangerZoneHeight,
       },
       miniCardSize: {
         width: miniCardWidth,
-        height: miniCardWidth / PAGE_RATIO,
-        fullBleedHeight:
-          miniCardWidth / PAGE_RATIO - miniCardWidth / TWO_THIRDS_RATIO,
+        height: miniCardHeightOptions.fullBleedHeight,
+        dangerZoneHeight: miniCardHeightOptions.dangerZoneHeight,
       },
       miniWrapperSize: {
         width: miniCardWidth + CARD_WRAPPER_BUFFER,
-        height: miniCardWidth / PAGE_RATIO + CARD_WRAPPER_BUFFER,
+        height:
+          miniCardHeightOptions.fullBleedHeight +
+          miniCardHeightOptions.dangerZoneHeight +
+          CARD_WRAPPER_BUFFER,
       },
       gap: CARD_GAP * dimensionMultiplier,
     };
   }, [dimensionMultiplier]);
-
   const handleMiniCardClick = useCallback((index) => {
     setActivePageIndex(index);
   }, []);

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -22,7 +22,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
  * Internal dependencies
  */
 import { UnitsProvider } from '../../../edit-story/units';
-import { PAGE_RATIO, STORY_PAGE_STATE } from '../../constants';
+import {
+  PAGE_RATIO,
+  STORY_PAGE_STATE,
+  TWO_THIRDS_RATIO,
+} from '../../constants';
 import { StoryPropType } from '../../types';
 import PreviewPage from '../previewPage';
 import {
@@ -59,10 +63,14 @@ function CardGallery({ story }) {
       activeCardSize: {
         width: activeCardWidth,
         height: activeCardWidth / PAGE_RATIO,
+        fullBleedHeight:
+          activeCardWidth / PAGE_RATIO - activeCardWidth / TWO_THIRDS_RATIO,
       },
       miniCardSize: {
         width: miniCardWidth,
         height: miniCardWidth / PAGE_RATIO,
+        fullBleedHeight:
+          miniCardWidth / PAGE_RATIO - miniCardWidth / TWO_THIRDS_RATIO,
       },
       miniWrapperSize: {
         width: miniCardWidth + CARD_WRAPPER_BUFFER,
@@ -118,7 +126,7 @@ function CardGallery({ story }) {
                 onClick={() => handleMiniCardClick(index)}
               >
                 <MiniCard {...metrics.miniCardSize}>
-                  <PreviewPage page={page} />
+                  <PreviewPage page={page} pageSize={metrics.miniCardSize} />
                 </MiniCard>
               </MiniCardWrapper>
             ))}
@@ -130,6 +138,7 @@ function CardGallery({ story }) {
           <ActiveCard {...metrics.activeCardSize}>
             <PreviewPage
               page={pages[activePageIndex]}
+              pageSize={metrics.activeCardSize}
               animationState={STORY_PAGE_STATE.PLAYING}
             />
           </ActiveCard>

--- a/assets/src/dashboard/components/cardGallery/stories/index.js
+++ b/assets/src/dashboard/components/cardGallery/stories/index.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
  * Internal dependencies
  */
 import CardGallery from '../index';
@@ -27,13 +32,16 @@ export default {
   component: CardGallery,
 };
 
+const CardGalleryContainer = styled.div`
+  padding: 20px;
+`;
 export const _default = () => {
   return (
     <FontProvider>
       <TransformProvider>
-        <div style={{ padding: '20px' }}>
+        <CardGalleryContainer>
           <CardGallery story={formattedTemplatesArray[0]} />
-        </div>
+        </CardGalleryContainer>
       </TransformProvider>
     </FontProvider>
   );

--- a/assets/src/dashboard/components/cardGallery/stories/index.js
+++ b/assets/src/dashboard/components/cardGallery/stories/index.js
@@ -18,6 +18,9 @@
  * Internal dependencies
  */
 import CardGallery from '../index';
+import formattedTemplatesArray from '../../../storybookUtils/formattedTemplatesArray';
+import FontProvider from '../../../app/font/fontProvider';
+import { TransformProvider } from '../../../../edit-story/components/transform';
 
 export default {
   title: 'Dashboard/Components/CardGallery',
@@ -25,25 +28,13 @@ export default {
 };
 
 export const _default = () => {
-  const cards = [
-    'red',
-    'orange',
-    'green',
-    'blue',
-    'purple',
-    'aqua',
-    'yellow',
-    'grey',
-  ].map((color) => (
-    <div
-      key={color}
-      style={{ backgroundColor: color, width: '100%', height: '100%' }}
-    />
-  ));
-
   return (
-    <div style={{ padding: '20px' }}>
-      <CardGallery>{cards}</CardGallery>
-    </div>
+    <FontProvider>
+      <TransformProvider>
+        <div style={{ padding: '20px' }}>
+          <CardGallery story={formattedTemplatesArray[0]} />
+        </div>
+      </TransformProvider>
+    </FontProvider>
   );
 };

--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -56,7 +56,10 @@ DashboardGrid.propTypes = {
 
 const CardGrid = ({ children, pageSize }) => {
   return (
-    <DashboardGrid columnWidth={pageSize.width} columnHeight={pageSize.height}>
+    <DashboardGrid
+      columnWidth={pageSize.width}
+      columnHeight={pageSize.containerHeight}
+    >
       {children}
     </DashboardGrid>
   );

--- a/assets/src/dashboard/components/cardGrid/stories/index.js
+++ b/assets/src/dashboard/components/cardGrid/stories/index.js
@@ -52,7 +52,7 @@ const StorybookGridItem = (
         targetAction: '',
         label: 'Preview',
       }}
-      pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}
+      pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}
     >
       <Card>{text('Sample Story Content', 'Sample Story')}</Card>
     </CardPreviewContainer>
@@ -71,7 +71,7 @@ const itemArray = new Array(12).fill(StorybookGridItem);
 
 export const _default = () => {
   return (
-    <CardGrid pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}>
+    <CardGrid pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}>
       {itemArray.map((gridItem, index) => (
         <div key={index}>{gridItem}</div>
       ))}

--- a/assets/src/dashboard/components/cardGrid/stories/index.js
+++ b/assets/src/dashboard/components/cardGrid/stories/index.js
@@ -24,9 +24,10 @@ import { text } from '@storybook/addon-knobs';
 /**
  * Internal dependencies
  */
-import CardGrid from '../';
-import { CardGridItem, CardPreviewContainer, CardTitle } from '../../';
 import { STORY_STATUS } from '../../../constants';
+import { STORYBOOK_PAGE_SIZE } from '../../../storybookUtils';
+import { CardGridItem, CardPreviewContainer, CardTitle } from '../../';
+import CardGrid from '../';
 
 export default {
   title: 'Dashboard/Components/CardGrid',
@@ -52,7 +53,7 @@ const StorybookGridItem = (
         targetAction: '',
         label: 'Preview',
       }}
-      pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}
+      pageSize={STORYBOOK_PAGE_SIZE}
     >
       <Card>{text('Sample Story Content', 'Sample Story')}</Card>
     </CardPreviewContainer>
@@ -71,7 +72,7 @@ const itemArray = new Array(12).fill(StorybookGridItem);
 
 export const _default = () => {
   return (
-    <CardGrid pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}>
+    <CardGrid pageSize={STORYBOOK_PAGE_SIZE}>
       {itemArray.map((gridItem, index) => (
         <div key={index}>{gridItem}</div>
       ))}

--- a/assets/src/dashboard/components/cardGrid/stories/index.js
+++ b/assets/src/dashboard/components/cardGrid/stories/index.js
@@ -52,7 +52,7 @@ const StorybookGridItem = (
         targetAction: '',
         label: 'Preview',
       }}
-      pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}
+      pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}
     >
       <Card>{text('Sample Story Content', 'Sample Story')}</Card>
     </CardPreviewContainer>
@@ -71,7 +71,7 @@ const itemArray = new Array(12).fill(StorybookGridItem);
 
 export const _default = () => {
   return (
-    <CardGrid pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}>
+    <CardGrid pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}>
       {itemArray.map((gridItem, index) => (
         <div key={index}>{gridItem}</div>
       ))}

--- a/assets/src/dashboard/components/cardGrid/stories/index.js
+++ b/assets/src/dashboard/components/cardGrid/stories/index.js
@@ -52,7 +52,7 @@ const StorybookGridItem = (
         targetAction: '',
         label: 'Preview',
       }}
-      pageSize={{ width: 210, height: 316 }}
+      pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}
     >
       <Card>{text('Sample Story Content', 'Sample Story')}</Card>
     </CardPreviewContainer>
@@ -71,7 +71,7 @@ const itemArray = new Array(12).fill(StorybookGridItem);
 
 export const _default = () => {
   return (
-    <CardGrid pageSize={{ width: 210, height: 316 }}>
+    <CardGrid pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}>
       {itemArray.map((gridItem, index) => (
         <div key={index}>{gridItem}</div>
       ))}

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -39,7 +39,7 @@ import { ActionLabel } from './types';
 const PreviewPane = styled.div`
   position: relative;
   border-radius: ${({ theme }) => theme.storyPreview.borderRadius}px;
-  height: ${({ cardSize }) => `${cardSize.containerheight}px`};
+  height: ${({ cardSize }) => `${cardSize.containerHeight}px`};
   box-shadow: ${({ theme }) => theme.storyPreview.shadow};
   border: ${({ theme }) => theme.storyPreview.border};
   width: 100%;

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -39,7 +39,8 @@ import { ActionLabel } from './types';
 const PreviewPane = styled.div`
   position: relative;
   border-radius: ${({ theme }) => theme.storyPreview.borderRadius}px;
-  height: ${({ cardSize }) => `${cardSize.height}px`};
+  height: ${({ cardSize }) =>
+    `${cardSize.height + cardSize.dangerZoneHeight}px`};
   box-shadow: ${({ theme }) => theme.storyPreview.shadow};
   border: ${({ theme }) => theme.storyPreview.border};
   width: 100%;
@@ -51,7 +52,8 @@ PreviewPane.propTypes = {
 };
 
 const EditControls = styled.div`
-  height: ${({ cardSize }) => `${cardSize.height}px`};
+  height: ${({ cardSize }) =>
+    `${cardSize.height + cardSize.dangerZoneHeight}px`};
   width: ${({ cardSize }) => `${cardSize.width}px`};
   position: absolute;
   display: flex;
@@ -159,6 +161,7 @@ const CardPreviewContainer = ({
       <PreviewPane cardSize={pageSize}>
         <PreviewErrorBoundary>
           <PreviewPage
+            pageSize={pageSize}
             page={storyPages[pageIndex]}
             animationState={
               CARD_STATE.ACTIVE === cardState

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -39,8 +39,7 @@ import { ActionLabel } from './types';
 const PreviewPane = styled.div`
   position: relative;
   border-radius: ${({ theme }) => theme.storyPreview.borderRadius}px;
-  height: ${({ cardSize }) =>
-    `${cardSize.height + cardSize.dangerZoneHeight}px`};
+  height: ${({ cardSize }) => `${cardSize.containerheight}px`};
   box-shadow: ${({ theme }) => theme.storyPreview.shadow};
   border: ${({ theme }) => theme.storyPreview.border};
   width: 100%;
@@ -52,8 +51,7 @@ PreviewPane.propTypes = {
 };
 
 const EditControls = styled.div`
-  height: ${({ cardSize }) =>
-    `${cardSize.height + cardSize.dangerZoneHeight}px`};
+  height: ${({ cardSize }) => `${cardSize.containerHeight}px`};
   width: ${({ cardSize }) => `${cardSize.width}px`};
   position: absolute;
   display: flex;

--- a/assets/src/dashboard/components/cardGridItem/stories/index.js
+++ b/assets/src/dashboard/components/cardGridItem/stories/index.js
@@ -19,18 +19,19 @@
  */
 import styled from 'styled-components';
 import moment from 'moment';
+import { text } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
  */
-import { text } from '@storybook/addon-knobs';
+import { STORY_STATUS } from '../../../constants';
+import { STORYBOOK_PAGE_SIZE } from '../../../storybookUtils';
 import {
   CardGrid,
   CardGridItem,
   CardPreviewContainer,
   CardTitle,
 } from '../../';
-import { STORY_STATUS } from '../../../constants';
 
 export default {
   title: 'Dashboard/Components/CardGridItem',
@@ -47,7 +48,7 @@ const Card = styled.div`
 
 export const _default = () => {
   return (
-    <CardGrid pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}>
+    <CardGrid pageSize={STORYBOOK_PAGE_SIZE}>
       <CardGridItem>
         <CardPreviewContainer
           bottomAction={{
@@ -58,7 +59,7 @@ export const _default = () => {
             targetAction: '',
             label: 'Preview',
           }}
-          pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}
+          pageSize={STORYBOOK_PAGE_SIZE}
           story={{}}
         >
           <Card>{text('Sample Story Content', 'Sample Story')}</Card>
@@ -78,7 +79,7 @@ export const _default = () => {
 
 export const _publishedStory = () => {
   return (
-    <CardGrid pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}>
+    <CardGrid pageSize={STORYBOOK_PAGE_SIZE}>
       <CardGridItem>
         <CardPreviewContainer
           bottomAction={{
@@ -89,7 +90,7 @@ export const _publishedStory = () => {
             targetAction: '',
             label: 'Preview',
           }}
-          pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}
+          pageSize={STORYBOOK_PAGE_SIZE}
           story={{}}
         >
           <Card>{text('Sample Story Content', 'Sample Story')}</Card>

--- a/assets/src/dashboard/components/cardGridItem/stories/index.js
+++ b/assets/src/dashboard/components/cardGridItem/stories/index.js
@@ -47,7 +47,7 @@ const Card = styled.div`
 
 export const _default = () => {
   return (
-    <CardGrid pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}>
+    <CardGrid pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}>
       <CardGridItem>
         <CardPreviewContainer
           bottomAction={{
@@ -58,7 +58,7 @@ export const _default = () => {
             targetAction: '',
             label: 'Preview',
           }}
-          pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}
+          pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}
           story={{}}
         >
           <Card>{text('Sample Story Content', 'Sample Story')}</Card>
@@ -78,7 +78,7 @@ export const _default = () => {
 
 export const _publishedStory = () => {
   return (
-    <CardGrid pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}>
+    <CardGrid pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}>
       <CardGridItem>
         <CardPreviewContainer
           bottomAction={{
@@ -89,7 +89,7 @@ export const _publishedStory = () => {
             targetAction: '',
             label: 'Preview',
           }}
-          pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}
+          pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}
           story={{}}
         >
           <Card>{text('Sample Story Content', 'Sample Story')}</Card>

--- a/assets/src/dashboard/components/cardGridItem/stories/index.js
+++ b/assets/src/dashboard/components/cardGridItem/stories/index.js
@@ -47,7 +47,7 @@ const Card = styled.div`
 
 export const _default = () => {
   return (
-    <CardGrid pageSize={{ width: 210, height: 316 }}>
+    <CardGrid pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}>
       <CardGridItem>
         <CardPreviewContainer
           bottomAction={{
@@ -58,7 +58,7 @@ export const _default = () => {
             targetAction: '',
             label: 'Preview',
           }}
-          pageSize={{ width: 210, height: 316 }}
+          pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}
           story={{}}
         >
           <Card>{text('Sample Story Content', 'Sample Story')}</Card>
@@ -78,7 +78,7 @@ export const _default = () => {
 
 export const _publishedStory = () => {
   return (
-    <CardGrid pageSize={{ width: 210, height: 316 }}>
+    <CardGrid pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}>
       <CardGridItem>
         <CardPreviewContainer
           bottomAction={{
@@ -89,7 +89,7 @@ export const _publishedStory = () => {
             targetAction: '',
             label: 'Preview',
           }}
-          pageSize={{ width: 210, height: 316 }}
+          pageSize={{ width: 212, height: 377.9, fullBleedHeight: 58.94 }}
           story={{}}
         >
           <Card>{text('Sample Story Content', 'Sample Story')}</Card>

--- a/assets/src/dashboard/components/cardGridItem/stories/index.js
+++ b/assets/src/dashboard/components/cardGridItem/stories/index.js
@@ -47,7 +47,7 @@ const Card = styled.div`
 
 export const _default = () => {
   return (
-    <CardGrid pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}>
+    <CardGrid pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}>
       <CardGridItem>
         <CardPreviewContainer
           bottomAction={{
@@ -58,7 +58,7 @@ export const _default = () => {
             targetAction: '',
             label: 'Preview',
           }}
-          pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}
+          pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}
           story={{}}
         >
           <Card>{text('Sample Story Content', 'Sample Story')}</Card>
@@ -78,7 +78,7 @@ export const _default = () => {
 
 export const _publishedStory = () => {
   return (
-    <CardGrid pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}>
+    <CardGrid pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}>
       <CardGridItem>
         <CardPreviewContainer
           bottomAction={{
@@ -89,7 +89,7 @@ export const _publishedStory = () => {
             targetAction: '',
             label: 'Preview',
           }}
-          pageSize={{ width: 212, height: 377.9, dangerZoneHeight: 58.94 }}
+          pageSize={{ width: 212, height: 318, containerHeight: 376.89 }}
           story={{}}
         >
           <Card>{text('Sample Story Content', 'Sample Story')}</Card>

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -25,19 +25,36 @@ import styled from 'styled-components';
  */
 import DisplayElement from '../../edit-story/components/canvas/displayElement';
 import StoryPropTypes from '../../edit-story/types';
-import { STORY_PAGE_STATE } from '../constants';
 import generatePatternStyles from '../../edit-story/utils/generatePatternStyles';
+import { STORY_PAGE_STATE } from '../constants';
+import { PageSizePropType } from '../types';
 import StoryAnimation, { useStoryAnimationContext } from './storyAnimation';
 
 const PreviewWrapper = styled.div`
-  height: 100%;
+  overflow: initial;
   position: relative;
-  overflow: hidden;
+  width: 100%;
+  height: 100%;
   background-color: white;
   ${({ background }) => generatePatternStyles(background)};
 `;
 
-function PreviewPageController({ page, animationState, subscribeGlobalTime }) {
+const PageContainerSafeZone = styled.div`
+  width: 100%;
+  height: ${({ pageSize }) =>
+    `${pageSize.height - pageSize.dangerZoneHeight}px`};
+  overflow: visible;
+  position: absolute;
+  margin: 0;
+  top: ${({ pageSize }) => `${pageSize.dangerZoneHeight / 2}px`};
+`;
+
+function PreviewPageController({
+  page,
+  animationState,
+  subscribeGlobalTime,
+  pageSize,
+}) {
   const {
     actions: { WAAPIAnimationMethods },
   } = useStoryAnimationContext();
@@ -68,21 +85,24 @@ function PreviewPageController({ page, animationState, subscribeGlobalTime }) {
 
   return (
     <PreviewWrapper background={page.backgroundColor}>
-      {page.elements.map(({ id, ...rest }) => (
-        <DisplayElement
-          previewMode
-          key={id}
-          page={page}
-          element={{ id, ...rest }}
-          isAnimatable
-        />
-      ))}
+      <PageContainerSafeZone pageSize={pageSize}>
+        {page.elements.map(({ id, ...rest }) => (
+          <DisplayElement
+            previewMode
+            key={id}
+            page={page}
+            element={{ id, ...rest }}
+            isAnimatable
+          />
+        ))}
+      </PageContainerSafeZone>
     </PreviewWrapper>
   );
 }
 
 function PreviewPage({
   page,
+  pageSize,
   animationState = STORY_PAGE_STATE.RESET,
   onAnimationComplete,
   subscribeGlobalTime,
@@ -94,6 +114,7 @@ function PreviewPage({
     >
       <PreviewPageController
         page={page}
+        pageSize={pageSize}
         animationState={animationState}
         onAnimationComplete={onAnimationComplete}
         subscribeGlobalTime={subscribeGlobalTime}
@@ -104,6 +125,7 @@ function PreviewPage({
 
 PreviewPage.propTypes = {
   page: StoryPropTypes.page.isRequired,
+  pageSize: PageSizePropType.isRequired,
   animationState: PropTypes.oneOf(Object.values(STORY_PAGE_STATE)),
   onAnimationComplete: PropTypes.func,
   subscribeGlobalTime: PropTypes.func,
@@ -111,6 +133,7 @@ PreviewPage.propTypes = {
 
 PreviewPageController.propTypes = {
   page: StoryPropTypes.page.isRequired,
+  pageSize: PageSizePropType.isRequired,
   animationState: PropTypes.oneOf(Object.values(STORY_PAGE_STATE)),
   subscribeGlobalTime: PropTypes.func,
 };

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -30,23 +30,33 @@ import { STORY_PAGE_STATE } from '../constants';
 import { PageSizePropType } from '../types';
 import StoryAnimation, { useStoryAnimationContext } from './storyAnimation';
 
-const PreviewWrapper = styled.div`
-  overflow: initial;
-  position: relative;
+/**
+ * A quick note about how height works with the 9:16 aspect ratio (FULLBLEED_RATIO)
+ * The unitProvider that sizes page previews still needs the 2:3 ratio,
+ * this is passed in here as pageSize.height. It is the true height of the story
+ * That said, we also need a height for the 9:16 that acts as the container for the story
+ * to allow for fullBleed overflow.
+ * So, you'll notice that containerHeight is getting used to wrap the PreviewSafeZone height
+ * to make sure that the overflow has the proper size.
+ * Reference edit-story/components/canvas/layout for more details
+ */
+const FullBleedPreviewWrapper = styled.div`
+  height: ${({ pageSize }) => `${pageSize.containerHeight}px`};
   width: 100%;
-  height: 100%;
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  align-items: center;
   background-color: white;
   ${({ background }) => generatePatternStyles(background)};
 `;
 
-const PageContainerSafeZone = styled.div`
+const PreviewSafeZone = styled.div`
   width: 100%;
-  height: ${({ pageSize }) =>
-    `${pageSize.height - pageSize.dangerZoneHeight}px`};
+  height: ${({ pageSize }) => `${pageSize.height}px`};
   overflow: visible;
   position: absolute;
   margin: 0;
-  top: ${({ pageSize }) => `${pageSize.dangerZoneHeight / 2}px`};
 `;
 
 function PreviewPageController({
@@ -84,8 +94,11 @@ function PreviewPageController({
   useEffect(() => () => WAAPIAnimationMethods.reset(), [WAAPIAnimationMethods]);
 
   return (
-    <PreviewWrapper background={page.backgroundColor}>
-      <PageContainerSafeZone pageSize={pageSize}>
+    <FullBleedPreviewWrapper
+      pageSize={pageSize}
+      background={page.backgroundColor}
+    >
+      <PreviewSafeZone pageSize={pageSize}>
         {page.elements.map(({ id, ...rest }) => (
           <DisplayElement
             previewMode
@@ -95,8 +108,8 @@ function PreviewPageController({
             isAnimatable
           />
         ))}
-      </PageContainerSafeZone>
-    </PreviewWrapper>
+      </PreviewSafeZone>
+    </FullBleedPreviewWrapper>
   );
 }
 

--- a/assets/src/dashboard/constants/pageStructure.js
+++ b/assets/src/dashboard/constants/pageStructure.js
@@ -17,9 +17,10 @@
 /**
  * Internal dependencies
  */
-import { PAGE_HEIGHT, PAGE_WIDTH } from '../../edit-story/constants';
+import { FULLBLEED_RATIO } from '../../edit-story/constants';
+
 export const WPBODY_ID = 'wpbody';
-export const PAGE_RATIO = PAGE_WIDTH / PAGE_HEIGHT;
+export const PAGE_RATIO = FULLBLEED_RATIO;
 
 export const DASHBOARD_LEFT_NAV_WIDTH = 190;
 export const DASHBOARD_TOP_MARGIN = 45;

--- a/assets/src/dashboard/constants/pageStructure.js
+++ b/assets/src/dashboard/constants/pageStructure.js
@@ -21,6 +21,7 @@ import { FULLBLEED_RATIO } from '../../edit-story/constants';
 
 export const WPBODY_ID = 'wpbody';
 export const PAGE_RATIO = FULLBLEED_RATIO;
+export const TWO_THIRDS_RATIO = 2 / 3;
 
 export const DASHBOARD_LEFT_NAV_WIDTH = 190;
 export const DASHBOARD_TOP_MARGIN = 45;

--- a/assets/src/dashboard/constants/pageStructure.js
+++ b/assets/src/dashboard/constants/pageStructure.js
@@ -17,10 +17,9 @@
 /**
  * Internal dependencies
  */
-import { FULLBLEED_RATIO } from '../../edit-story/constants';
+export { FULLBLEED_RATIO } from '../../edit-story/constants';
 
 export const WPBODY_ID = 'wpbody';
-export const PAGE_RATIO = FULLBLEED_RATIO;
 export const TWO_THIRDS_RATIO = 2 / 3;
 
 export const DASHBOARD_LEFT_NAV_WIDTH = 190;

--- a/assets/src/dashboard/constants/pageStructure.js
+++ b/assets/src/dashboard/constants/pageStructure.js
@@ -17,10 +17,9 @@
 /**
  * Internal dependencies
  */
-export { FULLBLEED_RATIO } from '../../edit-story/constants';
+export { FULLBLEED_RATIO, PAGE_RATIO } from '../../edit-story/constants';
 
 export const WPBODY_ID = 'wpbody';
-export const TWO_THIRDS_RATIO = 2 / 3;
 
 export const DASHBOARD_LEFT_NAV_WIDTH = 190;
 export const DASHBOARD_TOP_MARGIN = 45;

--- a/assets/src/dashboard/storybookUtils/index.js
+++ b/assets/src/dashboard/storybookUtils/index.js
@@ -16,5 +16,12 @@
 
 export { default as AMPStoryWrapper } from './ampStoryWrapper';
 export { default as formattedStoriesArray } from './formattedStoriesArray';
+export { default as formattedTemplatesArray } from './formattedTemplatesArray';
 export { default as formattedUsersObject } from './formattedUsersObject';
 export { default as PlayButton } from './playButton';
+
+export const STORYBOOK_PAGE_SIZE = {
+  width: 212,
+  height: 318,
+  containerHeight: 376.89,
+};

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -93,7 +93,7 @@ export const TotalStoriesByStatusPropType = PropTypes.shape({
 export const PageSizePropType = PropTypes.shape({
   width: PropTypes.number,
   height: PropTypes.number,
-  dangerZoneHeight: PropTypes.number,
+  containerHeight: PropTypes.number,
 });
 
 export const StoryMenuPropType = PropTypes.shape({

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -93,7 +93,7 @@ export const TotalStoriesByStatusPropType = PropTypes.shape({
 export const PageSizePropType = PropTypes.shape({
   width: PropTypes.number,
   height: PropTypes.number,
-  fullBleedHeight: PropTypes.number,
+  dangerZoneHeight: PropTypes.number,
 });
 
 export const StoryMenuPropType = PropTypes.shape({

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -93,6 +93,7 @@ export const TotalStoriesByStatusPropType = PropTypes.shape({
 export const PageSizePropType = PropTypes.shape({
   width: PropTypes.number,
   height: PropTypes.number,
+  fullBleedHeight: PropTypes.number,
 });
 
 export const StoryMenuPropType = PropTypes.shape({

--- a/assets/src/dashboard/utils/index.js
+++ b/assets/src/dashboard/utils/index.js
@@ -23,7 +23,10 @@ export { default as memoize } from './memoize';
 export { default as throttleToAnimationFrame } from './throttleToAnimationFrame';
 export { default as useDashboardResultsLabel } from './useDashboardResultsLabel';
 export { default as useFocusOut } from './useFocusOut';
-export { default as usePagePreviewSize } from './usePagePreviewSize';
+export {
+  default as usePagePreviewSize,
+  getPagePreviewHeights,
+} from './usePagePreviewSize';
 export { default as useStoryView } from './useStoryView';
 export { default as useTemplateView } from './useTemplateView';
 

--- a/assets/src/dashboard/utils/test/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/test/usePagePreviewSize.js
@@ -20,20 +20,16 @@
 import { getPagePreviewHeights } from '../usePagePreviewSize';
 
 describe('getPagePreviewHeights', () => {
-  it('should return { fullBleedHeight: 359.1111111111111, storyHeight: 303 } when width is 202', () => {
+  it('should return { fullBleedHeight: 359.11, storyHeight: 303 } when width is 202', () => {
     const previewHeights = getPagePreviewHeights(202);
 
-    expect(previewHeights).toStrictEqual({
-      fullBleedHeight: 359.1111111111111,
-      storyHeight: 303,
-    });
+    expect(previewHeights.fullBleedHeight).toBeCloseTo(359.11);
+    expect(previewHeights.storyHeight).toBeCloseTo(303);
   });
-  it('should return { fullBleedHeight: 451.55555555555554, storyHeight: 381 } when width is 202', () => {
+  it('should return { fullBleedHeight: 451.55, storyHeight: 381 } when width is 202', () => {
     const previewHeights = getPagePreviewHeights(254);
 
-    expect(previewHeights).toStrictEqual({
-      fullBleedHeight: 451.55555555555554,
-      storyHeight: 381,
-    });
+    expect(previewHeights.fullBleedHeight).toBeCloseTo(451.56);
+    expect(previewHeights.storyHeight).toBeCloseTo(381);
   });
 });

--- a/assets/src/dashboard/utils/test/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/test/usePagePreviewSize.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getPagePreviewHeights } from '../usePagePreviewSize';
+
+describe('getPagePreviewHeights', () => {
+  it('should return { fullBleedHeight: 359.1111111111111, storyHeight: 303 } when width is 202', () => {
+    const previewHeights = getPagePreviewHeights(202);
+
+    expect(previewHeights).toStrictEqual({
+      fullBleedHeight: 359.1111111111111,
+      storyHeight: 303,
+    });
+  });
+  it('should return { fullBleedHeight: 451.55555555555554, storyHeight: 381 } when width is 202', () => {
+    const previewHeights = getPagePreviewHeights(254);
+
+    expect(previewHeights).toStrictEqual({
+      fullBleedHeight: 451.55555555555554,
+      storyHeight: 381,
+    });
+  });
+});

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -23,9 +23,22 @@ import { useDebouncedCallback } from 'use-debounce';
  * Internal dependencies
  */
 import theme from '../theme';
-import { DASHBOARD_LEFT_NAV_WIDTH, PAGE_RATIO, WPBODY_ID } from '../constants';
+import {
+  DASHBOARD_LEFT_NAV_WIDTH,
+  PAGE_RATIO,
+  WPBODY_ID,
+  TWO_THIRDS_RATIO,
+} from '../constants';
 import { useResizeEffect } from './';
 
+const getHeightOptions = (width) => {
+  const fullBleedHeight = width / PAGE_RATIO;
+  const twoThirdsRatio = width / TWO_THIRDS_RATIO;
+
+  const dangerZoneHeight = fullBleedHeight - twoThirdsRatio;
+
+  return { fullBleedHeight, dangerZoneHeight };
+};
 const descendingBreakpointKeys = Object.keys(theme.breakpoint.raw).sort(
   (a, b) => theme.breakpoint.raw[b] - theme.breakpoint.raw[a]
 );
@@ -48,7 +61,8 @@ const sizeFromWidth = (
   { bp, respectSetWidth, availableContainerSpace }
 ) => {
   if (respectSetWidth) {
-    return { width, height: width / PAGE_RATIO };
+    const { fullBleedHeight, dangerZoneHeight } = getHeightOptions(width);
+    return { width, height: fullBleedHeight, dangerZoneHeight };
   }
 
   if (bp === 'desktop') {
@@ -63,9 +77,11 @@ const sizeFromWidth = (
   const addToWidthValue = remainingSpace / itemsInRow;
 
   const trueWidth = width + addToWidthValue;
+  const { fullBleedHeight, dangerZoneHeight } = getHeightOptions(trueWidth);
   return {
     width: trueWidth,
-    height: trueWidth / PAGE_RATIO,
+    height: fullBleedHeight,
+    dangerZoneHeight,
   };
 };
 

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -25,20 +25,33 @@ import { useDebouncedCallback } from 'use-debounce';
 import theme from '../theme';
 import {
   DASHBOARD_LEFT_NAV_WIDTH,
-  PAGE_RATIO,
+  FULLBLEED_RATIO,
   WPBODY_ID,
   TWO_THIRDS_RATIO,
 } from '../constants';
 import { useResizeEffect } from './';
 
-export const getHeightOptions = (width) => {
-  const fullBleedHeight = width / PAGE_RATIO;
-  const twoThirdsRatio = width / TWO_THIRDS_RATIO;
+/**
+ * Here we need to calculate two heights for every pagePreview in use.
+ * 1. The height that is 9:16 aspect ratio, this is the default FULLBLEED_RATIO
+ * This height is used anywhere we need the height of the container holding a pagePreview.
+ * It is the true boundary for overflow.
+ * It is the 'fullBleedHeight'
+ * 2. The height for the actual story, used in our shared components with edit-story
+ * This means things like the unitsProvider and displayElements that we import to the Dashboard from the editor
+ * It's maintaining a 2:3 aspect ratio.
+ * When fullbleed is visible (as it is for our reqs) we use the 2:3 aspect ratio w/ overflow to allow the fullBleed height to be visible
+ *
+ * @param width
+ * @return { fullBleedHeight: Number, storyHeight: Number}
+ */
+export const getPagePreviewHeights = (width) => {
+  const fullBleedHeight = width / FULLBLEED_RATIO;
+  const storyHeight = width / TWO_THIRDS_RATIO;
 
-  const dangerZoneHeight = fullBleedHeight - twoThirdsRatio;
-
-  return { fullBleedHeight, dangerZoneHeight };
+  return { fullBleedHeight, storyHeight };
 };
+
 const descendingBreakpointKeys = Object.keys(theme.breakpoint.raw).sort(
   (a, b) => theme.breakpoint.raw[b] - theme.breakpoint.raw[a]
 );
@@ -55,14 +68,14 @@ const getCurrentBp = (availableContainerSpace) =>
 // subtract those values from the availableContainer space to get remaining space
 // divide the remaining space by the itemsInRow
 // attach that extra space to the width
-// get height by dividing new with by PAGE_RATIO
+// get height by dividing new with by FULLBLEED_RATIO
 const sizeFromWidth = (
   width,
   { bp, respectSetWidth, availableContainerSpace }
 ) => {
   if (respectSetWidth) {
-    const { fullBleedHeight, dangerZoneHeight } = getHeightOptions(width);
-    return { width, height: fullBleedHeight, dangerZoneHeight };
+    const { fullBleedHeight, storyHeight } = getPagePreviewHeights(width);
+    return { width, height: storyHeight, containerHeight: fullBleedHeight };
   }
 
   if (bp === 'desktop') {
@@ -77,11 +90,12 @@ const sizeFromWidth = (
   const addToWidthValue = remainingSpace / itemsInRow;
 
   const trueWidth = width + addToWidthValue;
-  const { fullBleedHeight, dangerZoneHeight } = getHeightOptions(trueWidth);
+  const { fullBleedHeight, storyHeight } = getPagePreviewHeights(trueWidth);
+
   return {
     width: trueWidth,
-    height: fullBleedHeight,
-    dangerZoneHeight,
+    height: storyHeight,
+    containerHeight: fullBleedHeight,
   };
 };
 

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -46,8 +46,8 @@ import { useResizeEffect } from './';
  * @return {Object}       heights to use in pagePreviews { fullBleedHeight: Number, storyHeight: Number}
  */
 export const getPagePreviewHeights = (width) => {
-  const fullBleedHeight = width / FULLBLEED_RATIO;
-  const storyHeight = width / PAGE_RATIO;
+  const fullBleedHeight = Math.round((width / FULLBLEED_RATIO) * 100) / 100;
+  const storyHeight = Math.round((width / PAGE_RATIO) * 100) / 100;
 
   return { fullBleedHeight, storyHeight };
 };

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -26,8 +26,8 @@ import theme from '../theme';
 import {
   DASHBOARD_LEFT_NAV_WIDTH,
   FULLBLEED_RATIO,
+  PAGE_RATIO,
   WPBODY_ID,
-  TWO_THIRDS_RATIO,
 } from '../constants';
 import { useResizeEffect } from './';
 
@@ -47,7 +47,7 @@ import { useResizeEffect } from './';
  */
 export const getPagePreviewHeights = (width) => {
   const fullBleedHeight = width / FULLBLEED_RATIO;
-  const storyHeight = width / TWO_THIRDS_RATIO;
+  const storyHeight = width / PAGE_RATIO;
 
   return { fullBleedHeight, storyHeight };
 };

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -42,8 +42,8 @@ import { useResizeEffect } from './';
  * It's maintaining a 2:3 aspect ratio.
  * When fullbleed is visible (as it is for our reqs) we use the 2:3 aspect ratio w/ overflow to allow the fullBleed height to be visible
  *
- * @param width
- * @return { fullBleedHeight: Number, storyHeight: Number}
+ * @param {number} width  width of page to base ratios on
+ * @return {Object}       heights to use in pagePreviews { fullBleedHeight: Number, storyHeight: Number}
  */
 export const getPagePreviewHeights = (width) => {
   const fullBleedHeight = width / FULLBLEED_RATIO;
@@ -68,7 +68,7 @@ const getCurrentBp = (availableContainerSpace) =>
 // subtract those values from the availableContainer space to get remaining space
 // divide the remaining space by the itemsInRow
 // attach that extra space to the width
-// get height by dividing new with by FULLBLEED_RATIO
+// get heights for page and container in getPagePreviewHeights
 const sizeFromWidth = (
   width,
   { bp, respectSetWidth, availableContainerSpace }

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -31,7 +31,7 @@ import {
 } from '../constants';
 import { useResizeEffect } from './';
 
-const getHeightOptions = (width) => {
+export const getHeightOptions = (width) => {
   const fullBleedHeight = width / PAGE_RATIO;
   const twoThirdsRatio = width / TWO_THIRDS_RATIO;
 

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -90,6 +90,7 @@ StoryPropTypes.link = PropTypes.shape({
 StoryPropTypes.size = PropTypes.exact({
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
+  containerHeight: PropTypes.number,
 });
 
 StoryPropTypes.box = PropTypes.exact({

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -90,7 +90,6 @@ StoryPropTypes.link = PropTypes.shape({
 StoryPropTypes.size = PropTypes.exact({
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
-  containerHeight: PropTypes.number,
 });
 
 StoryPropTypes.box = PropTypes.exact({


### PR DESCRIPTION
## Summary
Updates the dashboard's preview component to use 9 : 16 ratio instead of 2 : 3 to allow for full bleed.
![Screen Shot 2020-06-17 at 11 39 00 AM](https://user-images.githubusercontent.com/10720454/84936518-37ba7580-b08f-11ea-97d2-9d5b310788b4.png)
![Screen Shot 2020-06-17 at 11 39 09 AM](https://user-images.githubusercontent.com/10720454/84936528-3ab56600-b08f-11ea-874c-1b2d6d28aa44.png)
![Screen Shot 2020-06-17 at 12 54 16 PM](https://user-images.githubusercontent.com/10720454/84944538-c2ed3880-b09a-11ea-8229-2858ee3be0e0.png)


## Relevant Technical Choices
- I referenced edit-story/components/canvas/layout to make the changes necessary to our usePagePreview util as well as components/previewPage. 
- In previewPage we now have 2 divs that wrap around the `displayElement` imported from edit-sory. They are: `PreviewSafeZone` (new bonus wrapper to control the overflow) and `FullBleedPreviewWrapper` (formerly: `previewWrapper`). The `FullBleedPreviewWrapper` identifies the total space for the preview including the full bleed (9:16 ratio). The PreviewSafeZone still relies on the 2:3 ratio and allows overflow so that the fullbleed area can be seen within the previewWrapper but not baked into the height that the unitsProvider expects to calculate the story.  
- I added a new function in `usePagePreviewSize` to calculate two widths based on the fullbleed ratio (9:16) and two thirds ratio (2:3). The 2:3 ratio is the default height. 
- I added another key to the `pageSize` that's getting passed through where ever we are previewing a story or a template called `containerHeight`. To avoid cluttering up the StoryPropTypes.size in edit-story i broke down the pageSize prop on the dashboard to only pass height and width through to the unitProvider while allowing pageSize to have the extra containerHeight key in the dashboard. 

## User-facing changes
- Ratio should be updated to 9 : 16

## Testing Instructions
- Make a story and put something in the danger zone area and see that it renders in the dashboard previews on grid
- Also see that this holds true for the different dashboard views and storybook - i think i got them all. 
- (this is a helpful link for sanely checking the aspect ratio repeatedly: https://calculateaspectratio.com/) 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2557
