### PR TITLE
Replace existing test containers for frames

### DIFF
--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -20,6 +20,11 @@
 import { memo } from 'react';
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { useStory } from '../../app';
@@ -43,7 +48,11 @@ function DisplayLayer() {
   );
 
   return (
-    <Layer data-testid="DisplayLayer" pointerEvents="none">
+    <Layer
+      data-testid="DisplayLayer"
+      pointerEvents="none"
+      aria-label={__('Display', 'web-stories')}
+    >
       <PageArea
         ref={setPageContainer}
         fullbleedRef={setFullbleedContainer}

--- a/assets/src/edit-story/components/canvas/karma/carousel.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/carousel.karma.js
@@ -108,12 +108,7 @@ xdescribe('Carousel integration', () => {
 
     // Exit.
     await fixture.events.keyboard.press('Esc');
-    const framesLayer = fixture.querySelector('[data-testid="FramesLayer"]');
-    await waitFor(() => {
-      if (!framesLayer.contains(document.activeElement)) {
-        throw new Error('Focus is not set on the canvas yet');
-      }
-    });
+    await fixture.editor.canvas.framesLayer.waitFocusedWithin();
   });
 
   it('should click into carousel on the second page', async () => {

--- a/assets/src/edit-story/components/canvas/karma/keys.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/keys.karma.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { waitFor } from '@testing-library/react';
-
-/**
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
@@ -46,14 +41,7 @@ describe('Canvas keys integration', () => {
       })
     );
 
-    // @todo: The focusing is currently done via timeout. Find a way to
-    // make this nicer.
-    const framesLayer = fixture.querySelector('[data-testid="FramesLayer"]');
-    await waitFor(() => {
-      if (!framesLayer.contains(document.activeElement)) {
-        throw new Error('Focus is not set on the canvas yet');
-      }
-    });
+    await fixture.editor.canvas.framesLayer.waitFocusedWithin();
   });
 
   afterEach(() => {

--- a/assets/src/edit-story/components/canvas/karma/multiSelectionMovable.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/multiSelectionMovable.karma.js
@@ -88,9 +88,9 @@ describe('Multi-selection Movable integration', () => {
         })
       );
 
-      frame1 = fixture.editor.canvas.framesLayer.frame(element1.id);
-      frame2 = fixture.editor.canvas.framesLayer.frame(element2.id);
-      frame3 = fixture.editor.canvas.framesLayer.frame(element3.id);
+      frame1 = fixture.editor.canvas.framesLayer.frame(element1.id).node;
+      frame2 = fixture.editor.canvas.framesLayer.frame(element2.id).node;
+      frame3 = fixture.editor.canvas.framesLayer.frame(element3.id).node;
     });
 
     it('should render initial content', async () => {

--- a/assets/src/edit-story/components/canvas/karma/multiSelectionMovable.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/multiSelectionMovable.karma.js
@@ -27,19 +27,12 @@ describe('Multi-selection Movable integration', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-
     await fixture.render();
   });
 
   afterEach(() => {
     fixture.restore();
   });
-
-  function getElementFrame(id) {
-    return fixture.querySelector(
-      `[data-testid="frameElement"][data-element-id="${id}"]`
-    );
-  }
 
   async function clickOnTarget(target, key = false) {
     const { x, y, width, height } = target.getBoundingClientRect();
@@ -95,9 +88,9 @@ describe('Multi-selection Movable integration', () => {
         })
       );
 
-      frame1 = getElementFrame(element1.id);
-      frame2 = getElementFrame(element2.id);
-      frame3 = getElementFrame(element3.id);
+      frame1 = fixture.editor.canvas.framesLayer.frame(element1.id);
+      frame2 = fixture.editor.canvas.framesLayer.frame(element2.id);
+      frame3 = fixture.editor.canvas.framesLayer.frame(element3.id);
     });
 
     it('should render initial content', async () => {

--- a/assets/src/edit-story/components/canvas/karma/pageMenuActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/pageMenuActions.karma.js
@@ -55,18 +55,16 @@ describe('PageMenu integration', () => {
       );
       // @todo: The focusing is currently done via timeout. Find a way to
       // make this nicer.
-      const framesLayer = fixture.querySelector('[data-testid="FramesLayer"]');
+      const framesLayer = fixture.editor.canvas.framesLayer;
       await waitFor(() => {
-        if (!framesLayer.contains(document.activeElement)) {
+        if (!framesLayer.node.contains(document.activeElement)) {
           throw new Error('Focus is not set on the canvas yet');
         }
       });
     });
 
     function getFrame() {
-      return fixture.querySelector(
-        `[data-element-id="${element.id}"] [data-testid="textFrame"]`
-      );
+      return fixture.editor.canvas.framesLayer.frame(element.id);
     }
 
     async function getSelection() {
@@ -75,7 +73,7 @@ describe('PageMenu integration', () => {
     }
 
     it('should render initial content and make it selected', async () => {
-      expect(getFrame().textContent).toEqual('hello world!');
+      expect(getFrame().node.textContent).toEqual('hello world!');
       expect(await getSelection()).toEqual([element.id]);
     });
 

--- a/assets/src/edit-story/components/canvas/karma/pageMenuActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/pageMenuActions.karma.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { waitFor } from '@testing-library/react';
-
-/**
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
@@ -53,14 +48,7 @@ describe('PageMenu integration', () => {
           width: 250,
         })
       );
-      // @todo: The focusing is currently done via timeout. Find a way to
-      // make this nicer.
-      const framesLayer = fixture.editor.canvas.framesLayer;
-      await waitFor(() => {
-        if (!framesLayer.node.contains(document.activeElement)) {
-          throw new Error('Focus is not set on the canvas yet');
-        }
-      });
+      await fixture.editor.canvas.framesLayer.waitFocusedWithin();
     });
 
     function getFrame() {

--- a/assets/src/edit-story/components/canvas/karma/selection.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/selection.karma.js
@@ -49,12 +49,6 @@ describe('Selection integration', () => {
     fixture.restore();
   });
 
-  function getFrame(elementId) {
-    return fixture.querySelector(
-      `[data-element-id="${elementId}"] [data-testid="textFrame"]`
-    );
-  }
-
   async function getSelection() {
     const storyContext = await fixture.renderHook(() => useStory());
     return storyContext.state.selectedElementIds;
@@ -65,7 +59,7 @@ describe('Selection integration', () => {
   });
 
   it('should show the selection lines when out of page area', async () => {
-    const frame1 = getFrame(element1.id);
+    const frame1 = fixture.editor.canvas.framesLayer.frame(element1.id).node;
     await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
       moveRel(frame1, 5, 5),
       down(),
@@ -77,7 +71,7 @@ describe('Selection integration', () => {
   });
 
   it('should show the selection under the page menu', async () => {
-    const frame1 = getFrame(element1.id);
+    const frame1 = fixture.editor.canvas.framesLayer.frame(element1.id).node;
     const fbcr = frame1.getBoundingClientRect();
     await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
       moveRel(frame1, 5, 5),

--- a/assets/src/edit-story/components/dropTargets/karma/order.karma.js
+++ b/assets/src/edit-story/components/dropTargets/karma/order.karma.js
@@ -33,18 +33,6 @@ describe('Drop-Target order', () => {
     fixture.restore();
   });
 
-  function getFrame(elementId) {
-    return fixture.querySelector(
-      `[data-testid="FramesLayer"] [data-element-id="${elementId}"]`
-    );
-  }
-
-  function getDisplay(elementId) {
-    return fixture.querySelector(
-      `[data-testid="DisplayLayer"] [data-element-id="${elementId}"]`
-    );
-  }
-
   it('should replace top image when bg image is set and another one is on top', async () => {
     const insertElement = await fixture.renderHook(() => useInsertElement());
 
@@ -63,7 +51,9 @@ describe('Drop-Target order', () => {
     const replacementImage = await fixture.act(() =>
       insertElement('image', curiosityImageProps)
     );
-    const replacementImageFrame = getFrame(replacementImage.id);
+    const replacementImageFrame = fixture.editor.canvas.framesLayer.frame(
+      replacementImage.id
+    ).node;
 
     await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
       moveRel(replacementImageFrame, 10, 10),
@@ -74,8 +64,12 @@ describe('Drop-Target order', () => {
 
     const backgroundId = await getBackgroundElementId(fixture);
     // TODO: refactor after #2386?
-    const topImageImg = getDisplay(topImage.id).querySelector('img');
-    const backgroundImg = getDisplay(backgroundId).querySelector('img');
+    const topImageImg = fixture.editor.canvas.displayLayer
+      .display(topImage.id)
+      .node.querySelector('img');
+    const backgroundImg = fixture.editor.canvas.displayLayer
+      .display(backgroundId)
+      .node.querySelector('img');
     // TODO: improve with custom matchers
     expect(topImageImg.src).toBe(replacementImage.resource.src);
     expect(backgroundImg.src).toBe(bgImage.resource.src);
@@ -95,7 +89,9 @@ describe('Drop-Target order', () => {
     const replacementImage = await fixture.act(() =>
       insertElement('image', { ...curiosityImageProps, x: 100, y: 100 })
     );
-    const replacementImageFrame = getFrame(replacementImage.id);
+    const replacementImageFrame = fixture.editor.canvas.framesLayer.frame(
+      replacementImage.id
+    ).node;
 
     await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
       moveRel(replacementImageFrame, 10, 10),
@@ -104,8 +100,12 @@ describe('Drop-Target order', () => {
       up(),
     ]);
 
-    const topImageImg = getDisplay(topImage.id).querySelector('img');
-    const bottomImageImg = getDisplay(bottomImage.id).querySelector('img');
+    const topImageImg = fixture.editor.canvas.displayLayer
+      .display(topImage.id)
+      .node.querySelector('img');
+    const bottomImageImg = fixture.editor.canvas.displayLayer
+      .display(bottomImage.id)
+      .node.querySelector('img');
     expect(topImageImg.src).toBe(replacementImage.resource.src);
     expect(bottomImageImg.src).toBe(bottomImage.resource.src);
   });

--- a/assets/src/edit-story/components/richText/karma/itf.karma.js
+++ b/assets/src/edit-story/components/richText/karma/itf.karma.js
@@ -108,16 +108,9 @@ describe('Background Overlay Panel', () => {
     await fixture.events.keyboard.shortcut('Escape');
   }
 
-  function getCanvasElementWrapperById(id) {
-    return fixture.querySelector(
-      `[data-testid="safezone"] [data-element-id="${id}"]`
-    );
-  }
-
   async function clickElement(elementId) {
-    const wrapper = await getCanvasElementWrapperById(elementId);
-    const rect = wrapper.getBoundingClientRect();
-    await fixture.events.mouse.click(rect.left + 1, rect.top + 1);
+    const frame = fixture.editor.canvas.framesLayer.frame(elementId).node;
+    await fixture.events.mouse.clickOn(frame, 1, 1);
   }
 
   async function getTextContent() {

--- a/assets/src/edit-story/elements/text/karma/edit.karma.js
+++ b/assets/src/edit-story/elements/text/karma/edit.karma.js
@@ -57,9 +57,7 @@ describe('TextEdit integration', () => {
         })
       );
 
-      frame = fixture.querySelector(
-        `[data-element-id="${element.id}"] [data-testid="textFrame"]`
-      );
+      frame = fixture.editor.canvas.framesLayer.frame(element.id).node;
     });
 
     it('should render initial content', () => {
@@ -116,7 +114,8 @@ describe('TextEdit integration', () => {
         );
 
         // The content is updated in the frame.
-        expect(frame.innerHTML).toEqual(
+        // @todo: What to do with `<p>` and containers?
+        expect(frame.querySelector('p').innerHTML).toEqual(
           '<span style="font-weight: 700">hello world!</span>'
         );
       });

--- a/assets/src/edit-story/elements/text/karma/frame.karma.js
+++ b/assets/src/edit-story/elements/text/karma/frame.karma.js
@@ -62,18 +62,16 @@ describe('TextFrame integration', () => {
     });
 
     it('clicking', async () => {
-      await clickFixtureElement(fixture, canvas);
+      await fixture.events.mouse.clickOn(canvas);
 
-      frame = fixture.querySelector(
-        `[data-element-id="${element.id}"] [data-testid="textFrame"]`
-      );
+      frame = fixture.editor.canvas.framesLayer.frame(element.id);
 
-      await fixture.events.click(frame, { clickCount: 3 });
+      await fixture.events.click(frame.node, { clickCount: 3 });
 
       await fixture.events.keyboard.type('hello world after select element!');
 
       editor = fixture.querySelector(`[data-testid="textEditor"]`);
-      await clickFixtureElement(fixture, editor, { offset: { x: 10, y: 0 } });
+      await fixture.events.mouse.clickOn(editor, -10, 0);
 
       const storyContext = await fixture.renderHook(() => useStory());
       expect(storyContext.state.selectedElementIds).toEqual([element.id]);
@@ -81,26 +79,24 @@ describe('TextFrame integration', () => {
         'hello world after select element!'
       );
 
-      expect(frame.innerHTML).toEqual('hello world after select element!');
+      expect(frame.node.textContent).toEqual(
+        'hello world after select element!'
+      );
     });
 
     it('pressing Enter', async () => {
-      await clickFixtureElement(fixture, canvas);
+      await fixture.events.mouse.clickOn(canvas);
 
-      frame = fixture.querySelector(
-        `[data-element-id="${element.id}"] [data-testid="textFrame"]`
-      );
+      frame = fixture.editor.canvas.framesLayer.frame(element.id);
 
-      await clickFixtureElement(fixture, frame);
+      await fixture.events.mouse.clickOn(frame.node);
 
       await fixture.events.keyboard.press('Enter');
 
       await fixture.events.keyboard.type('hello world after press Enter!');
 
       editor = fixture.querySelector(`[data-testid="textEditor"]`);
-      await clickFixtureElement(fixture, editor, {
-        offset: { x: 10, y: 0 },
-      });
+      await fixture.events.mouse.clickOn(editor, -10, 0);
 
       const storyContext = await fixture.renderHook(() => useStory());
       expect(storyContext.state.selectedElementIds).toEqual([element.id]);
@@ -108,24 +104,20 @@ describe('TextFrame integration', () => {
         'hello world after press Enter!'
       );
 
-      expect(frame.innerHTML).toEqual('hello world after press Enter!');
+      expect(frame.node.textContent).toEqual('hello world after press Enter!');
     });
 
     it('typing', async () => {
-      await clickFixtureElement(fixture, canvas);
+      await fixture.events.mouse.clickOn(canvas);
 
-      frame = fixture.querySelector(
-        `[data-element-id="${element.id}"] [data-testid="textFrame"]`
-      );
+      frame = fixture.editor.canvas.framesLayer.frame(element.id);
 
-      await clickFixtureElement(fixture, frame);
+      await fixture.events.mouse.clickOn(frame.node);
 
       await fixture.events.keyboard.type('hello world after type!');
 
       editor = fixture.querySelector(`[data-testid="textEditor"]`);
-      await clickFixtureElement(fixture, editor, {
-        offset: { x: 10, y: 0 },
-      });
+      await fixture.events.mouse.clickOn(editor, -10, 0);
 
       const storyContext = await fixture.renderHook(() => useStory());
       expect(storyContext.state.selectedElementIds).toEqual([element.id]);
@@ -133,17 +125,7 @@ describe('TextFrame integration', () => {
         'hello world after type!'
       );
 
-      expect(frame.innerHTML).toEqual('hello world after type!');
+      expect(frame.node.textContent).toEqual('hello world after type!');
     });
   });
 });
-
-async function clickFixtureElement(fixture, target, options = {}) {
-  const { offset } = options;
-  const offsetX = offset ? offset.x : 0;
-  const offsetY = offset ? offset.y : 0;
-
-  const { x, y } = target.getBoundingClientRect();
-  await fixture.events.mouse.move(x - offsetX, y - offsetY);
-  await fixture.events.mouse.down();
-}

--- a/assets/src/edit-story/karma/fixture/containers/canvas.js
+++ b/assets/src/edit-story/karma/fixture/containers/canvas.js
@@ -29,8 +29,11 @@ export class Canvas extends Container {
   }
 
   get displayLayer() {
-    // @todo: display layer.
-    return null;
+    return this._get(
+      this.getByRole('region', { name: 'Display' }),
+      'displayLayer',
+      DisplayLayer
+    );
   }
 
   get framesLayer() {
@@ -43,6 +46,42 @@ export class Canvas extends Container {
 
   get editLayer() {
     return null;
+  }
+}
+
+/**
+ * Contains element displays.
+ */
+class DisplayLayer extends Container {
+  constructor(node, path) {
+    super(node, path);
+  }
+
+  get displays() {
+    return this._getAll(
+      // @todo: improve query.
+      this.node.querySelectorAll('[data-element-id]'),
+      (node) => `displays[${node.getAttribute('data-element-id')}]`,
+      Frame
+    );
+  }
+
+  display(elementId) {
+    return this._get(
+      // @todo: improve query.
+      this.node.querySelector(`[data-element-id="${elementId}"]`),
+      `displays[${elementId}]`,
+      Display
+    );
+  }
+}
+
+/**
+ * An element's display.
+ */
+class Display extends Container {
+  constructor(node, path) {
+    super(node, path);
   }
 }
 
@@ -61,7 +100,7 @@ class FramesLayer extends Container {
   get frames() {
     return this._getAll(
       // @todo: improve query.
-      this.node.querySelectorAll('[data-testid="frameElement"]'),
+      this.node.querySelectorAll('[data-element-id]'),
       (node) => `frames[${node.getAttribute('data-element-id')}]`,
       Frame
     );

--- a/assets/src/edit-story/karma/fixture/containers/container.js
+++ b/assets/src/edit-story/karma/fixture/containers/container.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { getByRole, queryByRole } from '@testing-library/react';
+import { getByRole, queryByRole, waitFor } from '@testing-library/react';
 
 export class Container {
   /**
@@ -35,6 +35,18 @@ export class Container {
 
   get path() {
     return this._path;
+  }
+
+  /**
+   * @return {!Promise} Resolve when the element or one of its children becomes
+   * focused.
+   */
+  waitFocusedWithin() {
+    return waitFor(() => {
+      if (!this._node.contains(document.activeElement)) {
+        throw new Error(`Focus is not set within the <${this._path}> yet`);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
A follow up on https://github.com/google/web-stories-wp/pull/2386 to replace the already-supported test containers in the current tests.