### PR TITLE
Removed role=grid in MediaGallery

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/mediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaGallery.js
@@ -71,7 +71,7 @@ function MediaGallery({ resources, onInsert, providerType }) {
   );
 
   return (
-    <div role={'grid'}>
+    <div>
       <Gallery
         targetRowHeight={110}
         direction={'row'}


### PR DESCRIPTION
## Summary

This was added as part of #3285, but full aria row support in media gallery isn't that simple. Let's remove this for now and fix it in a separate ticket (#3579). We don't have aria support in our current column-based gallery anyway.

## User-facing changes
None
