### PR TITLE
Install jest-axe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20180,6 +20180,70 @@
         }
       }
     },
+    "jest-axe": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-3.4.0.tgz",
+      "integrity": "sha512-iKAq/cBxvyizSkpSY+CTndsXy2v5IWAkYXqanPF6bGaGXJ3fEtzEWQRVeZ0SHCEbsjnvDaOly5nwiiDOz0suDw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^3.5.1",
+        "chalk": "^3.0.0",
+        "jest-matcher-utils": "^25.1.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "jest-canvas-mock": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "husky": "^4.2.5",
     "jasmine-core": "^3.5.0",
     "jest": "^25.5.4",
+    "jest-axe": "^3.4.0",
     "jest-canvas-mock": "^2.2.0",
     "jest-extended": "^0.11.5",
     "jest-fetch-mock": "^3.0.3",

--- a/tests/js/jest.setup.js
+++ b/tests/js/jest.setup.js
@@ -19,10 +19,12 @@
  */
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 import { setDefaultOptions } from 'jsdom-screenshot';
+
 // Extend Jest matchers.
 // See https://github.com/testing-library/jest-dom.
 import 'jest-extended';
 import '@testing-library/jest-dom';
+import 'jest-axe/extend-expect';
 
 // Allow using toBeEmpty which is also defined by jest-extended.
 // See https://github.com/facebook/jest/issues/9678.


### PR DESCRIPTION
## Summary

Installs `jest-axe` to enable accessibility scans for smaller units during tests.

**Does not include any tests.** Tests can be added by the relevant pods on a case-by-case basis in separate PRs.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1619
