### PR TITLE
Pull out common parts of local/reducer.js to media/common/reducer.js

### DIFF
--- a/assets/src/edit-story/app/media/common/reducer.js
+++ b/assets/src/edit-story/app/media/common/reducer.js
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import * as types from '../types';
+
+export const INITIAL_STATE = {
+  media: [],
+  // TODO(https://github.com/google/web-stories-wp/issues/2828):
+  // Rename pagingNum to pageToken.
+  pagingNum: 1,
+  hasMore: true,
+  totalPages: 1,
+  isMediaLoading: false,
+  isMediaLoaded: false,
+};
+
+function reducer(state = INITIAL_STATE, { type, payload }) {
+  switch (type) {
+    case types.INITIAL_STATE:
+      return state;
+
+    case types.FETCH_MEDIA_START: {
+      return {
+        ...state,
+        isMediaLoaded: false,
+        isMediaLoading: true,
+      };
+    }
+
+    case types.FETCH_MEDIA_SUCCESS: {
+      const { media, pagingNum, totalPages } = payload;
+      const hasMore = pagingNum < totalPages;
+      return {
+        ...state,
+        media: [...state.media, ...media],
+        pagingNum,
+        totalPages,
+        hasMore,
+        isMediaLoaded: true,
+        isMediaLoading: false,
+      };
+    }
+
+    case types.FETCH_MEDIA_ERROR: {
+      return {
+        ...state,
+        isMediaLoaded: true,
+        isMediaLoading: false,
+      };
+    }
+
+    case types.SET_NEXT_PAGE: {
+      return {
+        ...state,
+        pagingNum: state.pagingNum + 1,
+      };
+    }
+
+    case types.UPDATE_MEDIA_ELEMENT: {
+      const { id, ...properties } = payload;
+
+      const mediaIndex = state.media.findIndex((media) => media.id === id);
+      if (mediaIndex === -1) {
+        return state;
+      }
+
+      const updatedMediaElement = {
+        ...state.media[mediaIndex],
+        ...properties,
+      };
+
+      const newMedia = [
+        ...state.media.slice(0, mediaIndex),
+        updatedMediaElement,
+        ...state.media.slice(mediaIndex + 1),
+      ];
+
+      return {
+        ...state,
+        media: newMedia,
+      };
+    }
+
+    case types.DELETE_MEDIA_ELEMENT: {
+      const { id } = payload;
+      return {
+        ...state,
+        media: state.media.filter((media) => media.id !== id),
+      };
+    }
+
+    default:
+      return state;
+  }
+}
+
+export default reducer;

--- a/assets/src/edit-story/app/media/local/reducer.js
+++ b/assets/src/edit-story/app/media/local/reducer.js
@@ -21,55 +21,26 @@
  */
 import * as types from '../types';
 
+import commonReducer, {
+  INITIAL_STATE as COMMON_INITIAL_STATE,
+} from '../common/reducer';
+
 const INITIAL_STATE = {
-  media: [],
+  ...COMMON_INITIAL_STATE,
   processing: [],
   processed: [],
-  pagingNum: 1,
-  totalPages: 1,
-  hasMore: true,
   mediaType: '',
   searchTerm: '',
-  isMediaLoading: false,
-  isMediaLoaded: false,
 };
 
 function reducer(state = INITIAL_STATE, { type, payload }) {
   switch (type) {
-    case types.INITIAL_STATE:
-      return state;
-
-    case types.FETCH_MEDIA_START: {
-      return {
-        ...state,
-        isMediaLoaded: false,
-        isMediaLoading: true,
-      };
-    }
-
     case types.FETCH_MEDIA_SUCCESS: {
-      const { media, mediaType, searchTerm, pagingNum, totalPages } = payload;
+      const { mediaType, searchTerm } = payload;
       if (mediaType === state.mediaType && searchTerm === state.searchTerm) {
-        const hasMore = pagingNum < totalPages;
-        return {
-          ...state,
-          media: [...state.media, ...media],
-          pagingNum,
-          totalPages,
-          hasMore,
-          isMediaLoaded: true,
-          isMediaLoading: false,
-        };
+        return commonReducer(state, { type, payload });
       }
       return state;
-    }
-
-    case types.FETCH_MEDIA_ERROR: {
-      return {
-        ...state,
-        isMediaLoaded: true,
-        isMediaLoading: false,
-      };
     }
 
     case types.RESET_FILTERS: {
@@ -109,13 +80,6 @@ function reducer(state = INITIAL_STATE, { type, payload }) {
       };
     }
 
-    case types.SET_NEXT_PAGE: {
-      return {
-        ...state,
-        pagingNum: state.pagingNum + 1,
-      };
-    }
-
     case types.SET_MEDIA: {
       const { media } = payload;
 
@@ -151,41 +115,8 @@ function reducer(state = INITIAL_STATE, { type, payload }) {
       };
     }
 
-    case types.UPDATE_MEDIA_ELEMENT: {
-      const { id, ...properties } = payload;
-
-      const mediaIndex = state.media.findIndex((media) => media.id === id);
-      if (mediaIndex === -1) {
-        return state;
-      }
-
-      const updatedMediaElement = {
-        ...state.media[mediaIndex],
-        ...properties,
-      };
-
-      const newMedia = [
-        ...state.media.slice(0, mediaIndex),
-        updatedMediaElement,
-        ...state.media.slice(mediaIndex + 1),
-      ];
-
-      return {
-        ...state,
-        media: newMedia,
-      };
-    }
-
-    case types.DELETE_MEDIA_ELEMENT: {
-      const { id } = payload;
-      return {
-        ...state,
-        media: state.media.filter((media) => media.id !== id),
-      };
-    }
-
     default:
-      throw new Error(`Unknown media reducer action: ${type}`);
+      return commonReducer(state, { type, payload });
   }
 }
 


### PR DESCRIPTION
## Summary

Pull out action reducers from media/local/reducer.js into common that will be shared for media/media3p/reducer.js.

This PR is a code move without any change to functionality or code paths.

As per:
https://docs.google.com/document/d/1S9jTh6Lz3UEhj9Wkb7S7x_kJGvRVpEaNOqk2aCyb4y8.

Unit tests for both local and common will be written as a part of https://github.com/google/web-stories-wp/issues/2512.

## Testing Instructions

* Open the media pane to verify that it appears.
* Scroll down to verify the next page of results in returned.
* Upload an image successfully.
* Upload a video successfully.
