### PR TITLE
Rename 'pagingNum' -> 'pageToken' for consistency between local / media3p

### DIFF
--- a/assets/src/edit-story/app/media/actions.js
+++ b/assets/src/edit-story/app/media/actions.js
@@ -19,20 +19,20 @@
  */
 import * as types from './types';
 
-export const fetchMediaStart = (dispatch) => ({ pagingNum }) => {
-  dispatch({ type: types.FETCH_MEDIA_START, payload: { pagingNum } });
+export const fetchMediaStart = (dispatch) => ({ pageToken }) => {
+  dispatch({ type: types.FETCH_MEDIA_START, payload: { pageToken } });
 };
 
 export const fetchMediaSuccess = (dispatch) => ({
   media,
   mediaType,
   searchTerm,
-  pagingNum,
+  pageToken,
   totalPages,
 }) => {
   dispatch({
     type: types.FETCH_MEDIA_SUCCESS,
-    payload: { media, mediaType, searchTerm, pagingNum, totalPages },
+    payload: { media, mediaType, searchTerm, pageToken, totalPages },
   });
 };
 

--- a/assets/src/edit-story/app/media/common/reducer.js
+++ b/assets/src/edit-story/app/media/common/reducer.js
@@ -21,9 +21,7 @@ import * as types from '../types';
 
 export const INITIAL_STATE = {
   media: [],
-  // TODO(https://github.com/google/web-stories-wp/issues/2828):
-  // Rename pagingNum to pageToken.
-  pagingNum: 1,
+  pageToken: 1,
   hasMore: true,
   totalPages: 1,
   isMediaLoading: false,
@@ -44,12 +42,12 @@ function reducer(state = INITIAL_STATE, { type, payload }) {
     }
 
     case types.FETCH_MEDIA_SUCCESS: {
-      const { media, pagingNum, totalPages } = payload;
-      const hasMore = pagingNum < totalPages;
+      const { media, pageToken, totalPages } = payload;
+      const hasMore = pageToken < totalPages;
       return {
         ...state,
         media: [...state.media, ...media],
-        pagingNum,
+        pageToken,
         totalPages,
         hasMore,
         isMediaLoaded: true,
@@ -68,7 +66,7 @@ function reducer(state = INITIAL_STATE, { type, payload }) {
     case types.SET_NEXT_PAGE: {
       return {
         ...state,
-        pagingNum: state.pagingNum + 1,
+        pageToken: state.pageToken + 1,
       };
     }
 

--- a/assets/src/edit-story/app/media/local/useContextValueProvider.js
+++ b/assets/src/edit-story/app/media/local/useContextValueProvider.js
@@ -32,7 +32,7 @@ export default function useContextValueProvider(reducerState, reducerActions) {
     processing,
     processed,
     media,
-    pagingNum,
+    pageToken,
     mediaType,
     searchTerm,
   } = reducerState;
@@ -58,12 +58,12 @@ export default function useContextValueProvider(reducerState, reducerActions) {
     (
       {
         searchTerm: currentSearchTerm = '',
-        pagingNum: p = 1,
+        pageToken: p = 1,
         mediaType: currentMediaType,
       } = {},
       callback
     ) => {
-      fetchMediaStart({ pagingNum: p });
+      fetchMediaStart({ pageToken: p });
       getMedia({
         mediaType: currentMediaType,
         searchTerm: currentSearchTerm,
@@ -76,7 +76,7 @@ export default function useContextValueProvider(reducerState, reducerActions) {
             media: mediaArray,
             mediaType: currentMediaType,
             searchTerm: currentSearchTerm,
-            pagingNum: p,
+            pageToken: p,
             totalPages,
           });
         })
@@ -103,17 +103,17 @@ export default function useContextValueProvider(reducerState, reducerActions) {
 
   const resetWithFetch = useCallback(() => {
     // eslint-disable-next-line no-shadow
-    const { mediaType, pagingNum, searchTerm } = stateRef.current;
+    const { mediaType, pageToken, searchTerm } = stateRef.current;
 
     resetFilters();
-    if (!mediaType && !searchTerm && pagingNum === 1) {
+    if (!mediaType && !searchTerm && pageToken === 1) {
       fetchMedia({ mediaType }, fetchMediaSuccess);
     }
   }, [fetchMedia, fetchMediaSuccess, resetFilters]);
 
   useEffect(() => {
-    fetchMedia({ searchTerm, pagingNum, mediaType }, fetchMediaSuccess);
-  }, [fetchMedia, fetchMediaSuccess, mediaType, pagingNum, searchTerm]);
+    fetchMedia({ searchTerm, pageToken, mediaType }, fetchMediaSuccess);
+  }, [fetchMedia, fetchMediaSuccess, mediaType, pageToken, searchTerm]);
 
   const uploadVideoPoster = useCallback(
     (id, src) => {


### PR DESCRIPTION
## Summary

Rename local media `pagingNum` to `pageToken` for consistency between media3p and local.

This will eventually remove the assumption that `pageToken` (formally `pagingNum`) is always an integer that represents a page number. This allows local and media3p pagination to behave in a consistent manner, for example:

local: `pageToken == <page number>`
coverr:   `pageToken == <page number>`
unsplash: `pageToken == <next page url>`
tenor:    `pageToken == <page token>`

This PR is a code rename without any change to functionality or code paths.

## To-do

- In a follow-up PR, pageToken will be treated less like an int and more like an opaque reference to the current page:

https://github.com/google/web-stories-wp/pull/2834

- Write tests for local/reducer.js and common/reducer.js (https://github.com/google/web-stories-wp/issues/2512).

## User-facing changes

No user-facing changes.

## Testing Instructions

* Open the media pane to verify that it appears.
* Scroll down to verify the next page of results in returned.
* Upload an image successfully.
* Upload a video successfully.
