### PR TITLE
Animations: Add Fly In animation effect

### DIFF
--- a/assets/src/dashboard/animations/constants.js
+++ b/assets/src/dashboard/animations/constants.js
@@ -30,6 +30,7 @@ export const ANIMATION_TYPES = {
 
 export const ANIMATION_EFFECTS = {
   FADE_IN: 'effect-fade-in',
+  FLY_IN: 'effect-fly-in',
   PULSE: 'effect-pulse',
 };
 

--- a/assets/src/dashboard/animations/effects/flyIn/index.js
+++ b/assets/src/dashboard/animations/effects/flyIn/index.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { AnimationMove } from '../../parts/move';
+import getOffPageOffset from '../../utils/getOffPageOffset';
+import { DIRECTION } from '../../constants';
+
+export function EffectFlyIn({
+  duration = 500,
+  direction = DIRECTION.TOP_TO_BOTTOM,
+  delay,
+  easing,
+  element,
+}) {
+  const { offsetTop, offsetLeft, offsetRight, offsetBottom } = getOffPageOffset(
+    element
+  );
+
+  const offsetLookup = {
+    [DIRECTION.TOP_TO_BOTTOM]: {
+      offsetY: offsetTop,
+    },
+    [DIRECTION.BOTTOM_TO_TOP]: {
+      offsetY: offsetBottom,
+    },
+    [DIRECTION.LEFT_TO_RIGHT]: {
+      offsetX: offsetLeft,
+    },
+    [DIRECTION.RIGHT_TO_LEFT]: {
+      offsetX: offsetRight,
+    },
+  };
+
+  return new AnimationMove({
+    ...offsetLookup[direction],
+    duration,
+    delay,
+    easing,
+  });
+}

--- a/assets/src/dashboard/animations/effects/flyIn/stories/index.js
+++ b/assets/src/dashboard/animations/effects/flyIn/stories/index.js
@@ -76,7 +76,7 @@ export const _default = () => {
   return (
     <AMPStoryWrapper>
       <amp-story-page id={`page-1`}>
-        <p style={{ textAlign: 'center', color: '#fff' }}>{'AMP Drop'}</p>
+        <p style={{ textAlign: 'center', color: '#fff' }}>{'AMP Fly In'}</p>
 
         <amp-story-grid-layer
           template="vertical"
@@ -119,7 +119,7 @@ export const _default = () => {
         <StoryAnimation.Provider animations={animations} elements={elements}>
           <StoryAnimation.AMPAnimations />
           <p style={{ textAlign: 'center', color: '#fff' }}>
-            {'Custom Drop Effect'}
+            {'Custom Fly In Effect'}
           </p>
 
           <amp-story-grid-layer

--- a/assets/src/dashboard/animations/effects/flyIn/stories/index.js
+++ b/assets/src/dashboard/animations/effects/flyIn/stories/index.js
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import StoryAnimation from '../../../../components/storyAnimation';
+import {
+  AMPStoryWrapper,
+  AMP_STORY_ASPECT_RATIO,
+} from '../../../../storybookUtils';
+import { ANIMATION_EFFECTS, DIRECTION } from '../../../constants';
+import { getBox } from '../../../../../edit-story/units/dimensions';
+
+export default {
+  title: 'Animations/Effects/Fly-In',
+};
+
+const animations = [
+  {
+    targets: ['e1'],
+    type: ANIMATION_EFFECTS.FLY_IN,
+  },
+  {
+    targets: ['e2'],
+    type: ANIMATION_EFFECTS.FLY_IN,
+    delay: 500,
+    direction: DIRECTION.LEFT_TO_RIGHT,
+  },
+  {
+    targets: ['e3'],
+    type: ANIMATION_EFFECTS.FLY_IN,
+    delay: 1000,
+    direction: DIRECTION.RIGHT_TO_LEFT,
+  },
+  {
+    targets: ['e4'],
+    type: ANIMATION_EFFECTS.FLY_IN,
+    delay: 1500,
+    direction: DIRECTION.BOTTOM_TO_TOP,
+  },
+];
+
+const elements = [
+  { id: 'e1', color: 'red', x: 50, y: 100, width: 50, height: 50 },
+  { id: 'e2', color: 'orange', x: 50, y: 175, width: 50, height: 50 },
+  { id: 'e3', color: 'blue', x: 50, y: 250, width: 50, height: 50 },
+  { id: 'e4', color: 'yellow', x: 50, y: 325, width: 50, height: 50 },
+];
+
+const defaultStyles = {
+  position: 'relative',
+  width: '50px',
+  height: '50px',
+};
+
+export const _default = () => {
+  const elementBoxes = elements.map((element) => ({
+    ...element,
+    ...getBox(element, 100, 100),
+  }));
+
+  return (
+    <AMPStoryWrapper>
+      <amp-story-page id={`page-1`}>
+        <p style={{ textAlign: 'center', color: '#fff' }}>{'AMP Drop'}</p>
+
+        <amp-story-grid-layer
+          template="vertical"
+          aspect-ratio={AMP_STORY_ASPECT_RATIO}
+        >
+          <div
+            animate-in="fly-in-top"
+            style={{
+              backgroundColor: 'red',
+              ...defaultStyles,
+            }}
+          />
+          <div
+            animate-in="fly-in-left"
+            animate-in-delay="0.5s"
+            style={{
+              backgroundColor: 'orange',
+              ...defaultStyles,
+            }}
+          />
+          <div
+            animate-in="fly-in-right"
+            animate-in-delay="1.0s"
+            style={{
+              backgroundColor: 'blue',
+              ...defaultStyles,
+            }}
+          />
+          <div
+            animate-in="fly-in-bottom"
+            animate-in-delay="1.5s"
+            style={{
+              backgroundColor: 'yellow',
+              ...defaultStyles,
+            }}
+          />
+        </amp-story-grid-layer>
+      </amp-story-page>
+      <amp-story-page id={`page-2`}>
+        <StoryAnimation.Provider animations={animations} elements={elements}>
+          <StoryAnimation.AMPAnimations />
+          <p style={{ textAlign: 'center', color: '#fff' }}>
+            {'Custom Drop Effect'}
+          </p>
+
+          <amp-story-grid-layer
+            template="vertical"
+            aspect-ratio={AMP_STORY_ASPECT_RATIO}
+          >
+            <div className="page-fullbleed-area">
+              <div className="page-safe-area">
+                {elementBoxes.map(({ id, color, x, y, width, height }) => (
+                  <div
+                    key={id}
+                    style={{
+                      position: 'absolute',
+                      top: `${y}%`,
+                      left: `${x}%`,
+                      width: `${width}%`,
+                      height: `${height}%`,
+                    }}
+                  >
+                    <StoryAnimation.AMPWrapper target={id}>
+                      <div
+                        style={{
+                          width: '100%',
+                          height: '100%',
+                          backgroundColor: color,
+                        }}
+                      />
+                    </StoryAnimation.AMPWrapper>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </amp-story-grid-layer>
+        </StoryAnimation.Provider>
+      </amp-story-page>
+    </AMPStoryWrapper>
+  );
+};

--- a/assets/src/dashboard/animations/parts/index.js
+++ b/assets/src/dashboard/animations/parts/index.js
@@ -24,6 +24,7 @@ import PropTypes from 'prop-types';
  */
 import { ANIMATION_TYPES, ANIMATION_EFFECTS, BEZIER } from '../constants';
 import { EffectFadeIn } from '../effects/fadeIn';
+import { EffectFlyIn } from '../effects/flyIn';
 import { EffectPulse } from '../effects/pulse';
 import { AnimationBounce } from './bounce';
 import { AnimationBlinkOn } from './blinkOn';
@@ -75,6 +76,7 @@ export function AnimationPart(type, args) {
       [ANIMATION_TYPES.SPIN]: AnimationSpin,
       [ANIMATION_TYPES.ZOOM]: AnimationZoom,
       [ANIMATION_EFFECTS.FADE_IN]: EffectFadeIn,
+      [ANIMATION_EFFECTS.FLY_IN]: EffectFlyIn,
       [ANIMATION_EFFECTS.PULSE]: EffectPulse,
     }[type] || throughput;
 

--- a/assets/src/dashboard/animations/utils/getOffPageOffset.js
+++ b/assets/src/dashboard/animations/utils/getOffPageOffset.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getBox, dataToEditorY } from '../../../edit-story/units/dimensions';
+import { PAGE_HEIGHT, PAGE_WIDTH, FULLBLEED_RATIO } from '../../constants';
+
+const FULLBLEED_HEIGHT = PAGE_WIDTH / FULLBLEED_RATIO;
+const DANGER_ZONE_HEIGHT = (FULLBLEED_HEIGHT - PAGE_HEIGHT) / 2;
+
+function calcTopOffset(box, dangerZoneOffset) {
+  const { y, height } = box;
+  const toTop = dangerZoneOffset + y;
+  return -Number((toTop / height) * 100.0 + 100.0).toFixed(5);
+}
+
+function calcBottomOffset(box, dangerZoneOffset) {
+  const { y, height } = box;
+  const toBottom = 100 - y + dangerZoneOffset;
+  return Number((toBottom / height) * 100.0).toFixed(5);
+}
+
+function calcLeftOffset(box) {
+  const { x, width } = box;
+  return -Number((x / width) * 100.0 + 100.0).toFixed(5);
+}
+
+function calcRightOffset(box) {
+  const { x, width } = box;
+  const toRight = 100 - x;
+  return Number((toRight / width) * 100.0).toFixed(5);
+}
+
+function getOffPageOffset(element) {
+  const box = getBox(element, 100, 100);
+  const dangerZoneOffset = dataToEditorY(DANGER_ZONE_HEIGHT, 100);
+
+  return {
+    offsetTop: calcTopOffset(box, dangerZoneOffset),
+    offsetBottom: calcBottomOffset(box, dangerZoneOffset),
+    offsetLeft: calcLeftOffset(box),
+    offsetRight: calcRightOffset(box),
+  };
+}
+
+export default getOffPageOffset;

--- a/assets/src/dashboard/animations/utils/test/defaultUnit.js
+++ b/assets/src/dashboard/animations/utils/test/defaultUnit.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Internal dependencies
  */

--- a/assets/src/dashboard/animations/utils/test/getOffPageOffset.js
+++ b/assets/src/dashboard/animations/utils/test/getOffPageOffset.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { PAGE_HEIGHT, PAGE_WIDTH, FULLBLEED_RATIO } from '../../../constants';
+import getOffPageOffset from '../getOffPageOffset';
+
+const FULLBLEED_HEIGHT = PAGE_WIDTH / FULLBLEED_RATIO;
+const DANGER_ZONE_HEIGHT = (FULLBLEED_HEIGHT - PAGE_HEIGHT) / 2;
+
+describe('getOffPageOffset', () => {
+  const element = {
+    x: 20,
+    y: 100,
+    width: 75,
+    height: 50,
+  };
+
+  it('returns the correct offset to place element on top of page', () => {
+    const { offsetTop } = getOffPageOffset(element);
+    const offset = element.y + element.height + DANGER_ZONE_HEIGHT;
+
+    expect((offsetTop / 100.0) * element.height).toBeCloseTo(-offset);
+  });
+
+  it('returns the correct offset to place element below page', () => {
+    const { offsetBottom } = getOffPageOffset(element);
+    const offset = PAGE_HEIGHT - element.y + DANGER_ZONE_HEIGHT;
+
+    expect((offsetBottom / 100) * element.height).toBeCloseTo(offset);
+  });
+
+  it('returns the correct offset to place element to the left of the page', () => {
+    const { offsetLeft } = getOffPageOffset(element);
+    const offset = element.x + element.width;
+
+    expect((offsetLeft / 100.0) * element.width).toBeCloseTo(-offset);
+  });
+
+  it('returns the correct offset to place element to the right of the page', () => {
+    const { offsetRight } = getOffPageOffset(element);
+    const offset = PAGE_WIDTH - element.x;
+
+    expect((offsetRight / 100.0) * element.width).toBeCloseTo(offset);
+  });
+});

--- a/assets/src/dashboard/components/storyAnimation/provider.js
+++ b/assets/src/dashboard/components/storyAnimation/provider.js
@@ -36,6 +36,7 @@ import { useFeature } from 'flagged';
 import { AnimationPart, throughput } from '../../animations/parts';
 import { AnimationProps } from '../../animations/parts/types';
 import { clamp } from '../../utils';
+import StoryPropTypes from '../../../edit-story/types';
 
 const Context = createContext(null);
 
@@ -58,23 +59,35 @@ const createOnFinishPromise = (animation) => {
   });
 };
 
-function Provider({ animations, children, onWAAPIFinish }) {
+function Provider({ animations, elements, children, onWAAPIFinish }) {
   const enableAnimation = useFeature('enableAnimation');
+
+  const elementsMap = useMemo(() => {
+    return (elements || []).reduce((map, element) => {
+      map.set(element.id, element);
+      return map;
+    }, new Map());
+  }, [elements]);
+
   const animationPartsMap = useMemo(() => {
     return (animations || []).reduce((map, animation) => {
-      const { targets, type, ...args } = animation;
+      const { id, targets, type, ...args } = animation;
 
       (targets || []).forEach((t) => {
         const generatedParts = map.get(t) || [];
+        const element = elementsMap.get(t);
+
         map.set(t, [
           ...generatedParts,
-          enableAnimation ? AnimationPart(type, args) : throughput(),
+          enableAnimation
+            ? AnimationPart(type, { ...args, element })
+            : throughput(),
         ]);
       });
 
       return map;
     }, new Map());
-  }, [animations, enableAnimation]);
+  }, [animations, enableAnimation, elementsMap]);
 
   const providerId = useMemo(() => uuidv4(), []);
 
@@ -208,6 +221,7 @@ function Provider({ animations, children, onWAAPIFinish }) {
 
 Provider.propTypes = {
   animations: PropTypes.arrayOf(PropTypes.shape(AnimationProps)),
+  elements: PropTypes.arrayOf(StoryPropTypes.element),
   children: PropTypes.node.isRequired,
   onWAAPIFinish: PropTypes.func,
 };

--- a/assets/src/dashboard/constants/components.js
+++ b/assets/src/dashboard/constants/components.js
@@ -18,6 +18,7 @@ export const PILL_LABEL_TYPES = {
   SWATCH: 'swatch',
   DEFAULT: 'default',
 };
+
 export const PILL_INPUT_TYPES = {
   CHECKBOX: 'checkbox',
   RADIO: 'radio',

--- a/assets/src/dashboard/constants/pageStructure.js
+++ b/assets/src/dashboard/constants/pageStructure.js
@@ -17,7 +17,12 @@
 /**
  * Internal dependencies
  */
-export { FULLBLEED_RATIO, PAGE_RATIO } from '../../edit-story/constants';
+export {
+  FULLBLEED_RATIO,
+  PAGE_RATIO,
+  PAGE_WIDTH,
+  PAGE_HEIGHT,
+} from '../../edit-story/constants';
 
 export const WPBODY_ID = 'wpbody';
 

--- a/assets/src/dashboard/storybookUtils/ampStoryWrapper.js
+++ b/assets/src/dashboard/storybookUtils/ampStoryWrapper.js
@@ -19,9 +19,17 @@
  */
 import PropTypes from 'prop-types';
 
+/**
+ * Internal dependencies
+ */
+import Boilerplate from '../../edit-story/output/utils/ampBoilerplate';
+import CustomCSS from '../../edit-story/output/utils/styles';
+
 function AMPStoryWrapper({ children }) {
   return (
     <div style={{ width: '100%', height: '640px' }}>
+      <Boilerplate />
+      <CustomCSS />
       <amp-story
         standalone
         title="My Story"

--- a/assets/src/dashboard/storybookUtils/index.js
+++ b/assets/src/dashboard/storybookUtils/index.js
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * Internal dependencies
+ */
+import { PAGE_WIDTH, PAGE_HEIGHT } from '../constants';
+
 export { default as AMPStoryWrapper } from './ampStoryWrapper';
 export { default as formattedStoriesArray } from '../dataUtils/formattedStoriesArray';
 export { default as formattedTemplatesArray } from '../dataUtils/formattedTemplatesArray';
@@ -25,3 +30,5 @@ export const STORYBOOK_PAGE_SIZE = {
   height: 318,
   containerHeight: 376.89,
 };
+
+export const AMP_STORY_ASPECT_RATIO = `${PAGE_WIDTH}:${PAGE_HEIGHT}`;


### PR DESCRIPTION
## Summary

This PR adds the `Fly In` animation effect to our repo.  It was a little tricky because the "Fly In" effect requires that the element flies in from off the page 😱 

## Relevant Technical Choices

I updated our animation provider to accept an array of `elements` that it'll associate with its respective `animationPart`.  This way special animation parts (like our "Fly In" effect) can use the element's properties (i.e. x, y, width, height) to calculate correct start positions as needed.

## To-do

- I need to update our preview animation and generated AMP story code to pass in `elements` so effects that require them will work.  The work to apply this update is captured in this ticket #3562 

## User-facing changes 

None.

## Testing Instructions

1.)  Open up Story Book and go to Animations -> Effects -> Fly In
2.) Toggle back and forth between both pages, notice how they animate the same (and from off page 🎉). 

NOTE: In order to get the offset calculations to work, I had to render the squares a little differently than I do on the first page so their sizes aren't a perfect match.

Also the AMP code doesn't recognize our "danger zone" so the first red box in the AMP version doesn't start properly off screen like it should... luckily our version does 😎 

Fixes #3421 

## Screenshot

![fly_in_effect](https://user-images.githubusercontent.com/40646372/88947786-e2ed4b80-d245-11ea-9da7-b2dd9499b5a1.gif)
