### PR TITLE
Fix/Simplify `replace_editor` filter

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -222,21 +222,19 @@ class Story_Post_Type {
 	}
 
 	/**
-	 * Highjack editor with custom editor.
+	 * Replace default post editor with our own implementation.
+	 *
+	 * @codeCoverageIgnore
 	 *
 	 * @param bool    $replace Bool if to replace editor or not.
 	 * @param WP_Post $post    Current post object.
 	 *
-	 * @return bool
+	 * @return bool Whether the editor has been replaced.
 	 */
 	public function replace_editor( $replace, $post ) {
 		if ( self::POST_TYPE_SLUG === get_post_type( $post ) ) {
-			$replace = true;
-			// In lieu of an action being available to actually load the replacement editor, include it here
-			// after the current_screen action has occurred because the replace_editor filter fires twice.
-			if ( did_action( 'current_screen' ) ) {
-				require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/admin/edit-story.php';
-			}
+			require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/admin/edit-story.php';
+			return true;
 		}
 
 		return $replace;

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -64,15 +64,6 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		);
 	}
 
-	public function setUp() {
-		parent::setUp();
-
-		do_action( 'init' );
-
-		// Registered during init.
-		unregister_block_type( 'web-stories/embed' );
-	}
-
 	/**
 	 * @covers ::init
 	 */
@@ -210,7 +201,6 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		$skip_amp         = $post_type_object->skip_amp( true, get_post( self::$story_id ) );
 		$this->assertTrue( $skip_amp );
 	}
-
 
 	/**
 	 * @covers ::filter_template_include

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -221,13 +221,4 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		$show_admin_bar   = $post_type_object->show_admin_bar( 'current' );
 		$this->assertFalse( $show_admin_bar );
 	}
-
-	/**
-	 * @covers ::replace_editor
-	 */
-	public function test_replace_editor() {
-		$post_type_object = new \Google\Web_Stories\Story_Post_Type();
-		$replace_editor   = $post_type_object->replace_editor( false, get_post( self::$story_id ) );
-		$this->assertTrue( $replace_editor );
-	}
 }


### PR DESCRIPTION
## Summary

I just stumbled over this while working on the Yoast SEO integration and realized that the doc block was not really accurate and that the `replace_editor` function can be simplified.

With this change applied I haven't encountered any issues so far.

## Relevant Technical Choices

* Removes unnecessary `did_action( 'current_screen' )` check.
* Removes `test_replace_editor` test because the `replace_editor` method does a `require_once` call which we cannot really test.
* Exempts `replace_editor` from code coverage because of it.
* Removes unnecessary `setUp` method from test because it is not needed. Tests still pass.


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None.

## Testing Instructions

See if the editor still works.
