### PR TITLE
Color Presets: Fix opacity detection

### DIFF
--- a/assets/src/edit-story/components/panels/stylePreset/test/panel.js
+++ b/assets/src/edit-story/components/panels/stylePreset/test/panel.js
@@ -68,6 +68,7 @@ function setupPanel(extraStylePresets, extraStateProps) {
     actions: { updateStory, updateElementsById, updateCurrentPageProperties },
   };
   const {
+    getAllByRole,
     getByRole,
     getByText,
     queryByLabelText,
@@ -80,6 +81,7 @@ function setupPanel(extraStylePresets, extraStateProps) {
     </StoryContext.Provider>
   );
   return {
+    getAllByRole,
     getByRole,
     getByText,
     queryByText,
@@ -388,7 +390,7 @@ describe('Panels/StylePreset', () => {
 
     it('should not apply colors with opacity as Page background', () => {
       const extraStylePresets = {
-        colors: [createSolid(1, 1, 1, 0.5)],
+        colors: [createSolid(1, 1, 1, 0.5), createSolid(1, 1, 1, 0)],
       };
       const extraStateProps = {
         selectedElements: [
@@ -398,17 +400,24 @@ describe('Panels/StylePreset', () => {
         ],
       };
       presetHasOpacity.mockImplementation((color) => {
-        return Boolean(color.color?.a && color.color.a < 1);
+        return Boolean(color.color?.a !== undefined && color.color.a < 1);
       });
-      const { getByRole, updateCurrentPageProperties } = setupPanel(
+      const { getAllByRole, updateCurrentPageProperties } = setupPanel(
         extraStylePresets,
         extraStateProps
       );
 
-      const applyPreset = getByRole('button', { name: APPLY_PRESET });
-      expect(applyPreset).toBeDefined();
+      const applyPresetButtons = getAllByRole('button', { name: APPLY_PRESET });
+      const applyPreset1 = applyPresetButtons[0];
+      expect(applyPreset1).toBeDefined();
 
-      fireEvent.click(applyPreset);
+      fireEvent.click(applyPreset1);
+      expect(updateCurrentPageProperties).toHaveBeenCalledTimes(0);
+
+      const applyPreset2 = applyPresetButtons[1];
+      expect(applyPreset2).toBeDefined();
+
+      fireEvent.click(applyPreset2);
       expect(updateCurrentPageProperties).toHaveBeenCalledTimes(0);
     });
 

--- a/assets/src/edit-story/components/panels/stylePreset/utils.js
+++ b/assets/src/edit-story/components/panels/stylePreset/utils.js
@@ -91,7 +91,7 @@ export function getPagePreset(page, stylePresets) {
 }
 
 function colorHasTransparency(color) {
-  return color.a && color.a < 1;
+  return color.a !== undefined && color.a < 1;
 }
 
 export function presetHasOpacity(preset) {


### PR DESCRIPTION
## Summary

Fixes a bug where having opacity 0 is considered not having opacity.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
1. Add a color preset from Shape which has gradient where the opacity of one of the stops is 0.
2. Select the Page
3. Verify that this color preset can't be used for the background.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2811 
