### PR TITLE
Dashboard: Updated Travel template's page 7 layout

### DIFF
--- a/assets/src/dashboard/templates/raw/travel.json
+++ b/assets/src/dashboard/templates/raw/travel.json
@@ -2025,73 +2025,6 @@
           "isDefaultBackground": true
         },
         {
-          "x": 324.5,
-          "y": -57,
-          "width": 88,
-          "height": 88,
-          "type": "shape",
-          "opacity": 100,
-          "flip": {
-            "vertical": false,
-            "horizontal": false
-          },
-          "rotationAngle": 0,
-          "backgroundColor": {
-            "color": {
-              "r": 9,
-              "g": 66,
-              "b": 40
-            }
-          },
-          "scale": 100,
-          "focalX": 50,
-          "focalY": 50,
-          "mask": {
-            "type": "rectangle"
-          },
-          "id": "7c4a2686-3bcc-4e41-92ed-f12b899b615b",
-          "lockAspectRatio": true
-        },
-        {
-          "x": 324.5,
-          "y": -23.5,
-          "width": 88,
-          "height": 21,
-          "font": {
-            "service": "fonts.google.com",
-            "family": "Oswald",
-            "fallbacks": ["sans-serif"]
-          },
-          "type": "text",
-          "opacity": 100,
-          "flip": {
-            "vertical": false,
-            "horizontal": false
-          },
-          "rotationAngle": 0,
-          "backgroundTextMode": "NONE",
-          "lineHeight": 1,
-          "textAlign": "center",
-          "backgroundColor": {
-            "color": {
-              "r": 196,
-              "g": 196,
-              "b": 196
-            }
-          },
-          "scale": 100,
-          "focalX": 50,
-          "focalY": 50,
-          "basedOn": "3cf17fb8-a5ae-4f32-8e5f-d3a0513215de",
-          "id": "4f71e74f-fd3f-4840-9ea4-8c0f59363952",
-          "content": "<span style=\"color: rgba(255, 255, 255, 1)\">NO. 3</span>",
-          "fontSize": 21,
-          "padding": {
-            "horizontal": 0,
-            "vertical": 0
-          }
-        },
-        {
           "x": 42,
           "y": 381,
           "width": 152,
@@ -2170,7 +2103,7 @@
           }
         },
         {
-          "x": -2,
+          "x": 0,
           "y": -57,
           "width": 327,
           "height": 402,
@@ -2208,6 +2141,73 @@
             "alt": "",
             "local": false,
             "sizes": []
+          }
+        },
+        {
+          "x": 238.734375,
+          "y": 257,
+          "width": 88,
+          "height": 88,
+          "type": "shape",
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundColor": {
+            "color": {
+              "r": 9,
+              "g": 66,
+              "b": 40
+            }
+          },
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "id": "7c4a2686-3bcc-4e41-92ed-f12b899b615b",
+          "lockAspectRatio": true
+        },
+        {
+          "x": 238.734375,
+          "y": 290.5,
+          "width": 88,
+          "height": 21,
+          "font": {
+            "service": "fonts.google.com",
+            "family": "Oswald",
+            "fallbacks": ["sans-serif"]
+          },
+          "type": "text",
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "backgroundTextMode": "NONE",
+          "lineHeight": 1,
+          "textAlign": "center",
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "3cf17fb8-a5ae-4f32-8e5f-d3a0513215de",
+          "id": "4f71e74f-fd3f-4840-9ea4-8c0f59363952",
+          "content": "<span style=\"color: rgba(255, 255, 255, 1)\">NO. 3</span>",
+          "fontSize": 21,
+          "padding": {
+            "horizontal": 0,
+            "vertical": 0
           }
         }
       ],
@@ -2300,7 +2300,7 @@
           "type": "move",
           "overflowHidden": false,
           "offsetX": 0,
-          "offsetY": "-100%",
+          "offsetY": "100%",
           "id": "6ddb06d9-4246-45b1-af1f-26149f6d80b3",
           "duration": 600,
           "delay": 900,
@@ -2313,7 +2313,7 @@
           "type": "move",
           "overflowHidden": true,
           "offsetX": 0,
-          "offsetY": "100%",
+          "offsetY": "-100%",
           "id": "d4ed474b-a264-4730-bde5-31b227bf575e",
           "duration": 600,
           "delay": 900,


### PR DESCRIPTION
## Summary

This PR updates page 7 of the Travel template.  It moves the green "No. 3" box from the top right of the page to the bottom right corner of the main image on the page.

**From this**:
<img src="https://user-images.githubusercontent.com/40646372/87596785-8c103f80-c6a5-11ea-9021-6b4be5dc400e.png" height="300">

**To this**:
<img src="https://user-images.githubusercontent.com/40646372/87597420-9da61700-c6a6-11ea-8ce2-f9c28a669581.png" height="300">

## User-facing changes

Page 7 of the Travel Template should now look like this:
<img src="https://user-images.githubusercontent.com/40646372/87598135-d72b5200-c6a7-11ea-8115-ca41bac90f93.png" height="500">

## Testing Instructions

1.) Go to "Explore Templates".
2.) Click "view" on the Travel template.
3.) Navigate to page 7 of the Travel template and make sure it appears like the image above.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2873 

## Animations
Animations for the page still work 🎉 
![wellbeing_page7_anim](https://user-images.githubusercontent.com/40646372/87600598-d9da7700-c6a8-11ea-936a-263473aa52bf.gif)

