### PR TITLE
3P Media: Add pagination support

### DIFF
--- a/assets/src/edit-story/app/media/media3p/useProviderContextValueProvider.js
+++ b/assets/src/edit-story/app/media/media3p/useProviderContextValueProvider.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+
+/**
  * Internal dependencies
  */
 import useFetchMediaEffect from './useFetchMediaEffect';
@@ -55,5 +60,11 @@ export default function useProviderContextValueProvider(
 
   return {
     state: reducerState[provider],
+    actions: {
+      setNextPage: useCallback(() => reducerActions.setNextPage({ provider }), [
+        reducerActions,
+        provider,
+      ]),
+    },
   };
 }

--- a/assets/src/edit-story/components/library/panes/media/common/mediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaGallery.js
@@ -67,16 +67,14 @@ function MediaGallery({ resources, onInsert, providerType }) {
   );
 
   return (
-    resources?.length && (
-      <Gallery
-        targetRowHeight={110}
-        direction={'row'}
-        // This should match the actual margin the element is styled with.
-        margin={PHOTO_MARGIN}
-        photos={photos}
-        renderImage={imageRenderer}
-      />
-    )
+    <Gallery
+      targetRowHeight={110}
+      direction={'row'}
+      // This should match the actual margin the element is styled with.
+      margin={PHOTO_MARGIN}
+      photos={photos}
+      renderImage={imageRenderer}
+    />
   );
 }
 

--- a/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
@@ -32,6 +32,7 @@ import MediaGallery from '../common/mediaGallery';
 import useIntersectionEffect from '../../../../../utils/useIntersectionEffect';
 import {
   MediaGalleryContainer,
+  MediaGalleryInnerContainer,
   MediaGalleryLoadingPill,
   MediaGalleryMessage,
 } from '../common/styles';
@@ -127,7 +128,7 @@ function PaginatedMediaGallery({
       data-testid="media-gallery-container"
       ref={refCallbackContainer}
     >
-      {mediaGallery}
+      <MediaGalleryInnerContainer>{mediaGallery}</MediaGalleryInnerContainer>
     </MediaGalleryContainer>
   );
 }

--- a/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { memo, useLayoutEffect, useRef, useState } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import MediaGallery from '../common/mediaGallery';
+import useIntersectionEffect from '../../../../../utils/useIntersectionEffect';
+import {
+  MediaGalleryContainer,
+  MediaGalleryLoadingPill,
+  MediaGalleryMessage,
+} from '../common/styles';
+
+const ROOT_MARGIN = 300;
+
+function PaginatedMediaGallery({
+  providerType,
+  resources,
+  isMediaLoading,
+  isMediaLoaded,
+  hasMore,
+  onInsert,
+  setNextPage,
+}) {
+  // TODO(#1698): Ensure scrollbars auto-disappear in MacOS.
+  // State and callback ref necessary to recalculate the padding of the list
+  // given the scrollbar width.
+  const [scrollbarWidth, setScrollbarWidth] = useState(0);
+  const refContainer = useRef();
+  const refCallbackContainer = (element) => {
+    refContainer.current = element;
+    if (!element) {
+      return;
+    }
+    setScrollbarWidth(element.offsetWidth - element.clientWidth);
+  };
+
+  // Recalculates padding so that it stays centered.
+  // As of May 2020 this cannot be achieved without js (as the scrollbar-gutter
+  // prop is not yet ready).
+  useLayoutEffect(() => {
+    if (!scrollbarWidth) {
+      return;
+    }
+    const currentPaddingLeft = parseFloat(
+      window
+        .getComputedStyle(refContainer.current, null)
+        .getPropertyValue('padding-left')
+    );
+    refContainer.current.style['padding-right'] =
+      currentPaddingLeft - scrollbarWidth + 'px';
+  }, [scrollbarWidth, refContainer]);
+
+  const refContainerFooter = useRef();
+  useIntersectionEffect(
+    refContainerFooter,
+    {
+      root: refContainer,
+      // This rootMargin is added so that we load an extra page when the
+      // "loading" footer is "close" to the bottom of the container, even if
+      // it's not yet visible.
+      rootMargin: `0px 0px ${ROOT_MARGIN}px 0px`,
+    },
+    (entry) => {
+      if (
+        !isMediaLoaded ||
+        isMediaLoading ||
+        !hasMore ||
+        !entry.isIntersecting
+      ) {
+        return;
+      }
+      setNextPage();
+    },
+    [hasMore, isMediaLoading, isMediaLoaded, setNextPage]
+  );
+
+  const mediaGallery =
+    isMediaLoaded && resources.length === 0 ? (
+      <MediaGalleryMessage>
+        {__('No media found', 'web-stories')}
+      </MediaGalleryMessage>
+    ) : (
+      <>
+        <div style={{ marginBottom: 15 }}>
+          <MediaGallery
+            providerType={providerType}
+            resources={resources}
+            onInsert={onInsert}
+          />
+        </div>
+        {hasMore && (
+          <MediaGalleryLoadingPill ref={refContainerFooter}>
+            {__('Loading…', 'web-stories')}
+          </MediaGalleryLoadingPill>
+        )}
+      </>
+    );
+
+  return (
+    <MediaGalleryContainer
+      data-testid="media-gallery-container"
+      ref={refCallbackContainer}
+    >
+      {mediaGallery}
+    </MediaGalleryContainer>
+  );
+}
+
+PaginatedMediaGallery.propTypes = {
+  providerType: PropTypes.string.isRequired,
+  resources: PropTypes.arrayOf(PropTypes.object).isRequired,
+  isMediaLoading: PropTypes.bool.isRequired,
+  isMediaLoaded: PropTypes.bool.isRequired,
+  hasMore: PropTypes.bool.isRequired,
+  onInsert: PropTypes.func.isRequired,
+  setNextPage: PropTypes.func.isRequired,
+};
+
+export default memo(PaginatedMediaGallery);

