### PR TITLE
Dashboard: Display error messages in UI

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -178,9 +178,11 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
           type: STORY_ACTION_TYPES.UPDATE_STORY,
           payload: reshapeStoryObject(editStoryURL)(response),
         });
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e);
+      } catch (err) {
+        dispatch({
+          type: STORY_ACTION_TYPES.UPDATE_STORY_FAILURE,
+          payload: { message: err.message, code: err.code },
+        });
       }
     },
     [storyApi, dataAdapter, editStoryURL]
@@ -196,9 +198,11 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
           type: STORY_ACTION_TYPES.TRASH_STORY,
           payload: { id: story.id, storyStatus: story.status },
         });
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e);
+      } catch (err) {
+        dispatch({
+          type: STORY_ACTION_TYPES.TRASH_STORY_FAILURE,
+          payload: { message: err.message, code: err.code },
+        });
       }
     },
     [storyApi, dataAdapter]
@@ -292,9 +296,11 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
           type: STORY_ACTION_TYPES.DUPLICATE_STORY,
           payload: reshapeStoryObject(editStoryURL)(response),
         });
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.error(e);
+      } catch (err) {
+        dispatch({
+          type: STORY_ACTION_TYPES.DUPLICATE_STORY_FAILURE,
+          payload: { message: err.message, code: err.code },
+        });
       }
     },
     [storyApi, dataAdapter, editStoryURL]

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -105,7 +105,12 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
       if (!storyApi) {
         dispatch({
           type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
-          payload: true,
+          payload: {
+            message: {
+              body: __('Cannot connect to data source', 'web-stories'),
+              title: __('Unable to Load Stories', 'web-stories'),
+            },
+          },
         });
         return;
       }
@@ -156,7 +161,13 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
       } catch (err) {
         dispatch({
           type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
-          payload: { message: err.message, code: err.code },
+          payload: {
+            message: {
+              body: err.message,
+              title: __('Unable to Load Stories', 'web-stories'),
+            },
+            code: err.code,
+          },
         });
       } finally {
         dispatch({
@@ -181,7 +192,13 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
       } catch (err) {
         dispatch({
           type: STORY_ACTION_TYPES.UPDATE_STORY_FAILURE,
-          payload: { message: err.message, code: err.code },
+          payload: {
+            message: {
+              body: err.message,
+              title: __('Unable to Update Story', 'web-stories'),
+            },
+            code: err.code,
+          },
         });
       }
     },
@@ -201,7 +218,13 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
       } catch (err) {
         dispatch({
           type: STORY_ACTION_TYPES.TRASH_STORY_FAILURE,
-          payload: { message: err.message, code: err.code },
+          payload: {
+            message: {
+              body: err.message,
+              title: __('Unable to Delete Story', 'web-stories'),
+            },
+            code: err.code,
+          },
         });
       }
     },
