### PR TITLE
Media: add test for searchTerm states

### DIFF
--- a/assets/src/edit-story/app/media/local/reducer.js
+++ b/assets/src/edit-story/app/media/local/reducer.js
@@ -46,7 +46,7 @@ const INITIAL_STATE = {
  * @param {Object} obj.payload The details of the action, specific to the action
  * @return {Object} The new state
  */
-function reducer(state = INITIAL_STATE, { type, payload }) {
+export function reducer(state = INITIAL_STATE, { type, payload }) {
   switch (type) {
     case commonTypes.FETCH_MEDIA_SUCCESS: {
       const { provider, mediaType, searchTerm } = payload;

--- a/assets/src/edit-story/app/media/media3p/reducer.js
+++ b/assets/src/edit-story/app/media/media3p/reducer.js
@@ -65,7 +65,7 @@ function reduceProviderStates(state, { type, payload }) {
  * @param {Object} obj.payload The details of the action, specific to the action
  * @return {Object} The new state
  */
-function reducer(state = INITIAL_STATE, { type, payload }) {
+export function reducer(state = INITIAL_STATE, { type, payload }) {
   state = reduceProviderStates(state, { type, payload });
 
   switch (type) {

--- a/assets/src/edit-story/app/media/media3p/test/reducer.js
+++ b/assets/src/edit-story/app/media/media3p/test/reducer.js
@@ -22,16 +22,18 @@ import { renderHook } from '@testing-library/react-hooks';
 /**
  * Internal dependencies
  */
-import reducer from '../reducer';
+import { reducer as media3pReducer } from '../reducer';
+import { reducer as localReducer } from '../../local/reducer';
 import useMediaReducer from '../../useMediaReducer';
 import * as media3pActionsToWrap from '../actions';
+import * as localMediaActionsToWrap from '../../local/actions';
 import * as types from '../../types';
 
 describe('reducer', () => {
   let initialValue;
 
   beforeEach(() => {
-    initialValue = reducer(undefined, { type: types.INITIAL_STATE });
+    initialValue = media3pReducer(undefined, { type: types.INITIAL_STATE });
   });
 
   it('should provide initial state for each provider', () => {
@@ -42,7 +44,7 @@ describe('reducer', () => {
 
   it('should reduce each provider state', () => {
     const { result } = renderHook(() =>
-      useMediaReducer(reducer, media3pActionsToWrap)
+      useMediaReducer(media3pReducer, media3pActionsToWrap)
     );
 
     result.current.actions.fetchMediaSuccess({
@@ -60,7 +62,7 @@ describe('reducer', () => {
 
   it('should assign selectedProvider on setSelectedProvider', () => {
     const { result } = renderHook(() =>
-      useMediaReducer(reducer, media3pActionsToWrap)
+      useMediaReducer(media3pReducer, media3pActionsToWrap)
     );
 
     result.current.actions.setSelectedProvider({ provider: 'unsplash' });
@@ -74,7 +76,7 @@ describe('reducer', () => {
 
   it('should assign searchTerm on setSearchTerm', () => {
     const { result } = renderHook(() =>
-      useMediaReducer(reducer, media3pActionsToWrap)
+      useMediaReducer(media3pReducer, media3pActionsToWrap)
     );
 
     result.current.actions.setSearchTerm({ searchTerm: 'cats' });
@@ -82,6 +84,53 @@ describe('reducer', () => {
     expect(result.current.state).toStrictEqual(
       expect.objectContaining({
         searchTerm: 'cats',
+      })
+    );
+  });
+
+  it('setting local search term does not affect media3p search term', () => {
+    const { result: localMediaResult } = renderHook(() =>
+      useMediaReducer(localReducer, localMediaActionsToWrap)
+    );
+
+    localMediaResult.current.actions.setSearchTerm({ searchTerm: 'cats' });
+
+    const { result: media3pResult } = renderHook(() =>
+      useMediaReducer(media3pReducer, media3pActionsToWrap)
+    );
+
+    expect(localMediaResult.current.state).toStrictEqual(
+      expect.objectContaining({
+        searchTerm: 'cats',
+      })
+    );
+    expect(media3pResult.current.state).toStrictEqual(
+      expect.objectContaining({
+        searchTerm: '',
+      })
+    );
+  });
+
+  it('setting media3p search term does not affect local search term', () => {
+    const { result: media3pResult } = renderHook(() =>
+      useMediaReducer(media3pReducer, media3pActionsToWrap)
+    );
+
+    media3pResult.current.actions.setSearchTerm({ searchTerm: 'cats' });
+
+    const { result: localMediaResult } = renderHook(() =>
+      useMediaReducer(localReducer, localMediaActionsToWrap)
+    );
+
+    expect(media3pResult.current.state).toStrictEqual(
+      expect.objectContaining({
+        searchTerm: 'cats',
+      })
+    );
+
+    expect(localMediaResult.current.state).toStrictEqual(
+      expect.objectContaining({
+        searchTerm: '',
       })
     );
   });


### PR DESCRIPTION
Adds a test to verify that the `searchTerm` states don't pollute each other