### PR TITLE
Dashboard: Settings view context foundation (Google Analytics)

### DIFF
--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -53,7 +53,7 @@ export default function ApiProvider({ children }) {
   const { api: fontApi } = useFontApi(dataAdapter, { fontApi: api.fonts });
 
   const { settings, api: settingsApi } = useSettingsApi(dataAdapter, {
-    wordPressSettingsApi: api.settings,
+    globalStoriesSettingsApi: api.settings,
   });
 
   const value = useMemo(

--- a/assets/src/dashboard/app/api/apiProvider.js
+++ b/assets/src/dashboard/app/api/apiProvider.js
@@ -29,6 +29,7 @@ import useFontApi from './useFontApi';
 import useStoryApi from './useStoryApi';
 import useTemplateApi from './useTemplateApi';
 import useUsersApi from './useUserApi';
+import useSettingsApi from './useSettingsApi';
 
 export const ApiContext = createContext({ state: {}, actions: {} });
 
@@ -51,21 +52,37 @@ export default function ApiProvider({ children }) {
 
   const { api: fontApi } = useFontApi(dataAdapter, { fontApi: api.fonts });
 
+  const { settings, api: settingsApi } = useSettingsApi(dataAdapter, {
+    wordPressSettingsApi: api.settings,
+  });
+
   const value = useMemo(
     () => ({
       state: {
+        settings,
         stories,
         templates,
         users,
       },
       actions: {
+        settingsApi,
         storyApi,
         templateApi,
         fontApi,
         usersApi,
       },
     }),
-    [users, stories, templates, storyApi, templateApi, fontApi, usersApi]
+    [
+      settings,
+      stories,
+      templates,
+      users,
+      settingsApi,
+      storyApi,
+      templateApi,
+      fontApi,
+      usersApi,
+    ]
   );
 
   return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;

--- a/assets/src/dashboard/app/api/test/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/test/useSettingsApi.js
@@ -25,33 +25,33 @@ import useSettingsApi from '../useSettingsApi';
 import wpAdapter from '../wpAdapter';
 
 describe('useSettingsApi', () => {
-  it('should return an error when fetching google analytics API request fails', async () => {
+  it('should return an error when fetching settings API request fails', async () => {
     const { result } = renderHook(() =>
       useSettingsApi(wpAdapter, { globalStoriesSettingsApi: 'wordpress' })
     );
 
     await act(async () => {
-      await result.current.api.fetchGoogleAnalyticsId();
+      await result.current.api.fetchSettings();
     });
 
     expect(result.current.settings.error.message).toStrictEqual({
       body: 'The response is not a valid JSON response.',
-      title: 'Unable to find google analytics ID',
+      title: 'Unable to find settings data',
     });
   });
 
-  it('should return an error when updating google analytics API request fails', async () => {
+  it('should return an error when updating settings API request fails', async () => {
     const { result } = renderHook(() =>
       useSettingsApi(wpAdapter, { globalStoriesSettingsApi: 'wordpress' })
     );
 
     await act(async () => {
-      await result.current.api.updateGoogleAnalyticsId('2738237892739');
+      await result.current.api.updateSettings('2738237892739');
     });
 
     expect(result.current.settings.error.message).toStrictEqual({
       body: 'The response is not a valid JSON response.',
-      title: 'Unable to update google analytics ID',
+      title: 'Unable to update settings data',
     });
   });
 });

--- a/assets/src/dashboard/app/api/test/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/test/useSettingsApi.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+import useSettingsApi from '../useSettingsApi';
+import wpAdapter from '../wpAdapter';
+
+describe('useSettingsApi', () => {
+  it('should return an error when fetching google analytics API request fails', async () => {
+    const { result } = renderHook(() =>
+      useSettingsApi(wpAdapter, { wordPressSettingsApi: 'wordpress' })
+    );
+
+    await act(async () => {
+      await result.current.api.fetchGoogleAnalyticsId();
+    });
+
+    expect(result.current.settings.error.message).toStrictEqual({
+      body: 'The response is not a valid JSON response.',
+      title: 'Unable to find google analytics ID',
+    });
+  });
+
+  it('should return an error when updating google analytics API request fails', async () => {
+    const { result } = renderHook(() =>
+      useSettingsApi(wpAdapter, { wordPressSettingsApi: 'wordpress' })
+    );
+
+    await act(async () => {
+      await result.current.api.updateGoogleAnalyticsId();
+    });
+
+    expect(result.current.settings.error.message).toStrictEqual({
+      body: 'The response is not a valid JSON response.',
+      title: 'Unable to update google analytics ID',
+    });
+  });
+});

--- a/assets/src/dashboard/app/api/test/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/test/useSettingsApi.js
@@ -27,7 +27,7 @@ import wpAdapter from '../wpAdapter';
 describe('useSettingsApi', () => {
   it('should return an error when fetching google analytics API request fails', async () => {
     const { result } = renderHook(() =>
-      useSettingsApi(wpAdapter, { wordPressSettingsApi: 'wordpress' })
+      useSettingsApi(wpAdapter, { globalStoriesSettingsApi: 'wordpress' })
     );
 
     await act(async () => {
@@ -42,11 +42,11 @@ describe('useSettingsApi', () => {
 
   it('should return an error when updating google analytics API request fails', async () => {
     const { result } = renderHook(() =>
-      useSettingsApi(wpAdapter, { wordPressSettingsApi: 'wordpress' })
+      useSettingsApi(wpAdapter, { globalStoriesSettingsApi: 'wordpress' })
     );
 
     await act(async () => {
-      await result.current.api.updateGoogleAnalyticsId();
+      await result.current.api.updateGoogleAnalyticsId('2738237892739');
     });
 
     expect(result.current.settings.error.message).toStrictEqual({

--- a/assets/src/dashboard/app/api/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/useSettingsApi.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo, useReducer } from 'react';
+import queryString from 'query-string';
+
+/**
+ * Internal dependencies
+ */
+import settingsReducer, {
+  defaultSettingsState,
+  ACTION_TYPES as SETTINGS_ACTION_TYPES,
+} from '../reducer/settings';
+
+export default function useSettingsApi(dataAdapter, { wordPressSettingsApi }) {
+  const [state, dispatch] = useReducer(settingsReducer, defaultSettingsState);
+
+  const fetchGoogleAnalyticsId = useCallback(async () => {
+    if (!wordPressSettingsApi) {
+      dispatch({
+        type: SETTINGS_ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE,
+        payload: {
+          message: {
+            body: __('Cannot connect to data source', 'web-stories'),
+            title: __('Unable to find google analytics ID', 'web-stories'),
+          },
+        },
+      });
+    }
+    try {
+      const response = await dataAdapter.get(
+        queryString.stringifyUrl({
+          url: wordPressSettingsApi,
+        })
+      );
+
+      dispatch({
+        type: SETTINGS_ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_SUCCESS,
+        payload: response.googleAnalyticsId,
+      });
+    } catch (err) {
+      dispatch({
+        type: SETTINGS_ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE,
+        payload: {
+          message: {
+            body: err.message,
+            title: __('Unable to find google analytics ID', 'web-stories'),
+          },
+        },
+      });
+    }
+  }, [dataAdapter, wordPressSettingsApi]);
+
+  const updateGoogleAnalyticsId = useCallback(async () => {
+    try {
+      const response = await dataAdapter.post(
+        queryString.stringifyUrl({
+          url: wordPressSettingsApi,
+        })
+      );
+
+      dispatch({
+        type: SETTINGS_ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_SUCCESS,
+        payload: response.googleAnalyticsId,
+      });
+    } catch (err) {
+      dispatch({
+        type: SETTINGS_ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_FAILURE,
+        payload: {
+          message: {
+            body: err.message,
+            title: __('Unable to update google analytics ID', 'web-stories'),
+          },
+        },
+      });
+    }
+  }, [dataAdapter, wordPressSettingsApi]);
+
+  const api = useMemo(
+    () => ({
+      fetchGoogleAnalyticsId,
+      updateGoogleAnalyticsId,
+    }),
+    [fetchGoogleAnalyticsId, updateGoogleAnalyticsId]
+  );
+
+  return { settings: state, api };
+}

--- a/assets/src/dashboard/app/api/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/useSettingsApi.js
@@ -33,11 +33,14 @@ import settingsReducer, {
   ACTION_TYPES as SETTINGS_ACTION_TYPES,
 } from '../reducer/settings';
 
-export default function useSettingsApi(dataAdapter, { wordPressSettingsApi }) {
+export default function useSettingsApi(
+  dataAdapter,
+  { globalStoriesSettingsApi }
+) {
   const [state, dispatch] = useReducer(settingsReducer, defaultSettingsState);
 
   const fetchGoogleAnalyticsId = useCallback(async () => {
-    if (!wordPressSettingsApi) {
+    if (!globalStoriesSettingsApi) {
       dispatch({
         type: SETTINGS_ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE,
         payload: {
@@ -51,7 +54,7 @@ export default function useSettingsApi(dataAdapter, { wordPressSettingsApi }) {
     try {
       const response = await dataAdapter.get(
         queryString.stringifyUrl({
-          url: wordPressSettingsApi,
+          url: globalStoriesSettingsApi,
         })
       );
 
@@ -70,32 +73,38 @@ export default function useSettingsApi(dataAdapter, { wordPressSettingsApi }) {
         },
       });
     }
-  }, [dataAdapter, wordPressSettingsApi]);
+  }, [dataAdapter, globalStoriesSettingsApi]);
 
-  const updateGoogleAnalyticsId = useCallback(async () => {
-    try {
-      const response = await dataAdapter.post(
-        queryString.stringifyUrl({
-          url: wordPressSettingsApi,
-        })
-      );
+  const updateGoogleAnalyticsId = useCallback(
+    async (newAnalyticsId) => {
+      const query = { analyticsId: newAnalyticsId };
 
-      dispatch({
-        type: SETTINGS_ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_SUCCESS,
-        payload: response.googleAnalyticsId,
-      });
-    } catch (err) {
-      dispatch({
-        type: SETTINGS_ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_FAILURE,
-        payload: {
-          message: {
-            body: err.message,
-            title: __('Unable to update google analytics ID', 'web-stories'),
+      try {
+        const response = await dataAdapter.post(
+          queryString.stringifyUrl({
+            url: globalStoriesSettingsApi,
+            query,
+          })
+        );
+
+        dispatch({
+          type: SETTINGS_ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_SUCCESS,
+          payload: response.googleAnalyticsId,
+        });
+      } catch (err) {
+        dispatch({
+          type: SETTINGS_ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_FAILURE,
+          payload: {
+            message: {
+              body: err.message,
+              title: __('Unable to update google analytics ID', 'web-stories'),
+            },
           },
-        },
-      });
-    }
-  }, [dataAdapter, wordPressSettingsApi]);
+        });
+      }
+    },
+    [dataAdapter, globalStoriesSettingsApi]
+  );
 
   const api = useMemo(
     () => ({

--- a/assets/src/dashboard/app/api/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/useSettingsApi.js
@@ -39,14 +39,14 @@ export default function useSettingsApi(
 ) {
   const [state, dispatch] = useReducer(settingsReducer, defaultSettingsState);
 
-  const fetchGoogleAnalyticsId = useCallback(async () => {
+  const fetchSettings = useCallback(async () => {
     if (!globalStoriesSettingsApi) {
       dispatch({
-        type: SETTINGS_ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE,
+        type: SETTINGS_ACTION_TYPES.FETCH_SETTINGS_FAILURE,
         payload: {
           message: {
             body: __('Cannot connect to data source', 'web-stories'),
-            title: __('Unable to find google analytics ID', 'web-stories'),
+            title: __('Unable to find settings data', 'web-stories'),
           },
         },
       });
@@ -59,25 +59,25 @@ export default function useSettingsApi(
       );
 
       dispatch({
-        type: SETTINGS_ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_SUCCESS,
-        payload: response.googleAnalyticsId,
+        type: SETTINGS_ACTION_TYPES.FETCH_SETTINGS_SUCCESS,
+        payload: response,
       });
     } catch (err) {
       dispatch({
-        type: SETTINGS_ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE,
+        type: SETTINGS_ACTION_TYPES.FETCH_SETTINGS_FAILURE,
         payload: {
           message: {
             body: err.message,
-            title: __('Unable to find google analytics ID', 'web-stories'),
+            title: __('Unable to find settings data', 'web-stories'),
           },
         },
       });
     }
   }, [dataAdapter, globalStoriesSettingsApi]);
 
-  const updateGoogleAnalyticsId = useCallback(
-    async (newAnalyticsId) => {
-      const query = { analyticsId: newAnalyticsId };
+  const updateSettings = useCallback(
+    async (settings) => {
+      const query = { googleAnalyticsId: settings.googleAnalyticsId };
 
       try {
         const response = await dataAdapter.post(
@@ -88,16 +88,16 @@ export default function useSettingsApi(
         );
 
         dispatch({
-          type: SETTINGS_ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_SUCCESS,
+          type: SETTINGS_ACTION_TYPES.UPDATE_SETTINGS_SUCCESS,
           payload: response.googleAnalyticsId,
         });
       } catch (err) {
         dispatch({
-          type: SETTINGS_ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_FAILURE,
+          type: SETTINGS_ACTION_TYPES.UPDATE_SETTINGS_FAILURE,
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to update google analytics ID', 'web-stories'),
+              title: __('Unable to update settings data', 'web-stories'),
             },
           },
         });
@@ -108,10 +108,10 @@ export default function useSettingsApi(
 
   const api = useMemo(
     () => ({
-      fetchGoogleAnalyticsId,
-      updateGoogleAnalyticsId,
+      fetchSettings,
+      updateSettings,
     }),
-    [fetchGoogleAnalyticsId, updateGoogleAnalyticsId]
+    [fetchSettings, updateSettings]
   );
 
   return { settings: state, api };

--- a/assets/src/dashboard/app/api/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/useSettingsApi.js
@@ -76,14 +76,12 @@ export default function useSettingsApi(
   }, [dataAdapter, globalStoriesSettingsApi]);
 
   const updateSettings = useCallback(
-    async (settings) => {
-      const query = { googleAnalyticsId: settings.googleAnalyticsId };
-
+    async (settings = {}) => {
       try {
         const response = await dataAdapter.post(
           queryString.stringifyUrl({
             url: globalStoriesSettingsApi,
-            query,
+            query: settings,
           })
         );
 

--- a/assets/src/dashboard/app/reducer/settings.js
+++ b/assets/src/dashboard/app/reducer/settings.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const ACTION_TYPES = {
+  UPDATE_GOOGLE_ANALYTICS_SUCCESS: 'update_google_analytics_success',
+  UPDATE_GOOGLE_ANALYTICS_FAILURE: 'update_google_analytics_failure',
+  FETCH_GOOGLE_ANALYTICS_SUCCESS: 'fetch_google_analytics_success',
+  FETCH_GOOGLE_ANALYTICS_FAILURE: 'fetch_google_analytics_failure',
+};
+
+export const defaultSettingsState = {
+  error: {},
+  googleAnalyticsId: null,
+};
+
+function settingsReducer(state, action) {
+  switch (action.type) {
+    case ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_FAILURE:
+    case ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE: {
+      return {
+        ...state,
+        error: { ...action.payload, id: Date.now() },
+      };
+    }
+
+    case ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_SUCCESS:
+    case ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_SUCCESS: {
+      return {
+        ...state,
+        error: {},
+        googleAnalyticsId: action.payload,
+      };
+    }
+
+    default:
+      return state;
+  }
+}
+
+export default settingsReducer;

--- a/assets/src/dashboard/app/reducer/settings.js
+++ b/assets/src/dashboard/app/reducer/settings.js
@@ -15,10 +15,10 @@
  */
 
 export const ACTION_TYPES = {
-  UPDATE_GOOGLE_ANALYTICS_SUCCESS: 'update_google_analytics_success',
-  UPDATE_GOOGLE_ANALYTICS_FAILURE: 'update_google_analytics_failure',
-  FETCH_GOOGLE_ANALYTICS_SUCCESS: 'fetch_google_analytics_success',
-  FETCH_GOOGLE_ANALYTICS_FAILURE: 'fetch_google_analytics_failure',
+  UPDATE_SETTINGS_SUCCESS: 'update_settings_success',
+  UPDATE_SETTINGS_FAILURE: 'update_settings_failure',
+  FETCH_SETTINGS_SUCCESS: 'fetch_settings_success',
+  FETCH_SETTINGS_FAILURE: 'fetch_settings_failure',
 };
 
 export const defaultSettingsState = {
@@ -28,20 +28,20 @@ export const defaultSettingsState = {
 
 function settingsReducer(state, action) {
   switch (action.type) {
-    case ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_FAILURE:
-    case ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE: {
+    case ACTION_TYPES.UPDATE_SETTINGS_FAILURE:
+    case ACTION_TYPES.FETCH_SETTINGS_FAILURE: {
       return {
         ...state,
         error: { ...action.payload, id: Date.now() },
       };
     }
 
-    case ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_SUCCESS:
-    case ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_SUCCESS: {
+    case ACTION_TYPES.UPDATE_SETTINGS_SUCCESS:
+    case ACTION_TYPES.FETCH_SETTINGS_SUCCESS: {
       return {
         ...state,
         error: {},
-        googleAnalyticsId: action.payload,
+        googleAnalyticsId: action.payload.googleAnalyticsId,
       };
     }
 

--- a/assets/src/dashboard/app/reducer/test/settings.js
+++ b/assets/src/dashboard/app/reducer/test/settings.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import settingsReducer, { ACTION_TYPES } from '../settings';
+
+describe('settingsReducer', () => {
+  const initialState = {
+    error: {},
+    googleAnalyticsId: null,
+  };
+
+  beforeAll(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => 1592844570916);
+  });
+
+  it(`should update settings state when ${ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_SUCCESS} is called`, () => {
+    const result = settingsReducer(initialState, {
+      type: ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_SUCCESS,
+      payload: 'fakeId12345',
+    });
+    expect(result).toMatchObject({
+      error: {},
+      googleAnalyticsId: 'fakeId12345',
+    });
+  });
+
+  it(`should update settings state when ${ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE} is called`, () => {
+    const result = settingsReducer(initialState, {
+      type: ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE,
+      payload: {
+        message: {
+          body: 'The response is not a valid JSON response.',
+          title: 'Unable to find google analytics ID',
+        },
+        code: 'my_error_code',
+      },
+    });
+    expect(result).toMatchObject({
+      googleAnalyticsId: null,
+      error: {
+        message: {
+          body: 'The response is not a valid JSON response.',
+          title: 'Unable to find google analytics ID',
+        },
+        id: Date.now(),
+        code: 'my_error_code',
+      },
+    });
+  });
+
+  it(`should update settings state when ${ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_FAILURE} is called`, () => {
+    const result = settingsReducer(initialState, {
+      type: ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_FAILURE,
+      payload: {
+        message: {
+          body: 'The response is not a valid JSON response.',
+          title: 'Unable to update google analytics ID',
+        },
+        code: 'my_error_code',
+      },
+    });
+    expect(result).toMatchObject({
+      googleAnalyticsId: null,
+      error: {
+        message: {
+          body: 'The response is not a valid JSON response.',
+          title: 'Unable to update google analytics ID',
+        },
+        id: Date.now(),
+        code: 'my_error_code',
+      },
+    });
+  });
+
+  it(`should update settings state when ${ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_SUCCESS} is called`, () => {
+    const result = settingsReducer(initialState, {
+      type: ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_SUCCESS,
+      payload: 'fakeId12345NEW',
+    });
+    expect(result).toMatchObject({
+      error: {},
+      googleAnalyticsId: 'fakeId12345NEW',
+    });
+  });
+});

--- a/assets/src/dashboard/app/reducer/test/settings.js
+++ b/assets/src/dashboard/app/reducer/test/settings.js
@@ -25,8 +25,10 @@ describe('settingsReducer', () => {
     googleAnalyticsId: null,
   };
 
+  const MOCK_ERROR_ID = Date.now();
+
   beforeAll(() => {
-    jest.spyOn(Date, 'now').mockImplementation(() => 1592844570916);
+    jest.spyOn(Date, 'now').mockImplementation(() => MOCK_ERROR_ID);
   });
 
   it(`should update settings state when ${ACTION_TYPES.FETCH_SETTINGS_SUCCESS} is called`, () => {
@@ -58,7 +60,7 @@ describe('settingsReducer', () => {
           body: 'The response is not a valid JSON response.',
           title: 'Unable to find settings data',
         },
-        id: Date.now(),
+        id: MOCK_ERROR_ID,
         code: 'my_error_code',
       },
     });
@@ -82,7 +84,7 @@ describe('settingsReducer', () => {
           body: 'The response is not a valid JSON response.',
           title: 'Unable to update settings data',
         },
-        id: Date.now(),
+        id: MOCK_ERROR_ID,
         code: 'my_error_code',
       },
     });

--- a/assets/src/dashboard/app/reducer/test/settings.js
+++ b/assets/src/dashboard/app/reducer/test/settings.js
@@ -29,9 +29,9 @@ describe('settingsReducer', () => {
     jest.spyOn(Date, 'now').mockImplementation(() => 1592844570916);
   });
 
-  it(`should update settings state when ${ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_SUCCESS} is called`, () => {
+  it(`should update settings state when ${ACTION_TYPES.FETCH_SETTINGS_SUCCESS} is called`, () => {
     const result = settingsReducer(initialState, {
-      type: ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_SUCCESS,
+      type: ACTION_TYPES.FETCH_SETTINGS_SUCCESS,
       payload: 'fakeId12345',
     });
     expect(result).toMatchObject({
@@ -40,9 +40,9 @@ describe('settingsReducer', () => {
     });
   });
 
-  it(`should update settings state when ${ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE} is called`, () => {
+  it(`should update settings state when ${ACTION_TYPES.FETCH_SETTINGS_FAILURE} is called`, () => {
     const result = settingsReducer(initialState, {
-      type: ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_FAILURE,
+      type: ACTION_TYPES.FETCH_SETTINGS_FAILURE,
       payload: {
         message: {
           body: 'The response is not a valid JSON response.',
@@ -64,9 +64,9 @@ describe('settingsReducer', () => {
     });
   });
 
-  it(`should update settings state when ${ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_FAILURE} is called`, () => {
+  it(`should update settings state when ${ACTION_TYPES.UPDATE_SETTINGS_FAILURE} is called`, () => {
     const result = settingsReducer(initialState, {
-      type: ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_FAILURE,
+      type: ACTION_TYPES.UPDATE_SETTINGS_FAILURE,
       payload: {
         message: {
           body: 'The response is not a valid JSON response.',
@@ -88,9 +88,9 @@ describe('settingsReducer', () => {
     });
   });
 
-  it(`should update settings state when ${ACTION_TYPES.UPDATE_GOOGLE_ANALYTICS_SUCCESS} is called`, () => {
+  it(`should update settings state when ${ACTION_TYPES.UPDATE_SETTINGS_SUCCESS} is called`, () => {
     const result = settingsReducer(initialState, {
-      type: ACTION_TYPES.FETCH_GOOGLE_ANALYTICS_SUCCESS,
+      type: ACTION_TYPES.FETCH_SETTINGS_SUCCESS,
       payload: 'fakeId12345NEW',
     });
     expect(result).toMatchObject({

--- a/assets/src/dashboard/app/reducer/test/settings.js
+++ b/assets/src/dashboard/app/reducer/test/settings.js
@@ -32,7 +32,7 @@ describe('settingsReducer', () => {
   it(`should update settings state when ${ACTION_TYPES.FETCH_SETTINGS_SUCCESS} is called`, () => {
     const result = settingsReducer(initialState, {
       type: ACTION_TYPES.FETCH_SETTINGS_SUCCESS,
-      payload: 'fakeId12345',
+      payload: { googleAnalyticsId: 'fakeId12345' },
     });
     expect(result).toMatchObject({
       error: {},
@@ -46,7 +46,7 @@ describe('settingsReducer', () => {
       payload: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to find google analytics ID',
+          title: 'Unable to find settings data',
         },
         code: 'my_error_code',
       },
@@ -56,7 +56,7 @@ describe('settingsReducer', () => {
       error: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to find google analytics ID',
+          title: 'Unable to find settings data',
         },
         id: Date.now(),
         code: 'my_error_code',
@@ -70,7 +70,7 @@ describe('settingsReducer', () => {
       payload: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to update google analytics ID',
+          title: 'Unable to update settings data',
         },
         code: 'my_error_code',
       },
@@ -80,7 +80,7 @@ describe('settingsReducer', () => {
       error: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to update google analytics ID',
+          title: 'Unable to update settings data',
         },
         id: Date.now(),
         code: 'my_error_code',
@@ -91,7 +91,7 @@ describe('settingsReducer', () => {
   it(`should update settings state when ${ACTION_TYPES.UPDATE_SETTINGS_SUCCESS} is called`, () => {
     const result = settingsReducer(initialState, {
       type: ACTION_TYPES.FETCH_SETTINGS_SUCCESS,
-      payload: 'fakeId12345NEW',
+      payload: { googleAnalyticsId: 'fakeId12345NEW' },
     });
     expect(result).toMatchObject({
       error: {},

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -29,8 +29,10 @@ describe('storyReducer', () => {
     totalPages: null,
   };
 
+  const MOCK_ERROR_ID = Date.now();
+
   beforeAll(() => {
-    jest.spyOn(Date, 'now').mockImplementation(() => 1592844570916);
+    jest.spyOn(Date, 'now').mockImplementation(() => MOCK_ERROR_ID);
   });
 
   it(`should update stories state when ${ACTION_TYPES.TRASH_STORY} is called`, () => {
@@ -100,7 +102,7 @@ describe('storyReducer', () => {
           body: 'my trash story failure message',
           title: 'Unable to Delete Story',
         },
-        id: Date.now(),
+        id: MOCK_ERROR_ID,
         code: 'my_error_code',
       },
     });
@@ -172,7 +174,7 @@ describe('storyReducer', () => {
           title: 'Unable to Duplciate Story',
           body: 'my duplicate story failure message',
         },
-        id: Date.now(),
+        id: MOCK_ERROR_ID,
         code: 'my_error_code',
       },
     });
@@ -326,7 +328,7 @@ describe('storyReducer', () => {
           title: 'Unable to Load Stories',
           body: 'my error message',
         },
-        id: Date.now(),
+        id: MOCK_ERROR_ID,
         code: 'my_error_code',
       },
     });
@@ -354,7 +356,7 @@ describe('storyReducer', () => {
           title: 'Unable to Create Story From Template',
           body: 'my error message',
         },
-        id: Date.now(),
+        id: MOCK_ERROR_ID,
         code: 'my_error_code',
       },
     });
@@ -410,7 +412,7 @@ describe('storyReducer', () => {
           title: 'Unable to Update Story',
           body: 'my error message',
         },
-        id: Date.now(),
+        id: MOCK_ERROR_ID,
         code: 'my_error_code',
       },
     });

--- a/assets/src/dashboard/app/reducer/test/templates.js
+++ b/assets/src/dashboard/app/reducer/test/templates.js
@@ -23,8 +23,10 @@ import templateReducer, {
 } from '../templates';
 
 describe('templateReducer', () => {
+  const MOCK_ERROR_ID = Date.now();
+
   beforeAll(() => {
-    jest.spyOn(Date, 'now').mockImplementation(() => 1592844570916);
+    jest.spyOn(Date, 'now').mockImplementation(() => MOCK_ERROR_ID);
   });
 
   it(`should update templates state when ${ACTION_TYPES.FETCH_TEMPLATES_SUCCESS} is called`, () => {
@@ -209,7 +211,7 @@ describe('templateReducer', () => {
           title: 'Unable to Load Templates',
           body: 'test error message',
         },
-        id: Date.now(),
+        id: MOCK_ERROR_ID,
         code: 'test-error-code',
       },
     });
@@ -237,7 +239,7 @@ describe('templateReducer', () => {
           title: 'Unable to Create Template from Story',
           body: 'test error message',
         },
-        id: Date.now(),
+        id: MOCK_ERROR_ID,
         code: 'test-error-code',
       },
     });

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { TypographyPresets, InlineInputForm } from '../../../components';
+import { TypographyPresets } from '../../../components';
 import { visuallyHiddenStyles } from '../../../utils/visuallyHiddenStyles';
 
 export const Wrapper = styled.div`
@@ -72,9 +72,12 @@ export const SettingHeading = styled.h2`
   line-height: 140%;
   color: ${({ theme }) => theme.colors.gray600};
 `;
-export const TextInput = styled(InlineInputForm)`
-  width: 100%;
-  height: 32px;
+
+export const FormContainer = styled.div`
+  input {
+    width: 100%;
+    height: 32px;
+  }
 `;
 
 export const TextInputHelperText = styled.p`

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -20,6 +20,11 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import { useContext, useState, useCallback, useEffect } from 'react';
+
+/**
  * Internal dependencies
  */
 import {
@@ -28,6 +33,7 @@ import {
   TextInput,
   TextInputHelperText,
 } from '../components';
+import { ApiContext } from '../../../api/apiProvider';
 
 const TEXT = {
   CONTEXT: __(
@@ -40,6 +46,32 @@ const TEXT = {
 };
 // todo add link
 function GoogleAnalyticsSettings() {
+  const {
+    actions: {
+      settingsApi: { fetchGoogleAnalyticsId, updateGoogleAnalyticsId },
+    },
+    state: {
+      settings: { googleAnalyticsId },
+    },
+  } = useContext(ApiContext);
+
+  const [analyticsId, setAnalyticsId] = useState(googleAnalyticsId);
+
+  useEffect(() => {
+    fetchGoogleAnalyticsId();
+  }, [fetchGoogleAnalyticsId]);
+
+  const handleCancelUpdateId = useCallback(() => {
+    setAnalyticsId(googleAnalyticsId);
+  }, [googleAnalyticsId]);
+
+  const handleCompleteUpdateId = useCallback(
+    (newValue) => {
+      updateGoogleAnalyticsId(newValue);
+    },
+    [updateGoogleAnalyticsId]
+  );
+
   return (
     <SettingForm>
       <SettingHeading htmlFor="gaTrackingID">

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -66,8 +66,8 @@ function GoogleAnalyticsSettings() {
   }, [googleAnalyticsId]);
 
   const handleCompleteUpdateId = useCallback(
-    (newValue) => {
-      updateGoogleAnalyticsId(newValue);
+    (newId) => {
+      updateGoogleAnalyticsId(newId);
     },
     [updateGoogleAnalyticsId]
   );

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -40,16 +40,16 @@ const TEXT = {
   CONTEXT: __(
     "The story editor will append a default, configurable AMP analytics configuration to your story. If you're interested in going beyond what the default configuration is, read this article.",
     'web-stories'
-  ),
+  ), // TODO update this text to have link to article once confirmed what article is
   SECTION_HEADING: __('Google Analytics Tracking ID', 'web-stories'),
   PLACEHOLDER: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
   ARIA_LABEL: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
 };
-// todo add link
+
 function GoogleAnalyticsSettings() {
   const {
     actions: {
-      settingsApi: { fetchGoogleAnalyticsId, updateGoogleAnalyticsId },
+      settingsApi: { fetchSettings, updateSettings },
     },
     state: {
       settings: { googleAnalyticsId },
@@ -59,8 +59,8 @@ function GoogleAnalyticsSettings() {
   const [analyticsId, setAnalyticsId] = useState(googleAnalyticsId);
 
   useEffect(() => {
-    fetchGoogleAnalyticsId();
-  }, [fetchGoogleAnalyticsId]);
+    fetchSettings();
+  }, [fetchSettings]);
 
   const handleCancelUpdateId = useCallback(() => {
     setAnalyticsId(googleAnalyticsId);
@@ -68,9 +68,9 @@ function GoogleAnalyticsSettings() {
 
   const handleCompleteUpdateId = useCallback(
     (newId) => {
-      updateGoogleAnalyticsId(newId);
+      updateSettings({ googleAnalyticsId: newId });
     },
-    [updateGoogleAnalyticsId]
+    [updateSettings]
   );
 
   return (

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -22,12 +22,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useContext, useState, useCallback, useEffect } from 'react';
+import { useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
-import { ApiContext } from '../../../api/apiProvider';
 import { InlineInputForm } from '../../../../components';
 import {
   FormContainer,
@@ -46,21 +46,11 @@ const TEXT = {
   ARIA_LABEL: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
 };
 
-function GoogleAnalyticsSettings() {
-  const {
-    actions: {
-      settingsApi: { fetchSettings, updateSettings },
-    },
-    state: {
-      settings: { googleAnalyticsId },
-    },
-  } = useContext(ApiContext);
-
+function GoogleAnalyticsSettings({
+  googleAnalyticsId = '',
+  onUpdateGoogleAnalyticsId,
+}) {
   const [analyticsId, setAnalyticsId] = useState(googleAnalyticsId);
-
-  useEffect(() => {
-    fetchSettings();
-  }, [fetchSettings]);
 
   const handleCancelUpdateId = useCallback(() => {
     setAnalyticsId(googleAnalyticsId);
@@ -68,9 +58,9 @@ function GoogleAnalyticsSettings() {
 
   const handleCompleteUpdateId = useCallback(
     (newId) => {
-      updateSettings({ googleAnalyticsId: newId });
+      onUpdateGoogleAnalyticsId({ googleAnalyticsId: newId });
     },
-    [updateSettings]
+    [onUpdateGoogleAnalyticsId]
   );
 
   return (
@@ -92,5 +82,9 @@ function GoogleAnalyticsSettings() {
     </SettingForm>
   );
 }
+GoogleAnalyticsSettings.propTypes = {
+  onUpdateGoogleAnalyticsId: PropTypes.func,
+  googleAnalyticsId: PropTypes.string,
+};
 
 export default GoogleAnalyticsSettings;

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -81,8 +81,10 @@ function GoogleAnalyticsSettings() {
         <TextInput
           label={TEXT.ARIA_LABEL}
           id="gaTrackingId"
-          value=""
-          placeholder={TEXT.PLACEHOLDER}
+          value={analyticsId}
+          onEditCancel={handleCancelUpdateId}
+          onEditComplete={handleCompleteUpdateId}
+          placeholder={TEXT.placeholder}
         />
         <TextInputHelperText>{TEXT.CONTEXT}</TextInputHelperText>
       </div>

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -27,13 +27,13 @@ import { useContext, useState, useCallback, useEffect } from 'react';
 /**
  * Internal dependencies
  */
+import { ApiContext } from '../../../api/apiProvider';
 import {
   SettingForm,
   SettingHeading,
   TextInput,
   TextInputHelperText,
 } from '../components';
-import { ApiContext } from '../../../api/apiProvider';
 
 const TEXT = {
   CONTEXT: __(

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -28,10 +28,11 @@ import { useContext, useState, useCallback, useEffect } from 'react';
  * Internal dependencies
  */
 import { ApiContext } from '../../../api/apiProvider';
+import { InlineInputForm } from '../../../../components';
 import {
+  FormContainer,
   SettingForm,
   SettingHeading,
-  TextInput,
   TextInputHelperText,
 } from '../components';
 
@@ -77,8 +78,8 @@ function GoogleAnalyticsSettings() {
       <SettingHeading htmlFor="gaTrackingID">
         {TEXT.SECTION_HEADING}
       </SettingHeading>
-      <div>
-        <TextInput
+      <FormContainer>
+        <InlineInputForm
           label={TEXT.ARIA_LABEL}
           id="gaTrackingId"
           value={analyticsId}
@@ -87,7 +88,7 @@ function GoogleAnalyticsSettings() {
           placeholder={TEXT.PLACEHOLDER}
         />
         <TextInputHelperText>{TEXT.CONTEXT}</TextInputHelperText>
-      </div>
+      </FormContainer>
     </SettingForm>
   );
 }

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -84,7 +84,7 @@ function GoogleAnalyticsSettings() {
           value={analyticsId}
           onEditCancel={handleCancelUpdateId}
           onEditComplete={handleCompleteUpdateId}
-          placeholder={TEXT.placeholder}
+          placeholder={TEXT.PLACEHOLDER}
         />
         <TextInputHelperText>{TEXT.CONTEXT}</TextInputHelperText>
       </div>

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
@@ -15,6 +15,12 @@
  */
 
 /**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import { text } from '@storybook/addon-knobs';
+
+/**
  * Internal dependencies
  */
 import GoogleAnalyticsSettings from '../';
@@ -25,5 +31,10 @@ export default {
 };
 
 export const _default = () => {
-  return <GoogleAnalyticsSettings />;
+  return (
+    <GoogleAnalyticsSettings
+      onUpdateGoogleAnalyticsId={action('update google analytics id submitted')}
+      googleAnalyticsId={text('googleAnalyticsId', '638261718182736363-83737')}
+    />
+  );
 };

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -18,22 +18,43 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+/**
+ * External dependencies
+ */
+import { useContext, useEffect } from 'react';
 
 /**
  * Internal dependencies
  */
+import { ApiContext } from '../../api/apiProvider';
 import GoogleAnalyticsSettings from './googleAnalytics';
 import PublisherLogoSettings from './publisherLogo';
 import { Wrapper, Header, Heading, Main } from './components';
 
 function EditorSettings() {
+  const {
+    actions: {
+      settingsApi: { fetchSettings, updateSettings },
+    },
+    state: {
+      settings: { googleAnalyticsId },
+    },
+  } = useContext(ApiContext);
+
+  useEffect(() => {
+    fetchSettings();
+  }, [fetchSettings]);
+
   return (
     <Wrapper>
       <Header>
         <Heading>{__('Settings', 'web-stories')}</Heading>
       </Header>
       <Main>
-        <GoogleAnalyticsSettings />
+        <GoogleAnalyticsSettings
+          onUpdateGoogleAnalytics={updateSettings}
+          googleAnalyticsId={googleAnalyticsId}
+        />
         <PublisherLogoSettings />
       </Main>
     </Wrapper>


### PR DESCRIPTION
## Summary
Setting up hooks for settings data 

## Relevant Technical Choices
- Create new hook for `useSettingsApi` that will eventually give us the data we need for accessing google analytics ids (not part of default wordpress settings api) 
- Wire up event handlers using inline input component 

## To-do
- [x] Figure out a plan for getting the API endpoint necessary wired up (then wire it up and write tests for successful responses) (see here: https://github.com/google/web-stories-wp/issues/3031)
- [ ] Confirm how we want to handle "submit" actions in this feature. Right now it responds to 'enter' just like renaming a story. 

## User-facing changes
Invisible change at the moment 

## Testing Instructions
- See unit tests are working properly 

---

<!-- Please reference the issue(s) this PR addresses. -->

addresses #2747 
