### PR TITLE
Fix autoloading for Tests namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Google\\Web_Stories\\Tests\\": "tests/phpunit/tests"
+      "Google\\Web_Stories\\Tests\\": "tests/phpunit/includes"
     }
   },
   "prefer-stable": true

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -38,10 +38,6 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 
-// Manually require Private_Access trait
-// @todo Check why isn't auto-loading working.
-require_once dirname( dirname( __DIR__ ) ) . '/tests/phpunit/includes/Private_Access.php';
-
 /**
  * Manually load the plugin being tested.
  */


### PR DESCRIPTION
## Summary

This PR updates the PSR-4 autoloading path for the `Google\Web_Stories\Tests` namespace which was previously configured to autoload the tests directory. This is unnecessary as PHPUnit handles the loading of test cases automatically, so autoloading for this namespace should be configured to target the `includes` directory as the starting point for this namespace.

## Relevant Technical Choices

* Removed manual loading of `Private_Access` trait in `bootstrap.php` which is now handled by the autoloader.

## To-do

* N/A

## User-facing changes

* N/A

## Testing Instructions

* Run `npm run test:php` as usual 😄 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
