### PR TITLE
Fix: Flags are now passed into getStoryMarkup 

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -25,6 +25,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo, useReducer } from 'react';
 import moment from 'moment';
 import queryString from 'query-string';
+import { useFeatures } from 'flagged';
 
 /**
  * Internal dependencies
@@ -85,6 +86,7 @@ export function reshapeStoryObject(editStoryURL) {
 
 const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
   const [state, dispatch] = useReducer(storyReducer, defaultStoriesState);
+  const flags = useFeatures();
 
   const fetchStories = useCallback(
     async ({
@@ -211,8 +213,6 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
 
       try {
         const { createdBy, pages, version } = template;
-        const { flags } = window.webStoriesDashboardSettings;
-
         const storyPropsToSave = await getStoryPropsToSave({
           story: {
             status: 'auto-draft',
@@ -256,7 +256,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
         });
       }
     },
-    [dataAdapter, editStoryURL, storyApi]
+    [dataAdapter, editStoryURL, storyApi, flags]
   );
 
   const duplicateStory = useCallback(

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -211,6 +211,8 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
 
       try {
         const { createdBy, pages, version } = template;
+        const { flags } = window.webStoriesDashboardSettings;
+
         const storyPropsToSave = await getStoryPropsToSave({
           story: {
             status: 'auto-draft',
@@ -221,6 +223,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
               name: createdBy,
             },
           },
+          flags,
         });
         const response = await dataAdapter.post(storyApi, {
           data: {

--- a/assets/src/dashboard/app/views/storyAnimTool/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/index.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { useContext, useEffect, useState, useMemo, useCallback } from 'react';
+import { useFeatures } from 'flagged';
 
 /**
  * Internal dependencies
@@ -65,6 +66,7 @@ function StoryAnimTool() {
   const [selectedElementIds, setSelectedElementIds] = useState({});
   const [isElementSelectable, setIsElementSelectable] = useState(false);
   const globalTimeSubscription = useMemo(() => emitter(), []);
+  const flags = useFeatures();
 
   const {
     actions: {
@@ -232,7 +234,6 @@ function StoryAnimTool() {
       },
     };
 
-    const { flags } = window.webStoriesDashboardSettings;
     const storyMarkup = getStoryMarkup(
       story,
       activeStory.pages,
@@ -262,7 +263,7 @@ function StoryAnimTool() {
     iframeDoc.open();
     iframeDoc.write(storyMarkup.toString());
     iframeDoc.close();
-  }, [activeStory]);
+  }, [activeStory, flags]);
 
   useEffect(() => {
     setSelectedElementIds(

--- a/assets/src/dashboard/app/views/storyAnimTool/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/index.js
@@ -232,13 +232,19 @@ function StoryAnimTool() {
       },
     };
 
-    const storyMarkup = getStoryMarkup(story, activeStory.pages, {
-      fallbackPoster: '',
-      logoPlaceholder: '',
-      publisher: {
-        name: 'Demo',
+    const { flags } = window.webStoriesDashboardSettings;
+    const storyMarkup = getStoryMarkup(
+      story,
+      activeStory.pages,
+      {
+        fallbackPoster: '',
+        logoPlaceholder: '',
+        publisher: {
+          name: 'Demo',
+        },
       },
-    });
+      flags
+    );
 
     const popup = window.open('about:blank', '_blank');
 

--- a/assets/src/edit-story/app/story/actions/useAutoSave.js
+++ b/assets/src/edit-story/app/story/actions/useAutoSave.js
@@ -41,17 +41,18 @@ function useAutoSave({ storyId, pages, story }) {
   } = useAPI();
   const { metadata } = useConfig();
   const [isAutoSaving, setIsAutoSaving] = useState(false);
+  const { flags } = window.webStoriesEditorSettings;
 
   const autoSave = useCallback(
     (props) => {
       setIsAutoSaving(true);
       return autoSaveById({
         storyId,
-        ...getStoryPropsToSave({ story, pages, metadata }),
+        ...getStoryPropsToSave({ story, pages, metadata, flags }),
         ...props,
       }).finally(() => setIsAutoSaving(false));
     },
-    [story, pages, metadata, autoSaveById, storyId]
+    [story, pages, metadata, autoSaveById, storyId, flags]
   );
 
   return { autoSave, isAutoSaving };

--- a/assets/src/edit-story/app/story/actions/useAutoSave.js
+++ b/assets/src/edit-story/app/story/actions/useAutoSave.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { useCallback, useState } from 'react';
+import { useFeatures } from 'flagged';
 
 /**
  * Internal dependencies
@@ -41,7 +42,7 @@ function useAutoSave({ storyId, pages, story }) {
   } = useAPI();
   const { metadata } = useConfig();
   const [isAutoSaving, setIsAutoSaving] = useState(false);
-  const { flags } = window.webStoriesEditorSettings;
+  const flags = useFeatures();
 
   const autoSave = useCallback(
     (props) => {

--- a/assets/src/edit-story/app/story/actions/useSaveStory.js
+++ b/assets/src/edit-story/app/story/actions/useSaveStory.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { useCallback, useState } from 'react';
+import { useFeatures } from 'flagged';
 
 /**
  * WordPress dependencies
@@ -51,7 +52,7 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
   const {
     actions: { resetNewChanges },
   } = useHistory();
-  const { flags } = window.webStoriesEditorSettings;
+  const flags = useFeatures();
   const { metadata } = useConfig();
   const { showSnackbar } = useSnackbar();
   const [isSaving, setIsSaving] = useState(false);

--- a/assets/src/edit-story/app/story/actions/useSaveStory.js
+++ b/assets/src/edit-story/app/story/actions/useSaveStory.js
@@ -51,6 +51,7 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
   const {
     actions: { resetNewChanges },
   } = useHistory();
+  const { flags } = window.webStoriesEditorSettings;
   const { metadata } = useConfig();
   const { showSnackbar } = useSnackbar();
   const [isSaving, setIsSaving] = useState(false);
@@ -68,7 +69,7 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
 
       return saveStoryById({
         storyId,
-        ...getStoryPropsToSave({ story, pages, metadata }),
+        ...getStoryPropsToSave({ story, pages, metadata, flags }),
         ...props,
       })
         .then((post) => {
@@ -96,6 +97,7 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
     [
       story,
       pages,
+      flags,
       metadata,
       saveStoryById,
       storyId,

--- a/assets/src/edit-story/app/story/utils/getStoryPropsToSave.js
+++ b/assets/src/edit-story/app/story/utils/getStoryPropsToSave.js
@@ -35,7 +35,8 @@ function getStoryPropsToSave({ story, pages, metadata }) {
     'autoAdvance',
     'defaultPageDuration',
   ]);
-  const content = getStoryMarkup(story, pages, metadata);
+  const { flags } = window.webStoriesEditorSettings;
+  const content = getStoryMarkup(story, pages, metadata, flags);
   return {
     content,
     pages,

--- a/assets/src/edit-story/app/story/utils/getStoryPropsToSave.js
+++ b/assets/src/edit-story/app/story/utils/getStoryPropsToSave.js
@@ -19,7 +19,7 @@
 import objectPick from '../../../utils/objectPick';
 import getStoryMarkup from '../../../output/utils/getStoryMarkup';
 
-function getStoryPropsToSave({ story, pages, metadata }) {
+function getStoryPropsToSave({ story, pages, metadata, flags }) {
   const propsFromStory = objectPick(story, [
     'title',
     'status',
@@ -35,7 +35,7 @@ function getStoryPropsToSave({ story, pages, metadata }) {
     'autoAdvance',
     'defaultPageDuration',
   ]);
-  const { flags } = window.webStoriesEditorSettings;
+
   const content = getStoryMarkup(story, pages, metadata, flags);
   return {
     content,

--- a/assets/src/edit-story/app/story/utils/test/getStoryPropsToSave.js
+++ b/assets/src/edit-story/app/story/utils/test/getStoryPropsToSave.js
@@ -51,7 +51,7 @@ describe('getStoryPropsToSave', () => {
     getStoryMarkup.mockImplementation(() => {
       return 'Hello World!';
     });
-    const props = getStoryPropsToSave({ story, pages, metadata });
+    const props = getStoryPropsToSave({ story, pages, metadata, flags: {} });
 
     expect(props).toStrictEqual({
       content: 'Hello World!',

--- a/assets/src/edit-story/output/utils/getStoryMarkup.js
+++ b/assets/src/edit-story/output/utils/getStoryMarkup.js
@@ -31,13 +31,12 @@ import OutputStory from '../story';
  * @param {import('../../../types').Story} story Story object.
  * @param {Array<Object>} pages List of pages.
  * @param {Object} metadata Metadata.
+ * @param {Object} featureFlags Boolean flags to enable/disable features
  * @return {string} Story markup.
  */
