### PR TITLE
Media: Fix video poster extraction on Firefox and drag/paste on Safari

### DIFF
--- a/assets/src/edit-story/app/media/utils/getFirstFrameOfVideo.js
+++ b/assets/src/edit-story/app/media/utils/getFirstFrameOfVideo.js
@@ -26,6 +26,9 @@ function getFirstFrameOfVideo(src) {
   const video = document.createElement('video');
   video.muted = true;
   video.crossOrigin = 'anonymous';
+  // Since  we want to get the actual frames, we need to make sure to preload the whole video
+  // and not just metadata.
+  // See https://github.com/google/web-stories-wp/issues/2922.
   video.preload = 'auto';
 
   return new Promise((resolve, reject) => {
@@ -34,7 +37,11 @@ function getFirstFrameOfVideo(src) {
     video.addEventListener(
       'canplay',
       () => {
-        video.currentTime = 0.5; // Needed to seek forward.
+        // Need to seek forward to ensure we get a proper frame.
+        // Doing it inside the event listener to prevent the event
+        // from being fired twice.
+        // See https://github.com/google/web-stories-wp/issues/2923
+        video.currentTime = 0.5;
 
         const canvas = document.createElement('canvas');
         canvas.width = video.videoWidth;

--- a/assets/src/edit-story/app/media/utils/getFirstFrameOfVideo.js
+++ b/assets/src/edit-story/app/media/utils/getFirstFrameOfVideo.js
@@ -41,8 +41,16 @@ function getFirstFrameOfVideo(src) {
         // Doing it inside the event listener to prevent the event
         // from being fired twice.
         // See https://github.com/google/web-stories-wp/issues/2923
-        video.currentTime = 0.5;
+        // Translates to real-world 0.28
+        // See "Reduced time precision" https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentTime
+        video.currentTime = 0.99;
+      },
+      { once: true } // Important because 'canplay' can be fired hundreds of times.
+    );
 
+    video.addEventListener(
+      'seeked',
+      () => {
         const canvas = document.createElement('canvas');
         canvas.width = video.videoWidth;
         canvas.height = video.videoHeight;
@@ -52,7 +60,7 @@ function getFirstFrameOfVideo(src) {
 
         canvas.toBlob(resolve, 'image/jpeg');
       },
-      { once: true } // Important because 'canplay' can be fired hundreds of times.
+      { once: true }
     );
 
     video.src = src;


### PR DESCRIPTION
## Summary

Works around a difference in behavior in Firefox.

## Relevant Technical Choices

Browsers can fire the `canplay` event multiple times. We need to ensure that we only listen to it once, and that we do it at the right time (after seeking forward a little bit). Otherwise the first frame is not yet available, and will be simply transparent, or the first frame will be black.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Upload a video in Firefox/Chrome/Safari/other
1. Verify that poster is generated successfully in all browsers.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2922
Fixes #2923