### PR TITLE
Re-enable carousel integration tests

### DIFF
--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -66,7 +66,7 @@ import useCarouselKeys from './useCarouselKeys';
 
 const CAROUSEL_BOTTOM_SCROLL_MARGIN = 8;
 
-const Wrapper = styled.div`
+const Wrapper = styled.section`
   position: relative;
   display: grid;
   grid: 'space prev-navigation carousel next-navigation menu' auto / 53px 53px 1fr 53px 53px;
@@ -251,6 +251,7 @@ function Carousel() {
     width: COMPACT_THUMB_WIDTH,
     height: COMPACT_THUMB_HEIGHT,
   });
+  const [resizedForPages, setResizedForPages] = useState(0);
 
   const isCompact =
     calculateThumbnailHeight(carouselSize) < MIN_CAROUSEL_THUMB_HEIGHT;
@@ -266,6 +267,7 @@ function Carousel() {
       setHasHorizontalOverflow(Math.ceil(scrollWidth) > Math.ceil(offsetWidth));
       setScrollPercentage(scrollLeft / max);
       setCarouselSize(currentCarouselSize);
+      setResizedForPages(pages.length);
     },
     [pages.length]
   );
@@ -361,7 +363,12 @@ function Carousel() {
 
   return (
     <>
-      <Wrapper ref={wrapperRef} data-testid="PageCarousel">
+      <Wrapper
+        ref={wrapperRef}
+        data-testid="PageCarousel"
+        aria-label={__('Page Carousel', 'web-stories')}
+        data-ready={resizedForPages === pages.length}
+      >
         <NavArea area="space" />
         <NavArea area="prev-navigation" marginBottom={arrowsBottomMargin}>
           <PrevButton
@@ -405,6 +412,7 @@ function Carousel() {
                   <Page
                     onClick={handleClickPage(page)}
                     role="option"
+                    data-page-id={page.id}
                     ariaLabel={
                       isCurrentPage
                         ? sprintf(

--- a/assets/src/edit-story/components/canvas/karma/carousel.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/carousel.karma.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { waitFor } from '@testing-library/react';
-
-/**
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
@@ -28,12 +23,9 @@ import { useInsertElement } from '..';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
 import createSolid from '../../../utils/createSolid';
 
-// @todo: Figure out the flakiness source and enable.
-// eslint-disable-next-line jasmine/no-disabled-tests
-xdescribe('Carousel integration', () => {
+describe('Carousel integration', () => {
   let fixture;
   let element1;
-  let carousel;
 
   beforeEach(async () => {
     fixture = new Fixture();
@@ -55,8 +47,6 @@ xdescribe('Carousel integration', () => {
         width: 250,
       })
     );
-
-    carousel = fixture.container.querySelector('[data-testid="PageCarousel"]');
   });
 
   afterEach(() => {
@@ -80,11 +70,11 @@ xdescribe('Carousel integration', () => {
     return pages.map(({ id }) => id);
   }
 
-  function getThumbnail(index) {
-    const thumbnails = carousel.querySelectorAll(
-      '[role="listbox"] button[role="option"]'
-    );
-    return thumbnails[index];
+  async function clickOnThumbnail(index) {
+    await fixture.editor.carousel.waitReady();
+    const thumb = fixture.editor.carousel.pages[index];
+    thumb.node.scrollIntoView();
+    await fixture.events.mouse.clickOn(thumb.node, 5, 5);
   }
 
   it('should select the current page', async () => {
@@ -93,18 +83,15 @@ xdescribe('Carousel integration', () => {
   });
 
   it('should click into carousel on the first page', async () => {
-    await fixture.events.mouse.clickOn(getThumbnail(0), 5, 5);
+    await clickOnThumbnail(0);
     expect(await getCurrentPageId()).toEqual('page1');
     expect(await getSelection()).toEqual([]);
   });
 
   it('should exit the carousel on Esc', async () => {
-    await fixture.events.mouse.clickOn(getThumbnail(0), 5, 5);
-    await waitFor(() => {
-      if (!carousel.contains(document.activeElement)) {
-        throw new Error('Focus is not set on the carousel yet');
-      }
-    });
+    // Enter.
+    await clickOnThumbnail(0);
+    await fixture.editor.carousel.waitFocusedWithin();
 
     // Exit.
     await fixture.events.keyboard.press('Esc');
@@ -112,13 +99,13 @@ xdescribe('Carousel integration', () => {
   });
 
   it('should click into carousel on the second page', async () => {
-    await fixture.events.mouse.clickOn(getThumbnail(1), 5, 5);
+    await clickOnThumbnail(1);
     expect(await getCurrentPageId()).toEqual('page2');
     expect(await getSelection()).toEqual([]);
   });
 
   it('should navigate the page with keys', async () => {
-    await fixture.events.mouse.clickOn(getThumbnail(1), 5, 5);
+    await clickOnThumbnail(1);
     expect(await getCurrentPageId()).toEqual('page2');
 
     // Go left.
@@ -147,7 +134,7 @@ xdescribe('Carousel integration', () => {
   });
 
   it('should reorder the page with keys', async () => {
-    await fixture.events.mouse.clickOn(getThumbnail(1), 5, 5);
+    await clickOnThumbnail(1);
     expect(await getCurrentPageId()).toEqual('page2');
 
     // Order left.
@@ -192,7 +179,7 @@ xdescribe('Carousel integration', () => {
   });
 
   it('should delete the first page', async () => {
-    await fixture.events.mouse.clickOn(getThumbnail(0), 5, 5);
+    await clickOnThumbnail(0);
     await fixture.events.keyboard.down('del');
     await fixture.events.keyboard.up('del');
     expect(await getPageIds()).toEqual(['page2', 'page3', 'page4']);
@@ -200,7 +187,7 @@ xdescribe('Carousel integration', () => {
   });
 
   it('should delete the second page', async () => {
-    await fixture.events.mouse.clickOn(getThumbnail(1), 5, 5);
+    await clickOnThumbnail(1);
     await fixture.events.keyboard.down('del');
     await fixture.events.keyboard.up('del');
     expect(await getPageIds()).toEqual(['page1', 'page3', 'page4']);
@@ -208,7 +195,7 @@ xdescribe('Carousel integration', () => {
   });
 
   it('should duplicate the first page', async () => {
-    await fixture.events.mouse.clickOn(getThumbnail(0), 5, 5);
+    await clickOnThumbnail(0);
     await fixture.events.keyboard.shortcut('mod+D');
     const newPageId = await getCurrentPageId();
     expect(await getPageIds()).toEqual([

--- a/assets/src/edit-story/karma/fixture/containers/canvas.js
+++ b/assets/src/edit-story/karma/fixture/containers/canvas.js
@@ -20,7 +20,7 @@
 import { Container } from './container';
 
 /**
- * The editor's canvas. Includes: display, frames, editor layers, carousel,
+ * The editor's canvas. Includes: display, frames, editor layers,
  * navigation buttons, page menu.
  */
 export class Canvas extends Container {

--- a/assets/src/edit-story/karma/fixture/containers/carousel.js
+++ b/assets/src/edit-story/karma/fixture/containers/carousel.js
@@ -18,44 +18,47 @@
  * Internal dependencies
  */
 import { Container } from './container';
-import { Canvas } from './canvas';
-import { Carousel } from './carousel';
-import { Library } from './library';
 
 /**
- * The complete editor container, including library, canvas, inspector, etc.
+ * The page carousel.
  */
-export class Editor extends Container {
+export class Carousel extends Container {
   constructor(node, path) {
     super(node, path);
   }
 
-  get canvas() {
-    return this._get(
-      this.getByRole('region', { name: 'Canvas' }),
-      'canvas',
-      Canvas
+  get pages() {
+    const pageList = this.getByRole('listbox', { name: 'Pages List' });
+    if (!pageList) {
+      return null;
+    }
+    return this._getAll(
+      // @todo: improve query.
+      pageList.querySelectorAll('button[role="option"]'),
+      (node) => `pages[${node.getAttribute('data-page-id')}]`,
+      PageThumb
     );
   }
 
-  get titleBar() {
-    // @todo: title bar container.
-    return null;
-  }
-
-  get library() {
+  page(pageId) {
+    const pageList = this.getByRole('listbox', { name: 'Pages List' });
+    if (!pageList) {
+      return null;
+    }
     return this._get(
-      this.getByRole('region', { name: 'Library' }),
-      'library',
-      Library
+      // @todo: improve query.
+      pageList.querySelector(`button[data-page-id="${pageId}"]`),
+      `pages[${pageId}]`,
+      PageThumb
     );
   }
+}
 
-  get carousel() {
-    return this._get(
-      this.getByRole('region', { name: 'Page Carousel' }),
-      'carousel',
-      Carousel
-    );
+/**
+ * A page thumbnail.
+ */
+class PageThumb extends Container {
+  constructor(node, path) {
+    super(node, path);
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/carousel.js
+++ b/assets/src/edit-story/karma/fixture/containers/carousel.js
@@ -30,7 +30,7 @@ export class Carousel extends Container {
   get pages() {
     const pageList = this.getByRole('listbox', { name: 'Pages List' });
     if (!pageList) {
-      return null;
+      return [];
     }
     return this._getAll(
       // @todo: improve query.
@@ -41,15 +41,8 @@ export class Carousel extends Container {
   }
 
   page(pageId) {
-    const pageList = this.getByRole('listbox', { name: 'Pages List' });
-    if (!pageList) {
-      return null;
-    }
-    return this._get(
-      // @todo: improve query.
-      pageList.querySelector(`button[data-page-id="${pageId}"]`),
-      `pages[${pageId}]`,
-      PageThumb
+    return this.pages.find(
+      (page) => page.node.getAttribute('data-page-id') === pageId
     );
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/container.js
+++ b/assets/src/edit-story/karma/fixture/containers/container.js
@@ -38,6 +38,21 @@ export class Container {
   }
 
   /**
+   * The container can indicate that it's not ready by setting the
+   * `data-ready="false"` attribute.
+   *
+   * @return {!Promise} Resolve when the container is ready.
+   */
+  waitReady() {
+    // @todo: consider joining on the parent waitReady as well.
+    return waitFor(() => {
+      if (this._node.getAttribute('data-ready') === 'false') {
+        throw new Error(`Container <${this._path}>is not ready  yet`);
+      }
+    });
+  }
+
+  /**
    * @return {!Promise} Resolve when the element or one of its children becomes
    * focused.
    */


### PR DESCRIPTION
## Technical considerations

This pull requests contains a few minor changes (e.g. it creates a test container for the carousel), but also one important consideration to guard against flakes - the `Container.waitReady` API. Some components such as carousel use `ResizeObserver` to complete their layout and testing before it happens is a big source of flakes. In other words - the layout of such components is asynchronous and unobservable to the test. `waitReady` takes care of it, by allowing the component to declare that it needs time to finish its layout and when it actually happens.

For now, a test should "know" and use this API when testing a relevant feature. I think this is ok since most of components have a good auto-layout, and this is more of an exception.
