### PR TITLE
Replaced support link with feedback form

### DIFF
--- a/beta/index.html
+++ b/beta/index.html
@@ -882,7 +882,7 @@
             </dd>
         
             <dt>I found a bug or missing feature! How do I report it?</dt>
-            <dd>Awesome! That’s exactly what the beta is for. Please submit feedback and <a href="https://github.com/google/web-stories-wp/issues">file a bug or feature request on Github</a> for now - we'll follow up with an easier-to-use feedback form in the next days. Your help is greatly appreciated.</dd>
+            <dd>Awesome! That’s exactly what the beta is for. Please submit feedback using this <a href="https://docs.google.com/forms/d/1xo5J7hdvPGDpEENZtlF3G4-mo3Q0E-S7oRvSyOjZ_I4/viewform">feedback form</a> or <a href="https://github.com/google/web-stories-wp/issues">file a bug or feature request on Github</a>. Your help is greatly appreciated.</dd>
 
             <dt>When is the final version shipping, and what will be included?</dt>
             <dd>Later this summer. In addition to stabilization, performance fixes and bug fixes, the final version will also include animation and page attachment support.</dd>


### PR DESCRIPTION
## Summary

Adds the feedback form link to the micro site.

## Testing Instructions

Can't be tested using our usual method. QA needs to be skipped.
