### PR TITLE
Use the 'scroll' event to load more media results

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
@@ -92,7 +92,9 @@ function PaginatedMediaGallery({
         !isMediaLoaded ||
         isMediaLoading ||
         !hasMore ||
-        !entry.isIntersecting
+        !entry.isIntersecting ||
+        // Avoid loading the next page while <Gallery> is rendering.
+        entry.boundingClientRect.y < ROOT_MARGIN + 50
       ) {
         return;
       }

--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -101,7 +101,9 @@ describe('Media3pPane fetching', () => {
         '[data-testid=mediaElement]'
       );
       if (!mediaElements || mediaElements.length !== expectedCount) {
-        throw new Error('Not ready');
+        throw new Error(
+          `Not ready: ${mediaElements?.length} != ${expectedCount}`
+        );
       }
     });
     expect(mediaElements.length).toBe(expectedCount);

--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -14,130 +14,129 @@
  * limitations under the License.
  */
 
-// TODO(#3182): Fix these flakey tests; actual element count can be 40 != 20.
-// /**
-//  * External dependencies
-//  */
-// import { waitFor } from '@testing-library/react';
+/**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
 
-// /**
-//  * Internal dependencies
-//  */
-// import apiFetcher from '../../../../../../app/media/media3p/api/apiFetcher';
-// import { Fixture, MEDIA_PER_PAGE } from '../../../../../../karma/fixture';
-// import { ROOT_MARGIN } from '../../local/mediaPane';
+/**
+ * Internal dependencies
+ */
+import apiFetcher from '../../../../../../app/media/media3p/api/apiFetcher';
+import { Fixture, MEDIA_PER_PAGE } from '../../../../../../karma/fixture';
+import { ROOT_MARGIN } from '../../local/mediaPane';
 
-// const createMediaResource = (name) => ({
-//   name,
-//   provider: 'UNSPLASH',
-//   imageUrls: [
-//     {
-//       imageName: 'full',
-//       url: 'http://www.img.com/1',
-//       width: 640,
-//       height: 480,
-//       mimeType: 'image/png',
-//     },
-//     {
-//       imageName: 'large',
-//       url: 'http://www.img.com/2',
-//       width: 300,
-//       height: 200,
-//       mimeType: 'image/png',
-//     },
-//     {
-//       imageName: 'web_stories_thumbnail',
-//       url: 'http://www.img.com/3',
-//       width: 200,
-//       height: 100,
-//       mimeType: 'image/png',
-//     },
-//   ],
-//   description: 'A cat',
-//   type: 'IMAGE',
-//   createTime: '1234',
-//   updateTime: '5678',
-// });
+const createMediaResource = (name) => ({
+  name,
+  provider: 'UNSPLASH',
+  imageUrls: [
+    {
+      imageName: 'full',
+      url: 'http://www.img.com/1',
+      width: 640,
+      height: 480,
+      mimeType: 'image/png',
+    },
+    {
+      imageName: 'large',
+      url: 'http://www.img.com/2',
+      width: 300,
+      height: 200,
+      mimeType: 'image/png',
+    },
+    {
+      imageName: 'web_stories_thumbnail',
+      url: 'http://www.img.com/3',
+      width: 200,
+      height: 100,
+      mimeType: 'image/png',
+    },
+  ],
+  description: 'A cat',
+  type: 'IMAGE',
+  createTime: '1234',
+  updateTime: '5678',
+});
 
-// const mediaPage1 = [...new Array(20).keys()].map((n) =>
-//   createMediaResource(`media/unsplash:${n + 1}`)
-// );
-// const mediaPage2 = [...new Array(20).keys()].map((n) =>
-//   createMediaResource(`media/unsplash:${n + 21}`)
-// );
+const mediaPage1 = [...new Array(20).keys()].map((n) =>
+  createMediaResource(`media/unsplash:${n + 1}`)
+);
+const mediaPage2 = [...new Array(20).keys()].map((n) =>
+  createMediaResource(`media/unsplash:${n + 21}`)
+);
 
