### PR TITLE
Build Workflow: Prevent nested ZIP files

### DIFF
--- a/.github/workflows/continuous-integration-build.yml
+++ b/.github/workflows/continuous-integration-build.yml
@@ -61,37 +61,40 @@ jobs:
           CI: true
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 
-      - name: Bundle plugin
+      - name: Build plugin
         run: |
           npm run build:js
           npm run workflow:version -- --nightly
-          npm run workflow:build-plugin -- --cdn --composer --zip web-stories-composer.zip
-          npm run workflow:build-plugin -- --cdn --zip web-stories.zip
 
-      - name: Bundle development version
-        run: |
-          rm -rf assets/css/* assets/js/*
-          NODE_ENV=development npx webpack --config webpack.config.cjs
-          npm run workflow:version -- --nightly
-          npm run workflow:build-plugin -- --cdn --zip web-stories-dev.zip
-
-      - name: Upload full bundle
-        uses: actions/upload-artifact@v2
-        with:
-          name: web-stories
-          path: build/web-stories.zip
+      - name: Bundle composer version
+        run: npm run workflow:build-plugin -- --cdn --composer
 
       - name: Upload composer bundle
         uses: actions/upload-artifact@v2
         with:
           name: web-stories-composer
-          path: build/web-stories-composer.zip
+          path: build/web-stories
+
+      - name: Bundle regular version
+        run: npm run workflow:build-plugin -- --cdn
+
+      - name: Upload regular bundle
+        uses: actions/upload-artifact@v2
+        with:
+          name: web-stories
+          path: build/web-stories
+
+      - name: Bundle development version
+        run: |
+          rm -rf assets/css/* assets/js/*
+          NODE_ENV=development npx webpack --config webpack.config.cjs
+          npm run workflow:build-plugin -- --cdn
 
       - name: Upload development bundle
         uses: actions/upload-artifact@v2
         with:
           name: web-stories-dev
-          path: build/web-stories-dev.zip
+          path: build/web-stories
 
       - name: Upload bundles in combined ZIP file
         uses: actions/upload-artifact@v2
@@ -110,11 +113,20 @@ jobs:
           ref: master
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download combined ZIP file
+      - name: Download all artifacts
         uses: actions/download-artifact@v2
         with:
-          name: All ZIP Files
           path: ${{ github.ref }}
+
+      - name: ZIP artifacts
+        run: |
+          rm -rf web-stories.zip web-stories-composer.zip web-stories-dev.zip
+          zip -mrT web-stories.zip web-stories
+          mv web-stories-composer web-stories
+          zip -mrT web-stories-composer.zip web-stories
+          mv web-stories-dev web-stories
+          zip -mrT web-stories-dev.zip web-stories
+        working-directory: ${{ github.ref }}
 
       - name: Commit updates
         run: |


### PR DESCRIPTION
The build workflow here on GitHub creates ZIP files and then puts these ZIP files into another ZIP file... That means when you download it and try to directly upload it to WordPress, it won't work.

Never noticed this personally as my unarchiver tool automatically extracts nested ZIP files.

Reported at https://github.com/Yoast/wordpress-seo/pull/15532

![47tnq8](https://user-images.githubusercontent.com/841956/87142640-1ff89a80-c2a5-11ea-9b42-8786abc0addc.jpg)

