### PR TITLE
Animation: Passing elements to animation providers

### DIFF
--- a/assets/src/dashboard/animations/constants.js
+++ b/assets/src/dashboard/animations/constants.js
@@ -32,7 +32,7 @@ export const ANIMATION_EFFECTS = {
   FADE_IN: 'effect-fade-in',
   FLY_IN: 'effect-fly-in',
   PULSE: 'effect-pulse',
-  TWIRL_IN: 'twirl-in',
+  TWIRL_IN: 'effect-twirl-in',
   ZOOM: 'effect-zoom',
 };
 

--- a/assets/src/dashboard/animations/effects/flyIn/animationsProps.js
+++ b/assets/src/dashboard/animations/effects/flyIn/animationsProps.js
@@ -20,7 +20,7 @@
 import { FIELD_TYPES, DIRECTION } from '../../constants';
 
 export default {
-  floatOnDir: {
+  flyInDir: {
     type: FIELD_TYPES.DROPDOWN,
     values: [
       DIRECTION.TOP_TO_BOTTOM,

--- a/assets/src/dashboard/animations/effects/flyIn/index.js
+++ b/assets/src/dashboard/animations/effects/flyIn/index.js
@@ -23,7 +23,7 @@ import { DIRECTION } from '../../constants';
 
 export function EffectFlyIn({
   duration = 500,
-  direction = DIRECTION.TOP_TO_BOTTOM,
+  flyInDir = DIRECTION.TOP_TO_BOTTOM,
   delay,
   easing,
   element,
@@ -34,21 +34,21 @@ export function EffectFlyIn({
 
   const offsetLookup = {
     [DIRECTION.TOP_TO_BOTTOM]: {
-      offsetY: offsetTop,
+      offsetY: `${offsetTop}%`,
     },
     [DIRECTION.BOTTOM_TO_TOP]: {
-      offsetY: offsetBottom,
+      offsetY: `${offsetBottom}%`,
     },
     [DIRECTION.LEFT_TO_RIGHT]: {
-      offsetX: offsetLeft,
+      offsetX: `${offsetLeft}%`,
     },
     [DIRECTION.RIGHT_TO_LEFT]: {
-      offsetX: offsetRight,
+      offsetX: `${offsetRight}%`,
     },
   };
 
   return new AnimationMove({
-    ...offsetLookup[direction],
+    ...offsetLookup[flyInDir],
     duration,
     delay,
     easing,

--- a/assets/src/dashboard/animations/effects/flyIn/stories/index.js
+++ b/assets/src/dashboard/animations/effects/flyIn/stories/index.js
@@ -38,19 +38,19 @@ const animations = [
     targets: ['e2'],
     type: ANIMATION_EFFECTS.FLY_IN,
     delay: 500,
-    direction: DIRECTION.LEFT_TO_RIGHT,
+    flyInDir: DIRECTION.LEFT_TO_RIGHT,
   },
   {
     targets: ['e3'],
     type: ANIMATION_EFFECTS.FLY_IN,
     delay: 1000,
-    direction: DIRECTION.RIGHT_TO_LEFT,
+    flyInDir: DIRECTION.RIGHT_TO_LEFT,
   },
   {
     targets: ['e4'],
     type: ANIMATION_EFFECTS.FLY_IN,
     delay: 1500,
-    direction: DIRECTION.BOTTOM_TO_TOP,
+    flyInDir: DIRECTION.BOTTOM_TO_TOP,
   },
 ];
 

--- a/assets/src/dashboard/animations/effects/pulse/animationProps.js
+++ b/assets/src/dashboard/animations/effects/pulse/animationProps.js
@@ -17,17 +17,12 @@
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES, DIRECTION } from '../../constants';
+import { FIELD_TYPES } from '../../constants';
 
 export default {
-  floatOnDir: {
-    type: FIELD_TYPES.DROPDOWN,
-    values: [
-      DIRECTION.TOP_TO_BOTTOM,
-      DIRECTION.BOTTOM_TO_TOP,
-      DIRECTION.LEFT_TO_RIGHT,
-      DIRECTION.RIGHT_TO_LEFT,
-    ],
-    defaultValue: DIRECTION.BOTTOM_TO_TOP,
+  scale: {
+    tooltip: 'Valid values are greater than or equal to 0',
+    type: FIELD_TYPES.FLOAT,
+    defaultValue: 0.5,
   },
 };

--- a/assets/src/dashboard/animations/parts/defaultAnimationProps.js
+++ b/assets/src/dashboard/animations/parts/defaultAnimationProps.js
@@ -17,7 +17,12 @@
 /**
  * Internal dependencies
  */
-import { ANIMATION_TYPES, FIELD_TYPES, BEZIER } from '../constants';
+import {
+  ANIMATION_TYPES,
+  ANIMATION_EFFECTS,
+  FIELD_TYPES,
+  BEZIER,
+} from '../constants';
 
 export default {
   id: {
@@ -26,7 +31,10 @@ export default {
   type: {
     label: 'Animation Type',
     type: FIELD_TYPES.DROPDOWN,
-    values: Object.values(ANIMATION_TYPES),
+    values: [
+      ...Object.values(ANIMATION_TYPES),
+      ...Object.values(ANIMATION_EFFECTS),
+    ],
   },
   duration: {
     label: 'Duration (ms)',
@@ -46,7 +54,7 @@ export default {
   easingPreset: {
     label: 'Easing Presets',
     type: FIELD_TYPES.DROPDOWN,
-    values: Object.keys(BEZIER),
+    values: ['Use Default', ...Object.keys(BEZIER)],
     defaultValue: Object.keys(BEZIER)[0],
   },
   easing: {

--- a/assets/src/dashboard/animations/parts/floatOn/index.js
+++ b/assets/src/dashboard/animations/parts/floatOn/index.js
@@ -41,7 +41,7 @@ const keyframesLookup = {
 };
 
 export function AnimationFloatOn({
-  direction = DIRECTION.BOTTOM_TO_TOP,
+  floatOnDir = DIRECTION.BOTTOM_TO_TOP,
   ...args
 }) {
   const timings = {
@@ -49,8 +49,8 @@ export function AnimationFloatOn({
     ...args,
   };
 
-  const animationName = `dir-${direction}-${ANIMATION_TYPES.FLOAT_ON}`;
-  const keyframes = keyframesLookup[direction];
+  const animationName = `dir-${floatOnDir}-${ANIMATION_TYPES.FLOAT_ON}`;
+  const keyframes = keyframesLookup[floatOnDir];
 
   const { id, WAAPIAnimation, AMPTarget, AMPAnimation } = SimpleAnimation(
     animationName,

--- a/assets/src/dashboard/animations/parts/floatOn/stories/index.js
+++ b/assets/src/dashboard/animations/parts/floatOn/stories/index.js
@@ -32,28 +32,28 @@ const animations = [
     targets: ['e1'],
     type: ANIMATION_TYPES.FLOAT_ON,
     duration,
-    direction: DIRECTION.TOP_TO_BOTTOM,
+    floatOnDir: DIRECTION.TOP_TO_BOTTOM,
   },
   {
     targets: ['e2'],
     type: ANIMATION_TYPES.FLOAT_ON,
     duration,
     delay: duration,
-    direction: DIRECTION.BOTTOM_TO_TOP,
+    floatOnDir: DIRECTION.BOTTOM_TO_TOP,
   },
   {
     targets: ['e3'],
     type: ANIMATION_TYPES.FLOAT_ON,
     duration,
     delay: duration * 2,
-    direction: DIRECTION.LEFT_TO_RIGHT,
+    floatOnDir: DIRECTION.LEFT_TO_RIGHT,
   },
   {
     targets: ['e4'],
     type: ANIMATION_TYPES.FLOAT_ON,
     duration,
     delay: duration * 3,
-    direction: DIRECTION.RIGHT_TO_LEFT,
+    floatOnDir: DIRECTION.RIGHT_TO_LEFT,
   },
 ];
 

--- a/assets/src/dashboard/animations/parts/index.js
+++ b/assets/src/dashboard/animations/parts/index.js
@@ -28,6 +28,9 @@ import { EffectFlyIn } from '../effects/flyIn';
 import { EffectPulse } from '../effects/pulse';
 import { EffectTwirlIn } from '../effects/twirlIn';
 import { EffectZoom } from '../effects/zoom';
+import flyInProps from '../effects/flyIn/animationsProps';
+import pulseProps from '../effects/pulse/animationProps';
+
 import { AnimationBounce } from './bounce';
 import { AnimationBlinkOn } from './blinkOn';
 import { AnimationFade } from './fade';
@@ -99,6 +102,8 @@ export function AnimationProps(type) {
     [ANIMATION_TYPES.MOVE]: moveProps,
     [ANIMATION_TYPES.SPIN]: spinProps,
     [ANIMATION_TYPES.ZOOM]: zoomProps,
+    [ANIMATION_EFFECTS.FLY_IN]: flyInProps,
+    [ANIMATION_EFFECTS.PULSE]: pulseProps,
   };
 
   const { type: animationType, ...remaining } = defaultAnimationProps;

--- a/assets/src/dashboard/animations/parts/types.js
+++ b/assets/src/dashboard/animations/parts/types.js
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { ANIMATION_TYPES } from '../constants';
+import { ANIMATION_TYPES, ANIMATION_EFFECTS } from '../constants';
 import { GeneralAnimationPropTypes } from '../outputs/types';
 
 export const WAAPIAnimationProps = {
@@ -39,7 +39,10 @@ export const AMPAnimationProps = {
 
 export const AnimationProps = {
   id: PropTypes.string.isRequired,
-  type: PropTypes.oneOf(Object.values(ANIMATION_TYPES)),
+  type: PropTypes.oneOf([
+    ...Object.values(ANIMATION_TYPES),
+    ...Object.values(ANIMATION_EFFECTS),
+  ]),
   targets: PropTypes.arrayOf(PropTypes.string),
   ...GeneralAnimationPropTypes,
 };

--- a/assets/src/dashboard/components/previewPage.js
+++ b/assets/src/dashboard/components/previewPage.js
@@ -117,6 +117,7 @@ function PreviewPage({
   return (
     <StoryAnimation.Provider
       animations={page.animations}
+      elements={page.elements}
       onWAAPIFinish={onAnimationComplete}
     >
       <PreviewPageController

--- a/assets/src/edit-story/output/page.js
+++ b/assets/src/edit-story/output/page.js
@@ -49,7 +49,7 @@ function OutputPage({ page, autoAdvance, defaultPageDuration }) {
       id={id}
       auto-advance-after={autoAdvance ? autoAdvanceAfter : undefined}
     >
-      <StoryAnimation.Provider animations={animations}>
+      <StoryAnimation.Provider animations={animations} elements={elements}>
         <StoryAnimation.AMPAnimations />
 
         {backgroundElement && (


### PR DESCRIPTION
## Summary

This PR updates instances of `StoryAnimation.Provider`, within our preview story code and generated story code, to receive the `elements` of the current story page.  This enables our effects (like `fly-In`) to work in a story preview and generated story page.

I also updated our `story-anim-tool` to support our new effects.

## User-facing changes

None.  All hidden behind the animation feature flag.

## Testing Instructions

1.) Go to our `story-anim-tool`.
2.) Choose a random story to apply animations to.
3.) Apply the `Fly-In` effect to a few elements.
4.) Click play to see the animation work in the story preview, and click the "Preview Story" button to see the animation work in a generated story.

NOTE: You'll need to enable animations using the new "Experiments" page.

Fixes #3562 

## Screenshots

Fly-In working in Preview Story
![fly_in_preview](https://user-images.githubusercontent.com/40646372/89672415-7273a980-d899-11ea-82d2-f44dce2922b1.gif)

Fly-In working in Generated Story
![fly_in_story](https://user-images.githubusercontent.com/40646372/89672404-70114f80-d899-11ea-9af5-8189ff7b7393.gif)
