### PR TITLE
Dashboard: Fixed text typos in templates

### DIFF
--- a/assets/src/dashboard/templates/raw/entertainment.json
+++ b/assets/src/dashboard/templates/raw/entertainment.json
@@ -61,7 +61,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_page1_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_page1_bg.jpg",
             "width": 220,
             "height": 330,
             "posterId": 0,
@@ -873,7 +873,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_page2_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_page2_image1.jpg",
             "width": 220,
             "height": 330,
             "posterId": 0,
@@ -2370,7 +2370,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_page4_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_page4_image1.jpg",
             "width": 220,
             "height": 329,
             "posterId": 0,
@@ -3714,7 +3714,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_icon_white_star.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_icon_white_star.png",
             "width": 50,
             "height": 47,
             "posterId": 0,
@@ -3751,7 +3751,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_icon_white_star.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_icon_white_star.png",
             "width": 50,
             "height": 47,
             "posterId": 0,
@@ -3789,7 +3789,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_icon_white_star.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_icon_white_star.png",
             "width": 50,
             "height": 47,
             "posterId": 0,
@@ -3825,7 +3825,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_icon_white_star.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_icon_white_star.png",
             "width": 50,
             "height": 47,
             "posterId": 0,
@@ -3863,7 +3863,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_icon_white_star.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_icon_white_star.png",
             "width": 50,
             "height": 47,
             "posterId": 0,
@@ -4374,7 +4374,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_page6_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_page6_image1.jpg",
             "width": 220,
             "height": 330,
             "posterId": 0,
@@ -5218,7 +5218,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_page7_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_page7_image1.jpg",
             "width": 220,
             "height": 330,
             "posterId": 0,
@@ -5486,7 +5486,7 @@
           "type": "text",
           "basedOn": "ff9a77cf-c942-4a04-84ea-d7134d97f360",
           "id": "b0d4ee54-76eb-4050-821d-5d11181b6a2c",
