### PR TITLE
Combine local and media3p actions for useMediaReducer

### DIFF
--- a/assets/src/edit-story/app/media/media3p/useProviderContextValueProvider.js
+++ b/assets/src/edit-story/app/media/media3p/useProviderContextValueProvider.js
@@ -26,7 +26,7 @@ import useFetchMediaEffect from './useFetchMediaEffect';
  * @param provider The 3p provider to return the context value for
  * @param reducerState The 'media3p/[provider]' fragment of the state
  * returned from {@link useMediaReducer}
- * @param reducerAction The 'media3p/[provider]' fragment of the actions
+ * @param reducerActions The 'media3p/[provider]' fragment of the actions
  * returned from {@link useMediaReducer}
  */
 export default function useProviderContextValueProvider(

--- a/assets/src/edit-story/app/media/mediaProvider.js
+++ b/assets/src/edit-story/app/media/mediaProvider.js
@@ -30,8 +30,11 @@ import Context from './context';
 function MediaProvider({ children }) {
   const { state, actions } = useMediaReducer();
 
-  const local = useLocalContextValueProvider(state.local, actions);
-  const media3p = useMedia3pContextValueProvider(state.media3p, actions);
+  const local = useLocalContextValueProvider(state.local, actions.local);
+  const media3p = useMedia3pContextValueProvider(
+    state.media3p,
+    actions.media3p
+  );
 
   const context = { local, media3p };
   return <Context.Provider value={context}>{children}</Context.Provider>;

--- a/assets/src/edit-story/app/media/test/useMediaReducer.js
+++ b/assets/src/edit-story/app/media/test/useMediaReducer.js
@@ -25,10 +25,21 @@ import { renderHook } from '@testing-library/react-hooks';
 import useMediaReducer from '../useMediaReducer';
 
 describe('useMediaReducer', () => {
-  it('should return the initial value for state', () => {
+  it('should return initial state', () => {
     const { result } = renderHook(() => useMediaReducer());
-    expect(result.current.state.local).toStrictEqual(
-      expect.objectContaining({ media: [], hasMore: true })
-    );
+    expect(result.current.state).toStrictEqual({
+      local: expect.objectContaining({ media: [], hasMore: true }),
+      media3p: expect.objectContaining({
+        unsplash: expect.objectContaining({ media: [], hasMore: true })
+      }),
+    });
+  });
+
+  it('should return actions', () => {
+    const { result } = renderHook(() => useMediaReducer());
+    expect(result.current.actions).toStrictEqual({
+      local: expect.objectContaining({ fetchMediaStart: expect.any(Function) }),
+      media3p: expect.objectContaining({ setSelectedProvider: expect.any(Function), fetchMediaStart: expect.any(Function) }),
+    });
   });
 });

--- a/assets/src/edit-story/app/media/test/useMediaReducer.js
+++ b/assets/src/edit-story/app/media/test/useMediaReducer.js
@@ -30,7 +30,7 @@ describe('useMediaReducer', () => {
     expect(result.current.state).toStrictEqual({
       local: expect.objectContaining({ media: [], hasMore: true }),
       media3p: expect.objectContaining({
-        unsplash: expect.objectContaining({ media: [], hasMore: true })
+        unsplash: expect.objectContaining({ media: [], hasMore: true }),
       }),
     });
   });
@@ -39,7 +39,10 @@ describe('useMediaReducer', () => {
     const { result } = renderHook(() => useMediaReducer());
     expect(result.current.actions).toStrictEqual({
       local: expect.objectContaining({ fetchMediaStart: expect.any(Function) }),
-      media3p: expect.objectContaining({ setSelectedProvider: expect.any(Function), fetchMediaStart: expect.any(Function) }),
+      media3p: expect.objectContaining({
+        setSelectedProvider: expect.any(Function),
+        fetchMediaStart: expect.any(Function),
+      }),
     });
   });
 });

--- a/assets/src/edit-story/app/media/useMediaReducer.js
+++ b/assets/src/edit-story/app/media/useMediaReducer.js
@@ -25,6 +25,7 @@ import { useReducer, useMemo } from 'react';
 import localReducer from './local/reducer';
 import media3pReducer from './media3p/reducer';
 import * as localActionsToWrap from './local/actions';
+import * as media3pActionsToWrap from './media3p/actions';
 import * as types from './types';
 
 function rootReducer(state = {}, { type, payload }) {
@@ -34,19 +35,37 @@ function rootReducer(state = {}, { type, payload }) {
   };
 }
 
-const wrapWithDispatch = (actions, dispatch) =>
-  Object.keys(actions).reduce(
+const wrapWithDispatch = (actionFnOrActionObject, dispatch) => {
+  if (actionFnOrActionObject instanceof Function) {
+    return actionFnOrActionObject(dispatch);
+  }
+
+  const actions = actionFnOrActionObject;
+  return Object.keys(actions).reduce(
     (collection, action) => ({
       ...collection,
-      [action]: actions[action](dispatch),
+      [action]: wrapWithDispatch(actions[action], dispatch),
     }),
     {}
   );
+};
 
-function useMediaReducer(
-  reducer = rootReducer,
-  actionsToWrap = localActionsToWrap
-) {
+/**
+ * The media state reducer and action dispatcher functions.
+ *
+ * @param {Function} reducer The reducer, which may be overriden for unit
+ * testing purposes
+ * @param {Object} actionsToWrap The action dispatcher functions, that are
+ * wrapped with the `dispatch` function and may be overriden for unit testing
+ * purposes
+ */
+function useMediaReducer(reducer = rootReducer, actionsToWrap) {
+  const defaultActionsToWrap = useMemo(
+    () => ({ local: localActionsToWrap, media3p: media3pActionsToWrap }),
+    []
+  );
+  actionsToWrap = actionsToWrap ?? defaultActionsToWrap;
+
   const initialValue = useMemo(
     () => reducer(undefined, { type: types.INITIAL_STATE }),
     [reducer]


### PR DESCRIPTION
## Summary

Combine local and media3p actions in useMediaReducer, so that they form the appropriate hierarchy:
```
const {
  state: { local, media3p: { unsplash } },
  actions: { local, media3p },
} = useMediaReducer();
```

## Testing Instructions

- Open the media pane to verify that it appears.
- Scroll down to verify a page of results in returned.
- Upload an image successfully.
- Upload a video successfully.
