### PR TITLE
Workspace: Add Save and Select All Keyboard Events

### DIFF
--- a/assets/src/edit-story/app/story/storyProvider.js
+++ b/assets/src/edit-story/app/story/storyProvider.js
@@ -23,7 +23,6 @@ import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
-import { useGlobalKeyDownEffect } from '../../components/keyboard';
 import Context from './context';
 
 import useLoadStory from './effects/useLoadStory';
@@ -108,18 +107,6 @@ function StoryProvider({ storyId, children }) {
     pages,
     story,
   });
-
-  useGlobalKeyDownEffect(
-    { key: ['mod+s'] },
-    (event) => {
-      event.preventDefault();
-      if (isSaving) {
-        return;
-      }
-      saveStory();
-    },
-    [saveStory, isSaving]
-  );
 
   const state = {
     state: {

--- a/assets/src/edit-story/app/story/storyProvider.js
+++ b/assets/src/edit-story/app/story/storyProvider.js
@@ -23,6 +23,7 @@ import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
+import { useGlobalKeyDownEffect } from '../../components/keyboard';
 import Context from './context';
 
 import useLoadStory from './effects/useLoadStory';
@@ -107,6 +108,18 @@ function StoryProvider({ storyId, children }) {
     pages,
     story,
   });
+
+  useGlobalKeyDownEffect(
+    { key: ['mod+s'] },
+    (event) => {
+      event.preventDefault();
+      if (isSaving) {
+        return;
+      }
+      saveStory();
+    },
+    [saveStory, isSaving]
+  );
 
   const state = {
     state: {

--- a/assets/src/edit-story/components/canvas/karma/canvasKeys.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/canvasKeys.karma.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+import { useStory } from '../../../app/story';
+import useInsertElement from '../useInsertElement';
+import createSolidFromString from '../../../utils/createSolidFromString';
+
+describe('Canvas Keyboard Shortcuts', () => {
+  let fixture;
+  let element1;
+  let element2;
+  let element3;
+  let fullbleed;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+
+    fullbleed = fixture.container.querySelector('[data-testid="fullbleed"]');
+
+    const insertElement = await fixture.renderHook(() => useInsertElement());
+    element1 = await fixture.act(() =>
+      insertElement('shape', {
+        backgroundColor: createSolidFromString('#f00123'),
+        mask: { type: 'rectangle' },
+        x: 10,
+        y: 10,
+        width: 50,
+        height: 50,
+      })
+    );
+    element2 = await fixture.act(() =>
+      insertElement('shape', {
+        backgroundColor: createSolidFromString('#f00123'),
+        mask: { type: 'rectangle' },
+        x: 100,
+        y: 100,
+        width: 50,
+        height: 50,
+      })
+    );
+    element3 = await fixture.act(() =>
+      insertElement('shape', {
+        backgroundColor: createSolidFromString('#f00123'),
+        mask: { type: 'rectangle' },
+        x: 200,
+        y: 200,
+        width: 50,
+        height: 50,
+      })
+    );
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  async function getSelection() {
+    const storyContext = await fixture.renderHook(() => useStory());
+    return storyContext.state.selectedElementIds;
+  }
+
+  it('should have the last element selected by default', async () => {
+    await fixture.events.focus(fullbleed);
+    await fixture.events.keyboard.shortcut('mod+a');
+    expect(await getSelection()).toEqual([
+      element1.id,
+      element2.id,
+      element3.id,
+    ]);
+  });
+});

--- a/assets/src/edit-story/components/canvas/test/useCanvasKeys.js
+++ b/assets/src/edit-story/components/canvas/test/useCanvasKeys.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { useRef } from 'react';
+import useCanvasKeys from '../useCanvasKeys';
+import StoryContext from '../../../app/story/context.js';
+import CanvasContext from '../../../components/canvas/context.js';
+
+const Canvas = () => {
+  const ref = useRef(null);
+  useCanvasKeys(ref);
+  return <div ref={ref} />;
+};
+
+describe('useCanvasKeys', function () {
+  it('should select all elements and collect their IDs when mod+a is pressed.', async function () {
+    const setSelectedElementsById = jest.fn();
+
+    const { container } = render(
+      <StoryContext.Provider
+        value={{
+          actions: { setSelectedElementsById },
+          state: {
+            currentPage: { elements: [{ id: '123' }, { id: '456' }] },
+          },
+        }}
+      >
+        <Canvas />
+      </StoryContext.Provider>
+    );
+
+    await fireEvent.keyDown(container, {
+      key: 'a',
+      which: 65,
+      ctrlKey: true,
+    });
+
+    expect(setSelectedElementsById).toHaveBeenCalledWith({
+      elementIds: ['123', '456'],
+    });
+  });
+
+  it('should enter edit mode when the element can when the "Enter" key is pressed.', async function () {
+    const setEditingElement = jest.fn();
+
+    const { container } = render(
+      <StoryContext.Provider
+        value={{
+          actions: { addElements: () => {} },
+          state: {
+            selectedElements: [{ id: 'abc123', type: 'text' }],
+          },
+        }}
+      >
+        <CanvasContext.Provider
+          value={{
+            actions: { setEditingElement },
+          }}
+        >
+          <Canvas />
+        </CanvasContext.Provider>
+      </StoryContext.Provider>
+    );
+
+    await fireEvent.keyDown(container, {
+      key: 'Enter',
+      which: 13,
+    });
+
+    expect(setEditingElement).toHaveBeenCalledWith('abc123');
+  });
+
+  it('should delete selected elements when the "Delete" key is pressed.', async function () {
+    const deleteSelectedElements = jest.fn();
+
+    const { container } = render(
+      <StoryContext.Provider
+        value={{
+          state: {
+            currentPage: { elements: [{ id: '123' }] },
+            selectedElements: [{ id: '123' }],
+          },
+          actions: { deleteSelectedElements },
+        }}
+      >
+        <Canvas />
+      </StoryContext.Provider>
+    );
+
+    await fireEvent.keyDown(container, {
+      key: 'Backspace',
+      which: 8,
+    });
+
+    expect(deleteSelectedElements).toHaveBeenCalledWith();
+  });
+
+  it('should deselect items when the "Escape" key is pressed.', async function () {
+    const clearSelection = jest.fn();
+
+    const { container } = render(
+      <StoryContext.Provider
+        value={{
+          state: {
+            currentPage: { elements: [{ id: '123' }] },
+            selectedElements: [{ id: '123' }],
+          },
+          actions: { clearSelection },
+        }}
+      >
+        <Canvas />
+      </StoryContext.Provider>
+    );
+
+    await fireEvent.keyDown(container, {
+      key: 'Escape',
+      which: 27,
+    });
+
+    expect(clearSelection).toHaveBeenCalledWith();
+  });
+});

--- a/assets/src/edit-story/components/canvas/useCanvasKeys.js
+++ b/assets/src/edit-story/components/canvas/useCanvasKeys.js
@@ -128,7 +128,7 @@ function useCanvasKeys(ref) {
       const elementIds = currentPage.elements.map(({ id }) => id);
       setSelectedElementsById({ elementIds });
     },
-    [clearSelection, currentPage, setSelectedElementsById]
+    [currentPage, setSelectedElementsById]
   );
 
   // Position (x/y) key handler.

--- a/assets/src/edit-story/components/canvas/useCanvasKeys.js
+++ b/assets/src/edit-story/components/canvas/useCanvasKeys.js
@@ -46,23 +46,28 @@ function useCanvasKeys(ref) {
     clearSelection,
     deleteSelectedElements,
     updateSelectedElements,
+    setSelectedElementsById,
+    currentPage,
   } = useStory(
     ({
-      state: { selectedElementIds, selectedElements },
+      state: { selectedElementIds, selectedElements, currentPage },
       actions: {
         arrangeSelection,
         clearSelection,
         deleteSelectedElements,
         updateSelectedElements,
+        setSelectedElementsById,
       },
     }) => {
       return {
+        currentPage,
         selectedElementIds,
         selectedElements,
         arrangeSelection,
         clearSelection,
         deleteSelectedElements,
         updateSelectedElements,
+        setSelectedElementsById,
       };
     }
   );
@@ -116,6 +121,15 @@ function useCanvasKeys(ref) {
     deleteSelectedElements,
   ]);
   useGlobalKeyDownEffect('esc', () => clearSelection(), [clearSelection]);
+
+  useGlobalKeyDownEffect(
+    { key: ['mod+a'] },
+    () => {
+      const elementIds = currentPage.elements.map(({ id }) => id);
+      setSelectedElementsById({ elementIds });
+    },
+    [clearSelection, currentPage, setSelectedElementsById]
+  );
 
   // Position (x/y) key handler.
   useGlobalKeyDownEffect(

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -35,6 +35,7 @@ import useRefreshPostEditURL from '../../utils/useRefreshPostEditURL';
 import { Outline, Primary } from '../button';
 import CircularProgress from '../circularProgress';
 import escapeHTML from '../../utils/escapeHTML';
+import { useGlobalKeyDownEffect } from '../keyboard';
 import PreviewErrorDialog from './previewErrorDialog';
 import PostPublishDialog from './postPublishDialog';
 
@@ -248,6 +249,18 @@ function Update() {
   const {
     state: { hasNewChanges },
   } = useHistory();
+
+  useGlobalKeyDownEffect(
+    { key: ['mod+s'] },
+    (event) => {
+      event.preventDefault();
+      if (isSaving) {
+        return;
+      }
+      saveStory();
+    },
+    [saveStory, isSaving]
+  );
 
   let text;
   switch (status) {

--- a/assets/src/edit-story/components/keyboard/index.js
+++ b/assets/src/edit-story/components/keyboard/index.js
@@ -87,7 +87,7 @@ function useKeyEffectInternal(
       const handler = createKeyHandler(node, keySpec, batchingCallback);
       mousetrap.bind(keySpec.key, handler, type);
       return () => {
-        mousetrap.unbind(keySpec.key);
+        mousetrap.unbind(keySpec.key, type);
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

- Adds Save and Select All Element Keyboard Events
- Adds Test coverage for a number of `useCanvasKeys` events
- Fixes a bug with the callback that caused the `Cut` event to crash at times

## Relevant Technical Choices

- Use existing global key hooks to add more key events

## User-facing changes

- Cmd+a (Mac) Ctrl+a (Windows) should select all elements
- Cmd+s (Mac) Ctrl+s (Windows) should save the document
- Cmd+x (Mac) Ctrl+x (Windows) should cut and not crash 

<!-- Please describe your changes. -->

## Testing Instructions

1. Open a story with elements (to test select all) in the workspace 
2. Press Cmd+a (Mac) Ctrl+a (Windows) and it should select all elements on the page
3. Press Cmd+s (Mac) Ctrl+s (Windows) and it should save the document
4. Press Cmd+x (Mac) Ctrl+x (Windows) when an element is selected and it should be cut from the workspace

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Part of #3527
