### PR TITLE
Dashboard: Display Scheduled Stories 

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -34,6 +34,7 @@ import {
   STORY_SORT_OPTIONS,
   ORDER_BY_SORT,
   STORIES_PER_REQUEST,
+  STORY_STATUS,
 } from '../../constants';
 import storyReducer, {
   defaultStoriesState,
@@ -104,7 +105,12 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
             editStoryURL,
             stories: response.body,
             totalPages,
-            totalStoriesByStatus,
+            totalStoriesByStatus: {
+              ...totalStoriesByStatus,
+              [STORY_STATUS.PUBLISHED_AND_FUTURE]:
+                totalStoriesByStatus[STORY_STATUS.PUBLISH] +
+                totalStoriesByStatus[STORY_STATUS.FUTURE],
+            },
             page,
           },
         });

--- a/assets/src/dashboard/app/reducer/stories.js
+++ b/assets/src/dashboard/app/reducer/stories.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { STORY_STATUS } from '../../constants';
 import reshapeStoryObject from '../serializers/stories';
 
 export const ACTION_TYPES = {
@@ -81,7 +82,12 @@ function storyReducer(state, action) {
         },
       };
 
-    case ACTION_TYPES.TRASH_STORY:
+    case ACTION_TYPES.TRASH_STORY: {
+      const storyGroupStatus =
+        action.payload.storyStatus === STORY_STATUS.DRAFT
+          ? STORY_STATUS.DRAFT
+          : STORY_STATUS.PUBLISHED_AND_FUTURE;
+
       return {
         ...state,
         error: {},
@@ -91,8 +97,7 @@ function storyReducer(state, action) {
         totalStoriesByStatus: {
           ...state.totalStoriesByStatus,
           all: state.totalStoriesByStatus.all - 1,
-          [action.payload.storyStatus]:
-            state.totalStoriesByStatus[action.payload.storyStatus] - 1,
+          [storyGroupStatus]: state.totalStoriesByStatus[storyGroupStatus] - 1,
         },
         stories: Object.keys(state.stories).reduce((memo, storyId) => {
           if (parseInt(storyId) !== action.payload.id) {
@@ -101,6 +106,7 @@ function storyReducer(state, action) {
           return memo;
         }, {}),
       };
+    }
 
     case ACTION_TYPES.DUPLICATE_STORY:
       return {

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -18,6 +18,7 @@
  * Internal dependencies
  */
 import storyReducer, { ACTION_TYPES } from '../stories';
+import { STORY_STATUS } from '../../../constants';
 
 describe('storyReducer', () => {
   const initialState = {
@@ -48,8 +49,8 @@ describe('storyReducer', () => {
         },
         totalStoriesByStatus: {
           all: 44,
-          draft: 40,
-          publish: 4,
+          [STORY_STATUS.DRAFT]: 40,
+          [STORY_STATUS.PUBLISHED_AND_FUTURE]: 4,
         },
         totalPages: 4,
       },
@@ -73,8 +74,8 @@ describe('storyReducer', () => {
       },
       totalStoriesByStatus: {
         all: 43,
-        draft: 40,
-        publish: 3,
+        [STORY_STATUS.DRAFT]: 40,
+        [STORY_STATUS.PUBLISHED_AND_FUTURE]: 3,
       },
       totalPages: 4,
     });
@@ -121,8 +122,8 @@ describe('storyReducer', () => {
         },
         totalStoriesByStatus: {
           all: 44,
-          draft: 40,
-          publish: 4,
+          [STORY_STATUS.DRAFT]: 40,
+          [STORY_STATUS.PUBLISHED_AND_FUTURE]: 4,
         },
         totalPages: 4,
       },
@@ -145,8 +146,8 @@ describe('storyReducer', () => {
       },
       totalStoriesByStatus: {
         all: 45,
-        draft: 41,
-        publish: 4,
+        [STORY_STATUS.DRAFT]: 41,
+        [STORY_STATUS.PUBLISHED_AND_FUTURE]: 4,
       },
       totalPages: 4,
     });
@@ -221,8 +222,8 @@ describe('storyReducer', () => {
         ],
         totalStoriesByStatus: {
           all: 44,
-          draft: 40,
-          publish: 4,
+          [STORY_STATUS.DRAFT]: 40,
+          [STORY_STATUS.PUBLISHED_AND_FUTURE]: 4,
         },
         totalPages: 4,
       },
@@ -240,8 +241,8 @@ describe('storyReducer', () => {
       },
       totalStoriesByStatus: {
         all: 44,
-        draft: 40,
-        publish: 4,
+        [STORY_STATUS.DRAFT]: 40,
+        [STORY_STATUS.PUBLISHED_AND_FUTURE]: 4,
       },
       totalPages: 4,
       allPagesFetched: false,
@@ -291,8 +292,8 @@ describe('storyReducer', () => {
           ],
           totalStoriesByStatus: {
             all: 18,
-            draft: 14,
-            publish: 4,
+            [STORY_STATUS.DRAFT]: 14,
+            [STORY_STATUS.PUBLISHED_AND_FUTURE]: 4,
           },
           totalPages: 2,
         },
@@ -310,8 +311,8 @@ describe('storyReducer', () => {
       },
       totalStoriesByStatus: {
         all: 18,
-        draft: 14,
-        publish: 4,
+        [STORY_STATUS.DRAFT]: 14,
+        [STORY_STATUS.PUBLISHED_AND_FUTURE]: 4,
       },
       totalPages: 2,
       allPagesFetched: true,

--- a/assets/src/dashboard/app/views/myStories/header/test/header.js
+++ b/assets/src/dashboard/app/views/myStories/header/test/header.js
@@ -71,7 +71,11 @@ describe('My Stories <Header />', function () {
           stories={fakeStories}
           search={{ keyword: '', setKeyword: jest.fn() }}
           sort={{ value: STORY_SORT_OPTIONS.NAME, set: jest.fn() }}
-          totalStoriesByStatus={{ all: 19, draft: 9, publish: 10 }}
+          totalStoriesByStatus={{
+            all: 19,
+            draft: 9,
+            [STORY_STATUS.PUBLISHED_AND_FUTURE]: 10,
+          }}
           view={{
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
@@ -91,7 +95,11 @@ describe('My Stories <Header />', function () {
           stories={fakeStories}
           search={{ keyword: 'Harry Potter', setKeyword: jest.fn() }}
           sort={{ value: STORY_SORT_OPTIONS.NAME, set: jest.fn() }}
-          totalStoriesByStatus={{ all: 19, draft: 9, publish: 10 }}
+          totalStoriesByStatus={{
+            all: 19,
+            draft: 9,
+            [STORY_STATUS.PUBLISHED_AND_FUTURE]: 10,
+          }}
           view={{
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
@@ -112,7 +120,11 @@ describe('My Stories <Header />', function () {
           stories={fakeStories}
           search={{ keyword: '', setKeyword: jest.fn() }}
           sort={{ value: STORY_SORT_OPTIONS.NAME, set: jest.fn() }}
-          totalStoriesByStatus={{ all: 19, draft: 9, published: 10 }}
+          totalStoriesByStatus={{
+            all: 19,
+            draft: 9,
+            [STORY_STATUS.PUBLISHED_AND_FUTURE]: 10,
+          }}
           view={{
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
@@ -132,7 +144,11 @@ describe('My Stories <Header />', function () {
           stories={fakeStories}
           search={{ keyword: '', setKeyword: jest.fn() }}
           sort={{ value: STORY_SORT_OPTIONS.NAME, set: jest.fn() }}
-          totalStoriesByStatus={{ all: 19, draft: 9, publish: 10 }}
+          totalStoriesByStatus={{
+            all: 19,
+            draft: 9,
+            [STORY_STATUS.PUBLISHED_AND_FUTURE]: 10,
+          }}
           view={{
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
@@ -155,7 +171,11 @@ describe('My Stories <Header />', function () {
           stories={fakeStories}
           search={{ keyword: 'Harry Potter', setKeyword: setKeywordFn }}
           sort={{ value: STORY_SORT_OPTIONS.NAME, set: jest.fn() }}
-          totalStoriesByStatus={{ all: 19, draft: 9, published: 10 }}
+          totalStoriesByStatus={{
+            all: 19,
+            draft: 9,
+            [STORY_STATUS.PUBLISHED_AND_FUTURE]: 10,
+          }}
           view={{
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
@@ -179,7 +199,11 @@ describe('My Stories <Header />', function () {
           stories={fakeStories}
           search={{ keyword: 'Harry Potter', setKeyword: jest.fn() }}
           sort={{ value: STORY_SORT_OPTIONS.CREATED_BY, set: setSortFn }}
-          totalStoriesByStatus={{ all: 19, draft: 9, published: 10 }}
+          totalStoriesByStatus={{
+            all: 19,
+            draft: 9,
+            [STORY_STATUS.PUBLISHED_AND_FUTURE]: 10,
+          }}
           view={{
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },

--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -214,7 +214,8 @@ describe('CUJ: Creator can view their stories in grid view', () => {
 
     it('should switch to the Published Tab', async () => {
       const numPublished = formattedStoriesArray.filter(
-        ({ status }) => status === STORY_STATUS.PUBLISHED
+        ({ status }) =>
+          status === STORY_STATUS.PUBLISH || status === STORY_STATUS.FUTURE
       ).length;
 
       expect(numPublished).toBeGreaterThan(0);
@@ -228,7 +229,9 @@ describe('CUJ: Creator can view their stories in grid view', () => {
       await fixture.events.click(publishedTabButton);
 
       const viewPublishedText = fixture.screen.getByText(
-        new RegExp('^' + STORY_VIEWING_LABELS[STORY_STATUS.PUBLISHED] + '$')
+        new RegExp(
+          '^' + STORY_VIEWING_LABELS[STORY_STATUS.PUBLISHED_AND_FUTURE] + '$'
+        )
       );
 
       expect(viewPublishedText).toBeTruthy();

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -42,6 +42,7 @@ import {
   RenameStoryPropType,
 } from '../../../types';
 import { getFormattedDisplayDate } from '../../../utils';
+import { STORY_STATUS } from '../../../constants';
 
 export const DetailRow = styled.div`
   display: flex;
@@ -110,10 +111,11 @@ const StoryGridView = ({
                     ? __('Google', 'web-stories')
                     : users[story.author]?.name
                 }
-                displayDate={getFormattedDisplayDate(
-                  story?.modified,
-                  dateFormat
-                )}
+                displayDate={
+                  story?.status === STORY_STATUS.DRAFT
+                    ? getFormattedDisplayDate(story?.modified, dateFormat)
+                    : getFormattedDisplayDate(story?.created, dateFormat)
+                }
                 {...titleRenameProps}
               />
 

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -276,8 +276,10 @@ export default function StoryListView({
               </TableCell>
               {storyStatus !== STORY_STATUS.DRAFT && (
                 <TableStatusCell>
-                  {story.status === STORY_STATUS.PUBLISHED &&
+                  {story.status === STORY_STATUS.PUBLISH &&
                     __('Published', 'web-stories')}
+                  {story.status === STORY_STATUS.FUTURE &&
+                    __('Scheduled', 'web-stories')}
                 </TableStatusCell>
               )}
             </TableRow>

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -85,17 +85,28 @@ const CardTitle = ({
     if (!displayDate) {
       return null;
     }
-    return status === STORY_STATUS.PUBLISHED
-      ? sprintf(
+
+    switch (status) {
+      case STORY_STATUS.PUBLISH:
+        return sprintf(
           /* translators: %s: last modified date */
           __('Published %s', 'web-stories'),
           displayDate
-        )
-      : sprintf(
+        );
+      case STORY_STATUS.FUTURE:
+        return sprintf(
+          /* translators: %s: last modified date */
+          __('Scheduled %s', 'web-stories'),
+          displayDate
+        );
+
+      default:
+        return sprintf(
           /* translators: %s: last modified date */
           __('Modified %s', 'web-stories'),
           displayDate
         );
+    }
   }, [status, displayDate]);
 
   return (

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -89,13 +89,13 @@ const CardTitle = ({
     switch (status) {
       case STORY_STATUS.PUBLISH:
         return sprintf(
-          /* translators: %s: last modified date */
+          /* translators: %s: published date */
           __('Published %s', 'web-stories'),
           displayDate
         );
       case STORY_STATUS.FUTURE:
         return sprintf(
-          /* translators: %s: last modified date */
+          /* translators: %s: future publish date */
           __('Scheduled %s', 'web-stories'),
           displayDate
         );

--- a/assets/src/dashboard/components/cardGridItem/stories/index.js
+++ b/assets/src/dashboard/components/cardGridItem/stories/index.js
@@ -99,7 +99,7 @@ export const _publishedStory = () => {
           title="The 6 fingered man"
           author="Inigo Moñtoya"
           displayDate={moment('04-19-2020', 'MM-DD-YYYY')}
-          status={STORY_STATUS.PUBLISHED}
+          status={STORY_STATUS.PUBLISH}
           onEditCancel={() => {}}
           onEditComplete={() => {}}
         />

--- a/assets/src/dashboard/components/cardGridItem/test/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/test/cardTitle.js
@@ -75,6 +75,36 @@ describe('CardTitle', () => {
     expect(getByText('draft')).toBeDefined();
   });
 
+  it(`should display "Scheduled" before created date when ${STORY_STATUS.FUTURE}`, () => {
+    const { getByText } = renderWithTheme(
+      <CardTitle
+        title="Sample Story"
+        displayDate={moment('04/23/2020', 'MM/DD/YYYY')}
+        status={STORY_STATUS.FUTURE}
+        onEditCancel={jest.fn}
+        onEditComplete={jest.fn}
+        editMode={false}
+      />
+    );
+
+    expect(getByText(/^Scheduled/)).toBeDefined();
+  });
+
+  it(`should display "Published" before created date when ${STORY_STATUS.PUBLISH}`, () => {
+    const { getByText } = renderWithTheme(
+      <CardTitle
+        title="Sample Story"
+        displayDate={moment('04/23/2020', 'MM/DD/YYYY')}
+        status={STORY_STATUS.PUBLISH}
+        onEditCancel={jest.fn}
+        onEditComplete={jest.fn}
+        editMode={false}
+      />
+    );
+
+    expect(getByText(/^Published/)).toBeDefined();
+  });
+
   it('should render Card Title with an author', () => {
     const { getByText } = renderWithTheme(
       <CardTitle

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -126,7 +126,7 @@ export const STORY_STATUSES = [
   },
   {
     label: __('Published', 'web-stories'),
-    value: `${STORY_STATUS.PUBLISH},${STORY_STATUS.FUTURE}`,
+    value: PUBLISHED_AND_FUTURE,
     status: STORY_STATUS.PUBLISHED_AND_FUTURE,
   },
 ];

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -100,13 +100,15 @@ export const STORY_SORT_MENU_ITEMS = [
 ];
 
 export const STORY_STATUS = {
-  ALL: 'publish,draft',
-  PUBLISHED: 'publish',
+  ALL: 'publish,draft,future',
+  PUBLISHED_AND_FUTURE: 'publish,future',
   DRAFT: 'draft',
+  FUTURE: 'future',
+  PUBLISH: 'publish',
 };
 
 export const STORY_ITEM_CENTER_ACTION_LABELS = {
-  [STORY_STATUS.PUBLISHED]: __('View', 'web-stories'),
+  [STORY_STATUS.PUBLISHED_AND_FUTURE]: __('View', 'web-stories'),
   [STORY_STATUS.DRAFT]: __('Preview', 'web-stories'),
 };
 
@@ -123,15 +125,18 @@ export const STORY_STATUSES = [
   },
   {
     label: __('Published', 'web-stories'),
-    value: STORY_STATUS.PUBLISHED,
-    status: STORY_STATUS.PUBLISHED,
+    value: `${STORY_STATUS.PUBLISH},${STORY_STATUS.FUTURE}`,
+    status: STORY_STATUS.PUBLISH,
   },
 ];
 
 export const STORY_VIEWING_LABELS = {
   [STORY_STATUS.ALL]: __('Viewing all stories', 'web-stories'),
   [STORY_STATUS.DRAFT]: __('Viewing drafts', 'web-stories'),
-  [STORY_STATUS.PUBLISHED]: __('Viewing published stories', 'web-stories'),
+  [STORY_STATUS.PUBLISHED_AND_FUTURE]: __(
+    'Viewing published stories',
+    'web-stories'
+  ),
 };
 
 export const STORY_PAGE_STATE = {

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -126,7 +126,7 @@ export const STORY_STATUSES = [
   },
   {
     label: __('Published', 'web-stories'),
-    value: PUBLISHED_AND_FUTURE,
+    value: STORY_STATUS.PUBLISHED_AND_FUTURE,
     status: STORY_STATUS.PUBLISHED_AND_FUTURE,
   },
 ];

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -108,7 +108,8 @@ export const STORY_STATUS = {
 };
 
 export const STORY_ITEM_CENTER_ACTION_LABELS = {
-  [STORY_STATUS.PUBLISHED_AND_FUTURE]: __('View', 'web-stories'),
+  [STORY_STATUS.PUBLISH]: __('View', 'web-stories'),
+  [STORY_STATUS.FUTURE]: __('View', 'web-stories'),
   [STORY_STATUS.DRAFT]: __('Preview', 'web-stories'),
 };
 
@@ -126,7 +127,7 @@ export const STORY_STATUSES = [
   {
     label: __('Published', 'web-stories'),
     value: `${STORY_STATUS.PUBLISH},${STORY_STATUS.FUTURE}`,
-    status: STORY_STATUS.PUBLISH,
+    status: STORY_STATUS.PUBLISHED_AND_FUTURE,
   },
 ];
 

--- a/assets/src/dashboard/utils/test/useDashboardResultsLabel.js
+++ b/assets/src/dashboard/utils/test/useDashboardResultsLabel.js
@@ -77,13 +77,15 @@ describe('useGenericResultsLabel()', function () {
     const { result } = renderHook(
       () =>
         useDashboardResultsLabel({
-          currentFilter: STORY_STATUS.PUBLISHED,
+          currentFilter: STORY_STATUS.PUBLISHED_AND_FUTURE,
           view: DASHBOARD_VIEWS.MY_STORIES,
         }),
       {}
     );
     expect(result.current).toBe(
-      RESULT_LABELS[DASHBOARD_VIEWS.MY_STORIES][STORY_STATUS.PUBLISHED]
+      RESULT_LABELS[DASHBOARD_VIEWS.MY_STORIES][
+        STORY_STATUS.PUBLISHED_AND_FUTURE
+      ]
     );
   });
 
@@ -93,7 +95,7 @@ describe('useGenericResultsLabel()', function () {
         useDashboardResultsLabel({
           isActiveSearch: true,
           totalResults: 4,
-          currentFilter: STORY_STATUS.PUBLISHED,
+          currentFilter: STORY_STATUS.PUBLISHED_AND_FUTURE,
           view: DASHBOARD_VIEWS.MY_STORIES,
         }),
       {}
@@ -107,7 +109,7 @@ describe('useGenericResultsLabel()', function () {
         useDashboardResultsLabel({
           isActiveSearch: true,
           totalResults: 1,
-          currentFilter: STORY_STATUS.PUBLISHED,
+          currentFilter: STORY_STATUS.PUBLISHED_AND_FUTURE,
           view: DASHBOARD_VIEWS.MY_STORIES,
         }),
       {}
@@ -121,7 +123,7 @@ describe('useGenericResultsLabel()', function () {
         useDashboardResultsLabel({
           isActiveSearch: true,
           totalResults: 0,
-          currentFilter: STORY_STATUS.PUBLISHED,
+          currentFilter: STORY_STATUS.PUBLISHED_AND_FUTURE,
           view: DASHBOARD_VIEWS.MY_STORIES,
         }),
       {}

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -124,7 +124,7 @@ class Dashboard {
 		$preload_paths = [
 			'/web-stories/v1/fonts',
 			'/wp/v2/settings',
-			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=publish%2Cdraft&_web_stories_envelope=true',
+			'/wp/v2/web-story?context=edit&order=desc&orderby=modified&page=1&per_page=24&status=publish%2Cdraft%2future&_web_stories_envelope=true',
 		];
 
 		/**

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -301,8 +301,8 @@ class Stories_Controller extends Stories_Base_Controller {
 
 		// Add counts for other statuses.
 		$statuses = [
-			'all'     => [ 'publish', 'draft' ],
-			'publish' => 'publish',
+			'all'     => [ 'publish', 'draft', 'future' ],
+			'publish' => [ 'publish', 'future' ],
 			'draft'   => 'draft',
 		];
 

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -303,7 +303,7 @@ class Stories_Controller extends Stories_Base_Controller {
 		$statuses = [
 			'all'     => [ 'publish', 'draft', 'future' ],
 			'publish' => [ 'publish' ],
-			'future' => [ 'future' ],
+			'future'  => [ 'future' ],
 			'draft'   => 'draft',
 		];
 

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -302,8 +302,8 @@ class Stories_Controller extends Stories_Base_Controller {
 		// Add counts for other statuses.
 		$statuses = [
 			'all'     => [ 'publish', 'draft', 'future' ],
-			'publish' => [ 'publish' ],
-			'future'  => [ 'future' ],
+			'publish' => 'publish',
+			'future'  => 'future',
 			'draft'   => 'draft',
 		];
 

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -302,7 +302,8 @@ class Stories_Controller extends Stories_Base_Controller {
 		// Add counts for other statuses.
 		$statuses = [
 			'all'     => [ 'publish', 'draft', 'future' ],
-			'publish' => [ 'publish', 'future' ],
+			'publish' => [ 'publish' ],
+			'future' => [ 'future' ],
 			'draft'   => 'draft',
 		];
 

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -72,6 +72,18 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 			]
 		);
 
+		$future_date = strtotime( '+1 day' );
+
+		$factory->post->create_many(
+			3,
+			[
+				'post_status' => 'future',
+				'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date ),
+				'post_author' => self::$user_id,
+				'post_type'   => $post_type,
+			]
+		);
+
 		$factory->post->create_many(
 			2,
 			[

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -78,7 +78,7 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 			3,
 			[
 				'post_status' => 'future',
-				'post_date'    => strftime( '%Y-%m-%d %H:%M:%S', $future_date ),
+				'post_date'   => strftime( '%Y-%m-%d %H:%M:%S', $future_date ),
 				'post_author' => self::$user_id,
 				'post_type'   => $post_type,
 			]

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -163,8 +163,8 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$this->assertArrayHasKey( 'publish', $statues_decode );
 		$this->assertArrayHasKey( 'draft', $statues_decode );
 
-		$this->assertEquals( 10, $statues_decode['all'] );
-		$this->assertEquals( 7, $statues_decode['publish'] );
+		$this->assertEquals( 13, $statues_decode['all'] );
+		$this->assertEquals( 10, $statues_decode['publish'] );
 		$this->assertEquals( 3, $statues_decode['draft'] );
 
 		$this->assertEquals( 3, $headers['X-WP-Total'] );

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -164,7 +164,8 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		$this->assertArrayHasKey( 'draft', $statues_decode );
 
 		$this->assertEquals( 13, $statues_decode['all'] );
-		$this->assertEquals( 10, $statues_decode['publish'] );
+		$this->assertEquals( 7, $statues_decode['publish'] );
+		$this->assertEquals( 3, $statues_decode['future'] );
 		$this->assertEquals( 3, $statues_decode['draft'] );
 
 		$this->assertEquals( 3, $headers['X-WP-Total'] );


### PR DESCRIPTION
## Summary
Account for scheduled stories that are set to be published at a future time. 

## Relevant Technical Choices
- We weren't accounting for status type `future` in our requests for story data
- The actual update to solve this bug is all in the constants/stories file, we were using `STORY_STATUS.PUBLISHED` for everything related to `status=publish` but that blows up when it needs to be status of `publish` or `future` so I updated the constants to be more flexible. The other updates in dashboard are all to play catch up on text that shows when something is published and test updates. (Dillon's work with Karma made this update so much easier) 
- Updated the response header to include future statuses to keep our counts accurate. 

## To-do
- N/A

## User-facing changes
- If you schedule a story to publish at a future date it should now show up in the dashboard 
- If the story is scheduled its modifier on the story title area should say 'scheduled' 

## Testing Instructions
- Verify that scheduled stories show up in grid and list views 
- Regression testing on display text of header toggle buttons, the count area that says `Viewing all stories` or `Viewing published stories`, the modifiers on the card titles should say 'published' for published stories and I added in 'scheduled' for future statuses. 

---

<!-- Please reference the issue(s) this PR addresses. -->

addresses #2951 
