### PR TITLE
Dashboard: Update document title on route changes

### DIFF
--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import { StyleSheetManager, ThemeProvider } from 'styled-components';
 import stylisRTLPlugin from 'stylis-plugin-rtl';
 import PropTypes from 'prop-types';
@@ -27,7 +27,7 @@ import PropTypes from 'prop-types';
  */
 import theme, { GlobalStyle } from '../theme';
 import KeyboardOnlyOutline from '../utils/keyboardOnlyOutline';
-import { APP_ROUTES, NESTED_APP_ROUTES } from '../constants';
+import { APP_ROUTES, NESTED_APP_ROUTES, APP_ROUTE_TITLES } from '../constants';
 
 import {
   AppFrame,
@@ -52,6 +52,11 @@ const AppContent = () => {
   const {
     state: { currentPath },
   } = useContext(RouterContext);
+
+  useEffect(() => {
+    window.document.title =
+      APP_ROUTE_TITLES[currentPath] || APP_ROUTE_TITLES.DEFAULT;
+  }, [currentPath]);
 
   const hideLeftRail =
     matchPath(currentPath, NESTED_APP_ROUTES.SAVED_TEMPLATE_DETAIL) ||

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -67,7 +67,7 @@ const AppContent = () => {
     const dynamicPageTitle = ROUTE_TITLES[currentPath] || ROUTE_TITLES.DEFAULT;
     window.document.title = sprintf(
       /* translators: Admin screen title. 1: Admin screen name, 2: Network or site name. */
-      __('%1$s < %2$s - WordPress', 'web-stories'),
+      __('%1$s \u2039 %2$s \u2212 WordPress', 'web-stories'),
       dynamicPageTitle,
       ADMIN_TITLE
     );

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * External dependencies
  */
 import { useContext, useEffect } from 'react';
@@ -27,7 +32,12 @@ import PropTypes from 'prop-types';
  */
 import theme, { GlobalStyle } from '../theme';
 import KeyboardOnlyOutline from '../utils/keyboardOnlyOutline';
-import { APP_ROUTES, NESTED_APP_ROUTES, APP_ROUTE_TITLES } from '../constants';
+import {
+  APP_ROUTES,
+  NESTED_APP_ROUTES,
+  ROUTE_TITLES,
+  ADMIN_TITLE,
+} from '../constants';
 
 import {
   AppFrame,
@@ -54,8 +64,13 @@ const AppContent = () => {
   } = useContext(RouterContext);
 
   useEffect(() => {
-    window.document.title =
-      APP_ROUTE_TITLES[currentPath] || APP_ROUTE_TITLES.DEFAULT;
+    const dynamicPageTitle = ROUTE_TITLES[currentPath] || ROUTE_TITLES.DEFAULT;
+    window.document.title = sprintf(
+      /* translators: Admin screen title. 1: Admin screen name, 2: Network or site name. */
+      __('%1$s < %2$s - WordPress', 'web-stories'),
+      dynamicPageTitle,
+      ADMIN_TITLE
+    );
   }, [currentPath]);
 
   const hideLeftRail =

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -64,7 +64,7 @@ export const ROUTE_TITLES = {
     'web-stories'
   ),
   [APP_ROUTES.EDITOR_SETTINGS]: __('Editor Settings', 'web-stories'),
-  [APP_ROUTES.SUPPORT]: __('Support ‹ Web Stories — WordPress', 'web-stories'),
+  [APP_ROUTES.SUPPORT]: __('Support', 'web-stories'),
   DEFAULT: __('My Stories', 'web-stories'),
 };
 

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -53,53 +53,43 @@ export const NESTED_APP_ROUTES = {
   SAVED_TEMPLATE_DETAIL: `${APP_ROUTES.SAVED_TEMPLATES}/${APP_ROUTES.TEMPLATE_DETAIL}`,
 };
 
-export const APP_ROUTE_TITLES = {
-  [APP_ROUTES.MY_STORIES]: __(
-    'My Stories ‹ Web Stories — WordPress',
-    'web-stories'
-  ),
-  [APP_ROUTES.SAVED_TEMPLATES]: __(
-    'Saved Templates ‹ Web Stories — WordPress',
-    'web-stories'
-  ),
-  [APP_ROUTES.TEMPLATES_GALLERY]: __(
-    'Explore Templates ‹ Web Stories — WordPress',
-    'web-stories'
-  ),
+export const ADMIN_TITLE = __('Web Stories', 'web-stories');
+
+export const ROUTE_TITLES = {
+  [APP_ROUTES.MY_STORIES]: __('My Stories', 'web-stories'),
+  [APP_ROUTES.SAVED_TEMPLATES]: __('Saved Templates', 'web-stories'),
+  [APP_ROUTES.TEMPLATES_GALLERY]: __('Explore Templates', 'web-stories'),
   [`${APP_ROUTES.TEMPLATES_GALLERY}/${APP_ROUTES.TEMPLATE_DETAIL}`]: __(
-    'Template Details < Web Stories - WordPress',
+    'Template Details',
     'web-stories'
   ),
-  [APP_ROUTES.EDITOR_SETTINGS]: __(
-    'Editor Settings ‹ Web Stories — WordPress',
-    'web-stories'
-  ),
+  [APP_ROUTES.EDITOR_SETTINGS]: __('Editor Settings', 'web-stories'),
   [APP_ROUTES.SUPPORT]: __('Support ‹ Web Stories — WordPress', 'web-stories'),
-  DEFAULT: __('Dashboard ‹ Web Stories — WordPress', 'web-stories'),
+  DEFAULT: __('My Stories', 'web-stories'),
 };
 
 export const primaryPaths = [
-  { value: APP_ROUTES.MY_STORIES, label: __('My Stories', 'web-stories') },
+  { value: APP_ROUTES.MY_STORIES, label: ROUTE_TITLES[APP_ROUTES.MY_STORIES] },
   {
     value: APP_ROUTES.SAVED_TEMPLATES,
-    label: __('Saved Templates', 'web-stories'),
+    label: ROUTE_TITLES[APP_ROUTES.SAVED_TEMPLATES],
     inProgress: true,
   },
   {
     value: APP_ROUTES.TEMPLATES_GALLERY,
-    label: __('Explore Templates', 'web-stories'),
+    label: ROUTE_TITLES[APP_ROUTES.TEMPLATES_GALLERY],
   },
 ];
 
 export const secondaryPaths = [
   {
     value: APP_ROUTES.EDITOR_SETTINGS,
-    label: __('Editor Settings', 'web-stories'),
+    label: ROUTE_TITLES[APP_ROUTES.EDITOR_SETTINGS],
     inProgress: true,
   },
   {
     value: APP_ROUTES.SUPPORT,
-    label: __('Support', 'web-stories'),
+    label: ROUTE_TITLES[APP_ROUTES.SUPPORT],
     inProgress: true,
   },
 ];

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -53,6 +53,27 @@ export const NESTED_APP_ROUTES = {
   SAVED_TEMPLATE_DETAIL: `${APP_ROUTES.SAVED_TEMPLATES}/${APP_ROUTES.TEMPLATE_DETAIL}`,
 };
 
+export const APP_ROUTE_TITLES = {
+  [APP_ROUTES.MY_STORIES]: __(
+    'My Stories ‹ Web Stories — WordPress',
+    'web-stories'
+  ),
+  [APP_ROUTES.SAVED_TEMPLATES]: __(
+    'Saved Templates ‹ Web Stories — WordPress',
+    'web-stories'
+  ),
+  [APP_ROUTES.TEMPLATES_GALLERY]: __(
+    'Explore Templates ‹ Web Stories — WordPress',
+    'web-stories'
+  ),
+  [APP_ROUTES.EDITOR_SETTINGS]: __(
+    'Editor Settings ‹ Web Stories — WordPress',
+    'web-stories'
+  ),
+  [APP_ROUTES.SUPPORT]: __('Support ‹ Web Stories — WordPress', 'web-stories'),
+  DEFAULT: __('Dashboard ‹ Web Stories — WordPress', 'web-stories'),
+};
+
 export const primaryPaths = [
   { value: APP_ROUTES.MY_STORIES, label: __('My Stories', 'web-stories') },
   {

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -66,6 +66,10 @@ export const APP_ROUTE_TITLES = {
     'Explore Templates ‹ Web Stories — WordPress',
     'web-stories'
   ),
+  [`${APP_ROUTES.TEMPLATES_GALLERY}/${APP_ROUTES.TEMPLATE_DETAIL}`]: __(
+    'Template Details < Web Stories - WordPress',
+    'web-stories'
+  ),
   [APP_ROUTES.EDITOR_SETTINGS]: __(
     'Editor Settings ‹ Web Stories — WordPress',
     'web-stories'

--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -28,6 +28,9 @@ import {
   setBrowserViewport,
 } from '@wordpress/e2e-test-utils';
 
+// Extend Jest matchers.
+import 'jest-extended';
+
 /**
  * Environment variables
  */

--- a/tests/e2e/specs/dashboard/documentTitle.js
+++ b/tests/e2e/specs/dashboard/documentTitle.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { visitDashboard } from '../../utils';
+
+describe('Document Title', () => {
+  it('should update the document title during navigation', async () => {
+    await visitDashboard();
+
+    await expect(page).toMatch('My Stories');
+    await expect(await page.title()).toStartWith('My Stories');
+
+    await expect(page).toClick('a', { text: 'Explore Templates' });
+
+    await expect(page).toMatch('Viewing all templates');
+    await expect(await page.title()).toStartWith('Explore Templates');
+
+    const firstTemplate = await expect(page).toMatchElement(
+      '[data-testid="template-grid-item-1"]'
+    );
+    await expect(firstTemplate).toClick('a', { text: 'View' });
+    await expect(await page.title()).toStartWith('Template Details');
+
+    await expect(page).toClick('a', { text: 'Close' });
+
+    await expect(page).toMatch('Viewing all templates');
+    await expect(await page.title()).toStartWith('Explore Templates');
+  });
+});


### PR DESCRIPTION
## Summary
Updates document title according to dashboard view

## Relevant Technical Choices
Add a useEffect hook to watch for `currentPath` to be updated, when it is update the `window.document.title`.

## To-do
- I'm a little stumped as far as tests that make sense for this, open to suggestions!

## User-facing changes
Document title should update according to current view: 
```
   My Stories ‹ Web Stories — WordPress
   Saved Templates ‹ Web Stories — WordPress
   Explore Templates ‹ Web Stories — WordPress
   Editor Settings ‹ Web Stories — WordPress
   Support ‹ Web Stories — WordPress
```

`My Stories ‹ Web Stories — WordPress` if path doesn't have a key.

## Testing Instructions
- Swap dashboard routes and see the browser tab title update

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #3097 
