### PR TITLE
Dashboard: Honor scrollbar system preferences while maintaining layout dimensions

### DIFF
--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -54,16 +54,14 @@ DashboardGrid.propTypes = {
   columnWidth: PropTypes.number.isRequired,
 };
 
-const CardGrid = ({ children, pageSize }) => {
-  return (
-    <DashboardGrid
-      columnWidth={pageSize.width}
-      columnHeight={pageSize.containerHeight}
-    >
-      {children}
-    </DashboardGrid>
-  );
-};
+const CardGrid = ({ children, pageSize }) => (
+  <DashboardGrid
+    columnWidth={pageSize.width}
+    columnHeight={pageSize.containerHeight}
+  >
+    {children}
+  </DashboardGrid>
+);
 
 CardGrid.propTypes = {
   children: PropTypes.node.isRequired,

--- a/assets/src/dashboard/components/layout/scrollable.js
+++ b/assets/src/dashboard/components/layout/scrollable.js
@@ -16,7 +16,6 @@
 /**
  * External dependencies
  */
-import { useEffect, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -55,22 +54,10 @@ const Scrollable = ({ children }) => {
   const {
     state: { scrollFrameRef, squishContentHeight },
   } = useLayoutContext();
-  const [scrollbarWidth, setScrollbarWidth] = useState(0);
 
-  const getScrollbarWidth = useCallback(() => {
-    const { current } = scrollFrameRef;
-
-    setScrollbarWidth(current.offsetWidth - current.clientWidth);
-  }, [scrollFrameRef]);
-
-  useEffect(() => {
-    if (!scrollFrameRef.current) {
-      return () => {};
-    }
-    getScrollbarWidth();
-
-    return () => {};
-  }, [getScrollbarWidth, scrollFrameRef]);
+  const scrollbarWidth = scrollFrameRef?.current
+    ? scrollFrameRef.current.offsetWidth - scrollFrameRef.current.clientWidth
+    : 0;
 
   return (
     <ScrollContent ref={scrollFrameRef}>

--- a/assets/src/dashboard/components/layout/scrollable.js
+++ b/assets/src/dashboard/components/layout/scrollable.js
@@ -16,8 +16,10 @@
 /**
  * External dependencies
  */
+import { useEffect, useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+
 /**
  * Internal dependencies
  */
@@ -42,6 +44,7 @@ const ScrollContent = styled.div`
 const Inner = styled.div`
   position: relative;
   padding-top: ${(props) => props.paddingTop || 0}px;
+  width: ${({ scrollbarWidth }) => `calc(100% + ${scrollbarWidth}px)`};
 `;
 
 Inner.propTypes = {
@@ -52,10 +55,28 @@ const Scrollable = ({ children }) => {
   const {
     state: { scrollFrameRef, squishContentHeight },
   } = useLayoutContext();
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+
+  const getScrollbarWidth = useCallback(() => {
+    const { current } = scrollFrameRef;
+
+    setScrollbarWidth(current.offsetWidth - current.clientWidth);
+  }, [scrollFrameRef]);
+
+  useEffect(() => {
+    if (!scrollFrameRef.current) {
+      return () => {};
+    }
+    getScrollbarWidth();
+
+    return () => {};
+  }, [getScrollbarWidth, scrollFrameRef]);
 
   return (
     <ScrollContent ref={scrollFrameRef}>
-      <Inner paddingTop={squishContentHeight}>{children}</Inner>
+      <Inner scrollbarWidth={scrollbarWidth} paddingTop={squishContentHeight}>
+        {children}
+      </Inner>
     </ScrollContent>
   );
 };


### PR DESCRIPTION
## Summary
Trying out one possible idea to honor users' system preferences for showing scroll bars while maintaining a tight scrollable layout.

## Relevant Technical Choices
To find the width of the browser defined scrollbar that is a setting the user chooses in their system preferences (completely out of our control) you can take the offsetWidth of the scrollable container and subtract the clientWidth. In the case of the dashboard's layout we have a set "Scrollable" area of the layout. Inside this is always a grid. The grid is tight in that it's "responsive" but using specific pixel dimensions to define each item in the grid. So I decided to see about adjusting the available width of the scrollable container's child (`Inner`). 

By adding the width of the browser based scrollbar to the `Inner` width (`calc(100% + scrollbarWidth)`) we're taking care of whatever user preferences - honoring them - but adjusting our scrollable content to stretch past the scrollbar to maintain our layout dimensions. 


## To-do
- PC based testing 

## User-facing changes
The grid should never have a weird chunk of empty space. 

## Testing Instructions
Open your system prefs -> general (this is on a mac) and set show scroll bars to any option, refresh dashboard grid see that the layout is intact. Repeat this with the other options (Automatically based on mouse, When scrolling, and Always). 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2707
