### PR TITLE
Fix drop/paste video in Safari

### DIFF
--- a/assets/src/edit-story/app/media/utils/getFirstFrameOfVideo.js
+++ b/assets/src/edit-story/app/media/utils/getFirstFrameOfVideo.js
@@ -26,7 +26,7 @@ function getFirstFrameOfVideo(src) {
   const video = document.createElement('video');
   video.muted = true;
   video.crossOrigin = 'anonymous';
-  video.preload = 'metadata';
+  video.preload = 'auto';
   video.currentTime = 0.5; // Needed to seek forward.
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
We can either set `preload="auto"` or `video.autoplay = true` (both should have the same effect, but it's Safari so not 100% sure), otherwise `canplay` event is never fired/Promise resolved - stopping the whole process the whole process.

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2922
