### PR TITLE
Dashboard: Fixed bug that caused some animations to not play

### DIFF
--- a/assets/src/dashboard/app/views/storyAnimTool/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/index.js
@@ -112,13 +112,16 @@ function StoryAnimTool() {
         saveActiveStoryUpdates(activeStory);
       }
 
+      // Deselect animation
+      setActiveAnimation({});
+
+      // Reset active page
+      setActivePageIndex(0);
+
       const story = orderedStories.find(
         (s) => s.id === parseInt(e.target.value)
       );
       setActiveStory(story);
-
-      //Deselect animation
-      setActiveAnimation({});
     },
     [activeStory, saveActiveStoryUpdates, orderedStories]
   );

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -104,6 +104,7 @@ function Provider({ animations, children, onWAAPIFinish }) {
   const hoistWAAPIAnimation = useCallback((WAPPIAnimation) => {
     const symbol = Symbol();
     WAAPIAnimationMap.current.set(symbol, WAPPIAnimation);
+
     setWAAPIAnimations(Array.from(WAAPIAnimationMap.current.values()));
     return () => {
       WAPPIAnimation?.cancel();
@@ -114,7 +115,16 @@ function Provider({ animations, children, onWAAPIFinish }) {
 
   const WAAPIAnimationMethods = useMemo(() => {
     const play = () =>
-      WAAPIAnimations.forEach((animation) => animation?.play());
+      WAAPIAnimations.forEach((animation) => {
+        // Sometimes an animation part can get into a
+        // stuck state where executing `play` doesn't
+        // trigger the animation. A workaround to avoid
+        // this is to first `cancel` the animation
+        // before playing.
+        animation?.cancel();
+
+        animation?.play();
+      });
     const pause = () =>
       WAAPIAnimations.forEach((animation) => animation?.pause());
     const setCurrentTime = (time) =>


### PR DESCRIPTION
## Summary

This PR implements a "fix" (more like a workaround) to make sure all our animation parts play as expected.

When building out template animations, I noticed that certain combinations of `duration` and `delay` would cause the animation part _not_ to play 😱 But if I modified either value by just 1 (i.e. 1100 => 1101) then it suddenly worked.  

After a bit of sleuthing, I found out that the animation object itself calculates an internal value called `_holdTime` and hold time seems to be the sum of `duration` and `delay`.  Most of the time that `_holdTime` is a whole number, some times it comes out to something like 899.999999999 (which works just fine), however, when `_holdTime` is set to a number like 1700.0000000000002 (when `duration` is 800 and `delay` is 900) then... the animation part (in Chrome) simply won't play.

![image](https://user-images.githubusercontent.com/40646372/88320621-b334c580-ccd2-11ea-88c2-b87c73344285.png)

But, for whatever reason, calling `cancel` before executing `play` when trying to play all animations, fixes the issue.

## User-facing changes

None

## Testing Instructions

1.) Checkout `main` and go to our `story-anim-tool` and enable animations for dashboard.
2.) Choose a random story to test with.
3.) Apply a random animation to any element on the first page and set the duration to `800` and the delay to `400`.
4.) Play the animations, notice that the element you just applied an animation to should _not_ play 😱 
5.) Pull down this branch and switch to it (make sure to enable animations for dashboard).
6.) Go to our `story-anim-tool` and select the story and page you just applied an animation to.
7.) Play the animations, this time the `800/400` animation _should_ play 🎉 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3223 
