### PR TITLE
Templates: Added links to DIY, Fashion, and Fitness

### DIFF
--- a/assets/src/dashboard/templates/raw/diy.json
+++ b/assets/src/dashboard/templates/raw/diy.json
@@ -60,7 +60,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page1_bg.jpg",
             "width": 220,
             "height": 330,
             "posterId": 0,
@@ -68,99 +68,7 @@
             "title": "diy_page1_bg",
             "alt": "diy_page1_bg",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page1_bg-200x300.jpg",
-                "width": 200,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-200x300.jpg"
-              },
-              "large": {
-                "file": "diy_page1_bg-683x1024.jpg",
-                "width": 683,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-683x1024.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page1_bg-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page1_bg-768x1152.jpg",
-                "width": 768,
-                "height": 1152,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-768x1152.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page1_bg-1024x1536.jpg",
-                "width": 1024,
-                "height": 1536,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-1024x1536.jpg"
-              },
-              "2048x2048": {
-                "file": "diy_page1_bg-1365x2048.jpg",
-                "width": 1365,
-                "height": 2048,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-1365x2048.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page1_bg-1200x1800.jpg",
-                "width": 1200,
-                "height": 1800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-1200x1800.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "diy_page1_bg-1980x2970.jpg",
-                "width": 1980,
-                "height": 2970,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-1980x2970.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page1_bg-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page1_bg-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page1_bg-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page1_bg-150x225.jpg",
-                "width": 150,
-                "height": 225,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-150x225.jpg"
-              },
-              "full": {
-                "file": "diy_page1_bg-scaled.jpg",
-                "width": 1707,
-                "height": 2560,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page1_bg-scaled.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -348,7 +256,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page2_bg.jpg",
             "width": 220,
             "height": 330,
             "posterId": 0,
@@ -356,99 +264,7 @@
             "title": "diy_page2_bg",
             "alt": "diy_page2_bg",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page2_bg-200x300.jpg",
-                "width": 200,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-200x300.jpg"
-              },
-              "large": {
-                "file": "diy_page2_bg-683x1024.jpg",
-                "width": 683,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-683x1024.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page2_bg-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page2_bg-768x1152.jpg",
-                "width": 768,
-                "height": 1152,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-768x1152.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page2_bg-1024x1536.jpg",
-                "width": 1024,
-                "height": 1536,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-1024x1536.jpg"
-              },
-              "2048x2048": {
-                "file": "diy_page2_bg-1365x2048.jpg",
-                "width": 1365,
-                "height": 2048,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-1365x2048.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page2_bg-1200x1800.jpg",
-                "width": 1200,
-                "height": 1800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-1200x1800.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "diy_page2_bg-1980x2970.jpg",
-                "width": 1980,
-                "height": 2970,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-1980x2970.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page2_bg-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page2_bg-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page2_bg-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page2_bg-150x225.jpg",
-                "width": 150,
-                "height": 225,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-150x225.jpg"
-              },
-              "full": {
-                "file": "diy_page2_bg-scaled.jpg",
-                "width": 1707,
-                "height": 2560,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page2_bg-scaled.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -608,7 +424,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page3_image1.jpg",
             "width": 220,
             "height": 147,
             "posterId": 0,
@@ -616,99 +432,7 @@
             "title": "diy_page3_image1",
             "alt": "diy_page3_image1",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page3_image1-300x200.jpg",
-                "width": 300,
-                "height": 200,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-300x200.jpg"
-              },
-              "large": {
-                "file": "diy_page3_image1-1024x683.jpg",
-                "width": 1024,
-                "height": 683,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-1024x683.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page3_image1-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page3_image1-768x512.jpg",
-                "width": 768,
-                "height": 512,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-768x512.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page3_image1-1536x1024.jpg",
-                "width": 1536,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-1536x1024.jpg"
-              },
-              "2048x2048": {
-                "file": "diy_page3_image1-2048x1365.jpg",
-                "width": 2048,
-                "height": 1365,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-2048x1365.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page3_image1-1200x800.jpg",
-                "width": 1200,
-                "height": 800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-1200x800.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "diy_page3_image1-1980x1320.jpg",
-                "width": 1980,
-                "height": 1320,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-1980x1320.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page3_image1-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page3_image1-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page3_image1-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page3_image1-150x100.jpg",
-                "width": 150,
-                "height": 100,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1-150x100.jpg"
-              },
-              "full": {
-                "file": "diy_page3_image1.jpg",
-                "width": 2400,
-                "height": 1600,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page3_image1.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -968,7 +692,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page4_page5_bg.jpg",
             "width": 220,
             "height": 275,
             "posterId": 0,
@@ -976,99 +700,7 @@
             "title": "diy_page4_page5_bg",
             "alt": "diy_page4_page5_bg",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page4_page5_bg-1-240x300.jpg",
-                "width": 240,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-240x300.jpg"
-              },
-              "large": {
-                "file": "diy_page4_page5_bg-1-819x1024.jpg",
-                "width": 819,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-819x1024.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page4_page5_bg-1-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page4_page5_bg-1-768x960.jpg",
-                "width": 768,
-                "height": 960,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-768x960.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page4_page5_bg-1-1229x1536.jpg",
-                "width": 1229,
-                "height": 1536,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-1229x1536.jpg"
-              },
-              "2048x2048": {
-                "file": "diy_page4_page5_bg-1-1638x2048.jpg",
-                "width": 1638,
-                "height": 2048,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-1638x2048.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page4_page5_bg-1-1200x1500.jpg",
-                "width": 1200,
-                "height": 1500,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-1200x1500.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "diy_page4_page5_bg-1-1980x2475.jpg",
-                "width": 1980,
-                "height": 2475,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-1980x2475.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page4_page5_bg-1-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page4_page5_bg-1-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page4_page5_bg-1-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page4_page5_bg-1-150x188.jpg",
-                "width": 150,
-                "height": 188,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-150x188.jpg"
-              },
-              "full": {
-                "file": "diy_page4_page5_bg-1-scaled.jpg",
-                "width": 2048,
-                "height": 2560,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-scaled.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -1189,7 +821,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page4_page5_bg.jpg",
             "width": 220,
             "height": 275,
             "posterId": 0,
@@ -1197,99 +829,7 @@
             "title": "diy_page4_page5_bg",
             "alt": "diy_page4_page5_bg",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page4_page5_bg-1-240x300.jpg",
-                "width": 240,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-240x300.jpg"
-              },
-              "large": {
-                "file": "diy_page4_page5_bg-1-819x1024.jpg",
-                "width": 819,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-819x1024.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page4_page5_bg-1-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page4_page5_bg-1-768x960.jpg",
-                "width": 768,
-                "height": 960,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-768x960.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page4_page5_bg-1-1229x1536.jpg",
-                "width": 1229,
-                "height": 1536,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-1229x1536.jpg"
-              },
-              "2048x2048": {
-                "file": "diy_page4_page5_bg-1-1638x2048.jpg",
-                "width": 1638,
-                "height": 2048,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-1638x2048.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page4_page5_bg-1-1200x1500.jpg",
-                "width": 1200,
-                "height": 1500,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-1200x1500.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "diy_page4_page5_bg-1-1980x2475.jpg",
-                "width": 1980,
-                "height": 2475,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-1980x2475.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page4_page5_bg-1-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page4_page5_bg-1-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page4_page5_bg-1-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page4_page5_bg-1-150x188.jpg",
-                "width": 150,
-                "height": 188,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-150x188.jpg"
-              },
-              "full": {
-                "file": "diy_page4_page5_bg-1-scaled.jpg",
-                "width": 2048,
-                "height": 2560,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page4_page5_bg-1-scaled.jpg"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -1568,7 +1108,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page6_bg.jpg",
             "width": 220,
             "height": 147,
             "posterId": 0,
@@ -1576,99 +1116,7 @@
             "title": "diy_page6_bg",
             "alt": "diy_page6_bg",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page6_bg-300x200.jpg",
-                "width": 300,
-                "height": 200,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-300x200.jpg"
-              },
-              "large": {
-                "file": "diy_page6_bg-1024x683.jpg",
-                "width": 1024,
-                "height": 683,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-1024x683.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page6_bg-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page6_bg-768x512.jpg",
-                "width": 768,
-                "height": 512,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-768x512.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page6_bg-1536x1024.jpg",
-                "width": 1536,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-1536x1024.jpg"
-              },
-              "2048x2048": {
-                "file": "diy_page6_bg-2048x1365.jpg",
-                "width": 2048,
-                "height": 1365,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-2048x1365.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page6_bg-1200x800.jpg",
-                "width": 1200,
-                "height": 800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-1200x800.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "diy_page6_bg-1980x1320.jpg",
-                "width": 1980,
-                "height": 1320,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-1980x1320.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page6_bg-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page6_bg-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page6_bg-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page6_bg-150x100.jpg",
-                "width": 150,
-                "height": 100,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg-150x100.jpg"
-              },
-              "full": {
-                "file": "diy_page6_bg.jpg",
-                "width": 2400,
-                "height": 1600,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page6_bg.jpg"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -1985,39 +1433,14 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page7_bg.jpg",
             "width": 330,
             "height": 442,
             "id": 1563,
             "title": "diy_page7_bg",
             "alt": "diy_page7_bg",
             "local": false,
-            "sizes": {
-              "thumbnail": {
-                "height": 150,
-                "width": 150,
-                "url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-150x150.jpg",
-                "orientation": "landscape"
-              },
-              "medium": {
-                "height": 300,
-                "width": 224,
-                "url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-224x300.jpg",
-                "orientation": "portrait"
-              },
-              "large": {
-                "height": 777,
-                "width": 580,
-                "url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-764x1024.jpg",
-                "orientation": "portrait"
-              },
-              "full": {
-                "url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg.jpg",
-                "height": 1104,
-                "width": 824,
-                "orientation": "portrait"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -2302,7 +1725,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page8_image1.jpg",
             "width": 220,
             "height": 131,
             "posterId": 0,
@@ -2310,99 +1733,7 @@
             "title": "diy_page8_image1",
             "alt": "diy_page8_image1",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page8_image1-300x178.jpg",
-                "width": 300,
-                "height": 178,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-300x178.jpg"
-              },
-              "large": {
-                "file": "diy_page8_image1-1024x608.jpg",
-                "width": 1024,
-                "height": 608,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-1024x608.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page8_image1-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page8_image1-768x456.jpg",
-                "width": 768,
-                "height": 456,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-768x456.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page8_image1-1536x911.jpg",
-                "width": 1536,
-                "height": 911,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-1536x911.jpg"
-              },
-              "2048x2048": {
-                "file": "diy_page8_image1-2048x1215.jpg",
-                "width": 2048,
-                "height": 1215,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-2048x1215.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page8_image1-1200x712.jpg",
-                "width": 1200,
-                "height": 712,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-1200x712.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "diy_page8_image1-1980x1175.jpg",
-                "width": 1980,
-                "height": 1175,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-1980x1175.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page8_image1-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page8_image1-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page8_image1-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page8_image1-150x89.jpg",
-                "width": 150,
-                "height": 89,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1-150x89.jpg"
-              },
-              "full": {
-                "file": "diy_page8_image1.jpg",
-                "width": 2400,
-                "height": 1424,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image1.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -2434,7 +1765,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page8_image2.jpg",
             "width": 220,
             "height": 147,
             "posterId": 0,
@@ -2442,99 +1773,7 @@
             "title": "diy_page8_image2",
             "alt": "diy_page8_image2",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page8_image2-300x200.jpg",
-                "width": 300,
-                "height": 200,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-300x200.jpg"
-              },
-              "large": {
-                "file": "diy_page8_image2-1024x683.jpg",
-                "width": 1024,
-                "height": 683,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-1024x683.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page8_image2-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page8_image2-768x512.jpg",
-                "width": 768,
-                "height": 512,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-768x512.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page8_image2-1536x1024.jpg",
-                "width": 1536,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-1536x1024.jpg"
-              },
-              "2048x2048": {
-                "file": "diy_page8_image2-2048x1365.jpg",
-                "width": 2048,
-                "height": 1365,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-2048x1365.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page8_image2-1200x800.jpg",
-                "width": 1200,
-                "height": 800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-1200x800.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "diy_page8_image2-1980x1320.jpg",
-                "width": 1980,
-                "height": 1320,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-1980x1320.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page8_image2-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page8_image2-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page8_image2-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page8_image2-150x100.jpg",
-                "width": 150,
-                "height": 100,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2-150x100.jpg"
-              },
-              "full": {
-                "file": "diy_page8_image2.jpg",
-                "width": 2400,
-                "height": 1600,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image2.jpg"
-              }
-            }
+            "sizes": []
           },
           "basedOn": "ae3014b3-9828-4285-991d-4b0aa1fc83a6",
           "id": "ad72e216-61e5-474b-b187-9f06a613a4d5"