--- a/assets/src/edit-story/components/library/panes/media/common/styles.js
+++ b/assets/src/edit-story/components/library/panes/media/common/styles.js
@@ -41,9 +41,15 @@ export const MediaGalleryContainer = styled.div`
   grid-area: infinitescroll;
   overflow: auto;
   grid-template-columns: 1fr;
-  padding: 0 1.2em 0 1.2em;
+  padding: 0 24px;
   margin-top: 1em;
   position: relative;
+  width: 100%;
+`;
+
+// 312px is the width of the gallery minus the 24px paddings.
+export const MediaGalleryInnerContainer = styled.div`
+  width: 312px;
 `;
 
 export const MediaGalleryLoadingPill = styled.div`

--- a/assets/src/edit-story/components/library/panes/media/common/styles.js
+++ b/assets/src/edit-story/components/library/panes/media/common/styles.js
@@ -17,6 +17,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import { rgba } from 'polished';
 /**
  * Internal dependencies
  */
@@ -36,16 +37,32 @@ export const PaneHeader = styled.div`
 `;
 
 export const MediaGalleryContainer = styled.div`
+  display: grid;
   grid-area: infinitescroll;
   overflow: auto;
-  padding: 0 24px;
+  grid-template-columns: 1fr;
+  padding: 0 1.2em 0 1.2em;
   margin-top: 1em;
-  width: 100%;
+  position: relative;
 `;
 
-// 312px is the width of the gallery minus the 24px paddings.
-export const MediaGalleryInnerContainer = styled.div`
-  width: 312px;
+export const MediaGalleryLoadingPill = styled.div`
+  grid-column: 1 / span 2;
+  margin-bottom: 16px;
+  text-align: center;
+  padding: 8px 80px;
+  background-color: ${({ theme }) => rgba(theme.colors.bg.v0, 0.4)};
+  border-radius: 100px;
+  margin-top: auto;
+  font-size: ${({ theme }) => theme.fonts.label.size};
+  line-height: ${({ theme }) => theme.fonts.label.lineHeight};
+  font-weight: 500;
+`;
+
+export const MediaGalleryMessage = styled.div`
+  color: ${({ theme }) => theme.colors.fg.v1};
+  font-size: 16px;
+  padding: 1em;
 `;
 
 export const StyledPane = styled(Pane)`

--- a/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import { rgba } from 'polished';
 import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useDebouncedCallback } from 'use-debounce';
@@ -41,6 +40,8 @@ import {
 } from '../../../../../app/media/utils';
 import MediaElement from '../common/mediaElement';
 import {
+  MediaGalleryLoadingPill,
+  MediaGalleryMessage,
   PaneHeader,
   PaneInner,
   SearchInputContainer,
@@ -62,12 +63,6 @@ const Container = styled.div`
 
 const Column = styled.div`
   position: relative;
-`;
-
-const Message = styled.div`
-  color: ${({ theme }) => theme.colors.fg.v1};
-  font-size: 16px;
-  padding: 1em;
 `;
 
 const FilterArea = styled.div`
@@ -92,19 +87,6 @@ const FilterButton = styled.button`
   font-size: ${({ theme }) => theme.fonts.label.size};
   font-weight: ${({ active }) => (active ? 'bold' : 'normal')};
   line-height: ${({ theme }) => theme.fonts.label.lineHeight};
