### PR TITLE
Disable block editor logic for story post type

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -136,6 +136,7 @@ class Story_Post_Type {
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_enqueue_scripts' ] );
 		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ] ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 		add_filter( 'replace_editor', [ __CLASS__, 'replace_editor' ], 10, 2 );
+		add_filter( 'use_block_editor_for_post_type', [ __CLASS__, 'filter_use_block_editor_for_post_type' ], 10, 2 );
 
 		add_filter( 'rest_' . self::POST_TYPE_SLUG . '_collection_params', [ __CLASS__, 'filter_rest_collection_params' ], 10, 2 );
 
@@ -225,6 +226,24 @@ class Story_Post_Type {
 		}
 
 		return $replace;
+	}
+
+	/**
+	 * Filters whether post type supports the block editor.
+	 *
+	 * Disables the block editor and associated logic (like enqueueing assets)
+	 * for the story post type.
+	 *
+	 * @param bool   $use_block_editor  Whether the post type can be edited or not. Default true.
+	 * @param string $post_type         The post type being checked.
+	 * @return bool Whether to use the block editor.
+	 */
+	public static function filter_use_block_editor_for_post_type( $use_block_editor, $post_type ) {
+		if ( self::POST_TYPE_SLUG === $post_type ) {
+			return false;
+		}
+
+		return $use_block_editor;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

Just using `replace_editor` is not enough. We also have to filter `use_block_editor_for_post_type`, otherwise `WP_Screen::is_block_editor()` is `true` and `wp_enqueue_registered_block_scripts_and_styles` is eventually called.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None. Ideally the editor loads faster.

## Testing Instructions

1. Open story editor
1. View source

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2591
