### PR TITLE
Dashboad: CUJ karma test for WordPress list view

### DIFF
--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -776,8 +776,18 @@ describe('CUJ: Creator can view their stories in list view', () => {
   });
 
   describe('Action: Go to WP list view to do any action', () => {
-    // Disable reason: Not implemented yet
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should add a link to the classic WordPress list view', () => {});
+    it('should add a link to the classic WordPress list view', async () => {
+      const listViewButton = fixture.screen.getByLabelText(
+        new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
+      );
+
+      await fixture.events.click(listViewButton);
+
+      const wpListViewLink = fixture.screen.getByRole('link', {
+        name: /^See classic WP list view$/,
+      });
+
+      expect(wpListViewLink).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Implements a karma/jasmine test for the following CUJ test:

`CUJ: Creator can view their stories in list view` -> `Action: Go to WP list view to do any action` -> `should add a link to the classic WordPress list view`

## Relevant Technical Choices

Because our karma/jasmine tests do not run in a WordPress context we will simply assert that the WP List View link is rendered/available.

## User-facing changes

None

## Testing Instructions

Verify the karma test passes
