### PR TITLE
Media: Fade in images and videos in the gallery

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
@@ -351,6 +351,8 @@ function getInnerElement(
         >
           <source src={src} type={mimeType} />
         </Video>
+        {/* This hidden image allows us to fade in the poster image in the
+        gallery as there's no event when a video's poster loads. */}
         <HiddenPosterImage src={poster} onLoad={makeImageVisible} />
         {showVideoDetail && <Duration>{lengthFormatted}</Duration>}
       </>

--- a/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
@@ -39,6 +39,7 @@ const styledTiles = css`
   width: 100%;
   cursor: pointer;
   transition: 0.2s transform, 0.15s opacity;
+  opacity: 0;
 `;
 
 const Image = styled.img`
@@ -54,6 +55,7 @@ const Container = styled.div`
   position: relative;
   display: flex;
   margin-bottom: 10px;
+  background-color: ${({ theme }) => theme.colors.bg.v3};
   body${KEYBOARD_USER_SELECTOR} &:focus {
     outline: solid 2px #fff;
   }
@@ -103,6 +105,10 @@ const UploadingIndicator = styled.div`
       transition-property: width;
     }
   }
+`;
+
+const HiddenPosterImage = styled.img`
+  display: none;
 `;
 
 /**
@@ -309,6 +315,9 @@ function getInnerElement(
     dropTargetsBindings,
   }
 ) {
+  const makeImageVisible = () => {
+    ref.current.style.opacity = '1';
+  };
   if (type === 'image') {
     return (
       <Image
@@ -320,6 +329,7 @@ function getInnerElement(
         alt={alt}
         loading={'lazy'}
         onClick={onClick}
+        onLoad={makeImageVisible}
         {...dropTargetsBindings}
       />
     );
@@ -341,6 +351,7 @@ function getInnerElement(
         >
           <source src={src} type={mimeType} />
         </Video>
+        <HiddenPosterImage src={poster} onLoad={makeImageVisible} />
         {showVideoDetail && <Duration>{lengthFormatted}</Duration>}
       </>
     );


### PR DESCRIPTION
## Summary

Fade in images and videos with a very short opacity transition. Also give them a background color (while not yet loaded) as it looks nicer.

Video: [fadein.mov.zip](https://github.com/google/web-stories-wp/files/4964364/fadein.mov.zip)

## Relevant Technical Choices

There's no JS event when a poster image is loaded, so added a hidden image and wait for the onLoad of that to make the video visible.

See https://stackoverflow.com/questions/18571424/how-to-add-event-listener-to-html5-video-poster-image-load-event

## To-do

None.

## User-facing changes

Images and videos now fade instead of popping in.

## Testing Instructions

Load images in the gallery (both upload and media3p tab).

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #1199