@@ -2569,7 +1808,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page8_image3.jpg",
             "width": 220,
             "height": 147,
             "posterId": 0,
@@ -2577,99 +1816,7 @@
             "title": "diy_page8_image3",
             "alt": "diy_page8_image3",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page8_image3-300x200.jpg",
-                "width": 300,
-                "height": 200,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-300x200.jpg"
-              },
-              "large": {
-                "file": "diy_page8_image3-1024x683.jpg",
-                "width": 1024,
-                "height": 683,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-1024x683.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page8_image3-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page8_image3-768x512.jpg",
-                "width": 768,
-                "height": 512,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-768x512.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page8_image3-1536x1024.jpg",
-                "width": 1536,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-1536x1024.jpg"
-              },
-              "2048x2048": {
-                "file": "diy_page8_image3-2048x1365.jpg",
-                "width": 2048,
-                "height": 1365,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-2048x1365.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page8_image3-1200x800.jpg",
-                "width": 1200,
-                "height": 800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-1200x800.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "diy_page8_image3-1980x1320.jpg",
-                "width": 1980,
-                "height": 1320,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-1980x1320.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page8_image3-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page8_image3-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page8_image3-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page8_image3-150x100.jpg",
-                "width": 150,
-                "height": 100,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3-150x100.jpg"
-              },
-              "full": {
-                "file": "diy_page8_image3.jpg",
-                "width": 2400,
-                "height": 1600,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_page8_image3.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -3034,7 +2181,7 @@
             "type": "image",
             "mimeType": "image/jpeg",
             "creationDate": "2020-06-22T16:42:02",
-            "src": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page7_bg.jpg",
             "width": 330,
             "height": 442,
             "posterId": 0,
@@ -3042,71 +2189,7 @@
             "title": "diy_page7_bg",
             "alt": "diy_page7_bg",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page7_bg-224x300.jpg",
-                "width": 224,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-224x300.jpg"
-              },
-              "large": {
-                "file": "diy_page7_bg-764x1024.jpg",
-                "width": 764,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-764x1024.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page7_bg-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page7_bg-768x1029.jpg",
-                "width": 768,
-                "height": 1029,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-768x1029.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page7_bg-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page7_bg-824x928.jpg",
-                "width": 824,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-824x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page7_bg-824x696.jpg",
-                "width": 824,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-824x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page7_bg-150x201.jpg",
-                "width": 150,
-                "height": 201,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg-150x201.jpg"
-              },
-              "full": {
-                "file": "diy_page7_bg.jpg",
-                "width": 824,
-                "height": 1104,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page7_bg.jpg"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -3246,7 +2329,11 @@
           },
           "basedOn": "957322bc-5f94-4cf4-9163-6816b86d8e43",
           "id": "6c3bb33f-1d89-4624-96bb-b543e6336251",
