### PR TITLE
Dashboard: Preview template from template details view

### DIFF
--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -214,8 +214,8 @@ function TemplateDetails() {
   }, [createStoryFromTemplate, template]);
 
   const handlePreviewTemplate = useCallback(
-    (previewTemplate) => {
-      previewVisible.set(previewTemplate);
+    (e, previewTemplate) => {
+      previewVisible.set(e, previewTemplate);
     },
     [previewVisible]
   );
@@ -229,7 +229,7 @@ function TemplateDetails() {
       <PreviewStoryView
         isTemplate
         story={previewVisible.value}
-        handleClose={() => handlePreviewTemplate()}
+        handleClose={handlePreviewTemplate}
       />
     );
   }

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -39,13 +39,14 @@ import {
   PaginationButton,
   Pill,
 } from '../../../components';
-import { clamp, usePagePreviewSize } from '../../../utils/';
+import { clamp, usePagePreviewSize, useTemplateView } from '../../../utils/';
 import { ApiContext } from '../../api/apiProvider';
 import { useConfig } from '../../config';
 import FontProvider from '../../font/fontProvider';
 import { resolveRelatedTemplateRoute } from '../../router';
 import useRouteHistory from '../../router/useRouteHistory';
 import { TemplateGridView } from '../shared';
+import { PreviewStoryView } from '..';
 import {
   ByLine,
   Column,
@@ -77,7 +78,7 @@ function TemplateDetails() {
 
   const {
     state: {
-      templates: { templates, templatesOrderById },
+      templates: { templates, templatesOrderById, totalPages },
     },
     actions: {
       storyApi: { createStoryFromTemplate },
@@ -88,6 +89,8 @@ function TemplateDetails() {
       },
     },
   } = useContext(ApiContext);
+
+  const { previewVisible } = useTemplateView({ totalPages });
 
   useEffect(() => {
     if (!templateId) {
@@ -210,8 +213,25 @@ function TemplateDetails() {
     createStoryFromTemplate(template);
   }, [createStoryFromTemplate, template]);
 
+  const handlePreviewTemplate = useCallback(
+    (previewTemplate) => {
+      previewVisible.set(previewTemplate);
+    },
+    [previewVisible]
+  );
+
   if (!template) {
     return null;
+  }
+
+  if (previewVisible.value) {
+    return (
+      <PreviewStoryView
+        isTemplate
+        story={previewVisible.value}
+        handleClose={() => handlePreviewTemplate()}
+      />
+    );
   }
 
   return (
@@ -282,7 +302,10 @@ function TemplateDetails() {
                       <TemplateGridView
                         templates={relatedTemplates}
                         pageSize={pageSize}
-                        templateActions={{ createStoryFromTemplate }}
+                        templateActions={{
+                          createStoryFromTemplate,
+                          handlePreviewTemplate,
+                        }}
                       />
                     </UnitsProvider>
                   </RowContainer>

--- a/assets/src/dashboard/app/views/templateDetails/karma/templateDetails.karma.js
+++ b/assets/src/dashboard/app/views/templateDetails/karma/templateDetails.karma.js
@@ -32,64 +32,64 @@ import {
 } from '../../../../constants';
 
 describe('CUJ: Creator can browse templates in grid view', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+
+    await navigateToFirstTemplate();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  async function navigateToFirstTemplate() {
+    const exploreTemplatesMenuItem = fixture.screen.queryByRole('link', {
+      name: /^Explore Templates$/,
+    });
+
+    await fixture.events.click(exploreTemplatesMenuItem);
+
+    const { templatesOrderById } = await getTemplatesState();
+
+    const firstTemplate = getTemplateElementById(templatesOrderById[0]);
+
+    const utils = within(firstTemplate);
+
+    await fixture.events.hover(firstTemplate);
+
+    const view = utils.getByText(
+      new RegExp(`^${TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS.template}$`)
+    );
+
+    await fixture.events.click(view);
+  }
+
+  function getTemplateElementById(id) {
+    const template = fixture.screen.getByTestId(`template-grid-item-${id}`);
+
+    return template;
+  }
+
+  async function getTemplatesState() {
+    const {
+      state: { templates },
+    } = await fixture.renderHook(() => useContext(ApiContext));
+    return templates;
+  }
+
+  function getQueryParams() {
+    return qs.parse(
+      qs.extract(
+        qs.parseUrl(window.location.href, { parseFragmentIdentifier: true })
+          .fragmentIdentifier ?? ''
+      )
+    );
+  }
+
   describe('Action: See pre-built template details page', () => {
-    let fixture;
-
-    beforeEach(async () => {
-      fixture = new Fixture();
-      await fixture.render();
-
-      await navigateToFirstTemplate();
-    });
-
-    afterEach(() => {
-      fixture.restore();
-    });
-
-    async function navigateToFirstTemplate() {
-      const exploreTemplatesMenuItem = fixture.screen.queryByRole('link', {
-        name: /^Explore Templates$/,
-      });
-
-      await fixture.events.click(exploreTemplatesMenuItem);
-
-      const { templatesOrderById } = await getTemplatesState();
-
-      const firstTemplate = getTemplateElementById(templatesOrderById[0]);
-
-      const utils = within(firstTemplate);
-
-      await fixture.events.hover(firstTemplate);
-
-      const view = utils.getByText(
-        new RegExp(`^${TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS.template}$`)
-      );
-
-      await fixture.events.click(view);
-    }
-
-    function getTemplateElementById(id) {
-      const template = fixture.screen.getByTestId(`template-grid-item-${id}`);
-
-      return template;
-    }
-
-    async function getTemplatesState() {
-      const {
-        state: { templates },
-      } = await fixture.renderHook(() => useContext(ApiContext));
-      return templates;
-    }
-
-    function getQueryParams() {
-      return qs.parse(
-        qs.extract(
-          qs.parseUrl(window.location.href, { parseFragmentIdentifier: true })
-            .fragmentIdentifier ?? ''
-        )
-      );
-    }
-
     it('should navigate to "Explore Templates" when "Close" is clicked', async () => {
       const closeLink = fixture.screen.getByRole('link', { name: /^Close$/ });
 
@@ -265,6 +265,65 @@ describe('CUJ: Creator can browse templates in grid view', () => {
         name: /Template Title/,
       });
       expect(nextTemplateTitle.innerText).toEqual(nextTemplate.title);
+    });
+  });
+
+  describe('Action: See template preview from detail template view', () => {
+    beforeEach(async () => {
+      fixture.setFlags({ enableTemplatePreviews: true });
+
+      await fixture.render();
+    });
+
+    it('should trigger template preview when user clicks a related template', async () => {
+      await getTemplatesState();
+
+      const relatedTemplatesSection = await fixture.screen.getByRole('region', {
+        name: /Related Templates/,
+      });
+
+      // // Select the first related template (all related templates have the data-testid attribute)
+      const firstRelatedTemplate = relatedTemplatesSection.querySelector(
+        '[data-testid]'
+      );
+      const utils = within(firstRelatedTemplate);
+
+      const activeCard = utils.getByTestId('card-action-container');
+      expect(activeCard).toBeTruthy();
+
+      const { x, y } = activeCard.getBoundingClientRect();
+      // x, y of the first related template in detail view gives us the outer edge and top, we need to add slightly to these dimension to have anything be clickable
+      await fixture.events.mouse.click(x + 20, y + 10);
+
+      const viewPreviewStory = await fixture.screen.queryByTestId(
+        'preview-iframe'
+      );
+
+      expect(viewPreviewStory).toBeTruthy();
+    });
+
+    it('should trigger template preview when user presses Enter while focused on a card', async () => {
+      await getTemplatesState();
+      const relatedTemplatesSection = fixture.screen.getByRole('region', {
+        name: /Related Templates/,
+      });
+
+      // // Select the first related template (all related templates have the data-testid attribute)
+      const firstRelatedTemplate = relatedTemplatesSection.querySelector(
+        '[data-testid]'
+      );
+      const utils = within(firstRelatedTemplate);
+      const activeCard = utils.getByTestId('card-action-container');
+      expect(activeCard).toBeTruthy();
+
+      await fixture.events.focus(activeCard);
+      await fixture.events.keyboard.press('Enter');
+
+      const viewPreviewStory = await fixture.screen.queryByTestId(
+        'preview-iframe'
+      );
+
+      expect(viewPreviewStory).toBeTruthy();
     });
   });
 });

--- a/assets/src/dashboard/app/views/templateDetails/karma/templateDetails.karma.js
+++ b/assets/src/dashboard/app/views/templateDetails/karma/templateDetails.karma.js
@@ -276,6 +276,8 @@ describe('CUJ: Creator can browse templates in grid view', () => {
     });
 
     it('should trigger template preview when user clicks a related template', async () => {
+      // this await is necessary to get the related template section painted.
+      // TODO update once we have an api to connect to for actual related templates not just randomized static templates
       await getTemplatesState();
 
       const relatedTemplatesSection = await fixture.screen.getByRole('region', {
@@ -303,6 +305,8 @@ describe('CUJ: Creator can browse templates in grid view', () => {
     });
 
     it('should trigger template preview when user presses Enter while focused on a card', async () => {
+      // this await is necessary to get the related template section painted.
+      // TODO update once we have an api to connect to for actual related templates not just randomized static templates
       await getTemplatesState();
       const relatedTemplatesSection = fixture.screen.getByRole('region', {
         name: /Related Templates/,


### PR DESCRIPTION
## Summary
Adds the ability to preview a template by clicking on a template in the 'related templates' section from a template detail view.

## Relevant Technical Choices
Hooks into the `useTemplateView` `previewVisible` state and reuses the `PreviewStoryView` component. 

## To Do
I still think it's clunky to have this functionality only work by clicking the cards themselves. It would be nice to have this functionality within an icon or a button somewhere within the card. 

## User-facing changes
Now when you click on a 'related template' in the detail template view it will open a preview of that template (so long as you do not click on either of the existing buttons on the template).

## Testing Instructions
- Navigate to a detail view of a template and go to the related templates section. Click on any related template and see that the preview model opens. 
- See that the added Karma tests work.

![preview from detail](https://user-images.githubusercontent.com/10720454/89472015-56a2c300-d734-11ea-9d25-975dc0d559d6.gif)
 

---

Addresses #3390 