### PR TITLE
Color Presets: expand panel when adding first color

### DIFF
--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -61,10 +61,8 @@ function Panel({ resizeable, canCollapse, initialHeight, name, children }) {
   );
 
   useEffect(() => {
-    if (!canCollapse) {
-      setIsCollapsed(false);
-      expand(true);
-    }
+    setIsCollapsed(!canCollapse);
+    expand(true);
   }, [canCollapse, expand]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

When there are no saved colors, and one is added, make sure the panel is expanded correctly.

When removing the last saved color, make sure the panel is collapsed correctly.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

![ezgif-4-2aaa76b4e976](https://user-images.githubusercontent.com/841956/85867921-e5353380-b7c9-11ea-96b4-2b7b16fc4acc.gif)

## Testing Instructions

1. When there are no saved colors, and one is added, verify that the panel is expanded correctly.
1. When removing the last saved color, verify that the panel is collapsed correctly.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2783
