### PR TITLE
Animations: Added duration-based ruler to animation timeline.

### DIFF
--- a/assets/src/edit-story/components/animationTimeline/components.js
+++ b/assets/src/edit-story/components/animationTimeline/components.js
@@ -22,36 +22,45 @@ import styled from 'styled-components';
 import { rgba } from 'polished';
 
 const ROW_HEIGHT = 35;
+const LEGEND_WIDTH = 246;
+const TIMELINE_HEIGHT = 180;
 
 export const TimelineContainer = styled.div`
-  height: 180px;
-  background: ${({ theme }) => theme.colors.bg.v16};
-  color: ${({ theme }) => theme.colors.fg.v1};
-  overflow-y: scroll;
-`;
-
-export const TimelineContent = styled.div`
   display: flex;
-  min-height: calc(100% - ${ROW_HEIGHT}px);
+  box-sizing: border-box;
+  font-family: Roboto;
+  height: ${TIMELINE_HEIGHT}px;
+  background: ${({ theme }) => theme.colors.bg.v16};
+  color: ${({ theme }) => theme.colors.fg.white};
+  overflow: scroll;
+  position: relative;
 `;
 
 export const TimelineLegend = styled.div`
-  flex: 0 1 246px;
+  min-width: ${LEGEND_WIDTH}px;
+  background: ${({ theme }) => theme.colors.bg.v16};
+  height: max-content;
+  position: sticky;
+  left: 0;
   box-shadow: 2px 0px 10px rgba(0, 0, 0, 0.4);
+  z-index: 3;
 `;
 
 export const TimelineTimingContainer = styled.div`
-  flex: 1;
+  height: max-content;
 `;
 
 export const TimelineTitleBar = styled.div`
   display: flex;
   position: sticky;
   top: 0;
+  flex-direction: column;
+  justify-content: flex-end;
   height: ${ROW_HEIGHT}px;
   min-width: 100%;
   background: ${({ theme }) => theme.colors.bg.v16};
   border-bottom: 1px solid ${({ theme }) => theme.colors.fg.v9};
+  z-index: 2;
 `;
 
 export const TimelineRow = styled.div`

--- a/assets/src/edit-story/components/animationTimeline/index.js
+++ b/assets/src/edit-story/components/animationTimeline/index.js
@@ -25,42 +25,42 @@ import propTypes from 'prop-types';
  */
 import {
   TimelineContainer,
-  TimelineContent,
   TimelineLegend,
   TimelineTimingContainer,
   TimelineTitleBar,
   TimelineRow,
 } from './components';
+import AnimationRuler from './ruler';
 
-export default function AnimationTimeline({ animations }) {
+export default function AnimationTimeline({ animations, duration }) {
   return (
     <TimelineContainer>
-      <TimelineTitleBar>
-        <TimelineLegend />
-      </TimelineTitleBar>
-      <TimelineContent>
-        <TimelineLegend>
-          {animations.map((animation, index) => (
-            <TimelineRow
-              key={`timeline-animation-item-${animation.id}-legend`}
-              alternating={Boolean(index % 2)}
-            />
-          ))}
-        </TimelineLegend>
-        <TimelineTimingContainer>
-          {animations.map((animation, index) => (
-            <TimelineRow
-              data-testid="timeline-animation-item"
-              key={`timeline-animation-item-${animation.id}`}
-              alternating={Boolean(index % 2)}
-            />
-          ))}
-        </TimelineTimingContainer>
-      </TimelineContent>
+      <TimelineLegend>
+        <TimelineTitleBar />
+        {animations.map((animation, index) => (
+          <TimelineRow
+            key={`timeline-animation-item-${animation.id}-legend`}
+            alternating={Boolean(index % 2)}
+          />
+        ))}
+      </TimelineLegend>
+      <TimelineTimingContainer>
+        <TimelineTitleBar>
+          <AnimationRuler duration={duration} />
+        </TimelineTitleBar>
+        {animations.map((animation, index) => (
+          <TimelineRow
+            data-testid="timeline-animation-item"
+            key={`timeline-animation-item-${animation.id}`}
+            alternating={Boolean(index % 2)}
+          />
+        ))}
+      </TimelineTimingContainer>
     </TimelineContainer>
   );
 }
 
 AnimationTimeline.propTypes = {
   animations: propTypes.arrayOf(propTypes.object).isRequired,
+  duration: propTypes.number.isRequired,
 };

--- a/assets/src/edit-story/components/animationTimeline/ruler.js
+++ b/assets/src/edit-story/components/animationTimeline/ruler.js
@@ -17,7 +17,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { sprintf, _n } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -45,7 +45,7 @@ const RULER_HEIGHT = 24.0;
 const isMajor = (index) => index % 10 === 0;
 
 export default function AnimationRuler({ duration }) {
-  const numberOfMarks = Math.ceil((duration / 60) * 10);
+  const numberOfMarks = Math.ceil(duration / 100);
   const range = [...Array(numberOfMarks).keys()];
   return (
     <svg
@@ -61,8 +61,11 @@ export default function AnimationRuler({ duration }) {
             <>
               {isValueMajor && (
                 <Text x={value * MARK_OFFSET + 5} y={20}>
-                  {index / 10}
-                  {__('s', 'web-stories')}
+                  {sprintf(
+                    /* translators: %s: number of seconds */
+                    _n('%ss', '%ss', index / 10, 'web-stories'),
+                    index / 10
+                  )}
                 </Text>
               )}
               <Path

--- a/assets/src/edit-story/components/animationTimeline/ruler.js
+++ b/assets/src/edit-story/components/animationTimeline/ruler.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import propTypes from 'prop-types';
+import styled from 'styled-components';
+import { rgba } from 'polished';
+
+const Path = styled.path`
+  fill: none;
+  stroke: ${({ theme }) => rgba(theme.colors.fg.white, 0.4)};
+  shape-rendering: crispEdges;
+`;
+
+const Text = styled.text`
+  font-family: Roboto;
+  font-size: 13px;
+  fill: ${({ theme }) => rgba(theme.colors.fg.white, 0.8)};
+`;
+
+const MARK_OFFSET = 40.0;
+const RULER_HEIGHT = 24.0;
+
+const isMajor = (index) => index % 10 === 0;
+
+export default function AnimationRuler({ duration }) {
+  const numberOfMarks = Math.ceil((duration / 60) * 10);
+  const range = [...Array(numberOfMarks).keys()];
+  return (
+    <svg
+      width={numberOfMarks * MARK_OFFSET}
+      height={RULER_HEIGHT}
+      xmlns="http://www.w3.org/2000/svg"
+      version="1.1"
+    >
+      <g>
+        {range.map((value, index) => {
+          const isValueMajor = isMajor(index);
+          return (
+            <>
+              {isValueMajor && (
+                <Text x={value * MARK_OFFSET + 5} y={20}>
+                  {index / 10}
+                  {__('s', 'web-stories')}
+                </Text>
+              )}
+              <Path
+                key={`mark-${value}`}
+                strokeWidth={isValueMajor ? 2 : 1}
+                d={`M${value * MARK_OFFSET},${RULER_HEIGHT} V${
+                  isValueMajor ? 8 : 18
+                },${RULER_HEIGHT} Z`}
+              />
+            </>
+          );
+        })}
+      </g>
+    </svg>
+  );
+}
+
+AnimationRuler.propTypes = {
+  duration: propTypes.number.isRequired,
+};

--- a/assets/src/edit-story/components/animationTimeline/stories/index.js
+++ b/assets/src/edit-story/components/animationTimeline/stories/index.js
@@ -30,9 +30,9 @@ const animations = Array.from(Array(10).keys()).map((id) => ({
 }));
 
 export const _default = () => {
-  return <AnimationTimeline animations={animations} />;
+  return <AnimationTimeline animations={animations} duration={320} />;
 };
 
 export const noAnimations = () => {
-  return <AnimationTimeline animations={[]} />;
+  return <AnimationTimeline animations={[]} duration={500} />;
 };

--- a/assets/src/edit-story/components/animationTimeline/stories/index.js
+++ b/assets/src/edit-story/components/animationTimeline/stories/index.js
@@ -30,9 +30,9 @@ const animations = Array.from(Array(10).keys()).map((id) => ({
 }));
 
 export const _default = () => {
-  return <AnimationTimeline animations={animations} duration={320} />;
+  return <AnimationTimeline animations={animations} duration={3500} />;
 };
 
 export const noAnimations = () => {
-  return <AnimationTimeline animations={[]} duration={500} />;
+  return <AnimationTimeline animations={[]} duration={5000} />;
 };

--- a/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
+++ b/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
@@ -26,7 +26,7 @@ describe('<AnimationTimeline />', function () {
       id,
     }));
     const { queryAllByTestId } = renderWithTheme(
-      <AnimationTimeline animations={animations} />
+      <AnimationTimeline animations={animations} duration={6000} />
     );
     expect(queryAllByTestId('timeline-animation-item')).toHaveLength(
       animations.length


### PR DESCRIPTION
## Summary

Adds a duration-based time ruler to the animation timeline. The timeline ruler and left-column labels are sticky when the main content scrolls either vertically or horizontally. (Shown in GIF).

![Kapture 2020-08-05 at 15 19 54](https://user-images.githubusercontent.com/1738349/89482844-5d472f80-d760-11ea-8c2c-36ca3dd34d58.gif)


## Relevant Technical Choices

- Uses SVG to draw the ruler, tick marks, and labels
- Uses milliseconds as the unit

## User-facing changes

- Adds a time-based ruler to the animation timeline control (Storybook only)

## Testing Instructions

- Open Storybook and see the time-based ruler on the animation timeline

---

<!-- Please reference the issue(s) this PR addresses. -->

#3440 
