### PR TITLE
Fix blob URLs after elements manipulation while uploading

### DIFF
--- a/assets/src/edit-story/components/canvas/useUploadWithPreview.js
+++ b/assets/src/edit-story/components/canvas/useUploadWithPreview.js
@@ -91,7 +91,7 @@ function useUploadWithPreview() {
     ({ element }) => {
       deleteElementById({ elementId: element.id });
       showSnackbar({
-        message: __('Upload failed, preview was removed', 'web-stories'),
+        message: __('Upload failed, the element was removed', 'web-stories'),
       });
     },
     [deleteElementById, showSnackbar]


### PR DESCRIPTION
## Summary

This will fix the happy path (element was manipulated but the resource uploaded successfully) for the given [issue](https://github.com/google/web-stories-wp/issues/2706).
Failure case is still evaluated.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Upload file (big enough so you have the time to duplicate it and set as BG).
2. Duplicate it and set it as BG.
3. After the upload is done, Save the story.
4. Reload the editor.
5. Both images should be fine.

---