-          "content": "<span style=\"color: #fff\">It’s one thing to listen to music; it’s another to learn how it’s made! We’ll take your through the production process of one of our favorite songs.</span>",
+          "content": "<span style=\"color: #fff\">It’s one thing to listen to music; it’s another to learn how it’s made! We’ll take you through the production process of one of our favorite songs.</span>",
           "fontSize": 16,
           "padding": {
             "horizontal": 0,
@@ -5754,7 +5754,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_page8_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_page8_image1.jpg",
             "width": 220,
             "height": 90,
             "posterId": 0,
@@ -5868,7 +5868,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_page8_image2.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_page8_image2.jpg",
             "width": 220,
             "height": 147,
             "posterId": 0,
@@ -6758,7 +6758,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_page9_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_page9_image1.jpg",
             "width": 220,
             "height": 165,
             "posterId": 0,
@@ -6800,7 +6800,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_page9_image2.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_page9_image2.jpg",
             "width": 220,
             "height": 275,
             "posterId": 0,
@@ -6842,7 +6842,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/plugins/web-stories//assets/images/templates/entertainment/ent_page9_image3.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/entertainment/ent_page9_image3.jpg",
             "width": 220,
             "height": 147,
             "posterId": 0,

--- a/assets/src/dashboard/templates/raw/fashion.json
+++ b/assets/src/dashboard/templates/raw/fashion.json
@@ -2016,7 +2016,7 @@
           "focalY": 50,
           "type": "text",
           "id": "bad4432f-b82b-4579-bb2d-d9858f7feec2",
-          "content": "<span style=\"color: #ffece3; letter-spacing: -0.01em\">KEPLER&nbsp;</span>",
+          "content": "<span style=\"color: #ffece3; letter-spacing: -0.01em\">KEPLER</span>",
           "fontSize": 132,
           "padding": {
             "horizontal": 0,

--- a/assets/src/dashboard/templates/raw/fashion.json
+++ b/assets/src/dashboard/templates/raw/fashion.json
@@ -333,89 +333,6 @@
           "isDefaultBackground": true
         },
         {
-          "x": 18,
-          "y": 11,
-          "width": 356,
-          "height": 300,
-          "font": {
-            "service": "fonts.google.com",
-            "family": "Playfair Display",
-            "fallbacks": [
-              "serif"
-            ]
-          },
-          "type": "text",
-          "opacity": 100,
-          "flip": {
-            "vertical": false,
-            "horizontal": false
-          },
-          "rotationAngle": 0,
-          "lockAspectRatio": true,
-          "backgroundTextMode": "NONE",
-          "backgroundColor": {
-            "color": {
-              "r": 196,
-              "g": 196,
-              "b": 196
-            }
-          },
-          "lineHeight": 1,
-          "textAlign": "initial",
-          "scale": 100,
-          "focalX": 50,
-          "focalY": 50,
-          "id": "d773925c-2f95-44c0-9b0e-0743d45476f2",
-          "content": "<span style=\"color: #212121; letter-spacing: -0.01em\">“IF YOU CAN'T BE BETTER THAN YOUR COMPETITION, JUST DRESS BETTER”</span>",
-          "fontSize": 50,
-          "padding": {
-            "horizontal": 0,
-            "vertical": 0
-          }
-        },
-        {
-          "x": 19,
-          "y": 493,
-          "width": 354,
-          "height": 100,
-          "font": {
-            "service": "fonts.google.com",
-            "family": "Playfair Display",
-            "fallbacks": [
-              "serif"
-            ]
-          },
-          "type": "text",
-          "opacity": 100,
-          "flip": {
-            "vertical": false,
-            "horizontal": false
-          },
-          "rotationAngle": 0,
-          "lockAspectRatio": true,
-          "backgroundTextMode": "NONE",
-          "backgroundColor": {
-            "color": {
-              "r": 196,
-              "g": 196,
-              "b": 196
-            }
-          },
-          "lineHeight": 1,
-          "textAlign": "initial",
-          "scale": 100,
-          "focalX": 50,
-          "focalY": 50,
-          "basedOn": "d773925c-2f95-44c0-9b0e-0743d45476f2",
-          "id": "61d23551-31e3-4aad-ac15-b8fc5e4be2ec",
-          "content": "<span style=\"color: #212121; letter-spacing: -0.01em\">— ANNA</span>\n<span style=\"color: #212121; letter-spacing: -0.01em\">WINTOUR</span>",
-          "fontSize": 50,
-          "padding": {
-            "horizontal": 0,
-            "vertical": 0
-          }
-        },
-        {
           "opacity": 100,
           "flip": {
             "vertical": false,
@@ -479,6 +396,89 @@
           },
           "type": "image",
           "id": "99696270-286f-4c14-b062-aad2a021672a"
+        },
+        {
+          "x": 18,
+          "y": 524,
+          "width": 229,
+          "height": 28,
+          "font": {
+            "service": "fonts.google.com",
+            "family": "Playfair Display",
+            "fallbacks": [
+              "serif"
+            ]
+          },
+          "type": "text",
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "d773925c-2f95-44c0-9b0e-0743d45476f2",
+          "id": "61d23551-31e3-4aad-ac15-b8fc5e4be2ec",
+          "content": "<span style=\"color: #212121; letter-spacing: -0.01em\">— ANONYMOUS</span>",
+          "fontSize": 28,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
+        },
+        {
+          "x": 18,
+          "y": 11,
+          "width": 371,
+          "height": 250,
+          "font": {
+            "service": "fonts.google.com",
+            "family": "Playfair Display",
+            "fallbacks": [
+              "serif"
+            ]
+          },
+          "type": "text",
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "d773925c-2f95-44c0-9b0e-0743d45476f2",
+          "content": "<span style=\"color: #212121; letter-spacing: -0.01em\">“WHEN WE DRESS WELL, WE NATURALLY BOOST OUR CONFIDENCE”</span>",
+          "fontSize": 50,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
+          }
         }
       ],
       "type": "page",
@@ -2016,7 +2016,7 @@
           "focalY": 50,
           "type": "text",
           "id": "bad4432f-b82b-4579-bb2d-d9858f7feec2",
