### PR TITLE
Animations: Added Drop Animation Effect

### DIFF
--- a/assets/src/dashboard/animations/constants.js
+++ b/assets/src/dashboard/animations/constants.js
@@ -29,6 +29,7 @@ export const ANIMATION_TYPES = {
 };
 
 export const ANIMATION_EFFECTS = {
+  DROP: 'effect-drop',
   FADE_IN: 'effect-fade-in',
   FLY_IN: 'effect-fly-in',
   PULSE: 'effect-pulse',

--- a/assets/src/dashboard/animations/effects/drop/index.js
+++ b/assets/src/dashboard/animations/effects/drop/index.js
@@ -13,53 +13,81 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
-'drop': {
-    duration: 1600,
-    keyframes(dimensions) {
-      const maxBounceHeight = Math.max(
-        160,
-        dimensions.targetY + dimensions.targetHeight
-      );
+/**
+ * Internal dependencies
+ */
+import { editorToDataY } from '../../../../edit-story/units/dimensions';
+import SimpleAnimation from '../../parts/simpleAnimation';
+import getOffPageOffset from '../../utils/getOffPageOffset';
 
-      return [
-        {
-          offset: 0,
-          transform: `translateY(${px(-maxBounceHeight)})`,
-          easing: 'cubic-bezier(.75,.05,.86,.08)',
-        },
-        {
-          offset: 0.3,
-          transform: 'translateY(0)',
-          easing: 'cubic-bezier(.22,.61,.35,1)',
-        },
-        {
-          offset: 0.52,
-          transform: `translateY(${px(-0.6 * maxBounceHeight)})`,
-          easing: 'cubic-bezier(.75,.05,.86,.08)',
-        },
-        {
-          offset: 0.74,
-          transform: 'translateY(0)',
-          easing: 'cubic-bezier(.22,.61,.35,1)',
-        },
-        {
-          offset: 0.83,
-          transform: `translateY(${px(-0.3 * maxBounceHeight)})`,
-          easing: 'cubic-bezier(.75,.05,.86,.08)',
-        },
-        {
-          offset: 1,
-          transform: 'translateY(0)',
-          easing: 'cubic-bezier(.22,.61,.35,1)',
-        },
-      ];
+const animationName = 'drop-effect';
+
+const getMinTopOffset = (element) =>
+  getOffPageOffset({
+    ...element,
+    y: editorToDataY(160, 100),
+  }).offsetTop;
+
+export function EffectDrop({
+  element,
+  fill = 'both',
+  duration = 1600,
+  delay = 0,
+}) {
+  const minTopOffset = getMinTopOffset(element);
+  const { offsetTop } = getOffPageOffset(element);
+  const maxBounceHeight = Math.max(minTopOffset, offsetTop);
+
+  const keyframes = [
+    {
+      offset: 0,
+      transform: `translateY(${maxBounceHeight}%)`,
+      easing: 'cubic-bezier(.75,.05,.86,.08)',
     },
-  },
-*/
-export function EffectDrop({ duration = 1600 }) {
-  // const { offsetTop, offsetLeft, offsetRight, offsetBottom } = getOffPageOffset(
-  //   element
-  // );
-  return duration;
+    {
+      offset: 0.3,
+      transform: 'translateY(0)',
+      easing: 'cubic-bezier(.22,.61,.35,1)',
+    },
+    {
+      offset: 0.52,
+      transform: `translateY(${0.6 * maxBounceHeight}%)`,
+      easing: 'cubic-bezier(.75,.05,.86,.08)',
+    },
+    {
+      offset: 0.74,
+      transform: 'translateY(0)',
+      easing: 'cubic-bezier(.22,.61,.35,1)',
+    },
+    {
+      offset: 0.83,
+      transform: `translateY(${0.3 * maxBounceHeight}%)`,
+      easing: 'cubic-bezier(.75,.05,.86,.08)',
+    },
+    {
+      offset: 1,
+      transform: 'translateY(0)',
+      easing: 'cubic-bezier(.22,.61,.35,1)',
+    },
+  ];
+
+  const { id, WAAPIAnimation, AMPTarget, AMPAnimation } = SimpleAnimation(
+    animationName,
+    keyframes,
+    {
+      fill,
+      duration,
+      delay,
+    }
+  );
+
+  return {
+    id,
+    WAAPIAnimation,
+    AMPTarget,
+    AMPAnimation,
+    generatedKeyframes: {
+      [animationName]: keyframes,
+    },
+  };
 }

--- a/assets/src/dashboard/animations/effects/drop/index.js
+++ b/assets/src/dashboard/animations/effects/drop/index.js
@@ -16,16 +16,13 @@
 /**
  * Internal dependencies
  */
-import { editorToDataY } from '../../../../edit-story/units/dimensions';
 import SimpleAnimation from '../../parts/simpleAnimation';
 import getOffPageOffset from '../../utils/getOffPageOffset';
-
-const animationName = 'drop-effect';
 
 const getMinTopOffset = (element) =>
   getOffPageOffset({
     ...element,
-    y: editorToDataY(160, 100),
+    y: 160,
   }).offsetTop;
 
 export function EffectDrop({
@@ -36,8 +33,10 @@ export function EffectDrop({
 }) {
   const minTopOffset = getMinTopOffset(element);
   const { offsetTop } = getOffPageOffset(element);
-  const maxBounceHeight = Math.max(minTopOffset, offsetTop);
+  const maxBounceHeight =
+    -1 * Math.max(Math.abs(minTopOffset), Math.abs(offsetTop));
 
+  const animationName = `drop-effect-${maxBounceHeight}`;
   const keyframes = [
     {
       offset: 0,

--- a/assets/src/dashboard/animations/effects/drop/index.js
+++ b/assets/src/dashboard/animations/effects/drop/index.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+'drop': {
+    duration: 1600,
+    keyframes(dimensions) {
+      const maxBounceHeight = Math.max(
+        160,
+        dimensions.targetY + dimensions.targetHeight
+      );
+
+      return [
+        {
+          offset: 0,
+          transform: `translateY(${px(-maxBounceHeight)})`,
+          easing: 'cubic-bezier(.75,.05,.86,.08)',
+        },
+        {
+          offset: 0.3,
+          transform: 'translateY(0)',
+          easing: 'cubic-bezier(.22,.61,.35,1)',
+        },
+        {
+          offset: 0.52,
+          transform: `translateY(${px(-0.6 * maxBounceHeight)})`,
+          easing: 'cubic-bezier(.75,.05,.86,.08)',
+        },
+        {
+          offset: 0.74,
+          transform: 'translateY(0)',
+          easing: 'cubic-bezier(.22,.61,.35,1)',
+        },
+        {
+          offset: 0.83,
+          transform: `translateY(${px(-0.3 * maxBounceHeight)})`,
+          easing: 'cubic-bezier(.75,.05,.86,.08)',
+        },
+        {
+          offset: 1,
+          transform: 'translateY(0)',
+          easing: 'cubic-bezier(.22,.61,.35,1)',
+        },
+      ];
+    },
+  },
+*/
+export function EffectDrop({ duration = 1600 }) {
+  // const { offsetTop, offsetLeft, offsetRight, offsetBottom } = getOffPageOffset(
+  //   element
+  // );
+  return duration;
+}

--- a/assets/src/dashboard/animations/effects/drop/stories/index.js
+++ b/assets/src/dashboard/animations/effects/drop/stories/index.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { AMPStoryWrapper } from '../../../../storybookUtils';
+
+export default {
+  title: 'Animations/Effects/Drop',
+};
+
+const redSquareStyles = {
+  backgroundColor: 'red',
+  height: '50px',
+  width: '50px',
+  top: 'calc(100% - 50px)',
+  left: 'calc(50% - 25px)',
+  position: 'absolute',
+};
+
+export const _default = () => (
+  <AMPStoryWrapper>
+    <amp-story-page id="page-1">
+      <amp-story-grid-layer template="vertical">
+        <div animate-in="drop" style={redSquareStyles} />
+      </amp-story-grid-layer>
+    </amp-story-page>
+    <amp-story-page id="page-2">
+      <amp-story-grid-layer template="vertical">
+        <div animate-in="drop" style={redSquareStyles} />
+      </amp-story-grid-layer>
+    </amp-story-page>
+  </AMPStoryWrapper>
+);

--- a/assets/src/dashboard/animations/effects/drop/stories/index.js
+++ b/assets/src/dashboard/animations/effects/drop/stories/index.js
@@ -16,32 +16,101 @@
 /**
  * Internal dependencies
  */
-import { AMPStoryWrapper } from '../../../../storybookUtils';
+import { PAGE_WIDTH, PAGE_HEIGHT } from '../../../../../edit-story/constants';
+import StoryAnimation from '../../../../components/storyAnimation';
+import {
+  AMPStoryWrapper,
+  AMP_STORY_ASPECT_RATIO,
+} from '../../../../storybookUtils';
+import { ANIMATION_EFFECTS } from '../../../constants';
+import { getBox } from '../../../../../edit-story/units/dimensions';
 
 export default {
   title: 'Animations/Effects/Drop',
 };
 
-const redSquareStyles = {
-  backgroundColor: 'red',
-  height: '50px',
-  width: '50px',
-  top: 'calc(100% - 50px)',
-  left: 'calc(50% - 25px)',
-  position: 'absolute',
-};
+const elements = [
+  {
+    id: 'e1',
+    color: 'red',
+    x: (PAGE_WIDTH - 50) / 2,
+    y: PAGE_HEIGHT - 50,
+    width: 50,
+    height: 50,
+  },
+];
 
-export const _default = () => (
-  <AMPStoryWrapper>
-    <amp-story-page id="page-1">
-      <amp-story-grid-layer template="vertical">
-        <div animate-in="drop" style={redSquareStyles} />
-      </amp-story-grid-layer>
-    </amp-story-page>
-    <amp-story-page id="page-2">
-      <amp-story-grid-layer template="vertical">
-        <div animate-in="drop" style={redSquareStyles} />
-      </amp-story-grid-layer>
-    </amp-story-page>
-  </AMPStoryWrapper>
-);
+const animations = [{ targets: ['e1'], type: ANIMATION_EFFECTS.DROP }];
+
+export const _default = () => {
+  const elementBoxes = elements.map((element) => ({
+    ...element,
+    ...getBox(element, 100, 100),
+  }));
+
+  return (
+    <AMPStoryWrapper>
+      <amp-story-page id="page-1">
+        <p style={{ textAlign: 'center', color: '#fff' }}>
+          {'AMP Drop Effect'}
+        </p>
+        <amp-story-grid-layer
+          template="vertical"
+          aspect-ration={AMP_STORY_ASPECT_RATIO}
+        >
+          <div
+            animate-in="drop"
+            style={{
+              position: 'absolute',
+              height: '50px',
+              width: '50px',
+              top: 'calc(100% - 50px)',
+              left: 'calc(50% - 25px)',
+              backgroundColor: 'red',
+            }}
+          />
+        </amp-story-grid-layer>
+      </amp-story-page>
+      <amp-story-page id="page-2">
+        <StoryAnimation.Provider animations={animations} elements={elements}>
+          <StoryAnimation.AMPAnimations />
+          <p style={{ textAlign: 'center', color: '#fff' }}>
+            {'Custom Drop Effect'}
+          </p>
+
+          <amp-story-grid-layer
+            template="vertical"
+            aspect-ration={AMP_STORY_ASPECT_RATIO}
+          >
+            <div className="page-fullbleed-area">
+              <div className="page-safe-area">
+                {elementBoxes.map((elem) => (
+                  <div
+                    key={elem.id}
+                    style={{
+                      position: 'absolute',
+                      top: `${elem.y}%`,
+                      left: `${elem.x}%`,
+                      width: `${elem.width}%`,
+                      height: `${elem.height}%`,
+                    }}
+                  >
+                    <StoryAnimation.AMPWrapper target={elem.id}>
+                      <div
+                        style={{
+                          height: '100%',
+                          width: '100%',
+                          backgroundColor: elem.color,
+                        }}
+                      />
+                    </StoryAnimation.AMPWrapper>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </amp-story-grid-layer>
+        </StoryAnimation.Provider>
+      </amp-story-page>
+    </AMPStoryWrapper>
+  );
+};

--- a/assets/src/dashboard/animations/parts/index.js
+++ b/assets/src/dashboard/animations/parts/index.js
@@ -23,6 +23,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { ANIMATION_TYPES, ANIMATION_EFFECTS, BEZIER } from '../constants';
+import { EffectDrop } from '../effects/drop';
 import { EffectFadeIn } from '../effects/fadeIn';
 import { EffectFlyIn } from '../effects/flyIn';
 import { EffectPulse } from '../effects/pulse';
@@ -85,6 +86,7 @@ export function AnimationPart(type, args) {
       [ANIMATION_EFFECTS.PULSE]: EffectPulse,
       [ANIMATION_EFFECTS.TWIRL_IN]: EffectTwirlIn,
       [ANIMATION_EFFECTS.ZOOM]: EffectZoom,
+      [ANIMATION_EFFECTS.DROP]: EffectDrop,
     }[type] || throughput;
 
   args.easing = args.easing || BEZIER[args.easingPreset];


### PR DESCRIPTION
## Summary
This PR adds in the Drop effect. Just created a custom inline animation part for this and pulled the keyframes from the AMP source code for the `drop` preset.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
NA

## Testing Instructions
1.) Go to our Storybook: "Animations -> Effects -> Drop"
2.) Compare that both pages work the same.

(May have slight deviation because our drop accounts for our danger zone height which makes the entrance higher)
---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3418 

![drop_example_30fps](https://user-images.githubusercontent.com/35983235/89572055-df2d6c00-d7e5-11ea-8a86-cadbd46da413.gif)

