### PR TITLE
Embed Block: Fix attribute type in block.json

### DIFF
--- a/assets/src/story-embed-block/block/block.json
+++ b/assets/src/story-embed-block/block/block.json
@@ -3,7 +3,7 @@
   "category": "embed",
   "attributes": {
     "url": {
-      "type": "url"
+      "type": "string"
     },
     "title": {
       "type": "string"


### PR DESCRIPTION
Gutenberg block do not support type url. It must be set to string.

See #3330
See #3298