### PR TITLE
Fix GitHub actions for forks

### DIFF
--- a/.github/workflows/continuous-integration-build.yml
+++ b/.github/workflows/continuous-integration-build.yml
@@ -104,8 +104,11 @@ jobs:
           path: build/*.zip
 
   deploy-to-wiki:
-    runs-on: ubuntu-latest
+    name: Deploy for QA
     needs: build
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.fork == false
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration-gh-pages.yml
+++ b/.github/workflows/continuous-integration-gh-pages.yml
@@ -59,6 +59,7 @@ jobs:
           path: assets/images/templates
 
   deploy-gh-pages:
+    name: Deploy to GH Pages
     runs-on: ubuntu-latest
     needs: [build-storybook, upload-static-assets]
     steps:

--- a/.github/workflows/continuous-integration-lint-js.yml
+++ b/.github/workflows/continuous-integration-lint-js.yml
@@ -41,12 +41,20 @@ jobs:
           CI: true
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
 
+      # todo: use eslint-output to basically run lint:js and lint:js:report in one step.
+      - name: Detect coding standard violations (ESLint)
+        run: npm run lint:js
+        continue-on-error: true
+        if: github.event.pull_request.head.repo.fork
+
       - name: Detect coding standard violations (ESLint)
         run: npm run lint:js:report
         continue-on-error: true
+        if: github.event.pull_request.head.repo.fork == false
 
       - name: Annotate Code Linting Results
         uses: ataylorme/eslint-annotate-action@1.1.2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'build/lint-js-report.json'
+        if: github.event.pull_request.head.repo.fork == false


### PR DESCRIPTION
Forks don't have access to the secret environment variables needed to do things like inline code annotations and deploying to the repository needed for QA.