-`;
-
-const Loading = styled.div`
-  grid-column: 1 / span 2;
-  margin-bottom: 16px;
-  text-align: center;
-  padding: 8px 80px;
-  background-color: ${({ theme }) => rgba(theme.colors.bg.v0, 0.4)};
-  border-radius: 100px;
-  margin-top: auto;
-  font-size: ${({ theme }) => theme.fonts.label.size};
-  line-height: ${({ theme }) => theme.fonts.label.lineHeight};
-  font-weight: 500;
 `;
 
 const FILTERS = [
@@ -340,7 +322,9 @@ function MediaPane(props) {
         </PaneHeader>
 
         {isMediaLoaded && !media.length ? (
-          <Message>{__('No media found', 'web-stories')}</Message>
+          <MediaGalleryMessage>
+            {__('No media found', 'web-stories')}
+          </MediaGalleryMessage>
         ) : (
           <Container data-testid="mediaLibrary" ref={refCallbackContainer}>
             <Column>
@@ -368,9 +352,9 @@ function MediaPane(props) {
                 ))}
             </Column>
             {hasMore && (
-              <Loading ref={refContainerFooter}>
+              <MediaGalleryLoadingPill ref={refContainerFooter}>
                 {__('Loading…', 'web-stories')}
-              </Loading>
+              </MediaGalleryLoadingPill>
             )}
           </Container>
         )}

--- a/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
@@ -340,6 +340,7 @@ function MediaPane(props) {
     return () => node.removeEventListener('scroll', handleScroll);
   }, [handleScroll]);
 
+  // TODO(#3160): Update MediaPane to use PaginatedMediaGallery
   const mediaLibrary = isRowBasedGallery ? (
     // Arranges elements in rows.
     <RowContainer

--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -22,101 +22,121 @@ import { waitFor } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { Fixture } from '../../../../../../karma/fixture';
 import apiFetcher from '../../../../../../app/media/media3p/api/apiFetcher';
+import { Fixture, MEDIA_PER_PAGE } from '../../../../../../karma/fixture';
+import { ROOT_MARGIN } from '../../local/mediaPane';
 
-const media = [
-  {
-    name: 'media/unsplash:1',
-    provider: 'UNSPLASH',
-    imageUrls: [
-      {
-        imageName: 'full',
-        url: 'http://www.img.com/1',
-        width: 640,
-        height: 480,
-        mimeType: 'image/png',
-      },
-      {
-        imageName: 'large',
-        url: 'http://www.img.com/2',
-        width: 300,
-        height: 200,
-        mimeType: 'image/png',
-      },
-      {
-        imageName: 'web_stories_thumbnail',
-        url: 'http://www.img.com/3',
-        width: 200,
-        height: 100,
-        mimeType: 'image/png',
-      },
-    ],
-    description: 'A cat',
-    type: 'IMAGE',
-    createTime: '1234',
-    updateTime: '5678',
-  },
-  {
-    name: 'media/unsplash:2',
-    provider: 'UNSPLASH',
-    imageUrls: [
-      {
-        imageName: 'full',
-        url: 'http://www.img.com/4',
-        width: 640,
-        height: 480,
-        mimeType: 'image/png',
-      },
-      {
-        imageName: 'large',
-        url: 'http://www.img.com/5',
-        width: 300,
-        height: 200,
-        mimeType: 'image/png',
-      },
-      {
-        imageName: 'web_stories_thumbnail',
-        url: 'http://www.img.com/6',
-        width: 200,
-        height: 100,
-        mimeType: 'image/png',
-      },
-    ],
-    description: 'A dog',
-    type: 'IMAGE',
-    createTime: '91234',
-    updateTime: '95678',
-  },
-];
+const createMediaResource = (name) => ({
+  name,
+  provider: 'UNSPLASH',
+  imageUrls: [
+    {
+      imageName: 'full',
+      url: 'http://www.img.com/1',
+      width: 640,
+      height: 480,
+      mimeType: 'image/png',
+    },
+    {
+      imageName: 'large',
+      url: 'http://www.img.com/2',
+      width: 300,
+      height: 200,
+      mimeType: 'image/png',
+    },
+    {
+      imageName: 'web_stories_thumbnail',
+      url: 'http://www.img.com/3',
+      width: 200,
+      height: 100,
+      mimeType: 'image/png',
+    },
+  ],
+  description: 'A cat',
+  type: 'IMAGE',
+  createTime: '1234',
+  updateTime: '5678',
+});
+
+const mediaPage1 = [...new Array(20).keys()].map((n) =>
+  createMediaResource(`media/unsplash:${n + 1}`)
+);
+const mediaPage2 = [...new Array(20).keys()].map((n) =>
+  createMediaResource(`media/unsplash:${n + 21}`)
+);
 
 describe('Media3pPane fetching', () => {
   let fixture;
+  let media3pTab;
+  let media3pPane;
 
   beforeEach(async () => {
     fixture = new Fixture();
     fixture.setFlags({ media3pTab: true });
 
-    spyOn(apiFetcher, 'listMedia').and.callFake(() => ({ media }));
-
     await fixture.render();
+
+    media3pTab = fixture.querySelector('#library-tab-media3p');
+    media3pPane = fixture.querySelector('#library-pane-media3p');
   });
 
-  it('should fetch media resources', async () => {
-    const media3pTab = fixture.querySelector('#library-tab-media3p');
-    fixture.events.click(media3pTab);
+  function mockListMedia() {
+    /* eslint-disable-next-line jasmine/no-unsafe-spy */
+    spyOn(apiFetcher, 'listMedia').and.callFake(({ pageToken }) => {
+      switch (pageToken) {
+        case undefined:
+          return { media: mediaPage1, nextPageToken: 'page2' };
+        case 'page2':
+          return { media: mediaPage2, nextPageToken: undefined };
+        default:
+          throw new Error(`Unexpected pageToken: ${pageToken}`);
+      }
+    });
+  }
 
-    const media3pPane = fixture.querySelector('#library-pane-media3p');
-
+  async function expectMediaElements(expectedCount) {
     let mediaElements;
     await waitFor(() => {
       mediaElements = media3pPane.querySelectorAll(
         '[data-testid=mediaElement]'
       );
-      if (!mediaElements || mediaElements.length === 0) {
+      if (!mediaElements || mediaElements.length !== expectedCount) {
         throw new Error('Not ready');
       }
     });
-    expect(mediaElements.length).toBe(2);
+    expect(mediaElements.length).toBe(expectedCount);
+  }
+
+  it('should render no results message', async () => {
+    spyOn(apiFetcher, 'listMedia').and.callFake(() => ({ media: [] }));
+    fixture.events.click(media3pTab);
+
+    await waitFor(() => {
+      expect(
+        fixture.screen.getByText(new RegExp('^No media found$'))
+      ).toBeTruthy();
+    });
+  });
+
+  it('should fetch media resources', async () => {
+    mockListMedia();
+    fixture.events.click(media3pTab);
+    await expectMediaElements(MEDIA_PER_PAGE);
+  });
+
+  it('should fetch 2nd page', async () => {
+    mockListMedia();
+    fixture.events.click(media3pTab);
+
+    const mediaGallery = media3pPane.querySelector(
+      '[data-testid="media-gallery-container"]'
+    );
+    await expectMediaElements(MEDIA_PER_PAGE);
+
+    mediaGallery.scrollTo(
+      0,
+      mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN
+    );
+    await expectMediaElements(MEDIA_PER_PAGE * 2);
   });
 });


### PR DESCRIPTION
## Summary

Add pagination support for media3p results, including:
- Call to setNextPage to assign nextPageToken -> pageToken state and load the next page.
- Empty results message and loading indicator.

## Todo

Update MediaPane to use PaginatedMediaGallery - https://github.com/google/web-stories-wp/issues/3160

---

Fixes #2395
