### PR TITLE
3P Media: fix search and pagination

### DIFF
--- a/assets/src/edit-story/app/media/media3p/providerReducer.js
+++ b/assets/src/edit-story/app/media/media3p/providerReducer.js
@@ -20,7 +20,6 @@
 import commonReducer, {
   INITIAL_STATE as COMMON_INITIAL_STATE,
 } from '../common/reducer';
-import * as types from './types';
 
 const INITIAL_STATE = {
   ...COMMON_INITIAL_STATE,
@@ -40,16 +39,7 @@ const INITIAL_STATE = {
  * @return {Object} The new state
  */
 function providerReducer(state = INITIAL_STATE, { type, payload }) {
-  state = commonReducer(state, { type, payload });
-
-  if (type === types.SET_SEARCH_TERM) {
-    return {
-      pageToken: undefined,
-      nextPageToken: undefined,
-      ...state,
-    };
-  }
-  return state;
+  return commonReducer(state, { type, payload });
 }
 
 export default providerReducer;

--- a/assets/src/edit-story/app/media/media3p/reducer.js
+++ b/assets/src/edit-story/app/media/media3p/reducer.js
@@ -76,10 +76,16 @@ function reducer(state = INITIAL_STATE, { type, payload }) {
       };
     }
     case types.SET_SEARCH_TERM: {
-      return {
+      let resultState = {
         ...state,
         searchTerm: payload.searchTerm,
       };
+      // Clear out the pageToken and nextPageToken for all providers.
+      for (const provider of providers) {
+        resultState[provider].pageToken = undefined;
+        resultState[provider].nextPageToken = undefined;
+      }
+      return resultState;
     }
     default:
       return state;


### PR DESCRIPTION
Search was broken wrt pagination because we were clearing the pageToken and nextPageToken in the wrong page. Basically, the SET_SEARCH_TERM action is never reduced by the per-provider reducers because it doesn't have a provider in its payload (search is global to all providers).

This also changes to have different action types for local and media3p