### PR TITLE
Fix link protocol handling

### DIFF
--- a/assets/src/edit-story/components/form/text.js
+++ b/assets/src/edit-story/components/form/text.js
@@ -105,7 +105,7 @@ function TextInput({
       );
     }
     if (onBlur) {
-      onBlur();
+      onBlur({ onClear: true });
     }
   };
 

--- a/assets/src/edit-story/components/panels/link/index.js
+++ b/assets/src/edit-story/components/panels/link/index.js
@@ -105,7 +105,6 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
       pushUpdateForObject(
         'link',
         (prev) => ({
-          url,
           desc: title ? title : prev.desc,
           icon: icon ? toAbsoluteUrl(url, icon) : prev.icon,
         }),
@@ -182,6 +181,16 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
           onChange={(value) =>
             handleChange({ url: value }, !value /* submit */)
           }
+          onBlur={(atts = {}) => {
+            const { onClear } = atts;
+            // If the onBlur is not clearing the field, add protocol.
+            if (link.url?.length > 0 && !onClear) {
+              const urlWithProtocol = withProtocol(link.url);
+              if (urlWithProtocol !== link.url) {
+                handleChange({ url: urlWithProtocol }, true /* submit */);
+              }
+            }
+          }}
           value={link.url || ''}
           clear
           aria-label={__('Edit: Element link', 'web-stories')}

--- a/assets/src/edit-story/karma/fixture/fixture.js
+++ b/assets/src/edit-story/karma/fixture/fixture.js
@@ -491,7 +491,12 @@ class APIProviderFixture {
       );
 
       const getLinkMetadata = useCallback(
-        () => jasmine.createSpy('getLinkMetadata'),
+        () =>
+          asyncResponse({
+            url: 'https://example.com',
+            title: 'Example Site',
+            image: 'example.jpg',
+          }),
         []
       );
 

--- a/assets/src/edit-story/karma/link.cuj.karma.js
+++ b/assets/src/edit-story/karma/link.cuj.karma.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import createSolidFromString from '../utils/createSolidFromString';
+import useInsertElement from '../components/canvas/useInsertElement';
+import { Fixture } from './fixture';
+
+describe('CUJ: Creator Can Add A Link', () => {
+  let fixture;
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  describe('Action: Add Web Address', () => {
+    let frame;
+    const addElement = async () => {
+      const insertElement = await fixture.renderHook(() => useInsertElement());
+      const element = await fixture.act(() =>
+        insertElement('shape', {
+          backgroundColor: createSolidFromString('#ff00ff'),
+          mask: { type: 'rectangle' },
+          x: 10,
+          y: 10,
+          width: 50,
+          height: 50,
+        })
+      );
+      frame = fixture.editor.canvas.framesLayer.frame(element.id).node;
+    };
+    const clickOnTarget = async (target) => {
+      const { x, y, width, height } = target.getBoundingClientRect();
+      await fixture.events.mouse.click(x + width / 2, y + height / 2);
+    };
+    const addLink = async (link) => {
+      // Type in link.
+      const input = fixture.screen.getByLabelText('Edit: Element link');
+      await fixture.events.click(input);
+      await fixture.events.keyboard.type(link);
+    };
+
+    it('should add protocol automatically on blurring', async () => {
+      await addElement();
+      await clickOnTarget(frame);
+      await addLink('example.com');
+      const input = fixture.screen.getByLabelText('Edit: Element link');
+      await input.dispatchEvent(new window.Event('blur'));
+      expect(input.value).toBe('http://example.com');
+    });
+
+    it('should not add additional protocol if already present', async () => {
+      await addElement();
+      await clickOnTarget(frame);
+      await addLink('https://example.com');
+      const input = fixture.screen.getByLabelText('Edit: Element link');
+      await input.dispatchEvent(new window.Event('blur'));
+      expect(input.value).toBe('https://example.com');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds protocol only once the user moves the focus away from the link input to avoid adding the protocol unexpectedly in the middle of typing.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Link protocol is now added only when the user moves away from the link input.
<!-- Please describe your changes. -->

## Testing Instructions
I
1. Add any element
2. Start adding link, typing it very slowly.
3. Verify that the protocol is not added while typing.
4. Leave the focus to another field.
5. Verify that the protocol is added.

II
1. Add any element.
2. Add a link with https:// protocol
3. Move to the next field.
4. Verify that additional protocol was not added.

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2745 
