### PR TITLE
(demo) Separate pagination actions from local/media3p

### DIFF
--- a/assets/src/edit-story/app/media/local/actions.js
+++ b/assets/src/edit-story/app/media/local/actions.js
@@ -17,21 +17,7 @@
 /**
  * Internal dependencies
  */
-import * as common from '../pagination/actions';
 import * as types from './types';
-
-export const fetchMediaStart = (dispatch) => (properties) =>
-  common.fetchMediaStart(dispatch)({ ...properties, provider: 'local' });
-export const fetchMediaSuccess = (dispatch) => (properties) =>
-  common.fetchMediaSuccess(dispatch)({ ...properties, provider: 'local' });
-export const fetchMediaError = (dispatch) => (properties) =>
-  common.fetchMediaError(dispatch)({ ...properties, provider: 'local' });
-export const setNextPage = (dispatch) => (properties) =>
-  common.setNextPage(dispatch)({ ...properties, provider: 'local' });
-export const updateMediaElement = (dispatch) => (properties) =>
-  common.updateMediaElement(dispatch)({ ...properties, provider: 'local' });
-export const deleteMediaElement = (dispatch) => (properties) =>
-  common.deleteMediaElement(dispatch)({ ...properties, provider: 'local' });
 
 export const resetFilters = (dispatch) => () => {
   dispatch({ type: types.LOCAL_MEDIA_RESET_FILTERS });

--- a/assets/src/edit-story/app/media/local/useContextValueProvider.js
+++ b/assets/src/edit-story/app/media/local/useContextValueProvider.js
@@ -37,7 +37,7 @@ import { getResourceFromAttachment } from '../utils';
  * from `useMediaReducer`
  * @return {Object} Context.
  */
-export default function useContextValueProvider(reducerState, reducerActions) {
+export default function useContextValueProvider(reducerState, paginationReducerActions, localReducerActions) {
   const {
     processing,
     processed,
@@ -50,16 +50,16 @@ export default function useContextValueProvider(reducerState, reducerActions) {
     fetchMediaStart,
     fetchMediaSuccess,
     fetchMediaError,
+    updateMediaElement,
+  } = paginationReducerActions;
+  const {
     resetFilters,
     setMedia,
     setMediaType,
     setSearchTerm,
-    setNextPage,
     setProcessing,
     removeProcessing,
-    updateMediaElement,
-    deleteMediaElement,
-  } = reducerActions;
+  } = localReducerActions;
   const {
     actions: { getMedia },
   } = useAPI();
@@ -73,7 +73,7 @@ export default function useContextValueProvider(reducerState, reducerActions) {
       } = {},
       callback
     ) => {
-      fetchMediaStart({ pageToken: p });
+      fetchMediaStart({ provider: 'local', pageToken: p });
       getMedia({
         mediaType: currentMediaType,
         searchTerm: currentSearchTerm,
@@ -92,7 +92,7 @@ export default function useContextValueProvider(reducerState, reducerActions) {
             totalPages,
           });
         })
-        .catch(fetchMediaError);
+        .catch(() => fetchMediaError({ provider: 'local' }));
     },
     [fetchMediaError, fetchMediaStart, getMedia]
   );
