### PR TITLE
[WIP/Experimental] Eye dropper functionality on color picker

### DIFF
--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -36,6 +36,7 @@ import SelectionCanvas from './selectionCanvas';
 import { useLayoutParams, useLayoutParamsCssVars } from './layout';
 import CanvasUploadDropTarget from './canvasUploadDropTarget';
 import CanvasElementDropzone from './canvasElementDropzone';
+import useCanvas from './useCanvas';
 
 const Background = styled.section.attrs({
   'aria-label': __('Canvas', 'web-stories'),
@@ -53,11 +54,15 @@ function CanvasLayout() {
   useLayoutParams(backgroundRef);
   const layoutParamsCss = useLayoutParamsCssVars();
 
+  const { setDisplayLayer } = useCanvas(({ actions: { setDisplayLayer } }) => ({
+    setDisplayLayer,
+  }));
+
   return (
     <Background ref={backgroundRef} style={layoutParamsCss}>
       <CanvasUploadDropTarget>
         <CanvasElementDropzone>
-          <SelectionCanvas>
+          <SelectionCanvas ref={setDisplayLayer}>
             <DisplayLayer />
             <FramesLayer />
             <NavLayer />

--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -39,6 +39,7 @@ function CanvasProvider({ children }) {
   });
   const [pageContainer, setPageContainer] = useState(null);
   const [fullbleedContainer, setFullbleedContainer] = useState(null);
+  const [displayLayer, setDisplayLayer] = useState(null);
   const [showSafeZone, setShowSafeZone] = useState(true);
 
   const {
@@ -155,6 +156,7 @@ function CanvasProvider({ children }) {
       state: {
         pageContainer,
         fullbleedContainer,
+        displayLayer,
         nodesById,
         editingElement,
         editingElementState,
@@ -166,6 +168,7 @@ function CanvasProvider({ children }) {
       actions: {
         setPageContainer,
         setFullbleedContainer,
+        setDisplayLayer,
         getNodeForElement,
         setNodeForElement,
         setEditingElement: setEditingElementWithoutState,
@@ -180,6 +183,7 @@ function CanvasProvider({ children }) {
     [
       pageContainer,
       fullbleedContainer,
+      displayLayer,
       nodesById,
       editingElement,
       editingElementState,
@@ -188,6 +192,7 @@ function CanvasProvider({ children }) {
       showSafeZone,
       setPageContainer,
       setFullbleedContainer,
+      setDisplayLayer,
       getNodeForElement,
       setNodeForElement,
       setEditingElementWithoutState,

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -36,15 +36,15 @@ function DisplayLayer() {
   const { currentPage } = useStory((state) => ({
     currentPage: state.state.currentPage,
   }));
-  const {
-    editingElement,
-    setPageContainer,
-    setFullbleedContainer,
-  } = useCanvas(
+  const { editingElement, setPageContainer, setFullbleedContainer } = useCanvas(
     ({
       state: { editingElement },
       actions: { setPageContainer, setFullbleedContainer },
-    }) => ({ editingElement, setPageContainer, setFullbleedContainer })
+    }) => ({
+      editingElement,
+      setPageContainer,
+      setFullbleedContainer,
+    })
   );
 
   return (

--- a/assets/src/edit-story/components/canvas/selectionCanvas.js
+++ b/assets/src/edit-story/components/canvas/selectionCanvas.js
@@ -19,7 +19,7 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, forwardRef } from 'react';
 
 /**
  * Internal dependencies
@@ -57,7 +57,7 @@ const Lasso = styled.div`
   z-index: 1;
 `;
 
-function SelectionCanvas({ children }) {
+function SelectionCanvas({ children }, forwardedRef) {
   const { selectedElements, currentPage, clearSelection } = useStory(
     ({
       state: { selectedElements, currentPage },
@@ -202,6 +202,7 @@ function SelectionCanvas({ children }) {
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
       onMouseUp={onMouseUp}
+      ref={forwardedRef}
     >
       {children}
       <InOverlay ref={overlayRef}>
@@ -215,4 +216,4 @@ SelectionCanvas.propTypes = {
   children: PropTypes.node,
 };
 
-export default SelectionCanvas;
+export default forwardRef(SelectionCanvas);

--- a/assets/src/edit-story/utils/getColorFromCanvas.js
+++ b/assets/src/edit-story/utils/getColorFromCanvas.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Wrapper around the canvas getImageData API
+ * Source: https://github.com/fregante/get-canvas-pixel-color
+ *
+ * @param  {Element|CanvasRenderingContext2D} ctx The canvas from which to take the color
+ * @param  {number} x The x coordinate of the pixel to read
+ * @param  {number} y The y coordinate of the pixel to read
+ * @return {Array|Object} The rgb values of the read pixel
+ */
+function getColorFromCanvas(ctx, x, y) {
+  // if it's not a context, it's probably a canvas element
+  if (!ctx.getImageData) {
+    ctx = ctx.getContext('2d');
+  }
+
+  // extract the pixel data from the canvas
+  let pixel = ctx.getImageData(x, y, 1, 1).data;
+
+  // set each color property
+  pixel.r = pixel[0];
+  pixel.g = pixel[1];
+  pixel.b = pixel[2];
+  pixel.a = pixel[3];
+
+  // convenience CSS strings
+  pixel.rgb = 'rgb(' + pixel.r + ',' + pixel.g + ',' + pixel.b + ')';
+  pixel.rgba =
+    'rgba(' + pixel.r + ',' + pixel.g + ',' + pixel.b + ',' + pixel.a + ')';
+
+  return pixel;
+}
+
+export default getColorFromCanvas;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15186,6 +15186,21 @@
         "timsort": "^0.3.0"
       }
     },
+    "css-line-break": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-1.1.1.tgz",
+      "integrity": "sha512-1feNVaM4Fyzdj4mKPIQNL2n70MmuYzAXZ1aytlROFX1JsOo070OsugwGjj7nl6jnDJWHDM8zRZswkmeYVWZJQA==",
+      "requires": {
+        "base64-arraybuffer": "^0.2.0"
+      },
+      "dependencies": {
+        "base64-arraybuffer": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+          "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
+        }
+      }
+    },
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -19373,6 +19388,14 @@
             "object.getownpropertydescriptors": "^2.0.3"
           }
         }
+      }
+    },
+    "html2canvas": {
+      "version": "1.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-rc.5.tgz",
+      "integrity": "sha512-DtNqPxJNXPoTajs+lVQzGS1SULRI4GQaROeU5R41xH8acffHukxRh/NBVcTBsfCkJSkLq91rih5TpbEwUP9yWA==",
+      "requires": {
+        "css-line-break": "1.1.1"
       }
     },
     "htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "draftjs-filters": "^2.3.0",
     "flagged": "^2.0.1",
     "history": "^5.0.0",
+    "html2canvas": "^1.0.0-rc.5",
     "mockdate": "^3.0.2",
     "moment": "^2.27.0",
     "mousetrap": "^1.6.5",


### PR DESCRIPTION

![Eye dropper demo](https://user-images.githubusercontent.com/591655/86560740-e70e9d80-bf13-11ea-9a1b-d835eed06264.gif)


## Summary

Adds the eye dropper tool to the color picker which enables users to pick a color from any existing element on the canvas.

## Relevant Technical Choices

- Used `html2canvas` to take a "screenshot" of the editor's canvas on click and use the generated `<canvas>` element to get the color at the clicked pixel location

## To-do

- [ ] Fix some oddities with capturing the click event (prevent closing the color picker while the user is still choosing colors)
- [ ] Refactor and clean up code
- [ ] Add karma tests
- [ ] Specify a default color (out of canvas)

## User-facing changes

The eye dropper tool is now active and usable.

## Testing Instructions

- Insert an element into the canvas
- Click on the background/page
- Click on the page color setting to open the color picker
- Tap on the eye dropper tool
- Click anywhere on the previously inserted element
- The page's background color should now change to match the color at the clicked pixel location

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #262 
