### PR TITLE
Dashboard: First half of Travel template animated

### DIFF
--- a/assets/src/dashboard/templates/raw/travel.json
+++ b/assets/src/dashboard/templates/raw/travel.json
@@ -21,7 +21,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page1_bg.jpg",
             "width": 220,
             "height": 147,
             "poster": "",
@@ -30,99 +30,7 @@
             "title": "travel_page1_bg",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page1_bg-300x200.jpg",
-                "width": 300,
-                "height": 200,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-300x200.jpg"
-              },
-              "large": {
-                "file": "travel_page1_bg-1024x683.jpg",
-                "width": 1024,
-                "height": 683,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-1024x683.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page1_bg-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page1_bg-768x512.jpg",
-                "width": 768,
-                "height": 512,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-768x512.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page1_bg-1536x1024.jpg",
-                "width": 1536,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-1536x1024.jpg"
-              },
-              "2048x2048": {
-                "file": "travel_page1_bg-2048x1365.jpg",
-                "width": 2048,
-                "height": 1365,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-2048x1365.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page1_bg-1200x800.jpg",
-                "width": 1200,
-                "height": 800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-1200x800.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "travel_page1_bg-1980x1320.jpg",
-                "width": 1980,
-                "height": 1320,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-1980x1320.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page1_bg-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page1_bg-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page1_bg-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page1_bg-150x100.jpg",
-                "width": 150,
-                "height": 100,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg-150x100.jpg"
-              },
-              "full": {
-                "file": "travel_page1_bg.jpg",
-                "width": 2400,
-                "height": 1600,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page1_bg.jpg"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -141,9 +49,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Playfair Display",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -181,9 +87,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -255,7 +159,7 @@
             "type": "image",
             "mimeType": "image/png",
             "creationDate": "2020-06-17T21:30:34",
-            "src": "http://localhost:8899/wp-content/uploads/2020/06/travel_icon_logo.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_icon_logo.png",
             "width": 32,
             "height": 10,
             "posterId": 0,
@@ -277,6 +181,92 @@
             "ratio": 1
           },
           "id": "a6b25c2c-a676-404b-ab44-5bd5b49598f5"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "type": "shape",
+          "x": 412,
+          "y": -57,
+          "width": 412,
+          "height": 246,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "id": "cfa7515e-1238-4be7-ab33-3657543f7b87"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "type": "shape",
+          "width": 412,
+          "height": 246,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "cfa7515e-1238-4be7-ab33-3657543f7b87",
+          "id": "187db729-f157-4714-8ef0-a2951894e5c5",
+          "x": 412,
+          "y": 186
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "type": "shape",
+          "width": 412,
+          "height": 246,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "187db729-f157-4714-8ef0-a2951894e5c5",
+          "id": "e7e33f6b-d3d1-443a-bdc4-ef55adbf7fd2",
+          "x": 411,
+          "y": 430
         }
       ],
       "type": "page",
