### PR TITLE
Dashboard: Safeguard against NaN page numbers to fetch stories

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -118,7 +118,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
         context: 'edit',
         search: searchTerm || undefined,
         orderby: sortOption,
-        page,
+        page: typeof page === 'number' ? page : 1,
         per_page: perPage,
         order: sortDirection || ORDER_BY_SORT[sortOption],
         status,


### PR DESCRIPTION
## Summary
This is a weird one that i cannot reproduce unless i force the environment and hardcode the wrong value for the page - I've completely reset my local database to clear everything out and follow steps to reproduce. 

The gist of the bug is that the API for stories was breaking because the page number passed in for the query was `NaN`. 
`/web-story?context=edit&order=desc&orderby=modified&page=NaN&per_page=24&status=draft&_locale=user`
(where `page=NaN`)

The default page value is 1 and if it is undefined when it gets passed to fetch the stories it is set as 1. So somewhere in this reported bug the page value is becoming something other than an integer on that initial load. To prevent against this I am checking that the page value is `typeof === number` as we go to make the API call and if not making sure 1 is the page number passed to the query.


## Relevant Technical Choices
- Check that page value is indeed a number, if it is not pass 1 as page query

## To-do
- If page is NaN when it gets to the API it could be set to page 1 in the dashboard controller instead. 

## User-facing changes
- Should be an invisible change unless you were seeing this bug! 

## Testing Instructions
- See that the first page of stories loads in your dashboard when you navigate to it. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2950
