### PR TITLE
Dashboard: Prevent scroll to top on pagination

### DIFF
--- a/assets/src/dashboard/app/views/myStories/content/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/index.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useEffect, useRef } from 'react';
+import { memo } from 'react';
 import PropTypes from 'prop-types';
 
 /**
@@ -34,7 +34,6 @@ import {
   InfiniteScroller,
   Layout,
   StandardViewContentGutter,
-  useLayoutContext,
 } from '../../../../components';
 import {
   UsersPropType,
@@ -64,27 +63,6 @@ function Content({
   view,
   dateFormat,
 }) {
-  const {
-    actions: { scrollToTop },
-  } = useLayoutContext();
-
-  const previousFilter = useRef(filter);
-  const previousViewStyle = useRef(view.style);
-
-  useEffect(() => {
-    /**
-     * Ensure we only scroll back to top when the filter or view style change.
-     */
-    if (
-      previousFilter.current !== filter ||
-      previousViewStyle.current !== view.style
-    ) {
-      previousFilter.current = filter;
-      previousViewStyle.current = view.style;
-      scrollToTop();
-    }
-  }, [filter, scrollToTop, view]);
-
   return (
     <Layout.Scrollable>
       <FontProvider>
@@ -136,4 +114,4 @@ Content.propTypes = {
   dateFormat: PropTypes.string,
 };
 
-export default Content;
+export default memo(Content);

--- a/assets/src/dashboard/app/views/myStories/header/index.js
+++ b/assets/src/dashboard/app/views/myStories/header/index.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useMemo, memo } from 'react';
+import { useMemo, memo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 /**
  * Internal dependencies
@@ -125,7 +125,13 @@ function Header({
         handleLayoutSelect={view.toggleStyle}
         currentSort={sort.value}
         pageSortOptions={STORY_SORT_MENU_ITEMS}
-        handleSortChange={sort.set}
+        handleSortChange={useCallback(
+          (newSort) => {
+            sort.set(newSort);
+            scrollToTop();
+          },
+          [scrollToTop, sort]
+        )}
         wpListURL={wpListURL}
         sortDropdownAriaLabel={__(
           'Choose sort option for display',

--- a/assets/src/dashboard/app/views/myStories/header/index.js
+++ b/assets/src/dashboard/app/views/myStories/header/index.js
@@ -22,12 +22,16 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useMemo } from 'react';
+import { useMemo, memo } from 'react';
 import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Layout, ToggleButtonGroup } from '../../../../components';
+import {
+  Layout,
+  ToggleButtonGroup,
+  useLayoutContext,
+} from '../../../../components';
 import {
   DASHBOARD_VIEWS,
   STORY_STATUSES,
@@ -59,6 +63,10 @@ function Header({
   view,
   wpListURL,
 }) {
+  const {
+    actions: { scrollToTop },
+  } = useLayoutContext();
+
   const resultsLabel = useDashboardResultsLabel({
     currentFilter: filter.value,
     isActiveSearch: Boolean(search.keyword),
@@ -79,7 +87,10 @@ function Header({
         <ToggleButtonGroup
           buttons={STORY_STATUSES.map((storyStatus) => {
             return {
-              handleClick: () => filter.set(storyStatus.value),
+              handleClick: () => {
+                filter.set(storyStatus.value);
+                scrollToTop();
+              },
               key: storyStatus.value,
               isActive: filter.value === storyStatus.value,
               disabled: totalStoriesByStatus?.[storyStatus.status] <= 0,
@@ -93,7 +104,7 @@ function Header({
         />
       </HeaderToggleButtonContainer>
     );
-  }, [filter, totalStoriesByStatus]);
+  }, [filter, scrollToTop, totalStoriesByStatus]);
 
   return (
     <Layout.Squishable>
@@ -135,4 +146,4 @@ Header.propTypes = {
   wpListURL: PropTypes.string,
 };
 
-export default Header;
+export default memo(Header);

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -16,6 +16,7 @@
 /**
  * External dependencies
  */
+import { useMemo } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
@@ -105,6 +106,8 @@ const PageHeading = ({
   handleTypeaheadChange,
   typeaheadValue = '',
 }) => {
+  const typeaheadResults = useMemo(() => stories.slice(0, 5), [stories]);
+
   return (
     <Container>
       <HeadingBodyWrapper>
@@ -119,7 +122,7 @@ const PageHeading = ({
               <TypeaheadSearch
                 placeholder={searchPlaceholder}
                 currentValue={typeaheadValue}
-                stories={stories}
+                stories={typeaheadResults}
                 handleChange={handleTypeaheadChange}
               />
             </SearchInner>


### PR DESCRIPTION
## Summary
Omar identified a bug that we didn't notice with the update to implement scroll to top when you swap from 'all results' to 'draft' or 'publish', we didn't notice it because when that was implemented we were also loading 100 stories at a time so it wasn't as visible - now with our 24 results at a time it's noticeable :D 
**Bug**
![bad scroll](https://user-images.githubusercontent.com/10720454/86185824-2ee48d80-baec-11ea-8026-b9ca014f6b51.gif)

**Solution**
(pardon my glitchy recording)
Paginate without scrolling 
![paginate without scroll to top](https://user-images.githubusercontent.com/10720454/86184844-cf857e00-bae9-11ea-98d7-8d1b576022b6.gif)

Scroll up with switch in filter
![switch to drafts scroll](https://user-images.githubusercontent.com/10720454/86184857-d6ac8c00-bae9-11ea-941a-dca0a61152d7.gif)

Scroll to top on sort update 
![sort scroll to top](https://user-images.githubusercontent.com/10720454/86185812-22603500-baec-11ea-9623-30232cc71e6d.gif)


## Relevant Technical Choices
- moving scroll to top in dashboard to be associated with filtering by button clicks in header in stead of with body content, this prevents `Content` from scrolling to top when a new page is loaded and keeps the actions tight. 
- wrapped `Content` and `Header` in memo since they are pure components that load a lot of props with a lot of data. This will be expanded on later but for now just the default comparison. 
- slicing the first 5 results from returned stories to show in typeahead, there's no reason we need to send all of that to the typeahead when it's locked to show only the first 5, that said - i'm making a new ticket to implement scrolling on this - that was an iteration that got lost in the shuffle of more important matters. 

## To-do
- [x] Make a new ticket to enable scrolling on typeahead

## User-facing changes
- Scroll up on my stories should only occur when you click on another quick filter in the header area (all stories, draft, published)

## Testing Instructions
- Scroll down the list of stories in your dashboard, see that there's no attempt to send you to the top of the page again 
- click a different quick filter and see that you are scrolled to the top 
- scroll down the view and change the sort and see that you are scrolled to the top
- Since I adjusted the quantity of data getting sent through to the typeahead verify that typeahead is still loading results 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2884 
