### PR TITLE
Media: Use different cursor on the image editor indicating panning

### DIFF
--- a/assets/src/edit-story/elements/media/edit.js
+++ b/assets/src/edit-story/elements/media/edit.js
@@ -65,6 +65,7 @@ const cropMediaCSS = css`
   ${mediaWithScale}
   ${elementWithFlip}
   position: absolute;
+  cursor: grab;
   opacity: ${({ opacity }) =>
     opacity ? 1 - (1 - opacity) / (1 - opacity * MEDIA_MASK_OPACITY) : null};
 `;


### PR DESCRIPTION
## Summary

Simple change for displaying a different cursor on the draggable portions of the image/video editor

## Relevant Technical Choices

None

## To-do

None

## User-facing changes

User will see a `grab` cursor instead of the default cursor when panning/moving the image in edit mode

## Testing Instructions

1. Insert an shape into the canvas
2. Drag an image/video onto the shape to created a masked image/video
3. Enter edit mode by double-clicking on the element
4. Try to move/pan the image/video, the cursor should look like a hand instead of its default appearance.


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1192
