### PR TITLE
Dashboard: Added Fade In animation effect

### DIFF
--- a/assets/src/dashboard/animations/constants.js
+++ b/assets/src/dashboard/animations/constants.js
@@ -27,6 +27,10 @@ export const ANIMATION_TYPES = {
   ZOOM: 'zoom',
 };
 
+export const ANIMATION_EFFECTS = {
+  FADE_IN: 'effect-fade-in',
+};
+
 export const DIRECTION = {
   TOP_TO_BOTTOM: 'topToBottom',
   BOTTOM_TO_TOP: 'bottomToTop',

--- a/assets/src/dashboard/animations/effects/fadeIn/index.js
+++ b/assets/src/dashboard/animations/effects/fadeIn/index.js
@@ -20,13 +20,11 @@
 import { AnimationFade } from '../../parts/fade';
 
 export function EffectFadeIn({ duration = 500, delay, easing }) {
-  return {
-    ...AnimationFade({
-      fadeFrom: 0,
-      fadeTo: 1,
-      duration,
-      delay,
-      easing,
-    }),
-  };
+  return AnimationFade({
+    fadeFrom: 0,
+    fadeTo: 1,
+    duration,
+    delay,
+    easing,
+  });
 }

--- a/assets/src/dashboard/animations/effects/fadeIn/index.js
+++ b/assets/src/dashboard/animations/effects/fadeIn/index.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { AnimationFade } from '../../parts/fade';
+
+export function EffectFadeIn({ duration = 500, delay, easing }) {
+  return {
+    ...AnimationFade({
+      fadeFrom: 0,
+      fadeTo: 1,
+      duration,
+      delay,
+      easing,
+    }),
+  };
+}

--- a/assets/src/dashboard/animations/effects/fadeIn/stories/index.js
+++ b/assets/src/dashboard/animations/effects/fadeIn/stories/index.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import StoryAnimation from '../../../../components/storyAnimation';
+import { AMPStoryWrapper } from '../../../../storybookUtils';
+import { ANIMATION_EFFECTS } from '../../../constants';
+
+export default {
+  title: 'Animations/Effects/Fade-In',
+};
+
+const animations = [
+  { targets: ['e1'], type: ANIMATION_EFFECTS.FADE_IN, duration: 1000 },
+  {
+    targets: ['e2'],
+    type: ANIMATION_EFFECTS.FADE_IN,
+    duration: 2500,
+  },
+];
+
+const elements = [
+  { id: 'e1', color: 'red' },
+  { id: 'e2', color: 'orange' },
+];
+
+const defaultStyles = {
+  position: 'relative',
+  width: '50px',
+  height: '50px',
+};
+
+export const _default = () => {
+  return (
+    <AMPStoryWrapper>
+      <amp-story-page id={`page-1`}>
+        <p style={{ textAlign: 'center', color: '#fff' }}>{'AMP Fade In'}</p>
+
+        <amp-story-grid-layer template="horizontal">
+          <div
+            animate-in="fade-in"
+            animate-in-duration="1s"
+            style={{
+              backgroundColor: 'red',
+              ...defaultStyles,
+            }}
+          />
+          <div
+            animate-in="fade-in"
+            animate-in-duration="2.5s"
+            style={{
+              backgroundColor: 'orange',
+              ...defaultStyles,
+            }}
+          />
+        </amp-story-grid-layer>
+      </amp-story-page>
+      <amp-story-page id={`page-2`}>
+        <StoryAnimation.Provider animations={animations}>
+          <StoryAnimation.AMPAnimations />
+          <p style={{ textAlign: 'center', color: '#fff' }}>
+            {'Custom Fade In Effect'}
+          </p>
+
+          <amp-story-grid-layer template="horizontal">
+            {elements.map(({ id, color }) => (
+              <div key={id} style={defaultStyles}>
+                <StoryAnimation.AMPWrapper target={id}>
+                  <div
+                    style={{
+                      width: '100%',
+                      height: '100%',
+                      backgroundColor: color,
+                    }}
+                  />
+                </StoryAnimation.AMPWrapper>
+              </div>
+            ))}
+          </amp-story-grid-layer>
+        </StoryAnimation.Provider>
+      </amp-story-page>
+    </AMPStoryWrapper>
+  );
+};

--- a/assets/src/dashboard/animations/parts/blinkOn/stories/index.js
+++ b/assets/src/dashboard/animations/parts/blinkOn/stories/index.js
@@ -22,7 +22,7 @@ import StoryAnimation from '../../../../components/storyAnimation';
 import { ANIMATION_TYPES } from '../../../constants';
 
 export default {
-  title: 'Dashboard/Animations/BlinkOn',
+  title: 'Animations/Parts/BlinkOn',
 };
 
 const animations = [
@@ -82,19 +82,24 @@ export const AMPStory = () => {
 
             <amp-story-grid-layer template="horizontal">
               {elements.map(({ id, color }) => (
-                <StoryAnimation.AMPWrapper
+                <div
                   key={id}
-                  target={id}
-                  style={{ width: '50px', height: '50px' }}
+                  style={{
+                    position: 'relative',
+                    width: '50px',
+                    height: '50px',
+                  }}
                 >
-                  <div
-                    style={{
-                      width: '100%',
-                      height: '100%',
-                      backgroundColor: color,
-                    }}
-                  />
-                </StoryAnimation.AMPWrapper>
+                  <StoryAnimation.AMPWrapper target={id}>
+                    <div
+                      style={{
+                        width: '100%',
+                        height: '100%',
+                        backgroundColor: color,
+                      }}
+                    />
+                  </StoryAnimation.AMPWrapper>
+                </div>
               ))}
             </amp-story-grid-layer>
           </StoryAnimation.Provider>

--- a/assets/src/dashboard/animations/parts/bounce/stories/index.js
+++ b/assets/src/dashboard/animations/parts/bounce/stories/index.js
@@ -22,7 +22,7 @@ import { PlayButton, AMPStoryWrapper } from '../../../../storybookUtils';
 import { ANIMATION_TYPES } from '../../../constants';
 
 export default {
-  title: 'Dashboard/Animations/Bounce',
+  title: 'Animations/Parts/Bounce',
 };
 
 const animations = [
@@ -70,19 +70,24 @@ export const AMPStory = () => {
 
             <amp-story-grid-layer template="vertical">
               {elements.map(({ id, color, width }) => (
-                <StoryAnimation.AMPWrapper
+                <div
                   key={id}
-                  target={id}
-                  style={{ width, height: '50px' }}
+                  style={{
+                    position: 'relative',
+                    height: '50px',
+                    width,
+                  }}
                 >
-                  <div
-                    style={{
-                      width: '100%',
-                      height: '100%',
-                      backgroundColor: color,
-                    }}
-                  />
-                </StoryAnimation.AMPWrapper>
+                  <StoryAnimation.AMPWrapper target={id}>
+                    <div
+                      style={{
+                        width: '100%',
+                        height: '100%',
+                        backgroundColor: color,
+                      }}
+                    />
+                  </StoryAnimation.AMPWrapper>
+                </div>
               ))}
             </amp-story-grid-layer>
           </StoryAnimation.Provider>

--- a/assets/src/dashboard/animations/parts/fade/stories/index.js
+++ b/assets/src/dashboard/animations/parts/fade/stories/index.js
@@ -22,7 +22,7 @@ import { PlayButton, AMPStoryWrapper } from '../../../../storybookUtils';
 import { ANIMATION_TYPES } from '../../../constants';
 
 export default {
-  title: 'Dashboard/Animations/Fade',
+  title: 'Animations/Parts/Fade',
 };
 
 const animations = [
@@ -42,6 +42,7 @@ const elements = [
 ];
 
 const defaultStyles = {
+  position: 'relative',
   width: '50px',
   height: '50px',
 };
@@ -77,19 +78,17 @@ export const AMPStory = () => {
 
             <amp-story-grid-layer template="horizontal">
               {elements.map(({ id, color }) => (
-                <StoryAnimation.AMPWrapper
-                  key={id}
-                  target={id}
-                  style={defaultStyles}
-                >
-                  <div
-                    style={{
-                      width: '100%',
-                      height: '100%',
-                      backgroundColor: color,
-                    }}
-                  />
-                </StoryAnimation.AMPWrapper>
+                <div key={id} style={defaultStyles}>
+                  <StoryAnimation.AMPWrapper target={id}>
+                    <div
+                      style={{
+                        width: '100%',
+                        height: '100%',
+                        backgroundColor: color,
+                      }}
+                    />
+                  </StoryAnimation.AMPWrapper>
+                </div>
               ))}
             </amp-story-grid-layer>
           </StoryAnimation.Provider>

--- a/assets/src/dashboard/animations/parts/flip/stories/index.js
+++ b/assets/src/dashboard/animations/parts/flip/stories/index.js
@@ -22,7 +22,7 @@ import { PlayButton, AMPStoryWrapper } from '../../../../storybookUtils';
 import { ANIMATION_TYPES, ROTATION, AXIS } from '../../../constants';
 
 export default {
-  title: 'Dashboard/Animations/Flip',
+  title: 'Animations/Parts/Flip',
 };
 
 const duration = 600;
@@ -69,6 +69,7 @@ const elements = [
 ];
 
 const defaultStyles = {
+  position: 'relative',
   width: '200px',
   height: '20px',
 };
@@ -105,13 +106,11 @@ export const AMPStory = () => {
 
             <amp-story-grid-layer template="vertical">
               {elements.map(({ id, text }) => (
-                <StoryAnimation.AMPWrapper
-                  key={id}
-                  target={id}
-                  style={defaultStyles}
-                >
-                  {text}
-                </StoryAnimation.AMPWrapper>
+                <div key={id} style={defaultStyles}>
+                  <StoryAnimation.AMPWrapper target={id}>
+                    {text}
+                  </StoryAnimation.AMPWrapper>
+                </div>
               ))}
             </amp-story-grid-layer>
           </StoryAnimation.Provider>

--- a/assets/src/dashboard/animations/parts/floatOn/stories/index.js
+++ b/assets/src/dashboard/animations/parts/floatOn/stories/index.js
@@ -22,7 +22,7 @@ import { PlayButton, AMPStoryWrapper } from '../../../../storybookUtils';
 import { ANIMATION_TYPES, DIRECTION } from '../../../constants';
 
 export default {
-  title: 'Dashboard/Animations/FloatOn',
+  title: 'Animations/Parts/FloatOn',
 };
 
 const duration = 600;
@@ -65,6 +65,7 @@ const elements = [
 ];
 
 const defaultStyles = {
+  position: 'relative',
   width: '200px',
   height: '100px',
 };
@@ -101,13 +102,11 @@ export const AMPStory = () => {
 
             <amp-story-grid-layer template="vertical">
               {elements.map(({ id, text }) => (
-                <StoryAnimation.AMPWrapper
-                  key={id}
-                  target={id}
-                  style={defaultStyles}
-                >
-                  {text}
-                </StoryAnimation.AMPWrapper>
+                <div key={id} style={defaultStyles}>
+                  <StoryAnimation.AMPWrapper target={id}>
+                    {text}
+                  </StoryAnimation.AMPWrapper>
+                </div>
               ))}
             </amp-story-grid-layer>
           </StoryAnimation.Provider>

--- a/assets/src/dashboard/animations/parts/index.js
+++ b/assets/src/dashboard/animations/parts/index.js
@@ -22,7 +22,8 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { ANIMATION_TYPES, BEZIER } from '../constants';
+import { ANIMATION_TYPES, ANIMATION_EFFECTS, BEZIER } from '../constants';
+import { EffectFadeIn } from '../effects/fadeIn';
 import { AnimationBounce } from './bounce';
 import { AnimationBlinkOn } from './blinkOn';
 import { AnimationFade } from './fade';
@@ -70,6 +71,7 @@ export function AnimationPart(type, args) {
       [ANIMATION_TYPES.MOVE]: AnimationMove,
       [ANIMATION_TYPES.SPIN]: AnimationSpin,
       [ANIMATION_TYPES.ZOOM]: AnimationZoom,
+      [ANIMATION_EFFECTS.FADE_IN]: EffectFadeIn,
     }[type] || throughput;
 
   args.easing = args.easing || BEZIER[args.easingPreset];

--- a/assets/src/dashboard/animations/parts/move/stories/index.js
+++ b/assets/src/dashboard/animations/parts/move/stories/index.js
@@ -22,7 +22,7 @@ import { PlayButton, AMPStoryWrapper } from '../../../../storybookUtils';
 import { ANIMATION_TYPES } from '../../../constants';
 
 export default {
-  title: 'Dashboard/Animations/Move',
+  title: 'Animations/Parts/Move',
 };
 
 const duration = 600;
@@ -90,22 +90,23 @@ export const AMPStory = () => {
           <StoryAnimation.Provider animations={animations}>
             <StoryAnimation.AMPAnimations />
             {elements.map(({ id, color, ...styles }) => (
-              <StoryAnimation.AMPWrapper
+              <div
                 key={id}
-                target={id}
                 style={{
                   ...defaultStyles,
                   ...styles,
                 }}
               >
-                <div
-                  style={{
-                    width: '100%',
-                    height: '100%',
-                    backgroundColor: color,
-                  }}
-                />
-              </StoryAnimation.AMPWrapper>
+                <StoryAnimation.AMPWrapper target={id}>
+                  <div
+                    style={{
+                      width: '100%',
+                      height: '100%',
+                      backgroundColor: color,
+                    }}
+                  />
+                </StoryAnimation.AMPWrapper>
+              </div>
             ))}
           </StoryAnimation.Provider>
         </amp-story-page>

--- a/assets/src/dashboard/animations/parts/spin/stories/index.js
+++ b/assets/src/dashboard/animations/parts/spin/stories/index.js
@@ -27,7 +27,7 @@ import { PlayButton, AMPStoryWrapper } from '../../../../storybookUtils';
 import { ANIMATION_TYPES } from '../../../constants';
 
 export default {
-  title: 'Dashboard/Animations/Spin',
+  title: 'Animations/Parts/Spin',
 };
 
 const animations = [
@@ -137,8 +137,15 @@ export const AMPStory = () => {
             <StoryAnimation.AMPAnimations />
             <amp-story-grid-layer template="vertical">
               {elements.map(({ id, color }) => (
-                <div key={id} style={{ marginBottom: '20px' }}>
-                  <StoryAnimation.AMPWrapper target={id} style={defaultStyles}>
+                <div
+                  key={id}
+                  style={{
+                    position: 'relative',
+                    marginBottom: '20px',
+                    ...defaultStyles,
+                  }}
+                >
+                  <StoryAnimation.AMPWrapper target={id}>
                     <SimpleStar color={color} />
                   </StoryAnimation.AMPWrapper>
                 </div>

--- a/assets/src/dashboard/animations/parts/zoom/stories/index.js
+++ b/assets/src/dashboard/animations/parts/zoom/stories/index.js
@@ -22,7 +22,7 @@ import { PlayButton, AMPStoryWrapper } from '../../../../storybookUtils';
 import { ANIMATION_TYPES } from '../../../constants';
 
 export default {
-  title: 'Dashboard/Animations/Zoom',
+  title: 'Animations/Parts/Zoom',
 };
 
 const animations = [
@@ -45,18 +45,22 @@ const animations = [
 const elements = [
   {
     id: 'e1',
-    src: 'https://i.picsum.photos/id/1025/4951/3301.jpg',
+    src:
+      'https://i.picsum.photos/id/1025/4951/3301.jpg?hmac=_aGh5AtoOChip_iaMo8ZvvytfEojcgqbCH7dzaz-H8Y',
     transform: 'translate(0px, 100px) scale(2)',
   },
   {
     id: 'e2',
-    src: 'https://i.picsum.photos/id/1062/5092/3395.jpg',
+    src:
+      'https://i.picsum.photos/id/1062/5092/3395.jpg?hmac=o9m7qeU51uOLfXvepXcTrk2ZPiSBJEkiiOp-Qvxja-k',
   },
 ];
 
 const defaultStyles = {
+  position: 'relative',
   width: '300px',
   height: '200px',
+  overflow: 'hidden',
 };
 
 export const _default = () => {
@@ -67,7 +71,6 @@ export const _default = () => {
         <div
           key={id}
           style={{
-            position: 'relative',
             marginBottom: '20px',
             ...defaultStyles,
           }}
@@ -99,21 +102,19 @@ export const AMPStory = () => {
 
             <amp-story-grid-layer template="vertical">
               {elements.map(({ id, src, ...style }) => (
-                <StoryAnimation.AMPWrapper
-                  key={id}
-                  target={id}
-                  style={defaultStyles}
-                >
-                  <img
-                    alt=""
-                    style={{
-                      width: '100%',
-                      height: '100%',
-                      ...style,
-                    }}
-                    src={src}
-                  />
-                </StoryAnimation.AMPWrapper>
+                <div key={id} style={defaultStyles}>
+                  <StoryAnimation.AMPWrapper target={id}>
+                    <img
+                      alt=""
+                      style={{
+                        width: '100%',
+                        height: '100%',
+                        ...style,
+                      }}
+                      src={src}
+                    />
+                  </StoryAnimation.AMPWrapper>
+                </div>
               ))}
             </amp-story-grid-layer>
           </StoryAnimation.Provider>


### PR DESCRIPTION
## Summary

This PR adds the `Fade In` animation effect to our repo.  It's basically a wrapper around the `Fade` animation part, it's pretty basic but I think this pattern will be useful when we want to combine multiple animation parts into one effect.

**NOTE:** I noticed that some of our other AMP Story animation storybook demos were broken because sizing was removed from the AMPWrapper and these stories weren't updated 😱 but now they're fixed 😎 

## Relevant Technical Choices

I decided to move "Animations" into its own section in our Storybook and then divide our animations into "Parts" (our existing animationParts) and "Effects" (the new stuff).

<img src="https://user-images.githubusercontent.com/40646372/88596144-4b0b1a00-d019-11ea-897f-48cd77d9203d.png" height="200">

## User-facing changes

None.  All the changes are in Storybook.

## Testing Instructions

1.) Open up our Storybook.
2.) Go to Animations -> Effects -> Fade In
3.) Switch back and forth between both pages and confirm that they're both animating the same (the first page uses the built in AMP Story Fade In and the second page is using our Fade In Effect).

Fixes #3420 

## Screenshots

![fade_in_effect](https://user-images.githubusercontent.com/40646372/88596418-e0a6a980-d019-11ea-9b2e-b58293359ef0.gif)

