### PR TITLE
Workspace: Add support for curated fonts in the new font picker

### DIFF
--- a/assets/src/edit-story/app/font/curatedFonts.js
+++ b/assets/src/edit-story/app/font/curatedFonts.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+// Curated Fonts list source:
+// https://github.com/google/web-stories-wp/issues/1989#issuecomment-662253222
 export const curatedFontNames = [
   'Karla',
   'Lato',

--- a/assets/src/edit-story/app/font/curatedFonts.js
+++ b/assets/src/edit-story/app/font/curatedFonts.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const curatedFontNames = [
+  'Karla',
+  'Lato',
+  'Lora',
+  'Merriweather',
+  'Montserrat',
+  'Nunito',
+  'Oswald',
+  'Playfair Display',
+  'Poppins',
+  'Raleway',
+  'Roboto',
+  'Roboto Condensed',
+  'Source Serif Pro',
+  'Titillium Web',
+  'Work Sans',
+  'Alegreya',
+  'Arimo',
+  'EB Garamond',
+  'IBM Plex Mono',
+  'IBM Plex Serif',
+  'Inconsolata',
+  'Muli',
+  'Noto Sans',
+  'Noto Serif',
+  'Open Sans',
+  'Open Sans Condensed',
+  'PT Mono',
+  'PT Sans',
+  'PT Serif',
+  'Roboto Mono',
+  'Source Sans Pro',
+  'Ubuntu',
+  'Anton',
+  'BioRhyme',
+  'Bungee',
+  'Bungee Shade',
+  'Cookie',
+  'Dancing Script',
+  'Monoton',
+  'Nothing You Could Do',
+  'Parisienne',
+  'Rock Salt',
+  'UnifrakturMaguntia',
+];

--- a/assets/src/edit-story/app/font/fontProvider.js
+++ b/assets/src/edit-story/app/font/fontProvider.js
@@ -23,7 +23,7 @@ import { __ } from '@wordpress/i18n';
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useCallback, useState, useRef } from 'react';
+import { useCallback, useState, useRef, useMemo } from 'react';
 
 /**
  * Internal dependencies
@@ -32,6 +32,7 @@ import loadStylesheet from '../../utils/loadStylesheet';
 import Context from './context';
 import useLoadFonts from './effects/useLoadFonts';
 import useLoadFontFiles from './actions/useLoadFontFiles';
+import { curatedFontNames } from './curatedFonts';
 
 const GOOGLE_MENU_FONT_URL = 'https://fonts.googleapis.com/css';
 
@@ -138,9 +139,15 @@ function FontProvider({ children }) {
 
   const maybeEnqueueFontStyle = useLoadFontFiles({ getFontByName });
 
+  const curatedFonts = useMemo(
+    () => fonts.filter((font) => curatedFontNames.includes(font.name)),
+    [fonts]
+  );
+
   const state = {
     state: {
       fonts,
+      curatedFonts,
       recentFonts,
     },
     actions: {

--- a/assets/src/edit-story/components/fontPicker/pickerContainer.js
+++ b/assets/src/edit-story/components/fontPicker/pickerContainer.js
@@ -155,7 +155,7 @@ const NoResult = styled.span`
 
 function FontPickerContainer({ value, onSelect, onClose, isOpen }) {
   const {
-    state: { fonts, recentFonts },
+    state: { fonts, recentFonts, curatedFonts },
     actions: { ensureMenuFontsLoaded },
   } = useFont();
 

--- a/assets/src/edit-story/components/fontPicker/pickerContainer.js
+++ b/assets/src/edit-story/components/fontPicker/pickerContainer.js
@@ -165,7 +165,7 @@ function FontPickerContainer({ value, onSelect, onClose, isOpen }) {
   const [searchKeyword, setSearchKeyword] = useState('');
   const [matchingFonts, setMatchingFonts] = useState([
     ...recentFonts,
-    ...fonts,
+    ...curatedFonts,
   ]);
 
   useEffect(() => {
@@ -196,7 +196,7 @@ function FontPickerContainer({ value, onSelect, onClose, isOpen }) {
       // Restore default if less than 2 characters.
       if (searchKeyword.trim().length < 2) {
         dividerIndexTracker.current = recentFonts.length - 1;
-        setMatchingFonts([...recentFonts, ...fonts]);
+        setMatchingFonts([...recentFonts, ...curatedFonts]);
         return;
       }
       const _fonts = fonts.filter(({ name }) =>
@@ -210,7 +210,7 @@ function FontPickerContainer({ value, onSelect, onClose, isOpen }) {
     },
     250,
     {},
-    [searchKeyword, fonts]
+    [searchKeyword, fonts, curatedFonts]
   );
 
   const handleSearchInputChanged = useCallback(

--- a/assets/src/edit-story/components/fontPicker/test/fontPicker.js
+++ b/assets/src/edit-story/components/fontPicker/test/fontPicker.js
@@ -26,6 +26,7 @@ import FontPicker from '../';
 import { FontProvider } from '../../../app/font';
 import APIContext from '../../../app/api/context';
 import { renderWithTheme } from '../../../testUtils';
+import { curatedFontNames } from '../../../app/font/curatedFonts';
 import fontsListResponse from './fontsResponse';
 
 async function getFontPicker(options) {
@@ -54,6 +55,10 @@ async function getFontPicker(options) {
   return accessors;
 }
 
+const availableCuratedFonts = fontsListResponse.filter(
+  (font) => curatedFontNames.indexOf(font.name) > 0
+);
+
 describe('Font Picker', () => {
   // Mock scrollTo
   const scrollTo = jest.fn();
@@ -75,7 +80,7 @@ describe('Font Picker', () => {
 
     // Should render all options
     const allOptionItems = getAllByRole('option');
-    expect(allOptionItems).toHaveLength(fontsListResponse.length);
+    expect(allOptionItems).toHaveLength(availableCuratedFonts.length);
   });
 
   it('should mark the currently selected font', async () => {
@@ -125,7 +130,7 @@ describe('Font Picker', () => {
     });
 
     // The second font in the list.
-    expect(onChangeFn).toHaveBeenCalledWith('Abel');
+    expect(onChangeFn).toHaveBeenCalledWith(availableCuratedFonts[1].name);
   });
 
   it('should close the menu when the Esc key is pressed.', async () => {
@@ -158,29 +163,29 @@ describe('Font Picker', () => {
     expect(fontsList).toBeInTheDocument();
 
     // Move down by 2
-    await act(() => {
+    act(() => {
       fireEvent.keyDown(fontsList, {
         key: 'ArrowDown',
       });
     });
-    await act(() => {
+    act(() => {
       fireEvent.keyDown(fontsList, {
         key: 'ArrowDown',
       });
     });
 
-    await act(() => {
+    act(() => {
       fireEvent.keyDown(fontsList, {
         key: 'ArrowUp',
       });
     });
 
-    await act(() => {
+    act(() => {
       fireEvent.keyDown(fontsList, { key: 'Enter' });
     });
 
-    // Moving down by 2 and back 1 up should end up with the second font: Abel.
-    expect(onChangeFn).toHaveBeenCalledWith('Abel');
+    // Moving down by 2 and back 1 up should end up with the second font: Roboto Condensed.
+    expect(onChangeFn).toHaveBeenCalledWith(availableCuratedFonts[1].name);
   });
 
   it('should search and filter the list to match the results.', async () => {
@@ -189,7 +194,7 @@ describe('Font Picker', () => {
     const selectButton = getByRole('button');
     fireEvent.click(selectButton);
 
-    expect(queryAllByRole('option')).toHaveLength(fontsListResponse.length);
+    expect(queryAllByRole('option')).toHaveLength(availableCuratedFonts.length);
 
     act(() => {
       fireEvent.change(getByRole('combobox'), {
@@ -208,7 +213,7 @@ describe('Font Picker', () => {
     const selectButton = getByRole('button');
     fireEvent.click(selectButton);
 
-    expect(queryAllByRole('option')).toHaveLength(fontsListResponse.length);
+    expect(queryAllByRole('option')).toHaveLength(availableCuratedFonts.length);
 
     act(() => {
       fireEvent.change(getByRole('combobox'), {


### PR DESCRIPTION
## Summary

- Adds support for curated fonts to be displayed in the main drop down list instead of the entire list

<img width="242" alt="Screen Shot 2020-07-28 at 4 00 37 PM" src="https://user-images.githubusercontent.com/1738349/88724951-f1761e80-d0f0-11ea-9e63-bb094c7e4e5b.png">


## User-facing changes

- Replaces the entire full list of fonts with a curated set
- The user can still search the entire full list

## Testing Instructions

- Enable the new font picker
- See that the dropdown only has a list of 30-40 fonts and that it scrolls much faster
- Ensure that you are able to still search for a font not in the curated list

---

<!-- Please reference the issue(s) this PR addresses. -->

#1989 
