### PR TITLE
Update plugin activation notice styling

### DIFF
--- a/assets/src/activation-notice/app/components/messageContent.js
+++ b/assets/src/activation-notice/app/components/messageContent.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -46,9 +45,9 @@ const Wrapper = styled.div`
   }
 `;
 
-function MessageContent({ onDoubleClick }) {
+function MessageContent() {
   return (
-    <Wrapper onDoubleClick={onDoubleClick}>
+    <Wrapper>
       <Dismiss />
       <SuccessMessage />
       <Step1 />
@@ -57,9 +56,5 @@ function MessageContent({ onDoubleClick }) {
     </Wrapper>
   );
 }
-
-MessageContent.propTypes = {
-  onDoubleClick: PropTypes.func.isRequired,
-};
 
 export default MessageContent;

--- a/assets/src/activation-notice/app/components/step1.js
+++ b/assets/src/activation-notice/app/components/step1.js
@@ -46,7 +46,7 @@ const Wrapper = styled.div`
 
 const Image = styled.img`
   transform: rotate(${(props) => props.$rotationAngle});
-  margin-top: -40px;
+  margin-top: -35px;
 `;
 
 const ParagraphWrapper = styled.div`

--- a/assets/src/activation-notice/app/components/step1.js
+++ b/assets/src/activation-notice/app/components/step1.js
@@ -67,7 +67,12 @@ function Step1() {
 
   return (
     <Wrapper>
-      <Link href={demoStoryURL} onClick={onClick}>
+      <Link
+        href={demoStoryURL}
+        onClick={onClick}
+        target="_blank"
+        rel="noreferrer"
+      >
         <Image
           src={`${assetsURL}images/plugin-activation/tips.png`}
           alt=""
@@ -89,7 +94,12 @@ function Step1() {
             _x('Read the', 'plugin activation', 'web-stories')
           }
           <br />
-          <Link href={demoStoryURL} onClick={onClick}>
+          <Link
+            href={demoStoryURL}
+            onClick={onClick}
+            target="_blank"
+            rel="noreferrer"
+          >
             {__('Get Started story', 'web-stories')}
           </Link>
         </Paragraph>

--- a/assets/src/activation-notice/app/components/successMessage.js
+++ b/assets/src/activation-notice/app/components/successMessage.js
@@ -50,6 +50,7 @@ const Title = styled.h2`
   font-family: ${({ theme }) => theme.fonts.title.family};
   font-size: ${({ theme }) => theme.fonts.title.size};
   line-height: ${({ theme }) => theme.fonts.title.lineHeight};
+  font-weight: normal;
   color: ${({ theme }) => theme.colors.primary};
   margin: 0 0 10px;
 `;

--- a/assets/src/activation-notice/app/components/successMessage.js
+++ b/assets/src/activation-notice/app/components/successMessage.js
@@ -63,6 +63,7 @@ const PrimaryLink = styled.a`
   padding: 5px 8px;
   cursor: pointer;
   text-decoration: none;
+  border-radius: 4px;
 
   &:focus,
   &:hover {

--- a/assets/src/activation-notice/app/index.js
+++ b/assets/src/activation-notice/app/index.js
@@ -20,7 +20,6 @@
 import { StyleSheetManager, ThemeProvider } from 'styled-components';
 import stylisRTLPlugin from 'stylis-plugin-rtl';
 import PropTypes from 'prop-types';
-import { useState } from 'react';
 
 /**
  * Internal dependencies
@@ -28,20 +27,19 @@ import { useState } from 'react';
 import { lightTheme, darkTheme, GlobalStyle } from '../theme';
 import MessageContent from './components/messageContent';
 import { ConfigProvider } from './config';
+import usePrefersDarkMode from './utils/usePrefersDarkMode';
 
 function App({ config }) {
   const { isRTL } = config;
 
-  const [theme, setTheme] = useState('light');
-  const toggleTheme = () =>
-    theme === 'light' ? setTheme('dark') : setTheme('light');
+  const prefersDarkMode = usePrefersDarkMode();
 
   return (
     <StyleSheetManager stylisPlugins={isRTL ? [stylisRTLPlugin] : []}>
-      <ThemeProvider theme={theme === 'light' ? lightTheme : darkTheme}>
+      <ThemeProvider theme={prefersDarkMode ? darkTheme : lightTheme}>
         <ConfigProvider config={config}>
           <GlobalStyle />
-          <MessageContent onDoubleClick={toggleTheme} />
+          <MessageContent />
         </ConfigProvider>
       </ThemeProvider>
     </StyleSheetManager>

--- a/assets/src/activation-notice/app/utils/usePrefersDarkMode.js
+++ b/assets/src/activation-notice/app/utils/usePrefersDarkMode.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useEffect, useState } from 'react';
+
+function usePrefersDarkMode() {
+  const [prefersDarkMode, setPrefersDarkMode] = useState(false);
+
+  useEffect(() => {
+    setPrefersDarkMode(
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+    );
+  }, []);
+
+  return prefersDarkMode;
+}
+
+export default usePrefersDarkMode;

--- a/includes/Activation_Notice.php
+++ b/includes/Activation_Notice.php
@@ -127,13 +127,15 @@ class Activation_Notice {
 			)
 		);
 
+		$demo_story_url = 'https://google.github.io/web-stories-wp/beta/tips.html';
+
 		// @todo Implement Get Started story - see https://github.com/google/web-stories-wp/pull/2845
 		return [
 			'id'     => 'web-stories-plugin-activation-notice',
 			'config' => [
 				'isRTL'        => is_rtl(),
 				'assetsURL'    => trailingslashit( WEBSTORIES_ASSETS_URL ),
-				'demoStoryURL' => '#',
+				'demoStoryURL' => $demo_story_url,
 				'newStoryURL'  => $new_story_url,
 				'dashboardURL' => $dashboard_url,
 			],

--- a/includes/Activation_Notice.php
+++ b/includes/Activation_Notice.php
@@ -129,7 +129,6 @@ class Activation_Notice {
 
 		$demo_story_url = 'https://google.github.io/web-stories-wp/beta/tips.html';
 
-		// @todo Implement Get Started story - see https://github.com/google/web-stories-wp/pull/2845
 		return [
 			'id'     => 'web-stories-plugin-activation-notice',
 			'config' => [


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<img width="1680" alt="Screenshot 2020-07-30 at 15 01 39" src="https://user-images.githubusercontent.com/841956/88926030-af2a1a00-d275-11ea-9558-1b951ca4ac9b.png">
<img width="1678" alt="Screenshot 2020-07-30 at 15 02 08" src="https://user-images.githubusercontent.com/841956/88926039-b3563780-d275-11ea-903a-5e013f13b622.png">

## Testing Instructions

1. Deactivate plugin
1. Activate plugin

Things to verify:

1. Title "You're all set. Tell some stories" is not bold.
1. The call-to-action button has rounded corners
1. The rotated story is truncated so that you don't see the left bottom corner
1. The Get Started story links point to https://google.github.io/web-stories-wp/beta/tips.html
1. When changing system preferences to prefer dark mode, the plugin activation notice will be in dark mode too.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3439
