### PR TITLE
Embed Block: use built in string type for url attribute

### DIFF
--- a/includes/Embed_Block.php
+++ b/includes/Embed_Block.php
@@ -62,7 +62,7 @@ class Embed_Block {
 			[
 				'attributes'      => [
 					'url'    => [
-						'type' => 'url',
+						'type' => 'string',
 					],
 					'title'  => [
 						'type'    => 'string',


### PR DESCRIPTION
## Summary



## Relevant Technical Choices

Fix a PHP notice: `url` is not a valid type, URLs are strings.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3298
