### PR TITLE
Dashboard: Update tooltip text for grid view

### DIFF
--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -109,9 +109,12 @@ export default function BodyViewOptions({
                 </ExternalLink>
               )}
               <ViewStyleBar
-                label={resultsLabel}
                 layoutStyle={layoutStyle}
                 onPress={handleLayoutSelect}
+                ariaLabel={__(
+                  'Toggle between showing stories as a grid or list.',
+                  'web-stories'
+                )}
               />
             </ControlsContainer>
           )}

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -111,10 +111,6 @@ export default function BodyViewOptions({
               <ViewStyleBar
                 layoutStyle={layoutStyle}
                 onPress={handleLayoutSelect}
-                ariaLabel={__(
-                  'Toggle between showing stories as a grid or list.',
-                  'web-stories'
-                )}
               />
             </ControlsContainer>
           )}

--- a/assets/src/dashboard/components/viewStyleBar/index.js
+++ b/assets/src/dashboard/components/viewStyleBar/index.js
@@ -62,11 +62,14 @@ const GridIcon = styled(GridSVG).attrs(ICON_METRICS.VIEW_STYLE)`
   align-items: center;
 `;
 
-export default function ViewStyleBar({ onPress, layoutStyle, ariaLabel }) {
+export default function ViewStyleBar({ onPress, layoutStyle }) {
   return (
     <Container>
       <Tooltip content={VIEW_STYLE_LABELS[layoutStyle]} position="right">
-        <ToggleButton aria-label={ariaLabel} onClick={onPress}>
+        <ToggleButton
+          aria-label={VIEW_STYLE_LABELS[layoutStyle]}
+          onClick={onPress}
+        >
           {layoutStyle === VIEW_STYLE.GRID && (
             <ListIcon data-testid="list-icon" />
           )}
@@ -80,7 +83,6 @@ export default function ViewStyleBar({ onPress, layoutStyle, ariaLabel }) {
 }
 
 ViewStyleBar.propTypes = {
-  ariaLabel: PropTypes.string,
   onPress: PropTypes.func,
   layoutStyle: PropTypes.oneOf([VIEW_STYLE.GRID, VIEW_STYLE.LIST]).isRequired,
 };

--- a/assets/src/dashboard/components/viewStyleBar/index.js
+++ b/assets/src/dashboard/components/viewStyleBar/index.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * External dependencies
  */
 import PropTypes from 'prop-types';
@@ -29,9 +24,9 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 
-import { Grid as GridSVG, List as ListSVG } from '../icons';
-import { ICON_METRICS, VIEW_STYLE, VIEW_STYLE_LABELS } from '../constants';
-import Tooltip from './tooltip';
+import { Grid as GridSVG, List as ListSVG } from '../../icons';
+import { ICON_METRICS, VIEW_STYLE, VIEW_STYLE_LABELS } from '../../constants';
+import Tooltip from '../tooltip';
 
 const Container = styled.div`
   display: flex;
@@ -67,19 +62,17 @@ const GridIcon = styled(GridSVG).attrs(ICON_METRICS.VIEW_STYLE)`
   align-items: center;
 `;
 
-export default function ViewStyleBar({ onPress, layoutStyle }) {
+export default function ViewStyleBar({ onPress, layoutStyle, ariaLabel }) {
   return (
     <Container>
       <Tooltip content={VIEW_STYLE_LABELS[layoutStyle]} position="right">
-        <ToggleButton
-          aria-label={__(
-            'Toggle between showing stories as a grid or list.',
-            'web-stories'
+        <ToggleButton aria-label={ariaLabel} onClick={onPress}>
+          {layoutStyle === VIEW_STYLE.GRID && (
+            <ListIcon data-testid="list-icon" />
           )}
-          onClick={onPress}
-        >
-          {layoutStyle === VIEW_STYLE.GRID && <ListIcon />}
-          {layoutStyle === VIEW_STYLE.LIST && <GridIcon />}
+          {layoutStyle === VIEW_STYLE.LIST && (
+            <GridIcon data-testid="grid-icon" />
+          )}
         </ToggleButton>
       </Tooltip>
     </Container>
@@ -87,6 +80,7 @@ export default function ViewStyleBar({ onPress, layoutStyle }) {
 }
 
 ViewStyleBar.propTypes = {
+  ariaLabel: PropTypes.string,
   onPress: PropTypes.func,
   layoutStyle: PropTypes.oneOf([VIEW_STYLE.GRID, VIEW_STYLE.LIST]).isRequired,
 };

--- a/assets/src/dashboard/components/viewStyleBar/stories/index.js
+++ b/assets/src/dashboard/components/viewStyleBar/stories/index.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { text, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+
+/**
+ * Internal dependencies
+ */
+import { VIEW_STYLE } from '../../../constants';
+import ViewStyleBar from '..';
+
+export default {
+  title: 'Dashboard/Components/ViewStyleBar',
+  component: ViewStyleBar,
+};
+
+export const _default = () => {
+  return (
+    <ViewStyleBar
+      layoutStyle={select('layoutStyle', VIEW_STYLE, VIEW_STYLE.LIST)}
+      onPress={action('on press clicked')}
+      ariaLabel={text('ariaLabel', 'My helpful aria label')}
+    />
+  );
+};

--- a/assets/src/dashboard/components/viewStyleBar/stories/index.js
+++ b/assets/src/dashboard/components/viewStyleBar/stories/index.js
@@ -16,7 +16,7 @@
 /**
  * External dependencies
  */
-import { text, select } from '@storybook/addon-knobs';
+import { select } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 /**
@@ -35,7 +35,6 @@ export const _default = () => {
     <ViewStyleBar
       layoutStyle={select('layoutStyle', VIEW_STYLE, VIEW_STYLE.LIST)}
       onPress={action('on press clicked')}
-      ariaLabel={text('ariaLabel', 'My helpful aria label')}
     />
   );
 };

--- a/assets/src/dashboard/components/viewStyleBar/test/viewStyleBar.js
+++ b/assets/src/dashboard/components/viewStyleBar/test/viewStyleBar.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { VIEW_STYLE } from '../../../constants';
+import { renderWithTheme } from '../../../testUtils/';
+import ViewStyleBar from '..';
+
+describe('<ViewStyleBar />', function () {
+  const mockPress = jest.fn();
+
+  it(`should render the list icon when layoutStyle is ${VIEW_STYLE.GRID}`, function () {
+    const { getByTestId, queryAllByTestId } = renderWithTheme(
+      <ViewStyleBar layoutStyle={VIEW_STYLE.GRID} onPress={mockPress} />
+    );
+
+    const listIcon = getByTestId('list-icon');
+    expect(listIcon).toBeInTheDocument();
+
+    const gridIcon = queryAllByTestId('grid-icon');
+    expect(gridIcon).toHaveLength(0);
+  });
+
+  it(`should render the grid icon when layoutStyle is ${VIEW_STYLE.LIST}`, function () {
+    const { getByTestId, queryAllByTestId } = renderWithTheme(
+      <ViewStyleBar layoutStyle={VIEW_STYLE.LIST} onPress={mockPress} />
+    );
+
+    const gridIcon = getByTestId('grid-icon');
+    expect(gridIcon).toBeInTheDocument();
+
+    const listIcon = queryAllByTestId('list-icon');
+    expect(listIcon).toHaveLength(0);
+  });
+
+  it('should have triggered mockPress once on onPress click', function () {
+    const { getByTestId } = renderWithTheme(
+      <ViewStyleBar layoutStyle={VIEW_STYLE.LIST} onPress={mockPress} />
+    );
+
+    const gridIcon = getByTestId('grid-icon');
+
+    fireEvent.click(gridIcon);
+    expect(mockPress).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -85,8 +85,8 @@ export const VIEW_STYLE = {
 };
 
 export const VIEW_STYLE_LABELS = {
-  [VIEW_STYLE.GRID]: __('Grid View', 'web-stories'),
-  [VIEW_STYLE.LIST]: __('List View', 'web-stories'),
+  [VIEW_STYLE.GRID]: __('Switch to List View', 'web-stories'),
+  [VIEW_STYLE.LIST]: __('Switch to Grid View', 'web-stories'),
 };
 
 export const ICON_METRICS = {


### PR DESCRIPTION
updating tooltip text for view toggle to tell users what to expect if they click icon button. Updating viewStyleBar component to match other components in directory - storybook and tests added

## Summary
Updating tooltip text for view toggle to tell users what to expect if they click icon button. Now if currently on the grid view it will say "Switch to List View" and if you are on the list view it will say "Switch to Grid View" when you hover over the toggle icon. 
![Screen Shot 2020-06-23 at 2 53 06 PM](https://user-images.githubusercontent.com/10720454/85473613-5a093300-b568-11ea-916a-9a3e298cd749.png)
![Screen Shot 2020-06-23 at 2 52 59 PM](https://user-images.githubusercontent.com/10720454/85473615-5aa1c980-b568-11ea-8b98-dd893c2490ce.png)

## Relevant Technical Choices
- Text update is in constants/ 
- While here also updated the `ViewStyleBar` component to have a directory with tests and storybook
- Removed redundant `label` prop that wasn't getting used 
- aria-label is now matching tooltip text
- Added `data-testid` to icons used in ViewStyleBar to write easier tests. 

## User-facing changes
- On hover of toggle view icons in dashboard (see screenshots attached) you should see the following text:
  - When in grid view: "Switch to List View"
  - When in list view: "Switch to Grid View"

## Testing Instructions
- Verify the above text updates 
- See that Dashboard/Components/ViewStyleBar works - it has a knob to toggle the view.
- See that new unit tests work

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2398 
