### PR TITLE
Dashboard: Update dialog relevant styles to match editor

### DIFF
--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -191,7 +191,7 @@ function StoriesView({
                 {__('Cancel', 'web-stories')}
               </Button>
               <Button
-                type={BUTTON_TYPES.CTA}
+                type={BUTTON_TYPES.DEFAULT}
                 onClick={() => {
                   storyActions.trashStory(activeStory);
                   setActiveDialog('');

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -66,19 +66,30 @@ const PrimaryButton = styled(StyledButton)`
   background-color: ${({ theme }) => theme.colors.bluePrimary};
 `;
 
-const DefaultButton = styled(StyledButton)(
-  ({ theme }) => `
-    background-color: ${theme.colors.white};
-    color: ${theme.colors.gray800};
-    border: ${theme.borders.gray800};
+const DefaultButton = styled(StyledButton)`
+  ${TypographyPresets.Medium};
+  ${({ theme }) => `
+    min-width: 50px;
+    padding: 4px 14px;
+    background: transparent;
+    color: ${theme.colors.bluePrimary};
+    border: ${theme.borders.transparent};
+    border-radius: 5px;
+    font-weight: 500;
+    text-transform: uppercase;
+    line-height: 24px;
+
     &:focus,
     &:active,
     &:hover {
-      color: ${theme.colors.gray900};
-      border-color: ${theme.colors.gray900};
+      color: ${theme.colors.bluePrimary};
+      border-color: ${theme.colors.blueLight};
+      background-color: ${theme.colors.blueLight};
     }
-  `
-);
+
+    transition: background-color 0.6s ease 0s;
+  `}
+`;
 
 // TODO: address CTA active styling
 const CtaButton = styled(StyledButton)`

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -78,6 +78,7 @@ const DefaultButton = styled(StyledButton)`
     font-weight: 500;
     text-transform: uppercase;
     line-height: 24px;
+    opacity: 1;
 
     &:focus,
     &:active,

--- a/assets/src/dashboard/components/dialog/index.js
+++ b/assets/src/dashboard/components/dialog/index.js
@@ -34,8 +34,7 @@ const DialogBox = styled.div(
     overflow-y: auto;
     max-width: 920px;
     max-height: calc(100% - 64px);
-    margin: 32px;
-    padding: 24px;
+    padding: 24px 0;
     flex-direction: column;
     background-color: ${colors.white};
     border-radius: 4px;
@@ -54,13 +53,14 @@ const DialogBox = styled.div(
 const DialogTitle = styled.h1`
   ${TypographyPresets.Large};
   flex: 0 0 auto;
-  margin: 0;
+  margin: 0 24px;
   font-weight: ${({ theme }) => theme.typography.weight.bold};
 `;
 const DialogContent = styled.div`
   ${TypographyPresets.Medium};
   flex: 1 1 auto;
-  padding: 16px 0;
+  padding: 24px 0 16px;
+  margin: 0 24px;
   overflow-y: auto;
   color: ${({ theme }) => theme.colors.gray700};
 `;
@@ -70,7 +70,7 @@ const DialogActions = styled.div`
   align-items: flex-end;
   align-items: center;
   justify-content: flex-end;
-  padding: 0;
+  margin: 0 16px;
 
   & > button {
     margin-right: 10px;

--- a/assets/src/dashboard/components/dialog/stories/index.js
+++ b/assets/src/dashboard/components/dialog/stories/index.js
@@ -24,6 +24,7 @@ import { text } from '@storybook/addon-knobs';
 /**
  * Internal dependencies
  */
+import { BUTTON_TYPES } from '../../../constants';
 import Button from '../../button';
 import Dialog from '..';
 
@@ -37,6 +38,7 @@ export const _default = () => {
 
   const ActionsNode = (
     <Button
+      type={BUTTON_TYPES.DEFAULT}
       onClick={() => {
         action('button clicked');
         setToggleDialog(!toggleDialog);
@@ -77,6 +79,7 @@ export const With2Actions = () => {
   const ActionsNode = (
     <>
       <Button
+        type={BUTTON_TYPES.DEFAULT}
         onClick={() => {
           action('cancel button clicked');
           setToggleDialog(!toggleDialog);
@@ -85,6 +88,7 @@ export const With2Actions = () => {
         {'cancel'}
       </Button>
       <Button
+        type={BUTTON_TYPES.DEFAULT}
         onClick={() => {
           action('button clicked');
         }}
@@ -103,7 +107,7 @@ export const With2Actions = () => {
           action('close dialog clicked');
           setToggleDialog(!toggleDialog);
         }}
-        isOpen={toggleDialog}
+        isOpen
         title={text('title', 'Dialog title')}
         contentLabel={'Dialog content Label for modal'}
         actions={ActionsNode}

--- a/assets/src/dashboard/components/dialog/stories/index.js
+++ b/assets/src/dashboard/components/dialog/stories/index.js
@@ -107,7 +107,7 @@ export const With2Actions = () => {
           action('close dialog clicked');
           setToggleDialog(!toggleDialog);
         }}
-        isOpen
+        isOpen={toggleDialog}
         title={text('title', 'Dialog title')}
         contentLabel={'Dialog content Label for modal'}
         actions={ActionsNode}


### PR DESCRIPTION
## Summary
Catching the dashboard's dialog UI up to the editor.

## Relevant Technical Choices
- `DEFAULT` button is only used in dialog right now (it will be great to have for settings page though!) so it made this update really localized as updating that only updates the buttons in the dialog. 
- Updating the default button to pretty near match the editor's dialog buttons. The main thing here I kept different intentionally is the primary blue that we're using elsewhere in the dashboard instead of using rbg(71, 160, 244). I also kept the small amount of space between 2 buttons so that if a button is focused and another is hovered they have some room between. 
- Updating dialog spacing to match dialog. I had set containers on the parts of the dialog so I applied margin for horizontal spacing and padding for vertical to keep in line with the patterning we have of space placement in the dashboard. 


## User-facing changes

Delete story dialog in dashboard should now look like this
![Screen Shot 2020-07-02 at 1 35 04 PM](https://user-images.githubusercontent.com/10720454/86406930-e1d9f600-bc68-11ea-9ae6-c887eedb509d.png)




## Testing Instructions
- Verify the above visual change. No functionality change.
- It should look like this one: https://google.github.io/web-stories-wp/storybook/?path=/story/stories-editor-components-dialog-delete-media--default

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2861 
