### PR TITLE
Dashboard: Make sure story menus are always within confines of browser 

### DIFF
--- a/assets/src/dashboard/components/popoverMenu/popoverCard.js
+++ b/assets/src/dashboard/components/popoverMenu/popoverCard.js
@@ -110,32 +110,32 @@ const ButtonInner = styled(Popover)`
   }
 
   ${MenuRevealer} {
-    transition: ${(props) => (props.isOpen ? transition : 'none')};
+    transition: ${(props) => (props.isReady ? transition : 'none')};
     ${(props) => {
       const translateFromScale = 100 * (1 - initialScale);
       switch (props.align) {
         case CORNER_DIRECTIONS.top_right:
           return css`
-            transform: ${props.isOpen
+            transform: ${props.isReady
               ? 'none'
               : `translate(${translateFromScale}%, -${translateFromScale}%)`};
           `;
         case CORNER_DIRECTIONS.top_left:
           return css`
-            transform: ${props.isOpen
+            transform: ${props.isReady
               ? 'none'
               : `translate(-${translateFromScale}%, -${translateFromScale}%)`};
           `;
         case CORNER_DIRECTIONS.bottom_right:
           return css`
-            transform: ${props.isOpen
+            transform: ${props.isReady
               ? 'none'
               : `translate(${translateFromScale}%, ${translateFromScale}%)`};
           `;
         case CORNER_DIRECTIONS.bottom_left:
         default:
           return css`
-            transform: ${props.isOpen
+            transform: ${props.isReady
               ? 'none'
               : `translate(-${translateFromScale}%, ${translateFromScale}%)`};
           `;
@@ -144,32 +144,32 @@ const ButtonInner = styled(Popover)`
   }
 
   ${MenuCounterRevealer} {
-    transition: ${(props) => (props.isOpen ? transition : 'none')};
+    transition: ${(props) => (props.isReady ? transition : 'none')};
     ${(props) => {
       const translateFromScale = 100 * (1 - initialScale);
       switch (props.align) {
         case CORNER_DIRECTIONS.top_right:
           return css`
-            transform: ${props.isOpen
+            transform: ${props.isReady
               ? 'none'
               : `translate(-${translateFromScale}%, ${translateFromScale}%)`};
           `;
         case CORNER_DIRECTIONS.top_left:
           return css`
-            transform: ${props.isOpen
+            transform: ${props.isReady
               ? 'none'
               : `translate(${translateFromScale}%, ${translateFromScale}%)`};
           `;
         case CORNER_DIRECTIONS.bottom_right:
           return css`
-            transform: ${props.isOpen
+            transform: ${props.isReady
               ? 'none'
               : `translate(-${translateFromScale}%, -${translateFromScale}%)`};
           `;
         case CORNER_DIRECTIONS.bottom_left:
         default:
           return css`
-            transform: ${props.isOpen
+            transform: ${props.isReady
               ? 'none'
               : `translate(${translateFromScale}%, -${translateFromScale}%)`};
           `;
@@ -178,8 +178,9 @@ const ButtonInner = styled(Popover)`
   }
 
   ${Shadow} {
-    transition: ${(props) => (props.isOpen ? transition : 'none')};
-    transform: ${(props) => (props.isOpen ? 'none' : `scale(${initialScale})`)};
+    transition: ${(props) => (props.isReady ? transition : 'none')};
+    transform: ${(props) =>
+      props.isReady ? 'none' : `scale(${initialScale})`};
     transform-origin: ${(props) => {
       switch (props.align) {
         case CORNER_DIRECTIONS.top_right:
@@ -197,7 +198,7 @@ const ButtonInner = styled(Popover)`
 `;
 ButtonInner.propTypes = {
   align: PropTypes.oneOf(Object.values(CORNER_DIRECTIONS)),
-  isOpen: PropTypes.bool,
+  isReady: PropTypes.bool,
 };
 
 function PopoverCard({ children, isOpen }) {
@@ -252,7 +253,8 @@ function PopoverCard({ children, isOpen }) {
   return (
     <ButtonInner
       ref={menuTogglePositionRef}
-      isOpen={isOpen && isReady}
+      isOpen={isOpen}
+      isReady={isReady}
       align={align}
     >
       <MenuWrapper>

--- a/assets/src/dashboard/components/popoverMenu/popoverCard.js
+++ b/assets/src/dashboard/components/popoverMenu/popoverCard.js
@@ -242,12 +242,11 @@ function PopoverCard({ children, isOpen }) {
    * Seems funky, but we need 1 full render where the proper
    * alignment is set before we animate in. This prevents react
    * from batching those renders and animating from wrong alignemnt.
-   *
-   * Other options include scheduling with something like rAF
-   * if we think it's a more robust solution.
    */
   useEffect(() => {
-    setIsReady(Boolean(align));
+    const frameId = requestAnimationFrame(() => setIsReady(Boolean(align)));
+
+    return () => cancelAnimationFrame(frameId);
   }, [align]);
 
   return (

--- a/assets/src/dashboard/components/popoverMenu/stories/index.js
+++ b/assets/src/dashboard/components/popoverMenu/stories/index.js
@@ -24,7 +24,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import PopoverMenu from '../';
+import PopoverMenu, { PopoverMenuCard } from '../';
 
 const demoItems = [
   { value: '1', label: 'one' },
@@ -46,6 +46,12 @@ const PopoverWrapper = styled.div`
   position: relative;
 `;
 
+const PopoverCardWrapper = styled.div`
+  width: 100px;
+  margin: 400px 0 0 200px;
+  position: relative;
+`;
+
 export const _default = () => (
   <PopoverWrapper>
     <PopoverMenu
@@ -57,4 +63,16 @@ export const _default = () => (
       }}
     />
   </PopoverWrapper>
+);
+
+export const _PopoverCard = () => (
+  <PopoverCardWrapper>
+    <PopoverMenuCard
+      items={demoItems}
+      isOpen={boolean('isOpen', true)}
+      onSelect={(item) => {
+        action(`clicked on dropdown item ${item.value}`)(item);
+      }}
+    />
+  </PopoverCardWrapper>
 );


### PR DESCRIPTION
## Summary
Makes sure that the story menu that's open for a story with the three vertical dots on hover of a story is always within the confines of the browser - shouldn't be cut off by the edge of the viewport anymore. 

![top right position](https://user-images.githubusercontent.com/10720454/85631767-fc89ea80-b62a-11ea-9cd7-d5036a5ca7f7.gif)
![bottom right position](https://user-images.githubusercontent.com/10720454/85631771-feec4480-b62a-11ea-9fd3-6f4f76fca9ed.gif)

<img width="527" alt="Screen Shot 2020-06-24 at 3 00 09 PM" src="https://user-images.githubusercontent.com/10720454/85632056-728e5180-b62b-11ea-919a-76375be69776.png">
<img width="537" alt="Screen Shot 2020-06-24 at 3 00 16 PM" src="https://user-images.githubusercontent.com/10720454/85632061-73bf7e80-b62b-11ea-8087-b5ebc37804c8.png">


## Relevant Technical Choices
- `getBoundingClientRect` on the refs that set alignment in `PopoverCard` were coming up 0 every time because the menu was using `isOpen` AND `isReady` to decide when to set align as well as transition. If we just let `isOpen` be the gatekeeper for the useLayoutEffect that sets alignment and then have `isReady`, which is triggered when `align` changes handle the css properties for transitioning the alignment Max worked on a few months ago and the transitions all work. 

## User-facing changes
- Story menus should now always be within the viewport

## Testing Instructions
- Try opening story menus in the browser at varying points of the window and see that the alignment updates. 
- You can also see it in storybook - Dashboard/Components/PopoverMenu/PopoverCard or Dashboard/Components/StoryMenu 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2219 
