### PR TITLE
Add loading pill delay

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
@@ -170,9 +170,8 @@ function PaginatedMediaGallery({
         setShowLoadingPill(isMediaLoading);
       }, SHOW_LOADING_PILL_DELAY_MS);
       return () => clearTimeout(showLoadingTimeout);
-    } else {
-      setShowLoadingPill(false);
     }
+    setShowLoadingPill(false);
     return undefined;
   }, [isMediaLoading]);
 

--- a/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
@@ -48,6 +48,8 @@ import { ProviderType } from '../../../../../app/media/providerType';
 
 const ROOT_MARGIN = 300;
 
+const SHOW_LOADING_PILL_DELAY_MS = 1000;
+
 function PaginatedMediaGallery({
   providerType,
   resources,
@@ -160,7 +162,21 @@ function PaginatedMediaGallery({
       </div>
     );
 
-  const displayLoadingPill = isMediaLoading && hasMore;
+  const [showLoadingPill, setShowLoadingPill] = useState(false);
+
+  useEffect(() => {
+    if (isMediaLoading) {
+      const showLoadingTimeout = setTimeout(() => {
+        setShowLoadingPill(isMediaLoading);
+      }, SHOW_LOADING_PILL_DELAY_MS);
+      return () => clearTimeout(showLoadingTimeout);
+    } else {
+      setShowLoadingPill(false);
+    }
+    return undefined;
+  }, [isMediaLoading]);
+
+  const displayLoadingPill = isMediaLoading && hasMore && showLoadingPill;
   const attribution =
     providerType !== ProviderType.LOCAL &&
     PROVIDERS[providerType].attributionComponent();

--- a/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
@@ -172,7 +172,7 @@ function PaginatedMediaGallery({
   const [showLoadingPill, setShowLoadingPill] = useState(false);
 
   useEffect(() => {
-    if (isMediaLoading) {
+    if (isMediaLoading && hasMore) {
       const showLoadingTimeout = setTimeout(() => {
         setShowLoadingPill(isMediaLoading);
       }, SHOW_LOADING_PILL_DELAY_MS);
@@ -180,9 +180,8 @@ function PaginatedMediaGallery({
     }
     setShowLoadingPill(false);
     return undefined;
-  }, [isMediaLoading]);
+  }, [isMediaLoading, hasMore]);
 
-  const displayLoadingPill = isMediaLoading && hasMore && showLoadingPill;
   const attribution =
     providerType !== ProviderType.LOCAL &&
     PROVIDERS[providerType].attributionComponent();
@@ -194,12 +193,12 @@ function PaginatedMediaGallery({
       >
         <MediaGalleryInnerContainer>{mediaGallery}</MediaGalleryInnerContainer>
       </MediaGalleryContainer>
-      {displayLoadingPill && (
+      {showLoadingPill && (
         <MediaGalleryLoadingPill data-testid={'loading-pill'}>
           {__('Loading…', 'web-stories')}
         </MediaGalleryLoadingPill>
       )}
-      {!displayLoadingPill && attribution}
+      {!showLoadingPill && attribution}
     </>
   );
 }


### PR DESCRIPTION
## Summary

This introduces a 1s delay before the loading pill is shown, as requested by UX.

## Relevant Technical Choices

setTimeout and some state to determine whether it must be shown.

## User-facing changes

Loading pill now takes 1s before appearing. If loading takes less than that, it doesn't appear at all.

## Testing Instructions

Verify that browsing works fine in the gallery, with the caveat that the loading pill takes longer to appear.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3501
