### PR TITLE
3P Media: Fix flickering caused by scrollbar

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/styles.js
+++ b/assets/src/edit-story/components/library/panes/media/common/styles.js
@@ -32,14 +32,20 @@ export const PaneInner = styled.div`
 `;
 export const PaneHeader = styled.div`
   grid-area: header;
-  padding-top: 1.5em;
+  padding-top: 24px;
 `;
 
 export const MediaGalleryContainer = styled.div`
   grid-area: infinitescroll;
   overflow: auto;
-  padding: 0 1.5em 0 1.5em;
+  padding: 0 24px;
   margin-top: 1em;
+  width: 100%;
+`;
+
+// 312px is the width of the gallery minus the 24px paddings.
+export const MediaGalleryInnerContainer = styled.div`
+  width: 312px;
 `;
 
 export const StyledPane = styled(Pane)`
@@ -49,5 +55,5 @@ export const StyledPane = styled(Pane)`
 `;
 
 export const SearchInputContainer = styled.div`
-  padding: 0 1.5em 0 1.5em;
+  padding: 0 24px;
 `;

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
@@ -42,6 +42,7 @@ import {
 } from '../../../../../app/media/media3p/useMedia3p';
 import {
   MediaGalleryContainer,
+  MediaGalleryInnerContainer,
   PaneHeader,
   PaneInner,
   SearchInputContainer,
@@ -54,13 +55,13 @@ import ProviderTab from './providerTab';
 
 const ProviderTabSection = styled.div`
   margin-top: 30px;
-  padding: 0 1.5em;
+  padding: 0 24px;
 `;
 
 const CategorySection = styled.div`
   background-color: ${({ theme }) => theme.colors.bg.v3};
   min-height: 94px;
-  padding: 30px 1.5em;
+  padding: 30px 24px;
 `;
 
 /**
@@ -149,11 +150,13 @@ function Media3pPane(props) {
           <CategorySection>{__('Coming soon', 'web-stories')}</CategorySection>
         </PaneHeader>
         <MediaGalleryContainer ref={refCallbackContainer}>
-          <MediaGallery
-            resources={media}
-            onInsert={onInsert}
-            providerType={ProviderType.UNSPLASH}
-          />
+          <MediaGalleryInnerContainer>
+            <MediaGallery
+              resources={media}
+              onInsert={onInsert}
+              providerType={ProviderType.UNSPLASH}
+            />
+          </MediaGalleryInnerContainer>
         </MediaGalleryContainer>
       </PaneInner>
     </StyledPane>


### PR DESCRIPTION
## Summary

Fixes a bad artifact when the scrollbar is not visible in the 3p media gallery.

## Relevant Technical Choices

Currently the logic that changes the width of the right padding in the gallery in media3p causes a very bad artifact when the scrollbar disappears. This is because the fact that the scrollbar disappears makes the width of the gallery wider, which triggers a re-render of the gallery component where some photos end up in different rows. This causes a very bad flickering.

This fixes the issue by introducing MediaGalleryInnerContainer wrapper that enforces the gallery to be exactly 312px wide, and allows the outer MediaGalleryContainer to be 100% of the width. The scrollbar logic thus works, and the images are not reshuffled because the width of the inner container is constant.

To do this I've replaced 1.5ems with 24px which is the equivalent and makes the maths simpler.

## To-do

Factor out this logic once the media gallery for upload PR is in.

## User-facing changes

Fixes a very noticeable flickering in the media3p gallery. This is behind a flag.

## Testing Instructions

Open the media3p gallery tab and resize the window to make it big enough for the sscrollbar to disappear.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3121
