### PR TITLE
Enable editing and deleting media via new dropdown

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -371,7 +371,7 @@ class Story_Post_Type {
 				 * Issue: #1319 and #354
 				 * Creation date: 2020-05-20
 				 */
-				'mediaDropdownMenu'            => false,
+				'mediaDropdownMenu'            => true,
 				/**
 				 * Description: Flag for new font picker with typeface previews in style panel.
 				 * Author: @carlos-kelly


### PR DESCRIPTION
This will enable the dropdown menu to appear on hover over any media element. This also enables the Edit and Delete features.

![Screen Shot 2020-06-23 at 1 37 44 PM](https://user-images.githubusercontent.com/15134432/85358378-e6aaf580-b556-11ea-9b39-1ab5c0fdc7fb.png)
![Screen Shot 2020-06-23 at 1 37 51 PM](https://user-images.githubusercontent.com/15134432/85358382-e9a5e600-b556-11ea-8582-ee7659f32161.png)
![Screen Shot 2020-06-23 at 1 37 58 PM](https://user-images.githubusercontent.com/15134432/85358384-ec084000-b556-11ea-96b4-f47558d0866c.png)

Fixes #354
Fixes #1319
