### PR TITLE
Karma: reset the pointer between tests

### DIFF
--- a/assets/src/edit-story/karma/_init.js
+++ b/assets/src/edit-story/karma/_init.js
@@ -172,7 +172,7 @@ afterAll(() => {
   }
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   // @todo: ideally we can find a way to use a new <body> for each test, but
   // there are too many browser APIs to patch to make it consistent.
 
@@ -192,6 +192,10 @@ beforeEach(() => {
     margin: 0;
   `;
   document.body.appendChild(rootEl);
+
+  // Each test should start with the pointer in the same location ([-1,-1]) to
+  // avoid flakes pointerover/mouseover/hover flakes.
+  await karmaPuppeteer.mouse.seq([{ type: 'move', x: -1, y: -1 }]);
 });
 
 afterEach(() => {

--- a/assets/src/edit-story/karma/_init.js
+++ b/assets/src/edit-story/karma/_init.js
@@ -194,7 +194,7 @@ beforeEach(async () => {
   document.body.appendChild(rootEl);
 
   // Each test should start with the pointer in the same location ([-1,-1]) to
-  // avoid flakes pointerover/mouseover/hover flakes.
+  // avoid pointerover/mouseover/hover flakes.
   await karmaPuppeteer.mouse.seq([{ type: 'move', x: -1, y: -1 }]);
 });
 

--- a/assets/src/edit-story/karma/fixture/fixture.js
+++ b/assets/src/edit-story/karma/fixture/fixture.js
@@ -187,11 +187,7 @@ export class Fixture {
    *
    * @return {Promise} Yields when the editor rendering is complete.
    */
-  async render() {
-    // Each test should start with the pointer in the same location ([0,0]) to
-    // avoid flakes pointerover/mouseover/hover flakes.
-    await this._events.mouse.move(0, 0);
-
+  render() {
     const root = document.querySelector('test-root');
     const { container, getByRole } = render(
       <FlagsProvider features={this._flags}>

--- a/assets/src/edit-story/karma/fixture/fixture.js
+++ b/assets/src/edit-story/karma/fixture/fixture.js
@@ -187,7 +187,11 @@ export class Fixture {
    *
    * @return {Promise} Yields when the editor rendering is complete.
    */
-  render() {
+  async render() {
+    // Each test should start with the pointer in the same location ([0,0]) to
+    // avoid flakes pointerover/mouseover/hover flakes.
+    await this._events.mouse.move(0, 0);
+
     const root = document.querySelector('test-root');
     const { container, getByRole } = render(
       <FlagsProvider features={this._flags}>


### PR DESCRIPTION
## Summary

The puppeteer pointer stays where the last test left it and it causes flakes for other tests.

## Relevant Technical Choices

The solution: move the pointer to 0,0 before each test.

## To-do

n/a

## User-facing changes

n/a

## Testing Instructions

n/a

---

