### PR TITLE
Add Media3p api fetcher

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/media3p/api/apiFetcher.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/api/apiFetcher.js
@@ -42,7 +42,7 @@ const OrderBy = {
 };
 
 /**
- * Perform a GET request to the Media3P API to list photos.
+ * Perform a GET request to the Media3P API to list media.
  * If the parameters are invalid or the server does not return a 200 response,
  * an error is thrown.
  *
@@ -69,7 +69,7 @@ const OrderBy = {
  * the call that provided the page token.
  * @return {Promise<Object>} The response from the API.
  */
-export async function listPhotos({
+export async function listMedia({
   languageCode = null,
   filter = null,
   orderBy = null,
@@ -97,7 +97,7 @@ export async function listPhotos({
   const data = await fetch(url);
 
   if (!data.length) {
-    throw new Error('Obtained an empty response from listPhotos call.');
+    throw new Error('Obtained an empty response from listMedia call.');
   }
 
   return JSON.parse(data);

--- a/assets/src/edit-story/components/library/panes/media/media3p/api/apiFetcher.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/api/apiFetcher.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import fetch from './fetch';
+
+const API_DOMAIN = 'https://staging-media3p.sandbox.googleapis.com';
+const API_KEY = 'AIzaSyAgauA-izuTeGWFe9d9O0d0id-pV43Y4kE';
+
+/**
+ * The methods exposed by the api
+ *
+ * @enum {string}
+ */
+const Paths = {
+  LIST_MEDIA: '/v1/media',
+};
+
+/**
+ * The supported order_by values.
+ *
+ * @enum {string}
+ */
+const OrderBy = {
+  RELEVANCE: 'relevance',
+  LATEST: 'latest',
+};
+
+/**
+ * Perform a GET request to the Media3P API to list photos.
+ * If the parameters are invalid or the server does not return a 200 response,
+ * an error is thrown.
+ *
+ * @param {Object} obj - An object with the options for the request.
+ * @param {?string} obj.languageCode The BCP-47 language code, such as "en-US"
+ * or "sr-Latn".
+ * @param {?string} obj.filter  Filter details for items returned.
+ * Filter fields available:
+ * > provider - The media provider to query, or a universal list/search if
+ * left blank.
+ * > type - The media type, either 'image' or 'video'.
+ * > query - A keyword search string.
+ * This may be specified without the 'query:' prefix.
+ * @param {?string} obj.orderBy The sort order for returned results.
+ * Valid sort fields are:
+ * > relevance - The default. This is 'most popular' when listing results,
+ * and 'most relevant' when applying a keyword search.
+ * > latest - Last updated time descending.
+ * @param {?number} obj.pageSize Maximum number of results to be returned by the
+ * server. If unspecified or zero, at most 20 media resources will be returned.
+ * @param {?string} obj.pageToken A page token, received from a previous
+ * `ListMedia` call. Provide this to retrieve the subsequent page.
+ * When paginating, all other parameters provided to `ListMedia` must match
+ * the call that provided the page token.
+ * @return {Promise<Object>} The response from the API.
+ */
+export async function listPhotos({
+  languageCode = null,
+  filter = null,
+  orderBy = null,
+  pageSize = null,
+  pageToken = null,
+} = {}) {
+  validateFilter(filter);
+  validateOrderBy(orderBy);
+  validatePageSize(pageSize);
+
+  const params = [
+    ['language_code', languageCode],
+    ['filter', filter],
+    ['order_by', orderBy],
+    ['page_size', pageSize],
+    ['page_token', pageToken],
+    ['key', API_KEY],
+  ].filter((entry) => Boolean(entry[1]));
+  // Querystring always has at least the api key
+  const queryString = params
+    .map((entry) => entry[0] + '=' + entry[1])
+    .join('&');
+  const url = API_DOMAIN + Paths.LIST_MEDIA + '?' + queryString;
+
+  const data = await fetch(url);
+
+  if (!data.length) {
+    throw new Error('Obtained an empty response from listPhotos call.');
+  }
+
+  return JSON.parse(data);
+}
+
+function validateFilter(filter) {
+  // TODO: implement.
+  return filter == null || filter === '';
+}
+
+function validateOrderBy(orderBy) {
+  if (
+    orderBy == null ||
+    Object.values(OrderBy).indexOf(orderBy.toLowerCase()) > -1
+  ) {
+    return;
+  }
+  throw new Error('Invalid order_by: ' + orderBy);
+}
+
+function validatePageSize(pageSize) {
+  if (pageSize == null || pageSize > 0) {
+    return;
+  }
+  throw new Error('Invalid page_size: ' + pageSize);
+}

--- a/assets/src/edit-story/components/library/panes/media/media3p/api/apiFetcher.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/api/apiFetcher.js
@@ -20,7 +20,7 @@
 import fetch from './fetch';
 
 const API_DOMAIN = 'https://staging-media3p.sandbox.googleapis.com';
-const API_KEY = 'AIzaSyAgauA-izuTeGWFe9d9O0d0id-pV43Y4kE';
+const API_KEY = 'AIzaSyAgauA-izuTeGWFe9d9O0d0id-pV43Y4kE'; // dev key
 
 /**
  * The methods exposed by the api

--- a/assets/src/edit-story/components/library/panes/media/media3p/api/apiFetcher.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/api/apiFetcher.js
@@ -76,7 +76,6 @@ export async function listMedia({
   pageSize = null,
   pageToken = null,
 } = {}) {
-  validateFilter(filter);
   validateOrderBy(orderBy);
   validatePageSize(pageSize);
 
@@ -89,10 +88,8 @@ export async function listMedia({
     ['key', API_KEY],
   ].filter((entry) => Boolean(entry[1]));
   // Querystring always has at least the api key
-  const queryString = params
-    .map((entry) => entry[0] + '=' + entry[1])
-    .join('&');
-  const url = API_DOMAIN + Paths.LIST_MEDIA + '?' + queryString;
+  const queryString = new URLSearchParams(Object.fromEntries(new Map(params)));
+  const url = API_DOMAIN + Paths.LIST_MEDIA + '?' + queryString.toString();
 
   const data = await fetch(url);
 
@@ -101,11 +98,6 @@ export async function listMedia({
   }
 
   return JSON.parse(data);
-}
-
-function validateFilter(filter) {
-  // TODO: implement.
-  return filter == null || filter === '';
 }
 
 function validateOrderBy(orderBy) {

--- a/assets/src/edit-story/components/library/panes/media/media3p/api/fetch.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/api/fetch.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import https from 'https';
+
+/**
+ * Simple utility function to make GET requests.
+ *
+ * Used to fetch data from the Google Fonts API.
+ *
+ * @param {string} url URL to request.
+ * @return {Promise<string>} Result.
+ */
+function fetch(url) {
+  return new Promise((resolve, reject) => {
+    const data = [];
+
+    https
+      .get(url, (res) => {
+        if (res.statusCode < 200 || res.statusCode > 299) {
+          reject(new Error('Error fetching ' + url + ': ' + res.statusCode));
+        }
+
+        res.on('data', (chunk) => data.push(chunk));
+        res.on('end', () => resolve(data.join('')));
+      })
+      .on('error', reject);
+  });
+}
+
+export default fetch;

--- a/assets/src/edit-story/components/library/panes/media/media3p/api/test/apiFetcher.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/api/test/apiFetcher.js
@@ -18,7 +18,7 @@
  * Internal dependencies
  */
 import fetch from '../fetch';
-import { listPhotos } from '../apiFetcher';
+import { listMedia } from '../apiFetcher';
 
 jest.mock('../fetch');
 
@@ -42,17 +42,17 @@ describe('ApiFetcher', () => {
     fetch.mockReset();
   };
 
-  it('listPhotos should perform a GET request', async () => {
+  it('listMedia should perform a GET request', async () => {
     setup();
     fetch.mockImplementationOnce(() =>
       Promise.resolve(VALID_LIST_PHOTOS_RESPONSE)
     );
 
-    const result = await listPhotos();
+    const result = await listMedia();
     expect(result.media[0].name).toBe('photo 29044');
   });
 
-  it('listPhotos should format request params correctly', async () => {
+  it('listMedia should format request params correctly', async () => {
     setup();
     fetch.mockImplementationOnce(() =>
       Promise.resolve(VALID_LIST_PHOTOS_RESPONSE)
@@ -63,7 +63,7 @@ describe('ApiFetcher', () => {
     const pageToken = '1234';
     const filter = 'cat';
 
-    const result = await listPhotos({
+    const result = await listMedia({
       languageCode,
       pageSize,
       orderBy,
@@ -87,33 +87,33 @@ describe('ApiFetcher', () => {
     expect(queryParams).toHaveLength(6); // Also includes the key
   });
 
-  it('listPhotos should throw an error for an invalid pageSize', async () => {
+  it('listMedia should throw an error for an invalid pageSize', async () => {
     expect.assertions(2);
 
     await expect(
-      listPhotos({
+      listMedia({
         pageSize: 'big',
       })
     ).rejects.toThrow(/Invalid page_size/);
 
     await expect(
-      listPhotos({
+      listMedia({
         pageSize: -30,
       })
     ).rejects.toThrow(/Invalid page_size/);
   });
 
-  it('listPhotos should throw an error for an invalid orderBy', async () => {
+  it('listMedia should throw an error for an invalid orderBy', async () => {
     expect.assertions(2);
 
     await expect(
-      listPhotos({
+      listMedia({
         orderBy: 'oldest',
       })
     ).rejects.toThrow(/Invalid order_by/);
 
     await expect(
-      listPhotos({
+      listMedia({
         orderBy: '',
       })
     ).rejects.toThrow(/Invalid order_by/);

--- a/assets/src/edit-story/components/library/panes/media/media3p/api/test/apiFetcher.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/api/test/apiFetcher.js
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import fetch from '../fetch';
+import { listPhotos } from '../apiFetcher';
+
+jest.mock('../fetch');
+
+const VALID_LIST_PHOTOS_RESPONSE = JSON.stringify({
+  media: [
+    {
+      name: 'photo 29044',
+      imageUrls: [
+        {
+          url:
+            'https://upload.wikimedia.org/wikipedia/en/2/2e/Donald_Duck_-_temper.png',
+          imageName: 'original',
+        },
+      ],
+    },
+  ],
+});
+
+describe('ApiFetcher', () => {
+  const setup = function () {
+    fetch.mockReset();
+  };
+
+  it('listPhotos should perform a GET request', async () => {
+    setup();
+    fetch.mockImplementationOnce(() =>
+      Promise.resolve(VALID_LIST_PHOTOS_RESPONSE)
+    );
+
+    const result = await listPhotos();
+    expect(result.media[0].name).toBe('photo 29044');
+  });
+
+  it('listPhotos should format request params correctly', async () => {
+    setup();
+    fetch.mockImplementationOnce(() =>
+      Promise.resolve(VALID_LIST_PHOTOS_RESPONSE)
+    );
+    const languageCode = 'es';
+    const pageSize = 15;
+    const orderBy = 'latest';
+    const pageToken = '1234';
+    const filter = 'cat';
+
+    const result = await listPhotos({
+      languageCode,
+      pageSize,
+      orderBy,
+      pageToken,
+      filter,
+    });
+    expect(result.media[0].name).toBe('photo 29044');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const fetchArg = fetch.mock.calls[0][0];
+    const queryString = fetchArg.substring(fetchArg.indexOf('?') + 1);
+    const queryParams = queryString.split('&');
+    expect(queryParams).toStrictEqual(
+      expect.arrayContaining([
+        'language_code=' + languageCode,
+        'page_size=' + pageSize,
+        'order_by=' + orderBy,
+        'page_token=' + pageToken,
+        'filter=' + filter,
+      ])
+    );
+    expect(queryParams).toHaveLength(6); // Also includes the key
+  });
+
+  it('listPhotos should throw an error for an invalid pageSize', async () => {
+    expect.assertions(2);
+
+    await expect(
+      listPhotos({
+        pageSize: 'big',
+      })
+    ).rejects.toThrow(/Invalid page_size/);
+
+    await expect(
+      listPhotos({
+        pageSize: -30,
+      })
+    ).rejects.toThrow(/Invalid page_size/);
+  });
+
+  it('listPhotos should throw an error for an invalid orderBy', async () => {
+    expect.assertions(2);
+
+    await expect(
+      listPhotos({
+        orderBy: 'oldest',
+      })
+    ).rejects.toThrow(/Invalid order_by/);
+
+    await expect(
+      listPhotos({
+        orderBy: '',
+      })
+    ).rejects.toThrow(/Invalid order_by/);
+  });
+});

--- a/bin/utils/fetch.js
+++ b/bin/utils/fetch.js
@@ -22,8 +22,6 @@ import https from 'https';
 /**
  * Simple utility function to make GET requests.
  *
- * Used to fetch data from the Google Fonts API.
- *
  * @param {string} url URL to request.
  * @return {Promise<string>} Result.
  */


### PR DESCRIPTION
## Summary

Adds a Media3P API fetcher file with "listMedia".

## Relevant Technical Choices

Copied an existing fetch.js file which was under `utils` file to this directory.

## To-do

Add other methods, add ApiProvider.

## User-facing changes

None.

## Testing Instructions

Unit tests provided.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2367