@@ -251,7 +274,13 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
       } catch (err) {
         dispatch({
           type: STORY_ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_FAILURE,
-          payload: { message: err.message, code: err.code },
+          payload: {
+            message: {
+              body: err.message,
+              title: __('Unable to Create Story From Template', 'web-stories'),
+            },
+            code: err.code,
+          },
         });
       } finally {
         dispatch({
@@ -299,7 +328,13 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
       } catch (err) {
         dispatch({
           type: STORY_ACTION_TYPES.DUPLICATE_STORY_FAILURE,
-          payload: { message: err.message, code: err.code },
+          payload: {
+            message: {
+              body: err.message,
+              title: __('Unable to Duplicate Story', 'web-stories'),
+            },
+            code: err.code,
+          },
         });
       }
     },

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * External dependencies
  */
 import { useCallback, useMemo, useReducer } from 'react';
@@ -98,7 +103,7 @@ const useTemplateApi = (dataAdapter, config) => {
     // Saved Templates = Bookmarked Templates + My Templates
     dispatch({
       type: TEMPLATE_ACTION_TYPES.PLACEHOLDER,
-      paylod: {
+      payload: {
         templates: [],
         totalPages: 0,
         totalTemplates: 0,
@@ -111,7 +116,7 @@ const useTemplateApi = (dataAdapter, config) => {
   const fetchBookmarkedTemplates = useCallback((filters) => {
     dispatch({
       type: TEMPLATE_ACTION_TYPES.PLACEHOLDER,
-      paylod: {
+      payload: {
         templates: [],
         totalPages: 0,
         totalTemplates: 0,
@@ -130,7 +135,12 @@ const useTemplateApi = (dataAdapter, config) => {
       if (!templateApi) {
         dispatch({
           type: TEMPLATE_ACTION_TYPES.FETCH_MY_TEMPLATES_FAILURE,
-          payload: { message: 'unable to connect to data', code: '' },
+          payload: {
+            message: {
+              body: __('Cannot connect to data source', 'web-stories'),
+              title: __('Unable to Load Templates', 'web-stories'),
+            },
+          },
         });
       }
 
@@ -174,7 +184,13 @@ const useTemplateApi = (dataAdapter, config) => {
       } catch (err) {
         dispatch({
           type: TEMPLATE_ACTION_TYPES.FETCH_MY_TEMPLATES_FAILURE,
-          payload: { message: err.message, code: err.code },
+          payload: {
+            message: {
+              body: err.message,
+              title: __('Unable to Load Templates', 'web-stories'),
+            },
+            code: err.code,
+          },
         });
       } finally {
         dispatch({
@@ -274,7 +290,13 @@ const useTemplateApi = (dataAdapter, config) => {
       } catch (err) {
         dispatch({
           type: TEMPLATE_ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_FAILURE,
-          payload: { message: err.message, code: err.code },
+          payload: {
+            message: {
+              body: err.message,
+              title: __('Unable to Create Template from Story', 'web-stories'),
+            },
+            code: err.code,
+          },
         });
       } finally {
         dispatch({

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -29,11 +29,18 @@ import theme, { GlobalStyle } from '../theme';
 import KeyboardOnlyOutline from '../utils/keyboardOnlyOutline';
 import { APP_ROUTES, NESTED_APP_ROUTES } from '../constants';
 
-import { AppFrame, LeftRail, NavProvider, PageContent } from '../components';
+import {
+  AppFrame,
+  LeftRail,
+  NavProvider,
+  PageContent,
+  ToastProvider,
+} from '../components';
 import ApiProvider from './api/apiProvider';
 import { Route, RouterProvider, RouterContext, matchPath } from './router';
 import { ConfigProvider } from './config';
 import {
+  ToasterView,
   MyStoriesView,
   TemplateDetailsView,
   ExploreTemplatesView,
@@ -82,6 +89,9 @@ const AppContent = () => {
           component={<StoryAnimTool />}
         />
       </PageContent>
+      <ToastProvider>
+        <ToasterView />
+      </ToastProvider>
     </AppFrame>
   );
 };

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -27,8 +27,11 @@ export const ACTION_TYPES = {
   FETCH_STORIES_SUCCESS: 'fetch_stories_success',
   FETCH_STORIES_FAILURE: 'fetch_stories_failure',
   UPDATE_STORY: 'update_story',
+  UPDATE_STORY_FAILURE: 'update_story_failure',
   TRASH_STORY: 'trash_story',
+  TRASH_STORY_FAILURE: 'trash_story_failure',
   DUPLICATE_STORY: 'duplicate_story',
+  DUPLICATE_STORY_FAILURE: 'duplicate_story_failure',
 };
 
 export const defaultStoriesState = {
@@ -51,10 +54,13 @@ function storyReducer(state, action) {
     }
 
     case ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_FAILURE:
-    case ACTION_TYPES.FETCH_STORIES_FAILURE: {
+    case ACTION_TYPES.FETCH_STORIES_FAILURE:
+    case ACTION_TYPES.UPDATE_STORY_FAILURE:
+    case ACTION_TYPES.TRASH_STORY_FAILURE:
+    case ACTION_TYPES.DUPLICATE_STORY_FAILURE: {
       return {
         ...state,
-        error: action.payload,
+        error: { ...action.payload, id: Date.now() },
       };
     }
 
@@ -68,6 +74,7 @@ function storyReducer(state, action) {
     case ACTION_TYPES.UPDATE_STORY:
       return {
         ...state,
+        error: {},
         stories: {
           ...state.stories,
           [action.payload.id]: action.payload,
@@ -77,6 +84,7 @@ function storyReducer(state, action) {
     case ACTION_TYPES.TRASH_STORY:
       return {
         ...state,
+        error: {},
         storiesOrderById: state.storiesOrderById.filter(
           (id) => id !== action.payload.id
         ),
@@ -97,6 +105,7 @@ function storyReducer(state, action) {
     case ACTION_TYPES.DUPLICATE_STORY:
       return {
         ...state,
+        error: {},
         storiesOrderById: [action.payload.id, ...state.storiesOrderById],
         totalStoriesByStatus: {
           ...state.totalStoriesByStatus,

--- a/assets/src/dashboard/app/reducer/templates.js
+++ b/assets/src/dashboard/app/reducer/templates.js
@@ -56,6 +56,7 @@ function templateReducer(state, action) {
     case ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_SUCCESS: {
       return {
         ...state,
+        error: {},
       };
     }
 
@@ -64,7 +65,7 @@ function templateReducer(state, action) {
     case ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_FAILURE:
       return {
         ...state,
-        error: action.payload,
+        error: { ...action.payload, id: Date.now() },
       };
 
     case ACTION_TYPES.FETCH_MY_TEMPLATES_SUCCESS: {
@@ -88,6 +89,7 @@ function templateReducer(state, action) {
         savedTemplatesOrderById: uniqueTemplateIds,
         totalTemplates: action.payload.totalTemplates,
         totalPages: action.payload.totalPages,
+        error: {},
       };
     }
 

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -74,6 +74,27 @@ describe('storyReducer', () => {
     });
   });
 
+  it(`should update error when ${ACTION_TYPES.TRASH_STORY_FAILURE} is called`, () => {
+    const result = storyReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.TRASH_STORY_FAILURE,
+        payload: {
+          message: 'my trash story failure message',
+          code: 'my_error_code',
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      error: {
+        message: 'my trash story failure message',
+        code: 'my_error_code',
+      },
+    });
+  });
+
   it(`should update stories state when ${ACTION_TYPES.DUPLICATE_STORY} is called`, () => {
     const result = storyReducer(
       {
@@ -115,6 +136,27 @@ describe('storyReducer', () => {
         publish: 4,
       },
       totalPages: 4,
+    });
+  });
+
+  it(`should update error when ${ACTION_TYPES.DUPLICATE_STORY_FAILURE} is called`, () => {
+    const result = storyReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.DUPLICATE_STORY_FAILURE,
+        payload: {
+          message: 'my duplicate story failure message',
+          code: 'my_error_code',
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      error: {
+        message: 'my duplicate story failure message',
+        code: 'my_error_code',
+      },
     });
   });
 
@@ -298,6 +340,27 @@ describe('storyReducer', () => {
         65: { id: 65, status: 'publish', title: 'new title for story' },
         78: { id: 78, status: 'draft', title: 'my test story 3' },
         12: { id: 12, status: 'draft', title: 'my test story 4' },
+      },
+    });
+  });
+
+  it(`should update error when ${ACTION_TYPES.UPDATE_STORY_FAILURE} is called`, () => {
+    const result = storyReducer(
+      { ...initialState },
+      {
+        type: ACTION_TYPES.UPDATE_STORY_FAILURE,
+        payload: {
+          message: 'my update story failure message',
+          code: 'my_error_code',
+        },
+      }
+    );
+
+    expect(result).toMatchObject({
+      ...initialState,
+      error: {
+        message: 'my update story failure message',
+        code: 'my_error_code',
       },
     });
   });

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -100,6 +100,7 @@ describe('storyReducer', () => {
           body: 'my trash story failure message',
           title: 'Unable to Delete Story',
         },
+        id: Date.now(),
         code: 'my_error_code',
       },
     });

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -29,6 +29,10 @@ describe('storyReducer', () => {
     totalPages: null,
   };
 
+  beforeAll(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => 1592844570916);
+  });
+
   it(`should update stories state when ${ACTION_TYPES.TRASH_STORY} is called`, () => {
     const result = storyReducer(
       {
@@ -80,7 +84,10 @@ describe('storyReducer', () => {
       {
         type: ACTION_TYPES.TRASH_STORY_FAILURE,
         payload: {
-          message: 'my trash story failure message',
+          message: {
+            body: 'my trash story failure message',
+            title: 'Unable to Delete Story',
+          },
           code: 'my_error_code',
         },
       }
@@ -89,7 +96,10 @@ describe('storyReducer', () => {
     expect(result).toMatchObject({
       ...initialState,
       error: {
-        message: 'my trash story failure message',
+        message: {
+          body: 'my trash story failure message',
+          title: 'Unable to Delete Story',
+        },
         code: 'my_error_code',
       },
     });
@@ -145,7 +155,10 @@ describe('storyReducer', () => {
       {
         type: ACTION_TYPES.DUPLICATE_STORY_FAILURE,
         payload: {
-          message: 'my duplicate story failure message',
+          message: {
+            title: 'Unable to Duplciate Story',
+            body: 'my duplicate story failure message',
+          },
           code: 'my_error_code',
         },
       }
@@ -154,7 +167,11 @@ describe('storyReducer', () => {
     expect(result).toMatchObject({
       ...initialState,
       error: {
-        message: 'my duplicate story failure message',
+        message: {
+          title: 'Unable to Duplciate Story',
+          body: 'my duplicate story failure message',
+        },
+        id: Date.now(),
         code: 'my_error_code',
       },
     });
@@ -291,13 +308,26 @@ describe('storyReducer', () => {
       { ...initialState },
       {
         type: ACTION_TYPES.FETCH_STORIES_FAILURE,
-        payload: { message: 'my error message', code: 'my_error_code' },
+        payload: {
+          message: {
+            title: 'Unable to Load Stories',
+            body: 'my error message',
+          },
+          code: 'my_error_code',
+        },
       }
     );
 
     expect(result).toMatchObject({
       ...initialState,
-      error: { message: 'my error message', code: 'my_error_code' },
+      error: {
+        message: {
+          title: 'Unable to Load Stories',
+          body: 'my error message',
+        },
+        id: Date.now(),
+        code: 'my_error_code',
+      },
     });
   });
 
@@ -306,13 +336,26 @@ describe('storyReducer', () => {
       { ...initialState },
       {
         type: ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_FAILURE,
-        payload: { message: 'my error message', code: 'my_error_code' },
+        payload: {
+          message: {
+            title: 'Unable to Create Story From Template',
+            body: 'my error message',
+          },
+          code: 'my_error_code',
+        },
       }
     );
 
     expect(result).toMatchObject({
       ...initialState,
-      error: { message: 'my error message', code: 'my_error_code' },
+      error: {
+        message: {
+          title: 'Unable to Create Story From Template',
+          body: 'my error message',
+        },
+        id: Date.now(),
+        code: 'my_error_code',
+      },
     });
   });
 
@@ -350,7 +393,10 @@ describe('storyReducer', () => {
       {
         type: ACTION_TYPES.UPDATE_STORY_FAILURE,
         payload: {
-          message: 'my update story failure message',
+          message: {
+            title: 'Unable to Update Story',
+            body: 'my error message',
+          },
           code: 'my_error_code',
         },
       }
@@ -359,7 +405,11 @@ describe('storyReducer', () => {
     expect(result).toMatchObject({
       ...initialState,
       error: {
-        message: 'my update story failure message',
+        message: {
+          title: 'Unable to Update Story',
+          body: 'my error message',
+        },
+        id: Date.now(),
         code: 'my_error_code',
       },
     });

--- a/assets/src/dashboard/app/reducer/test/templates.js
+++ b/assets/src/dashboard/app/reducer/test/templates.js
@@ -23,6 +23,10 @@ import templateReducer, {
 } from '../templates';
 
 describe('templateReducer', () => {
+  beforeAll(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => 1592844570916);
+  });
+
   it(`should update templates state when ${ACTION_TYPES.FETCH_TEMPLATES_SUCCESS} is called`, () => {
     const result = templateReducer(initialState, {
       type: ACTION_TYPES.FETCH_TEMPLATES_SUCCESS,
@@ -188,13 +192,26 @@ describe('templateReducer', () => {
       { ...initialState },
       {
         type: ACTION_TYPES.FETCH_TEMPLATES_FAILURE,
-        payload: { message: 'test error message', code: 'test-error-code' },
+        payload: {
+          message: {
+            title: 'Unable to Load Templates',
+            body: 'test error message',
+          },
+          code: 'test-error-code',
+        },
       }
     );
 
     expect(result).toMatchObject({
       ...initialState,
-      error: { message: 'test error message', code: 'test-error-code' },
+      error: {
+        message: {
+          title: 'Unable to Load Templates',
+          body: 'test error message',
+        },
+        id: Date.now(),
+        code: 'test-error-code',
+      },
     });
   });
 
@@ -203,13 +220,26 @@ describe('templateReducer', () => {
       { ...initialState },
       {
         type: ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_FAILURE,
-        payload: { message: 'test error message', code: 'test-error-code' },
+        payload: {
+          message: {
+            title: 'Unable to Create Template from Story',
+            body: 'test error message',
+          },
+          code: 'test-error-code',
+        },
       }
     );
 
     expect(result).toMatchObject({
       ...initialState,
-      error: { message: 'test error message', code: 'test-error-code' },
+      error: {
+        message: {
+          title: 'Unable to Create Template from Story',
+          body: 'test error message',
+        },
+        id: Date.now(),
+        code: 'test-error-code',
+      },
     });
   });
 

--- a/assets/src/dashboard/app/views/index.js
+++ b/assets/src/dashboard/app/views/index.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+export { default as ToasterView } from './toaster';
 export { default as MyStoriesView } from './myStories';
 export { default as ExploreTemplatesView } from './exploreTemplates';
 export { default as TemplateDetailsView } from './templateDetails';

--- a/assets/src/dashboard/app/views/index.js
+++ b/assets/src/dashboard/app/views/index.js
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { default as ToasterView } from './toaster';
 export { default as MyStoriesView } from './myStories';
 export { default as ExploreTemplatesView } from './exploreTemplates';
 export { default as TemplateDetailsView } from './templateDetails';
 export { default as SavedTemplatesView } from './savedTemplates';
 export { default as StoryAnimTool } from './storyAnimTool';
+export { default as ToasterView } from './toaster';

--- a/assets/src/dashboard/app/views/toaster/index.js
+++ b/assets/src/dashboard/app/views/toaster/index.js
@@ -40,7 +40,7 @@ function ToasterView() {
   } = useToastContext();
 
   useEffect(() => {
-    if (storyError?.message) {
+    if (storyError?.id) {
       addToast({
         message: storyError.message,
         severity: ALERT_SEVERITY.ERROR,
@@ -50,7 +50,7 @@ function ToasterView() {
   }, [storyError, addToast]);
 
   useEffect(() => {
-    if (templateError?.message) {
+    if (templateError?.id) {
       addToast({
         message: templateError.message,
         severity: ALERT_SEVERITY.ERROR,

--- a/assets/src/dashboard/app/views/toaster/index.js
+++ b/assets/src/dashboard/app/views/toaster/index.js
@@ -62,7 +62,7 @@ function ToasterView() {
   return (
     <Toaster
       activeToasts={activeToasts}
-      onRemoveToastClick={removeToast}
+      handleRemoveToast={removeToast}
       isAllowEarlyDismiss
     />
   );

--- a/assets/src/dashboard/app/views/toaster/index.js
+++ b/assets/src/dashboard/app/views/toaster/index.js
@@ -29,7 +29,8 @@ import { ALERT_SEVERITY } from '../../../constants';
 function ToasterView() {
   const {
     state: {
-      stories: { error },
+      stories: { error: storyError },
+      templates: { error: templateError },
     },
   } = useContext(ApiContext);
 
@@ -39,14 +40,24 @@ function ToasterView() {
   } = useToastContext();
 
   useEffect(() => {
-    if (error?.message) {
+    if (storyError?.message) {
       addToast({
-        message: error.message,
+        message: storyError.message,
         severity: ALERT_SEVERITY.ERROR,
-        id: error.id,
+        id: storyError.id,
       });
     }
-  }, [error, addToast]);
+  }, [storyError, addToast]);
+
+  useEffect(() => {
+    if (templateError?.message) {
+      addToast({
+        message: templateError.message,
+        severity: ALERT_SEVERITY.ERROR,
+        id: templateError.id,
+      });
+    }
+  }, [templateError, addToast]);
 
   return (
     <Toaster

--- a/assets/src/dashboard/app/views/toaster/index.js
+++ b/assets/src/dashboard/app/views/toaster/index.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useContext, useEffect } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { ApiContext } from '../../api/apiProvider';
+import { Toaster, useToastContext } from '../../../components/toaster';
+import { ALERT_SEVERITY } from '../../../constants';
+
+function ToasterView() {
+  const {
+    state: {
+      stories: { error },
+    },
+  } = useContext(ApiContext);
+
+  const {
+    actions: { removeToast, addToast },
+    state: { activeToasts },
+  } = useToastContext();
+
+  useEffect(() => {
+    if (error?.message) {
+      addToast({
+        message: error.message,
+        severity: ALERT_SEVERITY.ERROR,
+        id: error.id,
+      });
+    }
+  }, [error, addToast]);
+
+  return (
+    <Toaster
+      activeToasts={activeToasts}
+      onRemoveToastClick={removeToast}
+      isAllowEarlyDismiss
+    />
+  );
+}
+
+export default ToasterView;

--- a/assets/src/dashboard/app/views/toaster/stories/index.js
+++ b/assets/src/dashboard/app/views/toaster/stories/index.js
@@ -47,7 +47,7 @@ export const _default = () => {
       <Button
         onClick={() => {
           setErrorIndexToAdd(errorIndexToAdd + 1);
-          setError({ ...errors[errorIndexToAdd], id: errorIndexToAdd });
+          setError({ ...errors[errorIndexToAdd], id: Date.now() });
         }}
         isDisabled={errorIndexToAdd > errors.length - 1}
       >

--- a/assets/src/dashboard/app/views/toaster/stories/index.js
+++ b/assets/src/dashboard/app/views/toaster/stories/index.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '../../../../components';
+import { ToastProvider } from '../../../../components/toaster';
+import { ApiContext } from '../../../api/apiProvider';
+import ToasterView from '../';
+
+export default {
+  title: 'Dashboard/Views/Toaster',
+  component: ToasterView,
+};
+
+export const _default = () => {
+  const [error, setError] = useState();
+  const [errorIndexToAdd, setErrorIndexToAdd] = useState(0);
+  const errors = [
+    { message: 'i am an error' },
+    { message: 'i am a second error' },
+    { message: 'i am third' },
+    { message: 'something is really not working!' },
+    { message: 'oh no!' },
+  ];
+
+  return (
+    <ApiContext.Provider value={{ state: { stories: { error } } }}>
+      <Button
+        onClick={() => {
+          setErrorIndexToAdd(errorIndexToAdd + 1);
+          setError({ ...errors[errorIndexToAdd], id: errorIndexToAdd });
+        }}
+        isDisabled={errorIndexToAdd > errors.length - 1}
+      >
+        {errorIndexToAdd > errors.length - 1
+          ? 'No more practice alerts'
+          : 'Add practice alert'}
+      </Button>
+      <ToastProvider>
+        <ToasterView />
+      </ToastProvider>
+    </ApiContext.Provider>
+  );
+};

--- a/assets/src/dashboard/app/views/toaster/stories/index.js
+++ b/assets/src/dashboard/app/views/toaster/stories/index.js
@@ -31,29 +31,115 @@ export default {
   component: ToasterView,
 };
 
+const storyErrors = [
+  {
+    message: {
+      body: 'I am an error.',
+      title: 'Unable to Load Stories',
+    },
+  },
+  {
+    message: {
+      body: 'I am another error.',
+      title: 'Unable to Load Stories',
+    },
+  },
+  {
+    message: {
+      body: 'I am the third error.',
+      title: 'Unable to Update Story',
+    },
+  },
+  {
+    message: {
+      body: 'Something is really not working!',
+      title: 'Oh No!',
+    },
+  },
+  {
+    message: {
+      body: 'I am the last preloaded error for stories in this storybook.',
+      title: 'Unable to Load Stories',
+    },
+  },
+];
+
+const templateErrors = [
+  {
+    message: {
+      body: 'I am an error.',
+      title: 'Unable to Load Templates',
+    },
+  },
+  {
+    message: {
+      body: 'I am another error.',
+      title: 'Unable to Load Templates',
+    },
+  },
+  {
+    message: {
+      body: 'I am the third error.',
+      title: 'Unable to Create Story From Template',
+    },
+  },
+  {
+    message: {
+      body: 'Something is really not working!',
+      title: 'Oh No!',
+    },
+  },
+  {
+    message: {
+      body: 'I am the last preloaded error for templates in this storybook.',
+      title: 'Unable to Load Templates',
+    },
+  },
+];
+
 export const _default = () => {
-  const [error, setError] = useState();
-  const [errorIndexToAdd, setErrorIndexToAdd] = useState(0);
-  const errors = [
-    { message: 'i am an error' },
-    { message: 'i am a second error' },
-    { message: 'i am third' },
-    { message: 'something is really not working!' },
-    { message: 'oh no!' },
-  ];
+  const [storyError, setStoryError] = useState();
+  const [storyErrorIndexToAdd, setStoryErrorIndexToAdd] = useState(0);
+  const [templateError, setTemplateError] = useState();
+  const [templateErrorIndexToAdd, setTemplateErrorIndexToAdd] = useState(0);
 
   return (
-    <ApiContext.Provider value={{ state: { stories: { error } } }}>
+    <ApiContext.Provider
+      value={{
+        state: {
+          stories: { error: storyError },
+          templates: { error: templateError },
+        },
+      }}
+    >
       <Button
         onClick={() => {
-          setErrorIndexToAdd(errorIndexToAdd + 1);
-          setError({ ...errors[errorIndexToAdd], id: Date.now() });
+          setStoryErrorIndexToAdd(storyErrorIndexToAdd + 1);
+          setStoryError({
+            ...storyErrors[storyErrorIndexToAdd],
+            id: Date.now(),
+          });
         }}
-        isDisabled={errorIndexToAdd > errors.length - 1}
+        isDisabled={storyErrorIndexToAdd > storyErrors.length - 1}
       >
-        {errorIndexToAdd > errors.length - 1
-          ? 'No more practice alerts'
-          : 'Add practice alert'}
+        {storyErrorIndexToAdd > storyErrors.length - 1
+          ? 'No more practice story alerts'
+          : 'Add practice story alert'}
+      </Button>
+      <br />
+      <Button
+        onClick={() => {
+          setTemplateErrorIndexToAdd(templateErrorIndexToAdd + 1);
+          setTemplateError({
+            ...templateErrors[templateErrorIndexToAdd],
+            id: Date.now(),
+          });
+        }}
+        isDisabled={templateErrorIndexToAdd > templateErrors.length - 1}
+      >
+        {templateErrorIndexToAdd > templateErrors.length - 1
+          ? 'No more practice template alerts'
+          : 'Add practice template alert'}
       </Button>
       <ToastProvider>
         <ToasterView />

--- a/assets/src/dashboard/components/alert/components.js
+++ b/assets/src/dashboard/components/alert/components.js
@@ -22,11 +22,7 @@ import styled, { keyframes } from 'styled-components';
 /**
  * Internal dependencies
  */
-import {
-  ALERT_SEVERITY,
-  KEYBOARD_USER_SELECTOR,
-  Z_INDEX,
-} from '../../constants';
+import { ALERT_SEVERITY, KEYBOARD_USER_SELECTOR } from '../../constants';
 import { TypographyPresets } from '../typography';
 
 const slideIn = keyframes`
@@ -68,13 +64,17 @@ export const AlertContainer = styled.div`
   background-color: ${({ theme, severity }) =>
     theme.colors[getColor(severity)]};
   border-radius: 5px;
-  z-index: ${Z_INDEX.ALERT};
   animation: 0.5s ${slideIn} ease-out;
 `;
 
 export const AlertText = styled.p`
   ${TypographyPresets.Medium};
   width: calc(100% - 25px);
+`;
+
+export const AlertTitle = styled.span`
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
+  display: block;
 `;
 
 export const DismissButton = styled.button`

--- a/assets/src/dashboard/components/alert/index.js
+++ b/assets/src/dashboard/components/alert/index.js
@@ -44,10 +44,10 @@ const Alert = ({
   message,
   severity,
   title,
-  handleDismissClick,
+  handleDismiss,
 }) => {
   const autoDismissRef = useRef();
-  autoDismissRef.current = isPreventAutoDismiss ? () => {} : handleDismissClick;
+  autoDismissRef.current = isPreventAutoDismiss ? () => {} : handleDismiss;
 
   useEffect(() => {
     if (!autoDismissRef.current) {
@@ -73,7 +73,7 @@ const Alert = ({
       </AlertText>
       {isAllowDismiss && (
         <DismissButton
-          onClick={handleDismissClick}
+          onClick={handleDismiss}
           ariaLabel={__('Dismiss Alert', 'web-stories')}
         >
           <Close />
@@ -86,7 +86,7 @@ const Alert = ({
 Alert.propTypes = {
   isAllowDismiss: PropTypes.bool,
   message: PropTypes.string.isRequired,
-  handleDismissClick: PropTypes.func,
+  handleDismiss: PropTypes.func,
   isPreventAutoDismiss: PropTypes.bool,
   severity: AlertSeveritiesPropType,
   title: PropTypes.string,

--- a/assets/src/dashboard/components/alert/index.js
+++ b/assets/src/dashboard/components/alert/index.js
@@ -31,13 +31,19 @@ import { useRef, useEffect } from 'react';
 import { Close } from '../../icons';
 import { AlertSeveritiesPropType } from '../../types';
 import { AUTO_REMOVE_ALERT_TIME_INTERVAL } from '../../constants';
-import { AlertContainer, AlertText, DismissButton } from './components';
+import {
+  AlertContainer,
+  AlertText,
+  AlertTitle,
+  DismissButton,
+} from './components';
 
 const Alert = ({
   isPreventAutoDismiss,
   isAllowDismiss,
   message,
   severity,
+  title,
   handleDismissClick,
 }) => {
   const autoDismissRef = useRef();
@@ -61,7 +67,10 @@ const Alert = ({
       role="alert"
       aria-label={__('Alert Notification', 'web-stories')}
     >
-      <AlertText>{message}</AlertText>
+      <AlertText>
+        {title && <AlertTitle>{title}</AlertTitle>}
+        {message}
+      </AlertText>
       {isAllowDismiss && (
         <DismissButton
           onClick={handleDismissClick}
@@ -80,6 +89,7 @@ Alert.propTypes = {
   handleDismissClick: PropTypes.func,
   isPreventAutoDismiss: PropTypes.bool,
   severity: AlertSeveritiesPropType,
+  title: PropTypes.string,
 };
 
 export default Alert;

--- a/assets/src/dashboard/components/alert/stories/index.js
+++ b/assets/src/dashboard/components/alert/stories/index.js
@@ -42,28 +42,28 @@ export const _default = () => {
       <Alert
         isAllowDismiss={boolean('isAllowDismiss1')}
         handleDismissClick={action('error message dismiss')}
-        message={text('errorMessage', 'this is an error')}
+        message={text('errorMessage', 'This is an error.')}
         title={text('errorTitle', 'Error Title')}
         severity={ALERT_SEVERITY.ERROR}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss2')}
         handleDismissClick={action('warning message dismiss')}
-        message={text('warningMessage', 'this is a warning')}
+        message={text('warningMessage', 'This is a warning.')}
         title={text('warningTitle', 'Warning Title')}
         severity={ALERT_SEVERITY.WARNING}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss3')}
         handleDismissClick={action('info message dismiss')}
-        message={text('infoMessage', 'this is informational')}
+        message={text('infoMessage', 'This is informational.')}
         title={text('infoTitle', 'Info Title')}
         severity={ALERT_SEVERITY.INFO}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss4')}
         handleDismissClick={action('success message dismiss')}
-        message={text('successMessage', 'this is successful')}
+        message={text('successMessage', 'This is successful.')}
         title={text('successTitle', 'Success Title')}
         severity={ALERT_SEVERITY.SUCCESS}
       />
@@ -72,7 +72,7 @@ export const _default = () => {
         handleDismissClick={action('default message dismiss')}
         message={text(
           'defaultMessage',
-          'this is an alert without a severity passed in'
+          'This is an alert without a severity passed in.'
         )}
         title={text('defaultTitle', 'Default Title')}
       />
@@ -82,7 +82,7 @@ export const _default = () => {
         isPreventAutoDismiss
         message={text(
           'preventAutoDismiss',
-          'this is an alert that will not dismiss automatically after 10 seconds'
+          'This is an alert that will not dismiss automatically after 10 seconds.'
         )}
         title={text('noAutoDismissTitle', 'No Auto Dismiss Alert')}
       />

--- a/assets/src/dashboard/components/alert/stories/index.js
+++ b/assets/src/dashboard/components/alert/stories/index.js
@@ -43,24 +43,28 @@ export const _default = () => {
         isAllowDismiss={boolean('isAllowDismiss1')}
         handleDismissClick={action('error message dismiss')}
         message={text('errorMessage', 'this is an error')}
+        title={text('errorTitle', 'Error Title')}
         severity={ALERT_SEVERITY.ERROR}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss2')}
         handleDismissClick={action('warning message dismiss')}
         message={text('warningMessage', 'this is a warning')}
+        title={text('warningTitle', 'Warning Title')}
         severity={ALERT_SEVERITY.WARNING}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss3')}
         handleDismissClick={action('info message dismiss')}
         message={text('infoMessage', 'this is informational')}
+        title={text('infoTitle', 'Info Title')}
         severity={ALERT_SEVERITY.INFO}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss4')}
         handleDismissClick={action('success message dismiss')}
         message={text('successMessage', 'this is successful')}
+        title={text('successTitle', 'Success Title')}
         severity={ALERT_SEVERITY.SUCCESS}
       />
       <Alert
@@ -70,6 +74,7 @@ export const _default = () => {
           'defaultMessage',
           'this is an alert without a severity passed in'
         )}
+        title={text('defaultTitle', 'Default Title')}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss6')}
@@ -79,6 +84,7 @@ export const _default = () => {
           'preventAutoDismiss',
           'this is an alert that will not dismiss automatically after 10 seconds'
         )}
+        title={text('noAutoDismissTitle', 'No Auto Dismiss Alert')}
       />
     </Wrapper>
   );

--- a/assets/src/dashboard/components/alert/stories/index.js
+++ b/assets/src/dashboard/components/alert/stories/index.js
@@ -41,35 +41,35 @@ export const _default = () => {
     <Wrapper>
       <Alert
         isAllowDismiss={boolean('isAllowDismiss1')}
-        handleDismissClick={action('error message dismiss')}
+        handleDismiss={action('error message dismiss')}
         message={text('errorMessage', 'This is an error.')}
         title={text('errorTitle', 'Error Title')}
         severity={ALERT_SEVERITY.ERROR}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss2')}
-        handleDismissClick={action('warning message dismiss')}
+        handleDismiss={action('warning message dismiss')}
         message={text('warningMessage', 'This is a warning.')}
         title={text('warningTitle', 'Warning Title')}
         severity={ALERT_SEVERITY.WARNING}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss3')}
-        handleDismissClick={action('info message dismiss')}
+        handleDismiss={action('info message dismiss')}
         message={text('infoMessage', 'This is informational.')}
         title={text('infoTitle', 'Info Title')}
         severity={ALERT_SEVERITY.INFO}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss4')}
-        handleDismissClick={action('success message dismiss')}
+        handleDismiss={action('success message dismiss')}
         message={text('successMessage', 'This is successful.')}
         title={text('successTitle', 'Success Title')}
         severity={ALERT_SEVERITY.SUCCESS}
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss5')}
-        handleDismissClick={action('default message dismiss')}
+        handleDismiss={action('default message dismiss')}
         message={text(
           'defaultMessage',
           'This is an alert without a severity passed in.'
@@ -78,7 +78,7 @@ export const _default = () => {
       />
       <Alert
         isAllowDismiss={boolean('isAllowDismiss6')}
-        handleDismissClick={action('no auto dismiss dismiss clicked')}
+        handleDismiss={action('no auto dismiss dismiss clicked')}
         isPreventAutoDismiss
         message={text(
           'preventAutoDismiss',

--- a/assets/src/dashboard/components/alert/test/index.js
+++ b/assets/src/dashboard/components/alert/test/index.js
@@ -36,6 +36,19 @@ describe('Alert', () => {
 
     expect(alert).toBeInTheDocument();
   });
+  it('should render 1 alert with a title', () => {
+    const wrapper = renderWithTheme(
+      <Alert
+        message={'this is an error'}
+        title={'this is an alert title'}
+        severity={ALERT_SEVERITY.ERROR}
+      />
+    );
+
+    const alert = wrapper.getByText('this is an alert title');
+
+    expect(alert).toBeInTheDocument();
+  });
 
   it('should recognize click on DismissButton', () => {
     const mockDismissClick = jest.fn();

--- a/assets/src/dashboard/components/alert/test/index.js
+++ b/assets/src/dashboard/components/alert/test/index.js
@@ -57,7 +57,7 @@ describe('Alert', () => {
         isAllowDismiss={true}
         message={'this is an error'}
         severity={ALERT_SEVERITY.ERROR}
-        handleDismissClick={mockDismissClick}
+        handleDismiss={mockDismissClick}
       />
     );
 

--- a/assets/src/dashboard/components/toaster/stories/index.js
+++ b/assets/src/dashboard/components/toaster/stories/index.js
@@ -37,7 +37,7 @@ export const _default = () => {
   const alerts = [
     {
       message: {
-        body: 'i am an error reason',
+        body: 'I am an error reason.',
         title: 'Error Saving Story',
       },
       severity: ALERT_SEVERITY.ERROR,
@@ -45,7 +45,7 @@ export const _default = () => {
     },
     {
       message: {
-        body: 'i am a second error',
+        body: 'I am a second error.',
         title: 'Unable to Save Story',
       },
       severity: ALERT_SEVERITY.ERROR,
@@ -53,7 +53,7 @@ export const _default = () => {
     },
     {
       message: {
-        body: 'i am just here for fun',
+        body: 'I am just here for fun.',
         title: 'Just Dropping By',
       },
       severity: ALERT_SEVERITY.INFO,
@@ -61,7 +61,7 @@ export const _default = () => {
     },
     {
       message: {
-        body: 'seems like things are not bueno',
+        body: 'Seems like things are not bueno.',
         title: 'Connection Unstable',
       },
       severity: ALERT_SEVERITY.WARNING,

--- a/assets/src/dashboard/components/toaster/stories/index.js
+++ b/assets/src/dashboard/components/toaster/stories/index.js
@@ -36,27 +36,42 @@ export const _default = () => {
   const [toastIndexToAdd, setToastIndexToAdd] = useState(0);
   const alerts = [
     {
-      message: 'i am an error',
+      message: {
+        body: 'i am an error reason',
+        title: 'Error Saving Story',
+      },
       severity: ALERT_SEVERITY.ERROR,
       id: Date.now(),
     },
     {
-      message: 'i am a second error',
+      message: {
+        body: 'i am a second error',
+        title: 'Unable to Save Story',
+      },
       severity: ALERT_SEVERITY.ERROR,
       id: Date.now(),
     },
     {
-      message: 'i am just here for fun',
+      message: {
+        body: 'i am just here for fun',
+        title: 'Just Dropping By',
+      },
       severity: ALERT_SEVERITY.INFO,
       id: Date.now(),
     },
     {
-      message: 'seems like things are not bueno',
+      message: {
+        body: 'seems like things are not bueno',
+        title: 'Connection Unstable',
+      },
       severity: ALERT_SEVERITY.WARNING,
       id: Date.now(),
     },
     {
-      message: 'Everything is successful and peachy!',
+      message: {
+        body: 'Everything is successful and peachy!',
+        title: 'Story Title Updated',
+      },
       severity: ALERT_SEVERITY.SUCCESS,
       id: Date.now(),
     },

--- a/assets/src/dashboard/components/toaster/stories/index.js
+++ b/assets/src/dashboard/components/toaster/stories/index.js
@@ -98,7 +98,7 @@ export const _default = () => {
             <Toaster
               isAllowEarlyDismiss={boolean('isAllowEarlyDismiss')}
               activeToasts={state.activeToasts}
-              onRemoveToastClick={actions.removeToast}
+              handleRemoveToast={actions.removeToast}
             />
           </>
         )}

--- a/assets/src/dashboard/components/toaster/test/toaster.js
+++ b/assets/src/dashboard/components/toaster/test/toaster.js
@@ -39,7 +39,7 @@ describe('Toaster', () => {
       <Toaster
         activeToasts={[testToast]}
         isAllowEarlyDismiss={false}
-        onRemoveToastClick={mockRemoveToastClick}
+        handleRemoveToast={mockRemoveToastClick}
       />
     );
 
@@ -53,7 +53,7 @@ describe('Toaster', () => {
       <Toaster
         activeToasts={[testToast]}
         isAllowEarlyDismiss={false}
-        onRemoveToastClick={mockRemoveToastClick}
+        handleRemoveToast={mockRemoveToastClick}
       />
     );
 
@@ -67,7 +67,7 @@ describe('Toaster', () => {
       <Toaster
         activeToasts={[testToast]}
         isAllowEarlyDismiss={true}
-        onRemoveToastClick={mockRemoveToastClick}
+        handleRemoveToast={mockRemoveToastClick}
       />
     );
 

--- a/assets/src/dashboard/components/toaster/toaster.js
+++ b/assets/src/dashboard/components/toaster/toaster.js
@@ -38,7 +38,7 @@ const Wrapper = styled.div`
   z-index: ${Z_INDEX.TOASTER};
 `;
 
-function Toaster({ isAllowEarlyDismiss, activeToasts, onRemoveToastClick }) {
+function Toaster({ isAllowEarlyDismiss, activeToasts, handleRemoveToast }) {
   return (
     <Wrapper>
       {activeToasts.map((toast) => (
@@ -48,7 +48,7 @@ function Toaster({ isAllowEarlyDismiss, activeToasts, onRemoveToastClick }) {
           message={toast.message.body}
           title={toast.message.title}
           severity={toast.severity}
-          handleDismissClick={() => onRemoveToastClick(toast.id)}
+          handleDismiss={() => handleRemoveToast(toast.id)}
         />
       ))}
     </Wrapper>
@@ -58,6 +58,6 @@ function Toaster({ isAllowEarlyDismiss, activeToasts, onRemoveToastClick }) {
 Toaster.propTypes = {
   activeToasts: ToastMessagesPropType,
   isAllowEarlyDismiss: PropTypes.bool,
-  onRemoveToastClick: PropTypes.func,
+  handleRemoveToast: PropTypes.func,
 };
 export default Toaster;

--- a/assets/src/dashboard/components/toaster/toaster.js
+++ b/assets/src/dashboard/components/toaster/toaster.js
@@ -24,6 +24,7 @@ import styled from 'styled-components';
  */
 import { ToastMessagesPropType } from '../../types';
 import { Alert } from '../';
+import { Z_INDEX } from '../../constants';
 
 const Wrapper = styled.div`
   position: fixed;
@@ -34,6 +35,7 @@ const Wrapper = styled.div`
   align-items: flex-start;
   max-width: 300px;
   width: 40vw;
+  z-index: ${Z_INDEX.TOASTER};
 `;
 
 function Toaster({ isAllowEarlyDismiss, activeToasts, onRemoveToastClick }) {
@@ -43,7 +45,8 @@ function Toaster({ isAllowEarlyDismiss, activeToasts, onRemoveToastClick }) {
         <Alert
           isAllowDismiss={isAllowEarlyDismiss}
           key={`alert_${toast.id}`}
-          message={toast.message}
+          message={toast.message.body}
+          title={toast.message.title}
           severity={toast.severity}
           handleDismissClick={() => onRemoveToastClick(toast.id)}
         />

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -34,7 +34,7 @@ export const Z_INDEX = {
   POPOVER_MENU: 10,
   TYPEAHEAD_OPTIONS: 10,
   POPOVER_PANEL: 10,
-  ALERT: 15,
+  TOASTER: 15,
 };
 
 export const APP_ROUTES = {

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -119,7 +119,10 @@ export const AlertSeveritiesPropType = PropTypes.oneOf(
 );
 
 export const ToastMessagePropType = PropTypes.shape({
-  message: PropTypes.string.isRequired,
+  message: PropTypes.shape({
+    title: PropTypes.string,
+    body: PropTypes.string.isRequired,
+  }),
   severity: AlertSeveritiesPropType,
   id: PropTypes.number.isRequired,
 });


### PR DESCRIPTION
## Summary
Creates a new view component for the dashboard to display errors as toasts for stories and templates. 

## Relevant Technical Choices
- Revises `error` object to have a message.title and message.body to give context to displayed toasts. Adds `Date.now()` as a unique ID that will return in ascending order to maintain toast stack when there are many errors to display at once. 
- Mocking Date in reducer tests to get Date.now() equality. 

## User-facing changes
- Now when APIs return errors for the below actions you will see them in the UI:
  - Updating story
  - Deleting story
  - Duplicating story
  - Fetching stories
  - Creating story from template
  - Creating a template from a story

## Testing Instructions
- Storybook: Dashboard/Views/Toaster 
- Otherwise, you need to cause API failures. One way I have been testing this is the following:
  - view the dashboard, open your dev tools and go to the network tab. Right click on one of the 'web-story?' xhr requests and click 'block url' - repeat the action that triggered that request and see an error message show up. 
  - Alternatively you can always block the domain, but I find that to be a little noisy and harder to pinpoint what's going on. 

**unable to delete story**
![unable to delete story](https://user-images.githubusercontent.com/10720454/85322015-7e86e180-b47a-11ea-805d-d970b1005a27.gif)

**unable to update story**
![unable to update story](https://user-images.githubusercontent.com/10720454/85322027-847cc280-b47a-11ea-939a-7ffee032d2c7.gif)

**toaster consistency in grid to list**
![toaster consistency in grid to list](https://user-images.githubusercontent.com/10720454/85322035-86df1c80-b47a-11ea-9ead-0432c1f24d4e.gif)

**unable to load stories**
![unable to load stories](https://user-images.githubusercontent.com/10720454/85322045-8cd4fd80-b47a-11ea-8bc2-d95b5df11e8f.gif)


---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2262 
