### PR TITLE
Dashboard: Increase maximum number of stories per request

### DIFF
--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -94,7 +94,7 @@ export const ICON_METRICS = {
   LEFT_RIGHT_ARROW: { width: 16, height: 16 },
 };
 
-export const ITEMS_PER_PAGE = 20;
+export const ITEMS_PER_PAGE = 100; // default max per request
 
 export const DASHBOARD_VIEWS = {
   MY_STORIES: 'MY_STORIES',


### PR DESCRIPTION
## Summary
Updates quantity of stories per request to 100

## User-facing changes
- Loads 100 stories at a time instead of 20

## Testing Instructions
- Load the dashboard, see that the number of stories requested on initial load is now 100 not 20. 
- See that the per_page value in API queries on dashboard is now 100: `wp-json/wp/v2/web-story?` and `wp-json/wp/v2/users?per_page=100`
![Screen Shot 2020-06-25 at 9 25 12 AM](https://user-images.githubusercontent.com/10720454/85760428-ad919300-b6c6-11ea-9302-56d7f91e149f.png)
![Screen Shot 2020-06-25 at 9 29 22 AM](https://user-images.githubusercontent.com/10720454/85760432-aec2c000-b6c6-11ea-8f93-320d3e430417.png)


---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2076 
