### PR TITLE
Set react-modal app element in karma tests

### DIFF
--- a/assets/src/dashboard/karma/fixture.js
+++ b/assets/src/dashboard/karma/fixture.js
@@ -20,6 +20,7 @@
 import React from 'react';
 import { FlagsProvider } from 'flagged';
 import { act, render, screen } from '@testing-library/react';
+import Modal from 'react-modal';
 
 /**
  * Internal dependencies
@@ -147,6 +148,10 @@ export default class Fixture {
    */
   render() {
     const root = document.querySelector('test-root');
+
+    // see http://reactcommunity.org/react-modal/accessibility/
+    Modal.setAppElement(root);
+
     const { container } = render(
       <FlagsProvider features={this._flags}>
         <App key={Math.random()} config={this._config} />

--- a/assets/src/edit-story/karma/fixture/fixture.js
+++ b/assets/src/edit-story/karma/fixture/fixture.js
@@ -20,6 +20,7 @@
 import React, { useCallback, useState, useMemo, forwardRef } from 'react';
 import { FlagsProvider } from 'flagged';
 import { render, act, screen } from '@testing-library/react';
+import Modal from 'react-modal';
 
 /**
  * Internal dependencies
@@ -189,6 +190,10 @@ export class Fixture {
    */
   render() {
     const root = document.querySelector('test-root');
+
+    // see http://reactcommunity.org/react-modal/accessibility/
+    Modal.setAppElement(root);
+
     const { container, getByRole } = render(
       <FlagsProvider features={this._flags}>
         <App key={Math.random()} config={this._config} />


### PR DESCRIPTION
Updates the two `Fixture` classes to call `Modal.setAppElement()` in Karma tests as per the recommendation at http://reactcommunity.org/react-modal/accessibility/.

This is already done for the Dashboard & Editor apps themselves, but not for the test suite.

Doing this avoids lots of warnings in the test logs.

Fixes #3195

---

**NOTE**

Failing tests are due to #3182.