### PR TITLE
Pull out reducer type constants to local and common folders

### DIFF
--- a/assets/src/edit-story/app/media/common/actions.js
+++ b/assets/src/edit-story/app/media/common/actions.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import * as types from '../types';
+import * as types from './types';
 
 export const fetchMediaStart = (dispatch, defaultProvider) => ({
   pageToken,

--- a/assets/src/edit-story/app/media/common/reducer.js
+++ b/assets/src/edit-story/app/media/common/reducer.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import * as types from '../types';
+import * as types from './types';
 
 export const INITIAL_STATE = {
   media: [],
@@ -35,9 +35,6 @@ export const INITIAL_STATE = {
 
 function reducer(state = INITIAL_STATE, { type, payload }) {
   switch (type) {
-    case types.INITIAL_STATE:
-      return state;
-
     case types.FETCH_MEDIA_START: {
       return {
         ...state,

--- a/assets/src/edit-story/app/media/common/types.js
+++ b/assets/src/edit-story/app/media/common/types.js
@@ -14,4 +14,9 @@
  * limitations under the License.
  */
 
-export const INITIAL_STATE = 'INITIAL_STATE';
+export const FETCH_MEDIA_START = 'FETCH_MEDIA_START';
+export const FETCH_MEDIA_SUCCESS = 'FETCH_MEDIA_SUCCESS';
+export const FETCH_MEDIA_ERROR = 'FETCH_MEDIA_ERROR';
+export const SET_NEXT_PAGE = 'SET_NEXT_PAGE';
+export const UPDATE_MEDIA_ELEMENT = 'UPDATE_MEDIA_ELEMENT';
+export const DELETE_MEDIA_ELEMENT = 'DELETE_MEDIA_ELEMENT';

--- a/assets/src/edit-story/app/media/local/actions.js
+++ b/assets/src/edit-story/app/media/local/actions.js
@@ -18,7 +18,7 @@
  * Internal dependencies
  */
 import * as common from '../common/actions';
-import * as types from '../types';
+import * as types from './types';
 
 export const fetchMediaStart = (dispatch) =>
   common.fetchMediaStart(dispatch, 'local');

--- a/assets/src/edit-story/app/media/local/reducer.js
+++ b/assets/src/edit-story/app/media/local/reducer.js
@@ -19,11 +19,11 @@
 /**
  * Internal dependencies
  */
-import * as types from '../types';
-
+import * as commonTypes from '../common/types';
 import commonReducer, {
   INITIAL_STATE as COMMON_INITIAL_STATE,
 } from '../common/reducer';
+import * as types from './types';
 
 const INITIAL_STATE = {
   ...COMMON_INITIAL_STATE,
@@ -35,7 +35,7 @@ const INITIAL_STATE = {
 
 function reducer(state = INITIAL_STATE, { type, payload }) {
   switch (type) {
-    case types.FETCH_MEDIA_SUCCESS: {
+    case commonTypes.FETCH_MEDIA_SUCCESS: {
       const { provider, mediaType, searchTerm } = payload;
       if (
         provider === 'local' &&

--- a/assets/src/edit-story/app/media/local/types.js
+++ b/assets/src/edit-story/app/media/local/types.js
@@ -14,4 +14,9 @@
  * limitations under the License.
  */
 
-export const INITIAL_STATE = 'INITIAL_STATE';
+export const RESET_FILTERS = 'RESET_FILTERS';
+export const SET_SEARCH_TERM = 'SET_SEARCH_TERM';
+export const SET_MEDIA_TYPE = 'SET_MEDIA_TYPE';
+export const SET_MEDIA = 'SET_MEDIA';
+export const REMOVE_PROCESSING = 'REMOVE_PROCESSING';
+export const ADD_PROCESSING = 'ADD_PROCESSING';


### PR DESCRIPTION
## Summary

Pull out the reducer type.js constants to local and common folders, so that reducer+actions+types are appropriately encapsulated into their respective folders.

## Testing Instructions

* Open the media pane to verify that it appears.
* Scroll down to verify the next page of results in returned.
* Upload an image successfully.
* Upload a video successfully.

---

Fixes #2428
