### PR TITLE
Increase priority for template_include filter

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -138,7 +138,7 @@ class Story_Post_Type {
 		add_filter( 'rest_' . self::POST_TYPE_SLUG . '_collection_params', [ $this, 'filter_rest_collection_params' ], 10, 2 );
 
 		// Select the single-web-story.php template for Stories.
-		add_filter( 'template_include', [ $this, 'filter_template_include' ] );
+		add_filter( 'template_include', [ $this, 'filter_template_include' ], PHP_INT_MAX );
 
 		add_filter( 'amp_skip_post', [ $this, 'skip_amp' ], PHP_INT_MAX, 2 );
 

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -75,7 +75,7 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		$this->assertSame( 10, has_filter( 'show_admin_bar', [ $story_post_type, 'show_admin_bar' ] ) );
 		$this->assertSame( 10, has_filter( 'replace_editor', [ $story_post_type, 'replace_editor' ] ) );
 		$this->assertSame( 10, has_filter( 'use_block_editor_for_post_type', [ $story_post_type, 'filter_use_block_editor_for_post_type' ] ) );
-		$this->assertSame( 10, has_filter( 'template_include', [ $story_post_type, 'filter_template_include' ] ) );
+		$this->assertSame( PHP_INT_MAX, has_filter( 'template_include', [ $story_post_type, 'filter_template_include' ] ) );
 		$this->assertSame( PHP_INT_MAX, has_filter( 'amp_skip_post', [ $story_post_type, 'skip_amp' ] ) );
 		$this->assertSame( 10, has_filter( '_wp_post_revision_fields', [ $story_post_type, 'filter_revision_fields' ] ) );
 		$this->assertSame( 10, has_filter( 'jetpack_sitemap_post_types', [ $story_post_type, 'add_to_jetpack_sitemap' ] ) );


### PR DESCRIPTION
## Summary

Reduces the risk of conflicts with other plugins like page builders that override singular templates.

## Relevant Technical Choices

* Chose `PHP_INT_MAX` instead of the default `10` to make interference of other plugins highly unlikely.

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

1. Install a plugin that filters `template_include` at a high priority, e.g. the Oxygen page builder which runs at `99`.
1. Verify that viewing a single story still works as expecte

---

<!-- Please reference the issue(s) this PR addresses. -->

See #3623
