### PR TITLE
Dashboard: Scroll to top of My Stories when Filter or View style is changed

### DIFF
--- a/assets/src/dashboard/app/views/myStories/content/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/index.js
@@ -22,6 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
+import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 /**
@@ -33,6 +34,7 @@ import {
   InfiniteScroller,
   Layout,
   StandardViewContentGutter,
+  useLayoutContext,
 } from '../../../../components';
 import {
   UsersPropType,
@@ -61,6 +63,27 @@ function Content({
   users,
   view,
 }) {
+  const {
+    actions: { scrollToTop },
+  } = useLayoutContext();
+
+  const previousFilter = useRef(filter);
+  const previousViewStyle = useRef(view.style);
+
+  useEffect(() => {
+    /**
+     * Ensure we only scroll back to top when the filter or view style change.
+     */
+    if (
+      previousFilter.current !== filter ||
+      previousViewStyle.current !== view.style
+    ) {
+      previousFilter.current = filter;
+      previousViewStyle.current = view.style;
+      scrollToTop();
+    }
+  }, [filter, scrollToTop, view]);
+
   return (
     <Layout.Scrollable>
       <FontProvider>


### PR DESCRIPTION
## Summary

Scroll to the top of the view when a filter or view style is changed for the My Stories page in the Dashboard.

## Relevant Technical Choices

- The combination of `useEffect` hook and `useRef` for previous value reference storage to ensure we only scroll to top when it has changed.

## User-facing changes

- View scrolls to top when a filter or view setting is changed

## Testing Instructions

1. Visit the My Stories view on dashboard
2. Scroll down the page and select a new dashboard filter like Drafts, All, Published and see the view scroll to top
3. Scroll down the page and select the Grid/List view toggle and see the view scroll to top 
---

<!-- Please reference the issue(s) this PR addresses. -->

#2596 
