### PR TITLE
Workspace: Keyboard navigation in Grid View

### DIFF
--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -198,7 +198,9 @@ const ReorderablePage = styled(ReorderableItem).attrs({ role: 'option' })`
   }
 `;
 
-const GridViewContainer = styled.div`
+const GridViewContainer = styled.section.attrs({
+  'aria-label': __('Grid View', 'web-stories'),
+})`
   flex: 1;
   margin: 70px 170px 70px 170px;
   pointer-events: all;

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -509,7 +509,7 @@ function Carousel() {
         }}
       >
         <GridViewContainer>
-          <PlainStyled onClick={() => closeModal()}>
+          <PlainStyled onClick={closeModal}>
             {__('Back', 'web-stories')}
           </PlainStyled>
           <GridView />

--- a/assets/src/edit-story/components/canvas/gridview/index.js
+++ b/assets/src/edit-story/components/canvas/gridview/index.js
@@ -298,6 +298,7 @@ function GridView() {
                     dragIndicatorOffset={GRID_GAP / 2}
                     onClick={handleClickPage(page)}
                     isInteractive={isInteractive}
+                    gridRef={gridRef}
                   />
                 </ReorderableItem>
                 <PageSeparator

--- a/assets/src/edit-story/components/canvas/gridview/index.js
+++ b/assets/src/edit-story/components/canvas/gridview/index.js
@@ -244,7 +244,7 @@ function GridView() {
     <Container>
       <ThumbnailSizeControl value={zoomLevel} onChange={setZoomLevel} />
       <Wrapper
-        aria-label={__('Pages List', 'web-stories')}
+        aria-label={__('Grid View Pages List', 'web-stories')}
         ref={wrapperRef}
         onPositionChange={(oldPos, newPos) => {
           const pageId = pages[oldPos].id;

--- a/assets/src/edit-story/components/canvas/gridview/index.js
+++ b/assets/src/edit-story/components/canvas/gridview/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 import { useState, useRef } from 'react';
 
@@ -108,10 +108,12 @@ const Rectangle = styled.button`
     outline: none;
   }
 
-  &:disabled {
-    pointer-events: none;
-    opacity: 0.3;
-  }
+  ${({ disable }) =>
+    disable &&
+    css`
+      pointer-events: none;
+      opacity: 0.3;
+    `}
 
   svg {
     width: ${({ isLarge }) => (isLarge ? '20px' : '12px')};
@@ -175,11 +177,14 @@ function ThumbnailSizeControl({ value, onChange }) {
       break;
   }
 
+  const decreaseBtnDisabled = value === min;
+  const increaseBtnDisabled = value === max;
+
   return (
     <RangeInputWrapper>
       <Rectangle
-        onClick={() => updateRangeValue(-step)}
-        disabled={value === min}
+        onClick={() => !decreaseBtnDisabled && updateRangeValue(-step)}
+        disable={decreaseBtnDisabled}
         aria-label={__('Decrease thumbnail size', 'web-stories')}
       >
         <RectangleIcon />
@@ -198,8 +203,8 @@ function ThumbnailSizeControl({ value, onChange }) {
       <Space />
       <Rectangle
         isLarge
-        onClick={() => updateRangeValue(step)}
-        disabled={value === max}
+        onClick={() => !increaseBtnDisabled && updateRangeValue(step)}
+        disable={increaseBtnDisabled}
         aria-label={__('Increase thumbnail size', 'web-stories')}
       >
         <RectangleIcon />

--- a/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
+++ b/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
@@ -83,6 +83,11 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
           const button = thumbnail?.querySelector('button');
           if (button) {
             button.focus();
+            // button.addEventListener('blur', () => {
+            //   setFocusedPageId((currentFocusId) =>
+            //     currentFocusId === pageId ? currentPageId : currentFocusId
+            //   );
+            // });
           }
 
           break;
@@ -129,8 +134,10 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
           return;
       }
     },
-    [focusedPageId, isRTL, pageIds, pageRefs, gridRef]
+    [focusedPageId, isRTL, pageIds, pageRefs, gridRef, currentPageId]
   );
+
+  //
 }
 
 function getArrowDir(key, pos, neg, isRTL) {

--- a/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
+++ b/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
@@ -240,10 +240,10 @@ export function getGridColumnAndRowCount(gridElement) {
   );
   return {
     rows: gridTemplateRows.includes('none')
-      ? 1
+      ? 0
       : gridTemplateRows.trim().split(' ').length,
     columns: gridTemplateColumns.includes('none')
-      ? 1
+      ? 0
       : gridTemplateColumns.trim().split(' ').length,
   };
 }

--- a/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
+++ b/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+import { useState } from 'react';
+import { useKeyDownEffect } from '../../keyboard';
+import { useStory } from '../../../app';
+
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
+  const { currentPageId, pages } = useStory(
+    ({ state: { pages, currentPageId } }) => ({
+      currentPageId,
+      pages,
+    })
+  );
+
+  const [focusedPageId, setFocusedPageId] = useState(currentPageId);
+
+  const pageIds = useMemo(() => pages.map(({ id }) => id), [pages]);
+
+  // Navigate focus left, right, up, down
+  useKeyDownEffect(
+    ref,
+    { key: ['up', 'down', 'left', 'right'] },
+    ({ key }) => {
+      switch (key) {
+        case 'ArrowLeft':
+        case 'ArrowRight': {
+          const dir = getArrowDir(key, 'ArrowRight', 'ArrowLeft', isRTL);
+
+          if (dir === 0) {
+            return;
+          }
+
+          const index = pageIds.indexOf(focusedPageId);
+          const nextIndex = index + dir;
+
+          if (nextIndex < 0 || nextIndex === pageIds.length) {
+            return;
+          }
+
+          const pageId = pageIds[nextIndex];
+
+          setFocusedPageId(pageId);
+
+          const thumbnail = pageRefs.current && pageRefs.current[pageId];
+          // @todo: provide a cleaner `focusFirst()` API and takes into account
+          // `tabIndex`, `disabled`, links, buttons, inputs, etc.
+          const button = thumbnail?.querySelector('button');
+          if (button) {
+            button.focus();
+          }
+
+          break;
+        }
+        case 'ArrowUp':
+        case 'ArrowDown': {
+          const {
+            rows: numRows,
+            columns: numColumns,
+          } = getGridColumnAndRowCount(gridRef);
+          const currentIndex = pageIds.indexOf(focusedPageId);
+          const dir = key === 'ArrowDown' ? 1 : -1;
+
+          const currentRow = getRow(currentIndex, numColumns);
+          const currentColumn = getColumn(currentIndex, numColumns);
+
+          const nextIndex = getIndex(
+            currentRow + dir,
+            currentColumn,
+            numRows,
+            numColumns,
+            pageIds.length
+          );
+
+          if (nextIndex < 0) {
+            return;
+          }
+
+          const pageId = pageIds[nextIndex];
+
+          setFocusedPageId(pageId);
+
+          const thumbnail = pageRefs.current && pageRefs.current[pageId];
+          // @todo: provide a cleaner `focusFirst()` API and takes into account
+          // `tabIndex`, `disabled`, links, buttons, inputs, etc.
+          const button = thumbnail?.querySelector('button');
+          if (button) {
+            button.focus();
+          }
+
+          break;
+        }
+        default:
+          return;
+      }
+    },
+    [focusedPageId, isRTL, pageIds, pageRefs, gridRef]
+  );
+}
+
+function getArrowDir(key, pos, neg, isRTL) {
+  const rtlDir = isRTL ? -1 : 1;
+  if (key === pos) {
+    return rtlDir;
+  }
+  if (key === neg) {
+    return -1 * rtlDir;
+  }
+  return 0;
+}
+
+function getGridColumnAndRowCount(gridRef) {
+  const { gridTemplateColumns, gridTemplateRows } = getComputedStyle(
+    gridRef.current
+  );
+  return {
+    rows: gridTemplateRows.trim().split(' ').length,
+    columns: gridTemplateColumns.trim().split(' ').length,
+  };
+}
+
+// will return a 1 based index
+function getRow(index, numColumns) {
+  return Math.ceil((index + 1) / numColumns);
+}
+
+// will return a 1 based index
+function getColumn(index, numColumns) {
+  return (index % numColumns) + 1;
+}
+
+// will return a 0 based index
+function getIndex(row, column, numRows, numColumns, numItems) {
+  const isOutOfBounds =
+    row > numRows || row <= 0 || column > numColumns || column <= 0;
+
+  if (isOutOfBounds) {
+    return -1;
+  }
+
+  const index = numColumns * (row - 1) + (column - 1);
+
+  // If the index is greater than or equal to numItems default to the last index.
+  // This handles the case when we press ArrowDown and there is another row, but
+  // the column below is empty. It will default to the last item in the list.
+  return index >= numItems ? numItems - 1 : index;
+}
+
+export default useGridViewKeys;

--- a/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
+++ b/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
@@ -74,20 +74,20 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
           const {
             rows: numRows,
             columns: numColumns,
-          } = getGridColumnAndRowCount(gridRef.current);
+          } = getGridColumnAndRowCount(gridRef.current, pageIds.length);
           const currentIndex = pageIds.indexOf(focusedPageId);
           const dir = key === 'ArrowDown' ? 1 : -1;
 
           const currentRow = getRow(currentIndex, numColumns);
           const currentColumn = getColumn(currentIndex, numColumns);
 
-          const nextIndex = getIndex(
-            currentRow + dir,
-            currentColumn,
+          const nextIndex = getIndex({
+            row: currentRow + dir,
+            column: currentColumn,
             numRows,
             numColumns,
-            pageIds.length
-          );
+            numItems: pageIds.length,
+          });
 
           if (nextIndex < 0) {
             return;
@@ -161,20 +161,20 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
           const {
             rows: numRows,
             columns: numColumns,
-          } = getGridColumnAndRowCount(gridRef.current);
+          } = getGridColumnAndRowCount(gridRef.current, pageIds.length);
           const currentIndex = pageIds.indexOf(focusedPageId);
           const dir = key === 'ArrowDown' ? 1 : -1;
 
           const currentRow = getRow(currentIndex, numColumns);
           const currentColumn = getColumn(currentIndex, numColumns);
 
-          const nextIndex = getIndex(
-            currentRow + dir,
-            currentColumn,
+          const nextIndex = getIndex({
+            row: currentRow + dir,
+            column: currentColumn,
             numRows,
             numColumns,
-            pageIds.length
-          );
+            numItems: pageIds.length,
+          });
 
           if (nextIndex < 0) {
             return;
@@ -234,32 +234,35 @@ function getArrowDir(key, pos, neg, isRTL) {
   return 0;
 }
 
-export function getGridColumnAndRowCount(gridElement) {
-  const { gridTemplateColumns, gridTemplateRows } = getComputedStyle(
-    gridElement
-  );
-  return {
-    rows: gridTemplateRows.includes('none')
-      ? 0
-      : gridTemplateRows.trim().split(' ').length,
-    columns: gridTemplateColumns.includes('none')
-      ? 0
-      : gridTemplateColumns.trim().split(' ').length,
-  };
+function getGridColumnAndRowCount(grid, pageCount) {
+  let columns = 0;
+  let prevX;
+  for (const el of grid.children) {
+    const { x } = el.getBoundingClientRect();
+    if (prevX != null && x < prevX) {
+      break;
+    }
+    prevX = x;
+    columns++;
+  }
+
+  const rows = Math.ceil(pageCount / columns);
+
+  return { rows, columns };
 }
 
 // will return a 1 based index
-export function getRow(index, numColumns) {
+function getRow(index, numColumns) {
   return Math.ceil((index + 1) / numColumns);
 }
 
 // will return a 1 based index
-export function getColumn(index, numColumns) {
+function getColumn(index, numColumns) {
   return (index % numColumns) + 1;
 }
 
 // will return a 0 based index
-export function getIndex(row, column, numRows, numColumns, numItems) {
+function getIndex({ row, column, numRows, numColumns, numItems }) {
   const isOutOfBounds =
     row > numRows || row <= 0 || column > numColumns || column <= 0;
 

--- a/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
+++ b/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
@@ -63,7 +63,7 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
 
           setFocusedPageId(pageId);
 
-          const page = pageRefs.current && pageRefs.current[pageId];
+          const page = pageRefs?.current?.[pageId];
 
           focusOnPage(page);
 
@@ -97,7 +97,7 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
 
           setFocusedPageId(pageId);
 
-          const page = pageRefs.current && pageRefs.current[pageId];
+          const page = pageRefs?.current?.[pageId];
 
           focusOnPage(page);
 
@@ -148,8 +148,7 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
             arrangePage({ pageId: focusedPageId, position: nextIndex });
 
             // Focus on DOM element where this page is moving to
-            const page =
-              pageRefs.current && pageRefs.current[pageIds[nextIndex]];
+            const page = pageRefs?.current?.[pageIds[nextIndex]];
 
             focusOnPage(page);
           }
@@ -189,8 +188,7 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
             arrangePage({ pageId: focusedPageId, position: nextIndex });
 
             // Focus on DOM element where this page is moving to
-            const page =
-              pageRefs.current && pageRefs.current[pageIds[nextIndex]];
+            const page = pageRefs?.current?.[pageIds[nextIndex]];
 
             focusOnPage(page);
           }

--- a/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
+++ b/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
@@ -240,10 +240,10 @@ export function getGridColumnAndRowCount(gridElement) {
   );
   return {
     rows: gridTemplateRows.includes('none')
-      ? 0
+      ? 1
       : gridTemplateRows.trim().split(' ').length,
     columns: gridTemplateColumns.includes('none')
-      ? 0
+      ? 1
       : gridTemplateColumns.trim().split(' ').length,
   };
 }

--- a/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
+++ b/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
@@ -83,11 +83,6 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
           const button = thumbnail?.querySelector('button');
           if (button) {
             button.focus();
-            // button.addEventListener('blur', () => {
-            //   setFocusedPageId((currentFocusId) =>
-            //     currentFocusId === pageId ? currentPageId : currentFocusId
-            //   );
-            // });
           }
 
           break;
@@ -136,8 +131,6 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
     },
     [focusedPageId, isRTL, pageIds, pageRefs, gridRef, currentPageId]
   );
-
-  //
 }
 
 function getArrowDir(key, pos, neg, isRTL) {

--- a/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
+++ b/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
@@ -239,23 +239,27 @@ export function getGridColumnAndRowCount(gridElement) {
     gridElement
   );
   return {
-    rows: gridTemplateRows.trim().split(' ').length,
-    columns: gridTemplateColumns.trim().split(' ').length,
+    rows: gridTemplateRows.includes('none')
+      ? 0
+      : gridTemplateRows.trim().split(' ').length,
+    columns: gridTemplateColumns.includes('none')
+      ? 0
+      : gridTemplateColumns.trim().split(' ').length,
   };
 }
 
 // will return a 1 based index
-function getRow(index, numColumns) {
+export function getRow(index, numColumns) {
   return Math.ceil((index + 1) / numColumns);
 }
 
 // will return a 1 based index
-function getColumn(index, numColumns) {
+export function getColumn(index, numColumns) {
   return (index % numColumns) + 1;
 }
 
 // will return a 0 based index
-function getIndex(row, column, numRows, numColumns, numItems) {
+export function getIndex(row, column, numRows, numColumns, numItems) {
   const isOutOfBounds =
     row > numRows || row <= 0 || column > numColumns || column <= 0;
 

--- a/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
+++ b/assets/src/edit-story/components/canvas/gridview/useGridViewKeys.js
@@ -74,7 +74,7 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
           const {
             rows: numRows,
             columns: numColumns,
-          } = getGridColumnAndRowCount(gridRef);
+          } = getGridColumnAndRowCount(gridRef.current);
           const currentIndex = pageIds.indexOf(focusedPageId);
           const dir = key === 'ArrowDown' ? 1 : -1;
 
@@ -161,7 +161,7 @@ function useGridViewKeys(ref, gridRef, pageRefs, isRTL) {
           const {
             rows: numRows,
             columns: numColumns,
-          } = getGridColumnAndRowCount(gridRef);
+          } = getGridColumnAndRowCount(gridRef.current);
           const currentIndex = pageIds.indexOf(focusedPageId);
           const dir = key === 'ArrowDown' ? 1 : -1;
 
@@ -234,9 +234,9 @@ function getArrowDir(key, pos, neg, isRTL) {
   return 0;
 }
 
-function getGridColumnAndRowCount(gridRef) {
+export function getGridColumnAndRowCount(gridElement) {
   const { gridTemplateColumns, gridTemplateRows } = getComputedStyle(
-    gridRef.current
+    gridElement
   );
   return {
     rows: gridTemplateRows.trim().split(' ').length,

--- a/assets/src/edit-story/components/canvas/karma/grideView.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/grideView.karma.js
@@ -139,7 +139,7 @@ describe('GridView integration', () => {
     await focusOnPageList();
 
     // The initial focus should be on the first (and active) page.
-    const page1 = gridView.getByRole('button', { name: /Page 1/ });
+    let page1 = gridView.getByRole('button', { name: /Page 1/ });
     expect(page1).toEqual(document.activeElement);
 
     // go right by 1

--- a/assets/src/edit-story/components/canvas/karma/grideView.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/grideView.karma.js
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+/**
+ * External dependencies
+ */
+import { within } from '@testing-library/react';
+import { Fixture } from '../../../karma';
+import createSolid from '../../../utils/createSolid';
+import { useStory } from '../../../app';
+
+describe('GridView integration', () => {
+  let fixture;
+  let gridView;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    fixture.setPages([
+      { id: 'page1', backgroundColor: createSolid(255, 255, 255) },
+      { id: 'page2', backgroundColor: createSolid(255, 0, 0) },
+      { id: 'page3', backgroundColor: createSolid(0, 255, 0) },
+      { id: 'page4', backgroundColor: createSolid(0, 0, 255) },
+    ]);
+
+    await fixture.render();
+
+    await openGridView();
+
+    const gridViewRegion = fixture.screen.getByRole('region', {
+      name: /^Grid View$/,
+    });
+
+    gridView = within(gridViewRegion);
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  async function openGridView() {
+    const gridViewButton = fixture.editor.carousel.getByRole('button', {
+      name: /^Grid View$/,
+    });
+
+    await fixture.events.click(gridViewButton);
+
+    return Promise.resolve();
+  }
+
+  async function focusOnPageList() {
+    let limit = 0;
+    const pagesList = gridView.getByLabelText(/Grid View Pages List/);
+
+    while (!pagesList.contains(document.activeElement) && limit < 5) {
+      // eslint-disable-next-line no-await-in-loop
+      await fixture.events.keyboard.press('tab');
+      limit++;
+    }
+
+    return pagesList.contains(document.activeElement)
+      ? Promise.resolve()
+      : Promise.reject(new Error('could not focus on page list'));
+  }
+
+  async function getPageIds() {
+    const {
+      state: { pages },
+    } = await fixture.renderHook(() => useStory());
+    return pages.map(({ id }) => id);
+  }
+
+  it('should open grid view', () => {
+    const gridViewRegion = fixture.screen.getByRole('region', {
+      name: /^Grid View$/,
+    });
+    expect(gridViewRegion).toBeTruthy();
+  });
+
+  it('should use tab to jump between the "Back" button, Preview Size control, and page list', async () => {
+    // Tab cycle : Back -> Preview Size Control x3 stops -> Active/previously focused Page in Page List
+
+    // Back Button
+    await fixture.events.keyboard.press('tab');
+    const backButton = gridView.getByRole('button', { name: /^Back$/ });
+    expect(document.activeElement).toEqual(backButton);
+
+    // Decrease Preview Size Button
+    await fixture.events.keyboard.press('tab');
+    const decreaseButton = gridView.getByRole('button', {
+      name: /^Decrease thumbnail size$/,
+    });
+    expect(document.activeElement).toEqual(decreaseButton);
+
+    // Preview Range Control
+    await fixture.events.keyboard.press('tab');
+    const sizeRangeControl = gridView.getByLabelText(/^Thumbnail size$/);
+    expect(document.activeElement).toEqual(sizeRangeControl);
+
+    // Increase Preview Size Button
+    await fixture.events.keyboard.press('tab');
+    const increaseButton = gridView.getByRole('button', {
+      name: /^Increase thumbnail size$/,
+    });
+    expect(document.activeElement).toEqual(increaseButton);
+
+    // Active/previously fcoused page in Page List
+    await fixture.events.keyboard.press('tab');
+    const page = gridView.getByRole('button', { name: /(current page)/ });
+    expect(document.activeElement).toEqual(page);
+  });
+
+  // @todo test wrapping + up down
+  it('should use the up, down, left, right keys to navigate focus with wrapping', async () => {
+    await focusOnPageList();
+
+    // The initial focus should be on the first (and active) page.
+    const page1 = gridView.getByRole('button', { name: /Page 1/ });
+    expect(page1).toEqual(document.activeElement);
+
+    // go right by 1
+    await fixture.events.keyboard.press('right');
+    const page2 = gridView.getByRole('button', { name: /Page 2/ });
+    expect(page2).toEqual(document.activeElement);
+
+    // go left 1
+    await fixture.events.keyboard.press('left');
+    expect(page1).toEqual(document.activeElement);
+
+    // go left 1 (focus should remain on page 1)
+    await fixture.events.keyboard.press('left');
+    expect(page1).toEqual(document.activeElement);
+
+    // go right 3 (the end of the list)
+    const page4 = gridView.getByRole('button', { name: /Page 4/ });
+    await fixture.events.keyboard.seq(({ press }) => [
+      press('right'),
+      press('right'),
+      press('right'),
+    ]);
+    expect(page4).toEqual(document.activeElement);
+
+    // go right 1 (focus should remain on page 4)
+    await fixture.events.keyboard.press('right');
+    expect(page4).toEqual(document.activeElement);
+  });
+
+  // @todo test wrapping + up down
+  it('should reorder the pages using mod+left/right, mod+up/down and use shift+mod+dir to reorder to first/last', async () => {
+    const initialPageIds = await getPageIds();
+    let pageIds = [...initialPageIds];
+
+    await focusOnPageList();
+
+    // The initial focus should be on the first (and active) page.
+    const page1 = gridView.getByRole('button', { name: /Page 1/ });
+    expect(page1).toEqual(document.activeElement);
+
+    // move the first page to the right
+    await fixture.events.keyboard.shortcut('mod+right');
+    pageIds = await getPageIds();
+    expect(pageIds[1]).toEqual(initialPageIds[0]);
+
+    // move the first page back to the start
+    await fixture.events.keyboard.shortcut('mod+left');
+    pageIds = await getPageIds();
+    expect(pageIds).toEqual(initialPageIds);
+
+    // move the first page to the end
+    await fixture.events.keyboard.shortcut('shift+mod+right');
+    pageIds = await getPageIds();
+    expect(pageIds[pageIds.length - 1]).toEqual(initialPageIds[0]);
+
+    // focus on the penultimate page
+    await fixture.events.keyboard.press('left');
+    const page3 = gridView.getByRole('button', { name: /Page 3/ });
+    expect(page3).toEqual(document.activeElement);
+
+    // move page 4 to the start
+    await fixture.events.keyboard.shortcut('shift+mod+left');
+    pageIds = await getPageIds();
+    expect(pageIds[0]).toEqual(initialPageIds[3]);
+  });
+});

--- a/assets/src/edit-story/components/canvas/karma/grideView.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/grideView.karma.js
@@ -15,12 +15,13 @@
  */
 
 /**
- * Internal dependencies
- */
-/**
  * External dependencies
  */
 import { within, waitForElementToBeRemoved } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { Fixture } from '../../../karma';
 import createSolid from '../../../utils/createSolid';
 import { useStory } from '../../../app';

--- a/assets/src/edit-story/components/canvas/pagepreview/index.js
+++ b/assets/src/edit-story/components/canvas/pagepreview/index.js
@@ -77,13 +77,21 @@ function PagePreview({ index, ...props }) {
   }));
   const page = pages[index];
   const { backgroundColor } = page;
-  const { width: thumbWidth, height: thumbHeight } = props;
+  const {
+    width: thumbWidth,
+    height: thumbHeight,
+    isActive,
+    isInteractive,
+  } = props;
   const width = thumbWidth - THUMB_FRAME_WIDTH;
   const height = thumbHeight - THUMB_FRAME_HEIGHT;
+
+  const shouldFocus = isActive && isInteractive;
+
   return (
     <UnitsProvider pageSize={{ width, height }}>
       <TransformProvider>
-        <Page {...props}>
+        <Page tabIndex={shouldFocus ? 0 : -1} {...props}>
           <PreviewWrapper background={backgroundColor}>
             {page.elements.map(({ id, ...rest }) => (
               <DisplayElement
@@ -105,6 +113,7 @@ PagePreview.propTypes = {
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   isInteractive: PropTypes.bool,
+  isActive: PropTypes.bool,
 };
 
 PagePreview.defaultProps = {

--- a/assets/src/edit-story/components/canvas/pagepreview/index.js
+++ b/assets/src/edit-story/components/canvas/pagepreview/index.js
@@ -82,25 +82,20 @@ function PagePreview({ index, gridRef, ...props }) {
   const height = thumbHeight - THUMB_FRAME_HEIGHT;
   const [tabIndex, setTabIndex] = useState(isActive ? 0 : -1);
 
-  const handleOnBlur = (e) => {
+  const onBlur = (e) => {
     if (gridRef?.current?.contains(e.relatedTarget)) {
       setTabIndex(-1);
     }
   };
 
-  const handleOnFocus = () => {
+  const onFocus = () => {
     setTabIndex(0);
   };
 
   return (
     <UnitsProvider pageSize={{ width, height }}>
       <TransformProvider>
-        <Page
-          tabIndex={tabIndex}
-          onBlur={handleOnBlur}
-          onFocus={handleOnFocus}
-          {...props}
-        >
+        <Page tabIndex={tabIndex} onBlur={onBlur} onFocus={onFocus} {...props}>
           <PreviewWrapper background={backgroundColor}>
             {page.elements.map(({ id, ...rest }) => (
               <DisplayElement

--- a/assets/src/edit-story/components/canvas/pagepreview/index.js
+++ b/assets/src/edit-story/components/canvas/pagepreview/index.js
@@ -20,7 +20,7 @@
 import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 
 /**
  * Internal dependencies
@@ -71,27 +71,36 @@ const PreviewWrapper = styled.div`
   ${({ background }) => generatePatternStyles(background)}
 `;
 
-function PagePreview({ index, ...props }) {
+function PagePreview({ index, gridRef, ...props }) {
   const { pages } = useStory((state) => ({
     pages: state.state.pages,
   }));
   const page = pages[index];
   const { backgroundColor } = page;
-  const {
-    width: thumbWidth,
-    height: thumbHeight,
-    isActive,
-    isInteractive,
-  } = props;
+  const { width: thumbWidth, height: thumbHeight, isActive } = props;
   const width = thumbWidth - THUMB_FRAME_WIDTH;
   const height = thumbHeight - THUMB_FRAME_HEIGHT;
+  const [tabIndex, setTabIndex] = useState(isActive ? 0 : -1);
 
-  const shouldFocus = isActive && isInteractive;
+  const handleOnBlur = (e) => {
+    if (gridRef?.current?.contains(e.relatedTarget)) {
+      setTabIndex(-1);
+    }
+  };
+
+  const handleOnFocus = () => {
+    setTabIndex(0);
+  };
 
   return (
     <UnitsProvider pageSize={{ width, height }}>
       <TransformProvider>
-        <Page tabIndex={shouldFocus ? 0 : -1} {...props}>
+        <Page
+          tabIndex={tabIndex}
+          onBlur={handleOnBlur}
+          onFocus={handleOnFocus}
+          {...props}
+        >
           <PreviewWrapper background={backgroundColor}>
             {page.elements.map(({ id, ...rest }) => (
               <DisplayElement
@@ -114,6 +123,7 @@ PagePreview.propTypes = {
   height: PropTypes.number.isRequired,
   isInteractive: PropTypes.bool,
   isActive: PropTypes.bool,
+  gridRef: PropTypes.any,
 };
 
 PagePreview.defaultProps = {


### PR DESCRIPTION
## Summary
Add keyboard navigation support to GridView

## Relevant Technical Choices

The main change is the addition of the `useGridViewKeys` custom hook.  It takes inspiration and patterns from the `useCarouselKeys` hook.  


## To-do
- Add tests for up/down arrow key navigation/arrangement. See https://github.com/puppeteer/puppeteer/issues/6195


## User-facing changes
Users should now be able to navigate in the grid view using their keyboard.

## Testing Instructions
Launch into the editor's grid view and test the following scenarios:

1. Use tab to jump between "Back" button, "Preview size" range control (three stops), and the page list.
2. When jumping to the page list the currently selected page should be focused instead. Not the whole list.
3. Use ↕️ and ↔️ keys to navigate through the grid horizontally and vertically, and with wrapping.
4. Use mod+↕️ and mod+↔️ to reorder pages.
5. Use Enter to select a page.
6. The focus should be trapped inside the dialog. E.g. if at any point the focus leaves the dialog while it's still open, the focus should be returned back to the dialog.
7. Use Esc to exit the dialog at any time.

Also validate that the `edit-story` karma tests pass for this build as integrations tests were added for the above 7 requirements.

---

<!-- Please reference the issue(s) this PR addresses. -->

#2717