-          "link": null
+          "link": {
+            "url": "http://example.com/",
+            "icon": null,
+            "desc": "Example Domain"
+          }
         },
         {
           "x": 93,
@@ -3305,7 +2392,11 @@
           },
           "basedOn": "6c3bb33f-1d89-4624-96bb-b543e6336251",
           "id": "a0c96775-0f7f-48b3-9820-c19f6b6cc01f",
-          "link": null
+          "link": {
+            "url": "http://example.com/",
+            "icon": null,
+            "desc": "Example Domain"
+          }
         }
       ],
       "type": "page",
@@ -3547,7 +2638,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_fb.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_icon_fb.png",
             "width": 150,
             "height": 300,
             "posterId": 0,
@@ -3555,36 +2646,7 @@
             "title": "diy_icon_fb",
             "alt": "diy_icon_fb",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_icon_fb-150x300.png",
-                "width": 150,
-                "height": 300,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_fb-150x300.png"
-              },
-              "thumbnail": {
-                "file": "diy_icon_fb-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_fb-150x150.png"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_icon_fb-150x300.png",
-                "width": 150,
-                "height": 300,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_fb-150x300.png"
-              },
-              "full": {
-                "file": "diy_icon_fb.png",
-                "width": 300,
-                "height": 600,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_fb.png"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -3613,7 +2675,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_insta.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_icon_insta.png",
             "width": 150,
             "height": 150,
             "posterId": 0,
@@ -3621,36 +2683,7 @@
             "title": "diy_icon_insta",
             "alt": "diy_icon_insta",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_icon_insta-300x300.png",
-                "width": 300,
-                "height": 300,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_insta-300x300.png"
-              },
-              "thumbnail": {
-                "file": "diy_icon_insta-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_insta-150x150.png"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_icon_insta-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_insta-150x150.png"
-              },
-              "full": {
-                "file": "diy_icon_insta.png",
-                "width": 300,
-                "height": 300,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_insta.png"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -3679,7 +2712,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_yt.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_icon_yt.png",
             "width": 150,
             "height": 102,
             "posterId": 0,
@@ -3687,29 +2720,7 @@
             "title": "diy_icon_yt",
             "alt": "diy_icon_yt",
             "local": false,
-            "sizes": {
-              "thumbnail": {
-                "file": "diy_icon_yt-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_yt-150x150.png"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_icon_yt-150x102.png",
-                "width": 150,
-                "height": 102,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_yt-150x102.png"
-              },
-              "full": {
-                "file": "diy_icon_yt.png",
-                "width": 300,
-                "height": 204,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_yt.png"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -3738,7 +2749,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_tw.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_icon_tw.png",
             "width": 151,
             "height": 119,
             "posterId": 0,
@@ -3746,29 +2757,7 @@
             "title": "diy_icon_tw",
             "alt": "diy_icon_tw",
             "local": false,
-            "sizes": {
-              "thumbnail": {
-                "file": "diy_icon_tw-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_tw-150x150.png"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_icon_tw-150x119.png",
-                "width": 150,
-                "height": 119,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_tw-150x119.png"
-              },
-              "full": {
-                "file": "diy_icon_tw.png",
-                "width": 301,
-                "height": 238,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/diy_icon_tw.png"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -3981,7 +2970,7 @@
             "type": "image",
             "mimeType": "image/jpeg",
             "creationDate": "2020-06-22T17:12:23",
-            "src": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page10_image1.jpg",
             "width": 330,
             "height": 235,
             "posterId": 0,
@@ -3989,85 +2978,7 @@
             "title": "diy_page10_image1",
             "alt": "diy_page10_image1",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page10_image1-300x214.jpg",
-                "width": 300,
-                "height": 214,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1-300x214.jpg"
-              },
-              "large": {
-                "file": "diy_page10_image1-1024x731.jpg",
-                "width": 1024,
-                "height": 731,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1-1024x731.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page10_image1-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page10_image1-768x548.jpg",
-                "width": 768,
-                "height": 548,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1-768x548.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page10_image1-1536x1097.jpg",
-                "width": 1536,
-                "height": 1097,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1-1536x1097.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page10_image1-1200x857.jpg",
-                "width": 1200,
-                "height": 857,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1-1200x857.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page10_image1-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page10_image1-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page10_image1-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page10_image1-150x107.jpg",
-                "width": 150,
-                "height": 107,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1-150x107.jpg"
-              },
-              "full": {
-                "file": "diy_page10_image1.jpg",
-                "width": 1920,
-                "height": 1371,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image1.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -4102,7 +3013,7 @@
             "type": "image",
             "mimeType": "image/jpeg",
             "creationDate": "2020-06-22T17:12:21",
-            "src": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page10_image2.jpg",
             "width": 330,
             "height": 498,
             "posterId": 0,
@@ -4110,92 +3021,7 @@
             "title": "diy_page10_image2",
             "alt": "diy_page10_image2",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page10_image2-199x300.jpg",
-                "width": 199,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-199x300.jpg"
-              },
-              "large": {
-                "file": "diy_page10_image2-678x1024.jpg",
-                "width": 678,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-678x1024.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page10_image2-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page10_image2-768x1160.jpg",
-                "width": 768,
-                "height": 1160,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-768x1160.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page10_image2-1017x1536.jpg",
-                "width": 1017,
-                "height": 1536,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-1017x1536.jpg"
-              },
-              "2048x2048": {
-                "file": "diy_page10_image2-1356x2048.jpg",
-                "width": 1356,
-                "height": 2048,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-1356x2048.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page10_image2-1200x1812.jpg",
-                "width": 1200,
-                "height": 1812,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-1200x1812.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page10_image2-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page10_image2-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page10_image2-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page10_image2-150x226.jpg",
-                "width": 150,
-                "height": 226,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-150x226.jpg"
-              },
-              "full": {
-                "file": "diy_page10_image2-scaled.jpg",
-                "width": 1695,
-                "height": 2560,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image2-scaled.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -4230,7 +3056,7 @@
             "type": "image",
             "mimeType": "image/jpeg",
             "creationDate": "2020-06-22T17:12:19",
-            "src": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/diy/diy_page10_image3.jpg",
             "width": 330,
             "height": 220,
             "posterId": 0,
@@ -4238,85 +3064,7 @@
             "title": "diy_page10_image3",
             "alt": "diy_page10_image3",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "diy_page10_image3-300x200.jpg",
-                "width": 300,
-                "height": 200,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3-300x200.jpg"
-              },
-              "large": {
-                "file": "diy_page10_image3-1024x683.jpg",
-                "width": 1024,
-                "height": 683,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3-1024x683.jpg"
-              },
-              "thumbnail": {
-                "file": "diy_page10_image3-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "diy_page10_image3-768x512.jpg",
-                "width": 768,
-                "height": 512,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3-768x512.jpg"
-              },
-              "1536x1536": {
-                "file": "diy_page10_image3-1536x1024.jpg",
-                "width": 1536,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3-1536x1024.jpg"
-              },
-              "post-thumbnail": {
-                "file": "diy_page10_image3-1200x800.jpg",
-                "width": 1200,
-                "height": 800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3-1200x800.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "diy_page10_image3-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "diy_page10_image3-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "diy_page10_image3-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "diy_page10_image3-150x100.jpg",
-                "width": 150,
-                "height": 100,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3-150x100.jpg"
-              },
-              "full": {
-                "file": "diy_page10_image3.jpg",
-                "width": 1920,
-                "height": 1280,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/diy_page10_image3.jpg"
-              }
-            }
+            "sizes": []
           }
         }
       ],

