### PR TITLE
Dashboard: Settings view context foundation (Publisher Logos)

### DIFF
--- a/assets/src/dashboard/app/api/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/useSettingsApi.js
@@ -87,7 +87,7 @@ export default function useSettingsApi(
 
         dispatch({
           type: SETTINGS_ACTION_TYPES.UPDATE_SETTINGS_SUCCESS,
-          payload: response.googleAnalyticsId,
+          payload: response,
         });
       } catch (err) {
         dispatch({

--- a/assets/src/dashboard/app/reducer/settings.js
+++ b/assets/src/dashboard/app/reducer/settings.js
@@ -24,6 +24,7 @@ export const ACTION_TYPES = {
 export const defaultSettingsState = {
   error: {},
   googleAnalyticsId: null,
+  publisherLogos: [],
 };
 
 function settingsReducer(state, action) {
@@ -42,6 +43,7 @@ function settingsReducer(state, action) {
         ...state,
         error: {},
         googleAnalyticsId: action.payload.googleAnalyticsId,
+        publisherLogos: action.payload.publisherLogos,
       };
     }
 

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -37,7 +37,7 @@ function EditorSettings() {
       settingsApi: { fetchSettings, updateSettings },
     },
     state: {
-      settings: { googleAnalyticsId },
+      settings: { googleAnalyticsId, publisherLogos },
     },
   } = useContext(ApiContext);
 
@@ -55,7 +55,10 @@ function EditorSettings() {
           onUpdateGoogleAnalytics={updateSettings}
           googleAnalyticsId={googleAnalyticsId}
         />
-        <PublisherLogoSettings />
+        <PublisherLogoSettings
+          onUpdatePublisherLogo={updateSettings}
+          publisherLogos={publisherLogos}
+        />
       </Main>
     </Wrapper>
   );

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -20,6 +20,11 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
  * Internal dependencies
  */
 import {
@@ -42,7 +47,9 @@ const TEXT = {
   ),
   SUBMIT: __('Upload', 'web-stories'),
 };
-function PublisherLogoSettings() {
+
+// eslint-disable-next-line no-unused-vars
+function PublisherLogoSettings({ onUpdatePublisherLogo, publisherLogos }) {
   return (
     <SettingForm>
       <SettingHeading htmlFor="publisherLogo">
@@ -60,4 +67,15 @@ function PublisherLogoSettings() {
   );
 }
 
+PublisherLogoSettings.propTypes = {
+  onUpdatePublisherLogo: PropTypes.func,
+  publisherLogos: PropTypes.arrayOf(
+    PropTypes.shape({
+      src: PropTypes.string,
+      title: PropTypes.string,
+      alt: PropTypes.string,
+      id: PropTypes.string,
+    })
+  ),
+};
 export default PublisherLogoSettings;

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/stories/index.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+
+/**
  * Internal dependencies
  */
 import PublisherLogoSettings from '../';
@@ -25,5 +30,13 @@ export default {
 };
 
 export const _default = () => {
-  return <PublisherLogoSettings />;
+  return (
+    <PublisherLogoSettings
+      onUpdatePublisherLogo={(e) => {
+        e.preventDefault();
+        action('update publisher logo clicked');
+      }}
+      publisherLogos={[]}
+    />
+  );
 };


### PR DESCRIPTION
## Summary
We don't have access to an API for this yet, just laying ground work for connecting UI to API via context. 

## Relevant Technical Choices
- Following same patterning as google analytics. 
- Did not adjust for what data is returned in response to format reducer, will do that once we know what is going on. 

## To-do
- Functionality :) 
- Connect fileUpload #3059 w/ these changes

## User-facing changes
- None 

## Testing Instructions
- See that the publisher logos ui still renders in storybook. Honestly, this is pretty mellow - just wanted to do these changes separately after getting buy in on structure of `useSettingsApi`. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #2747 