### PR TITLE
Dashboard: Reduced loops into a single reduce for story fetching

### DIFF
--- a/assets/src/dashboard/app/api/test/useStoryApi.js
+++ b/assets/src/dashboard/app/api/test/useStoryApi.js
@@ -22,7 +22,7 @@ import moment from 'moment';
 /**
  * Internal dependencies
  */
-import { reshapeStoryObject } from '../useStoryApi';
+import reshapeStoryObject from '../../serializers/stories';
 
 describe('reshapeStoryObject', () => {
   it('should reshape the response object with a Moment date', () => {

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -139,14 +139,11 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
           response.headers &&
           JSON.parse(response.headers['X-WP-TotalByStatus']);
 
-        const reshapedStories = response.body
-          .map(reshapeStoryObject(editStoryURL))
-          .filter(Boolean);
-
         dispatch({
           type: STORY_ACTION_TYPES.FETCH_STORIES_SUCCESS,
           payload: {
-            stories: reshapedStories,
+            editStoryURL,
+            stories: response.body,
             totalPages,
             totalStoriesByStatus,
             page,

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -23,7 +23,6 @@ import { __, sprintf } from '@wordpress/i18n';
  * External dependencies
  */
 import { useCallback, useMemo, useReducer } from 'react';
-import moment from 'moment';
 import queryString from 'query-string';
 import { useFeatures } from 'flagged';
 
@@ -36,52 +35,12 @@ import {
   ORDER_BY_SORT,
   STORIES_PER_REQUEST,
 } from '../../constants';
-import { migrate, DATA_VERSION } from '../../../edit-story/migration/migrate';
 import storyReducer, {
   defaultStoriesState,
   ACTION_TYPES as STORY_ACTION_TYPES,
 } from '../reducer/stories';
 import { getStoryPropsToSave, addQueryArgs } from '../../utils';
-
-export function reshapeStoryObject(editStoryURL) {
-  return function (originalStoryData) {
-    const {
-      id,
-      title,
-      modified,
-      status,
-      date,
-      author,
-      story_data: storyData,
-    } = originalStoryData;
-    if (
-      !Array.isArray(storyData.pages) ||
-      !id ||
-      storyData.pages.length === 0
-    ) {
-      return null;
-    }
-
-    const updatedStoryData = {
-      ...migrate(storyData, storyData.version),
-      version: DATA_VERSION,
-    };
-
-    return {
-      id,
-      status,
-      title: title.raw,
-      modified: moment(modified),
-      created: moment(date),
-      pages: updatedStoryData.pages,
-      author,
-      centerTargetAction: '',
-      bottomTargetAction: `${editStoryURL}&post=${id}`,
-      editStoryLink: `${editStoryURL}&post=${id}`,
-      originalStoryData,
-    };
-  };
-}
+import reshapeStoryObject from '../serializers/stories';
 
 const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
   const [state, dispatch] = useReducer(storyReducer, defaultStoriesState);

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { reshapeStoryObject } from '../api/useStoryApi';
+import reshapeStoryObject from '../serializers/stories';
 
 export const ACTION_TYPES = {
   CREATING_STORY_FROM_TEMPLATE: 'creating_story_from_template',

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -186,10 +186,38 @@ describe('storyReducer', () => {
       payload: {
         page: 1,
         stories: [
-          { id: 94, status: 'draft', title: 'my test story 1' },
-          { id: 65, status: 'publish', title: 'my test story 2' },
-          { id: 78, status: 'draft', title: 'my test story 3' },
-          { id: 12, status: 'draft', title: 'my test story 4' },
+          {
+            id: 94,
+            status: 'draft',
+            title: { raw: 'my test story 1' },
+            story_data: {
+              pages: [{}],
+            },
+          },
+          {
+            id: 65,
+            status: 'publish',
+            title: { raw: 'my test story 2' },
+            story_data: {
+              pages: [{}],
+            },
+          },
+          {
+            id: 78,
+            status: 'draft',
+            title: { raw: 'my test story 3' },
+            story_data: {
+              pages: [{}],
+            },
+          },
+          {
+            id: 12,
+            status: 'draft',
+            title: { raw: 'my test story 4' },
+            story_data: {
+              pages: [{}],
+            },
+          },
         ],
         totalStoriesByStatus: {
           all: 44,
@@ -228,10 +256,38 @@ describe('storyReducer', () => {
         payload: {
           page: 2,
           stories: [
-            { id: 94, status: 'draft', title: 'my test story 1' },
-            { id: 65, status: 'publish', title: 'my test story 2' },
-            { id: 78, status: 'draft', title: 'my test story 3' },
-            { id: 12, status: 'draft', title: 'my test story 4' },
+            {
+              id: 94,
+              status: 'draft',
+              title: { raw: 'my test story 1' },
+              story_data: {
+                pages: [{}],
+              },
+            },
+            {
+              id: 65,
+              status: 'publish',
+              title: { raw: 'my test story 2' },
+              story_data: {
+                pages: [{}],
+              },
+            },
+            {
+              id: 78,
+              status: 'draft',
+              title: { raw: 'my test story 3' },
+              story_data: {
+                pages: [{}],
+              },
+            },
+            {
+              id: 12,
+              status: 'draft',
+              title: { raw: 'my test story 4' },
+              story_data: {
+                pages: [{}],
+              },
+            },
           ],
           totalStoriesByStatus: {
             all: 18,

--- a/assets/src/dashboard/app/serializers/stories.js
+++ b/assets/src/dashboard/app/serializers/stories.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import moment from 'moment';
+
+/**
+ * Internal dependencies
+ */
+import { migrate, DATA_VERSION } from '../../../edit-story/migration/migrate';
+
+export default function reshapeStoryObject(editStoryURL) {
+  return function (originalStoryData) {
+    const {
+      id,
+      title,
+      modified,
+      status,
+      date,
+      author,
+      story_data: storyData,
+    } = originalStoryData;
+    if (
+      !Array.isArray(storyData.pages) ||
+      !id ||
+      storyData.pages.length === 0
+    ) {
+      return null;
+    }
+
+    const updatedStoryData = {
+      ...migrate(storyData, storyData.version),
+      version: DATA_VERSION,
+    };
+
+    return {
+      id,
+      status,
+      title: title.raw,
+      modified: moment(modified),
+      created: moment(date),
+      pages: updatedStoryData.pages,
+      author,
+      centerTargetAction: '',
+      bottomTargetAction: `${editStoryURL}&post=${id}`,
+      editStoryLink: `${editStoryURL}&post=${id}`,
+      originalStoryData,
+    };
+  };
+}

--- a/assets/src/dashboard/app/views/myStories/content/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/index.js
@@ -22,7 +22,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { memo } from 'react';
 import PropTypes from 'prop-types';
 
 /**
@@ -114,4 +113,4 @@ Content.propTypes = {
   dateFormat: PropTypes.string,
 };
 
-export default memo(Content);
+export default Content;

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -23,12 +23,12 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import DisplayElement from '../../edit-story/components/canvas/displayElement';
 import StoryPropTypes from '../../edit-story/types';
 import generatePatternStyles from '../../edit-story/utils/generatePatternStyles';
 import { STORY_PAGE_STATE } from '../constants';
 import { PageSizePropType } from '../types';
 import StoryAnimation, { useStoryAnimationContext } from './storyAnimation';
+import PagePreviewElements from './previewPageElements';
 
 /*
  * A quick note about how height works with the 9:16 aspect ratio (FULLBLEED_RATIO)
@@ -101,15 +101,7 @@ function PreviewPageController({
       background={page.backgroundColor}
     >
       <PreviewSafeZone pageSize={pageSize}>
-        {page.elements.map(({ id, ...rest }) => (
-          <DisplayElement
-            previewMode
-            key={id}
-            page={page}
-            element={{ id, ...rest }}
-            isAnimatable
-          />
-        ))}
+        <PagePreviewElements page={page} />
       </PreviewSafeZone>
     </FullBleedPreviewWrapper>
   );

--- a/assets/src/dashboard/components/previewPageElements.js
+++ b/assets/src/dashboard/components/previewPageElements.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { memo } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import DisplayElement from '../../edit-story/components/canvas/displayElement';
+import StoryPropTypes from '../../edit-story/types';
+
+function PreviewPageElements({ page }) {
+  return page.elements.map(({ id, ...rest }) => (
+    <DisplayElement
+      previewMode
+      key={id}
+      page={page}
+      element={{ id, ...rest }}
+      isAnimatable
+    />
+  ));
+}
+
+PreviewPageElements.propTypes = {
+  page: StoryPropTypes.page.isRequired,
+};
+
+export default memo(PreviewPageElements);


### PR DESCRIPTION
## Summary

This reduces the amount of loops and then memoizes just the preview elements since caching the entire story grid content is too much.

## Relevant Technical Choices

Reduces the amount of times we loop over data when we receive it from the server from 3 to 1.

## User-facing changes

—

## Testing Instructions

Open up the Dashboard and see the stories come up faster.

<!-- Please reference the issue(s) this PR addresses. -->

#3017
