### PR TITLE
Fix prop types warning for font preview

### DIFF
--- a/assets/src/edit-story/components/library/text/fontPreview.js
+++ b/assets/src/edit-story/components/library/text/fontPreview.js
@@ -85,7 +85,7 @@ function FontPreview({ title, element, onClick }) {
 
 FontPreview.propTypes = {
   title: PropTypes.string.isRequired,
-  element: StoryPropTypes.elements.text.isRequired,
+  element: StoryPropTypes.textContent.isRequired,
   onClick: PropTypes.func.isRequired,
 };
 


### PR DESCRIPTION
## Summary

Fixes console error. The present example element do not have type, id etc. Just use textContent prop type. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2934
