### PR TITLE
Add useProviderContextValueProvider

### DIFF
--- a/assets/src/edit-story/app/media/media3p/test/useContextValueProvider.js
+++ b/assets/src/edit-story/app/media/media3p/test/useContextValueProvider.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import useContextValueProvider from '../useContextValueProvider';
+import useProviderContextValueProvider from '../useProviderContextValueProvider';
+
+jest.mock('../useProviderContextValueProvider');
+
+describe('useContextValueProvider', () => {
+  it('should provide initial state for each provider', () => {
+    useProviderContextValueProvider.mockReturnValueOnce({
+      state: { media: [] },
+    });
+    const value = useContextValueProvider();
+
+    expect(value).toStrictEqual(
+      expect.objectContaining({
+        unsplash: {
+          state: { media: [] },
+        },
+      })
+    );
+  });
+});

--- a/assets/src/edit-story/app/media/media3p/useContextValueProvider.js
+++ b/assets/src/edit-story/app/media/media3p/useContextValueProvider.js
@@ -14,9 +14,26 @@
  * limitations under the License.
  */
 
-// TODO(https://github.com/google/web-stories-wp/issues/2426):
-// Delegate work to new 'useProviderContextValueProvider' hook, and from there
-// re-use logic from media/common/useContextValueProvider.js.
-export default function useContextValueProvider() {
-  return {};
+/**
+ * Internal dependencies
+ */
+import useProviderContextValueProvider from './useProviderContextValueProvider';
+
+// TODO(https://github.com/google/web-stories-wp/issues/2804):
+// Use provider configuration json fragment.
+const providers = ['unsplash'];
+
+export default function useContextValueProvider(reducerState, reducerActions) {
+  const result = {};
+
+  // The 'providers' list is a constant, and so hooks are still called in the
+  // same order during a re-render as per rules-of-hooks.
+  for (const provider of providers) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    result[provider] = useProviderContextValueProvider(
+      reducerState,
+      reducerActions
+    );
+  }
+  return result;
 }

--- a/assets/src/edit-story/app/media/media3p/useProviderContextValueProvider.js
+++ b/assets/src/edit-story/app/media/media3p/useProviderContextValueProvider.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO(https://github.com/google/web-stories-wp/issues/2802):
+// Implement, re-using logic from media/common/useContextValueProvider.js.
+export default function useProviderContextValueProvider() {
+  return {};
+}


### PR DESCRIPTION
## Summary

Add useProviderContextValueProvider, which will be used to return the context value (state and actions) for each provider starting with Unsplash.

Call useProviderContextValueProvider from useContextValueProvider.

## Testing Instructions

Open the media pane to verify that it appears.
