### PR TITLE
Dashboard: Preload first page of stories

### DIFF
--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -33,13 +33,9 @@ jest.mock('../wpAdapter', () => ({
       headers: {
         'X-WP-Total': 1,
         'X-WP-TotalPages': 1,
+        'X-WP-TotalByStatus': '{"all":1,"publish":1,"draft":0}',
       },
-      totals: {
-        all: 1,
-        draft: 0,
-        publish: 1,
-      },
-      data: [
+      body: [
         {
           id: 123,
           status: 'publish',

--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -30,27 +30,28 @@ import { ConfigProvider } from '../../config';
 jest.mock('../wpAdapter', () => ({
   get: () =>
     Promise.resolve({
-      headers: {
-        get: () => '1',
+      totals: {
+        all: 1,
+        draft: 0,
+        publish: 1,
       },
-      json: () =>
-        Promise.resolve([
-          {
-            id: 123,
-            status: 'published',
-            author: 1,
-            title: { rendered: 'Carlos', raw: 'Carlos' },
-            story_data: { pages: [{ id: 1, elements: [] }] },
-            modified: '1970-01-01T00:00:00.000Z',
-            date: '1970-01-01T00:00:00.000Z',
-          },
-        ]),
+      data: [
+        {
+          id: 123,
+          status: 'publish',
+          author: 1,
+          title: { rendered: 'Carlos', raw: 'Carlos' },
+          story_data: { pages: [{ id: 1, elements: [] }] },
+          modified: '1970-01-01T00:00:00.000Z',
+          date: '1970-01-01T00:00:00.000Z',
+        },
+      ],
     }),
   post: (path, { data }) => {
     const title = typeof data.title === 'string' ? data.title : data.title.raw;
     return Promise.resolve({
       id: data.id || 456,
-      status: 'published',
+      status: 'publish',
       title: { rendered: title, raw: title },
       author: 1,
       story_data: { pages: [{ id: 1, elements: [] }] },
@@ -61,7 +62,7 @@ jest.mock('../wpAdapter', () => ({
   deleteRequest: (path, { data }) =>
     Promise.resolve({
       id: data.id,
-      status: 'published',
+      status: 'publish',
       title: { rendered: data.title, raw: data.title },
       story_data: { pages: [{ id: 1, elements: [] }] },
       modified: '1970-01-01T00:00:00.000Z',
@@ -99,7 +100,7 @@ describe('ApiProvider', () => {
           id: 123,
           modified: '1970-01-01T00:00:00.000Z',
           date: '1970-01-01T00:00:00.000Z',
-          status: 'published',
+          status: 'publish',
           author: 1,
           story_data: {
             pages: [
@@ -120,7 +121,7 @@ describe('ApiProvider', () => {
             id: 1,
           },
         ],
-        status: 'published',
+        status: 'publish',
         title: 'Carlos',
       },
     });
@@ -152,7 +153,7 @@ describe('ApiProvider', () => {
             id: 1,
           },
         ],
-        status: 'published',
+        status: 'publish',
         title: 'New Title',
       });
     });
@@ -170,7 +171,7 @@ describe('ApiProvider', () => {
           id: 123,
           modified: '1970-01-01T00:00:00.000Z',
           date: '1970-01-01T00:00:00.000Z',
-          status: 'published',
+          status: 'publish',
           author: 1,
           story_data: {
             pages: [
@@ -191,7 +192,7 @@ describe('ApiProvider', () => {
             id: 1,
           },
         ],
-        status: 'published',
+        status: 'publish',
         title: 'New Title',
       },
     });
@@ -221,7 +222,7 @@ describe('ApiProvider', () => {
             id: 1,
           },
         ],
-        status: 'published',
+        status: 'publish',
         title: 'Carlos',
         author: 1,
         originalStoryData: {
@@ -254,7 +255,7 @@ describe('ApiProvider', () => {
           id: 123,
           modified: '1970-01-01T00:00:00.000Z',
           date: '1970-01-01T00:00:00.000Z',
-          status: 'published',
+          status: 'publish',
           author: 1,
           story_data: {
             pages: [
@@ -275,7 +276,7 @@ describe('ApiProvider', () => {
             id: 1,
           },
         ],
-        status: 'published',
+        status: 'publish',
         title: 'Carlos',
       },
       '456': {
@@ -290,7 +291,7 @@ describe('ApiProvider', () => {
           id: 456,
           modified: '1970-01-01T00:00:00.000Z',
           date: '1970-01-01T00:00:00.000Z',
-          status: 'published',
+          status: 'publish',
           author: 1,
           story_data: {
             pages: [
@@ -311,7 +312,7 @@ describe('ApiProvider', () => {
             id: 1,
           },
         ],
-        status: 'published',
+        status: 'publish',
         title: 'Carlos (Copy)',
       },
     });

--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -30,6 +30,10 @@ import { ConfigProvider } from '../../config';
 jest.mock('../wpAdapter', () => ({
   get: () =>
     Promise.resolve({
+      headers: {
+        'X-WP-Total': 1,
+        'X-WP-TotalPages': 1,
+      },
       totals: {
         all: 1,
         draft: 0,

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -136,9 +136,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
         const totalPages = response.totals && parseInt(response.totals.all);
         const totalStoriesByStatus = response.totals;
 
-        const serverStoryResponse = response.data;
-
-        const reshapedStories = serverStoryResponse
+        const reshapedStories = response.data
           .map(reshapeStoryObject(editStoryURL))
           .filter(Boolean);
 

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -135,9 +135,11 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
 
         const totalPages =
           response.headers && parseInt(response.headers['X-WP-TotalPages']);
-        const totalStoriesByStatus = response.totals;
+        const totalStoriesByStatus =
+          response.headers &&
+          JSON.parse(response.headers['X-WP-TotalByStatus']);
 
-        const reshapedStories = response.data
+        const reshapedStories = response.body
           .map(reshapeStoryObject(editStoryURL))
           .filter(Boolean);
 

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -116,6 +116,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
 
       const query = {
         context: 'edit',
+        story_format: true,
         search: searchTerm || undefined,
         orderby: sortOption,
         page,
@@ -130,19 +131,12 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
           query,
         });
 
-        const response = await dataAdapter.get(path, {
-          parse: false,
-          cache: 'no-cache',
-        });
+        const response = await dataAdapter.get(path);
 
-        const totalPages =
-          response.headers && parseInt(response.headers.get('X-WP-TotalPages'));
+        const totalPages = response.totals && parseInt(response.totals.all);
+        const totalStoriesByStatus = response.totals;
 
-        const totalStoriesByStatus =
-          response.headers &&
-          JSON.parse(response.headers.get('X-WP-TotalByStatus'));
-
-        const serverStoryResponse = await response.json();
+        const serverStoryResponse = response.data;
 
         const reshapedStories = serverStoryResponse
           .map(reshapeStoryObject(editStoryURL))

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -133,7 +133,8 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
 
         const response = await dataAdapter.get(path);
 
-        const totalPages = response.totals && parseInt(response.totals.all);
+        const totalPages =
+          response.headers && parseInt(response.headers['X-WP-TotalPages']);
         const totalStoriesByStatus = response.totals;
 
         const reshapedStories = response.data

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -116,7 +116,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
 
       const query = {
         context: 'edit',
-        story_format: true,
+        _web_stories_envelope: true,
         search: searchTerm || undefined,
         orderby: sortOption,
         page,

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -124,6 +124,8 @@ class Dashboard {
 		$preload_paths = [
 			'/web-stories/v1/fonts',
 			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=publish%2Cdraft&story_format=true',
+			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=publish&story_format=true',
+			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=draft&story_format=true',
 		];
 
 		/**

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -123,7 +123,7 @@ class Dashboard {
 		// TODO Preload templates.
 		$preload_paths = [
 			'/web-stories/v1/fonts',
-			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=publish%2Cdraft&story_format=true',
+			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=publish%2Cdraft&_web_stories_envelope=true',
 		];
 
 		/**

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -123,6 +123,7 @@ class Dashboard {
 		// TODO Preload templates.
 		$preload_paths = [
 			'/web-stories/v1/fonts',
+			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=publish%2Cdraft&story_format=true',
 		];
 
 		/**

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -124,8 +124,6 @@ class Dashboard {
 		$preload_paths = [
 			'/web-stories/v1/fonts',
 			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=publish%2Cdraft&story_format=true',
-			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=publish&story_format=true',
-			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=draft&story_format=true',
 		];
 
 		/**

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -323,9 +323,11 @@ class Stories_Controller extends Stories_Base_Controller {
 
 		if ( $request['story_format'] ) {
 			$current_data = $response->get_data();
+			$headers      = $response->get_headers();
 			$data         = [
-				'totals' => $statuses_count,
-				'data'   => $current_data,
+				'totals'  => $statuses_count,
+				'headers' => $headers,
+				'data'    => $current_data,
 			];
 			$response     = rest_ensure_response( $data );
 		}

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -320,11 +320,38 @@ class Stories_Controller extends Stories_Base_Controller {
 			$posts_query->query( $query_args );
 			$statuses_count[ $key ] = absint( $posts_query->found_posts );
 		}
+
+		if( $request['story_format'] ) {
+			$current_data = $response->get_data();
+			$data         = [
+				'totals' => $statuses_count,
+				'data'   => $current_data,
+			];
+			$response     = rest_ensure_response( $data );
+		}
 		// Encode the array as headers do not support passing an array.
 		$encoded_statuses = wp_json_encode( $statuses_count );
 		if ( $encoded_statuses ) {
 			$response->header( 'X-WP-TotalByStatus', $encoded_statuses );
 		}
 		return $response;
+	}
+
+	/**
+	 * Retrieves the query params for the posts collection.
+	 *
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		$query_params = parent::get_collection_params();
+
+		$query_params['story_format'] = array(
+			'description' => __( 'Format as story format', 'web-stories' ),
+			'type'        => 'boolean',
+			'default'     => false,
+		);
+
+		return $query_params;
 	}
 }

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -321,23 +321,13 @@ class Stories_Controller extends Stories_Base_Controller {
 			$statuses_count[ $key ] = absint( $posts_query->found_posts );
 		}
 
-		if ( $request['_web_stories_envelope'] ) {
-			$current_data = $response->get_data();
-			$headers      = $response->get_headers();
-			$data         = [
-				'totals'  => $statuses_count,
-				'headers' => $headers,
-				'data'    => $current_data,
-			];
-			$response     = rest_ensure_response( $data );
-			foreach ( $headers as $header => $value ) {
-				$response->header( $header, $value );
-			}
-		}
 		// Encode the array as headers do not support passing an array.
 		$encoded_statuses = wp_json_encode( $statuses_count );
 		if ( $encoded_statuses ) {
 			$response->header( 'X-WP-TotalByStatus', $encoded_statuses );
+		}
+		if ( $request['_web_stories_envelope'] ) {
+			$response = rest_get_server()->envelope_response( $response, false );
 		}
 		return $response;
 	}

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -321,7 +321,7 @@ class Stories_Controller extends Stories_Base_Controller {
 			$statuses_count[ $key ] = absint( $posts_query->found_posts );
 		}
 
-		if( $request['story_format'] ) {
+		if ( $request['story_format'] ) {
 			$current_data = $response->get_data();
 			$data         = [
 				'totals' => $statuses_count,
@@ -340,17 +340,16 @@ class Stories_Controller extends Stories_Base_Controller {
 	/**
 	 * Retrieves the query params for the posts collection.
 	 *
-	 *
 	 * @return array Collection parameters.
 	 */
 	public function get_collection_params() {
 		$query_params = parent::get_collection_params();
 
-		$query_params['story_format'] = array(
+		$query_params['story_format'] = [
 			'description' => __( 'Format as story format', 'web-stories' ),
 			'type'        => 'boolean',
 			'default'     => false,
-		);
+		];
 
 		return $query_params;
 	}

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -330,6 +330,9 @@ class Stories_Controller extends Stories_Base_Controller {
 				'data'    => $current_data,
 			];
 			$response     = rest_ensure_response( $data );
+			foreach ( $headers as $header => $value ) {
+				$response->header( $header, $value );
+			}
 		}
 		// Encode the array as headers do not support passing an array.
 		$encoded_statuses = wp_json_encode( $statuses_count );

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -321,7 +321,7 @@ class Stories_Controller extends Stories_Base_Controller {
 			$statuses_count[ $key ] = absint( $posts_query->found_posts );
 		}
 
-		if ( $request['story_format'] ) {
+		if ( $request['_web_stories_envelope'] ) {
 			$current_data = $response->get_data();
 			$headers      = $response->get_headers();
 			$data         = [
@@ -350,8 +350,8 @@ class Stories_Controller extends Stories_Base_Controller {
 	public function get_collection_params() {
 		$query_params = parent::get_collection_params();
 
-		$query_params['story_format'] = [
-			'description' => __( 'Format as story format', 'web-stories' ),
+		$query_params['_web_stories_envelope'] = [
+			'description' => __( 'Envelope request for preloading.', 'web-stories' ),
 			'type'        => 'boolean',
 			'default'     => false,
 		];

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -166,7 +166,7 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/web-story' );
 		$request->set_param( 'status', [ 'draft' ] );
 		$request->set_param( 'context', 'edit' );
-		$request->set_param( 'story_format', true );
+		$request->set_param( '_web_stories_envelope', true );
 		$response       = rest_get_server()->dispatch( $request );
 		$headers        = $response->get_headers();
 		$data           = $response->get_data();

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -287,6 +287,7 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 
 	/**
 	 * @covers ::create_item
+	 * @covers \Google\Web_Stories\REST_API\Stories_Base_Controller::create_item
 	 */
 	public function test_create_item_as_author_should_not_strip_markup() {
 		wp_set_current_user( self::$author_id );
@@ -310,6 +311,7 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 
 	/**
 	 * @covers ::update_item
+	 * @covers \Google\Web_Stories\REST_API\Stories_Base_Controller::update_item
 	 */
 	public function test_update_item_as_author_should_not_strip_markup() {
 		wp_set_current_user( self::$author_id );

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -167,8 +167,8 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$request->set_param( 'status', [ 'draft' ] );
 		$request->set_param( 'context', 'edit' );
 		$request->set_param( '_web_stories_envelope', true );
-		$response       = rest_get_server()->dispatch( $request );
-		$data           = $response->get_data();
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
 
 		// Body of request.
 		$this->assertArrayHasKey( 'headers', $data );

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -21,6 +21,9 @@ use Google\Web_Stories\Tests\Story_Post_Type;
 use Spy_REST_Server;
 use WP_REST_Request;
 
+/**
+ * @coversDefaultClass \Google\Web_Stories\REST_API\Stories_Controller
+ */
 class Stories_Controller extends \WP_Test_REST_TestCase {
 	protected $server;
 
@@ -121,6 +124,9 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$wp_rest_server = null;
 	}
 
+	/**
+	 * @covers ::register_routes
+	 */
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 
@@ -128,6 +134,9 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$this->assertCount( 2, $routes['/wp/v2/web-story'] );
 	}
 
+	/**
+	 * @covers ::get_items
+	 */
 	public function test_get_items() {
 		wp_set_current_user( self::$user_id );
 		$request = new WP_REST_Request( 'GET', '/wp/v2/web-story' );
@@ -149,6 +158,47 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$this->assertEquals( 3, $headers['X-WP-Total'] );
 	}
 
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_get_items_format() {
+		wp_set_current_user( self::$user_id );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/web-story' );
+		$request->set_param( 'status', [ 'draft' ] );
+		$request->set_param( 'context', 'edit' );
+		$request->set_param( 'story_format', true );
+		$response       = rest_get_server()->dispatch( $request );
+		$headers        = $response->get_headers();
+		$data           = $response->get_data();
+		$statues        = $headers['X-WP-TotalByStatus'];
+		$statues_decode = json_decode( $statues, true );
+
+		// Headers.
+		$this->assertArrayHasKey( 'all', $statues_decode );
+		$this->assertArrayHasKey( 'publish', $statues_decode );
+		$this->assertArrayHasKey( 'draft', $statues_decode );
+
+		$this->assertEquals( 10, $statues_decode['all'] );
+		$this->assertEquals( 7, $statues_decode['publish'] );
+		$this->assertEquals( 3, $statues_decode['draft'] );
+
+		$this->assertEquals( 3, $headers['X-WP-Total'] );
+
+		// Body of request.
+		$this->assertArrayHasKey( 'totals', $data );
+		$this->assertArrayHasKey( 'headers', $data );
+		$this->assertArrayHasKey( 'data', $data );
+
+		$this->assertEquals( 10, $data['totals']['all'] );
+		$this->assertEquals( 7, $data['totals']['publish'] );
+		$this->assertEquals( 3, $data['totals']['draft'] );
+
+		$this->assertEquals( 3, $data['headers']['X-WP-Total'] );
+	}
+
+	/**
+	 * @covers ::get_item_schema
+	 */
 	public function test_get_item_schema() {
 		$request  = new WP_REST_Request( 'OPTIONS', '/wp/v2/web-story' );
 		$response = rest_get_server()->dispatch( $request );
@@ -161,6 +211,9 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$this->assertArrayHasKey( 'featured_media_url', $properties );
 	}
 
+	/**
+	 * @covers ::filter_posts_orderby
+	 */
 	public function test_filter_posts_by_author_display_names() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/web-story' );
 		$request->set_param( 'order', 'asc' );
@@ -205,6 +258,10 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		);
 	}
 
+	/**
+	 * @covers ::filter_posts_orderby
+	 * @covers ::filter_posts_clauses
+	 */
 	public function test_filter_posts_clauses_irrelevant_query() {
 		$controller = new \Google\Web_Stories\REST_API\Stories_Controller( \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG );
 
@@ -228,6 +285,9 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$this->assertEquals( $orderby, $initial_clauses );
 	}
 
+	/**
+	 * @covers ::create_item
+	 */
 	public function test_create_item_as_author_should_not_strip_markup() {
 		wp_set_current_user( self::$author_id );
 
@@ -248,6 +308,9 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$this->assertEquals( $unsanitized_story_data, $new_data['story_data'] );
 	}
 
+	/**
+	 * @covers ::update_item
+	 */
 	public function test_update_item_as_author_should_not_strip_markup() {
 		wp_set_current_user( self::$author_id );
 

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -185,13 +185,17 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$this->assertEquals( 3, $headers['X-WP-Total'] );
 
 		// Body of request.
-		$this->assertArrayHasKey( 'totals', $data );
 		$this->assertArrayHasKey( 'headers', $data );
-		$this->assertArrayHasKey( 'data', $data );
+		$this->assertArrayHasKey( 'body', $data );
+		$this->assertArrayHasKey( 'status', $data );
 
-		$this->assertEquals( 10, $data['totals']['all'] );
-		$this->assertEquals( 7, $data['totals']['publish'] );
-		$this->assertEquals( 3, $data['totals']['draft'] );
+		$statues        = $data['headers']['X-WP-TotalByStatus'];
+		$statues_decode = json_decode( $statues, true );
+
+		// Headers.
+		$this->assertArrayHasKey( 'all', $statues_decode );
+		$this->assertArrayHasKey( 'publish', $statues_decode );
+		$this->assertArrayHasKey( 'draft', $statues_decode );
 
 		$this->assertEquals( 3, $data['headers']['X-WP-Total'] );
 	}

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -168,21 +168,7 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$request->set_param( 'context', 'edit' );
 		$request->set_param( '_web_stories_envelope', true );
 		$response       = rest_get_server()->dispatch( $request );
-		$headers        = $response->get_headers();
 		$data           = $response->get_data();
-		$statues        = $headers['X-WP-TotalByStatus'];
-		$statues_decode = json_decode( $statues, true );
-
-		// Headers.
-		$this->assertArrayHasKey( 'all', $statues_decode );
-		$this->assertArrayHasKey( 'publish', $statues_decode );
-		$this->assertArrayHasKey( 'draft', $statues_decode );
-
-		$this->assertEquals( 10, $statues_decode['all'] );
-		$this->assertEquals( 7, $statues_decode['publish'] );
-		$this->assertEquals( 3, $statues_decode['draft'] );
-
-		$this->assertEquals( 3, $headers['X-WP-Total'] );
 
 		// Body of request.
 		$this->assertArrayHasKey( 'headers', $data );
@@ -216,7 +202,7 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * @covers ::filter_posts_orderby
+	 * @covers ::filter_posts_clauses
 	 */
 	public function test_filter_posts_by_author_display_names() {
 		$request = new WP_REST_Request( 'GET', '/wp/v2/web-story' );
@@ -263,7 +249,6 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * @covers ::filter_posts_orderby
 	 * @covers ::filter_posts_clauses
 	 */
 	public function test_filter_posts_clauses_irrelevant_query() {


### PR DESCRIPTION
## Summary

The PR two things. 

1. Preload published and draft REST API on page. 
2. Add a new format for responses, that no longer requires, gettings header to get totals. 

Preloading of does not work on requests that unparsed. See [this](https://github.com/WordPress/gutenberg/blob/master/packages/api-fetch/src/middlewares/preloading.js#L48). Currently these requests are unparsed, see [this](https://github.com/google/web-stories-wp/blob/fbd6d8f644283311e6a43e62e78b88cb4f7b9599/assets/src/dashboard/app/api/useStoryApi.js#L134).
The only reason these are unparsed is to get the total headers, see [this](https://github.com/google/web-stories-wp/blob/fbd6d8f644283311e6a43e62e78b88cb4f7b9599/assets/src/dashboard/app/api/useStoryApi.js#L138-L143).

Now if you pass `story_format=true` param in the REST API request, the format on the response changes. 

![Screenshot 2020-07-02 at 15 06 59](https://user-images.githubusercontent.com/237508/86368940-b6a9d380-bc75-11ea-92fb-0bf024127059.png)

With some small tweaks to the dashboard code 
1. Pass `story_format=true`  to the request
2. Map fields a little differently in useStoryApi.js, request will go through the cache. 



## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

See #2793