@@ -120,12 +120,12 @@ export default function useContextValueProvider(reducerState, reducerActions) {
     resetFilters();
     const isFirstPage = !pageToken;
     if (!mediaType && !searchTerm && isFirstPage) {
-      fetchMedia({ mediaType }, fetchMediaSuccess);
+      fetchMedia({ mediaType }, () => fetchMediaSuccess({ provider: 'local' }));
     }
   }, [fetchMedia, fetchMediaSuccess, resetFilters]);
 
   useEffect(() => {
-    fetchMedia({ searchTerm, pageToken, mediaType }, fetchMediaSuccess);
+    fetchMedia({ searchTerm, pageToken, mediaType }, () => fetchMediaSuccess({ provider: 'local' }));
   }, [fetchMedia, fetchMediaSuccess, mediaType, pageToken, searchTerm]);
 
   const uploadVideoPoster = useCallback(
@@ -177,15 +177,12 @@ export default function useContextValueProvider(reducerState, reducerActions) {
   return {
     state: { ...reducerState, isUploading },
     actions: {
-      setNextPage,
       setMediaType,
       setSearchTerm,
       resetFilters,
       uploadMedia,
       resetWithFetch,
       uploadVideoPoster,
-      deleteMediaElement,
-      updateMediaElement,
     },
   };
 }

--- a/assets/src/edit-story/app/media/media3p/actions.js
+++ b/assets/src/edit-story/app/media/media3p/actions.js
@@ -18,7 +18,6 @@
  * Internal dependencies
  */
 export * from './categories/actions';
-export * from '../pagination/actions';
 import * as types from './types';
 
 export const setSelectedProvider = (dispatch) => ({ provider }) => {

--- a/assets/src/edit-story/app/media/media3p/useContextValueProvider.js
+++ b/assets/src/edit-story/app/media/media3p/useContextValueProvider.js
@@ -23,7 +23,7 @@ import useProviderContextValueProvider from './useProviderContextValueProvider';
 // Use provider configuration json fragment.
 const providers = ['unsplash'];
 
-function useProviderSetContextValueProvider(reducerState, reducerActions) {
+function useProviderSetContextValueProvider(reducerState, paginationReducerActions, media3pReducerActions) {
   const result = {};
 
   // The 'providers' list is a constant, and so hooks are still called in the
@@ -33,7 +33,8 @@ function useProviderSetContextValueProvider(reducerState, reducerActions) {
     result[provider] = useProviderContextValueProvider(
       provider,
       reducerState,
-      reducerActions
+      paginationReducerActions,
+      media3pReducerActions,
     );
   }
   return result;
@@ -49,16 +50,16 @@ function useProviderSetContextValueProvider(reducerState, reducerActions) {
  * returned from `useMediaReducer`
  * @return {Object} Context.
  */
-export default function useContextValueProvider(reducerState, reducerActions) {
+export default function useContextValueProvider(reducerState, paginationReducerActions, media3pReducerActions) {
   return {
     state: {
       selectedProvider: reducerState.selectedProvider,
       searchTerm: reducerState.searchTerm,
     },
     actions: {
-      setSelectedProvider: reducerActions.setSelectedProvider,
-      setSearchTerm: reducerActions.setSearchTerm,
+      setSelectedProvider: media3pReducerActions.setSelectedProvider,
+      setSearchTerm: media3pReducerActions.setSearchTerm,
     },
-    ...useProviderSetContextValueProvider(reducerState, reducerActions),
+    ...useProviderSetContextValueProvider(reducerState, paginationReducerActions, media3pReducerActions),
   };
 }

--- a/assets/src/edit-story/app/media/media3p/useProviderContextValueProvider.js
+++ b/assets/src/edit-story/app/media/media3p/useProviderContextValueProvider.js
@@ -39,7 +39,8 @@ import useFetchCategoriesEffect from './useFetchCategoriesEffect';
 export default function useProviderContextValueProvider(
   provider,
   reducerState,
-  reducerActions
+  paginationReducerActions,
+  media3pReducerActions,
 ) {
   const { selectedProvider, searchTerm } = reducerState;
   const {
@@ -50,10 +51,12 @@ export default function useProviderContextValueProvider(
     fetchMediaStart,
     fetchMediaSuccess,
     fetchMediaError,
+  } = paginationReducerActions;
+  const {
     fetchCategoriesStart,
     fetchCategoriesSuccess,
     fetchCategoriesError,
-  } = reducerActions;
+  } = media3pReducerActions;
 
   // Fetch or re-fetch media when the state has changed.
   useFetchMediaEffect({
@@ -78,17 +81,13 @@ export default function useProviderContextValueProvider(
   return {
     state: reducerState[provider],
     actions: {
-      setNextPage: useCallback(() => reducerActions.setNextPage({ provider }), [
-        reducerActions,
-        provider,
-      ]),
       selectCategory: useCallback(
-        (categoryId) => reducerActions.selectCategory({ provider, categoryId }),
-        [reducerActions, provider]
+        (categoryId) => media3pReducerActions.selectCategory({ provider, categoryId }),
+        [media3pReducerActions, provider]
       ),
       deselectCategory: useCallback(
-        () => reducerActions.deselectCategory({ provider }),
-        [reducerActions, provider]
+        () => media3pReducerActions.deselectCategory({ provider }),
+        [media3pReducerActions, provider]
       ),
     },
   };

--- a/assets/src/edit-story/app/media/mediaProvider.js
+++ b/assets/src/edit-story/app/media/mediaProvider.js
@@ -30,13 +30,21 @@ import Context from './context';
 function MediaProvider({ children }) {
   const { state, actions } = useMediaReducer();
 
-  const local = useLocalContextValueProvider(state.local, actions.local);
+  const local = useLocalContextValueProvider(state.local, actions.pagination, actions.local);
   const media3p = useMedia3pContextValueProvider(
     state.media3p,
-    actions.media3p
+    actions.pagination,
+    actions.media3p,
   );
 
-  const context = { local, media3p };
+  const context = {
+    local,
+    media3p,
+    actions: {
+      setNextPage: actions.pagination.setNextPage,
+    },
+  };
+  console.warn('=======', context);
   return <Context.Provider value={context}>{children}</Context.Provider>;
 }
 

--- a/assets/src/edit-story/app/media/useMediaReducer.js
+++ b/assets/src/edit-story/app/media/useMediaReducer.js
@@ -26,6 +26,7 @@ import localReducer from './local/reducer';
 import media3pReducer from './media3p/reducer';
 import * as localActionsToWrap from './local/actions';
 import * as media3pActionsToWrap from './media3p/actions';
+import * as paginationActionsToWrap from './pagination/actions';
 import * as types from './types';
 
 function rootReducer(state = {}, { type, payload }) {
@@ -62,7 +63,11 @@ const wrapWithDispatch = (actionFnOrActionObject, dispatch) => {
  */
 function useMediaReducer(reducer = rootReducer, actionsToWrap) {
   const defaultActionsToWrap = useMemo(
-    () => ({ local: localActionsToWrap, media3p: media3pActionsToWrap }),
+    () => ({
+      local: localActionsToWrap,
+      pagination: paginationActionsToWrap,
+      media3p: media3pActionsToWrap,
+    }),
     []
   );
   actionsToWrap = actionsToWrap ?? defaultActionsToWrap;

--- a/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
+++ b/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
@@ -87,6 +87,7 @@ function useUploadVideoFrame({ updateMediaElement }) {
       });
       setProperties(id, newState);
       updateMediaElement({
+        provider: 'local',
         id,
         posterId,
         poster,

--- a/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
@@ -95,12 +95,12 @@ function PaginatedMediaGallery({
     const bottom =
       node.scrollHeight - node.scrollTop <= node.clientHeight + ROOT_MARGIN;
     if (bottom) {
-      setNextPage();
+      setNextPage({ provider });
     }
 
     // Load the next page if the page isn't full, ie. scrollbar is not visible.
     if (node.clientHeight === node.scrollHeight) {
-      setNextPage();
+      setNextPage({ provider });
     }
   }, [hasMore, isMediaLoaded, isMediaLoading, setNextPage]);
 

--- a/assets/src/edit-story/components/library/panes/media/local/mediaEditDialog.js
+++ b/assets/src/edit-story/components/library/panes/media/local/mediaEditDialog.js
@@ -149,7 +149,7 @@ function MediaEditDialog({ resource, onClose }) {
   const {
     actions: { updateMedia },
   } = useAPI();
-  const { updateMediaElement } = useLocalMedia((state) => ({
+  const { updateMediaElement } = useMedia((state) => ({
     updateMediaElement: state.actions.updateMediaElement,
   }));
   const { showSnackbar } = useSnackbar();
@@ -165,7 +165,7 @@ function MediaEditDialog({ resource, onClose }) {
       // Update server.
       await updateMedia(id, { alt_text: altText });
       // Update internal state.
-      updateMediaElement({ id, alt: altText });
+      updateMediaElement({ provider: 'local', id, alt: altText });
       onClose();
     } catch (err) {
       showSnackbar({


### PR DESCRIPTION
## Summary

Separate pagination actions from local/media3p.

## Relevant Technical Choices

This PR demonstrates what changes are required to separate local/actions and media3p/actions from pagination/actions, and what this looks like.

After these changes the MediaProvider context value would have this structure:
https://screenshot.googleplex.com/LxjKOWDFx3X