@@ -310,7 +300,161 @@
           "b": 255,
           "a": 1
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "zoom",
+          "zoomFrom": 1.1,
+          "zoomTo": 1,
+          "id": "8ee3cb5c-62a6-400b-86c4-ea77d19a01b9",
+          "duration": 5000,
+          "delay": 1000,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["ca140433-52d1-4423-896f-2e5c856cb22f"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 1.8,
+          "zoomTo": 1.1,
+          "id": "14b685f2-a08c-4b53-9a81-887af745b5ac",
+          "duration": 1000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["ca140433-52d1-4423-896f-2e5c856cb22f"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-100%",
+          "offsetY": 0,
+          "id": "cff193c4-5154-4c1e-a34b-cef341cf26ee",
+          "duration": 1000,
+          "delay": 200,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["7de325ef-2490-4e19-9c9c-7031bffa4b05"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": "100%",
+          "offsetY": 0,
+          "id": "ab0e2980-bef4-40dd-aa6b-00df41367924",
+          "duration": 1000,
+          "delay": 200,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["7de325ef-2490-4e19-9c9c-7031bffa4b05"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-100%",
+          "offsetY": 0,
+          "id": "af986e07-85b8-4014-9e5d-2b53afd4b2e8",
+          "duration": 300,
+          "delay": 625,
+          "direction": "normal",
+          "easingPreset": "outSine",
+          "fill": "both",
+          "targets": ["a6b25c2c-a676-404b-ab44-5bd5b49598f5"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": "100%",
+          "offsetY": 0,
+          "id": "a3551f64-c85b-4ae5-8e24-1312163696be",
+          "duration": 300,
+          "delay": 625,
+          "direction": "normal",
+          "easingPreset": "outSine",
+          "fill": "both",
+          "targets": ["a6b25c2c-a676-404b-ab44-5bd5b49598f5"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": 0,
+          "offsetY": "100%",
+          "id": "b5fd81bc-bb72-49d2-b141-3822ec246c50",
+          "duration": 300,
+          "delay": 775,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["d5ca2488-668b-4e21-a7d8-05c17084742b"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 2,
+          "zoomTo": 1,
+          "id": "ec85ac18-343b-4f7e-8a49-cff091eb97fa",
+          "duration": 500,
+          "delay": 900,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["3c00f665-e2ff-4393-aef4-6ca790f599fd"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "a8a4e82a-dce9-42ce-931e-3887915f75f9",
+          "duration": 500,
+          "delay": 900,
+          "direction": "normal",
+          "easingPreset": "inQuart",
+          "fill": "both",
+          "targets": ["3c00f665-e2ff-4393-aef4-6ca790f599fd"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-100%",
+          "offsetY": 0,
+          "id": "394de079-9006-4c5a-ab04-6c9c2beaa793",
+          "duration": 1000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["cfa7515e-1238-4be7-ab33-3657543f7b87"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-100%",
+          "offsetY": 0,
+          "id": "764b9090-8bb5-44d9-9cf8-86ea597b4f0e",
+          "duration": 1000,
+          "delay": 100,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["187db729-f157-4714-8ef0-a2951894e5c5"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-100%",
+          "offsetY": 0,
+          "id": "bdb8564a-c559-4dd3-9ab6-35bf4f5a76ac",
+          "duration": 1000,
+          "delay": 200,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["e7e33f6b-d3d1-443a-bdc4-ef55adbf7fd2"]
+        }
+      ]
     },
     {
       "elements": [
@@ -375,9 +519,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -415,9 +557,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -455,9 +595,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Lora",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -516,7 +654,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page2_image1.jpg",
             "width": 220,
             "height": 331,
             "poster": "",
@@ -525,99 +663,7 @@
             "title": "travel_page2_image1",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page2_image1-199x300.jpg",
-                "width": 199,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-199x300.jpg"
-              },
-              "large": {
-                "file": "travel_page2_image1-680x1024.jpg",
-                "width": 680,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-680x1024.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page2_image1-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page2_image1-768x1156.jpg",
-                "width": 768,
-                "height": 1156,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-768x1156.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page2_image1-1020x1536.jpg",
-                "width": 1020,
-                "height": 1536,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-1020x1536.jpg"
-              },
-              "2048x2048": {
-                "file": "travel_page2_image1-1360x2048.jpg",
-                "width": 1360,
-                "height": 2048,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-1360x2048.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page2_image1-1200x1807.jpg",
-                "width": 1200,
-                "height": 1807,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-1200x1807.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "travel_page2_image1-1980x2981.jpg",
-                "width": 1980,
-                "height": 2981,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-1980x2981.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page2_image1-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page2_image1-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page2_image1-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page2_image1-150x226.jpg",
-                "width": 150,
-                "height": 226,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-150x226.jpg"
-              },
-              "full": {
-                "file": "travel_page2_image1-scaled.jpg",
-                "width": 1701,
-                "height": 2560,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page2_image1-scaled.jpg"
-              }
-            }
+            "sizes": []
           }
         }
       ],
@@ -629,7 +675,87 @@
           "g": 255,
           "b": 255
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "-100%",
+          "offsetY": "0",
+          "id": "b26fd356-c198-4442-be43-7f21245c07d2",
+          "duration": 800,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["8a21c4e7-4e9b-4811-9b8b-f36d0297a9e4"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 3,
+          "zoomTo": 1,
+          "id": "b6b7e67a-f024-4e72-ae20-29df37de5eb3",
+          "duration": 800,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["8a21c4e7-4e9b-4811-9b8b-f36d0297a9e4"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "35%",
+          "id": "addd659b-22f5-42b0-b598-d753266da6b0",
+          "duration": 600,
+          "delay": 500,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": [
+            "bfd53cf2-f8e8-41f0-8449-48772b5194bb",
+            "90e3970e-a7be-4ecb-91a6-4f6065f28de1"
+          ]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "63a8dd09-fce2-4231-bf05-8310312c52b8",
+          "duration": 600,
+          "delay": 500,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["bfd53cf2-f8e8-41f0-8449-48772b5194bb"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "64648979-ec76-4ab0-abf5-874b238d948c",
+          "duration": 300,
+          "delay": 800,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["90e3970e-a7be-4ecb-91a6-4f6065f28de1"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": 0,
+          "offsetY": "100%",
+          "id": "24373715-0940-4b9c-b234-c9de3790c108",
+          "duration": 500,
+          "delay": 800,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["88df74ed-7334-4e91-957c-c48b8da344e4"]
+        }
+      ]
     },
     {
       "elements": [
@@ -688,7 +814,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page3_image1.jpg",
             "width": 220,
             "height": 275,
             "poster": "",
@@ -697,92 +823,7 @@
             "title": "travel_page3_image1",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page3_image1-240x300.jpg",
-                "width": 240,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-240x300.jpg"
-              },
-              "large": {
-                "file": "travel_page3_image1-819x1024.jpg",
-                "width": 819,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-819x1024.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page3_image1-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page3_image1-768x960.jpg",
-                "width": 768,
-                "height": 960,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-768x960.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page3_image1-1229x1536.jpg",
-                "width": 1229,
-                "height": 1536,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-1229x1536.jpg"
-              },
-              "2048x2048": {
-                "file": "travel_page3_image1-1638x2048.jpg",
-                "width": 1638,
-                "height": 2048,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-1638x2048.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page3_image1-1200x1500.jpg",
-                "width": 1200,
-                "height": 1500,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-1200x1500.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page3_image1-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page3_image1-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page3_image1-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page3_image1-150x188.jpg",
-                "width": 150,
-                "height": 188,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1-150x188.jpg"
-              },
-              "full": {
-                "file": "travel_page3_image1.jpg",
-                "width": 1920,
-                "height": 2400,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page3_image1.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -821,9 +862,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -861,9 +900,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Lora",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -901,9 +938,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -942,7 +977,122 @@
           "g": 255,
           "b": 255
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "100%",
+          "offsetY": "-100%",
+          "id": "3b26b562-b0cb-45d6-88d4-5bc16c95fa86",
+          "duration": 800,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["4c694857-df14-4ba9-8791-9b13935dbbbe"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 3,
+          "zoomTo": 1,
+          "id": "5cac8bdc-152a-4180-a0a3-dbba12c72c61",
+          "duration": 800,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["4c694857-df14-4ba9-8791-9b13935dbbbe"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "30%",
+          "id": "467ba339-3201-41d1-a912-0f74b3d64e23",
+          "duration": 600,
+          "delay": 400,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["6258d646-a291-498f-81ab-3095f352bb26"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "3eb085d0-43cf-4209-bcd0-281cc24d860d",
+          "duration": 600,
+          "delay": 400,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["6258d646-a291-498f-81ab-3095f352bb26"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "0",
+          "offsetY": "30%",
+          "id": "459e6d08-f1e2-492a-b0da-e66d9a4330dd",
+          "duration": 600,
+          "delay": 500,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["883808f1-b87b-4b35-b0f1-0945e0faef2e"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "d7c10ebd-5aa9-4603-9343-36ce18bc48eb",
+          "duration": 600,
+          "delay": 500,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["883808f1-b87b-4b35-b0f1-0945e0faef2e"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "-100%",
+          "id": "97fee6dc-d747-49af-8e2a-df2494276647",
+          "duration": 600,
+          "delay": 700,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["6e549d8a-d851-45c5-b168-f3e681261bab"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": 0,
+          "offsetY": "100%",
+          "id": "fa3b8dcb-8c98-42e0-96ef-5e03d14ff3ee",
+          "duration": 600,
+          "delay": 700,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["6e549d8a-d851-45c5-b168-f3e681261bab"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "b9fba506-e0bd-451a-a08c-e896aeabbe72",
+          "duration": 300,
+          "delay": 1000,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["3cf17fb8-a5ae-4f32-8e5f-d3a0513215de"]
+        }
+      ]
     },
     {
       "elements": [
@@ -964,7 +1114,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page4_bg.jpg",
             "width": 220,
             "height": 147,
             "poster": "",
@@ -973,99 +1123,7 @@
             "title": "travel_page4_bg",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page4_bg-300x200.jpg",
-                "width": 300,
-                "height": 200,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-300x200.jpg"
-              },
-              "large": {
-                "file": "travel_page4_bg-1024x683.jpg",
-                "width": 1024,
-                "height": 683,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-1024x683.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page4_bg-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page4_bg-768x512.jpg",
-                "width": 768,
-                "height": 512,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-768x512.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page4_bg-1536x1024.jpg",
-                "width": 1536,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-1536x1024.jpg"
-              },
-              "2048x2048": {
-                "file": "travel_page4_bg-2048x1365.jpg",
-                "width": 2048,
-                "height": 1365,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-2048x1365.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page4_bg-1200x800.jpg",
-                "width": 1200,
-                "height": 800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-1200x800.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "travel_page4_bg-1980x1320.jpg",
-                "width": 1980,
-                "height": 1320,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-1980x1320.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page4_bg-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page4_bg-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page4_bg-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page4_bg-150x100.jpg",
-                "width": 150,
-                "height": 100,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg-150x100.jpg"
-              },
-              "full": {
-                "file": "travel_page4_bg.jpg",
-                "width": 2400,
-                "height": 1600,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page4_bg.jpg"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -1111,9 +1169,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -1151,9 +1207,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Lora",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -1215,7 +1269,83 @@
           "b": 255,
           "a": 1
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "zoom",
+          "zoomFrom": 1.8,
+          "zoomTo": 1.1,
+          "id": "8ee3cb5c-62a6-400b-86c4-ea77d19a01b9",
+          "duration": 800,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["a920881d-6fab-4d96-8884-0df9f0b6a8fd"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 1,
+          "zoomTo": 0.91,
+          "id": "2308e8fe-febc-47ba-84e6-637944e516d6",
+          "duration": 6000,
+          "delay": 800,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": ["a920881d-6fab-4d96-8884-0df9f0b6a8fd"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "-100%",
+          "id": "26df4534-c53d-44c9-936c-4275bc3a0cd3",
+          "duration": 800,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["3d3b38a3-d8db-4a86-a4e2-0be30e92b177"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": 0,
+          "offsetY": "100%",
+          "id": "97ca74ea-431e-477f-9f30-39d91b9fbcb3",
+          "duration": 800,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["3d3b38a3-d8db-4a86-a4e2-0be30e92b177"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "73226782-d925-4ed9-b151-cf626ee2279c",
+          "duration": 600,
+          "delay": 350,
+          "direction": "normal",
+          "easingPreset": "outCubic",
+          "fill": "both",
+          "targets": ["1b892512-7510-4c09-a750-7dfd21ece74a"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "836c46b9-c2ff-4b08-af83-f6ce5ceb5147",
+          "duration": 600,
+          "delay": 500,
+          "direction": "normal",
+          "easingPreset": "outCubic",
+          "fill": "both",
+          "targets": ["d773e2ce-05a7-4195-a815-cfd66e93f66a"]
+        }
+      ]
     },
     {
       "elements": [
@@ -1237,7 +1367,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page5_bg.jpg",
             "width": 220,
             "height": 149,
             "poster": "",
@@ -1246,99 +1376,7 @@
             "title": "travel_page5_bg",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page5_bg-300x203.jpg",
-                "width": 300,
-                "height": 203,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-300x203.jpg"
-              },
-              "large": {
-                "file": "travel_page5_bg-1024x693.jpg",
-                "width": 1024,
-                "height": 693,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-1024x693.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page5_bg-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page5_bg-768x520.jpg",
-                "width": 768,
-                "height": 520,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-768x520.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page5_bg-1536x1039.jpg",
-                "width": 1536,
-                "height": 1039,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-1536x1039.jpg"
-              },
-              "2048x2048": {
-                "file": "travel_page5_bg-2048x1386.jpg",
-                "width": 2048,
-                "height": 1386,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-2048x1386.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page5_bg-1200x812.jpg",
-                "width": 1200,
-                "height": 812,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-1200x812.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "travel_page5_bg-1980x1340.jpg",
-                "width": 1980,
-                "height": 1340,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-1980x1340.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page5_bg-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page5_bg-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page5_bg-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page5_bg-150x102.jpg",
-                "width": 150,
-                "height": 102,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg-150x102.jpg"
-              },
-              "full": {
-                "file": "travel_page5_bg.jpg",
-                "width": 2400,
-                "height": 1624,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page5_bg.jpg"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -1351,15 +1389,13 @@
         },
         {
           "x": 103,
-          "y": 33,
+          "y": 13,
           "width": 206,
           "height": 42,
           "font": {
             "service": "fonts.google.com",
             "family": "Playfair Display",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -1391,15 +1427,13 @@
         },
         {
           "x": 0,
-          "y": 78,
+          "y": 58,
           "width": 411,
           "height": 98,
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -1437,9 +1471,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Lora",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -1501,7 +1533,111 @@
           "b": 255,
           "a": 1
         }
-      }
+      },
+      "animations": [
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": "25%",
+          "offsetY": "50%",
+          "id": "7f51ec50-918c-469b-b1ea-dde8b69a44b7",
+          "duration": 1000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["3b0ede46-334e-4bc5-abb7-f09dec3d6d48"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 2,
+          "zoomTo": 1.1,
+          "id": "6609ddb8-c2a4-46b4-803d-03fb75c3a07e",
+          "duration": 1000,
+          "delay": 0,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["3b0ede46-334e-4bc5-abb7-f09dec3d6d48"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 1,
+          "zoomTo": 0.91,
+          "id": "97db7f65-a66d-4257-b47a-a50d74e84067",
+          "duration": 6000,
+          "delay": 1000,
+          "direction": "normal",
+          "easingPreset": "linear",
+          "fill": "both",
+          "targets": [
+            "3b0ede46-334e-4bc5-abb7-f09dec3d6d48",
+            "95c08a42-48cd-4112-b0e2-f24362adc7bc"
+          ]
+        },
+        {
+          "type": "move",
+          "overflowHidden": true,
+          "offsetX": 0,
+          "offsetY": "100%",
+          "id": "8a386dc9-772c-470c-b52c-21a7d21e626a",
+          "duration": 600,
+          "delay": 100,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["65283dae-40f2-4ace-8b0a-0d9f2066a38a"]
+        },
+        {
+          "type": "zoom",
+          "zoomFrom": 3,
+          "zoomTo": 1.1,
+          "id": "d0e21379-5dd9-4efb-a46e-177f3ade2073",
+          "duration": 700,
+          "delay": 300,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["95c08a42-48cd-4112-b0e2-f24362adc7bc"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "dba3f937-00b6-47ba-b34e-668385551400",
+          "duration": 700,
+          "delay": 300,
+          "direction": "normal",
+          "easingPreset": "inOutQuad",
+          "fill": "both",
+          "targets": ["95c08a42-48cd-4112-b0e2-f24362adc7bc"]
+        },
+        {
+          "type": "move",
+          "overflowHidden": false,
+          "offsetX": 0,
+          "offsetY": "50%",
+          "id": "14b685f2-a08c-4b53-9a81-887af745b5ac",
+          "duration": 600,
+          "delay": 900,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["7dae1bd9-9f88-4ae8-93eb-f3d908cace09"]
+        },
+        {
+          "type": "fade",
+          "fadeFrom": 0,
+          "fadeTo": 1,
+          "id": "27c8b2b7-3872-44f9-9efd-bb68b90af5c5",
+          "duration": 600,
+          "delay": 900,
+          "direction": "normal",
+          "easingPreset": "inOutCubic",
+          "fill": "both",
+          "targets": ["7dae1bd9-9f88-4ae8-93eb-f3d908cace09"]
+        }
+      ]
     },
     {
       "elements": [
@@ -1523,7 +1659,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page6_bg.jpg",
             "width": 220,
             "height": 124,
             "poster": "",
@@ -1532,99 +1668,7 @@
             "title": "travel_page6_bg",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page6_bg-300x169.jpg",
-                "width": 300,
-                "height": 169,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-300x169.jpg"
-              },
-              "large": {
-                "file": "travel_page6_bg-1024x576.jpg",
-                "width": 1024,
-                "height": 576,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-1024x576.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page6_bg-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page6_bg-768x432.jpg",
-                "width": 768,
-                "height": 432,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-768x432.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page6_bg-1536x864.jpg",
-                "width": 1536,
-                "height": 864,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-1536x864.jpg"
-              },
-              "2048x2048": {
-                "file": "travel_page6_bg-2048x1152.jpg",
-                "width": 2048,
-                "height": 1152,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-2048x1152.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page6_bg-1200x675.jpg",
-                "width": 1200,
-                "height": 675,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-1200x675.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "travel_page6_bg-1980x1114.jpg",
-                "width": 1980,
-                "height": 1114,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-1980x1114.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page6_bg-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page6_bg-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page6_bg-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page6_bg-150x84.jpg",
-                "width": 150,
-                "height": 84,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg-150x84.jpg"
-              },
-              "full": {
-                "file": "travel_page6_bg.jpg",
-                "width": 2400,
-                "height": 1350,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_bg.jpg"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -1643,9 +1687,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -1683,11 +1725,7 @@
           "font": {
             "service": "system",
             "family": "Arial",
-            "fallbacks": [
-              "Helvetica Neue",
-              "Helvetica",
-              "sans-serif"
-            ]
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -1789,7 +1827,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_image1.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page6_image1.png",
             "width": 220,
             "height": 371,
             "poster": "",
@@ -1798,43 +1836,7 @@
             "title": "travel_page6_image1",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page6_image1-178x300.png",
-                "width": 178,
-                "height": 300,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_image1-178x300.png"
-              },
-              "thumbnail": {
-                "file": "travel_page6_image1-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_image1-150x150.png"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page6_image1-464x696.png",
-                "width": 464,
-                "height": 696,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_image1-464x696.png"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page6_image1-150x253.png",
-                "width": 150,
-                "height": 253,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_image1-150x253.png"
-              },
-              "full": {
-                "file": "travel_page6_image1.png",
-                "width": 464,
-                "height": 782,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page6_image1.png"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -1942,9 +1944,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -1983,9 +1983,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2024,9 +2022,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Lora",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2086,7 +2082,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page7_image1.jpg",
             "width": 220,
             "height": 330,
             "poster": "",
@@ -2095,92 +2091,7 @@
             "title": "travel_page7_image1",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page7_image1-200x300.jpg",
-                "width": 200,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-200x300.jpg"
-              },
-              "large": {
-                "file": "travel_page7_image1-683x1024.jpg",
-                "width": 683,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-683x1024.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page7_image1-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page7_image1-768x1152.jpg",
-                "width": 768,
-                "height": 1152,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-768x1152.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page7_image1-1024x1536.jpg",
-                "width": 1024,
-                "height": 1536,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-1024x1536.jpg"
-              },
-              "2048x2048": {
-                "file": "travel_page7_image1-1365x2048.jpg",
-                "width": 1365,
-                "height": 2048,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-1365x2048.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page7_image1-1200x1800.jpg",
-                "width": 1200,
-                "height": 1800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-1200x1800.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page7_image1-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page7_image1-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page7_image1-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page7_image1-150x225.jpg",
-                "width": 150,
-                "height": 225,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-150x225.jpg"
-              },
-              "full": {
-                "file": "travel_page7_image1-scaled.jpg",
-                "width": 1707,
-                "height": 2560,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page7_image1-scaled.jpg"
-              }
-            }
+            "sizes": []
           }
         }
       ],
@@ -2214,7 +2125,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page8_bg.jpg",
             "width": 220,
             "height": 147,
             "poster": "",
@@ -2223,99 +2134,7 @@
             "title": "travel_page8_bg",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page8_bg-300x200.jpg",
-                "width": 300,
-                "height": 200,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-300x200.jpg"
-              },
-              "large": {
-                "file": "travel_page8_bg-1024x683.jpg",
-                "width": 1024,
-                "height": 683,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-1024x683.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page8_bg-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page8_bg-768x512.jpg",
-                "width": 768,
-                "height": 512,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-768x512.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page8_bg-1536x1024.jpg",
-                "width": 1536,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-1536x1024.jpg"
-              },
-              "2048x2048": {
-                "file": "travel_page8_bg-2048x1365.jpg",
-                "width": 2048,
-                "height": 1365,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-2048x1365.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page8_bg-1200x800.jpg",
-                "width": 1200,
-                "height": 800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-1200x800.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "travel_page8_bg-1980x1320.jpg",
-                "width": 1980,
-                "height": 1320,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-1980x1320.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page8_bg-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page8_bg-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page8_bg-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page8_bg-150x100.jpg",
-                "width": 150,
-                "height": 100,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg-150x100.jpg"
-              },
-              "full": {
-                "file": "travel_page8_bg.jpg",
-                "width": 2400,
-                "height": 1600,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page8_bg.jpg"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -2391,9 +2210,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2432,9 +2249,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2473,9 +2288,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Lora",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2576,9 +2389,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2617,9 +2428,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2658,9 +2467,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2699,9 +2506,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2740,9 +2545,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Lora",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2781,9 +2584,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Lora",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2822,9 +2623,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Lora",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -2863,9 +2662,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Lora",
-            "fallbacks": [
-              "serif"
-            ]
+            "fallbacks": ["serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -3008,7 +2805,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page9_image1.jpg",
             "width": 220,
             "height": 165,
             "poster": "",
@@ -3017,99 +2814,7 @@
             "title": "travel_page9_image1",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page9_image1-300x225.jpg",
-                "width": 300,
-                "height": 225,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-300x225.jpg"
-              },
-              "large": {
-                "file": "travel_page9_image1-1024x768.jpg",
-                "width": 1024,
-                "height": 768,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-1024x768.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page9_image1-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page9_image1-768x576.jpg",
-                "width": 768,
-                "height": 576,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-768x576.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page9_image1-1536x1152.jpg",
-                "width": 1536,
-                "height": 1152,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-1536x1152.jpg"
-              },
-              "2048x2048": {
-                "file": "travel_page9_image1-2048x1536.jpg",
-                "width": 2048,
-                "height": 1536,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-2048x1536.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page9_image1-1200x900.jpg",
-                "width": 1200,
-                "height": 900,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-1200x900.jpg"
-              },
-              "twentytwenty-fullscreen": {
-                "file": "travel_page9_image1-1980x1485.jpg",
-                "width": 1980,
-                "height": 1485,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-1980x1485.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page9_image1-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page9_image1-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page9_image1-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page9_image1-150x113.jpg",
-                "width": 150,
-                "height": 113,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-150x113.jpg"
-              },
-              "full": {
-                "file": "travel_page9_image1-scaled.jpg",
-                "width": 2560,
-                "height": 1920,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image1-scaled.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -3142,7 +2847,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page9_image2.jpg",
             "width": 220,
             "height": 124,
             "poster": "",
@@ -3151,85 +2856,7 @@
             "title": "travel_page9_image2",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page9_image2-300x169.jpg",
-                "width": 300,
-                "height": 169,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2-300x169.jpg"
-              },
-              "large": {
-                "file": "travel_page9_image2-1024x576.jpg",
-                "width": 1024,
-                "height": 576,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2-1024x576.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page9_image2-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page9_image2-768x432.jpg",
-                "width": 768,
-                "height": 432,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2-768x432.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page9_image2-1536x864.jpg",
-                "width": 1536,
-                "height": 864,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2-1536x864.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page9_image2-1200x675.jpg",
-                "width": 1200,
-                "height": 675,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2-1200x675.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page9_image2-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page9_image2-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page9_image2-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page9_image2-150x84.jpg",
-                "width": 150,
-                "height": 84,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2-150x84.jpg"
-              },
-              "full": {
-                "file": "travel_page9_image2.jpg",
-                "width": 1920,
-                "height": 1080,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image2.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -3262,7 +2889,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page9_image4.jpg",
             "width": 220,
             "height": 147,
             "poster": "",
@@ -3271,85 +2898,7 @@
             "title": "travel_page9_image4",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page9_image4-300x200.jpg",
-                "width": 300,
-                "height": 200,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4-300x200.jpg"
-              },
-              "large": {
-                "file": "travel_page9_image4-1024x683.jpg",
-                "width": 1024,
-                "height": 683,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4-1024x683.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page9_image4-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page9_image4-768x512.jpg",
-                "width": 768,
-                "height": 512,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4-768x512.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page9_image4-1536x1024.jpg",
-                "width": 1536,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4-1536x1024.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page9_image4-1200x800.jpg",
-                "width": 1200,
-                "height": 800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4-1200x800.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page9_image4-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page9_image4-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page9_image4-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page9_image4-150x100.jpg",
-                "width": 150,
-                "height": 100,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4-150x100.jpg"
-              },
-              "full": {
-                "file": "travel_page9_image4.jpg",
-                "width": 1920,
-                "height": 1280,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image4.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -3382,7 +2931,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page9_image5.jpg",
             "width": 220,
             "height": 330,
             "poster": "",
@@ -3391,92 +2940,7 @@
             "title": "travel_page9_image5",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page9_image5-200x300.jpg",
-                "width": 200,
-                "height": 300,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-200x300.jpg"
-              },
-              "large": {
-                "file": "travel_page9_image5-683x1024.jpg",
-                "width": 683,
-                "height": 1024,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-683x1024.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page9_image5-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page9_image5-768x1152.jpg",
-                "width": 768,
-                "height": 1152,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-768x1152.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page9_image5-1024x1536.jpg",
-                "width": 1024,
-                "height": 1536,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-1024x1536.jpg"
-              },
-              "2048x2048": {
-                "file": "travel_page9_image5-1365x2048.jpg",
-                "width": 1365,
-                "height": 2048,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-1365x2048.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page9_image5-1200x1800.jpg",
-                "width": 1200,
-                "height": 1800,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-1200x1800.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page9_image5-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page9_image5-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page9_image5-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page9_image5-150x225.jpg",
-                "width": 150,
-                "height": 225,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-150x225.jpg"
-              },
-              "full": {
-                "file": "travel_page9_image5-scaled.jpg",
-                "width": 1707,
-                "height": 2560,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page9_image5-scaled.jpg"
-              }
-            }
+            "sizes": []
           }
         }
       ],
@@ -3583,9 +3047,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -3624,9 +3086,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -3665,9 +3125,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 100,
@@ -3706,9 +3164,7 @@
           "font": {
             "service": "fonts.google.com",
             "family": "Oswald",
-            "fallbacks": [
-              "sans-serif"
-            ]
+            "fallbacks": ["sans-serif"]
           },
           "type": "text",
           "opacity": 99,
@@ -3768,7 +3224,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page10_image1.jpg",
             "width": 220,
             "height": 112,
             "poster": "",
@@ -3777,85 +3233,7 @@
             "title": "travel_page10_image1",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page10_image1-300x153.jpg",
-                "width": 300,
-                "height": 153,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1-300x153.jpg"
-              },
-              "large": {
-                "file": "travel_page10_image1-1024x521.jpg",
-                "width": 1024,
-                "height": 521,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1-1024x521.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page10_image1-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page10_image1-768x391.jpg",
-                "width": 768,
-                "height": 391,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1-768x391.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page10_image1-1536x782.jpg",
-                "width": 1536,
-                "height": 782,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1-1536x782.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page10_image1-1200x611.jpg",
-                "width": 1200,
-                "height": 611,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1-1200x611.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page10_image1-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page10_image1-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page10_image1-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page10_image1-150x76.jpg",
-                "width": 150,
-                "height": 76,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1-150x76.jpg"
-              },
-              "full": {
-                "file": "travel_page10_image1.jpg",
-                "width": 1920,
-                "height": 977,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image1.jpg"
-              }
-            }
+            "sizes": []
           }
         },
         {
@@ -3886,7 +3264,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page10_image2.jpg",
             "width": 220,
             "height": 83,
             "poster": "",
@@ -3895,78 +3273,7 @@
             "title": "travel_page10_image2",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page10_image2-300x113.jpg",
-                "width": 300,
-                "height": 113,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2-300x113.jpg"
-              },
-              "large": {
-                "file": "travel_page10_image2-1024x386.jpg",
-                "width": 1024,
-                "height": 386,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2-1024x386.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page10_image2-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page10_image2-768x289.jpg",
-                "width": 768,
-                "height": 289,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2-768x289.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page10_image2-1200x452.jpg",
-                "width": 1200,
-                "height": 452,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2-1200x452.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page10_image2-696x565.jpg",
-                "width": 696,
-                "height": 565,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2-696x565.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page10_image2-928x565.jpg",
-                "width": 928,
-                "height": 565,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2-928x565.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page10_image2-928x565.jpg",
-                "width": 928,
-                "height": 565,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2-928x565.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page10_image2-150x57.jpg",
-                "width": 150,
-                "height": 57,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2-150x57.jpg"
-              },
-              "full": {
-                "file": "travel_page10_image2.jpg",
-                "width": 1499,
-                "height": 565,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image2.jpg"
-              }
-            }
+            "sizes": []
           },
           "basedOn": "85439d79-2100-4dc8-9b20-e6e51d2064af",
           "id": "19fd443d-f580-436b-82b4-ef2938c55e89"
@@ -3999,7 +3306,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/jpeg",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3.jpg",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_page10_image3.jpg",
             "width": 220,
             "height": 124,
             "poster": "",
@@ -4008,85 +3315,7 @@
             "title": "travel_page10_image3",
             "alt": "",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_page10_image3-300x170.jpg",
-                "width": 300,
-                "height": 170,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3-300x170.jpg"
-              },
-              "large": {
-                "file": "travel_page10_image3-1024x579.jpg",
-                "width": 1024,
-                "height": 579,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3-1024x579.jpg"
-              },
-              "thumbnail": {
-                "file": "travel_page10_image3-150x150.jpg",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3-150x150.jpg"
-              },
-              "medium_large": {
-                "file": "travel_page10_image3-768x434.jpg",
-                "width": 768,
-                "height": 434,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3-768x434.jpg"
-              },
-              "1536x1536": {
-                "file": "travel_page10_image3-1536x868.jpg",
-                "width": 1536,
-                "height": 868,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3-1536x868.jpg"
-              },
-              "post-thumbnail": {
-                "file": "travel_page10_image3-1200x678.jpg",
-                "width": 1200,
-                "height": 678,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3-1200x678.jpg"
-              },
-              "web-stories-poster-portrait": {
-                "file": "travel_page10_image3-696x928.jpg",
-                "width": 696,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3-696x928.jpg"
-              },
-              "web-stories-poster-square": {
-                "file": "travel_page10_image3-928x928.jpg",
-                "width": 928,
-                "height": 928,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3-928x928.jpg"
-              },
-              "web-stories-poster-landscape": {
-                "file": "travel_page10_image3-928x696.jpg",
-                "width": 928,
-                "height": 696,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3-928x696.jpg"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_page10_image3-150x85.jpg",
-                "width": 150,
-                "height": 85,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3-150x85.jpg"
-              },
-              "full": {
-                "file": "travel_page10_image3.jpg",
-                "width": 1920,
-                "height": 1085,
-                "mime_type": "image/jpeg",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_page10_image3.jpg"
-              }
-            }
+            "sizes": []
           },
           "basedOn": "19fd443d-f580-436b-82b4-ef2938c55e89",
           "id": "098c9143-7ca0-4b04-866f-02c5c48339d2"
@@ -4110,7 +3339,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_fb.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_icon_fb.png",
             "width": 150,
             "height": 300,
             "posterId": 0,
@@ -4118,36 +3347,7 @@
             "title": "travel_icon_fb",
             "alt": "travel_icon_fb",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_icon_fb-150x300.png",
-                "width": 150,
-                "height": 300,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_fb-150x300.png"
-              },
-              "thumbnail": {
-                "file": "travel_icon_fb-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_fb-150x150.png"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_icon_fb-150x300.png",
-                "width": 150,
-                "height": 300,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_fb-150x300.png"
-              },
-              "full": {
-                "file": "travel_icon_fb.png",
-                "width": 300,
-                "height": 600,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_fb.png"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -4176,7 +3376,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_insta.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_icon_insta.png",
             "width": 150,
             "height": 156,
             "posterId": 0,
@@ -4184,36 +3384,7 @@
             "title": "travel_icon_insta",
             "alt": "travel_icon_insta",
             "local": false,
-            "sizes": {
-              "medium": {
-                "file": "travel_icon_insta-288x300.png",
-                "width": 288,
-                "height": 300,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_insta-288x300.png"
-              },
-              "thumbnail": {
-                "file": "travel_icon_insta-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_insta-150x150.png"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_icon_insta-150x156.png",
-                "width": 150,
-                "height": 156,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_insta-150x156.png"
-              },
-              "full": {
-                "file": "travel_icon_insta.png",
-                "width": 300,
-                "height": 312,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_insta.png"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -4242,7 +3413,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_yt.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_icon_yt.png",
             "width": 150,
             "height": 106,
             "posterId": 0,
@@ -4250,29 +3421,7 @@
             "title": "travel_icon_yt",
             "alt": "travel_icon_yt",
             "local": false,
-            "sizes": {
-              "thumbnail": {
-                "file": "travel_icon_yt-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_yt-150x150.png"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_icon_yt-150x106.png",
-                "width": 150,
-                "height": 106,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_yt-150x106.png"
-              },
-              "full": {
-                "file": "travel_icon_yt.png",
-                "width": 300,
-                "height": 211,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_yt.png"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -4301,7 +3450,7 @@
           "resource": {
             "type": "image",
             "mimeType": "image/png",
-            "src": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_tw.png",
+            "src": "http://localhost:8899/wp-content/plugins/web-stories/assets/images/templates/travel/travel_icon_tw.png",
             "width": 150,
             "height": 121,
             "posterId": 0,
@@ -4309,29 +3458,7 @@
             "title": "travel_icon_tw",
             "alt": "travel_icon_tw",
             "local": false,
-            "sizes": {
-              "thumbnail": {
-                "file": "travel_icon_tw-150x150.png",
-                "width": 150,
-                "height": 150,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_tw-150x150.png"
-              },
-              "web_stories_thumbnail": {
-                "file": "travel_icon_tw-150x121.png",
-                "width": 150,
-                "height": 121,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_tw-150x121.png"
-              },
-              "full": {
-                "file": "travel_icon_tw.png",
-                "width": 300,
-                "height": 242,
-                "mime_type": "image/png",
-                "source_url": "http://localhost:8899/wp-content/uploads/2020/04/travel_icon_tw.png"
-              }
-            }
+            "sizes": []
           },
           "mask": {
             "type": "rectangle",
@@ -4352,5 +3479,7 @@
         }
       }
     }
-  ]
+  ],
+  "autoAdvance": true,
+  "defaultPageDuration": 7
 }


