### PR TITLE
Make a11y test less flaky by mocking just 1 page.

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -177,7 +177,14 @@ describe('Media3pPane fetching', () => {
   });
 
   it('should handle pressing right when the last element is focused', async () => {
-    mockListMedia();
+    // Only mock 1 page.
+    spyOn(apiFetcher, 'listMedia').and.callFake(({ pageToken }) => {
+      if (!pageToken) {
+        return { media: mediaPage2, nextPageToken: undefined };
+      }
+      throw new Error(`Unexpected pageToken: ${pageToken}`);
+    });
+
     await fixture.events.click(media3pTab);
 
     await expectMediaElements(MEDIA_PER_PAGE);


### PR DESCRIPTION
The test is flaky because sometimes focusing the last element and pressing right will load the next page and move the cursor, instead of not doing anything (which is what we want to test)