--- a/assets/src/dashboard/templates/raw/diy.json
+++ b/assets/src/dashboard/templates/raw/diy.json
@@ -2330,7 +2330,7 @@
           "basedOn": "957322bc-5f94-4cf4-9163-6816b86d8e43",
           "id": "6c3bb33f-1d89-4624-96bb-b543e6336251",
           "link": {
-            "url": "http://example.com/",
+            "url": "https://example.com/",
             "icon": null,
             "desc": "Example Domain"
           }
@@ -2393,7 +2393,7 @@
           "basedOn": "6c3bb33f-1d89-4624-96bb-b543e6336251",
           "id": "a0c96775-0f7f-48b3-9820-c19f6b6cc01f",
           "link": {
-            "url": "http://example.com/",
+            "url": "https://example.com/",
             "icon": null,
             "desc": "Example Domain"
           }

--- a/assets/src/dashboard/templates/raw/fashion.json
+++ b/assets/src/dashboard/templates/raw/fashion.json
@@ -4570,7 +4570,12 @@
           "basedOn": "6f7115f5-66d3-47b1-ad9c-ef16c1aabdf3",
           "id": "f8d34cbd-6ead-46c3-aef2-1113b01df08e",
           "x": 135,
-          "y": 114
+          "y": 114,
+          "link": {
+            "url": "http://example.com/",
+            "icon": null,
+            "desc": "Example Domain"
+          }
         },
         {
           "opacity": 100,
@@ -4628,7 +4633,12 @@
           "basedOn": "f8d34cbd-6ead-46c3-aef2-1113b01df08e",
           "id": "508d68d8-d633-4bc5-9937-cce7bb74930e",
           "x": 195,
-          "y": 253
+          "y": 253,
+          "link": {
+            "url": "http://example.com/",
+            "icon": null,
+            "desc": "Example Domain"
+          }
         },
         {
           "opacity": 100,
@@ -4686,7 +4696,12 @@
           "basedOn": "f8d34cbd-6ead-46c3-aef2-1113b01df08e",
           "id": "8eb53cc7-ce88-4d10-be25-43a29e030ce4",
           "x": 295,
-          "y": 385
+          "y": 385,
+          "link": {
+            "url": "http://example.com/",
+            "icon": null,
+            "desc": "Example Domain"
+          }
         },
         {
           "opacity": 100,
@@ -4744,7 +4759,12 @@
           "basedOn": "8eb53cc7-ce88-4d10-be25-43a29e030ce4",
           "id": "11becc4b-a92d-41ee-a39f-4a034cea7813",
           "x": 161,
-          "y": 546
+          "y": 546,
+          "link": {
+            "url": "http://example.com/",
+            "icon": null,
+            "desc": null
+          }
         }
       ],
       "type": "page",