### PR DESCRIPTION
## Summary

This PR adds animations to the first 5 pages of the Travel template.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

- Animate the last 5 pages
- Update our Animation spreadsheet with missing animations required to polish the Travel template.

## User-facing changes

- None.  Animations hidden by `enableAnimation` flag.

## Testing Instructions

1.) Toggle `enableAnimation` to `true` in `Dashboard.php`.
2.) Go to "Explore Templates" and hover over the Travel template to see some animation action.


## Screenshots

<img src="https://user-images.githubusercontent.com/40646372/87076895-346e6180-c1d7-11ea-972d-13c6dd7de68d.gif" height="200">

Page 1:
<img src="https://user-images.githubusercontent.com/40646372/87078265-36392480-c1d9-11ea-9712-896f3b16d922.gif" height="300">

Page 2:
<img src="https://user-images.githubusercontent.com/40646372/87078274-39ccab80-c1d9-11ea-9fa7-a3838732a41b.gif" height="300">

Page 3:
<img src="https://user-images.githubusercontent.com/40646372/87078278-3c2f0580-c1d9-11ea-8a89-23baaf259b07.gif" height="300">

Page 4:
<img src="https://user-images.githubusercontent.com/40646372/87078285-3df8c900-c1d9-11ea-85ee-4d3875b0f889.gif" height="300">

Page 5:
<img src="https://user-images.githubusercontent.com/40646372/87078292-405b2300-c1d9-11ea-8d20-45cbb8710190.gif" height="300">