-          "content": "<span style=\"color: #ffece3; letter-spacing: -0.01em\">CARDIN&nbsp;</span>",
+          "content": "<span style=\"color: #ffece3; letter-spacing: -0.01em\">KEPLER&nbsp;</span>",
           "fontSize": 132,
           "padding": {
             "horizontal": 0,
@@ -5538,7 +5538,7 @@
             "type": "image",
             "mimeType": "image/jpeg",
             "creationDate": "2020-06-29T20:54:29",
-            "src": "http://localhost:8899/wp-content/uploads/2020/06/fashion_page9_item4.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/fashion/fashion_page9_item4.jpg",
             "width": 330,
             "height": 494,
             "posterId": 0,
@@ -5546,22 +5546,7 @@
             "title": "fashion_page9_item4",
             "alt": "fashion_page9_item4",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "fashion_page9_item4-200x300.jpg",
-                "width": 200,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/fashion_page9_item4-200x300.jpg"
-              },
-              "full": {
-                "file": "fashion_page9_item4-scaled.jpg",
-                "width": 1707,
-                "height": 2560,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/fashion_page9_item4-scaled.jpg"
-              }
-            }
+            "sizes": []
           },
           "basedOn": "ba68ba92-edcd-4c5c-a4fe-5263fc994e2b",
           "id": "40d8eaeb-1fad-4346-b56b-eef002fcb4db",

--- a/assets/src/dashboard/templates/raw/travel.json
+++ b/assets/src/dashboard/templates/raw/travel.json
@@ -1,5 +1,5 @@
 {
-  "version": 23,
+  "version": 24,
   "pages": [
     {
       "elements": [
@@ -370,8 +370,8 @@
         {
           "x": 57,
           "y": 16,
-          "width": 297,
-          "height": 261,
+          "width": 265,
+          "height": 265,
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
@@ -400,7 +400,7 @@
           "focalX": 50,
           "focalY": 50,
           "id": "bfd53cf2-f8e8-41f0-8449-48772b5194bb",
-          "content": "<span style=\"color: #fff\">YOUR BODY IS</span>\n<span style=\"color: #fff\">NOT A TEMPLE,</span>\n<span style=\"color: #fff\">IT'S AN</span>\n<span style=\"color: #fff\">AMUSEMENT</span>\n<span style=\"color: #fff\">PARK.”</span>",
+          "content": "<span style=\"color: #fff\">I TRAVEL TO FIND MYSELF IN THE EYES AND HEARTS OF OTHERS”</span>",
           "fontSize": 53,
           "padding": {
             "horizontal": 0,
@@ -480,7 +480,7 @@
           "focalX": 50,
           "focalY": 50,
           "id": "88df74ed-7334-4e91-957c-c48b8da344e4",
-          "content": "<span style=\"color: #fff\">– Anthony Bordain</span>",
+          "content": "<span style=\"color: #fff\">– Anonymous</span>",
           "fontSize": 18,
           "padding": {
             "horizontal": 0,


### PR DESCRIPTION
## Summary

This PR fixes some typos and removes celebrity quotes with anonymous ones.  The templates updated are `Entertainmnet`, `Fashion`, and `Travel`.

## User-facing changes

- Small text changes the affect templates.

## Testing Instructions

1.) Go to "Explore Templates".
2.) Click on "View" for the `Entertainment`, `Fashion`, and `Travel` templates.
3.) Make sure the page in the screenshots below match what you see in your browser:

---

Fixes #2854 

## Screenshots

Travel - Page 2 (removed Anthony Bourdain quote):
<img src="https://user-images.githubusercontent.com/40646372/86165749-98eb3b80-bac8-11ea-9c70-b347ee69e254.png" height="400">

Entertainment - Page 7 (Fixed typo, changed "We'll take your" to "We'll take you"):
<img src="https://user-images.githubusercontent.com/40646372/86165831-b8826400-bac8-11ea-93e8-1d5458e1ab67.png" height="400">

Fashion - Page 2 (Remove Anna Wintour quote):
<img src="https://user-images.githubusercontent.com/40646372/86165896-d223ab80-bac8-11ea-9594-52dd48f60990.png" height="400">

Fashion - Page 5 (Changed side text from "Cardin" to "Kepler"):
<img src="https://user-images.githubusercontent.com/40646372/86166021-fd0dff80-bac8-11ea-982e-9b13a2e62f7d.png" height="400">
