### PR TITLE
3P Media Error Handling

### DIFF
--- a/assets/src/edit-story/app/media/media3p/test/useFetchCategoriesEffect.js
+++ b/assets/src/edit-story/app/media/media3p/test/useFetchCategoriesEffect.js
@@ -36,11 +36,7 @@ jest.mock('../api', () => ({
 
 const mockShowSnackbar = jest.fn();
 jest.mock('../../../snackbar', () => ({
-  useSnackbar: () => {
-    return {
-      showSnackbar: mockShowSnackbar,
-    };
-  },
+  useSnackbar: () => ({ showSnackbar: mockShowSnackbar }),
 }));
 
 describe('useFetchCategoriesEffect', () => {

--- a/assets/src/edit-story/app/media/media3p/test/useFetchCategoriesEffect.js
+++ b/assets/src/edit-story/app/media/media3p/test/useFetchCategoriesEffect.js
@@ -34,6 +34,15 @@ jest.mock('../api', () => ({
   }),
 }));
 
+const mockShowSnackbar = jest.fn();
+jest.mock('../../../snackbar', () => ({
+  useSnackbar: () => {
+    return {
+      showSnackbar: mockShowSnackbar,
+    };
+  },
+}));
+
 describe('useFetchCategoriesEffect', () => {
   let fetchCategoriesStart;
   let fetchCategoriesSuccess;
@@ -44,6 +53,7 @@ describe('useFetchCategoriesEffect', () => {
     fetchCategoriesStart = jest.fn();
     fetchCategoriesSuccess = jest.fn();
     fetchCategoriesError = jest.fn();
+    mockShowSnackbar.mockReset();
   });
 
   function renderUseFetchCategoriesEffect(propertyOverrides) {
@@ -92,6 +102,7 @@ describe('useFetchCategoriesEffect', () => {
         ],
       })
     );
+    expect(mockShowSnackbar).not.toHaveBeenCalled();
   });
 
   it('should call fetchCategoriesError if the fetch has failed', async () => {
@@ -102,6 +113,7 @@ describe('useFetchCategoriesEffect', () => {
     expect(fetchCategoriesStart.mock.calls).toHaveLength(1);
     expect(fetchCategoriesSuccess.mock.calls).toHaveLength(0);
     expect(fetchCategoriesError.mock.calls).toHaveLength(1);
+    expect(mockShowSnackbar).toHaveBeenCalledTimes(1);
   });
 
   it('should not fetch media if the provider is not the same as selected provider', async () => {
@@ -109,6 +121,9 @@ describe('useFetchCategoriesEffect', () => {
       provider: 'coverr',
       selectedProvider: 'unsplash',
     });
-    expect(fetchCategoriesStart.mock.calls).toHaveLength(0);
+    expect(fetchCategoriesStart).not.toHaveBeenCalledTimes(1);
+    expect(fetchCategoriesSuccess).not.toHaveBeenCalledTimes(1);
+    expect(fetchCategoriesError).not.toHaveBeenCalledTimes(1);
+    expect(mockShowSnackbar).not.toHaveBeenCalled();
   });
 });

--- a/assets/src/edit-story/app/media/media3p/test/useFetchMediaEffect.js
+++ b/assets/src/edit-story/app/media/media3p/test/useFetchMediaEffect.js
@@ -38,11 +38,7 @@ jest.mock('../api', () => ({
 
 const mockShowSnackbar = jest.fn();
 jest.mock('../../../snackbar', () => ({
-  useSnackbar: () => {
-    return {
-      showSnackbar: mockShowSnackbar,
-    };
-  },
+  useSnackbar: () => ({ showSnackbar: mockShowSnackbar }),
 }));
 
 describe('useFetchMediaEffect', () => {

--- a/assets/src/edit-story/app/media/media3p/test/useFetchMediaEffect.js
+++ b/assets/src/edit-story/app/media/media3p/test/useFetchMediaEffect.js
@@ -36,6 +36,15 @@ jest.mock('../api', () => ({
   }),
 }));
 
+const mockShowSnackbar = jest.fn();
+jest.mock('../../../snackbar', () => ({
+  useSnackbar: () => {
+    return {
+      showSnackbar: mockShowSnackbar,
+    };
+  },
+}));
+
 describe('useFetchMediaEffect', () => {
   let fetchMediaStart;
   let fetchMediaSuccess;
@@ -46,6 +55,7 @@ describe('useFetchMediaEffect', () => {
     fetchMediaStart = jest.fn();
     fetchMediaSuccess = jest.fn();
     fetchMediaError = jest.fn();
+    mockShowSnackbar.mockReset();
   });
 
   function renderUseFetchMediaEffect(propertyOverrides) {
@@ -86,6 +96,7 @@ describe('useFetchMediaEffect', () => {
       nextPageToken: 'nextPageToken',
       pageToken: 'pageToken',
     });
+    expect(mockShowSnackbar).not.toHaveBeenCalled();
   });
 
   it('should fetch media when the provider is set and search term', async () => {
@@ -110,6 +121,7 @@ describe('useFetchMediaEffect', () => {
       nextPageToken: 'nextPageToken',
       pageToken: 'pageToken',
     });
+    expect(mockShowSnackbar).not.toHaveBeenCalled();
   });
 
   it('should fetch media when the provider is set and category id', async () => {
@@ -134,6 +146,7 @@ describe('useFetchMediaEffect', () => {
       nextPageToken: 'nextPageToken',
       pageToken: 'pageToken',
     });
+    expect(mockShowSnackbar).not.toHaveBeenCalled();
   });
 
   it('should call fetchMediaError if the fetch has failed', async () => {
@@ -144,6 +157,7 @@ describe('useFetchMediaEffect', () => {
     expect(fetchMediaStart).toHaveBeenCalledTimes(1);
     expect(fetchMediaSuccess).not.toHaveBeenCalledWith();
     expect(fetchMediaError).toHaveBeenCalledTimes(1);
+    expect(mockShowSnackbar).toHaveBeenCalledTimes(1);
   });
 
   it('should not fetch media if the provider is not the same as selected provider', async () => {
@@ -152,5 +166,8 @@ describe('useFetchMediaEffect', () => {
       selectedProvider: 'unsplash',
     });
     expect(fetchMediaStart).not.toHaveBeenCalledTimes(1);
+    expect(fetchMediaSuccess).not.toHaveBeenCalledTimes(1);
+    expect(fetchMediaError).not.toHaveBeenCalledTimes(1);
+    expect(mockShowSnackbar).not.toHaveBeenCalledTimes(1);
   });
 });

--- a/assets/src/edit-story/app/media/media3p/useFetchCategoriesEffect.js
+++ b/assets/src/edit-story/app/media/media3p/useFetchCategoriesEffect.js
@@ -22,7 +22,20 @@ import { useEffect } from 'react';
 /**
  * Internal dependencies
  */
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { ProviderType } from '../../../components/library/panes/media/common/providerType';
+import { useSnackbar } from '../../snackbar';
 import { useMedia3pApi } from './api';
+
+function getFetchCategoriesErrorMessage(provider) {
+  if (provider === ProviderType.UNSPLASH) {
+    return __('Error loading categories from Unsplash', 'web-stories');
+  }
+  return __('Error loading categories', 'web-stories');
+}
 
 export default function useFetchCategoriesEffect({
   provider,
@@ -35,6 +48,8 @@ export default function useFetchCategoriesEffect({
     actions: { listCategories },
   } = useMedia3pApi();
 
+  const { showSnackbar } = useSnackbar();
+
   useEffect(() => {
     async function fetch() {
       fetchCategoriesStart({ provider });
@@ -43,6 +58,7 @@ export default function useFetchCategoriesEffect({
         fetchCategoriesSuccess({ provider, categories });
       } catch {
         fetchCategoriesError({ provider });
+        showSnackbar({ message: getFetchCategoriesErrorMessage(provider) });
       }
     }
 
@@ -50,6 +66,7 @@ export default function useFetchCategoriesEffect({
       fetch();
     }
   }, [
+    showSnackbar,
     // Fetch categories is triggered by changes to these.
     selectedProvider,
     // These attributes never change.

--- a/assets/src/edit-story/app/media/media3p/useFetchMediaEffect.js
+++ b/assets/src/edit-story/app/media/media3p/useFetchMediaEffect.js
@@ -22,7 +22,22 @@ import { useEffect } from 'react';
 /**
  * Internal dependencies
  */
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSnackbar } from '../../snackbar';
+import { ProviderType } from '../../../components/library/panes/media/common/providerType';
 import { useMedia3pApi } from './api';
+
+function getFetchMediaErrorMessage(provider) {
+  if (provider === ProviderType.UNSPLASH) {
+    return __('Error loading media from Unsplash', 'web-stories');
+  } else if (provider === ProviderType.LOCAL) {
+    return __('Error loading media from Wordpress', 'web-stories');
+  }
+  return __('Error loading media', 'web-stories');
+}
 
 export default function useFetchMediaEffect({
   provider,
@@ -37,6 +52,8 @@ export default function useFetchMediaEffect({
   const {
     actions: { listMedia, listCategoryMedia },
   } = useMedia3pApi();
+
+  const { showSnackbar } = useSnackbar();
 
   useEffect(() => {
     async function fetch() {
@@ -59,6 +76,7 @@ export default function useFetchMediaEffect({
         fetchMediaSuccess({ provider, media, pageToken, nextPageToken });
       } catch {
         fetchMediaError({ provider, pageToken });
+        showSnackbar({ message: getFetchMediaErrorMessage(provider) });
       }
     }
 
@@ -66,6 +84,7 @@ export default function useFetchMediaEffect({
       fetch();
     }
   }, [
+    showSnackbar,
     // Fetch media is triggered by changes to these.
     selectedProvider,
     pageToken,

--- a/assets/src/edit-story/app/snackbar/snackbarProvider.js
+++ b/assets/src/edit-story/app/snackbar/snackbarProvider.js
@@ -56,7 +56,12 @@ function SnackbarProvider({ children, place }) {
       timeout: notification.timeout || 5000,
       ...notification,
     };
-    setNotifications([...notifications, newNotification]);
+    // React may batch state updates, so use the setter that receives the
+    // previous state.
+    setNotifications((currentNotifications) => [
+      ...currentNotifications,
+      newNotification,
+    ]);
     removeNotification(newNotification);
   };
 


### PR DESCRIPTION
Adds error handling of media by hooking into the error catching logic in useFetch{Media|Categories}Effect.

TODO: Add this logic to the upload tab.

Fixes #2396