### PR TITLE
fix mediaFetching local karma test

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
@@ -122,11 +122,13 @@ function PaginatedMediaGallery({
       node.scrollHeight - node.scrollTop <= node.clientHeight + ROOT_MARGIN;
     if (bottom) {
       setNextPage();
+      return;
     }
 
     // Load the next page if the page isn't full, ie. scrollbar is not visible.
     if (node.clientHeight === node.scrollHeight) {
       setNextPage();
+      return;
     }
   }, [hasMore, isMediaLoaded, isMediaLoading, setNextPage]);
 

--- a/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
@@ -147,7 +147,7 @@ function PaginatedMediaGallery({
 
     async function loadNextPageIfNeededAfterGalleryRendering() {
       // Wait for <Gallery> to finish its render layout cycles first.
-      await sleep(50);
+      await sleep(200);
 
       loadNextPageIfNeeded();
     }

--- a/assets/src/edit-story/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -28,34 +28,47 @@ import { ROOT_MARGIN } from '../mediaPane';
 
 describe('MediaPane fetching', () => {
   let fixture;
+  let localPane;
 
   beforeEach(async () => {
     fixture = new Fixture();
+    fixture.setFlags({ rowBasedGallery: true });
     await fixture.render();
+
+    localPane = fixture.querySelector('#library-pane-media');
   });
 
   afterEach(() => {
     fixture.restore();
   });
 
-  it('should fetch 2nd page', async () => {
-    const mediaLibrary = fixture.querySelector('[data-testid="mediaLibrary"]');
-    let mediaElements = fixture.querySelectorAll('[data-testid=mediaElement]');
-
-    expect(mediaElements.length).toBe(MEDIA_PER_PAGE);
-
-    mediaLibrary.scrollTo(
-      0,
-      mediaLibrary.scrollHeight - mediaLibrary.clientHeight - ROOT_MARGIN / 2
-    );
-
+  async function expectMediaElements(expectedCount) {
+    let mediaElements;
     await waitFor(() => {
-      mediaElements = fixture.querySelectorAll('[data-testid=mediaElement]');
-      if (!(mediaElements.length === MEDIA_PER_PAGE * 2)) {
-        throw new Error('2nd page not yet loaded');
+      mediaElements = localPane.querySelectorAll('[data-testid=mediaElement]');
+      if (!mediaElements || mediaElements.length !== expectedCount) {
+        throw new Error(
+          `Not ready: ${mediaElements?.length} != ${expectedCount}`
+        );
       }
     });
+    expect(mediaElements.length).toBe(expectedCount);
+  }
 
-    expect(mediaElements.length).toBe(MEDIA_PER_PAGE * 2);
+  it('should fetch 2nd page', async () => {
+    const mediaGallery = localPane.querySelector(
+      '[data-testid="media-gallery-container"]'
+    );
+
+    await expectMediaElements(MEDIA_PER_PAGE);
+
+    // await karmaPause();
+
+    mediaGallery.scrollTo(
+      0,
+      mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
+    );
+
+    await expectMediaElements(MEDIA_PER_PAGE * 2);
   });
 });

--- a/assets/src/edit-story/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -62,8 +62,6 @@ describe('MediaPane fetching', () => {
 
     await expectMediaElements(MEDIA_PER_PAGE);
 
-    // await karmaPause();
-
     mediaGallery.scrollTo(
       0,
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2


### PR DESCRIPTION
Changes local/karma/mediaFetching.karma.js to use the `rowBasedGallery` flag.
Unfortunately had to increase the sleep for the <MediaGallery> component to finish rendering, as otherwise the logic that checks if we should load a 2nd page triggers before <MediaGallery> has had a chance to render the elements.