### PR TITLE
Dashboard: Update stories per request count to speed up time to first interaction

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -30,12 +30,11 @@ import { useFeatures } from 'flagged';
 /**
  * Internal dependencies
  */
-
 import {
   STORY_STATUSES,
   STORY_SORT_OPTIONS,
   ORDER_BY_SORT,
-  ITEMS_PER_PAGE,
+  STORIES_PER_REQUEST,
 } from '../../constants';
 import { migrate, DATA_VERSION } from '../../../edit-story/migration/migrate';
 import storyReducer, {
@@ -95,7 +94,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
       sortDirection,
       searchTerm,
       page = 1,
-      perPage = ITEMS_PER_PAGE,
+      perPage = STORIES_PER_REQUEST,
     }) => {
       dispatch({
         type: STORY_ACTION_TYPES.LOADING_STORIES,

--- a/assets/src/dashboard/app/api/useUserApi.js
+++ b/assets/src/dashboard/app/api/useUserApi.js
@@ -18,11 +18,12 @@
  * External dependencies
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import queryString from 'query-string';
 
 /**
  * Internal dependencies
  */
-import queryString from 'query-string';
+import { USERS_PER_REQUEST } from '../../constants';
 import groupBy from '../../utils/groupBy';
 import fetchAllFromTotalPages from './fetchAllFromPages';
 
@@ -33,7 +34,7 @@ export default function useUserApi(dataAdapter, { userApi }) {
       const response = await dataAdapter.get(
         queryString.stringifyUrl({
           url: userApi,
-          query: { per_page: 100 },
+          query: { per_page: USERS_PER_REQUEST },
         }),
         {
           parse: false,

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -94,8 +94,6 @@ export const ICON_METRICS = {
   LEFT_RIGHT_ARROW: { width: 16, height: 16 },
 };
 
-export const ITEMS_PER_PAGE = 100; // default max per request
-
 export const DASHBOARD_VIEWS = {
   MY_STORIES: 'MY_STORIES',
   SAVED_TEMPLATES: 'SAVED_TEMPLATES',
@@ -106,6 +104,11 @@ export const RESULT_LABELS = {
   [DASHBOARD_VIEWS.SAVED_TEMPLATES]: { ...SAVED_TEMPLATES_VIEWING_LABELS },
   [DASHBOARD_VIEWS.TEMPLATES_GALLERY]: { ...TEMPLATES_GALLERY_VIEWING_LABELS },
 };
+
+// API Query Constants
+export const ITEMS_PER_PAGE = 24;
+export const USERS_PER_REQUEST = 100;
+export const STORIES_PER_REQUEST = 24;
 
 export const DEFAULT_DATE_FORMAT = 'Y-m-d';
 


### PR DESCRIPTION
## Summary
I was a bit hasty in my update to set max stories per the original conversation attached to this PR's story :) Turns out that really slows things down! Per conversation with Omar, 24 stories per request is a happy medium for users with huge monitors and then the average user on a laptop or a tablet who is going to see max 10 stories (2 row of 5 at 1400px which is still large). 

## Relevant Technical Choices

**100 stories**
Stories API
50ish Mbps @ 100 stories per request API time takes 434 - 497ms to load 
3G slow @ 100 stories per request API time takes about 42s to load

Total timing
50ish Mbps:  Finish 5.9s, DOMContentLoaded 3.21s, Load 3.62s 
3G slow: Finish 1.8 min, DOMContentLoaded 44.30s, Load 47.43s

**60 Stories**  
Stories API 
50ish Mbps @ 60 stories per request API time takes 344 - 376ms to load 
3G slow @ 60 stories per request API time takes about 28s to load

Total timing
50ish Mbps:  Finish 1.54s, DOMContentLoaded 1.19s, Load 1.22s 
3G slow: Finish 1.2 min, DOMContentLoaded 44.39s, Load 47.43s

**24 Stories**  
Stories API 
50ish Mbps @ 24 stories per request API time takes about 203ms to load 
3G slow @ 24 stories per request API time takes about 13.11s to load

Total timing 
50ish Mbps:  Finish 1.38s, DOMContentLoaded 1.19s, Load 1.22s 
3G slow: Finish 57.34s, DOMContentLoaded 44.23s, Load 47.77s

## To-do
Deeper dive into perf 

## User-facing changes
- Dashboard should load faster

## Testing Instructions

- Verify that Dashboard loads faster 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2076 