-// describe('Media3pPane fetching', () => {
-//   let fixture;
-//   let media3pTab;
-//   let media3pPane;
+describe('Media3pPane fetching', () => {
+  let fixture;
+  let media3pTab;
+  let media3pPane;
 
-//   beforeEach(async () => {
-//     fixture = new Fixture();
-//     fixture.setFlags({ media3pTab: true });
+  beforeEach(async () => {
+    fixture = new Fixture();
+    fixture.setFlags({ media3pTab: true });
 
-//     await fixture.render();
+    await fixture.render();
 
-//     media3pTab = fixture.querySelector('#library-tab-media3p');
-//     media3pPane = fixture.querySelector('#library-pane-media3p');
-//   });
+    media3pTab = fixture.querySelector('#library-tab-media3p');
+    media3pPane = fixture.querySelector('#library-pane-media3p');
+  });
 
-//   function mockListMedia() {
-//     /* eslint-disable-next-line jasmine/no-unsafe-spy */
-//     spyOn(apiFetcher, 'listMedia').and.callFake(({ pageToken }) => {
-//       switch (pageToken) {
-//         case undefined:
-//           return { media: mediaPage1, nextPageToken: 'page2' };
-//         case 'page2':
-//           return { media: mediaPage2, nextPageToken: undefined };
-//         default:
-//           throw new Error(`Unexpected pageToken: ${pageToken}`);
-//       }
-//     });
-//   }
+  function mockListMedia() {
+    /* eslint-disable-next-line jasmine/no-unsafe-spy */
+    spyOn(apiFetcher, 'listMedia').and.callFake(({ pageToken }) => {
+      switch (pageToken) {
+        case undefined:
+          return { media: mediaPage1, nextPageToken: 'page2' };
+        case 'page2':
+          return { media: mediaPage2, nextPageToken: undefined };
+        default:
+          throw new Error(`Unexpected pageToken: ${pageToken}`);
+      }
+    });
+  }
 
-//   async function expectMediaElements(expectedCount) {
-//     let mediaElements;
-//     await waitFor(() => {
-//       mediaElements = media3pPane.querySelectorAll(
-//         '[data-testid=mediaElement]'
-//       );
-//       if (!mediaElements || mediaElements.length !== expectedCount) {
-//         throw new Error('Not ready');
-//       }
-//     });
-//     expect(mediaElements.length).toBe(expectedCount);
-//   }
+  async function expectMediaElements(expectedCount) {
+    let mediaElements;
+    await waitFor(() => {
+      mediaElements = media3pPane.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
+      if (!mediaElements || mediaElements.length !== expectedCount) {
+        throw new Error('Not ready');
+      }
+    });
+    expect(mediaElements.length).toBe(expectedCount);
+  }
 
-//   it('should render no results message', async () => {
-//     spyOn(apiFetcher, 'listMedia').and.callFake(() => ({ media: [] }));
-//     await fixture.events.click(media3pTab);
+  it('should render no results message', async () => {
+    spyOn(apiFetcher, 'listMedia').and.callFake(() => ({ media: [] }));
+    await fixture.events.click(media3pTab);
 
-//     await waitFor(() => {
-//       expect(
-//         fixture.screen.getByText(new RegExp('^No media found$'))
-//       ).toBeTruthy();
-//     });
-//   });
+    await waitFor(() => {
+      expect(
+        fixture.screen.getByText(new RegExp('^No media found$'))
+      ).toBeTruthy();
+    });
+  });
 
-//   it('should fetch media resources', async () => {
-//     mockListMedia();
-//     await fixture.events.click(media3pTab);
-//     await expectMediaElements(MEDIA_PER_PAGE);
-//   });
+  it('should fetch media resources', async () => {
+    mockListMedia();
+    await fixture.events.click(media3pTab);
+    await expectMediaElements(MEDIA_PER_PAGE);
+  });
 
-//   it('should fetch 2nd page', async () => {
-//     mockListMedia();
-//     await fixture.events.click(media3pTab);
+  it('should fetch 2nd page', async () => {
+    mockListMedia();
+    await fixture.events.click(media3pTab);
 
-//     const mediaGallery = media3pPane.querySelector(
-//       '[data-testid="media-gallery-container"]'
-//     );
-//     await expectMediaElements(MEDIA_PER_PAGE);
+    const mediaGallery = media3pPane.querySelector(
+      '[data-testid="media-gallery-container"]'
+    );
+    await expectMediaElements(MEDIA_PER_PAGE);
 
-//     mediaGallery.scrollTo(
-//       0,
-//       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN
-//     );
-//     await expectMediaElements(MEDIA_PER_PAGE * 2);
-//   });
-// });
+    mediaGallery.scrollTo(
+      0,
+      mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN
+    );
+    await expectMediaElements(MEDIA_PER_PAGE * 2);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the flakey media3p pagination test, by using the 'scroll' event instead of useIntersectionEffect:
* Call setNextPage when the 'scroll' event indicates the user is near the bottom.
* Call setNextPage if the scrollbar is not visible, with empty space available for more results.
This can happen if the user has a large monitor or zooms out.

The test was flakey because <Gallery> has multiple layout cycles, and so useIntersectionEffect would erroneously think that the user is near the bottom of the page during one of these cycles.

Fixes: https://github.com/google/web-stories-wp/issues/3182
