### PR TITLE
Dashboard: Typeahead options overlap in Safari

### DIFF
--- a/assets/src/dashboard/components/typeaheadInput/index.js
+++ b/assets/src/dashboard/components/typeaheadInput/index.js
@@ -35,6 +35,7 @@ import TypeaheadOptions from '../typeaheadOptions';
 import { TypographyPresets } from '../typography';
 
 const SearchContainer = styled.div`
+  width: 100%;
   display: flex;
   align-items: flex-end;
   flex-direction: column;

--- a/assets/src/dashboard/components/typeaheadOptions/index.js
+++ b/assets/src/dashboard/components/typeaheadOptions/index.js
@@ -54,10 +54,10 @@ const MenuItem = styled.li`
   ${TypographyPresets.Small};
   ${({ theme, isDisabled, itemBgColor }) => `
     padding: 10px 20px;
+    margin: 0; 
     background-color: ${itemBgColor ? theme.colors[itemBgColor] : 'none'};
     color: ${theme.colors.gray700};
     cursor: ${isDisabled ? 'default' : 'pointer'};
-    display: flex;
     width: 100%;
   `}
 `;
@@ -67,9 +67,12 @@ MenuItem.propTypes = {
 };
 
 const MenuItemContent = styled.span`
-  align-self: flex-start;
+  display: inline-block;
   height: 100%;
-  margin: auto 0;
+  width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const TypeaheadOptions = ({


### PR DESCRIPTION

## Summary
Fixes the styling in typeahead options so that longer names don't overlap in safari on search.  

## Relevant Technical Choices

- Fixing css for typeahead options so that in safari options center and don't stack on each other. 
- Adding width: 100% to typeahead container to make sure that width set in parent is always respected. 
- Ensuring that long titles are cut after 1 line with an ellipsis, no wrap. 
- Making sure the title span area gets 100% of width so that cutting text overflow works better. 
- No need for list items to be flex. 
- Setting list item margin to 0 to override common css.

## User-facing changes
Should go from this: 
![safari typeahead long options](https://user-images.githubusercontent.com/10720454/88096794-1516f300-cb4c-11ea-9f5f-5f3e299e59e8.gif)
![new search typeahead](https://user-images.githubusercontent.com/10720454/88096934-4c859f80-cb4c-11ea-9700-117a9b0b8b88.gif)


## Testing Instructions
Verify that typeahead options no longer overlap each other and if they are long the titles don't wrap and show an ellipsis. 

Chrome: 
![Screen Shot 2020-07-21 at 12 18 48 PM](https://user-images.githubusercontent.com/10720454/88097001-645d2380-cb4c-11ea-9917-3c84f57a83cd.png)

Safari: 
![Screen Shot 2020-07-21 at 12 19 22 PM](https://user-images.githubusercontent.com/10720454/88097026-6de68b80-cb4c-11ea-9b3a-82278b347eb7.png)

Firefox:
<img width="209" alt="Screen Shot 2020-07-21 at 12 19 43 PM" src="https://user-images.githubusercontent.com/10720454/88097071-7a6ae400-cb4c-11ea-9beb-e84c436cef4b.png">


---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #3342 
