### PR TITLE
Dashboard: Refactor detail nav bar to reuse for stories

### DIFF
--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -22,7 +22,6 @@ import { sprintf, __ } from '@wordpress/i18n';
  * External dependencies
  */
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -65,7 +64,6 @@ function TemplateDetails() {
   const [orderedTemplates, setOrderedTemplates] = useState([]);
   const { pageSize } = usePagePreviewSize({ isGrid: true });
   const { isRTL } = useConfig();
-  const enableBookmarks = useFeature('enableBookmarkActions');
 
   const {
     state: {
@@ -206,7 +204,6 @@ function TemplateDetails() {
               <DetailViewNavBar
                 ctaText={__('Use template', 'web-stories')}
                 handleCta={() => createStoryFromTemplate(template)}
-                isBookmarkingEnabled={enableBookmarks}
               />
             </Layout.Fixed>
             <Layout.Scrollable>

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -22,6 +22,7 @@ import { sprintf, __ } from '@wordpress/i18n';
  * External dependencies
  */
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -64,6 +65,7 @@ function TemplateDetails() {
   const [orderedTemplates, setOrderedTemplates] = useState([]);
   const { pageSize } = usePagePreviewSize({ isGrid: true });
   const { isRTL } = useConfig();
+  const enableBookmarks = useFeature('enableBookmarkActions');
 
   const {
     state: {
@@ -191,6 +193,8 @@ function TemplateDetails() {
     switchToTemplateByOffset,
   ]);
 
+  const handleBookmarkClickSelected = useCallback(() => {}, []);
+
   if (!template) {
     return null;
   }
@@ -203,6 +207,9 @@ function TemplateDetails() {
             <Layout.Fixed>
               <DetailViewNavBar
                 ctaText={__('Use template', 'web-stories')}
+                handleBookmarkClick={
+                  enableBookmarks && handleBookmarkClickSelected
+                }
                 handleCta={() => createStoryFromTemplate(template)}
               />
             </Layout.Fixed>

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -33,10 +33,10 @@ import {
   CardGallery,
   ColorList,
   DetailViewContentGutter,
+  DetailViewNavBar,
   Layout,
   PaginationButton,
   Pill,
-  TemplateNavBar,
 } from '../../../components';
 import { clamp, usePagePreviewSize } from '../../../utils/';
 import { ApiContext } from '../../api/apiProvider';
@@ -193,8 +193,6 @@ function TemplateDetails() {
     switchToTemplateByOffset,
   ]);
 
-  const handleBookmarkClickSelected = useCallback(() => {}, []);
-
   if (!template) {
     return null;
   }
@@ -205,11 +203,10 @@ function TemplateDetails() {
         <TransformProvider>
           <Layout.Provider>
             <Layout.Fixed>
-              <TemplateNavBar
+              <DetailViewNavBar
+                ctaText={__('Use template', 'web-stories')}
                 handleCta={() => createStoryFromTemplate(template)}
-                handleBookmarkClick={
-                  enableBookmarks ? handleBookmarkClickSelected : undefined
-                }
+                isBookmarkingEnabled={enableBookmarks}
               />
             </Layout.Fixed>
             <Layout.Scrollable>

--- a/assets/src/dashboard/components/detailViewNavBar/index.js
+++ b/assets/src/dashboard/components/detailViewNavBar/index.js
@@ -79,23 +79,32 @@ const CapitalizedButton = styled(Button)`
   text-transform: uppercase;
 `;
 
-export function TemplateNavBar({ handleCta, handleBookmarkClick }) {
+export function DetailViewNavBar({
+  handleCta,
+  handleBookmarkClick,
+  isBookmarkingEnabled,
+  ctaText,
+}) {
   return (
     <Nav>
       <Container>
         <CloseLink href={parentRoute()}>{__('Close', 'web-stories')}</CloseLink>
       </Container>
       <Container>
-        {handleBookmarkClick && <BookmarkToggle />}
+        {isBookmarkingEnabled && (
+          <BookmarkToggle onClick={handleBookmarkClick} />
+        )}
         <CapitalizedButton type={BUTTON_TYPES.CTA} onClick={handleCta}>
-          {__('Use template', 'web-stories')}
+          {ctaText}
         </CapitalizedButton>
       </Container>
     </Nav>
   );
 }
 
-TemplateNavBar.propTypes = {
+DetailViewNavBar.propTypes = {
+  ctaText: PropTypes.string.isRequired,
   handleBookmarkClick: PropTypes.func,
   handleCta: PropTypes.func.isRequired,
+  isBookmarkingEnabled: PropTypes.bool,
 };

--- a/assets/src/dashboard/components/detailViewNavBar/index.js
+++ b/assets/src/dashboard/components/detailViewNavBar/index.js
@@ -79,19 +79,14 @@ const CapitalizedButton = styled(Button)`
   text-transform: uppercase;
 `;
 
-export function DetailViewNavBar({
-  handleCta,
-  handleBookmarkClick,
-  isBookmarkingEnabled,
-  ctaText,
-}) {
+export function DetailViewNavBar({ handleCta, handleBookmarkClick, ctaText }) {
   return (
     <Nav>
       <Container>
         <CloseLink href={parentRoute()}>{__('Close', 'web-stories')}</CloseLink>
       </Container>
       <Container>
-        {isBookmarkingEnabled && (
+        {handleBookmarkClick && (
           <BookmarkToggle onClick={handleBookmarkClick} />
         )}
         <CapitalizedButton type={BUTTON_TYPES.CTA} onClick={handleCta}>
@@ -106,5 +101,4 @@ DetailViewNavBar.propTypes = {
   ctaText: PropTypes.string.isRequired,
   handleBookmarkClick: PropTypes.func,
   handleCta: PropTypes.func.isRequired,
-  isBookmarkingEnabled: PropTypes.bool,
 };

--- a/assets/src/dashboard/components/detailViewNavBar/stories/index.js
+++ b/assets/src/dashboard/components/detailViewNavBar/stories/index.js
@@ -17,21 +17,24 @@
  * External dependencies
  */
 import { action } from '@storybook/addon-actions';
+import { boolean, text } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
  */
-import { TemplateNavBar } from '../';
+import { DetailViewNavBar } from '../';
 
 export default {
-  title: 'Dashboard/Components/TemplateNavBar',
+  title: 'Dashboard/Components/DetailViewNavBar',
 };
 
 export const _default = () => {
   return (
-    <TemplateNavBar
+    <DetailViewNavBar
       handleCta={action('handle cta clicked')}
       handleBookmarkClick={action('handle bookmark clicked')}
+      isBookmarkingEnabled={boolean('isBookmarkingEnabled')}
+      ctaText={text('ctaText', 'Use template')}
     />
   );
 };

--- a/assets/src/dashboard/components/detailViewNavBar/stories/index.js
+++ b/assets/src/dashboard/components/detailViewNavBar/stories/index.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import { action } from '@storybook/addon-actions';
-import { boolean, text } from '@storybook/addon-knobs';
+import { text } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
@@ -33,7 +33,15 @@ export const _default = () => {
     <DetailViewNavBar
       handleCta={action('handle cta clicked')}
       handleBookmarkClick={action('handle bookmark clicked')}
-      isBookmarkingEnabled={boolean('isBookmarkingEnabled')}
+      ctaText={text('ctaText', 'Use template')}
+    />
+  );
+};
+
+export const NoBookmarking = () => {
+  return (
+    <DetailViewNavBar
+      handleCta={action('handle cta clicked')}
       ctaText={text('ctaText', 'Use template')}
     />
   );

--- a/assets/src/dashboard/components/detailViewNavBar/test/templateNavBar.js
+++ b/assets/src/dashboard/components/detailViewNavBar/test/templateNavBar.js
@@ -18,11 +18,11 @@
  * Internal dependencies
  */
 import { renderWithTheme } from '../../../testUtils/';
-import { TemplateNavBar } from '../';
+import { DetailViewNavBar } from '../';
 
-describe('TemplateNavBar', () => {
+describe('DetailViewNavBar', () => {
   it('should render nav bar for detail template view', () => {
-    const { getByRole } = renderWithTheme(<TemplateNavBar />);
+    const { getByRole } = renderWithTheme(<DetailViewNavBar />);
     const nav = getByRole('navigation');
 
     expect(nav).toBeDefined();

--- a/assets/src/dashboard/components/index.js
+++ b/assets/src/dashboard/components/index.js
@@ -29,6 +29,7 @@ export {
   DetailViewContentGutter,
   StandardViewContentGutter,
 } from './contentGutter';
+export { DetailViewNavBar } from './detailViewNavBar';
 export { default as Dialog } from './dialog';
 export { default as Dropdown } from './dropdown';
 export { default as InfiniteScroller } from './infiniteScroller';
@@ -69,7 +70,6 @@ export {
   TableStatusHeaderCell,
   TableStatusCell,
 } from './table';
-export { TemplateNavBar } from './templateNavBar';
 export { Toaster, ToastProvider, useToastContext } from './toaster';
 export { default as ToggleButtonGroup } from './toggleButtonGroup';
 export { default as TypeaheadInput } from './typeaheadInput';


### PR DESCRIPTION
## Summary
clean up template detail nav bar to be reusable for story details - first step in working on story previews. 

## Relevant Technical Choices
- renaming to be a generic detail view nav bar instead of template 
- moving actions and text out of component into parent view 
- cleaning up flagging for bookmarking so that we have a consistent boolean deciding if bookmarking is available

## User-facing changes
None

## Testing Instructions
- Confirm that the template detail view still has a nav bar with a back button and a cta to use template. 
- See storybook Dashboard/Components/DetailViewNavBar and see that you can toggle ability to bookmark and update cta text 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