-export default function getStoryMarkup(story, pages, metadata) {
-  const { flags } = window.webStoriesEditorSettings;
-
+export default function getStoryMarkup(story, pages, metadata, featureFlags) {
   return renderToStaticMarkup(
-    <FlagsProvider features={flags}>
+    <FlagsProvider features={featureFlags}>
       <OutputStory story={story} pages={pages} metadata={metadata} />
     </FlagsProvider>
   );

--- a/assets/src/edit-story/output/utils/test/getStoryMarkup.js
+++ b/assets/src/edit-story/output/utils/test/getStoryMarkup.js
@@ -92,7 +92,7 @@ describe('getStoryMarkup', () => {
         ],
       },
     ];
-    const markup = getStoryMarkup(story, pages, meta);
+    const markup = getStoryMarkup(story, pages, meta, {});
     expect(markup).toContain('Hello World');
     expect(markup).toContain('transform:rotate(1deg)');
     expect(markup).toContain(


### PR DESCRIPTION
## Summary

This PR fixes a bug where the call to `getStoryMarkup` was breaking when called from the dashboard.  The problem was that `getStoryMarkup` was dependent on the existence of `window.webStoriesEditorSettings` and that object doesn't exist when in the dashboard.

To fix this issue, I updated `getStoryMarkup` to accept `featureFlags` as a param, and this way the editor and dashboard can pass in the appropriate `flags` object.

## User-facing changes

None.

## Testing Instructions

There are two places where `getStoryMarkup` is called to generate an `amp-story`.

1.) Go to edit an existing story, and click on "Preview" from within the editor.  A new tab should open up with a correctly generated amp-story.

2.) Go to our `story-anim-tool`, select a story from the drop down, and click on "Preview Story".  A new tab should open up with a correctly generated amp-story.

Url for `story-anim-tool`: 
`/wp-admin/edit.php?post_type=web-story&page=stories-dashboard#/story-anim-tool`

---