### PR TITLE
Dashboard: Prevent current template from being listed as related

### DIFF
--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -318,7 +318,7 @@ const useTemplateApi = (dataAdapter, config) => {
         .filter((id) => id !== currentTemplateId) // Filter out the current/active template
         .sort(() => 0.5 - Math.random()) // Randomly sort the array of ids
         .map((id) => state.templates[id]) // Map the ids to templates
-        .slice(0, Math.floor(Math.random() * 4) + 1); // Return between 1 and 5 templates
+        .slice(0, Math.floor(Math.random() * 5) + 1); // Return between 1 and 5 templates
     },
     [state.templatesOrderById, state.templates]
   );

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -314,13 +314,11 @@ const useTemplateApi = (dataAdapter, config) => {
         return [];
       }
 
-      const shuffled = state.templatesOrderById
-        .filter((id) => id !== currentTemplateId)
-        .sort(() => 0.5 - Math.random())
-        .map((id) => state.templates[id]);
-
-      // Return between 1 and 5 random templates
-      return shuffled.slice(0, Math.floor(Math.random() * 4) + 1);
+      return state.templatesOrderById
+        .filter((id) => id !== currentTemplateId) // Filter out the current/active template
+        .sort(() => 0.5 - Math.random()) // Randomly sort the array of ids
+        .map((id) => state.templates[id]) // Map the ids to templates
+        .slice(0, Math.floor(Math.random() * 4) + 1); // Return between 1 and 5 templates
     },
     [state.templatesOrderById, state.templates]
   );

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -317,8 +317,9 @@ const useTemplateApi = (dataAdapter, config) => {
       const randomStartingIndex = Math.floor(
         Math.random() * state.templatesOrderById.length
       );
+
       return state.templatesOrderById
-        .filter((id) => id !== currentTemplateId) // filter out the active/current template
+        .filter((id) => String(id) !== String(currentTemplateId)) // filter out the active/current template
         .splice(randomStartingIndex, 5)
         .map((id) => {
           return state.templates[id];

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -308,20 +308,24 @@ const useTemplateApi = (dataAdapter, config) => {
     [dataAdapter, templateApi]
   );
 
-  const fetchRelatedTemplates = useCallback(() => {
-    if (!state.templates) {
-      return [];
-    }
-    // this will return anywhere between 1 and 5 "related" templates
-    const randomStartingIndex = Math.floor(
-      Math.random() * state.templatesOrderById.length
-    );
-    return [...state.templatesOrderById]
-      .splice(randomStartingIndex, 5)
-      .map((id) => {
-        return state.templates[id];
-      });
-  }, [state.templatesOrderById, state.templates]);
+  const fetchRelatedTemplates = useCallback(
+    (currentTemplateId) => {
+      if (!state.templates) {
+        return [];
+      }
+      // this will return anywhere between 1 and 5 "related" templates
+      const randomStartingIndex = Math.floor(
+        Math.random() * state.templatesOrderById.length
+      );
+      return state.templatesOrderById
+        .filter(({ id }) => id !== currentTemplateId) // filter out the active/current template
+        .splice(randomStartingIndex, 5)
+        .map((id) => {
+          return state.templates[id];
+        });
+    },
+    [state.templatesOrderById, state.templates]
+  );
 
   const api = useMemo(
     () => ({

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -310,20 +310,16 @@ const useTemplateApi = (dataAdapter, config) => {
 
   const fetchRelatedTemplates = useCallback(
     (currentTemplateId) => {
-      if (!state.templates) {
+      if (!state.templates || !currentTemplateId) {
         return [];
       }
-      // this will return anywhere between 1 and 5 "related" templates
-      const randomStartingIndex = Math.floor(
-        Math.random() * state.templatesOrderById.length
-      );
 
-      return state.templatesOrderById
-        .filter((id) => String(id) !== String(currentTemplateId)) // filter out the active/current template
-        .splice(randomStartingIndex, 5)
-        .map((id) => {
-          return state.templates[id];
-        });
+      const shuffled = state.templatesOrderById
+        .filter((id) => id !== currentTemplateId)
+        .sort(() => 0.5 - Math.random());
+
+      // Return between 1 and 5 random templates
+      return shuffled.slice(0, Math.floor(Math.random() * 4) + 1);
     },
     [state.templatesOrderById, state.templates]
   );

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -318,7 +318,7 @@ const useTemplateApi = (dataAdapter, config) => {
         Math.random() * state.templatesOrderById.length
       );
       return state.templatesOrderById
-        .filter(({ id }) => id !== currentTemplateId) // filter out the active/current template
+        .filter((id) => id !== currentTemplateId) // filter out the active/current template
         .splice(randomStartingIndex, 5)
         .map((id) => {
           return state.templates[id];

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -316,7 +316,8 @@ const useTemplateApi = (dataAdapter, config) => {
 
       const shuffled = state.templatesOrderById
         .filter((id) => id !== currentTemplateId)
-        .sort(() => 0.5 - Math.random());
+        .sort(() => 0.5 - Math.random())
+        .map((id) => state.templates[id]);
 
       // Return between 1 and 5 random templates
       return shuffled.slice(0, Math.floor(Math.random() * 4) + 1);

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -104,11 +104,14 @@ function TemplateDetails() {
   }, [fetchExternalTemplateById, fetchMyTemplateById, isLocal, templateId]);
 
   useEffect(() => {
-    if (!template) {
+    if (!template || !templateId) {
       return;
     }
+
+    const id = parseInt(templateId);
+
     setRelatedTemplates(
-      fetchRelatedTemplates(templateId).map((relatedTemplate) => ({
+      fetchRelatedTemplates(id).map((relatedTemplate) => ({
         ...relatedTemplate,
         centerTargetAction: resolveRelatedTemplateRoute(relatedTemplate),
       }))

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -108,7 +108,7 @@ function TemplateDetails() {
       return;
     }
     setRelatedTemplates(
-      fetchRelatedTemplates().map((relatedTemplate) => ({
+      fetchRelatedTemplates(templateId).map((relatedTemplate) => ({
         ...relatedTemplate,
         centerTargetAction: resolveRelatedTemplateRoute(relatedTemplate),
       }))
@@ -118,7 +118,13 @@ function TemplateDetails() {
         (templateByOrderId) => templates[templateByOrderId]
       )
     );
-  }, [fetchRelatedTemplates, template, templates, templatesOrderById]);
+  }, [
+    fetchRelatedTemplates,
+    template,
+    templates,
+    templatesOrderById,
+    templateId,
+  ]);
 
   const { byLine } = useMemo(() => {
     if (!template) {


### PR DESCRIPTION
## Summary

This prevents the current template in the Template Details View from being listed as a related template.  This will also help prevent the following test from failing:

> CUJ: Creator can browse templates in grid view Action: See pre-built template details page should navigate to a related templated when the view button is clicked

## User-facing changes

None

## Testing Instructions

- Refresh multiple times on the template details page and verify the current template is never listed

