### PR TITLE
Ensure raw story title is used for prefilling post title

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -166,7 +166,7 @@ BLOCK;
 
 		$post_id = absint( sanitize_text_field( (string) wp_unslash( $_GET['from-web-story'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		if ( ! $post_id || Story_Post_Type::POST_TYPE_SLUG !== get_post_type( $post_id ) ) {
+		if ( ! $post_id ) {
 			return $title;
 		}
 
@@ -176,7 +176,7 @@ BLOCK;
 
 		$post = get_post( $post_id );
 
-		if ( ! $post instanceof WP_Post ) {
+		if ( ! $post instanceof WP_Post || Story_Post_Type::POST_TYPE_SLUG !== $post->post_type ) {
 			return $title;
 		}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -174,6 +174,14 @@ BLOCK;
 			return $title;
 		}
 
-		return (string) get_the_title( $post_id );
+		$post = get_post( $post_id );
+
+		if ( ! $post instanceof WP_Post ) {
+			return $title;
+		}
+
+		// Not using get_the_title() because we need the raw title.
+		// Otherwise it runs through wptexturize() and the like, which we want to avoid.
+		return isset( $post->post_title ) ? $post->post_title : '';
 	}
 }

--- a/tests/phpunit/tests/Admin.php
+++ b/tests/phpunit/tests/Admin.php
@@ -130,4 +130,34 @@ class Admin extends \WP_UnitTestCase {
 		$this->assertSame( 'Example title', $result );
 	}
 
+	/**
+	 * @covers ::prefill_post_title
+	 */
+	public function test_prefill_post_title_no_texturize() {
+		$admin = new \Google\Web_Stories\Admin();
+		wp_set_current_user( self::$admin_id );
+		$_GET['from-web-story'] = self::$story_id;
+
+		$original_title = get_post( self::$story_id )->post_title;
+
+		wp_update_post(
+			[
+				'ID'         => self::$story_id,
+				// Not just a hyphen, but an en dash.
+				'post_title' => 'Story - Test',
+			] 
+		);
+
+		$result = $admin->prefill_post_title( 'current' );
+
+		// Cleanup.
+		wp_update_post(
+			[
+				'ID'         => self::$story_id,
+				'post_title' => $original_title,
+			] 
+		);
+
+		$this->assertSame( 'Story - Test', $result );
+	}
 }


### PR DESCRIPTION
## Summary

Ensures that the story title is used as-is for prefilling the post title, so that the titles match.

## Relevant Technical Choices

Uses `$post->post_title` as originally planned instead of `get_the_title()`.

Avoids the `the_title` filter and thus `wptexturize ` and the like from running.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

No texturized post titles.

Users will get `Story - Test`, not `Story &#8211; Test`

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2822