--- a/assets/src/dashboard/templates/raw/fashion.json
+++ b/assets/src/dashboard/templates/raw/fashion.json
@@ -4572,7 +4572,7 @@
           "x": 135,
           "y": 114,
           "link": {
-            "url": "http://example.com/",
+            "url": "https://example.com/",
             "icon": null,
             "desc": "Example Domain"
           }
@@ -4635,7 +4635,7 @@
           "x": 195,
           "y": 253,
           "link": {
-            "url": "http://example.com/",
+            "url": "https://example.com/",
             "icon": null,
             "desc": "Example Domain"
           }
@@ -4698,7 +4698,7 @@
           "x": 295,
           "y": 385,
           "link": {
-            "url": "http://example.com/",
+            "url": "https://example.com/",
             "icon": null,
             "desc": "Example Domain"
           }
@@ -4761,7 +4761,7 @@
           "x": 161,
           "y": 546,
           "link": {
-            "url": "http://example.com/",
+            "url": "https://example.com/",
             "icon": null,
             "desc": null
           }

--- a/assets/src/dashboard/templates/raw/fitness.json
+++ b/assets/src/dashboard/templates/raw/fitness.json
@@ -1999,7 +1999,7 @@
           "link": {
             "url": "http://example.com/",
             "icon": null,
-            "desc": null
+            "desc": "Example Domain"
           }
         },
         {

--- a/assets/src/dashboard/templates/raw/fitness.json
+++ b/assets/src/dashboard/templates/raw/fitness.json
@@ -1536,7 +1536,7 @@
             "type": "image",
             "mimeType": "image/png",
             "creationDate": "2020-06-30T20:40:21",
-            "src": "http://localhost:8899/wp-content/uploads/2020/06/fitness_page6_watch.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/fitness/fitness_page6_watch.png",
             "width": 330,
             "height": 330,
             "posterId": 0,
@@ -1544,64 +1544,7 @@
             "title": "fitness_page6_watch",
             "alt": "fitness_page6_watch",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "fitness_page6_watch-300x300.png",
-                "width": 300,
-                "height": 300,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/fitness_page6_watch-300x300.png"
-              },
-              "thumbnail": {
-                "file": "fitness_page6_watch-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/fitness_page6_watch-150x150.png"
-              },
-              "medium_large": {
-                "file": "fitness_page6_watch-768x768.png",
-                "width": 768,
-                "height": 768,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/fitness_page6_watch-768x768.png"
-              },
-              "web-stories-poster-portrait": {
-                "file": "fitness_page6_watch-696x928.png",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/fitness_page6_watch-696x928.png"
-              },
-              "web-stories-poster-square": {
-                "file": "fitness_page6_watch-928x928.png",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/fitness_page6_watch-928x928.png"
-              },
-              "web-stories-poster-landscape": {
-                "file": "fitness_page6_watch-928x696.png",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/fitness_page6_watch-928x696.png"
-              },
-              "web_stories_thumbnail": {
-                "file": "fitness_page6_watch-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/fitness_page6_watch-150x150.png"
-              },
-              "full": {
-                "file": "fitness_page6_watch.png",
-                "width": 1000,
-                "height": 1000,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/06/fitness_page6_watch.png"
-              }
-            }
+            "sizes": []
           },
           "type": "image",
           "x": 69,
