### PR TITLE
Readme: add block to list of tags

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Requires PHP:      5.6
 Stable tag:        1.0.0
 License:           Apache License 2.0
 License URI:       https://www.apache.org/licenses/LICENSE-2.0
-Tags:              web-stories, amp, stories, storytelling, google
+Tags:              web-stories, amp, stories, storytelling, google, block
 
 Stories is a visual storytelling format for the open web which immerses your readers in fast-loading, full-screen, and visually rich experiences.
 


### PR DESCRIPTION
## Summary
Add block to list of tags, so it appears in block compatible list of plugins when on WP.org. 

See https://github.com/google/web-stories-wp/issues/3330

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
