### PR TITLE
Dashboard: Refactor My Stories karma tests to use fixture.renderHook

### DIFF
--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -24,8 +24,6 @@ import { within } from '@testing-library/react';
  */
 import { useContext } from 'react';
 import Fixture from '../../../../karma/fixture';
-// import formattedStoriesArray from '../../../../dataUtils/formattedStoriesArray';
-import formattedUsersObject from '../../../../dataUtils/formattedUsersObject';
 import { getFormattedDisplayDate } from '../../../../utils';
 import {
   TEMPLATES_GALLERY_VIEWING_LABELS,
@@ -395,6 +393,14 @@ describe('CUJ: Creator can view their stories in list view', () => {
     return stories;
   }
 
+  async function getUsers() {
+    const {
+      state: { users },
+    } = await fixture.renderHook(() => useContext(ApiContext));
+
+    return users;
+  }
+
   describe('Action: See stories in list view', () => {
     it('should switch to List View', async () => {
       const listViewButton = fixture.screen.getByLabelText(
@@ -681,8 +687,10 @@ describe('CUJ: Creator can view their stories in list view', () => {
 
       expect(rows.length).toEqual(storiesOrderById.length);
 
+      const users = await getUsers();
+
       const storieAuthorsSortedByAuthor = storiesOrderById.map(
-        (id) => formattedUsersObject[stories[id].author].name
+        (id) => users[stories[id].author].name
       );
 
       // author is the third column

--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -140,6 +140,7 @@ describe('CUJ: Creator can view their stories in grid view', () => {
   it('should Delete a story', async () => {
     let stories = fixture.screen.getAllByTestId(/^story-grid-item/);
     const initialNumStories = stories.length;
+
     let firstStory = stories[0];
 
     await fixture.events.hover(firstStory);

--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -22,8 +22,9 @@ import { within } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+import { useContext } from 'react';
 import Fixture from '../../../../karma/fixture';
-import formattedStoriesArray from '../../../../dataUtils/formattedStoriesArray';
+// import formattedStoriesArray from '../../../../dataUtils/formattedStoriesArray';
 import formattedUsersObject from '../../../../dataUtils/formattedUsersObject';
 import { getFormattedDisplayDate } from '../../../../utils';
 import {
@@ -37,6 +38,7 @@ import {
   VIEW_STYLE_LABELS,
   VIEW_STYLE,
 } from '../../../../constants';
+import { ApiContext } from '../../../api/apiProvider';
 
 describe('CUJ: Creator can view their stories in grid view', () => {
   let fixture;
@@ -50,9 +52,18 @@ describe('CUJ: Creator can view their stories in grid view', () => {
     fixture.restore();
   });
 
-  it('should render', () => {
+  async function getStoriesState() {
+    const {
+      state: { stories },
+    } = await fixture.renderHook(() => useContext(ApiContext));
+
+    return stories;
+  }
+
+  it('should render', async () => {
+    const { storiesOrderById } = await getStoriesState();
     const stories = fixture.screen.getAllByTestId(/^story-grid-item/);
-    expect(stories.length).toEqual(formattedStoriesArray.length);
+    expect(stories.length).toEqual(storiesOrderById.length);
   });
 
   it('should navigate to Explore Templates', async () => {
@@ -190,7 +201,8 @@ describe('CUJ: Creator can view their stories in grid view', () => {
 
   describe('Action: Filter their stories by All stories, Drafts and Published', () => {
     it('should switch to the Drafts Tab', async () => {
-      const numDrafts = formattedStoriesArray.filter(
+      const { stories } = await getStoriesState();
+      const numDrafts = Object.values(stories).filter(
         ({ status }) => status === STORY_STATUS.DRAFT
       ).length;
 
@@ -208,12 +220,13 @@ describe('CUJ: Creator can view their stories in grid view', () => {
 
       expect(viewDraftsText).toBeTruthy();
 
-      const stories = fixture.screen.getAllByTestId(/^story-grid-item/);
-      expect(stories.length).toEqual(numDrafts);
+      const storyElements = fixture.screen.getAllByTestId(/^story-grid-item/);
+      expect(storyElements.length).toEqual(numDrafts);
     });
 
     it('should switch to the Published Tab', async () => {
-      const numPublished = formattedStoriesArray.filter(
+      const { stories } = await getStoriesState();
+      const numPublished = Object.values(stories).filter(
         ({ status }) =>
           status === STORY_STATUS.PUBLISH || status === STORY_STATUS.FUTURE
       ).length;
@@ -236,14 +249,16 @@ describe('CUJ: Creator can view their stories in grid view', () => {
 
       expect(viewPublishedText).toBeTruthy();
 
-      const stories = fixture.screen.getAllByTestId(/^story-grid-item/);
-      expect(stories.length).toEqual(numPublished);
+      const storyElements = fixture.screen.getAllByTestId(/^story-grid-item/);
+      expect(storyElements.length).toEqual(numPublished);
     });
   });
 
   describe('Action: Sort their stories (last modified, date created, author, title)', () => {
     it('should should search/filter using the Search Stories search input', async () => {
-      const firstStoryTitle = formattedStoriesArray[0].title;
+      const { stories } = await getStoriesState();
+
+      const firstStoryTitle = Object.values(stories)[0].title;
 
       const searchInput = fixture.screen.getByPlaceholderText('Search Stories');
 
@@ -253,10 +268,10 @@ describe('CUJ: Creator can view their stories in grid view', () => {
 
       await fixture.events.keyboard.type(firstStoryTitle);
 
-      const stories = fixture.screen.getAllByTestId(/^story-grid-item/);
+      const storyElements = fixture.screen.getAllByTestId(/^story-grid-item/);
 
-      expect(stories.length).toEqual(
-        formattedStoriesArray.filter(({ title }) =>
+      expect(storyElements.length).toEqual(
+        Object.values(stories).filter(({ title }) =>
           title.includes(firstStoryTitle)
         ).length
       );
@@ -279,36 +294,27 @@ describe('CUJ: Creator can view their stories in grid view', () => {
 
       await fixture.events.click(dateCreated);
 
-      const stories = fixture.screen.getAllByTestId(/^story-grid-item/);
+      const storyElements = fixture.screen.getAllByTestId(/^story-grid-item/);
 
-      const renderedStoriesById = stories.map(
-        ({ dataset }) => dataset['testid'].split('-').slice(-1)[0]
+      const renderedStoriesById = storyElements.map(({ dataset }) =>
+        Number(dataset['testid'].split('-').slice(-1)[0])
       );
 
-      const storyIdsSortedByCreated = formattedStoriesArray
-        .sort(
-          (a, b) =>
-            new Date(a.created).getTime() - new Date(b.created).getTime()
-        )
-        .map(({ id }) => String(id));
+      const { storiesOrderById } = await getStoriesState();
 
-      expect(renderedStoriesById).toEqual(storyIdsSortedByCreated);
+      expect(renderedStoriesById).toEqual(storiesOrderById);
     });
 
-    it('should sort by Last Modified', () => {
+    it('should sort by Last Modified', async () => {
+      const { storiesOrderById } = await getStoriesState();
       // last modified desc is the default sort
-      const stories = fixture.screen.getAllByTestId(/^story-grid-item/);
+      const storyElements = fixture.screen.getAllByTestId(/^story-grid-item/);
 
-      const renderedStoriesById = stories.map(
-        ({ dataset }) => dataset['testid'].split('-').slice(-1)[0]
+      const renderedStoriesById = storyElements.map(({ dataset }) =>
+        Number(dataset['testid'].split('-').slice(-1)[0])
       );
-      let copy = [...formattedStoriesArray];
 
-      const storyIdsSortedByLastModified = copy
-        .sort((a, b) => b.modified.diff(a.modified)) // initial sort is desc by modified
-        .map(({ id }) => String(id));
-
-      expect(renderedStoriesById).toEqual(storyIdsSortedByLastModified);
+      expect(renderedStoriesById).toEqual(storiesOrderById);
     });
 
     it('should sort by Name', async () => {
@@ -328,17 +334,15 @@ describe('CUJ: Creator can view their stories in grid view', () => {
 
       await fixture.events.click(name);
 
-      const stories = fixture.screen.getAllByTestId(/^story-grid-item/);
+      const storyElements = fixture.screen.getAllByTestId(/^story-grid-item/);
 
-      const renderedStoriesById = stories.map(
-        ({ dataset }) => dataset['testid'].split('-').slice(-1)[0]
+      const renderedStoriesById = storyElements.map(({ dataset }) =>
+        Number(dataset['testid'].split('-').slice(-1)[0])
       );
 
-      const storyIdsSortedByTitle = formattedStoriesArray
-        .sort((a, b) => a.title.localeCompare(b.title))
-        .map(({ id }) => String(id));
+      const { storiesOrderById } = await getStoriesState();
 
-      expect(renderedStoriesById).toEqual(storyIdsSortedByTitle);
+      expect(renderedStoriesById).toEqual(storiesOrderById);
     });
 
     it('should sort by Created By', async () => {
@@ -358,21 +362,15 @@ describe('CUJ: Creator can view their stories in grid view', () => {
 
       await fixture.events.click(createdBy);
 
-      const stories = fixture.screen.getAllByTestId(/^story-grid-item/);
+      const { storiesOrderById } = await getStoriesState();
 
-      const renderedStoriesById = stories.map(
-        ({ dataset }) => dataset['testid'].split('-').slice(-1)[0]
+      const storyElements = fixture.screen.getAllByTestId(/^story-grid-item/);
+
+      const renderedStoriesById = storyElements.map(({ dataset }) =>
+        Number(dataset['testid'].split('-').slice(-1)[0])
       );
 
-      const storyIdsSortedByTitle = formattedStoriesArray
-        .sort((a, b) =>
-          formattedUsersObject[a.author].name.localeCompare(
-            formattedUsersObject[b.author].name
-          )
-        )
-        .map(({ id }) => String(id));
-
-      expect(renderedStoriesById).toEqual(storyIdsSortedByTitle);
+      expect(renderedStoriesById).toEqual(storiesOrderById);
     });
   });
 });
@@ -388,6 +386,14 @@ describe('CUJ: Creator can view their stories in list view', () => {
   afterEach(() => {
     fixture.restore();
   });
+
+  async function getStoriesState() {
+    const {
+      state: { stories },
+    } = await fixture.renderHook(() => useContext(ApiContext));
+
+    return stories;
+  }
 
   describe('Action: See stories in list view', () => {
     it('should switch to List View', async () => {
@@ -423,15 +429,18 @@ describe('CUJ: Creator can view their stories in list view', () => {
 
       await fixture.events.click(gridViewButton);
 
-      const stories = fixture.screen.getAllByTestId(/^story-grid-item/);
+      const storyElements = fixture.screen.getAllByTestId(/^story-grid-item/);
 
-      expect(stories.length).toEqual(formattedStoriesArray.length);
+      const { storiesOrderById } = await getStoriesState();
+
+      expect(storyElements.length).toEqual(storiesOrderById.length);
     });
 
     it('should Rename a story', async () => {
-      const storiesSortedByModified = [...formattedStoriesArray].sort((a, b) =>
-        b.modified.diff(a.modified)
-      );
+      const { stories, storiesOrderById } = await getStoriesState();
+
+      const storiesSortedByModified = storiesOrderById.map((id) => stories[id]);
+
       const listViewButton = fixture.screen.getByLabelText(
         new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
       );
@@ -478,9 +487,10 @@ describe('CUJ: Creator can view their stories in list view', () => {
     });
 
     it('should Duplicate a story', async () => {
-      const storiesSortedByModified = [...formattedStoriesArray].sort((a, b) =>
-        b.modified.diff(a.modified)
-      );
+      const { stories, storiesOrderById } = await getStoriesState();
+
+      const storiesSortedByModified = storiesOrderById.map((id) => stories[id]);
+
       const listViewButton = fixture.screen.getByLabelText(
         new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
       );
@@ -521,9 +531,9 @@ describe('CUJ: Creator can view their stories in list view', () => {
     });
 
     it('should Delete a story', async () => {
-      const storiesSortedByModified = [...formattedStoriesArray].sort((a, b) =>
-        b.modified.diff(a.modified)
-      );
+      const { stories, storiesOrderById } = await getStoriesState();
+      const storiesSortedByModified = storiesOrderById.map((id) => stories[id]);
+
       const listViewButton = fixture.screen.getByLabelText(
         new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
       );
@@ -566,9 +576,9 @@ describe('CUJ: Creator can view their stories in list view', () => {
     });
 
     it('should not Delete a story if Cancel is clicked in the confirmation modal', async () => {
-      const storiesSortedByModified = [...formattedStoriesArray].sort((a, b) =>
-        b.modified.diff(a.modified)
-      );
+      const { stories, storiesOrderById } = await getStoriesState();
+      const storiesSortedByModified = storiesOrderById.map((id) => stories[id]);
+
       const listViewButton = fixture.screen.getByLabelText(
         new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
       );
@@ -627,11 +637,13 @@ describe('CUJ: Creator can view their stories in list view', () => {
       // drop the header row using slice
       let rows = fixture.screen.getAllByRole('row').slice(1);
 
-      expect(rows.length).toEqual(formattedStoriesArray.length);
+      const { stories, storiesOrderById } = await getStoriesState();
 
-      const storieTitlesSortedByTitle = [...formattedStoriesArray]
-        .sort((a, b) => a.title.localeCompare(b.title))
-        .map(({ title }) => title);
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      const storieTitlesSortedByTitle = storiesOrderById.map(
+        (id) => stories[id].title
+      );
 
       // title is the second column
       let rowTitles = rows.map((row) => row.children[1].innerText);
@@ -643,7 +655,7 @@ describe('CUJ: Creator can view their stories in list view', () => {
 
       rows = fixture.screen.getAllByRole('row').slice(1);
 
-      expect(rows.length).toEqual(formattedStoriesArray.length);
+      expect(rows.length).toEqual(storiesOrderById.length);
 
       // title is the second column
       rowTitles = rows.map((row) => row.children[1].innerText);
@@ -665,15 +677,13 @@ describe('CUJ: Creator can view their stories in list view', () => {
       // drop the header row using slice
       let rows = fixture.screen.getAllByRole('row').slice(1);
 
-      expect(rows.length).toEqual(formattedStoriesArray.length);
+      const { stories, storiesOrderById } = await getStoriesState();
 
-      const storieAuthorsSortedByAuthor = [...formattedStoriesArray]
-        .sort((a, b) =>
-          formattedUsersObject[a.author].name.localeCompare(
-            formattedUsersObject[b.author].name
-          )
-        )
-        .map(({ author }) => formattedUsersObject[author].name);
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      const storieAuthorsSortedByAuthor = storiesOrderById.map(
+        (id) => formattedUsersObject[stories[id].author].name
+      );
 
       // author is the third column
       let rowAuthors = rows.map((row) => row.children[2].innerText);
@@ -685,7 +695,7 @@ describe('CUJ: Creator can view their stories in list view', () => {
 
       rows = fixture.screen.getAllByRole('row').slice(1);
 
-      expect(rows.length).toEqual(formattedStoriesArray.length);
+      expect(rows.length).toEqual(storiesOrderById.length);
 
       // author is the third column
       rowAuthors = rows.map((row) => row.children[2].innerText);
@@ -707,15 +717,13 @@ describe('CUJ: Creator can view their stories in list view', () => {
       // drop the header row using slice
       let rows = fixture.screen.getAllByRole('row').slice(1);
 
-      expect(rows.length).toEqual(formattedStoriesArray.length);
+      const { stories, storiesOrderById } = await getStoriesState();
 
-      const storieDateCreatedSortedByDateCreated = [...formattedStoriesArray]
-        .sort(
-          (a, b) =>
-            new Date(a.created).getTime() - new Date(b.created).getTime()
-        )
-        .map(({ created }) => getFormattedDisplayDate(created))
-        .reverse(); // Default sort order in List View is Desc
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      const storieDateCreatedSortedByDateCreated = storiesOrderById.map((id) =>
+        getFormattedDisplayDate(stories[id].created)
+      );
 
       let rowDateCreatedValues = rows.map((row) => row.children[3].innerText);
 
@@ -728,7 +736,7 @@ describe('CUJ: Creator can view their stories in list view', () => {
 
       rows = fixture.screen.getAllByRole('row').slice(1);
 
-      expect(rows.length).toEqual(formattedStoriesArray.length);
+      expect(rows.length).toEqual(storiesOrderById.length);
 
       // author is the fourth column
       rowDateCreatedValues = rows.map((row) => row.children[3].innerText);
@@ -749,11 +757,13 @@ describe('CUJ: Creator can view their stories in list view', () => {
       // drop the header row using slice
       let rows = fixture.screen.getAllByRole('row').slice(1);
 
-      expect(rows.length).toEqual(formattedStoriesArray.length);
+      const { stories, storiesOrderById } = await getStoriesState();
 
-      const storieModifiedSortedByModified = [...formattedStoriesArray]
-        .sort((a, b) => b.modified.diff(a.modified)) //initial sort is desc by modified
-        .map(({ modified }) => getFormattedDisplayDate(modified));
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      const storieModifiedSortedByModified = storiesOrderById.map((id) =>
+        getFormattedDisplayDate(stories[id].modified)
+      );
 
       // Last Modified is the fifth column
       let rowModifiedValues = rows.map((row) => row.children[4].innerText);

--- a/assets/src/dashboard/dataUtils/formattedStoriesArray.js
+++ b/assets/src/dashboard/dataUtils/formattedStoriesArray.js
@@ -91,7 +91,7 @@ const formattedStoriesArray = [
     ],
     tags: [],
     categories: [],
-    author: 1,
+    author: 2,
     centerTargetAction: '',
     bottomTargetAction:
       'http://localhost:8899/wp-admin/post.php?action=edit&post=167',

--- a/assets/src/dashboard/karma/apiProviderFixture.js
+++ b/assets/src/dashboard/karma/apiProviderFixture.js
@@ -147,7 +147,7 @@ function fetchStories(
   const storiesState = { ...currentState } || getStoriesState();
   const statuses = status.split(',');
 
-  storiesState.storiesOrderById = [...formattedStoriesArray]
+  storiesState.storiesOrderById = Object.values(storiesState.stories)
     .filter(
       ({ status: storyStatus, title }) =>
         statuses.includes(storyStatus) && title.includes(searchTerm)


### PR DESCRIPTION
## Summary

Refactor My Stories karma tests to use fixture.renderHook rather than sorting the data utils array manually in each test.

## User-facing changes

None

## Testing Instructions

Verify that the karma integration tests pass