@@ -2052,7 +1995,12 @@
           },
           "type": "shape",
           "basedOn": "cf1d4db0-d5d9-47a2-ba70-85618df23959",
-          "id": "0584e281-ec48-468c-84ad-c6bc6be4855a"
+          "id": "0584e281-ec48-468c-84ad-c6bc6be4855a",
+          "link": {
+            "url": "http://example.com/",
+            "icon": null,
+            "desc": null
+          }
         },
         {
           "opacity": 100,
@@ -2118,7 +2066,12 @@
           "basedOn": "0584e281-ec48-468c-84ad-c6bc6be4855a",
           "id": "2858cbba-bfc8-49a1-b932-bb569e381864",
           "x": 235,
-          "y": 148.5
+          "y": 148.5,
+          "link": {
+            "url": "http://example.com/",
+            "icon": null,
+            "desc": "Example Domain"
+          }
         }
       ],
       "type": "page",

--- a/assets/src/dashboard/templates/raw/fitness.json
+++ b/assets/src/dashboard/templates/raw/fitness.json
@@ -1997,7 +1997,7 @@
           "basedOn": "cf1d4db0-d5d9-47a2-ba70-85618df23959",
           "id": "0584e281-ec48-468c-84ad-c6bc6be4855a",
           "link": {
-            "url": "http://example.com/",
+            "url": "https://example.com/",
             "icon": null,
             "desc": "Example Domain"
           }
