### PR TITLE
Workspace: Add keyboard shortcuts for text formatting

### DIFF
--- a/assets/src/edit-story/components/panels/test/textStyle.js
+++ b/assets/src/edit-story/components/panels/test/textStyle.js
@@ -484,6 +484,64 @@ describe('Panels/TextStyle', () => {
       await fireEvent.change(input, { target: { value: '' } });
       expect(pushUpdate).not.toHaveBeenCalled();
     });
+
+    it('should set the text bold when the key command is pressed', async () => {
+      const { pushUpdate, container } = renderTextStyle([textElement]);
+
+      await fireEvent.keyDown(container, {
+        key: 'b',
+        which: 66,
+        ctrlKey: true,
+      });
+
+      const updatingFunction = pushUpdate.mock.calls[0][0];
+      const resultOfUpdating = updatingFunction({ content: 'Hello world' });
+      expect(resultOfUpdating).toStrictEqual(
+        {
+          content: '<span style="font-weight: 700">Hello world</span>',
+        },
+        true
+      );
+    });
+
+    it('should set the text underline when the key command is pressed', async () => {
+      const { pushUpdate, container } = renderTextStyle([textElement]);
+
+      await fireEvent.keyDown(container, {
+        key: 'u',
+        which: 85,
+        ctrlKey: true,
+      });
+
+      const updatingFunction = pushUpdate.mock.calls[0][0];
+      const resultOfUpdating = updatingFunction({ content: 'Hello world' });
+      expect(resultOfUpdating).toStrictEqual(
+        {
+          content:
+            '<span style="text-decoration: underline">Hello world</span>',
+        },
+        true
+      );
+    });
+
+    it('should set the text italics when the key command is pressed', async () => {
+      const { pushUpdate, container } = renderTextStyle([textElement]);
+
+      await fireEvent.keyDown(container, {
+        key: 'i',
+        which: 73,
+        ctrlKey: true,
+      });
+
+      const updatingFunction = pushUpdate.mock.calls[0][0];
+      const resultOfUpdating = updatingFunction({ content: 'Hello world' });
+      expect(resultOfUpdating).toStrictEqual(
+        {
+          content: '<span style="font-style: italic">Hello world</span>',
+        },
+        true
+      );
+    });
   });
 
   describe('TextStyleControls', () => {

--- a/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
+++ b/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
@@ -29,6 +29,7 @@ import {
   getHTMLInfo,
 } from '../../richText/htmlManipulation';
 import { MULTIPLE_VALUE } from '../../form';
+import { useGlobalKeyDownEffect } from '../../keyboard';
 
 /**
  * Equality function for *primitives and color patterns* only.
@@ -132,6 +133,26 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
       handleSetColor: (color) => push(htmlFormatters.setColor, color),
     };
   }, [hasCurrentEditor, selectionActions, push]);
+
+  useGlobalKeyDownEffect(
+    { key: ['mod+b', 'mod+u', 'mod+i'] },
+    ({ key }) => {
+      switch (key) {
+        case 'b':
+          handlers.handleClickBold();
+          break;
+        case 'i':
+          handlers.handleClickItalic();
+          break;
+        case 'u':
+          handlers.handleClickUnderline();
+          break;
+        default:
+          break;
+      }
+    },
+    [handlers]
+  );
 
   return {
     textInfo,


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts for bold, italics, and underline when a text box is selected.

## Relevant Technical Choices

- Uses the existing `useGlobalKeyDownEffect` hook to add support for the keyboard events. 
- Since the majority of the required logic is in `useRichTextFormatting.js` it made more sense to add the events there than the global events file since the `pushUpdate` and font handler functions are not easily available there.

## User-facing changes

Selecting a text box in the editor and pressing <kbd>Ctrl/Cmd</kbd> + <kbd>b</kbd> should bold
Selecting a text box in the editor and pressing <kbd>Ctrl/Cmd</kbd> + <kbd>i</kbd> should set the text to italics
Selecting a text box in the editor and pressing <kbd>Ctrl/Cmd</kbd> + <kbd>u</kbd> should underline the text


## Testing Instructions

Open a story with text in the editor.

Command for Mac, Control for Windows/Linux.

Select a text box in the editor and pressing <kbd>Ctrl/Cmd</kbd> + <kbd>b</kbd> should bold the text
Select a text box in the editor and pressing <kbd>Ctrl/Cmd</kbd> + <kbd>i</kbd> should set the text to italics
Select a text box in the editor and pressing <kbd>Ctrl/Cmd</kbd> + <kbd>u</kbd> should underline the text

---

<!-- Please reference the issue(s) this PR addresses. -->

#1977
