### PR TITLE
Links: improve error detection for invalid URLs

### DIFF
--- a/includes/REST_API/Link_Controller.php
+++ b/includes/REST_API/Link_Controller.php
@@ -131,6 +131,10 @@ class Link_Controller extends WP_REST_Controller {
 
 		$response = wp_safe_remote_get( $url, $args );
 
+		if ( is_wp_error( $response ) && 'http_request_failed' === $response->get_error_code() ) {
+			return new WP_Error( 'rest_invalid_url', __( 'Invalid URL', 'web-stories' ), [ 'status' => 404 ] );
+		}
+
 		if ( WP_Http::OK !== wp_remote_retrieve_response_code( $response ) ) {
 			// Not saving to cache since the error might be temporary.
 			return rest_ensure_response( $data );

--- a/tests/phpunit/tests/REST_API/Link_Controller.php
+++ b/tests/phpunit/tests/REST_API/Link_Controller.php
@@ -3,21 +3,25 @@
 namespace Google\Web_Stories\Tests\REST_API;
 
 use Spy_REST_Server;
+use WP_Error;
 use WP_REST_Request;
+use WP_REST_Server;
 
 class Link_Controller extends \WP_Test_REST_TestCase {
 	/**
-	 * @var \WP_REST_Server
+	 * @var WP_REST_Server
 	 */
 	protected $server;
 
 	protected static $editor;
 	protected static $subscriber;
 
-	const INVALID_URL = 'https://www.notreallyawebsite.com/foobar.html';
-	const EMPTY_URL   = 'https://empty.example.com';
-	const EXAMPLE_URL = 'https://example.com';
-	const VALID_URL   = 'https://amp.dev';
+	const URL_INVALID          = 'https://https://invalid.commmm';
+	const URL_404              = 'https://404.example.com';
+	const URL_500              = 'https://500.example.com';
+	const URL_EMPTY_DOCUMENT   = 'https://empty.example.com';
+	const URL_VALID_TITLE_ONLY = 'https://example.com';
+	const URL_VALID            = 'https://amp.dev';
 
 	/**
 	 * Count of the number of requests attempted.
@@ -48,7 +52,7 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		/** @var \WP_REST_Server $wp_rest_server */
+		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$wp_rest_server = new Spy_REST_Server();
 		do_action( 'rest_api_init', $wp_rest_server );
@@ -61,7 +65,7 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 	public function tearDown() {
 		parent::tearDown();
 
-		/** @var \WP_REST_Server $wp_rest_server */
+		/** @var WP_REST_Server $wp_rest_server */
 		global $wp_rest_server;
 		$wp_rest_server = null;
 
@@ -74,12 +78,28 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 	 * @param mixed  $preempt Whether to preempt an HTTP request's return value. Default false.
 	 * @param mixed  $r       HTTP request arguments.
 	 * @param string $url     The request URL.
-	 * @return array Response data.
+	 * @return array|WP_Error Response data.
 	 */
 	public function mock_http_request( $preempt, $r, $url ) {
 		++ $this->request_count;
 
-		if ( false !== strpos( $url, self::EMPTY_URL ) ) {
+		if ( false !== strpos( $url, self::URL_INVALID ) ) {
+			return $preempt;
+		}
+
+		if ( false !== strpos( $url, self::URL_404 ) ) {
+			return [
+				'response' => [
+					'code' => 404,
+				],
+			];
+		}
+
+		if ( false !== strpos( $url, self::URL_500 ) ) {
+			return new WP_Error( 'http_request_failed', 'A valid URL was not provided.' );
+		}
+
+		if ( false !== strpos( $url, self::URL_EMPTY_DOCUMENT ) ) {
 			return [
 				'response' => [
 					'code' => 200,
@@ -88,7 +108,7 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 			];
 		}
 
-		if ( false !== strpos( $url, self::EXAMPLE_URL ) ) {
+		if ( false !== strpos( $url, self::URL_VALID_TITLE_ONLY ) ) {
 			return [
 				'response' => [
 					'code' => 200,
@@ -97,7 +117,7 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 			];
 		}
 
-		if ( false !== strpos( $url, self::VALID_URL ) ) {
+		if ( false !== strpos( $url, self::URL_VALID ) ) {
 			return [
 				'response' => [
 					'code' => 200,
@@ -106,11 +126,7 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 			];
 		}
 
-		return [
-			'response' => [
-				'code' => 404,
-			],
-		];
+		return $preempt;
 	}
 
 	public function test_register_routes() {
@@ -128,15 +144,15 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 
 	public function test_without_permission() {
 		// Test without a login.
-		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request  = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertEquals( 400, $response->get_status() );
 
 		// Test with a user that does not have edit_posts capability.
 		wp_set_current_user( self::$subscriber );
-		$request = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::VALID_URL );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request->set_param( 'url', self::URL_VALID );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertEquals( 403, $response->get_status() );
@@ -144,10 +160,32 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 		$this->assertEquals( $data['code'], 'rest_forbidden' );
 	}
 
-	public function test_invalid_url() {
+	public function test_url_invalid_url() {
 		wp_set_current_user( self::$editor );
-		$request = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::INVALID_URL );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request->set_param( 'url', self::URL_INVALID );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( $data['code'], 'rest_invalid_url' );
+	}
+
+	public function test_url_returning_500() {
+		wp_set_current_user( self::$editor );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request->set_param( 'url', self::URL_500 );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 404, $response->get_status() );
+		$this->assertEquals( $data['code'], 'rest_invalid_url' );
+	}
+
+	public function test_url_returning_404() {
+		wp_set_current_user( self::$editor );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request->set_param( 'url', self::URL_404 );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -164,7 +202,7 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 
 	public function test_url_empty_string() {
 		wp_set_current_user( self::$editor );
-		$request = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
 		$request->set_param( 'url', '' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
@@ -176,8 +214,8 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 
 	public function test_empty_url() {
 		wp_set_current_user( self::$editor );
-		$request = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::EMPTY_URL );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request->set_param( 'url', self::URL_EMPTY_DOCUMENT );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -197,8 +235,8 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 
 	public function test_example_url() {
 		wp_set_current_user( self::$editor );
-		$request = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::EXAMPLE_URL );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request->set_param( 'url', self::URL_VALID_TITLE_ONLY );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -218,8 +256,8 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 
 	public function test_valid_url() {
 		wp_set_current_user( self::$editor );
-		$request = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::VALID_URL );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request->set_param( 'url', self::URL_VALID );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -239,8 +277,8 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 
 	public function test_removes_trailing_slashes() {
 		wp_set_current_user( self::$editor );
-		$request = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::EXAMPLE_URL );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request->set_param( 'url', self::URL_VALID_TITLE_ONLY );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -250,8 +288,8 @@ class Link_Controller extends \WP_Test_REST_TestCase {
 			'description' => '',
 		];
 
-		$request = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/link' );
-		$request->set_param( 'url', self::EXAMPLE_URL . '/' );
+		$request = new WP_REST_Request( WP_REST_Server::READABLE, '/web-stories/v1/link' );
+		$request->set_param( 'url', self::URL_VALID_TITLE_ONLY . '/' );
 		rest_get_server()->dispatch( $request );
 		$this->assertEquals( 1, $this->request_count );
 


### PR DESCRIPTION
## Summary

Updates `Link_Controller` to cover more error cases.

## Relevant Technical Choices

Check for `WP_Error` objects to more accurately display errors in the editor for clearly invalid URLs.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Error message is reported more often.

## Testing Instructions

1. Add new element
1. Add link to `https://google.commss` -> verify that "Invalid web address" error is displayed
1. Add link to `https://google.com` -> verify that no error is displayed

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2815
