### PR TITLE
Media: Fix issue where dropdown menu was not appearing for videos

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
@@ -286,7 +286,7 @@ const MediaElement = ({
           <UploadingIndicator />
         </CSSTransition>
       )}
-      {hasDropdownMenu && !providerType === ProviderType.LOCAL && (
+      {hasDropdownMenu && providerType === ProviderType.LOCAL && (
         <DropDownMenu
           resource={resource}
           pointerEntered={pointerEntered}


### PR DESCRIPTION
## Summary
Fixed typo that accidentally disabled the dropdown menu for LOCAL providers (aka the Upload tab).

## TODO
Add tests for this in a separate PR.

## Testing Instructions
... icon should appear on hover for videos in the Uploads tab.

---
