### PR TITLE
Animations: Added Animation Timeline Base

### DIFF
--- a/assets/src/edit-story/components/animationTimeline/components.js
+++ b/assets/src/edit-story/components/animationTimeline/components.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import propTypes from 'prop-types';
+import styled from 'styled-components';
+import { rgba } from 'polished';
+
+const ROW_HEIGHT = 35;
+
+export const TimelineContainer = styled.div`
+  height: 180px;
+  background: ${({ theme }) => theme.colors.bg.v16};
+  color: ${({ theme }) => theme.colors.fg.v1};
+  overflow-y: scroll;
+`;
+
+export const TimelineContent = styled.div`
+  display: flex;
+  min-height: calc(100% - ${ROW_HEIGHT}px);
+`;
+
+export const TimelineLegend = styled.div`
+  flex: 0 1 246px;
+  box-shadow: 2px 0px 10px rgba(0, 0, 0, 0.4);
+`;
+
+export const TimelineTimingContainer = styled.div`
+  flex: 1;
+`;
+
+export const TimelineTitleBar = styled.div`
+  display: flex;
+  position: sticky;
+  top: 0;
+  height: ${ROW_HEIGHT}px;
+  min-width: 100%;
+  background: ${({ theme }) => theme.colors.bg.v16};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.fg.v9};
+`;
+
+export const TimelineRow = styled.div`
+  height: ${ROW_HEIGHT}px;
+  min-width: 100%;
+  ${({ alternating, theme }) =>
+    alternating && {
+      backgroundColor: rgba(theme.colors.fg.v1, 0.1),
+    }}
+`;
+
+TimelineRow.propTypes = {
+  alternating: propTypes.bool,
+};

--- a/assets/src/edit-story/components/animationTimeline/components.js
+++ b/assets/src/edit-story/components/animationTimeline/components.js
@@ -59,7 +59,7 @@ export const TimelineRow = styled.div`
   min-width: 100%;
   ${({ alternating, theme }) =>
     alternating && {
-      backgroundColor: rgba(theme.colors.fg.v1, 0.1),
+      backgroundColor: rgba(theme.colors.fg.white, 0.1),
     }}
 `;
 

--- a/assets/src/edit-story/components/animationTimeline/index.js
+++ b/assets/src/edit-story/components/animationTimeline/index.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import propTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import {
+  TimelineContainer,
+  TimelineContent,
+  TimelineLegend,
+  TimelineTimingContainer,
+  TimelineTitleBar,
+  TimelineRow,
+} from './components';
+
+export default function AnimationTimeline({ animations }) {
+  return (
+    <TimelineContainer>
+      <TimelineTitleBar>
+        <TimelineLegend />
+      </TimelineTitleBar>
+      <TimelineContent>
+        <TimelineLegend>
+          {animations.map((animation, index) => (
+            <TimelineRow
+              key={`timeline-animation-item-${animation.id}-legend`}
+              alternating={Boolean(index % 2)}
+            />
+          ))}
+        </TimelineLegend>
+        <TimelineTimingContainer>
+          {animations.map((animation, index) => (
+            <TimelineRow
+              data-testid="timeline-animation-item"
+              key={`timeline-animation-item-${animation.id}`}
+              alternating={Boolean(index % 2)}
+            />
+          ))}
+        </TimelineTimingContainer>
+      </TimelineContent>
+    </TimelineContainer>
+  );
+}
+
+AnimationTimeline.propTypes = {
+  animations: propTypes.arrayOf(propTypes.object).isRequired,
+};

--- a/assets/src/edit-story/components/animationTimeline/stories/index.js
+++ b/assets/src/edit-story/components/animationTimeline/stories/index.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+
+import AnimationTimeline from '../index';
+
+export default {
+  title: 'Animations/Timeline',
+  component: AnimationTimeline,
+};
+
+const animations = Array.from(Array(10).keys()).map((id) => ({
+  id,
+}));
+
+export const _default = () => {
+  return <AnimationTimeline animations={animations} />;
+};
+
+export const noAnimations = () => {
+  return <AnimationTimeline animations={[]} />;
+};

--- a/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
+++ b/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import AnimationTimeline from '..';
+import { renderWithTheme } from '../../../testUtils';
+
+describe('<AnimationTimeline />', function () {
+  it('should generate the number of rows for animations provided.', function () {
+    const animations = Array.from(Array(10).keys()).map((id) => ({
+      id,
+    }));
+    const { queryAllByTestId } = renderWithTheme(
+      <AnimationTimeline animations={animations} />
+    );
+    expect(queryAllByTestId('timeline-animation-item')).toHaveLength(
+      animations.length
+    );
+  });
+});

--- a/assets/src/edit-story/theme.js
+++ b/assets/src/edit-story/theme.js
@@ -104,6 +104,7 @@ const theme = {
       // v13: '#FFFFFF', <=> replaced with 'white'
       v14: '#3E445B',
       v15: '#212433',
+      v16: '#2C2C2C',
     },
     mg: {
       v1: '#616877',
@@ -123,6 +124,7 @@ const theme = {
       v6: '#232636',
       // v7: '#1A73E8', <=> replaced with accent.primary
       v8: '#E6E6E6',
+      v9: '#4D4E53',
     },
     hover: '#4285F4',
     accent: {


### PR DESCRIPTION
## Summary

Add Animation Timeline base structure with sticky header bar and metrics according to Figma.  

*Timeline with animations*
Titlebar remains sticky as animations scroll up and down

![Kapture 2020-08-03 at 15 02 59](https://user-images.githubusercontent.com/1738349/89223842-1ceb8400-d59d-11ea-9a0e-3ae95b75cd96.gif)


*Timeline with no animations*
25% legend with shadow still extends container

<img width="1198" alt="Screen Shot 2020-08-03 at 3 02 12 PM" src="https://user-images.githubusercontent.com/1738349/89223846-1eb54780-d59d-11ea-934b-db04fe860ca4.png">


## User-facing changes

None—everything is in Storybook for now.

## Testing Instructions

Run Storybook and test the two stories: `Timeline/Default` and `Timeline/No Animations`.


---

<!-- Please reference the issue(s) this PR addresses. -->

#3414 
