### PR TITLE
Hide elements tab

### DIFF
--- a/assets/src/edit-story/components/library/libraryProvider.js
+++ b/assets/src/edit-story/components/library/libraryProvider.js
@@ -40,7 +40,7 @@ function LibraryProvider({ children }) {
   const [tab, setTab] = useState(TAB_IDS.MEDIA);
   const insertElement = useInsertElement();
 
-  const { showAnimationTab, media3pTab } = useFeatures();
+  const { showAnimationTab, media3pTab, showElementsTab } = useFeatures();
 
   // Order here is important, as it denotes the actual visual order of elements.
   const tabs = useMemo(
@@ -50,10 +50,10 @@ function LibraryProvider({ children }) {
         media3pTab ? TAB_IDS.MEDIA3P : null,
         TAB_IDS.TEXT,
         TAB_IDS.SHAPES,
-        TAB_IDS.ELEMENTS,
+        showElementsTab ? TAB_IDS.ELEMENTS : null,
         showAnimationTab ? TAB_IDS.ANIMATION : null,
       ].filter(Boolean),
-    [media3pTab, showAnimationTab]
+    [media3pTab, showAnimationTab, showElementsTab]
   );
 
   const state = useMemo(

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -436,6 +436,13 @@ class Story_Post_Type {
 				 * Creation date: 2020-06-17
 				 */
 				'media3pTab'                   => false,
+				/**
+				 * Description: Flag to show or hide the elements tab.
+				 * Author: @diegovar
+				 * Issue: #2616
+				 * Creation date: 2020-06-23
+				 */
+				'showElementsTab'              => false,
 			],
 
 		];


### PR DESCRIPTION
## Summary

Hides the elements tab under a flag.

## Relevant Technical Choices

## To-do

## User-facing changes

The elements tab is no longer visible after this change.

## Testing Instructions

Verify the elements tab is not visible.
---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2616
