### PR TITLE
Dashboard: Feature flag & initial structuring for template previews

### DIFF
--- a/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/stories/index.js
@@ -48,6 +48,7 @@ const page = {
 
 const templateActions = {
   createStoryFromTemplate: action('create story from template clicked'),
+  handlePreviewTemplate: action('card was clicked to show preview mode'),
 };
 const defaultProps = {
   allPagesFetched: false,

--- a/assets/src/dashboard/app/views/exploreTemplates/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/index.js
@@ -17,7 +17,8 @@
 /**
  * External dependencies
  */
-import { useContext, useMemo, useEffect } from 'react';
+import { useCallback, useContext, useMemo, useEffect } from 'react';
+import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -30,6 +31,8 @@ import Content from './content';
 import Header from './header';
 
 function ExploreTemplates() {
+  const enableTemplatePreviews = useFeature('enableTemplatePreviews');
+
   const {
     state: {
       templates: {
@@ -47,7 +50,7 @@ function ExploreTemplates() {
     },
   } = useContext(ApiContext);
 
-  const { filter, page, search, sort, view } = useTemplateView({
+  const { filter, page, preview, search, sort, view } = useTemplateView({
     totalPages,
   });
 
@@ -60,6 +63,16 @@ function ExploreTemplates() {
       return templates[templateId];
     });
   }, [templatesOrderById, templates]);
+
+  const handlePreviewTemplate = useCallback(
+    (template) => {
+      if (!enableTemplatePreviews) {
+        return () => {};
+      }
+      return preview.set(template);
+    },
+    [enableTemplatePreviews, preview]
+  );
 
   return (
     <Layout.Provider>
@@ -79,7 +92,7 @@ function ExploreTemplates() {
         totalTemplates={totalTemplates}
         search={search}
         view={view}
-        templateActions={{ createStoryFromTemplate }}
+        templateActions={{ createStoryFromTemplate, handlePreviewTemplate }}
       />
       <Layout.Fixed>
         <ScrollToTop />

--- a/assets/src/dashboard/app/views/exploreTemplates/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/index.js
@@ -50,7 +50,7 @@ function ExploreTemplates() {
     },
   } = useContext(ApiContext);
 
-  const { filter, page, preview, search, sort, view } = useTemplateView({
+  const { filter, page, previewVisible, search, sort, view } = useTemplateView({
     totalPages,
   });
 
@@ -67,10 +67,10 @@ function ExploreTemplates() {
   const handlePreviewTemplate = useCallback(
     (template) => {
       if (enableTemplatePreviews) {
-        preview.set(template);
+        previewVisible.set(template);
       }
     },
-    [enableTemplatePreviews, preview]
+    [enableTemplatePreviews, previewVisible]
   );
 
   return (

--- a/assets/src/dashboard/app/views/exploreTemplates/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/index.js
@@ -66,10 +66,9 @@ function ExploreTemplates() {
 
   const handlePreviewTemplate = useCallback(
     (template) => {
-      if (!enableTemplatePreviews) {
-        return () => {};
+      if (enableTemplatePreviews) {
+        preview.set(template);
       }
-      return preview.set(template);
     },
     [enableTemplatePreviews, preview]
   );

--- a/assets/src/dashboard/app/views/exploreTemplates/karma/exploreTemplates.karma.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/karma/exploreTemplates.karma.js
@@ -161,6 +161,11 @@ describe('CUJ: Creator can browse templates in grid view', () => {
       await focusOnTemplateById(lastTemplateId);
       expect(lastTemplate.contains(document.activeElement)).toBeTrue();
     });
+
+    // eslint-disable-next-line jasmine/no-disabled-tests
+    xit('should trigger template preview when user clicks a card', () => {});
+    // eslint-disable-next-line jasmine/no-disabled-tests
+    xit('should trigger template preview when user presses Enter while focused on a card', () => {});
   });
 
   describe('Action: See pre-built template details page', () => {

--- a/assets/src/dashboard/app/views/exploreTemplates/karma/exploreTemplates.karma.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/karma/exploreTemplates.karma.js
@@ -102,10 +102,11 @@ describe('CUJ: Creator can browse templates in grid view', () => {
     }
 
     await fixture.events.keyboard.seq(({ press }) =>
-      Array.from(new Array(index), () => [press('tab'), press('tab')]).reduce(
-        (acc, curr) => acc.concat(curr),
-        []
-      )
+      Array.from(new Array(index), () => [
+        press('tab'),
+        press('tab'),
+        press('tab'),
+      ]).reduce((acc, curr) => acc.concat(curr), [])
     );
   }
 

--- a/assets/src/dashboard/app/views/shared/stories/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/stories/templateGridView.js
@@ -41,6 +41,7 @@ export const _default = () => {
       pageSize={STORYBOOK_PAGE_SIZE}
       templateActions={{
         createStoryFromTemplate: action('create story from template clicked'),
+        handlePreviewTemplate: action('card was clicked to show preview mode'),
       }}
     />
   );

--- a/assets/src/dashboard/app/views/shared/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/templateGridView.js
@@ -81,7 +81,9 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
               targetAction: targetAction(template),
               label: __('Use template', 'web-stories'),
             }}
-            onClickCard={() => templateActions.handlePreviewTemplate(template)}
+            containerAction={() =>
+              templateActions.handlePreviewTemplate(template)
+            }
           />
         </CardGridItem>
       ))}

--- a/assets/src/dashboard/app/views/shared/templateGridView.js
+++ b/assets/src/dashboard/app/views/shared/templateGridView.js
@@ -28,6 +28,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { trackEvent } from '../../../../tracking';
 import { TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS } from '../../../constants';
 import {
   CardGridItem,
@@ -39,7 +40,6 @@ import {
   TemplatesPropType,
   TemplateActionsPropType,
 } from '../../../types';
-import { trackEvent } from '../../../../tracking';
 
 const GridContainer = styled(CardGrid)`
   width: ${({ theme }) =>
@@ -81,6 +81,7 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
               targetAction: targetAction(template),
               label: __('Use template', 'web-stories'),
             }}
+            onClickCard={() => templateActions.handlePreviewTemplate(template)}
           />
         </CardGridItem>
       ))}

--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -145,6 +145,7 @@ const Button = ({
     <StyledButtonByType
       as={isLink ? 'a' : 'button'}
       disabled={isDisabled}
+      onClick={(e) => e.stopPropagation()} // this is here so that links stacked on containers that have click handlers don't bubble. if an onClick is present as a prop it'll override this with ...rest
       {...rest}
     >
       <StyledChildren isSecondary={type === BUTTON_TYPES.SECONDARY}>

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -121,7 +121,7 @@ const CardPreviewContainer = ({
   story,
   pageSize,
   children,
-  onClickCard = () => {},
+  containerAction = () => {},
 }) => {
   const [cardState, dispatch] = useReducer(cardReducer, CARD_STATE.IDLE);
   const [pageIndex, setPageIndex] = useState(0);
@@ -156,12 +156,12 @@ const CardPreviewContainer = ({
   }, [storyPages.length, cardState]);
 
   const handleKeyDownEditControls = useCallback(
-    ({ nativeEvent }) => {
-      if (nativeEvent.keyCode === 13) {
-        onClickCard();
+    ({ key }) => {
+      if (key === 'Enter') {
+        containerAction();
       }
     },
-    [onClickCard]
+    [containerAction]
   );
   return (
     <>
@@ -186,7 +186,7 @@ const CardPreviewContainer = ({
         onFocus={() => dispatch(CARD_ACTION.ACTIVATE)}
         onMouseEnter={() => dispatch(CARD_ACTION.ACTIVATE)}
         onMouseLeave={() => dispatch(CARD_ACTION.DEACTIVATE)}
-        onClick={onClickCard}
+        onClick={containerAction}
         onKeyDown={handleKeyDownEditControls}
         tabIndex={0}
       >
@@ -221,7 +221,7 @@ CardPreviewContainer.propTypes = {
   children: PropTypes.node,
   centerAction: ActionButtonPropType,
   bottomAction: ActionButtonPropType.isRequired,
-  onClickCard: PropTypes.func,
+  containerAction: PropTypes.func,
   pageSize: PageSizePropType.isRequired,
   story: StoryPropType,
 };

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect, useReducer, useRef, useState } from 'react';
+import { useEffect, useReducer, useRef, useState, useCallback } from 'react';
 import styled from 'styled-components';
 /**
  * Internal dependencies
@@ -155,6 +155,14 @@ const CardPreviewContainer = ({
     return () => intervalId && clearInterval(intervalId);
   }, [storyPages.length, cardState]);
 
+  const handleKeyDownEditControls = useCallback(
+    ({ nativeEvent }) => {
+      if (nativeEvent.keyCode === 13) {
+        onClickCard();
+      }
+    },
+    [onClickCard]
+  );
   return (
     <>
       <PreviewPane cardSize={pageSize}>
@@ -179,6 +187,8 @@ const CardPreviewContainer = ({
         onMouseEnter={() => dispatch(CARD_ACTION.ACTIVATE)}
         onMouseLeave={() => dispatch(CARD_ACTION.DEACTIVATE)}
         onClick={onClickCard}
+        onKeyDown={handleKeyDownEditControls}
+        tabIndex={0}
       >
         <EmptyActionContainer />
         {centerAction?.label && (

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -121,6 +121,7 @@ const CardPreviewContainer = ({
   story,
   pageSize,
   children,
+  onClickCard = () => {},
 }) => {
   const [cardState, dispatch] = useReducer(cardReducer, CARD_STATE.IDLE);
   const [pageIndex, setPageIndex] = useState(0);
@@ -177,6 +178,7 @@ const CardPreviewContainer = ({
         onFocus={() => dispatch(CARD_ACTION.ACTIVATE)}
         onMouseEnter={() => dispatch(CARD_ACTION.ACTIVATE)}
         onMouseLeave={() => dispatch(CARD_ACTION.DEACTIVATE)}
+        onClick={onClickCard}
       >
         <EmptyActionContainer />
         {centerAction?.label && (
@@ -209,6 +211,7 @@ CardPreviewContainer.propTypes = {
   children: PropTypes.node,
   centerAction: ActionButtonPropType,
   bottomAction: ActionButtonPropType.isRequired,
+  onClickCard: PropTypes.func,
   pageSize: PageSizePropType.isRequired,
   story: StoryPropType,
 };

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -82,6 +82,7 @@ export const StoryActionsPropType = PropTypes.shape({
 
 export const TemplateActionsPropType = PropTypes.shape({
   createStoryFromTemplate: PropTypes.func,
+  handlePreviewTemplate: PropTypes.func,
 });
 
 export const TotalStoriesByStatusPropType = PropTypes.shape({

--- a/assets/src/dashboard/utils/useTemplateView.js
+++ b/assets/src/dashboard/utils/useTemplateView.js
@@ -35,7 +35,7 @@ export default function useTemplateView({ totalPages }) {
   const [searchKeyword, _setSearchKeyword] = useState('');
   const [sort, _setSort] = useState(TEMPLATES_GALLERY_SORT_OPTIONS.POPULAR);
   const [page, setPage] = useState(1);
-  const [preview, setPreview] = useState();
+  const [previewVisible, setPreviewVisible] = useState();
 
   const { pageSize } = usePagePreviewSize({
     isGrid: true,
@@ -71,9 +71,9 @@ export default function useTemplateView({ totalPages }) {
 
   return useMemo(
     () => ({
-      preview: {
-        value: preview,
-        set: setPreview,
+      previewVisible: {
+        value: previewVisible,
+        set: setPreviewVisible,
       },
       view: {
         style: VIEW_STYLE.GRID,
@@ -98,8 +98,8 @@ export default function useTemplateView({ totalPages }) {
       },
     }),
     [
-      preview,
-      setPreview,
+      previewVisible,
+      setPreviewVisible,
       pageSize,
       sort,
       setSort,

--- a/assets/src/dashboard/utils/useTemplateView.js
+++ b/assets/src/dashboard/utils/useTemplateView.js
@@ -35,6 +35,7 @@ export default function useTemplateView({ totalPages }) {
   const [searchKeyword, _setSearchKeyword] = useState('');
   const [sort, _setSort] = useState(TEMPLATES_GALLERY_SORT_OPTIONS.POPULAR);
   const [page, setPage] = useState(1);
+  const [preview, setPreview] = useState();
 
   const { pageSize } = usePagePreviewSize({
     isGrid: true,
@@ -70,6 +71,10 @@ export default function useTemplateView({ totalPages }) {
 
   return useMemo(
     () => ({
+      preview: {
+        value: preview,
+        set: setPreview,
+      },
       view: {
         style: VIEW_STYLE.GRID,
         pageSize,
@@ -93,14 +98,15 @@ export default function useTemplateView({ totalPages }) {
       },
     }),
     [
-      page,
+      preview,
+      setPreview,
       pageSize,
+      sort,
+      setSort,
+      page,
       requestNextPage,
       searchKeyword,
-      setPage,
-      setSort,
       setSearchKeyword,
-      sort,
     ]
   );
 }

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -289,6 +289,13 @@ class Dashboard {
 				 * Creation date: 2020-06-11
 				 */
 				'enableBookmarkActions'           => false,
+				/**
+				 * Description: Enables template preview functionality.
+				 * Author: @brittanyirl
+				 * Issue: 3390
+				 * Creation date: 2020-07-23
+				 */
+				'enableTemplatePreviews'          => false,
 			],
 		];
 


### PR DESCRIPTION
## Summary
Lays groundwork for adding previews to dashboard

## Relevant Technical Choices
- sets a new feature flag to enable template previews (set to false currently) 
- adds new state called 'preview' to useTemplateView to prep for overlay and rendering preview 
- adds new callback for templateActions to set preview to selected template 
- tweaks the cardPreviewContainer to allow tab focus to div that is card item, add onClick to that div and onKeyDown w/ functionality for 'enter' 
- tweak to button component so that all the links we're rendering as buttons on top of the card items don't bubble up and also cause a preview! 


## To-do
- Lots more with previews, next up is setting up the overlay

## User-facing changes
- No changes

## Testing Instructions
- You can see the card level clicks trigger in storybook in Views/ExploreTemplates/Content 
- Regression testing the functionality of card items would be a good sanity check here since I had to tweak a few things. So, that would mean: Can you use a template? Can you 'view' the detail template? And also stories - can you open in editor? 

---

<!-- Please reference the issue(s) this PR addresses. -->

addresses #3390
