### PR TITLE
Hide story post type in the AMP plugin's settings

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -140,7 +140,9 @@ class Story_Post_Type {
 		// Select the single-web-story.php template for Stories.
 		add_filter( 'template_include', [ $this, 'filter_template_include' ] );
 
+		// AMP compatibility.
 		add_filter( 'amp_skip_post', [ $this, 'skip_amp' ], PHP_INT_MAX, 2 );
+		add_filter( 'amp_supportable_post_types', [ $this, 'filter_amp_supportable_post_types' ] );
 
 		add_filter( '_wp_post_revision_fields', [ $this, 'filter_revision_fields' ], 10, 2 );
 
@@ -176,6 +178,20 @@ class Story_Post_Type {
 			$skipped = true;
 		}
 		return $skipped;
+	}
+
+	/**
+	 * Filters the list of post types which may be supported for AMP.
+	 *
+	 * Removes this post type from that list.
+	 *
+	 * @since 2.0
+	 *
+	 * @param string[] $post_types Post types.
+	 * @return string[] Filtered list of post types eligible for AMP.
+	 */
+	public function filter_amp_supportable_post_types( $post_types ) {
+		return array_diff( $post_types, [ self::POST_TYPE_SLUG ] );
 	}
 
 	/**

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -77,6 +77,7 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		$this->assertSame( 10, has_filter( 'use_block_editor_for_post_type', [ $story_post_type, 'filter_use_block_editor_for_post_type' ] ) );
 		$this->assertSame( 10, has_filter( 'template_include', [ $story_post_type, 'filter_template_include' ] ) );
 		$this->assertSame( PHP_INT_MAX, has_filter( 'amp_skip_post', [ $story_post_type, 'skip_amp' ] ) );
+		$this->assertSame( 10, has_filter( 'amp_supportable_post_types', [ $story_post_type, 'filter_amp_supportable_post_types' ] ) );
 		$this->assertSame( 10, has_filter( '_wp_post_revision_fields', [ $story_post_type, 'filter_revision_fields' ] ) );
 		$this->assertSame( 10, has_filter( 'jetpack_sitemap_post_types', [ $story_post_type, 'add_to_jetpack_sitemap' ] ) );
 	}
@@ -180,6 +181,24 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		$story_post_type = new \Google\Web_Stories\Story_Post_Type();
 		$skip_amp        = $story_post_type->skip_amp( true, get_post( self::$story_id ) );
 		$this->assertTrue( $skip_amp );
+	}
+
+	/**
+	 * @covers ::filter_amp_supportable_post_types
+	 */
+	public function test_filter_amp_supportable_post_types() {
+		$story_post_type = new \Google\Web_Stories\Story_Post_Type();
+
+		$expected = [ 'post', 'page' ];
+		$actual   = $story_post_type->filter_amp_supportable_post_types(
+			[
+				'post',
+				\Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'page',
+			]
+		);
+
+		$this->assertEqualSets( $expected, $actual );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Removes the story post type from list of post types which may be supported for AMP

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Check AMP settings in the new 2.0 beta
1. Verify that the stories post type is not in the list of supportable post types

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3257
