### PR TITLE
Provide a separate type for TextOutputWithUnits to remove dev warnings

### DIFF
--- a/assets/src/edit-story/elements/text/output.js
+++ b/assets/src/edit-story/elements/text/output.js
@@ -173,7 +173,7 @@ export function TextOutputWithUnits({
 }
 
 TextOutputWithUnits.propTypes = {
-  element: StoryPropTypes.elements.text.isRequired,
+  element: StoryPropTypes.textContent.isRequired,
   dataToStyleX: PropTypes.func.isRequired,
   dataToStyleY: PropTypes.func.isRequired,
   dataToFontSizeY: PropTypes.func,

--- a/assets/src/edit-story/elements/text/util.js
+++ b/assets/src/edit-story/elements/text/util.js
@@ -23,12 +23,11 @@
  * @return {Object} The map of text style properties and values.
  */
 export function generateParagraphTextStyle(
-  element,
+  { font, fontSize, lineHeight, padding, textAlign },
   dataToStyleX,
   dataToStyleY,
   dataToFontSizeY = dataToStyleY
 ) {
-  const { font, fontSize, lineHeight, padding, textAlign } = element;
   return {
     whiteSpace: 'pre-wrap',
     margin: 0,

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -216,8 +216,7 @@ export const PaddingPropType = PropTypes.shape({
   ]),
 });
 
-StoryPropTypes.elements.text = PropTypes.shape({
-  ...StoryElementPropTypes,
+const StoryTextElementPropTypes = {
   content: PropTypes.string,
   backgroundTextMode: PropTypes.oneOf(Object.values(BACKGROUND_TEXT_MODE)),
   backgroundColor: PatternPropType,
@@ -226,6 +225,15 @@ StoryPropTypes.elements.text = PropTypes.shape({
   lineHeight: PropTypes.number,
   padding: PaddingPropType,
   textAlign: PropTypes.string,
+};
+
+StoryPropTypes.textContent = PropTypes.shape({
+  ...StoryTextElementPropTypes,
+});
+
+StoryPropTypes.elements.text = PropTypes.shape({
+  ...StoryElementPropTypes,
+  ...StoryTextElementPropTypes,
 });
 
 StoryPropTypes.elements.shape = PropTypes.shape({


### PR DESCRIPTION
The `TextOutputWithUnits` uses a narrow type and thus it spams warnings in console and karma tests. It accounts for ~30% of all warnings we see.