### PR TITLE
Animation: Added Whoosh-In animation effect

### DIFF
--- a/assets/src/dashboard/animations/constants.js
+++ b/assets/src/dashboard/animations/constants.js
@@ -33,6 +33,7 @@ export const ANIMATION_EFFECTS = {
   FLY_IN: 'effect-fly-in',
   PULSE: 'effect-pulse',
   TWIRL_IN: 'effect-twirl-in',
+  WHOOSH_IN: 'effect-whoosh-in',
   ZOOM: 'effect-zoom',
 };
 

--- a/assets/src/dashboard/animations/effects/whooshIn/animationProps.js
+++ b/assets/src/dashboard/animations/effects/whooshIn/animationProps.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES, DIRECTION } from '../../constants';
+
+export default {
+  whooshInDir: {
+    type: FIELD_TYPES.DROPDOWN,
+    values: [DIRECTION.LEFT_TO_RIGHT, DIRECTION.RIGHT_TO_LEFT],
+    defaultValue: DIRECTION.LEFT_TO_RIGHT,
+  },
+};

--- a/assets/src/dashboard/animations/effects/whooshIn/index.js
+++ b/assets/src/dashboard/animations/effects/whooshIn/index.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Internal dependencies
+ */
+import { AnimationMove } from '../../parts/move';
+import { AnimationFade } from '../../parts/fade';
+import { AnimationZoom } from '../../parts/zoom';
+import getOffPageOffset from '../../utils/getOffPageOffset';
+import { DIRECTION } from '../../constants';
+
+export function EffectWhooshIn({
+  duration = 400,
+  whooshInDir = DIRECTION.LEFT_TO_RIGHT,
+  easing = 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+  delay,
+  element,
+}) {
+  const id = uuidv4();
+
+  const { offsetLeft, offsetRight } = getOffPageOffset(element);
+
+  const offsetX =
+    whooshInDir === DIRECTION.RIGHT_TO_LEFT
+      ? `${offsetRight}%`
+      : `${offsetLeft}%`;
+
+  const {
+    WAAPIAnimation: moveWAAPIAnimation,
+    AMPTarget: moveAMPTarget,
+    AMPAnimation: moveAMPAnimation,
+    generatedKeyframes: moveKeyframes,
+  } = AnimationMove({
+    offsetX,
+    duration,
+    delay,
+    easing,
+  });
+
+  const {
+    WAAPIAnimation: fadeWAAPIAnimation,
+    AMPTarget: fadeAMPTarget,
+    AMPAnimation: fadeAMPAnimation,
+    generatedKeyframes: fadeKeyframes,
+  } = AnimationFade({
+    fadeFrom: 0,
+    fadeTo: 1,
+    duration,
+    delay,
+    easing,
+  });
+
+  const {
+    WAAPIAnimation: zoomWAAPIAnimation,
+    AMPTarget: zoomAMPTarget,
+    AMPAnimation: zoomAMPAnimation,
+    generatedKeyframes: zoomKeyframes,
+  } = AnimationZoom({
+    zoomFrom: 0.15,
+    zoomTo: 1,
+    duration,
+    delay,
+    easing,
+  });
+
+  return {
+    id,
+    WAAPIAnimation: ({ children, ...args }) =>
+      moveWAAPIAnimation({
+        children: fadeWAAPIAnimation({
+          children: zoomWAAPIAnimation({ children, ...args }),
+          ...args,
+        }),
+        ...args,
+      }),
+    AMPTarget: ({ children, ...args }) =>
+      moveAMPTarget({
+        children: fadeAMPTarget({
+          children: zoomAMPTarget({ children, ...args }),
+          ...args,
+        }),
+        ...args,
+      }),
+    AMPAnimation: function AMPAnimation() {
+      return (
+        <>
+          {moveAMPAnimation()}
+          {fadeAMPAnimation()}
+          {zoomAMPAnimation()}
+        </>
+      );
+    },
+    generatedKeyframes: {
+      ...moveKeyframes,
+      ...fadeKeyframes,
+      ...zoomKeyframes,
+    },
+  };
+}

