### PR TITLE
Use objects everywhere instead of static methods

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -45,9 +45,9 @@ class Admin {
 		$database_upgrader = new Database_Upgrader();
 		$database_upgrader->init();
 
-		add_filter( 'admin_body_class', [ __CLASS__, 'admin_body_class' ], 99 );
-		add_filter( 'default_content', [ __CLASS__, 'prefill_post_content' ] );
-		add_filter( 'default_title', [ __CLASS__, 'prefill_post_title' ] );
+		add_filter( 'admin_body_class', [ $this, 'admin_body_class' ], 99 );
+		add_filter( 'default_content', [ $this, 'prefill_post_content' ] );
+		add_filter( 'default_title', [ $this, 'prefill_post_title' ] );
 	}
 
 	/**
@@ -60,7 +60,7 @@ class Admin {
 	 *
 	 * @return string $class List of Classes.
 	 */
-	public static function admin_body_class( $class ) {
+	public function admin_body_class( $class ) {
 		$screen = get_current_screen();
 
 		if ( ! $screen instanceof WP_Screen ) {
@@ -93,7 +93,7 @@ class Admin {
 	 *
 	 * @return string Pre-filled post content if applicable, or the default content otherwise.
 	 */
-	public static function prefill_post_content( $content ) {
+	public function prefill_post_content( $content ) {
 		if ( ! isset( $_GET['from-web-story'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return $content;
 		}
@@ -163,7 +163,7 @@ BLOCK;
 	 *
 	 * @return string Pre-filled post title if applicable, or the default title otherwise.
 	 */
-	public static function prefill_post_title( $title ) {
+	public function prefill_post_title( $title ) {
 		if ( ! isset( $_GET['from-web-story'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return $title;
 		}

--- a/includes/Database_Upgrader.php
+++ b/includes/Database_Upgrader.php
@@ -26,8 +26,6 @@
 
 namespace Google\Web_Stories;
 
-use Google\Web_Stories\REST_API\Stories_Controller;
-
 /**
  * Class Database_Upgrader
  *
@@ -102,7 +100,7 @@ class Database_Upgrader {
 	 * @return void
 	 */
 	protected function v_2_replace_conic_style_presets() {
-		$style_presets = get_option( Stories_Controller::STYLE_PRESETS_OPTION, false );
+		$style_presets = get_option( Story_Post_Type::STYLE_PRESETS_OPTION, false );
 		// Nothing to do if style presets don't exist.
 		if ( ! $style_presets || ! is_array( $style_presets ) ) {
 			return;
@@ -144,7 +142,7 @@ class Database_Upgrader {
 			'textColors' => $style_presets['textColors'],
 			'textStyles' => $text_styles,
 		];
-		update_option( Stories_Controller::STYLE_PRESETS_OPTION, $updated_style_presets );
+		update_option( Story_Post_Type::STYLE_PRESETS_OPTION, $updated_style_presets );
 	}
 
 	/**
@@ -162,7 +160,7 @@ class Database_Upgrader {
 	 * @return void
 	 */
 	protected function remove_broken_text_styles() {
-		$style_presets = get_option( Stories_Controller::STYLE_PRESETS_OPTION, false );
+		$style_presets = get_option( Story_Post_Type::STYLE_PRESETS_OPTION, false );
 		// Nothing to do if style presets don't exist.
 		if ( ! $style_presets || ! is_array( $style_presets ) ) {
 			return;
@@ -183,7 +181,7 @@ class Database_Upgrader {
 			'textColors' => $style_presets['textColors'],
 			'textStyles' => $text_styles,
 		];
-		update_option( Stories_Controller::STYLE_PRESETS_OPTION, $updated_style_presets );
+		update_option( Story_Post_Type::STYLE_PRESETS_OPTION, $updated_style_presets );
 	}
 
 	/**

--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -99,7 +99,7 @@ class Discovery {
 	 * @return array $metadata All schema.org metadata for the post.
 	 */
 	protected function get_schemaorg_metadata() {
-		$publisher = self::get_publisher_data();
+		$publisher = $this->get_publisher_data();
 
 		$metadata = [
 			'@context'  => 'http://schema.org',
@@ -225,7 +225,7 @@ class Discovery {
 	 *
 	 * @return string|false Either the URL or false if error.
 	 */
-	private static function get_valid_publisher_image( $image_id ) {
+	private function get_valid_publisher_image( $image_id ) {
 		$logo_image_url = false;
 
 		// Get metadata for finding a square image.
@@ -266,14 +266,14 @@ class Discovery {
 	 *
 	 * @return string Publisher logo image URL. WordPress logo if no site icon or custom logo defined, and no logo provided via 'amp_site_icon_url' filter.
 	 */
-	public static function get_publisher_logo() {
+	public function get_publisher_logo() {
 		$logo_image_url = null;
 
 		$publisher_logo_settings = get_option( Stories_Controller::PUBLISHER_LOGOS_OPTION, [] );
 		$has_publisher_logo      = ! empty( $publisher_logo_settings['active'] );
 		if ( $has_publisher_logo ) {
 			$publisher_logo_id = absint( $publisher_logo_settings['active'] );
-			$logo_image_url    = self::get_valid_publisher_image( $publisher_logo_id );
+			$logo_image_url    = $this->get_valid_publisher_image()( $publisher_logo_id );
 		}
 
 		// @todo Once we are enforcing setting publisher logo in the editor, we shouldn't need the fallback options.
@@ -282,13 +282,13 @@ class Discovery {
 		// Finding fallback image.
 		$custom_logo_id = get_theme_mod( 'custom_logo' );
 		if ( empty( $logo_image_url ) && has_custom_logo() && $custom_logo_id ) {
-			$logo_image_url = self::get_valid_publisher_image( $custom_logo_id );
+			$logo_image_url = $this->get_valid_publisher_image()( $custom_logo_id );
 		}
 
 		// Try Site Icon, though it is not ideal for non-Story because it should be square.
 		$site_icon_id = get_option( 'site_icon' );
 		if ( empty( $logo_image_url ) && $site_icon_id ) {
-			$logo_image_url = self::get_valid_publisher_image( $site_icon_id );
+			$logo_image_url = $this->get_valid_publisher_image()( $site_icon_id );
 		}
 
 		// Fallback to serving the WordPress logo.
@@ -311,9 +311,9 @@ class Discovery {
 	 *
 	 * @return array Publisher name and logo.
 	 */
-	public static function get_publisher_data() {
+	public function get_publisher_data() {
 		$publisher      = get_bloginfo( 'name' );
-		$publisher_logo = self::get_publisher_logo();
+		$publisher_logo = $this->get_publisher_logo();
 
 		return [
 			'name' => $publisher,

--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -35,6 +35,8 @@ use WP_Post;
  * Discovery class.
  */
 class Discovery {
+
+	const PUBLISHER_LOGOS_OPTION = 'web_stories_publisher_logos';
 	/**
 	 * Initialize discovery functionality.
 	 *
@@ -269,7 +271,7 @@ class Discovery {
 	public function get_publisher_logo() {
 		$logo_image_url = null;
 
-		$publisher_logo_settings = get_option( Stories_Controller::PUBLISHER_LOGOS_OPTION, [] );
+		$publisher_logo_settings = get_option( self::PUBLISHER_LOGOS_OPTION, [] );
 		$has_publisher_logo      = ! empty( $publisher_logo_settings['active'] );
 		if ( $has_publisher_logo ) {
 			$publisher_logo_id = absint( $publisher_logo_settings['active'] );

--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -273,7 +273,7 @@ class Discovery {
 		$has_publisher_logo      = ! empty( $publisher_logo_settings['active'] );
 		if ( $has_publisher_logo ) {
 			$publisher_logo_id = absint( $publisher_logo_settings['active'] );
-			$logo_image_url    = $this->get_valid_publisher_image()( $publisher_logo_id );
+			$logo_image_url    = $this->get_valid_publisher_image( $publisher_logo_id );
 		}
 
 		// @todo Once we are enforcing setting publisher logo in the editor, we shouldn't need the fallback options.
@@ -282,13 +282,13 @@ class Discovery {
 		// Finding fallback image.
 		$custom_logo_id = get_theme_mod( 'custom_logo' );
 		if ( empty( $logo_image_url ) && has_custom_logo() && $custom_logo_id ) {
-			$logo_image_url = $this->get_valid_publisher_image()( $custom_logo_id );
+			$logo_image_url = $this->get_valid_publisher_image( $custom_logo_id );
 		}
 
 		// Try Site Icon, though it is not ideal for non-Story because it should be square.
 		$site_icon_id = get_option( 'site_icon' );
 		if ( empty( $logo_image_url ) && $site_icon_id ) {
-			$logo_image_url = $this->get_valid_publisher_image()( $site_icon_id );
+			$logo_image_url = $this->get_valid_publisher_image( $site_icon_id );
 		}
 
 		// Fallback to serving the WordPress logo.

--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -28,14 +28,17 @@
 
 namespace Google\Web_Stories;
 
-use Google\Web_Stories\REST_API\Stories_Controller;
 use WP_Post;
 
 /**
  * Discovery class.
  */
 class Discovery {
-
+	/**
+	 * Name of publisher option.
+	 *
+	 * @var string
+	 */
 	const PUBLISHER_LOGOS_OPTION = 'web_stories_publisher_logos';
 	/**
 	 * Initialize discovery functionality.

--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -306,6 +306,18 @@ class Discovery {
 		return apply_filters( 'web_stories_publisher_logo', $logo_image_url );
 	}
 
+
+	/**
+	 * Publisher logo placeholder for static content output which will be replaced server-side.
+	 *
+	 * Uses a fallback logo to always create valid AMP in FE.
+	 *
+	 * @return string
+	 */
+	public function get_publisher_logo_placeholder() {
+		return WEBSTORIES_PLUGIN_DIR_URL . 'assets/images/fallback-wordpress-publisher-logo.png';
+	}
+
 	/**
 	 * Returns the publisher data.
 	 *

--- a/includes/Embed_Block.php
+++ b/includes/Embed_Block.php
@@ -112,7 +112,7 @@ class Embed_Block {
 			]
 		);
 
-		add_filter( 'wp_kses_allowed_html', [ __CLASS__, 'filter_kses_allowed_html' ], 10, 2 );
+		add_filter( 'wp_kses_allowed_html', [ $this, 'filter_kses_allowed_html' ], 10, 2 );
 	}
 
 	/**
@@ -122,7 +122,7 @@ class Embed_Block {
 	 *
 	 * @return array|string Allowed tags.
 	 */
-	public static function filter_kses_allowed_html( $allowed_tags ) {
+	public function filter_kses_allowed_html( $allowed_tags ) {
 		if ( ! is_array( $allowed_tags ) ) {
 			return $allowed_tags;
 		}

--- a/includes/Fonts.php
+++ b/includes/Fonts.php
@@ -35,7 +35,7 @@ class Fonts {
 	 *
 	 * @return array Fonts.
 	 */
-	public static function get_fonts() {
+	public function get_fonts() {
 		static $fonts = null;
 
 		if ( isset( $fonts ) ) {
@@ -43,7 +43,7 @@ class Fonts {
 		}
 
 		$file  = __DIR__ . '/data/fonts.json';
-		$fonts = self::get_google_fonts( $file );
+		$fonts = $this->get_google_fonts( $file );
 
 		return $fonts;
 	}
@@ -55,7 +55,7 @@ class Fonts {
 	 *
 	 * @return array $fonts Fonts list.
 	 */
-	public static function get_google_fonts( $file ) {
+	public function get_google_fonts( $file ) {
 		if ( ! is_readable( $file ) ) {
 			return [];
 		}

--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -540,20 +540,11 @@ class KSES {
 	public function filter_content_save_pre_before_kses( $post_content ) {
 		return (string) preg_replace_callback(
 			'|(?P<before><\w+(?:-\w+)*\s[^>]*?)style=\\\"(?P<styles>[^"]*)\\\"(?P<after>([^>]+?)*>)|', // Extra slashes appear here because $post_content is pre-slashed..
-			[ $this, 'filter_content_save_pre_before_kses_matches' ],
+			static function ( $matches ) {
+				return $matches['before'] . sprintf( ' data-temp-style="%s" ', $matches['styles'] ) . $matches['after'];
+			},
 			$post_content
 		);
-	}
-
-	/**
-	 * Callback for preg replace.
-	 *
-	 * @param array $matches Array of matches.
-	 *
-	 * @return string
-	 */
-	public function filter_content_save_pre_before_kses_matches( $matches ) {
-		return $matches['before'] . sprintf( ' data-temp-style="%s" ', $matches['styles'] ) . $matches['after'];
 	}
 
 	/**
@@ -565,20 +556,11 @@ class KSES {
 	public function filter_content_save_pre_after_kses( $post_content ) {
 		return (string) preg_replace_callback(
 			'/ data-temp-style=\\\"(?P<styles>[^"]*)\\\"/',
-			[ $this, 'filter_content_save_pre_after_kses_matches' ],
+			function ( $matches ) {
+				$styles = str_replace( '&quot;', '\"', $matches['styles'] );
+				return sprintf( ' style="%s"', esc_attr( $this->safecss_filter_attr( wp_kses_stripslashes( $styles ) ) ) );
+			},
 			$post_content
 		);
-	}
-
-	/**
-	 * Callback for preg replace.
-	 *
-	 * @param array $matches Array of matches.
-	 *
-	 * @return string
-	 */
-	public function filter_content_save_pre_after_kses_matches( $matches ) {
-		$styles = str_replace( '&quot;', '\"', $matches['styles'] );
-		return sprintf( ' style="%s"', esc_attr( $this->safecss_filter_attr( wp_kses_stripslashes( $styles ) ) ) );
 	}
 }

--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -540,11 +540,20 @@ class KSES {
 	public function filter_content_save_pre_before_kses( $post_content ) {
 		return (string) preg_replace_callback(
 			'|(?P<before><\w+(?:-\w+)*\s[^>]*?)style=\\\"(?P<styles>[^"]*)\\\"(?P<after>([^>]+?)*>)|', // Extra slashes appear here because $post_content is pre-slashed..
-			static function ( $matches ) {
-				return $matches['before'] . sprintf( ' data-temp-style="%s" ', $matches['styles'] ) . $matches['after'];
-			},
+			[ $this, 'filter_content_save_pre_before_kses_matches' ],
 			$post_content
 		);
+	}
+
+	/**
+	 * Callback for preg replace.
+	 *
+	 * @param array $matches Array of matches.
+	 *
+	 * @return string
+	 */
+	public function filter_content_save_pre_before_kses_matches( $matches ) {
+		return $matches['before'] . sprintf( ' data-temp-style="%s" ', $matches['styles'] ) . $matches['after'];
 	}
 
 	/**
@@ -556,11 +565,20 @@ class KSES {
 	public function filter_content_save_pre_after_kses( $post_content ) {
 		return (string) preg_replace_callback(
 			'/ data-temp-style=\\\"(?P<styles>[^"]*)\\\"/',
-			function ( $matches ) {
-				$styles = str_replace( '&quot;', '\"', $matches['styles'] );
-				return sprintf( ' style="%s"', esc_attr( $this->safecss_filter_attr( wp_kses_stripslashes( $styles ) ) ) );
-			},
+			[ $this, 'filter_content_save_pre_after_kses_matches' ],
 			$post_content
 		);
+	}
+
+	/**
+	 * Callback for preg replace.
+	 *
+	 * @param array $matches Array of matches.
+	 *
+	 * @return string
+	 */
+	public function filter_content_save_pre_after_kses_matches( $matches ) {
+		$styles = str_replace( '&quot;', '\"', $matches['styles'] );
+		return sprintf( ' style="%s"', esc_attr( $this->safecss_filter_attr( wp_kses_stripslashes( $styles ) ) ) );
 	}
 }

--- a/includes/Media.php
+++ b/includes/Media.php
@@ -296,7 +296,7 @@ class Media {
 	/**
 	 * Update rest field callback.
 	 *
-	 * @param mixed   $value Value to update.
+	 * @param mixed    $value Value to update.
 	 * @param \WP_Post $object Object to update on.
 	 *
 	 * @return true|WP_Error

--- a/includes/Media.php
+++ b/includes/Media.php
@@ -296,11 +296,18 @@ class Media {
 	/**
 	 * Update rest field callback.
 	 *
-	 * @param mixed   $value Value to update.
-	 * @param WP_Post $object Object to update on.
+	 * @param mixed    $value Value to update.
+	 * @param \WP_Post $object Object to update on.
+	 *
+	 * @return true|\WP_Error
 	 */
 	public function update_callback_media_source( $value, $object ) {
-		wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );
+		$check = wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/Media.php
+++ b/includes/Media.php
@@ -298,9 +298,16 @@ class Media {
 	 *
 	 * @param mixed   $value Value to update.
 	 * @param \WP_Post $object Object to update on.
+	 *
+	 * @return true|WP_Error
 	 */
 	public static function update_callback_media_source( $value, $object ) {
-		wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );
+		$check = wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/Media.php
+++ b/includes/Media.php
@@ -98,7 +98,7 @@ class Media {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public function init() {
 
 		register_taxonomy(
 			self::STORY_MEDIA_TAXONOMY,
@@ -149,15 +149,15 @@ class Media {
 
 		add_image_size( self::STORY_THUMBNAIL_IMAGE_SIZE, 150, 9999, false );
 
-		add_action( 'pre_get_posts', [ __CLASS__, 'filter_poster_attachments' ] );
+		add_action( 'pre_get_posts', [ $this, 'filter_poster_attachments' ] );
 
-		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
+		add_action( 'rest_api_init', [ $this, 'rest_api_init' ] );
 
-		add_filter( 'wp_prepare_attachment_for_js', [ __CLASS__, 'wp_prepare_attachment_for_js' ], 10, 2 );
+		add_filter( 'wp_prepare_attachment_for_js', [ $this, 'wp_prepare_attachment_for_js' ], 10, 2 );
 
-		add_filter( 'upload_mimes', [ __CLASS__, 'upload_mimes' ] ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
+		add_filter( 'upload_mimes', [ $this, 'upload_mimes' ] ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
 
-		add_action( 'delete_attachment', [ __CLASS__, 'delete_video_poster' ] );
+		add_action( 'delete_attachment', [ $this, 'delete_video_poster' ] );
 	}
 
 	/**
@@ -168,7 +168,7 @@ class Media {
 	 * @param int|\WP_Post|null $post Post.
 	 * @return string[] Images.
 	 */
-	public static function get_story_meta_images( $post = null ) {
+	public function get_story_meta_images( $post = null ) {
 		$thumbnail_id = (int) get_post_thumbnail_id( $post );
 
 		if ( 0 === $thumbnail_id ) {
@@ -192,7 +192,7 @@ class Media {
 	 * @param \WP_Query $query WP_Query instance, passed by reference.
 	 * @return void
 	 */
-	public static function filter_poster_attachments( &$query ) {
+	public function filter_poster_attachments( &$query ) {
 		$post_type = (array) $query->get( 'post_type' );
 
 		if ( ! in_array( 'any', $post_type, true ) && ! in_array( 'attachment', $post_type, true ) ) {
@@ -214,7 +214,7 @@ class Media {
 	 *
 	 * @return void
 	 */
-	public static function rest_api_init() {
+	public function rest_api_init() {
 		register_rest_field(
 			'attachment',
 			'featured_media',
@@ -233,14 +233,14 @@ class Media {
 			'media_source',
 			[
 
-				'get_callback'    => [ __CLASS__, 'get_callback_media_source' ],
+				'get_callback'    => [ $this, 'get_callback_media_source' ],
 				'schema'          => [
 					'description' => __( 'Media source. ', 'web-stories' ),
 					'type'        => 'string',
 					'enum'        => [ 'editor' ],
 					'context'     => [ 'view', 'edit', 'embed' ],
 				],
-				'update_callback' => [ __CLASS__, 'update_callback_media_source' ],
+				'update_callback' => [ $this, 'update_callback_media_source' ],
 			]
 		);
 
@@ -248,7 +248,7 @@ class Media {
 			'attachment',
 			'featured_media_src',
 			[
-				'get_callback' => [ __CLASS__, 'get_callback_featured_media_src' ],
+				'get_callback' => [ $this, 'get_callback_featured_media_src' ],
 				'schema'       => [
 					'description' => __( 'URL, width and height.', 'web-stories' ),
 					'type'        => 'object',
@@ -280,7 +280,7 @@ class Media {
 	 *
 	 * @return string
 	 */
-	public static function get_callback_media_source( $prepared ) {
+	public function get_callback_media_source( $prepared ) {
 		$id = $prepared['id'];
 
 		$terms = wp_get_object_terms( $id, self::STORY_MEDIA_TAXONOMY );
@@ -296,18 +296,11 @@ class Media {
 	/**
 	 * Update rest field callback.
 	 *
-	 * @param mixed    $value Value to update.
-	 * @param \WP_Post $object Object to update on.
-	 *
-	 * @return true|\WP_Error
+	 * @param mixed   $value Value to update.
+	 * @param WP_Post $object Object to update on.
 	 */
-	public static function update_callback_media_source( $value, $object ) {
-		$check = wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );
-		if ( is_wp_error( $check ) ) {
-			return $check;
-		}
-
-		return true;
+	public function update_callback_media_source( $value, $object ) {
+		wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );
 	}
 
 	/**
@@ -317,7 +310,7 @@ class Media {
 	 *
 	 * @return array
 	 */
-	public static function get_callback_featured_media_src( $prepared ) {
+	public function get_callback_featured_media_src( $prepared ) {
 		$id    = $prepared['featured_media'];
 		$image = [];
 		if ( $id ) {
@@ -335,7 +328,7 @@ class Media {
 	 *
 	 * @return array $response;
 	 */
-	public static function wp_prepare_attachment_for_js( $response, $attachment ) {
+	public function wp_prepare_attachment_for_js( $response, $attachment ) {
 		if ( 'video' === $response['type'] ) {
 			$thumbnail_id = (int) get_post_thumbnail_id( $attachment );
 			$image        = '';
@@ -356,7 +349,7 @@ class Media {
 	 *
 	 * @return array
 	 */
-	public static function get_thumbnail_data( $thumbnail_id ) {
+	public function get_thumbnail_data( $thumbnail_id ) {
 		$img_src                       = wp_get_attachment_image_src( $thumbnail_id, 'full' );
 		list ( $src, $width, $height ) = $img_src;
 		$generated                     = (bool) get_post_meta( $thumbnail_id, self::POSTER_POST_META_KEY, true );
@@ -370,7 +363,7 @@ class Media {
 	 *
 	 * @return string[]
 	 */
-	public static function upload_mimes( array $mime_types ) {
+	public function upload_mimes( array $mime_types ) {
 		$mime_types['svg'] = 'image/svg+xml';
 		return $mime_types;
 	}
@@ -385,7 +378,7 @@ class Media {
 	 *
 	 * @return void
 	 */
-	public static function delete_video_poster( $attachment_id ) {
+	public function delete_video_poster( $attachment_id ) {
 		$post_id = get_post_meta( $attachment_id, self::POSTER_ID_POST_META_KEY, true );
 
 		if ( empty( $post_id ) ) {
@@ -405,7 +398,7 @@ class Media {
 	 *
 	 * @return array List of allowed file types.
 	 */
-	public static function get_allowed_file_types() {
+	public function get_allowed_file_types() {
 		$allowed_mime_types = self::get_allowed_mime_types();
 		$mime_types         = [];
 
@@ -434,7 +427,7 @@ class Media {
 	 *
 	 * @return array List of allowed mime types.
 	 */
-	public static function get_allowed_mime_types() {
+	public function get_allowed_mime_types() {
 		$default_allowed_mime_types = [
 			'image' => [
 				'image/png',

--- a/includes/Media.php
+++ b/includes/Media.php
@@ -321,7 +321,7 @@ class Media {
 		$id    = $prepared['featured_media'];
 		$image = [];
 		if ( $id ) {
-			$image = self::get_thumbnail_data( $id );
+			$image = $this->get_thumbnail_data( $id );
 		}
 
 		return $image;
@@ -340,7 +340,7 @@ class Media {
 			$thumbnail_id = (int) get_post_thumbnail_id( $attachment );
 			$image        = '';
 			if ( 0 !== $thumbnail_id ) {
-				$image = self::get_thumbnail_data( $thumbnail_id );
+				$image = $this->get_thumbnail_data( $thumbnail_id );
 			}
 			$response['featured_media']     = $thumbnail_id;
 			$response['featured_media_src'] = $image;
@@ -406,7 +406,7 @@ class Media {
 	 * @return array List of allowed file types.
 	 */
 	public function get_allowed_file_types() {
-		$allowed_mime_types = self::get_allowed_mime_types();
+		$allowed_mime_types = $this->get_allowed_mime_types();
 		$mime_types         = [];
 
 		foreach ( $allowed_mime_types as $mimes ) {

--- a/includes/Media.php
+++ b/includes/Media.php
@@ -299,7 +299,7 @@ class Media {
 	 * @param mixed    $value Value to update.
 	 * @param \WP_Post $object Object to update on.
 	 *
-	 * @return true|WP_Error
+	 * @return true|\WP_Error
 	 */
 	public static function update_callback_media_source( $value, $object ) {
 		$check = wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );

--- a/includes/Media.php
+++ b/includes/Media.php
@@ -297,7 +297,7 @@ class Media {
 	 * Update rest field callback.
 	 *
 	 * @param mixed   $value Value to update.
-	 * @param WP_Post $object Object to update on.
+	 * @param \WP_Post $object Object to update on.
 	 */
 	public static function update_callback_media_source( $value, $object ) {
 		wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );

--- a/includes/Media.php
+++ b/includes/Media.php
@@ -98,7 +98,7 @@ class Media {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public function init() {
 
 		register_taxonomy(
 			self::STORY_MEDIA_TAXONOMY,
@@ -149,15 +149,15 @@ class Media {
 
 		add_image_size( self::STORY_THUMBNAIL_IMAGE_SIZE, 150, 9999, false );
 
-		add_action( 'pre_get_posts', [ __CLASS__, 'filter_poster_attachments' ] );
+		add_action( 'pre_get_posts', [ $this, 'filter_poster_attachments' ] );
 
-		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
+		add_action( 'rest_api_init', [ $this, 'rest_api_init' ] );
 
-		add_filter( 'wp_prepare_attachment_for_js', [ __CLASS__, 'wp_prepare_attachment_for_js' ], 10, 2 );
+		add_filter( 'wp_prepare_attachment_for_js', [ $this, 'wp_prepare_attachment_for_js' ], 10, 2 );
 
-		add_filter( 'upload_mimes', [ __CLASS__, 'upload_mimes' ] ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
+		add_filter( 'upload_mimes', [ $this, 'upload_mimes' ] ); // phpcs:ignore WordPressVIPMinimum.Hooks.RestrictedHooks.upload_mimes
 
-		add_action( 'delete_attachment', [ __CLASS__, 'delete_video_poster' ] );
+		add_action( 'delete_attachment', [ $this, 'delete_video_poster' ] );
 	}
 
 	/**
@@ -168,7 +168,7 @@ class Media {
 	 * @param int|\WP_Post|null $post Post.
 	 * @return string[] Images.
 	 */
-	public static function get_story_meta_images( $post = null ) {
+	public function get_story_meta_images( $post = null ) {
 		$thumbnail_id = (int) get_post_thumbnail_id( $post );
 
 		if ( 0 === $thumbnail_id ) {
@@ -192,7 +192,7 @@ class Media {
 	 * @param \WP_Query $query WP_Query instance, passed by reference.
 	 * @return void
 	 */
-	public static function filter_poster_attachments( &$query ) {
+	public function filter_poster_attachments( &$query ) {
 		$post_type = (array) $query->get( 'post_type' );
 
 		if ( ! in_array( 'any', $post_type, true ) && ! in_array( 'attachment', $post_type, true ) ) {
@@ -214,7 +214,7 @@ class Media {
 	 *
 	 * @return void
 	 */
-	public static function rest_api_init() {
+	public function rest_api_init() {
 		register_rest_field(
 			'attachment',
 			'featured_media',
@@ -233,14 +233,14 @@ class Media {
 			'media_source',
 			[
 
-				'get_callback'    => [ __CLASS__, 'get_callback_media_source' ],
+				'get_callback'    => [ $this, 'get_callback_media_source' ],
 				'schema'          => [
 					'description' => __( 'Media source. ', 'web-stories' ),
 					'type'        => 'string',
 					'enum'        => [ 'editor' ],
 					'context'     => [ 'view', 'edit', 'embed' ],
 				],
-				'update_callback' => [ __CLASS__, 'update_callback_media_source' ],
+				'update_callback' => [ $this, 'update_callback_media_source' ],
 			]
 		);
 
@@ -248,7 +248,7 @@ class Media {
 			'attachment',
 			'featured_media_src',
 			[
-				'get_callback' => [ __CLASS__, 'get_callback_featured_media_src' ],
+				'get_callback' => [ $this, 'get_callback_featured_media_src' ],
 				'schema'       => [
 					'description' => __( 'URL, width and height.', 'web-stories' ),
 					'type'        => 'object',
@@ -280,7 +280,7 @@ class Media {
 	 *
 	 * @return string
 	 */
-	public static function get_callback_media_source( $prepared ) {
+	public function get_callback_media_source( $prepared ) {
 		$id = $prepared['id'];
 
 		$terms = wp_get_object_terms( $id, self::STORY_MEDIA_TAXONOMY );
@@ -299,7 +299,7 @@ class Media {
 	 * @param mixed   $value Value to update.
 	 * @param WP_Post $object Object to update on.
 	 */
-	public static function update_callback_media_source( $value, $object ) {
+	public function update_callback_media_source( $value, $object ) {
 		wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );
 	}
 
@@ -310,7 +310,7 @@ class Media {
 	 *
 	 * @return array
 	 */
-	public static function get_callback_featured_media_src( $prepared ) {
+	public function get_callback_featured_media_src( $prepared ) {
 		$id    = $prepared['featured_media'];
 		$image = [];
 		if ( $id ) {
@@ -328,7 +328,7 @@ class Media {
 	 *
 	 * @return array $response;
 	 */
-	public static function wp_prepare_attachment_for_js( $response, $attachment ) {
+	public function wp_prepare_attachment_for_js( $response, $attachment ) {
 		if ( 'video' === $response['type'] ) {
 			$thumbnail_id = (int) get_post_thumbnail_id( $attachment );
 			$image        = '';
@@ -349,7 +349,7 @@ class Media {
 	 *
 	 * @return array
 	 */
-	public static function get_thumbnail_data( $thumbnail_id ) {
+	public function get_thumbnail_data( $thumbnail_id ) {
 		$img_src                       = wp_get_attachment_image_src( $thumbnail_id, 'full' );
 		list ( $src, $width, $height ) = $img_src;
 		$generated                     = (bool) get_post_meta( $thumbnail_id, self::POSTER_POST_META_KEY, true );
@@ -363,7 +363,7 @@ class Media {
 	 *
 	 * @return string[]
 	 */
-	public static function upload_mimes( array $mime_types ) {
+	public function upload_mimes( array $mime_types ) {
 		$mime_types['svg'] = 'image/svg+xml';
 		return $mime_types;
 	}
@@ -378,7 +378,7 @@ class Media {
 	 *
 	 * @return void
 	 */
-	public static function delete_video_poster( $attachment_id ) {
+	public function delete_video_poster( $attachment_id ) {
 		$post_id = get_post_meta( $attachment_id, self::POSTER_ID_POST_META_KEY, true );
 
 		if ( empty( $post_id ) ) {
@@ -398,7 +398,7 @@ class Media {
 	 *
 	 * @return array List of allowed file types.
 	 */
-	public static function get_allowed_file_types() {
+	public function get_allowed_file_types() {
 		$allowed_mime_types = self::get_allowed_mime_types();
 		$mime_types         = [];
 
@@ -427,7 +427,7 @@ class Media {
 	 *
 	 * @return array List of allowed mime types.
 	 */
-	public static function get_allowed_mime_types() {
+	public function get_allowed_mime_types() {
 		$default_allowed_mime_types = [
 			'image' => [
 				'image/png',

--- a/includes/Media.php
+++ b/includes/Media.php
@@ -232,27 +232,15 @@ class Media {
 			'attachment',
 			'media_source',
 			[
+
+				'get_callback'    => [ __CLASS__, 'get_callback_media_source' ],
 				'schema'          => [
 					'description' => __( 'Media source. ', 'web-stories' ),
 					'type'        => 'string',
 					'enum'        => [ 'editor' ],
 					'context'     => [ 'view', 'edit', 'embed' ],
 				],
-				'get_callback'    => static function ( $prepared ) {
-					$id = $prepared['id'];
-
-					$terms = wp_get_object_terms( $id, self::STORY_MEDIA_TAXONOMY );
-					if ( is_array( $terms ) && $terms ) {
-						$term = array_shift( $terms );
-
-						return $term->slug;
-					}
-
-					return '';
-				},
-				'update_callback' => static function ( $value, $object ) {
-					wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );
-				},
+				'update_callback' => [ __CLASS__, 'update_callback_media_source' ],
 			]
 		);
 
@@ -260,16 +248,7 @@ class Media {
 			'attachment',
 			'featured_media_src',
 			[
-				'get_callback' => static function ( $prepared ) {
-
-					$id    = $prepared['featured_media'];
-					$image = [];
-					if ( $id ) {
-						$image = self::get_thumbnail_data( $id );
-					}
-
-					return $image;
-				},
+				'get_callback' => [ __CLASS__, 'get_callback_featured_media_src' ],
 				'schema'       => [
 					'description' => __( 'URL, width and height.', 'web-stories' ),
 					'type'        => 'object',
@@ -292,6 +271,53 @@ class Media {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Force media attachment as string instead of the default array.
+	 *
+	 * @param array $prepared Prepared data before response.
+	 *
+	 * @return string
+	 */
+	public static function get_callback_media_source( $prepared ) {
+		$id = $prepared['id'];
+
+		$terms = wp_get_object_terms( $id, self::STORY_MEDIA_TAXONOMY );
+		if ( is_array( $terms ) && $terms ) {
+			$term = array_shift( $terms );
+
+			return $term->slug;
+		}
+
+		return '';
+	}
+
+	/**
+	 * Update rest field callback.
+	 *
+	 * @param mixed   $value Value to update.
+	 * @param WP_Post $object Object to update on.
+	 */
+	public static function update_callback_media_source( $value, $object ) {
+		wp_set_object_terms( $object->ID, $value, self::STORY_MEDIA_TAXONOMY );
+	}
+
+	/**
+	 * Get attachment source for featured media.
+	 *
+	 * @param array $prepared Prepared data before response.
+	 *
+	 * @return array
+	 */
+	public static function get_callback_featured_media_src( $prepared ) {
+		$id    = $prepared['featured_media'];
+		$image = [];
+		if ( $id ) {
+			$image = self::get_thumbnail_data( $id );
+		}
+
+		return $image;
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -44,9 +44,14 @@ class Plugin {
 	 * @return void
 	 */
 	public function register() {
-		add_action( 'init', [ Media::class, 'init' ], 9 );
-		add_action( 'init', [ Story_Post_Type::class, 'init' ] );
-		add_action( 'init', [ Template_Post_Type::class, 'init' ] );
+		$media = new Media();
+		add_action( 'init', [ $media, 'init' ], 9 );
+
+		$story = new Story_Post_Type();
+		add_action( 'init', [ $story, 'init' ] );
+
+		$template = new Template_Post_Type();
+		add_action( 'init', [ $template, 'init' ] );
 
 		// Beta version updater.
 		$updater = new Updater();

--- a/includes/REST_API/Fonts_Controller.php
+++ b/includes/REST_API/Fonts_Controller.php
@@ -79,9 +79,9 @@ class Fonts_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$font        = new Fonts();
-		$fonts       = $font->get_fonts();
-		$total_fonts = count( $fonts );
+		$fonts       = new Fonts();
+		$fonts_list  = $fonts->get_fonts();
+		$total_fonts = count( $fonts_list );
 		$page        = $request['page'];
 		$per_page    = $request['per_page'];
 		$max_pages   = ceil( $total_fonts / (int) $per_page );
@@ -90,10 +90,10 @@ class Fonts_Controller extends WP_REST_Controller {
 			return new WP_Error( 'rest_post_invalid_page_number', __( 'The page number requested is larger than the number of pages available.', 'web-stories' ), [ 'status' => 400 ] );
 		}
 
-		$fonts = array_slice( $fonts, ( ( $page - 1 ) * $per_page ), $per_page );
+		$fonts_list = array_slice( $fonts_list, ( ( $page - 1 ) * $per_page ), $per_page );
 
 		$formatted_fonts = [];
-		foreach ( $fonts as $font ) {
+		foreach ( $fonts_list as $font ) {
 			$data              = $this->prepare_item_for_response( $font, $request );
 			$formatted_fonts[] = $this->prepare_response_for_collection( $data );
 		}

--- a/includes/REST_API/Fonts_Controller.php
+++ b/includes/REST_API/Fonts_Controller.php
@@ -79,7 +79,8 @@ class Fonts_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		$fonts       = Fonts::get_fonts();
+		$font        = new Fonts();
+		$fonts       = $font->get_fonts();
 		$total_fonts = count( $fonts );
 		$page        = $request['page'];
 		$per_page    = $request['per_page'];

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -49,8 +49,6 @@ class Stories_Controller extends Stories_Base_Controller {
 		'textStyles' => [],
 	];
 
-	const PUBLISHER_LOGOS_OPTION = 'web_stories_publisher_logos';
-
 	/**
 	 * Prepares a single story output for response. Add post_content_filtered field to output.
 	 *
@@ -110,9 +108,9 @@ class Stories_Controller extends Stories_Base_Controller {
 			$publisher_logo_id = $request->get_param( 'publisher_logo' );
 			if ( $publisher_logo_id ) {
 				// @todo This option can keep track of all available publisher logo IDs in the future, thus the array.
-				$publisher_logo_settings           = get_option( self::PUBLISHER_LOGOS_OPTION, [] );
+				$publisher_logo_settings           = get_option( Discovery::PUBLISHER_LOGOS_OPTION, [] );
 				$publisher_logo_settings['active'] = $publisher_logo_id;
-				update_option( self::PUBLISHER_LOGOS_OPTION, $publisher_logo_settings, false );
+				update_option( Discovery::PUBLISHER_LOGOS_OPTION, $publisher_logo_settings, false );
 			}
 
 			// If style presets are set.

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -38,7 +38,6 @@ use WP_REST_Response;
  * Stories_Controller class.
  */
 class Stories_Controller extends Stories_Base_Controller {
-	const STYLE_PRESETS_OPTION = 'web_stories_style_presets';
 
 	/**
 	 * Default style presets to pass if not set.
@@ -68,7 +67,7 @@ class Stories_Controller extends Stories_Base_Controller {
 		}
 
 		if ( in_array( 'style_presets', $fields, true ) ) {
-			$style_presets         = get_option( self::STYLE_PRESETS_OPTION, self::EMPTY_STYLE_PRESETS );
+			$style_presets         = get_option( Story_Post_Type::STYLE_PRESETS_OPTION, self::EMPTY_STYLE_PRESETS );
 			$data['style_presets'] = is_array( $style_presets ) ? $style_presets : self::EMPTY_STYLE_PRESETS;
 		}
 
@@ -116,7 +115,7 @@ class Stories_Controller extends Stories_Base_Controller {
 			// If style presets are set.
 			$style_presets = $request->get_param( 'style_presets' );
 			if ( is_array( $style_presets ) ) {
-				update_option( self::STYLE_PRESETS_OPTION, $style_presets );
+				update_option( Story_Post_Type::STYLE_PRESETS_OPTION, $style_presets );
 			}
 		}
 		return rest_ensure_response( $response );

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -65,7 +65,7 @@ class Stories_Controller extends Stories_Base_Controller {
 		$data     = $response->get_data();
 
 		if ( in_array( 'publisher_logo_url', $fields, true ) ) {
-			$discovery = new Discovery();
+			$discovery                  = new Discovery();
 			$data['publisher_logo_url'] = $discovery->get_publisher_logo();
 		}
 

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -65,7 +65,8 @@ class Stories_Controller extends Stories_Base_Controller {
 		$data     = $response->get_data();
 
 		if ( in_array( 'publisher_logo_url', $fields, true ) ) {
-			$data['publisher_logo_url'] = Discovery::get_publisher_logo();
+			$discovery = new Discovery();
+			$data['publisher_logo_url'] = $discovery->get_publisher_logo();
 		}
 
 		if ( in_array( 'style_presets', $fields, true ) ) {

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -133,11 +133,11 @@ class Story_Post_Type {
 			]
 		);
 
-
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 		add_filter( 'show_admin_bar', [ $this, 'show_admin_bar' ] ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 		add_filter( 'replace_editor', [ $this, 'replace_editor' ], 10, 2 );
 		add_filter( 'use_block_editor_for_post_type', [ $this, 'filter_use_block_editor_for_post_type' ], 10, 2 );
+
 
 		add_filter( 'rest_' . self::POST_TYPE_SLUG . '_collection_params', [ $this, 'filter_rest_collection_params' ], 10, 2 );
 

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -62,7 +62,12 @@ class Story_Post_Type {
 	 */
 	const REWRITE_SLUG = 'stories';
 
-
+	/**
+	 * Style Present options name.
+	 *
+	 * @var string
+	 */
+	const STYLE_PRESETS_OPTION = 'web_stories_style_presets';
 	/**
 	 * Registers the post type for stories.
 	 *

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -159,7 +159,7 @@ class Story_Post_Type {
 	 *
 	 * @return bool
 	 */
-	public static function skip_amp( $skipped, $post ) {
+	public function skip_amp( $skipped, $post ) {
 		if ( self::POST_TYPE_SLUG === get_post_type( $post ) ) {
 			$skipped = true;
 		}
@@ -173,7 +173,7 @@ class Story_Post_Type {
 	 * @param \WP_Post_Type $post_type Post type.
 	 * @return array Array of query params.
 	 */
-	public static function filter_rest_collection_params( $query_params, $post_type ) {
+	public function filter_rest_collection_params( $query_params, $post_type ) {
 		if ( self::POST_TYPE_SLUG !== $post_type->name ) {
 			return $query_params;
 		}
@@ -192,7 +192,7 @@ class Story_Post_Type {
 	 * @param array $story Story post array.
 	 * @return array Array of allowed fields.
 	 */
-	public static function filter_revision_fields( $fields, $story ) {
+	public function filter_revision_fields( $fields, $story ) {
 		if ( self::POST_TYPE_SLUG === $story['post_type'] ) {
 			$fields['post_content_filtered'] = __( 'Story data', 'web-stories' );
 		}
@@ -206,7 +206,7 @@ class Story_Post_Type {
 	 *
 	 * @return bool
 	 */
-	public static function show_admin_bar( $show ) {
+	public function show_admin_bar( $show ) {
 		if ( is_singular( self::POST_TYPE_SLUG ) ) {
 			$show = false;
 		}
@@ -222,7 +222,7 @@ class Story_Post_Type {
 	 *
 	 * @return bool
 	 */
-	public static function replace_editor( $replace, $post ) {
+	public function replace_editor( $replace, $post ) {
 		if ( self::POST_TYPE_SLUG === get_post_type( $post ) ) {
 			$replace = true;
 			// In lieu of an action being available to actually load the replacement editor, include it here
@@ -261,7 +261,7 @@ class Story_Post_Type {
 	 *
 	 * @return void
 	 */
-	public static function admin_enqueue_scripts( $hook ) {
+	public function admin_enqueue_scripts( $hook ) {
 		$screen = get_current_screen();
 
 		if ( ! $screen instanceof WP_Screen ) {
@@ -329,7 +329,7 @@ class Story_Post_Type {
 	 *
 	 * @return array
 	 */
-	public static function get_editor_settings() {
+	public function get_editor_settings() {
 		$post                     = get_post();
 		$story_id                 = ( $post ) ? $post->ID : null;
 		$rest_base                = self::POST_TYPE_SLUG;
@@ -478,7 +478,7 @@ class Story_Post_Type {
 	 *
 	 * @return string Template.
 	 */
-	public static function filter_template_include( $template ) {
+	public function filter_template_include( $template ) {
 		if ( is_singular( self::POST_TYPE_SLUG ) && ! is_embed() ) {
 			$template = WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/single-web-story.php';
 		}

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -361,7 +361,7 @@ class Story_Post_Type {
 		];
 
 		$discovery = new Discovery();
-		$media = new Media();
+		$media     = new Media();
 
 		$settings = [
 			'id'     => 'edit-story',

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -62,14 +62,6 @@ class Story_Post_Type {
 	 */
 	const REWRITE_SLUG = 'stories';
 
-	/**
-	 * Publisher logo placeholder for static content output which will be replaced server-side.
-	 *
-	 * Uses a fallback logo to always create valid AMP in FE.
-	 *
-	 * @var string
-	 */
-	const PUBLISHER_LOGO_PLACEHOLDER = WEBSTORIES_PLUGIN_DIR_URL . 'assets/images/fallback-wordpress-publisher-logo.png';
 
 	/**
 	 * Registers the post type for stories.
@@ -389,7 +381,7 @@ class Story_Post_Type {
 				],
 				'metadata'         => [
 					'publisher'       => $discovery->get_publisher_data(),
-					'logoPlaceholder' => self::PUBLISHER_LOGO_PLACEHOLDER,
+					'logoPlaceholder' => $discovery->get_publisher_logo_placeholder(),
 					'fallbackPoster'  => plugins_url( 'assets/images/fallback-poster.jpg', WEBSTORIES_PLUGIN_FILE ),
 				],
 			],

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -136,6 +136,8 @@ class Story_Post_Type {
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 		add_filter( 'show_admin_bar', [ $this, 'show_admin_bar' ] ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 		add_filter( 'replace_editor', [ $this, 'replace_editor' ], 10, 2 );
+		add_filter( 'use_block_editor_for_post_type', [ $this, 'filter_use_block_editor_for_post_type' ], 10, 2 );
+
 
 		add_filter( 'rest_' . self::POST_TYPE_SLUG . '_collection_params', [ $this, 'filter_rest_collection_params' ], 10, 2 );
 
@@ -231,6 +233,24 @@ class Story_Post_Type {
 		}
 
 		return $replace;
+	}
+
+	/**
+	 * Filters whether post type supports the block editor.
+	 *
+	 * Disables the block editor and associated logic (like enqueueing assets)
+	 * for the story post type.
+	 *
+	 * @param bool   $use_block_editor  Whether the post type can be edited or not. Default true.
+	 * @param string $post_type         The post type being checked.
+	 * @return bool Whether to use the block editor.
+	 */
+	public function filter_use_block_editor_for_post_type( $use_block_editor, $post_type ) {
+		if ( self::POST_TYPE_SLUG === $post_type ) {
+			return false;
+		}
+
+		return $use_block_editor;
 	}
 
 	/**

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -78,7 +78,7 @@ class Story_Post_Type {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public function init() {
 		register_post_type(
 			self::POST_TYPE_SLUG,
 			[
@@ -133,19 +133,20 @@ class Story_Post_Type {
 			]
 		);
 
-		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_enqueue_scripts' ] );
-		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ] ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
-		add_filter( 'replace_editor', [ __CLASS__, 'replace_editor' ], 10, 2 );
-		add_filter( 'use_block_editor_for_post_type', [ __CLASS__, 'filter_use_block_editor_for_post_type' ], 10, 2 );
 
-		add_filter( 'rest_' . self::POST_TYPE_SLUG . '_collection_params', [ __CLASS__, 'filter_rest_collection_params' ], 10, 2 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
+		add_filter( 'show_admin_bar', [ $this, 'show_admin_bar' ] ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+		add_filter( 'replace_editor', [ $this, 'replace_editor' ], 10, 2 );
+		add_filter( 'use_block_editor_for_post_type', [ $this, 'filter_use_block_editor_for_post_type' ], 10, 2 );
+
+		add_filter( 'rest_' . self::POST_TYPE_SLUG . '_collection_params', [ $this, 'filter_rest_collection_params' ], 10, 2 );
 
 		// Select the single-web-story.php template for Stories.
-		add_filter( 'template_include', [ __CLASS__, 'filter_template_include' ] );
+		add_filter( 'template_include', [ $this, 'filter_template_include' ] );
 
-		add_filter( 'amp_skip_post', [ __CLASS__, 'skip_amp' ], PHP_INT_MAX, 2 );
+		add_filter( 'amp_skip_post', [ $this, 'skip_amp' ], PHP_INT_MAX, 2 );
 
-		add_filter( '_wp_post_revision_fields', [ __CLASS__, 'filter_revision_fields' ], 10, 2 );
+		add_filter( '_wp_post_revision_fields', [ $this, 'filter_revision_fields' ], 10, 2 );
 	}
 
 	/**
@@ -244,7 +245,7 @@ class Story_Post_Type {
 	 * @param string $post_type         The post type being checked.
 	 * @return bool Whether to use the block editor.
 	 */
-	public static function filter_use_block_editor_for_post_type( $use_block_editor, $post_type ) {
+	public function filter_use_block_editor_for_post_type( $use_block_editor, $post_type ) {
 		if ( self::POST_TYPE_SLUG === $post_type ) {
 			return false;
 		}
@@ -359,14 +360,17 @@ class Story_Post_Type {
 			'preview_nonce' => wp_create_nonce( 'post_preview_' . $story_id ),
 		];
 
+		$discovery = new Discovery();
+		$media = new Media();
+
 		$settings = [
 			'id'     => 'edit-story',
 			'config' => [
 				'autoSaveInterval' => defined( 'AUTOSAVE_INTERVAL' ) ? AUTOSAVE_INTERVAL : null,
 				'isRTL'            => is_rtl(),
 				'timeFormat'       => get_option( 'time_format' ),
-				'allowedMimeTypes' => Media::get_allowed_mime_types(),
-				'allowedFileTypes' => Media::get_allowed_file_types(),
+				'allowedMimeTypes' => $media->get_allowed_mime_types(),
+				'allowedFileTypes' => $media->get_allowed_file_types(),
 				'postType'         => self::POST_TYPE_SLUG,
 				'storyId'          => $story_id,
 				'previewLink'      => get_preview_post_link( $story_id, $preview_query_args ),
@@ -384,7 +388,7 @@ class Story_Post_Type {
 					'link'    => '/web-stories/v1/link',
 				],
 				'metadata'         => [
-					'publisher'       => Discovery::get_publisher_data(),
+					'publisher'       => $discovery->get_publisher_data(),
 					'logoPlaceholder' => self::PUBLISHER_LOGO_PLACEHOLDER,
 					'fallbackPoster'  => plugins_url( 'assets/images/fallback-poster.jpg', WEBSTORIES_PLUGIN_FILE ),
 				],

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -292,7 +292,7 @@ class Story_Post_Type {
 
 		wp_set_script_translations( self::WEB_STORIES_SCRIPT_HANDLE, 'web-stories' );
 
-		$settings = self::get_editor_settings();
+		$settings = $this->get_editor_settings();
 
 		wp_localize_script(
 			self::WEB_STORIES_SCRIPT_HANDLE,

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -78,7 +78,7 @@ class Story_Post_Type {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public function init() {
 		register_post_type(
 			self::POST_TYPE_SLUG,
 			[
@@ -133,18 +133,18 @@ class Story_Post_Type {
 			]
 		);
 
-		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_enqueue_scripts' ] );
-		add_filter( 'show_admin_bar', [ __CLASS__, 'show_admin_bar' ] ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
-		add_filter( 'replace_editor', [ __CLASS__, 'replace_editor' ], 10, 2 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
+		add_filter( 'show_admin_bar', [ $this, 'show_admin_bar' ] ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+		add_filter( 'replace_editor', [ $this, 'replace_editor' ], 10, 2 );
 
-		add_filter( 'rest_' . self::POST_TYPE_SLUG . '_collection_params', [ __CLASS__, 'filter_rest_collection_params' ], 10, 2 );
+		add_filter( 'rest_' . self::POST_TYPE_SLUG . '_collection_params', [ $this, 'filter_rest_collection_params' ], 10, 2 );
 
 		// Select the single-web-story.php template for Stories.
-		add_filter( 'template_include', [ __CLASS__, 'filter_template_include' ] );
+		add_filter( 'template_include', [ $this, 'filter_template_include' ] );
 
-		add_filter( 'amp_skip_post', [ __CLASS__, 'skip_amp' ], PHP_INT_MAX, 2 );
+		add_filter( 'amp_skip_post', [ $this, 'skip_amp' ], PHP_INT_MAX, 2 );
 
-		add_filter( '_wp_post_revision_fields', [ __CLASS__, 'filter_revision_fields' ], 10, 2 );
+		add_filter( '_wp_post_revision_fields', [ $this, 'filter_revision_fields' ], 10, 2 );
 	}
 
 	/**
@@ -340,14 +340,17 @@ class Story_Post_Type {
 			'preview_nonce' => wp_create_nonce( 'post_preview_' . $story_id ),
 		];
 
+		$discovery = new Discovery();
+		$media = new Media();
+
 		$settings = [
 			'id'     => 'edit-story',
 			'config' => [
 				'autoSaveInterval' => defined( 'AUTOSAVE_INTERVAL' ) ? AUTOSAVE_INTERVAL : null,
 				'isRTL'            => is_rtl(),
 				'timeFormat'       => get_option( 'time_format' ),
-				'allowedMimeTypes' => Media::get_allowed_mime_types(),
-				'allowedFileTypes' => Media::get_allowed_file_types(),
+				'allowedMimeTypes' => $media->get_allowed_mime_types(),
+				'allowedFileTypes' => $media->get_allowed_file_types(),
 				'postType'         => self::POST_TYPE_SLUG,
 				'storyId'          => $story_id,
 				'previewLink'      => get_preview_post_link( $story_id, $preview_query_args ),
@@ -365,7 +368,7 @@ class Story_Post_Type {
 					'link'    => '/web-stories/v1/link',
 				],
 				'metadata'         => [
-					'publisher'       => Discovery::get_publisher_data(),
+					'publisher'       => $discovery->get_publisher_data(),
 					'logoPlaceholder' => self::PUBLISHER_LOGO_PLACEHOLDER,
 					'fallbackPoster'  => plugins_url( 'assets/images/fallback-poster.jpg', WEBSTORIES_PLUGIN_FILE ),
 				],

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -142,20 +142,26 @@ class Story_Post_Type {
 		// Select the single-web-story.php template for Stories.
 		add_filter( 'template_include', [ __CLASS__, 'filter_template_include' ] );
 
-		// @todo Improve AMP plugin compatibility, see https://github.com/google/web-stories-wp/issues/967
-		add_filter(
-			'amp_skip_post',
-			static function( $skipped, $post ) {
-				if ( self::POST_TYPE_SLUG === get_post_type( $post ) ) {
-					$skipped = true;
-				}
-				return $skipped;
-			},
-			PHP_INT_MAX,
-			2
-		);
+		add_filter( 'amp_skip_post', [ __CLASS__, 'skip_amp' ], PHP_INT_MAX, 2 );
 
 		add_filter( '_wp_post_revision_fields', [ __CLASS__, 'filter_revision_fields' ], 10, 2 );
+	}
+
+	/**
+	 * AMP plugin compatibility.
+	 *
+	 * @todo Improve AMP plugin compatibility, see https://github.com/google/web-stories-wp/issues/967
+	 *
+	 * @param bool    $skipped Should this post type be skipped.
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return bool
+	 */
+	public static function skip_amp( $skipped, $post ) {
+		if ( self::POST_TYPE_SLUG === get_post_type( $post ) ) {
+			$skipped = true;
+		}
+		return $skipped;
 	}
 
 	/**

--- a/includes/Story_Renderer.php
+++ b/includes/Story_Renderer.php
@@ -120,7 +120,7 @@ class Story_Renderer {
 	 * @return string Filtered markup.
 	 */
 	protected function add_publisher_logo( $content ) {
-		$discovery      = new Discovery();
+		$discovery = new Discovery();
 
 		return str_replace( $discovery->get_publisher_logo_placeholder(), $discovery->get_publisher_logo(), $content );
 	}

--- a/includes/Story_Renderer.php
+++ b/includes/Story_Renderer.php
@@ -120,7 +120,9 @@ class Story_Renderer {
 	 * @return string Filtered markup.
 	 */
 	protected function add_publisher_logo( $content ) {
-		$publisher_logo = Discovery::get_publisher_logo();
+		$discovery = new Discovery();
+		$publisher_logo = $discovery->get_publisher_logo();
+
 		return str_replace( Story_Post_Type::PUBLISHER_LOGO_PLACEHOLDER, $publisher_logo, $content );
 	}
 
@@ -132,7 +134,8 @@ class Story_Renderer {
 	 * @return string Filtered content.
 	 */
 	protected function add_poster_images( $content ) {
-		$poster_images = Media::get_story_meta_images( $this->post );
+		$media = new Media();
+		$poster_images = $media->get_story_meta_images( $this->post );
 
 		unset( $poster_images['poster-portrait'] ); // Already exists.
 

--- a/includes/Story_Renderer.php
+++ b/includes/Story_Renderer.php
@@ -121,9 +121,8 @@ class Story_Renderer {
 	 */
 	protected function add_publisher_logo( $content ) {
 		$discovery      = new Discovery();
-		$publisher_logo = $discovery->get_publisher_logo();
 
-		return str_replace( Story_Post_Type::PUBLISHER_LOGO_PLACEHOLDER, $publisher_logo, $content );
+		return str_replace( $discovery->get_publisher_logo_placeholder(), $discovery->get_publisher_logo(), $content );
 	}
 
 	/**

--- a/includes/Story_Renderer.php
+++ b/includes/Story_Renderer.php
@@ -120,7 +120,7 @@ class Story_Renderer {
 	 * @return string Filtered markup.
 	 */
 	protected function add_publisher_logo( $content ) {
-		$discovery = new Discovery();
+		$discovery      = new Discovery();
 		$publisher_logo = $discovery->get_publisher_logo();
 
 		return str_replace( Story_Post_Type::PUBLISHER_LOGO_PLACEHOLDER, $publisher_logo, $content );
@@ -134,7 +134,7 @@ class Story_Renderer {
 	 * @return string Filtered content.
 	 */
 	protected function add_poster_images( $content ) {
-		$media = new Media();
+		$media         = new Media();
 		$poster_images = $media->get_story_meta_images( $this->post );
 
 		unset( $poster_images['poster-portrait'] ); // Already exists.

--- a/includes/Template_Post_Type.php
+++ b/includes/Template_Post_Type.php
@@ -44,7 +44,7 @@ class Template_Post_Type {
 	 *
 	 * @return void
 	 */
-	public static function init() {
+	public function init() {
 		register_post_type(
 			self::POST_TYPE_SLUG,
 			[

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -46,7 +46,8 @@ function activate( $network_wide ) {
 		);
 	}
 
-	Story_Post_Type::init();
+	$story = new Story_Post_Type();
+	$story->init();
 	if ( ! defined( '\WPCOM_IS_VIP_ENV' ) || false === \WPCOM_IS_VIP_ENV ) {
 		flush_rewrite_rules( false ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
 	}

--- a/tests/phpunit/tests/Database_Upgrader.php
+++ b/tests/phpunit/tests/Database_Upgrader.php
@@ -17,8 +17,6 @@
 
 namespace Google\Web_Stories\Tests;
 
-use Google\Web_Stories\REST_API\Stories_Controller;
-
 class Database_Upgrader extends \WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
@@ -94,12 +92,12 @@ class Database_Upgrader extends \WP_UnitTestCase {
 				$radial_preset,
 			],
 		];
-		add_option( Stories_Controller::STYLE_PRESETS_OPTION, $presets );
+		add_option( \Google\Web_Stories\Story_Post_Type::STYLE_PRESETS_OPTION, $presets );
 
 		$object = new \Google\Web_Stories\Database_Upgrader();
 		$object->init();
 
-		$style_presets = get_option( Stories_Controller::STYLE_PRESETS_OPTION );
+		$style_presets = get_option( \Google\Web_Stories\Story_Post_Type::STYLE_PRESETS_OPTION );
 		$this->assertSame( $style_presets['textStyles'][1], $radial_preset );
 		$this->assertSame( $style_presets['textStyles'][0]['backgroundColor']['type'], 'linear' );
 		$this->assertSame( $style_presets['fillColors'][0]['type'], 'linear' );
@@ -112,7 +110,7 @@ class Database_Upgrader extends \WP_UnitTestCase {
 			]
 		);
 
-		delete_option( Stories_Controller::STYLE_PRESETS_OPTION );
+		delete_option( \Google\Web_Stories\Story_Post_Type::STYLE_PRESETS_OPTION );
 	}
 
 	public function test_remove_broken_text_styles() {
@@ -141,12 +139,12 @@ class Database_Upgrader extends \WP_UnitTestCase {
 			'textColors' => [],
 			'fillColors' => [],
 		];
-		add_option( Stories_Controller::STYLE_PRESETS_OPTION, $presets );
+		add_option( \Google\Web_Stories\Story_Post_Type::STYLE_PRESETS_OPTION, $presets );
 
 		$object = new \Google\Web_Stories\Database_Upgrader();
 		$object->init();
 
-		$style_presets = get_option( Stories_Controller::STYLE_PRESETS_OPTION );
+		$style_presets = get_option( \Google\Web_Stories\Story_Post_Type::STYLE_PRESETS_OPTION );
 		$this->assertSame(
 			$style_presets['textStyles'],
 			[
@@ -164,6 +162,6 @@ class Database_Upgrader extends \WP_UnitTestCase {
 			]
 		);
 
-		delete_option( Stories_Controller::STYLE_PRESETS_OPTION );
+		delete_option( \Google\Web_Stories\Story_Post_Type::STYLE_PRESETS_OPTION );
 	}
 }

--- a/tests/phpunit/tests/Fonts.php
+++ b/tests/phpunit/tests/Fonts.php
@@ -18,8 +18,19 @@
 namespace Google\Web_Stories\Tests;
 
 class Fonts extends \WP_UnitTestCase {
+
+	/**
+	 * Setup.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->fonts = new \Google\Web_Stories\Fonts();
+	}
+
 	public function test_get_fonts() {
-		$fonts = \Google\Web_Stories\Fonts::get_fonts();
+		$fonts = $this->fonts->get_fonts();
 		$this->assertInternalType( 'array', $fonts );
 
 		$arial_font = current(
@@ -74,7 +85,7 @@ class Fonts extends \WP_UnitTestCase {
 			$this->markTestSkipped( 'List of Google Fonts is missing' );
 		}
 
-		$fonts = \Google\Web_Stories\Fonts::get_google_fonts( $fonts_file );
+		$fonts = $this->fonts->get_google_fonts( $fonts_file );
 		$this->assertInternalType( 'array', $fonts );
 
 		$roboto_font = current(

--- a/tests/phpunit/tests/Fonts.php
+++ b/tests/phpunit/tests/Fonts.php
@@ -18,24 +18,14 @@
 namespace Google\Web_Stories\Tests;
 
 class Fonts extends \WP_UnitTestCase {
-
-	/**
-	 * Setup.
-	 *
-	 * @inheritdoc
-	 */
-	public function setUp() {
-		parent::setUp();
-		$this->fonts = new \Google\Web_Stories\Fonts();
-	}
-
 	public function test_get_fonts() {
-		$fonts = $this->fonts->get_fonts();
-		$this->assertInternalType( 'array', $fonts );
+		$fonts     = new \Google\Web_Stories\Fonts();
+		$font_list = $fonts->get_fonts();
+		$this->assertInternalType( 'array', $font_list );
 
 		$arial_font = current(
 			array_filter(
-				$fonts,
+				$font_list,
 				static function ( $font ) {
 					return 'Arial' === $font['family'];
 				}
@@ -44,7 +34,7 @@ class Fonts extends \WP_UnitTestCase {
 
 		$roboto_font = current(
 			array_filter(
-				$fonts,
+				$font_list,
 				static function ( $font ) {
 					return 'Roboto' === $font['family'];
 				}
@@ -84,13 +74,13 @@ class Fonts extends \WP_UnitTestCase {
 		if ( ! file_exists( $fonts_file ) ) {
 			$this->markTestSkipped( 'List of Google Fonts is missing' );
 		}
-
-		$fonts = $this->fonts->get_google_fonts( $fonts_file );
-		$this->assertInternalType( 'array', $fonts );
+		$fonts     = new \Google\Web_Stories\Fonts();
+		$font_list = $fonts->get_google_fonts( $fonts_file );
+		$this->assertInternalType( 'array', $font_list );
 
 		$roboto_font = current(
 			array_filter(
-				$fonts,
+				$font_list,
 				static function ( $font ) {
 					return 'Roboto' === $font['family'];
 				}

--- a/tests/phpunit/tests/Media.php
+++ b/tests/phpunit/tests/Media.php
@@ -79,7 +79,8 @@ class Media extends \WP_UnitTestCase {
 		add_post_meta( $poster_attachment_id, \Google\Web_Stories\Media::POSTER_POST_META_KEY, 'true' );
 		add_post_meta( $video_attachment_id, \Google\Web_Stories\Media::POSTER_ID_POST_META_KEY, $poster_attachment_id );
 
-		\Google\Web_Stories\Media::delete_video_poster( $video_attachment_id );
+		$media = new \Google\Web_Stories\Media();
+		$media->delete_video_poster( $video_attachment_id );
 		$this->assertNull( get_post( $poster_attachment_id ) );
 	}
 
@@ -103,7 +104,8 @@ class Media extends \WP_UnitTestCase {
 		);
 		set_post_thumbnail( $video_attachment_id, $poster_attachment_id );
 
-		\Google\Web_Stories\Media::delete_video_poster( $video_attachment_id );
+		$media = new \Google\Web_Stories\Media();
+		$media->delete_video_poster( $video_attachment_id );
 		$this->assertNotNull( get_post( $poster_attachment_id ) );
 	}
 

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -53,14 +53,14 @@ class Story_Post_Type extends \WP_UnitTestCase {
 	public function test_get_editor_settings_admin() {
 		wp_set_current_user( self::$admin_id );
 		$post_type = new \Google\Web_Stories\Story_Post_Type();
-		$results   = $post_type::get_editor_settings();
+		$results   = $post_type->get_editor_settings();
 		$this->assertTrue( $results['config']['capabilities']['hasUploadMediaAction'] );
 	}
 
 	public function test_get_editor_settings_sub() {
 		wp_set_current_user( self::$subscriber_id );
 		$post_type = new \Google\Web_Stories\Story_Post_Type();
-		$results   = $post_type::get_editor_settings();
+		$results   = $post_type->get_editor_settings();
 		$this->assertFalse( $results['config']['capabilities']['hasUploadMediaAction'] );
 	}
 
@@ -72,8 +72,9 @@ class Story_Post_Type extends \WP_UnitTestCase {
 			],
 		];
 
-		$post_type       = get_post_type_object( \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG );
-		$filtered_params = \Google\Web_Stories\Story_Post_Type::filter_rest_collection_params( $query_params, $post_type );
+		$post_type        = get_post_type_object( \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG );
+		$post_type_object = new \Google\Web_Stories\Story_Post_Type();
+		$filtered_params  = $post_type_object->filter_rest_collection_params( $query_params, $post_type );
 		$this->assertEquals(
 			$filtered_params,
 			[
@@ -95,7 +96,8 @@ class Story_Post_Type extends \WP_UnitTestCase {
 
 		$post_type       = new \stdClass();
 		$post_type->name = 'post';
-		$filtered_params = \Google\Web_Stories\Story_Post_Type::filter_rest_collection_params( $query_params, $post_type );
+		$post_type_object = new \Google\Web_Stories\Story_Post_Type();
+		$filtered_params = $post_type_object->filter_rest_collection_params( $query_params, $post_type );
 		$this->assertEquals( $filtered_params, $query_params );
 	}
 }

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -94,10 +94,10 @@ class Story_Post_Type extends \WP_UnitTestCase {
 			],
 		];
 
-		$post_type       = new \stdClass();
-		$post_type->name = 'post';
+		$post_type        = new \stdClass();
+		$post_type->name  = 'post';
 		$post_type_object = new \Google\Web_Stories\Story_Post_Type();
-		$filtered_params = $post_type_object->filter_rest_collection_params( $query_params, $post_type );
+		$filtered_params  = $post_type_object->filter_rest_collection_params( $query_params, $post_type );
 		$this->assertEquals( $filtered_params, $query_params );
 	}
 }

--- a/tests/phpunit/tests/Story_Renderer.php
+++ b/tests/phpunit/tests/Story_Renderer.php
@@ -17,7 +17,7 @@
 
 namespace Google\Web_Stories\Tests;
 
-use Google\Web_Stories\REST_API\Stories_Controller;
+use Google\Web_Stories\Discovery;
 
 class Story_Renderer extends \WP_UnitTestCase {
 	protected static $user;
@@ -116,7 +116,9 @@ class Story_Renderer extends \WP_UnitTestCase {
 	 * @covers \Google\Web_Stories\Story_Renderer::add_publisher_logo
 	 */
 	public function test_add_publisher_logo() {
-		$placeholder              = \Google\Web_Stories\Story_Post_Type::PUBLISHER_LOGO_PLACEHOLDER;
+		$discovery                = new Discovery();
+		$placeholder              = $discovery->get_publisher_logo_placeholder();
+		$option_name              = Discovery::PUBLISHER_LOGOS_OPTION;
 		$post_with_publisher_logo = self::factory()->post->create_and_get(
 			[
 				'post_content' => '<html><head></head><body><amp-story publisher-logo-src=""' . $placeholder . '"></amp-story></body></html>',
@@ -124,11 +126,11 @@ class Story_Renderer extends \WP_UnitTestCase {
 		);
 
 		$attachment_id = self::factory()->attachment->create_upload_object( __DIR__ . '/../data/attachment.jpg', 0 );
-		add_option( Stories_Controller::PUBLISHER_LOGOS_OPTION, [ 'active' => $attachment_id ] );
+		add_option( $option_name, [ 'active' => $attachment_id ] );
 		$renderer = new \Google\Web_Stories\Story_Renderer( $post_with_publisher_logo );
 		$rendered = $renderer->render();
 
-		delete_option( Stories_Controller::PUBLISHER_LOGOS_OPTION );
+		delete_option( $option_name );
 
 		$this->assertContains( 'attachment', $rendered );
 		$this->assertNotContains( $placeholder, $rendered );


### PR DESCRIPTION
## Summary
Part 2 of 3. 

Relays on https://github.com/google/web-stories-wp/pull/2593 

Remove static methods, to make the code more testable.

## Relevant Technical Choices

Note the following 
Stories_Controller
 - Use discovery class. 

Story_Post_Tpye
- Use discovery class. 
- Use media class. 

Story_Renderer
- Use discovery class. 
- Use media class. 

In these cases, a create a new object using these cases. In the next PR, I will use dependency injection to remove this objects. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
