### PR TITLE
Dashboard: Typeahead results to scroll & preserve current selection

### DIFF
--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -16,7 +16,6 @@
 /**
  * External dependencies
  */
-import { useMemo } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
@@ -106,8 +105,6 @@ const PageHeading = ({
   handleTypeaheadChange,
   typeaheadValue = '',
 }) => {
-  const typeaheadResults = useMemo(() => stories.slice(0, 5), [stories]);
-
   return (
     <Container>
       <HeadingBodyWrapper>
@@ -122,7 +119,7 @@ const PageHeading = ({
               <TypeaheadSearch
                 placeholder={searchPlaceholder}
                 currentValue={typeaheadValue}
-                stories={typeaheadResults}
+                stories={stories}
                 handleChange={handleTypeaheadChange}
               />
             </SearchInner>

--- a/assets/src/dashboard/app/views/shared/typeaheadSearch.js
+++ b/assets/src/dashboard/app/views/shared/typeaheadSearch.js
@@ -44,7 +44,7 @@ export default function TypeaheadSearch({
     <TypeaheadInput
       inputId="typeahead-search"
       items={typeaheadMenuOptions}
-      onChange={(val) => handleChange(val.trim())}
+      onChange={handleChange}
       value={currentValue}
       placeholder={placeholder}
       ariaLabel={placeholder}

--- a/assets/src/dashboard/components/typeaheadInput/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/index.js
@@ -137,7 +137,6 @@ const TypeaheadInput = ({
   className,
   disabled,
   onChange,
-  maxItemsVisible = 5,
   placeholder,
   value = '',
   ariaLabel,
@@ -173,10 +172,13 @@ const TypeaheadInput = ({
 
   const handleInputChange = useCallback(
     (item) => {
+      if (!showMenu) {
+        setShowMenu(true);
+      }
       setInputValue(item.label);
-      onChange(item.value);
+      onChange(item.value.trim());
     },
-    [onChange, setInputValue]
+    [onChange, setInputValue, setShowMenu, showMenu]
   );
 
   const handleMenuItemSelect = (item) => {
@@ -230,7 +232,7 @@ const TypeaheadInput = ({
             placeholder={placeholder}
           />
         </ControlVisibilityContainer>
-        {inputValue.length > 0 && !isMenuOpen && (
+        {inputValue.length > 0 && (
           <ClearInputButton
             data-testid="clear-search"
             onClick={handleInputClear}
@@ -245,7 +247,6 @@ const TypeaheadInput = ({
         <TypeaheadOptions
           isOpen={isMenuOpen}
           items={items}
-          maxItemsVisible={maxItemsVisible}
           onSelect={items && handleMenuItemSelect}
         />
       )}
@@ -266,7 +267,6 @@ TypeaheadInput.propTypes = {
   className: PropTypes.string,
   disabled: PropTypes.bool,
   isFiltering: PropTypes.bool,
-  maxItemsVisible: PropTypes.number,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),

--- a/assets/src/dashboard/components/typeaheadInput/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/index.js
@@ -245,6 +245,7 @@ const TypeaheadInput = ({
 
       {isMenuOpen && (
         <TypeaheadOptions
+          currentSelection={value}
           isOpen={isMenuOpen}
           items={items}
           onSelect={items && handleMenuItemSelect}

--- a/assets/src/dashboard/components/typeaheadInput/stories/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/stories/index.js
@@ -61,7 +61,6 @@ export const _default = () => {
           }
           action(`input changed ${inputValue}`)(inputValue);
         }}
-        maxItemsVisible={number('maxItemsVisible', 7)}
         value={value}
         placeholder={text('placeholder', 'Search Stories')}
         ariaLabel={text('ariaLabel', 'my search for seasonings')}

--- a/assets/src/dashboard/components/typeaheadInput/stories/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/stories/index.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { action } from '@storybook/addon-actions';
-import { boolean, number, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 import { useState } from 'react';
 import styled from 'styled-components';
 /**
@@ -60,6 +60,7 @@ export const _default = () => {
             setValue('');
           }
           action(`input changed ${inputValue}`)(inputValue);
+          setValue(inputValue);
         }}
         value={value}
         placeholder={text('placeholder', 'Search Stories')}

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -63,7 +63,7 @@ const MenuItem = styled.li`
 `;
 MenuItem.propTypes = {
   isDisabled: PropTypes.bool,
-  itemBgColor: PropTypes.oneOf('gray25', 'gray50'),
+  itemBgColor: PropTypes.oneOf(['gray25', 'gray50', false]),
 };
 
 const MenuItemContent = styled.span`

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -31,6 +31,8 @@ import { TypographyPresets } from '../typography';
 export const Menu = styled.ul`
   ${({ theme, isOpen }) => `
     width: 100%;
+    max-height: 300px;
+    overflow-y: scroll;
     align-items: flex-start;
     background-color: ${theme.colors.white};
     box-shadow: ${theme.expandedTypeahead.boxShadow};
@@ -39,7 +41,6 @@ export const Menu = styled.ul`
     flex-direction: column;
     margin: 5px 0 0;
     opacity: ${isOpen ? 1 : 0};
-    overflow: hidden;
     padding: 5px 0;
     pointer-events: ${isOpen ? 'auto' : 'none'};
     z-index: ${Z_INDEX.TYPEAHEAD_OPTIONS};
@@ -71,7 +72,7 @@ const MenuItemContent = styled.span`
   margin: auto 0;
 `;
 
-const TypeaheadOptions = ({ isOpen, items, maxItemsVisible = 5, onSelect }) => {
+const TypeaheadOptions = ({ isOpen, items, onSelect }) => {
   const [hoveredIndex, setHoveredIndex] = useState(0);
   const listRef = useRef(null);
 
@@ -85,7 +86,7 @@ const TypeaheadOptions = ({ isOpen, items, maxItemsVisible = 5, onSelect }) => {
             if (hoveredIndex > 0) {
               setHoveredIndex(hoveredIndex - 1);
               if (listRef.current) {
-                listRef.current.scrollToItem(hoveredIndex - 1);
+                listRef.current.children[hoveredIndex - 1].scrollIntoView();
               }
             }
             break;
@@ -95,7 +96,7 @@ const TypeaheadOptions = ({ isOpen, items, maxItemsVisible = 5, onSelect }) => {
             if (hoveredIndex < items.length - 1) {
               setHoveredIndex(hoveredIndex + 1);
               if (listRef.current) {
-                listRef.current.scrollToItem(hoveredIndex + 1);
+                listRef.current.children[hoveredIndex + 1].scrollIntoView();
               }
             }
             break;
@@ -119,7 +120,7 @@ const TypeaheadOptions = ({ isOpen, items, maxItemsVisible = 5, onSelect }) => {
 
   useEffect(() => {
     if (listRef.current) {
-      listRef.current.scrollToItem(0);
+      listRef.current.children[0].focus();
     }
     setHoveredIndex(0);
   }, [items]);
@@ -130,7 +131,7 @@ const TypeaheadOptions = ({ isOpen, items, maxItemsVisible = 5, onSelect }) => {
       <MenuItem
         key={`${item.value}_${index}`}
         isHovering={index === hoveredIndex}
-        onClick={() => !itemIsDisabled && onSelect && onSelect(item)}
+        onClick={() => !itemIsDisabled && onSelect(item)}
         onMouseEnter={() => setHoveredIndex(index)}
         isDisabled={itemIsDisabled}
       >
@@ -140,8 +141,8 @@ const TypeaheadOptions = ({ isOpen, items, maxItemsVisible = 5, onSelect }) => {
   };
 
   return (
-    <Menu isOpen={isOpen}>
-      {items.slice(0, maxItemsVisible).map((item, index) => {
+    <Menu isOpen={isOpen} ref={listRef}>
+      {items.map((item, index) => {
         return renderMenuItem(item, index);
       })}
     </Menu>
@@ -150,7 +151,6 @@ const TypeaheadOptions = ({ isOpen, items, maxItemsVisible = 5, onSelect }) => {
 
 TypeaheadOptions.propTypes = {
   items: PropTypes.arrayOf(DROPDOWN_ITEM_PROP_TYPE).isRequired,
-  maxItemsVisible: PropTypes.number,
   isOpen: PropTypes.bool,
   onSelect: PropTypes.func,
 };

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -126,31 +126,48 @@ const TypeaheadOptions = ({
   }, [hoveredIndex, items, onSelect, isOpen]);
 
   useEffect(() => {
-    if (listRef.current) {
-      listRef.current.children[0].focus();
+    if (!listRef.current) {
+      return () => {};
     }
+
+    listRef.current.children[0].focus();
+
+    return () => {};
   }, []);
 
   // we only want to set an existing value for currentSelection when the dropdown is newly opened
   useEffect(() => {
-    if (!isOptionMenuAlreadyOpen) {
-      setIsOptionMenuAlreadyOpen(true);
-      const existingValueOnMenuOpen = currentSelection
-        ? items.findIndex(
-            (item) =>
-              item.label.toLowerCase() === currentSelection.toLowerCase() ||
-              item.value.toLowerCase() === currentSelection.toLowerCase()
-          )
-        : -1;
-      existingValueOnMenuOpen > -1 && setSelectedIndex(existingValueOnMenuOpen);
+    if (isOptionMenuAlreadyOpen) {
+      return () => {};
     }
+
+    setIsOptionMenuAlreadyOpen(true);
+
+    const selectionToCheckFor = currentSelection.toLowerCase().trim();
+    const existingValueOnMenuOpen = selectionToCheckFor
+      ? items.findIndex(
+          (item) =>
+            (item.value &&
+              item.value.toLowerCase() === selectionToCheckFor.toLowerCase()) ||
+            item.label.toLowerCase() === selectionToCheckFor.toLowerCase()
+        )
+      : -1;
+    existingValueOnMenuOpen > -1 && setSelectedIndex(existingValueOnMenuOpen);
+
+    return () => {};
   }, [isOptionMenuAlreadyOpen, currentSelection, items]);
 
   // when selectedIndex is updated above we want to scroll it into view and focus it
   useEffect(() => {
+    if (!listRef.current || !listRef.current.children) {
+      return () => {};
+    }
+
     const selectedItem = listRef.current.children[selectedIndex];
-    selectedItem.scrollIntoView();
-    selectedItem.focus();
+    selectedItem?.scrollIntoView();
+    selectedItem?.focus();
+
+    return () => {};
   }, [selectedIndex]);
 
   const renderMenuItem = (item, index) => {

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -126,49 +126,40 @@ const TypeaheadOptions = ({
   }, [hoveredIndex, items, onSelect, isOpen]);
 
   useEffect(() => {
-    if (!listRef.current) {
-      return () => {};
+    if (listRef.current && listRef.current.children?.[0]) {
+      listRef.current.children[0].focus();
     }
-
-    listRef.current.children[0].focus();
-
-    return () => {};
   }, []);
 
   // we only want to set an existing value for currentSelection when the dropdown is newly opened
   useEffect(() => {
-    if (isOptionMenuAlreadyOpen) {
-      return () => {};
+    if (!isOptionMenuAlreadyOpen) {
+      setIsOptionMenuAlreadyOpen(true);
+
+      const selectionToCheckFor =
+        currentSelection && currentSelection.toLowerCase().trim();
+      const existingValueOnMenuOpen = selectionToCheckFor
+        ? items.findIndex(
+            (item) =>
+              (item.value &&
+                item.value.toLowerCase() === selectionToCheckFor) ||
+              item.label.toLowerCase() === selectionToCheckFor
+          )
+        : -1;
+
+      if (existingValueOnMenuOpen > -1) {
+        setSelectedIndex(existingValueOnMenuOpen);
+      }
     }
-
-    setIsOptionMenuAlreadyOpen(true);
-
-    const selectionToCheckFor =
-      currentSelection && currentSelection.toLowerCase().trim();
-    const existingValueOnMenuOpen = selectionToCheckFor
-      ? items.findIndex(
-          (item) =>
-            (item.value &&
-              item.value.toLowerCase() === selectionToCheckFor.toLowerCase()) ||
-            item.label.toLowerCase() === selectionToCheckFor.toLowerCase()
-        )
-      : -1;
-    existingValueOnMenuOpen > -1 && setSelectedIndex(existingValueOnMenuOpen);
-
-    return () => {};
   }, [isOptionMenuAlreadyOpen, currentSelection, items]);
 
   // when selectedIndex is updated above we want to scroll it into view and focus it
   useEffect(() => {
-    if (!listRef.current || !listRef.current.children) {
-      return () => {};
+    if (listRef.current && listRef.current.children) {
+      const selectedItem = listRef.current.children[selectedIndex];
+      selectedItem?.scrollIntoView();
+      selectedItem?.focus();
     }
-
-    const selectedItem = listRef.current.children[selectedIndex];
-    selectedItem?.scrollIntoView();
-    selectedItem?.focus();
-
-    return () => {};
   }, [selectedIndex]);
 
   const renderMenuItem = (item, index) => {

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -143,7 +143,8 @@ const TypeaheadOptions = ({
 
     setIsOptionMenuAlreadyOpen(true);
 
-    const selectionToCheckFor = currentSelection.toLowerCase().trim();
+    const selectionToCheckFor =
+      currentSelection && currentSelection.toLowerCase().trim();
     const existingValueOnMenuOpen = selectionToCheckFor
       ? items.findIndex(
           (item) =>

--- a/assets/src/dashboard/components/typeaheadOptions/stories/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/stories/index.js
@@ -35,6 +35,14 @@ const demoItems = [
     value: 'edge_case',
     label: 'i am a very very very very very very very long label',
   },
+  { value: 'dog', label: 'dog' },
+  { value: 'bat', label: 'bat' },
+  { value: 'cat', label: 'cat' },
+  { value: 'lemur', label: 'lemur' },
+  { value: 'rabbit', label: 'rabbit' },
+  { value: 'sloth', label: 'sloth' },
+  { value: 'turtle', label: 'turtle' },
+  { value: 'horse', label: 'horse' },
 ];
 
 export default {
@@ -50,7 +58,6 @@ export const _default = () => (
     <TypeaheadOptions
       items={demoItems}
       isOpen={boolean('isOpen', true)}
-      maxItemsVisible={number('maxItemsVisible')}
       onSelect={(item) => {
         action(`clicked on dropdown item ${item.value}`)(item);
       }}

--- a/assets/src/dashboard/components/typeaheadOptions/stories/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/stories/index.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { action } from '@storybook/addon-actions';
-import { boolean, number } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import styled from 'styled-components';
 
 /**
@@ -56,6 +56,7 @@ const TypeaheadOptionsWrapper = styled.div`
 export const _default = () => (
   <TypeaheadOptionsWrapper>
     <TypeaheadOptions
+      currentSelection={''}
       items={demoItems}
       isOpen={boolean('isOpen', true)}
       onSelect={(item) => {

--- a/assets/src/dashboard/components/typeaheadOptions/test/typeaheadOptions.js
+++ b/assets/src/dashboard/components/typeaheadOptions/test/typeaheadOptions.js
@@ -69,28 +69,13 @@ describe('TypeaheadOptions', () => {
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
 
-  it('should default to showing 5 items', () => {
+  it('should have 6 items', () => {
     const { getAllByRole } = renderWithTheme(
       <TypeaheadOptions onSelect={onClickMock} items={demoItems} isOpen />
     );
 
     const menuItems = getAllByRole('listitem');
 
-    expect(menuItems).toHaveLength(5);
-  });
-
-  it('should only show 3 items when maxItemsVisible is set', () => {
-    const { getAllByRole } = renderWithTheme(
-      <TypeaheadOptions
-        onSelect={onClickMock}
-        items={demoItems}
-        isOpen
-        maxItemsVisible={3}
-      />
-    );
-
-    const menuItems = getAllByRole('listitem');
-
-    expect(menuItems).toHaveLength(3);
+    expect(menuItems).toHaveLength(6);
   });
 });

--- a/assets/src/dashboard/components/typeaheadOptions/test/typeaheadOptions.js
+++ b/assets/src/dashboard/components/typeaheadOptions/test/typeaheadOptions.js
@@ -37,6 +37,9 @@ describe('TypeaheadOptions', () => {
 
   const onClickMock = jest.fn();
 
+  // https://stackoverflow.com/questions/53271193/typeerror-scrollintoview-is-not-a-function
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+
   it('should render a <TypeaheadOptions />', () => {
     const { getByText } = renderWithTheme(
       <TypeaheadOptions onSelect={onClickMock} items={demoItems} isOpen />
@@ -77,5 +80,51 @@ describe('TypeaheadOptions', () => {
     const menuItems = getAllByRole('listitem');
 
     expect(menuItems).toHaveLength(6);
+  });
+
+  it('should show selected value if one is present when menu is rendered that matches an item', () => {
+    const { getByText } = renderWithTheme(
+      <TypeaheadOptions
+        onSelect={onClickMock}
+        items={demoItems}
+        currentSelection={demoItems[1].value}
+        isOpen
+      />
+    );
+
+    const ActiveMenuItem = getByText(demoItems[1].label).parentElement;
+    const ActiveMenuItemStyle = window.getComputedStyle(ActiveMenuItem)
+      .backgroundColor;
+
+    expect(ActiveMenuItemStyle).toBe('rgb(238, 238, 238)');
+
+    const InactiveMenuItem = getByText(demoItems[3].label).parentElement;
+    const InactiveMenuItemStyle = window.getComputedStyle(InactiveMenuItem)
+      .backgroundColor;
+
+    expect(InactiveMenuItemStyle).toBe('');
+  });
+
+  it("should not show selected value if currentSelection doesn't match an item", () => {
+    const { getByText } = renderWithTheme(
+      <TypeaheadOptions
+        onSelect={onClickMock}
+        items={demoItems}
+        currentSelection={'fo'}
+        isOpen
+      />
+    );
+
+    const ActiveMenuItem = getByText(demoItems[1].label).parentElement;
+    const ActiveMenuItemStyle = window.getComputedStyle(ActiveMenuItem)
+      .backgroundColor;
+
+    expect(ActiveMenuItemStyle).toBe('');
+
+    const InactiveMenuItem = getByText(demoItems[3].label).parentElement;
+    const InactiveMenuItemStyle = window.getComputedStyle(InactiveMenuItem)
+      .backgroundColor;
+
+    expect(InactiveMenuItemStyle).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
Updates dashboard typeahead to be scrollable for when there are more than a few (5 was the limit) resulting search terms to pick from as you type. 
Also updates typeahead to preserve the previously chosen search term when it matches a value in the shown options. 
I did this together because the lack of current value getting preserved was a little jarring when testing the scrollability. 

## Relevant Technical Choices

**To scroll:** 
- remove the limit `maxItemsVisible` - we don't have any kind of virtual list set up here so limiting results in this fashion isn't applicable at the moment.
- set a max-height and allow overflow y to scroll 
- fi `scrollToView` that is attached to the listRef children to scroll into view - that wasn't working (just wasn't noticeable!) 


**To showing previously selected value when it matches on initial show of options:**
- update typeahead `handleInputChange` to re-expand the options menu (`setShowMenu` if that change is triggered again before exiting focus - this happens if you select something with a keyboard and then hit a non-tab key. Previously you would get locked out of seeing the typeahead options again. 
- add `currentSelection` prop from input to options. Add 1 piece of state to set the selected index (same style as hovered index) and also state to heck if option menu is already open so that we only set the selectedIndex when the options are initially expanded (on each expand). 
- New useEffect hooks to separate out the process of getting 2 things 
  - After initially focusing on the options menu when it expands for keyboard usability check for a currentSelection prop and if it's present check if one of the items values or labels match the selection. If this found index is > -1 then set the selectedIndex state. At this time also set the state that the menu's open so that we can block further attempts to find matching indexes as the search value is updated which would also update the current selection since we're querying results AS we search. 
  - Next useEffect hook we make sure the list ref has children (this is honestly mostly for RTL which struggles here) and then use `scrollIntoView` and `focus()` to make sure that if there's many items to scroll through the result you are currently selected when expanding is in view. 


## To-do
- The spacing/alignment of options in the typeahead are off in safari specifically, I'm working on this but figure it can be its own smaller PR/ticket since i already took liberty with increasing the scope with this ticket as is!
- The logic here makes sense to me but should probably be followed up on by UX. We might want to talk about if we want the search to filter as you type or when you hit enter (either in input or on an option) or click an option. Either way, doesn't really affect this fix for functionality and showing users what is currently selected. 

## User-facing changes
- You should now be able to scroll through options in dropdown when there's many matching results: 
![scrollable results](https://user-images.githubusercontent.com/10720454/87996282-8c924700-caa6-11ea-92a8-68237d34835e.gif)

- Your previously selected search term should be highlighted a slightly darker gray when you re-expand the typeahead results. This is _only_ if it's an exact match! So if you hit backspace nothing will be selected (just the normal hover) and if you type in 'cook' but the results are all 'cooking blah blah ...' then nothing will be selected (just the normal hover).

**Example of what results will look like if you re-expand results from either using a cursor after selecting something or have used a keyboard, hit enter, and tab and then tabbed back into results (so the search value is preserved)**
<img width="246" alt="Screen Shot 2020-07-20 at 4 54 28 PM" src="https://user-images.githubusercontent.com/10720454/87997465-02e47880-caaa-11ea-9368-8fbb1c88c6f2.png">


**Example of what results will look like if you make a selection with a keyboard and then hit backspace, where the search value is no longer preserved** 
<img width="255" alt="Screen Shot 2020-07-20 at 4 54 47 PM" src="https://user-images.githubusercontent.com/10720454/87997472-07a92c80-caaa-11ea-9ef6-62fdf34c9550.png">


## Testing Instructions

- Verify that you can scroll through options in the dropdown when applicable. Since we're filtering results with the search it's a pretty easy match up - the only caveat being that we're not paginating the search results! So if you have more than 24 (right now) matching results only 24 will be scrollable in the search input - however many results you have in your dashboard header (showing x results) is how many results you should be able to scroll through for the typeahead options. (this should work with a cursor or a keyboard) 

- Verify that a previously selected search value shows up a slightly darker gray when you re-expand the typeahead results ONLY if it's an exact match. 

- Regression test that other functionality of typeahead is still working (clearing results, keyboard functionality)

- Storybook typeaheadInput and typeaheadOptions are updated if you want to check functionality there for isolation too!

---



Addresses #2885 
