### PR TITLE
Improve Site Kit Analytics module detection

### DIFF
--- a/includes/Analytics.php
+++ b/includes/Analytics.php
@@ -26,8 +26,6 @@
 
 namespace Google\Web_Stories;
 
-use Google\Site_Kit\Core\Modules\Modules;
-
 /**
  * Class Analytics
  */
@@ -48,13 +46,40 @@ class Analytics {
 	 * @return bool Whether Site Kit's analytics module is active.
 	 */
 	protected function is_site_kit_analytics_module_active() {
-		if ( ! class_exists( 'Google\Site_Kit\Core\Modules\Modules' ) ) {
-			return false;
+		$modules = $this->get_site_kit_active_modules_option();
+
+		return in_array( 'analytics', $modules, true );
+	}
+
+	/**
+	 * Gets the option containing the active Site Kit modules.
+	 *
+	 * Checks two options as it was renamed at some point in Site Kit.
+	 *
+	 * Bails early if the Site Kit plugin itself is not active.
+	 *
+	 * @see \Google\Site_Kit\Core\Modules\Modules::get_active_modules_option
+	 *
+	 * @return array List of active module slugs.
+	 */
+	private function get_site_kit_active_modules_option() {
+		if ( ! defined( 'GOOGLESITEKIT_VERSION' ) ) {
+			return [];
 		}
 
-		$modules = (array) get_option( Modules::OPTION_ACTIVE_MODULES, [] );
+		$option = get_option( 'googlesitekit_active_modules' );
 
-		return array_key_exists( 'analytics', $modules );
+		if ( is_array( $option ) ) {
+			return $option;
+		}
+
+		$legacy_option = get_option( 'googlesitekit-active-modules' );
+
+		if ( is_array( $legacy_option ) ) {
+			return $legacy_option;
+		}
+
+		return [];
 	}
 
 	/**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,10 +9,13 @@ parameters:
   bootstrapFiles:
     - tests/phpstan/bootstrap.php
     - includes/namespace.php
+  dynamicConstantNames:
+    - WPCOM_IS_VIP_ENV
+    - IS_WPCOM
+    - WP_CLI
+    - GOOGLESITEKIT_VERSION
   ignoreErrors:
     # Uses func_get_args()
     - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
-    # False positives for WPCOM_IS_VIP_ENV check.
-    - '#^Strict comparison using === between false and true will always evaluate to false.$#'
     # False positive for wp_unslash()
     - '#^Cannot cast array<string>\|string to string.$#'


### PR DESCRIPTION
## Summary

Fixes the Site Kit analytics module detection:

* Checks whether `analytics` exists in the modules array (`googlesitekit_active_modules` option). Before that, it wrongly looked for `analytics` as an array _key_ instead of array _value_.
* Also checks for the `googlesitekit-active-modules` option. On some sites (including mine), only this legacy option exists.

## Relevant Technical Choices

* Simplifies PHPStan config to detect `defined()` checks.

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

1. Set tracking ID using `wp option add web_stories_ga_tracking_id abc1234`
1. Install and activate Site Kit
1. Activate Google Analytics module or just manually update the option using WP-CLI
1. Verify that no analytics code is being printed

Or alternatively: trust the tests :-)

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3131
