### PR TITLE
Karma: reduce flakes and better snapshots

### DIFF
--- a/assets/src/edit-story/karma/_init.js
+++ b/assets/src/edit-story/karma/_init.js
@@ -104,6 +104,24 @@ beforeAll(() => {
     return karmaPuppeteer.saveSnapshot(currentSpec?.fullName, name);
   };
 
+  // Disable transitions. These add unnecessarily flakiness into integration
+  // tests and snashots/screenshots.
+  withCleanupAll(() => {
+    const testRootStyles = document.createElement('style');
+    testRootStyles.setAttribute('data-desc', 'Karma test-root styles');
+    testRootStyles.textContent = `
+      * {
+        transition-property: none !important;
+        transition-delay: 0s !important;
+        transition-duration: 0s !important;
+      }
+    `;
+    document.head.appendChild(testRootStyles);
+    return () => {
+      testRootStyles.remove();
+    };
+  });
+
   // By default Jasmine doesn't report unhandled promise rejections.
   // But with `act()` it's very easy to do. So this is patched for Jasmine
   // here until the relevant issues are addressed.

--- a/karma/karma-puppeteer-launcher/snapshot.cjs
+++ b/karma/karma-puppeteer-launcher/snapshot.cjs
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+const path = require('path');
+const fs = require('fs').promises;
+
+const STATES = ['active', 'focus', 'focus-within', 'hover'];
+
+// E.g.: `/\:(hover|focus)\b/ig`.
+const STATE_CSS_RE = new RegExp(`\\:(${STATES.join('|')})\\b`, 'ig');
+
+/**
+ * @param {Object} frame
+ * @param {string} testName
+ * @param {string} snapshotName
+ */
+async function extractAndSaveSnapshot(frame, testName, snapshotName) {
+  if (!testName) {
+    testName = '_';
+  }
+  testName = testName.trim();
+  if (!snapshotName) {
+    snapshotName = 'default';
+  }
+  snapshotName = snapshotName.trim();
+
+  const snapshot = await extractSnapshot(frame, testName, snapshotName);
+
+  const dir = path.resolve(process.cwd(), '.test_artifacts', 'karma_snapshots');
+  try {
+    await fs.mkdir(dir, { recursive: true });
+  } catch (e) {
+    // Ignore. Let the file write fail instead.
+  }
+
+  // TODO: make "safe file name" rules better.
+  const maxFileName = 240;
+  let fileName = `${
+    testName.length + snapshotName.length < maxFileName
+      ? testName
+      : testName.substring(0, Math.max(maxFileName - snapshotName.length, 0))
+  }__${
+    snapshotName.length < maxFileName
+      ? snapshotName
+      : snapshotName.substring(0, maxFileName)
+  }`;
+  fileName = fileName.replace(/[^a-z0-9]/gi, '_');
+  const filePath = path.resolve(dir, fileName + '.html');
+  await fs.writeFile(filePath, snapshot);
+}
+
+/**
+ * @param {Object} frame
+ * @param {string} testName
+ * @param {string} snapshotName
+ */
+async function extractSnapshot(frame, testName, snapshotName) {
+  const { head, body } = await frame.evaluate((states) => {
+    // Mark the existing states on the elements. E.g. `matches(':hover')`
+    // becomes a `class="... karma-snapshot-hover"`.
+    const cleanup = [];
+    states.forEach((state) => {
+      document.querySelectorAll(`:${state}`).forEach((element) => {
+        const className = `karma-snapshot-${state}`;
+        element.classList.add(className);
+        cleanup.push(() => {
+          element.classList.remove(className);
+        });
+      });
+    });
+
+    // TODO: more careful head selection.
+    const result = {
+      head: document.head.innerHTML,
+      body: document.body.outerHTML,
+    };
+
+    // Cleanup: remove temporary state classes.
+    cleanup.forEach((c) => c());
+
+    return result;
+  }, STATES);
+
+  const transformHtml = (s) => {
+    // Transform CSS states: `:hover` -> `.karma-snapshot-hover`.
+    s = s.replace(STATE_CSS_RE, (_, state) => `.karma-snapshot-${state}`);
+    // Transform absolute URLs.
+    s = s.replace(/http:\/\/localhost:9876\//gi, '/');
+    return s;
+  };
+
+  return `<!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
+      <title>${testName}: ${snapshotName}</title>
+      <style>
+        body {
+          margin: 0;
+          width: 100vw;
+          height: 100vh;
+        }
+      </style>
+      ${transformHtml(head)}
+    </head>
+    ${transformHtml(body)}
+    </html>
+  `;
+}
+
+module.exports = extractAndSaveSnapshot;


### PR DESCRIPTION
## Summary

Snapshotting has been flaky for a couple of reasons:

1. Race conditions with CSS transitions.
2. Some CSS states are not transferred or transferred incorrectly to the snapshot.

## Relevant Technical Choices

The solution is thus:

1. The transitions are disabled in Karma tests. They are mostly harmful anyway since React's `act()` can't capture it.
2. The focused, active, hover and other states are transferred manually from the live document to snapshot via replacing these states with internal karma classes. Thus `x:hover` becomes `x.karma-snapshot-hover`.

An example of how the snapshots improves here is this diff:

![image](https://user-images.githubusercontent.com/726049/85445370-27e7d900-b548-11ea-9427-d8b7893c1547.png)
![image](https://user-images.githubusercontent.com/726049/85445407-30d8aa80-b548-11ea-827c-58fed1d29503.png)


## User-facing changes

n/a

## Testing Instructions

n/a

---

<!-- Please reference the issue(s) this PR addresses. -->

