### PR TITLE
Dashboard: Settings UI

### DIFF
--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -40,12 +40,12 @@ import ApiProvider from './api/apiProvider';
 import { Route, RouterProvider, RouterContext, matchPath } from './router';
 import { ConfigProvider } from './config';
 import {
-  ToasterView,
-  MyStoriesView,
-  TemplateDetailsView,
   ExploreTemplatesView,
+  MyStoriesView,
   SavedTemplatesView,
   StoryAnimTool,
+  TemplateDetailsView,
+  ToasterView,
 } from './views';
 
 const AppContent = () => {

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -22,10 +22,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import {
-  TypographyPresets,
-  TextInput as _TextInput,
-} from '../../../components';
+import { TypographyPresets, InlineInputForm } from '../../../components';
 import { visuallyHiddenStyles } from '../../../utils/visuallyHiddenStyles';
 
 export const Wrapper = styled.div`
@@ -68,14 +65,14 @@ export const SettingForm = styled.form`
   }
 `;
 
-export const SettingLabel = styled.label`
+export const SettingHeading = styled.h2`
   ${TypographyPresets.Large};
   font-size: 18.667px;
   font-weight: ${({ theme }) => theme.typography.weight.bold};
   line-height: 140%;
   color: ${({ theme }) => theme.colors.gray600};
 `;
-export const TextInput = styled(_TextInput)`
+export const TextInput = styled(InlineInputForm)`
   width: 100%;
   height: 32px;
 `;

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import {
+  TypographyPresets,
+  TextInput as _TextInput,
+} from '../../../components';
+
+export const Wrapper = styled.div`
+  margin: 0 107px;
+`;
+export const Header = styled.header`
+  padding-top: 100px;
+`;
+
+export const Heading = styled.h1`
+  ${TypographyPresets.ExtraExtraLarge};
+  font-size: 50.67px;
+  line-height: 140%;
+  padding: 0;
+  font-weight: bold;
+  color: ${({ theme }) => theme.colors.gray800};
+`;
+
+export const Main = styled.main`
+  display: flex;
+  flex-direction: column;
+  padding-top: 56px;
+  max-width: 945px;
+  width: 100%;
+`;
+
+export const SettingForm = styled.form`
+  display: grid;
+  grid-template-columns: 27% minmax(600px, 1fr);
+  column-gap: 6.56%;
+  padding-bottom: 52px;
+`;
+
+export const SettingLabel = styled.label`
+  ${TypographyPresets.Large};
+  font-size: 18.667px;
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
+  line-height: 140%;
+  color: ${({ theme }) => theme.colors.gray600};
+`;
+export const TextInput = styled(_TextInput)`
+  width: 100%;
+  height: 32px;
+`;
+
+export const TextInputHelperText = styled.p`
+  ${TypographyPresets.Small};
+  padding-top: 10px;
+  color: ${({ theme }) => theme.colors.gray500};
+`;
+
+export const FileUploadHelperText = styled.p`
+  ${TypographyPresets.Small};
+  font-size: 15px;
+  padding-bottom: 10px;
+  color: ${({ theme }) => theme.colors.gray900};
+`;
+
+export const FinePrintHelperText = styled.p`
+  ${TypographyPresets.ExtraSmall};
+  padding-top: 10px;
+  color: ${({ theme }) => theme.colors.gray500};
+`;
+
+export const UploadContainer = styled.div`
+  width: 100%;
+  height: 153px;
+  padding: 20px;
+  background-color: ${({ theme }) => theme.colors.gray25};
+`;

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -41,6 +41,10 @@ export const Heading = styled.h1`
   padding: 0;
   font-weight: bold;
   color: ${({ theme }) => theme.colors.gray800};
+
+  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
+    font-size: 40.67px;
+  }
 `;
 
 export const Main = styled.main`
@@ -53,9 +57,14 @@ export const Main = styled.main`
 
 export const SettingForm = styled.form`
   display: grid;
-  grid-template-columns: 27% minmax(600px, 1fr);
+  grid-template-columns: 27% minmax(400px, 1fr);
   column-gap: 6.56%;
   padding-bottom: 52px;
+
+  @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
+    grid-template-columns: 100%;
+    row-gap: 20px;
+  }
 `;
 
 export const SettingLabel = styled.label`

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -26,6 +26,7 @@ import {
   TypographyPresets,
   TextInput as _TextInput,
 } from '../../../components';
