### PR TITLE
Workspace: Add Tooltips to Carousel + Fix Icon Button display

### DIFF
--- a/assets/src/edit-story/components/button/index.js
+++ b/assets/src/edit-story/components/button/index.js
@@ -45,7 +45,7 @@ const Base = styled.button.attrs(({ isDisabled }) => ({
   border-style: solid;
   border-radius: 2px;
   background: transparent;
-  display: inline-block;
+  display: block;
   min-width: ${({ isIcon }) => (isIcon ? 'initial' : '63px')};
   max-height: 30px;
   padding: 0 10px;
@@ -54,7 +54,6 @@ const Base = styled.button.attrs(({ isDisabled }) => ({
   font-family: ${({ theme }) => theme.fonts.body2.family};
   font-size: ${({ theme }) => theme.fonts.body2.size};
   line-height: 28px;
-  text-decoration: none;
 
   &:active {
     outline: none;

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -60,6 +60,7 @@ import {
 import { PAGE_WIDTH, PAGE_HEIGHT, SCROLLBAR_WIDTH } from '../../../constants';
 
 import useCanvas from '../useCanvas';
+import WithTooltip from '../../tooltip';
 import CompactIndicator from './compactIndicator';
 import useCarouselKeys from './useCarouselKeys';
 
@@ -459,19 +460,33 @@ function Carousel() {
                 />
               </OverflowButtons>
             )}
-            <SafeZoneButton
-              active={showSafeZone}
-              onClick={() => setShowSafeZone((current) => !current)}
-              aria-label={
+            <WithTooltip
+              title={
                 showSafeZone
                   ? __('Disable Safe Zone', 'web-stories')
                   : __('Enable Safe Zone', 'web-stories')
               }
-            />
-            <StyledGridViewButton
-              onClick={openModal}
-              aria-label={__('Grid View', 'web-stories')}
-            />
+            >
+              <SafeZoneButton
+                active={showSafeZone}
+                onClick={() => setShowSafeZone((current) => !current)}
+                aria-label={
+                  showSafeZone
+                    ? __('Disable Safe Zone', 'web-stories')
+                    : __('Enable Safe Zone', 'web-stories')
+                }
+              />
+            </WithTooltip>
+            <WithTooltip
+              title={__('Grid View', 'web-stories')}
+              // onPointerLeave={() => console.log('leave')}
+              // onPointerEnter={() => console.log('enter')}
+            >
+              <StyledGridViewButton
+                onClick={openModal}
+                aria-label={__('Grid View', 'web-stories')}
+              />
+            </WithTooltip>
           </MenuIconsWrapper>
         </MenuArea>
       </Wrapper>

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -466,6 +466,7 @@ function Carousel() {
                   ? __('Disable Safe Zone', 'web-stories')
                   : __('Enable Safe Zone', 'web-stories')
               }
+              placement="left"
             >
               <SafeZoneButton
                 active={showSafeZone}
@@ -479,8 +480,7 @@ function Carousel() {
             </WithTooltip>
             <WithTooltip
               title={__('Grid View', 'web-stories')}
-              // onPointerLeave={() => console.log('leave')}
-              // onPointerEnter={() => console.log('enter')}
+              placement="left"
             >
               <StyledGridViewButton
                 onClick={openModal}


### PR DESCRIPTION
## Summary

Per discussion on #2096 this fixes the display issue with the Carousel buttons and adds tooltips.

## Relevant Technical Choices

Reverted a [change](https://github.com/google/web-stories-wp/commit/97f29fe63f277642f27569abf63b0a0a31e204ef#diff-afde5e2694872f1beb0fc59de477fb11R48) from another PR for the button base class. Additionally wrapped both buttons with the `WithTooltip` component.  

## User-facing changes

Hovering over the buttons in the Carousel should display tool tips and the buttons should now be vertical.

## Testing Instructions

1. Load into the editor
2. Verify the Carousel buttons are vertical
3. Hover both and see the tooltips

#2096 