--- a/assets/src/dashboard/animations/effects/whooshIn/index.js
+++ b/assets/src/dashboard/animations/effects/whooshIn/index.js
@@ -45,9 +45,9 @@ export function EffectWhooshIn({
       : `${offsetLeft}%`;
 
   const {
-    WAAPIAnimation: moveWAAPIAnimation,
-    AMPTarget: moveAMPTarget,
-    AMPAnimation: moveAMPAnimation,
+    WAAPIAnimation: MoveWAAPIAnimation,
+    AMPTarget: MoveAMPTarget,
+    AMPAnimation: MoveAMPAnimation,
     generatedKeyframes: moveKeyframes,
   } = AnimationMove({
     offsetX,
@@ -57,9 +57,9 @@ export function EffectWhooshIn({
   });
 
   const {
-    WAAPIAnimation: fadeWAAPIAnimation,
-    AMPTarget: fadeAMPTarget,
-    AMPAnimation: fadeAMPAnimation,
+    WAAPIAnimation: FadeWAAPIAnimation,
+    AMPTarget: FadeAMPTarget,
+    AMPAnimation: FadeAMPAnimation,
     generatedKeyframes: fadeKeyframes,
   } = AnimationFade({
     fadeFrom: 0,
@@ -70,9 +70,9 @@ export function EffectWhooshIn({
   });
 
   const {
-    WAAPIAnimation: zoomWAAPIAnimation,
-    AMPTarget: zoomAMPTarget,
-    AMPAnimation: zoomAMPAnimation,
+    WAAPIAnimation: ZoomWAAPIAnimation,
+    AMPTarget: ZoomAMPTarget,
+    AMPAnimation: ZoomAMPAnimation,
     generatedKeyframes: zoomKeyframes,
   } = AnimationZoom({
     zoomFrom: 0.15,
@@ -84,28 +84,34 @@ export function EffectWhooshIn({
 
   return {
     id,
-    WAAPIAnimation: ({ children, ...args }) =>
-      moveWAAPIAnimation({
-        children: fadeWAAPIAnimation({
-          children: zoomWAAPIAnimation({ children, ...args }),
-          ...args,
-        }),
-        ...args,
-      }),
-    AMPTarget: ({ children, ...args }) =>
-      moveAMPTarget({
-        children: fadeAMPTarget({
-          children: zoomAMPTarget({ children, ...args }),
-          ...args,
-        }),
-        ...args,
-      }),
+    // eslint-disable-next-line react/prop-types
+    WAAPIAnimation: function WAAPIAnimation({ children, hoistAnimation }) {
+      return (
+        <MoveWAAPIAnimation hoistAnimation={hoistAnimation}>
+          <FadeWAAPIAnimation hoistAnimation={hoistAnimation}>
+            <ZoomWAAPIAnimation hoistAnimation={hoistAnimation}>
+              {children}
+            </ZoomWAAPIAnimation>
+          </FadeWAAPIAnimation>
+        </MoveWAAPIAnimation>
+      );
+    },
+    // eslint-disable-next-line react/prop-types
+    AMPTarget: function AMPTarget({ children, style }) {
+      return (
+        <MoveAMPTarget style={style}>
+          <FadeAMPTarget style={style}>
+            <ZoomAMPTarget style={style}>{children}</ZoomAMPTarget>
+          </FadeAMPTarget>
+        </MoveAMPTarget>
+      );
+    },
     AMPAnimation: function AMPAnimation() {
       return (
         <>
-          {moveAMPAnimation()}
-          {fadeAMPAnimation()}
-          {zoomAMPAnimation()}
+          <MoveAMPAnimation />
+          <FadeAMPAnimation />
+          <ZoomAMPAnimation />
         </>
       );
     },

--- a/assets/src/dashboard/animations/effects/whooshIn/stories/index.js
+++ b/assets/src/dashboard/animations/effects/whooshIn/stories/index.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import StoryAnimation from '../../../../components/storyAnimation';
+import {
+  AMPStoryWrapper,
+  AMP_STORY_ASPECT_RATIO,
+} from '../../../../storybookUtils';
+import { ANIMATION_EFFECTS, DIRECTION } from '../../../constants';
+import { getBox } from '../../../../../edit-story/units/dimensions';
+
+export default {
+  title: 'Animations/Effects/Whoosh-In',
+};
+
+const animations = [
+  {
+    targets: ['e1'],
+    type: ANIMATION_EFFECTS.WHOOSH_IN,
+    delay: 500,
+  },
+  {
+    targets: ['e2'],
+    type: ANIMATION_EFFECTS.WHOOSH_IN,
+    delay: 1000,
+    whooshInDir: DIRECTION.RIGHT_TO_LEFT,
+  },
+];
+
+const elements = [
+  { id: 'e1', color: 'red', x: 315, y: 100, width: 50, height: 50 },
+  { id: 'e2', color: 'orange', x: 50, y: 175, width: 50, height: 50 },
+];
+
+const defaultStyles = {
+  position: 'relative',
+  width: '50px',
+  height: '50px',
+};
+
+export const _default = () => {
+  const elementBoxes = elements.map((element) => ({
+    ...element,
+    ...getBox(element, 100, 100),
+  }));
+
+  return (
+    <AMPStoryWrapper>
+      <amp-story-page id={`page-1`}>
+        <p style={{ textAlign: 'center', color: '#fff' }}>{'AMP Whoosh-In'}</p>
+
+        <amp-story-grid-layer
+          template="vertical"
+          aspect-ratio={AMP_STORY_ASPECT_RATIO}
+        >
+          <div
+            animate-in="whoosh-in-left"
+            animate-in-delay="0.5s"
+            style={{
+              backgroundColor: 'red',
+              ...defaultStyles,
+              left: '250px',
+            }}
+          />
+          <div
+            animate-in="whoosh-in-right"
+            animate-in-delay="1.0s"
+            style={{
+              backgroundColor: 'orange',
+              ...defaultStyles,
+            }}
+          />
+        </amp-story-grid-layer>
+      </amp-story-page>
+      <amp-story-page id={`page-2`}>
+        <StoryAnimation.Provider animations={animations} elements={elements}>
+          <StoryAnimation.AMPAnimations />
+          <p style={{ textAlign: 'center', color: '#fff' }}>
+            {'Custom Whoosh-In Effect'}
+          </p>
+
+          <amp-story-grid-layer
+            template="vertical"
+            aspect-ratio={AMP_STORY_ASPECT_RATIO}
+          >
+            <div className="page-fullbleed-area">
+              <div className="page-safe-area">
+                {elementBoxes.map(({ id, color, x, y, width, height }) => (
+                  <div
+                    key={id}
+                    style={{
+                      position: 'absolute',
+                      top: `${y}%`,
+                      left: `${x}%`,
+                      width: `${width}%`,
+                      height: `${height}%`,
+                    }}
+                  >
+                    <StoryAnimation.AMPWrapper target={id}>
+                      <div
+                        style={{
+                          width: '100%',
+                          height: '100%',
+                          backgroundColor: color,
+                        }}
+                      />
+                    </StoryAnimation.AMPWrapper>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </amp-story-grid-layer>
+        </StoryAnimation.Provider>
+      </amp-story-page>
+    </AMPStoryWrapper>
+  );
+};

--- a/assets/src/dashboard/animations/parts/index.js
+++ b/assets/src/dashboard/animations/parts/index.js
@@ -27,9 +27,11 @@ import { EffectFadeIn } from '../effects/fadeIn';
 import { EffectFlyIn } from '../effects/flyIn';
 import { EffectPulse } from '../effects/pulse';
 import { EffectTwirlIn } from '../effects/twirlIn';
+import { EffectWhooshIn } from '../effects/whooshIn';
 import { EffectZoom } from '../effects/zoom';
 import flyInProps from '../effects/flyIn/animationsProps';
 import pulseProps from '../effects/pulse/animationProps';
+import whooshInProps from '../effects/whooshIn/animationProps';
 
 import { AnimationBounce } from './bounce';
 import { AnimationBlinkOn } from './blinkOn';
@@ -84,6 +86,7 @@ export function AnimationPart(type, args) {
       [ANIMATION_EFFECTS.FLY_IN]: EffectFlyIn,
       [ANIMATION_EFFECTS.PULSE]: EffectPulse,
       [ANIMATION_EFFECTS.TWIRL_IN]: EffectTwirlIn,
+      [ANIMATION_EFFECTS.WHOOSH_IN]: EffectWhooshIn,
       [ANIMATION_EFFECTS.ZOOM]: EffectZoom,
     }[type] || throughput;
 
@@ -104,6 +107,7 @@ export function AnimationProps(type) {
     [ANIMATION_TYPES.ZOOM]: zoomProps,
     [ANIMATION_EFFECTS.FLY_IN]: flyInProps,
     [ANIMATION_EFFECTS.PULSE]: pulseProps,
+    [ANIMATION_EFFECTS.WHOOSH_IN]: whooshInProps,
   };
 
   const { type: animationType, ...remaining } = defaultAnimationProps;


### PR DESCRIPTION
## Summary

This PR adds the `Whoosh In` animation effect to our animation library.

## Relevant Technical Choices

I decided to re-create the whoosh-in effect by combining 3 of our existing animation parts: move, fade, and zoom.  It might have been cleaner to simply create a separate set of keyframes, but I think it was fun to compose the effect and it's a good proof-of-concept when we might want to do composition in the future that can't so easily be created with one set of keyframes.

## User-facing changes

None.

## Testing Instructions

1.) Go to our Storybook: "Animations -> Effects -> Whoosh-In"
2.) Flipped between both pages and notice that the whoosh looks good in both 🎉 

Fixes #3426 

## Screenshots

![whoosh_in_effect](https://user-images.githubusercontent.com/40646372/89693061-3c96eb00-d8c2-11ea-8069-37e3d2f10438.gif)
