### PR TITLE
Dashboard: fix inconsistency in the admin menu

### DIFF
--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -58,6 +58,7 @@ class Dashboard {
 	 */
 	public function init() {
 		add_action( 'admin_menu', [ $this, 'add_menu_page' ] );
+		add_action( 'admin_init', [ $this, 'redirect_menu_page' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'admin_notices', [ $this, 'display_link_to_dashboard' ] );
 		add_action( 'load-web-story_page_stories-dashboard', [ $this, 'load_stories_dashboard' ] );
@@ -87,6 +88,29 @@ class Dashboard {
 			[ $this, 'render' ],
 			0
 		);
+	}
+
+	/**
+	 * Redirects to the correct Dashboard page when clicking on the top-level "Stories" menu item.
+	 *
+	 * @return void
+	 */
+	public function redirect_menu_page() {
+		global $pagenow;
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( 'admin.php' === $pagenow && isset( $_GET['page'] ) && 'stories-dashboard' === $_GET['page'] ) {
+			wp_safe_redirect(
+				add_query_arg(
+					[
+						'post_type' => Story_Post_Type::POST_TYPE_SLUG,
+						'page'      => 'stories-dashboard',
+					],
+					admin_url( 'edit.php' )
+				)
+			);
+			exit;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Ensures that clicking on the top-level Stories menu item should highlight _Dashboard_

## Relevant Technical Choices

Uses a redirect to the correct admin page instead of trying to hack the admin menu in a complicated way.

There's no unit test as it would require `@runTestsInSeparateProcesses` and XDebug to check the `Location` HTTP headers, or alternatively overriding `wp_safe_redirect` for tests. Not really worth it I think.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

* Clicking on "Stories" and directly on "Dashboard" will now lead to the same result
* The "Dashboard" menu item is highlighted when clicking on "Stories"
* The admin menu is collapsed when clicking on "Stories"

## Testing Instructions

1. Click on the top-level "Stories" menu item in the WordPress admin menu.
1. Verify that you access the Stories dashboard
1. Verify that the admin menu is collapsed
1. Verify that the "Dashboard" menu item is highlighted

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #518
