### PR TITLE
Build Tool: Update version number in plugin header for pre-releases

### DIFF
--- a/bin/utils/test/updateVersionNumbers.js
+++ b/bin/utils/test/updateVersionNumbers.js
@@ -89,14 +89,29 @@ describe('updateVersionNumbers', () => {
     expect(readme).toContain('Stable tag:        7.8.9');
   });
 
-  it('should not update plugin headeer for pre-release', () => {
+  it('should update plugin header for pre-release', () => {
     updateVersionNumbers('/foo/plugin.php', '/foo/readme.txt', '7.8.9-alpha');
+    const pluginFile = readFileSync('/foo/plugin.php');
+
+    expect(pluginFile).toContain('* Version: 7.8.9-alpha');
+    expect(pluginFile).toContain(
+      `define( 'WEBSTORIES_VERSION', '7.8.9-alpha' );`
+    );
+  });
+
+  it('should not update plugin header for nightly build', () => {
+    updateVersionNumbers(
+      '/foo/plugin.php',
+      '/foo/readme.txt',
+      '1.0.0-alpha',
+      true
+    );
     const pluginFile = readFileSync('/foo/plugin.php');
 
     expect(pluginFile).toContain('* Version: 1.0.0');
     expect(pluginFile).not.toContain('* Version: 7.8.9-alpha');
     expect(pluginFile).toContain(
-      `define( 'WEBSTORIES_VERSION', '7.8.9-alpha' );`
+      `define( 'WEBSTORIES_VERSION', '1.0.0-alpha+1234567' );`
     );
   });
 

--- a/bin/utils/updateVersionNumbers.js
+++ b/bin/utils/updateVersionNumbers.js
@@ -55,7 +55,7 @@ function updateVersionNumbers(
 
   const isPrerelease = version.includes('-') || nightly;
 
-  if (!isPrerelease) {
+  if (!nightly) {
     // 'Version' plugin header must not include anything else beyond the version number,
     // i.e. no suffixes or similar.
     pluginFileContent = pluginFileContent.replace(
@@ -66,15 +66,11 @@ function updateVersionNumbers(
 
   const newVersion = nightly ? appendRevisionToVersion(version) : version;
 
-  const versionConstant = pluginFileContent.match(VERSION_CONSTANT_REGEX);
+  pluginFileContent = pluginFileContent.replace(VERSION_CONSTANT_REGEX, () => {
+    return `define( 'WEBSTORIES_VERSION', '${newVersion}' );`;
+  });
 
-  writeFileSync(
-    pluginFile,
-    pluginFileContent.replace(
-      versionConstant[0],
-      `define( 'WEBSTORIES_VERSION', '${newVersion}' );`
-    )
-  );
+  writeFileSync(pluginFile, pluginFileContent);
 
   // Update Stable tag in readme.txt if it's not a pre-release.
   if (!isPrerelease) {


### PR DESCRIPTION
## Summary

When running `npm run workflow:version 1.0.0-beta.2`, the build tool currently only updates the `WEBSTORIES_VERSION` constant, but not the `Version` field in the plugin header in `web-stories.php`.

That means when visiting `wp-admin/plugins.php` you will still see the old version number (i.e. `1.0.0-beta.1` right now) instead of the actual version number.

So when

## Relevant Technical Choices

Changes `updateVersionNumbers` so that the plugin header will be updated for pre-releases.

The plugin header won't be updated when passing the `--nightly` flag though.

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

Run `npm run workflow:version 1.0.0-beta.999` and verify that the plugin header is updated.
