### PR TITLE
Templates: hide sort dropdown depending on flag

### DIFF
--- a/assets/src/dashboard/app/views/exploreTemplates/header/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/header/index.js
@@ -124,6 +124,7 @@ function Header({ filter, totalTemplates, search, templates, sort, view }) {
         handleLayoutSelect={view.toggleStyle}
         currentSort={sort.value}
         pageSortOptions={TEMPLATES_GALLERY_SORT_MENU_ITEMS}
+        showSortDropdown={enableInProgressTemplateActions}
         handleSortChange={enableInProgressTemplateActions ? sort.set : () => {}}
         sortDropdownAriaLabel={__(
           'Choose sort option for display',

--- a/assets/src/dashboard/app/views/myStories/header/index.js
+++ b/assets/src/dashboard/app/views/myStories/header/index.js
@@ -108,6 +108,7 @@ function Header({
       </PageHeading>
       <BodyViewOptions
         showGridToggle
+        showSortDropdown
         resultsLabel={resultsLabel}
         layoutStyle={view.style}
         handleLayoutSelect={view.toggleStyle}

--- a/assets/src/dashboard/app/views/savedTemplates/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/index.js
@@ -71,6 +71,7 @@ function Header({ filter, search, sort, stories, view }) {
         typeaheadValue={search.keyword}
       />
       <BodyViewOptions
+        showSortDropdown
         resultsLabel={resultsLabel}
         layoutStyle={view.style}
         currentSort={sort.value}

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -80,6 +80,7 @@ export default function BodyViewOptions({
   layoutStyle,
   pageSortOptions = [],
   showGridToggle,
+  showSortDropdown,
   sortDropdownAriaLabel,
   wpListURL,
 }) {
@@ -88,7 +89,7 @@ export default function BodyViewOptions({
       <DisplayFormatContainer>
         <Label>{resultsLabel}</Label>
         <ControlsContainer>
-          {layoutStyle === VIEW_STYLE.GRID && Boolean(handleSortChange) && (
+          {layoutStyle === VIEW_STYLE.GRID && showSortDropdown && (
             <StorySortDropdownContainer>
               <SortDropdown
                 alignment="flex-end"
@@ -134,5 +135,6 @@ BodyViewOptions.propTypes = {
     })
   ),
   showGridToggle: PropTypes.bool,
+  showSortDropdown: PropTypes.bool,
   sortDropdownAriaLabel: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
## Summary
Hides the sort dropdown on explore templates that is not hooked up to anything and does not do anything yet. 

![Screen Shot 2020-06-18 at 9 30 50 AM](https://user-images.githubusercontent.com/10720454/85047274-6f382900-b146-11ea-8434-5473e9ed1417.png)


## Relevant Technical Choices
Adds a boolean prop to `BodyViewOptions` shared component that if false will hide the sort dropdown used on pages. If true, the dropdown shows. 

## User-facing changes
- Sort dropdown on explore templates should be hidden when `enableInProgressTemplateActions` flag is set to false. 

## Testing Instructions
- See that sort dropdown is hidden for explore templates and remains intact for my stories 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2381