+import { visuallyHiddenStyles } from '../../../utils/visuallyHiddenStyles';
 
 export const Wrapper = styled.div`
   margin: 0 107px;
@@ -104,3 +105,5 @@ export const UploadContainer = styled.div`
   padding: 20px;
   background-color: ${({ theme }) => theme.colors.gray25};
 `;
+
+export const VisuallyHiddenDescription = styled.span(visuallyHiddenStyles);

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -30,29 +30,29 @@ import {
 } from '../components';
 
 const TEXT = {
-  context: __(
+  CONTEXT: __(
     "The story editor will append a default, configurable AMP analytics configuration to your story. If you're interested in going beyond what the default configuration is, read this article.",
     'web-stories'
   ),
-  sectionHeading: __('Google Analytics Tracking ID', 'web-stories'),
-  placeholder: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
-  ariaLabel: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
+  SECTION_HEADING: __('Google Analytics Tracking ID', 'web-stories'),
+  PLACEHOLDER: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
+  ARIA_LABEL: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
 };
 // todo add link
 function GoogleAnalyticsSettings() {
   return (
     <SettingForm>
       <SettingHeading htmlFor="gaTrackingID">
-        {TEXT.sectionHeading}
+        {TEXT.SECTION_HEADING}
       </SettingHeading>
       <div>
         <TextInput
-          label={TEXT.ariaLabel}
+          label={TEXT.ARIA_LABEL}
           id="gaTrackingId"
           value=""
-          placeholder={TEXT.placeholder}
+          placeholder={TEXT.PLACEHOLDER}
         />
-        <TextInputHelperText>{TEXT.context}</TextInputHelperText>
+        <TextInputHelperText>{TEXT.CONTEXT}</TextInputHelperText>
       </div>
     </SettingForm>
   );

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -15,11 +15,43 @@
  */
 
 /**
- * External dependencies
+ * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import {
+  SettingForm,
+  SettingLabel,
+  TextInput,
+  TextInputHelperText,
+} from '../components';
+
+const TEXT = {
+  context: __(
+    "The story editor will append a default, configurable AMP analytics configuration to your story. If you're interested in going beyond what the default configuration is, read this article.",
+    'web-stories'
+  ),
+  label: __('Google Analytics Tracking ID', 'web-stories'),
+  placeholder: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
+};
+// todo add link
 function GoogleAnalyticsSettings() {
-  return <div>{'Google Analytics Placeholder'}</div>;
+  return (
+    <SettingForm>
+      <SettingLabel htmlFor="gaTrackingID">{TEXT.label}</SettingLabel>
+      <div>
+        <TextInput
+          type="text"
+          name="gaTrackingID"
+          placeholder={TEXT.placeholder}
+        />
+        <TextInputHelperText>{TEXT.context}</TextInputHelperText>
+      </div>
+    </SettingForm>
+  );
 }
 
 export default GoogleAnalyticsSettings;

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -27,6 +27,7 @@ import {
   SettingLabel,
   TextInput,
   TextInputHelperText,
+  VisuallyHiddenDescription,
 } from '../components';
 
 const TEXT = {
@@ -36,6 +37,7 @@ const TEXT = {
   ),
   label: __('Google Analytics Tracking ID', 'web-stories'),
   placeholder: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
+  ariaDescription: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
 };
 // todo add link
 function GoogleAnalyticsSettings() {
@@ -43,10 +45,15 @@ function GoogleAnalyticsSettings() {
     <SettingForm>
       <SettingLabel htmlFor="gaTrackingID">{TEXT.label}</SettingLabel>
       <div>
+        <VisuallyHiddenDescription id="ga-input-description">
+          {TEXT.ariaDescription}
+        </VisuallyHiddenDescription>
         <TextInput
           type="text"
+          id="gaTrackingID"
           name="gaTrackingID"
           placeholder={TEXT.placeholder}
+          aria-describedby="ga-input-description"
         />
         <TextInputHelperText>{TEXT.context}</TextInputHelperText>
       </div>

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -34,18 +34,20 @@ const TEXT = {
     "The story editor will append a default, configurable AMP analytics configuration to your story. If you're interested in going beyond what the default configuration is, read this article.",
     'web-stories'
   ),
-  label: __('Google Analytics Tracking ID', 'web-stories'),
+  sectionHeading: __('Google Analytics Tracking ID', 'web-stories'),
   placeholder: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
-  ariaDescription: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
+  ariaLabel: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
 };
 // todo add link
 function GoogleAnalyticsSettings() {
   return (
     <SettingForm>
-      <SettingHeading htmlFor="gaTrackingID">{TEXT.label}</SettingHeading>
+      <SettingHeading htmlFor="gaTrackingID">
+        {TEXT.sectionHeading}
+      </SettingHeading>
       <div>
         <TextInput
-          label={TEXT.ariaDescription}
+          label={TEXT.ariaLabel}
           id="gaTrackingId"
           value=""
           placeholder={TEXT.placeholder}

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { default as MyStoriesView } from './myStories';
-export { default as EditorSettingsView } from './editorSettings';
-export { default as ExploreTemplatesView } from './exploreTemplates';
-export { default as TemplateDetailsView } from './templateDetails';
-export { default as SavedTemplatesView } from './savedTemplates';
-export { default as StoryAnimTool } from './storyAnimTool';
-export { default as ToasterView } from './toaster';
+
+/**
+ * External dependencies
+ */
+
+function GoogleAnalyticsSettings() {
+  return <div>{'Google Analytics Placeholder'}</div>;
+}
+
+export default GoogleAnalyticsSettings;

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -24,10 +24,9 @@ import { __ } from '@wordpress/i18n';
  */
 import {
   SettingForm,
-  SettingLabel,
+  SettingHeading,
   TextInput,
   TextInputHelperText,
-  VisuallyHiddenDescription,
 } from '../components';
 
 const TEXT = {
@@ -43,17 +42,13 @@ const TEXT = {
 function GoogleAnalyticsSettings() {
   return (
     <SettingForm>
-      <SettingLabel htmlFor="gaTrackingID">{TEXT.label}</SettingLabel>
+      <SettingHeading htmlFor="gaTrackingID">{TEXT.label}</SettingHeading>
       <div>
-        <VisuallyHiddenDescription id="ga-input-description">
-          {TEXT.ariaDescription}
-        </VisuallyHiddenDescription>
         <TextInput
-          type="text"
-          id="gaTrackingID"
-          name="gaTrackingID"
+          label={TEXT.ariaDescription}
+          id="gaTrackingId"
+          value=""
           placeholder={TEXT.placeholder}
-          aria-describedby="ga-input-description"
         />
         <TextInputHelperText>{TEXT.context}</TextInputHelperText>
       </div>

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
@@ -15,12 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-// import { text } from '@storybook/addon-knobs';
-// import { action } from '@storybook/addon-actions';
-
-/**
  * Internal dependencies
  */
 import GoogleAnalyticsSettings from '../';

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
@@ -13,10 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { default as MyStoriesView } from './myStories';
-export { default as EditorSettingsView } from './editorSettings';
-export { default as ExploreTemplatesView } from './exploreTemplates';
-export { default as TemplateDetailsView } from './templateDetails';
-export { default as SavedTemplatesView } from './savedTemplates';
-export { default as StoryAnimTool } from './storyAnimTool';
-export { default as ToasterView } from './toaster';
+
+/**
+ * External dependencies
+ */
+// import { text } from '@storybook/addon-knobs';
+// import { action } from '@storybook/addon-actions';
+
+/**
+ * Internal dependencies
+ */
+import GoogleAnalyticsSettings from '../';
+
+export default {
+  title: 'Dashboard/Views/EditorSettings/GoogleAnalytics',
+  component: GoogleAnalyticsSettings,
+};
+
+export const _default = () => {
+  return <GoogleAnalyticsSettings />;
+};

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { default as MyStoriesView } from './myStories';
-export { default as EditorSettingsView } from './editorSettings';
-export { default as ExploreTemplatesView } from './exploreTemplates';
-export { default as TemplateDetailsView } from './templateDetails';
-export { default as SavedTemplatesView } from './savedTemplates';
-export { default as StoryAnimTool } from './storyAnimTool';
-export { default as ToasterView } from './toaster';
+
+/**
+ * External dependencies
+ */
+
+function EditorSettings() {
+  return <div>{'Editor Settings Placeholder'}</div>;
+}
+
+export default EditorSettings;

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -15,11 +15,29 @@
  */
 
 /**
- * External dependencies
+ * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import GoogleAnalyticsSettings from './googleAnalytics';
+import PublisherLogoSettings from './publisherLogo';
+import { Wrapper, Header, Heading, Main } from './components';
 
 function EditorSettings() {
-  return <div>{'Editor Settings Placeholder'}</div>;
+  return (
+    <Wrapper>
+      <Header>
+        <Heading>{__('Stories Global Settings', 'web-stories')}</Heading>
+      </Header>
+      <Main>
+        <GoogleAnalyticsSettings />
+        <PublisherLogoSettings />
+      </Main>
+    </Wrapper>
+  );
 }
 
 export default EditorSettings;

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -30,7 +30,7 @@ function EditorSettings() {
   return (
     <Wrapper>
       <Header>
-        <Heading>{__('Stories Global Settings', 'web-stories')}</Heading>
+        <Heading>{__('Settings', 'web-stories')}</Heading>
       </Header>
       <Main>
         <GoogleAnalyticsSettings />

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -15,11 +15,47 @@
  */
 
 /**
- * External dependencies
+ * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import {
+  SettingForm,
+  FileUploadHelperText,
+  FinePrintHelperText,
+  UploadContainer,
+  SettingLabel,
+} from '../components';
+
+const TEXT = {
+  label: __('Publisher Logo', 'web-stories'),
+  context: __(
+    'Upload your logos here and they will become available to any stories you create.',
+    'web-stories'
+  ),
+  instructions: __(
+    'Click on upload or drag a jpg, png, or static gif in the box above. Avoid vector files, such as svg or eps. Logos should be at least 96x96 pixels and a perfect square. The background should not be transparent.',
+    'web-stories'
+  ),
+  submit: __('Upload', 'web-stories'),
+};
 function PublisherLogoSettings() {
-  return <div>{'Publisher Logos Placeholder'}</div>;
+  return (
+    <SettingForm>
+      <SettingLabel htmlFor="publisherLogo">{TEXT.label}</SettingLabel>
+      <div>
+        <FileUploadHelperText>{TEXT.context}</FileUploadHelperText>
+        <UploadContainer>
+          <p>{'Upload Placeholder'}</p>
+          <button>{TEXT.submit}</button>
+        </UploadContainer>
+        <FinePrintHelperText>{TEXT.instructions}</FinePrintHelperText>
+      </div>
+    </SettingForm>
+  );
 }
 
 export default PublisherLogoSettings;

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -27,7 +27,7 @@ import {
   FileUploadHelperText,
   FinePrintHelperText,
   UploadContainer,
-  SettingLabel,
+  SettingHeading,
 } from '../components';
 
 const TEXT = {
@@ -45,7 +45,7 @@ const TEXT = {
 function PublisherLogoSettings() {
   return (
     <SettingForm>
-      <SettingLabel htmlFor="publisherLogo">{TEXT.label}</SettingLabel>
+      <SettingHeading htmlFor="publisherLogo">{TEXT.label}</SettingHeading>
       <div>
         <FileUploadHelperText>{TEXT.context}</FileUploadHelperText>
         <UploadContainer>

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -31,30 +31,30 @@ import {
 } from '../components';
 
 const TEXT = {
-  sectionHeading: __('Publisher Logo', 'web-stories'),
-  context: __(
+  SECTION_HEADING: __('Publisher Logo', 'web-stories'),
+  CONTEXT: __(
     'Upload your logos here and they will become available to any stories you create.',
     'web-stories'
   ),
-  instructions: __(
+  INSTRUCTIONS: __(
     'Click on upload or drag a jpg, png, or static gif in the box above. Avoid vector files, such as svg or eps. Logos should be at least 96x96 pixels and a perfect square. The background should not be transparent.',
     'web-stories'
   ),
-  submit: __('Upload', 'web-stories'),
+  SUBMIT: __('Upload', 'web-stories'),
 };
 function PublisherLogoSettings() {
   return (
     <SettingForm>
       <SettingHeading htmlFor="publisherLogo">
-        {TEXT.sectionHeading}
+        {TEXT.SECTION_HEADING}
       </SettingHeading>
       <div>
-        <FileUploadHelperText>{TEXT.context}</FileUploadHelperText>
+        <FileUploadHelperText>{TEXT.CONTEXT}</FileUploadHelperText>
         <UploadContainer>
           <p>{'Upload Placeholder'}</p>
-          <button>{TEXT.submit}</button>
+          <button>{TEXT.SUBMIT}</button>
         </UploadContainer>
-        <FinePrintHelperText>{TEXT.instructions}</FinePrintHelperText>
+        <FinePrintHelperText>{TEXT.INSTRUCTIONS}</FinePrintHelperText>
       </div>
     </SettingForm>
   );

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -31,7 +31,7 @@ import {
 } from '../components';
 
 const TEXT = {
-  label: __('Publisher Logo', 'web-stories'),
+  sectionHeading: __('Publisher Logo', 'web-stories'),
   context: __(
     'Upload your logos here and they will become available to any stories you create.',
     'web-stories'
@@ -45,7 +45,9 @@ const TEXT = {
 function PublisherLogoSettings() {
   return (
     <SettingForm>
-      <SettingHeading htmlFor="publisherLogo">{TEXT.label}</SettingHeading>
+      <SettingHeading htmlFor="publisherLogo">
+        {TEXT.sectionHeading}
+      </SettingHeading>
       <div>
         <FileUploadHelperText>{TEXT.context}</FileUploadHelperText>
         <UploadContainer>

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { default as MyStoriesView } from './myStories';
-export { default as EditorSettingsView } from './editorSettings';
-export { default as ExploreTemplatesView } from './exploreTemplates';
-export { default as TemplateDetailsView } from './templateDetails';
-export { default as SavedTemplatesView } from './savedTemplates';
-export { default as StoryAnimTool } from './storyAnimTool';
-export { default as ToasterView } from './toaster';
+
+/**
+ * External dependencies
+ */
+
+function PublisherLogoSettings() {
+  return <div>{'Publisher Logos Placeholder'}</div>;
+}
+
+export default PublisherLogoSettings;

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/stories/index.js
@@ -13,10 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { default as MyStoriesView } from './myStories';
-export { default as EditorSettingsView } from './editorSettings';
-export { default as ExploreTemplatesView } from './exploreTemplates';
-export { default as TemplateDetailsView } from './templateDetails';
-export { default as SavedTemplatesView } from './savedTemplates';
-export { default as StoryAnimTool } from './storyAnimTool';
-export { default as ToasterView } from './toaster';
+
+/**
+ * External dependencies
+ */
+// import { text } from '@storybook/addon-knobs';
+// import { action } from '@storybook/addon-actions';
+
+/**
+ * Internal dependencies
+ */
+import PublisherLogoSettings from '../';
+
+export default {
+  title: 'Dashboard/Views/EditorSettings/PublisherLogo',
+  component: PublisherLogoSettings,
+};
+
+export const _default = () => {
+  return <PublisherLogoSettings />;
+};

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/stories/index.js
@@ -15,12 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-// import { text } from '@storybook/addon-knobs';
-// import { action } from '@storybook/addon-actions';
-
-/**
  * Internal dependencies
  */
 import PublisherLogoSettings from '../';

--- a/assets/src/dashboard/app/views/editorSettings/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/stories/index.js
@@ -15,12 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-// import { text } from '@storybook/addon-knobs';
-// import { action } from '@storybook/addon-actions';
-
-/**
  * Internal dependencies
  */
 import EditorSettingsView from '../';

--- a/assets/src/dashboard/app/views/editorSettings/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/stories/index.js
@@ -13,10 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { default as MyStoriesView } from './myStories';
-export { default as EditorSettingsView } from './editorSettings';
-export { default as ExploreTemplatesView } from './exploreTemplates';
-export { default as TemplateDetailsView } from './templateDetails';
-export { default as SavedTemplatesView } from './savedTemplates';
-export { default as StoryAnimTool } from './storyAnimTool';
-export { default as ToasterView } from './toaster';
+
+/**
+ * External dependencies
+ */
+// import { text } from '@storybook/addon-knobs';
+// import { action } from '@storybook/addon-actions';
+
+/**
+ * Internal dependencies
+ */
+import EditorSettingsView from '../';
+
+export default {
+  title: 'Dashboard/Views/EditorSettings/View',
+  component: EditorSettingsView,
+};
+
+export const _default = () => {
+  return <EditorSettingsView />;
+};

--- a/assets/src/dashboard/app/views/myStories/header/index.js
+++ b/assets/src/dashboard/app/views/myStories/header/index.js
@@ -106,6 +106,14 @@ function Header({
     );
   }, [filter, scrollToTop, totalStoriesByStatus]);
 
+  const onSortChange = useCallback(
+    (newSort) => {
+      sort.set(newSort);
+      scrollToTop();
+    },
+    [scrollToTop, sort]
+  );
+
   return (
     <Layout.Squishable>
       <PageHeading
@@ -125,13 +133,7 @@ function Header({
         handleLayoutSelect={view.toggleStyle}
         currentSort={sort.value}
         pageSortOptions={STORY_SORT_MENU_ITEMS}
-        handleSortChange={useCallback(
-          (newSort) => {
-            sort.set(newSort);
-            scrollToTop();
-          },
-          [scrollToTop, sort]
-        )}
+        handleSortChange={onSortChange}
         wpListURL={wpListURL}
         sortDropdownAriaLabel={__(
           'Choose sort option for display',

--- a/assets/src/dashboard/components/inlineInputForm/index.js
+++ b/assets/src/dashboard/components/inlineInputForm/index.js
@@ -35,6 +35,7 @@ const InlineInputForm = ({
   onEditCancel,
   onEditComplete,
   value,
+  ...rest
 }) => {
   const inputContainerRef = useRef(null);
   const [newValue, setNewValue] = useState(value);
@@ -77,6 +78,7 @@ const InlineInputForm = ({
         value={newValue}
         onKeyDown={handleKeyPress}
         onChange={handleChange}
+        {...rest}
       />
     </div>
   );

--- a/assets/src/dashboard/components/inlineInputForm/index.js
+++ b/assets/src/dashboard/components/inlineInputForm/index.js
@@ -34,8 +34,8 @@ const InlineInputForm = ({
   label,
   onEditCancel,
   onEditComplete,
+  placeholder,
   value,
-  ...rest
 }) => {
   const inputContainerRef = useRef(null);
   const [newValue, setNewValue] = useState(value);
@@ -78,7 +78,7 @@ const InlineInputForm = ({
         value={newValue}
         onKeyDown={handleKeyPress}
         onChange={handleChange}
-        {...rest}
+        placeholder={placeholder}
       />
     </div>
   );
@@ -89,6 +89,7 @@ InlineInputForm.propTypes = {
   label: PropTypes.string.isRequired,
   onEditCancel: PropTypes.func.isRequired,
   onEditComplete: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
   value: PropTypes.string,
 };
 


### PR DESCRIPTION
## Summary
Lays groundwork for rest of settings page within the dashboard - file structure and the base UI brought in from Figma. 

![Screen Shot 2020-07-01 at 2 48 04 PM](https://user-images.githubusercontent.com/10720454/86294826-2d799a80-bbaa-11ea-96d6-569fc9378757.png)

## Relevant Technical Choices
- Adds views/editorSettings to dashboard/app. All work is visible in storybook alone right now to avoid messing with redundant feature flags and keep PRs smaller. 
- Separates GA and publisher logo into their own directories w/ components for each. 
- Sets up text
- Sets up styled components 
- Used theme from dashboard as much as possible, everywhere I didn't it's because these are different values from what the rest of the dashboard is using - considering the UI that Sam's working on I'm not worried about this as I know changes will be fluid. 
- Took small liberties around how wide the main (form) sections of this view will be so that resizing is graceful - figma shows the containers at 600px but the full size of the window is 1884px wide which is massive.

## To-do
(These will all be separate)
- Upload component 
- Adding link to text in publisherLogo instructions (need to find out what the link is, have a todo note for later)
- All functionality 🙃 
- Tests 
- Adding view inside of dashboard 

## User-facing changes
- None 

## Testing Instructions
- Check storybook Dashboard/Views/EditorSettings to see the full layout and by section (GA and logo). Figma docs for reference are https://www.figma.com/file/Cd9iacVknHK62RO4pRwb68/Stories-Editor?node-id=6136%3A198 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2747 