@@ -2068,7 +2068,7 @@
           "x": 235,
           "y": 148.5,
           "link": {
-            "url": "http://example.com/",
+            "url": "https://example.com/",
             "icon": null,
             "desc": "Example Domain"
           }


### PR DESCRIPTION
## Summary

This PR adds links to the link pages for our templates.

Here's a list of our templates and which page was updated:
- `Cooking`: This template does _not_ have a links page, no update required.

- `Entertainmnet`: This template does _not_ have a links page, no update required.

- `Travel`:  This template does _not_ have a links page, no update required.

- `Beauty`: Links will be added to its links page in a _separate_ PR.

- `Wellbeing`: Links were added to this template in [another PR](https://github.com/google/web-stories-wp/pull/3018), so no changes were made in this PR.

- `DIY`: Links were added to page 9.
<img src="https://user-images.githubusercontent.com/40646372/86813618-444e4000-c035-11ea-81a3-a9fdf8d52fe4.gif" height="200">

- `Fashion`: Links were added to page 8.
<img src="https://user-images.githubusercontent.com/40646372/86813628-4912f400-c035-11ea-9844-c6f4a2558c80.gif" height="200">

- `Fitness`: Links were added to page 7.
<img src="https://user-images.githubusercontent.com/40646372/86813636-4ca67b00-c035-11ea-97be-2c9afc4858f9.gif" height="200">

## To-do

- The Beauty template will get updated in a separate PR.

## User-facing changes

- The pages list above should have links embedded in them that link to `example.com`.

## Testing Instructions

1.) Go to "Explore Templates".
2.) Click on "Use Template" to create 3 new stories from the `DIY`, `Fashion`, and `Fitness` templates.
3.) Click on "Open in Editor" for each new story and navigate to its links page (DIY - page 9, Fashion - page 8, Fitness - page 7) and hover over the center of each link to see "Example Domain" pop up for each one.

Fixes #2888 
