### PR TITLE
Multisite: Run activation hook on new site creation

### DIFF
--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -94,7 +94,7 @@ if ( ! class_exists( '\Google\Web_Stories\Plugin' ) ) {
  *
  * @return void
  */
-function activate( $network_wide ) {
+function activate( $network_wide = false ) {
 	if ( version_compare( PHP_VERSION, WEBSTORIES_MINIMUM_PHP_VERSION, '<' ) ) {
 		wp_die(
 		/* translators: %s: PHP version number */
@@ -112,6 +112,25 @@ function activate( $network_wide ) {
 
 	do_action( 'web_stories_activation', $network_wide );
 }
+
+/**
+ * Hook into new site when they are created and run activation hook.
+ *
+ * @param int|WP_Site $site Site ID or object.
+ *
+ * @return void
+ */
+function new_site( $site ) {
+	if ( ! is_multisite() ) {
+		return;
+	}
+	$site    = get_site( $site );
+	$site_id = $site->blog_id;
+	switch_to_blog( $site_id );
+	activate();
+	restore_current_blog();
+}
+add_action( 'wp_initialize_site', __NAMESPACE__ . '\new_site', PHP_INT_MAX );
 
 /**
  * Handles plugin deactivation.

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -124,7 +124,10 @@ function new_site( $site ) {
 	if ( ! is_multisite() ) {
 		return;
 	}
-	$site    = get_site( $site );
+	$site = get_site( $site );
+	if ( ! $site ) {
+		return;
+	}
 	$site_id = (int) $site->blog_id;
 	switch_to_blog( $site_id );
 	activate();

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -116,7 +116,7 @@ function activate( $network_wide = false ) {
 /**
  * Hook into new site when they are created and run activation hook.
  *
- * @param int|WP_Site $site Site ID or object.
+ * @param int|\WP_Site $site Site ID or object.
  *
  * @return void
  */
@@ -125,7 +125,7 @@ function new_site( $site ) {
 		return;
 	}
 	$site    = get_site( $site );
-	$site_id = $site->blog_id;
+	$site_id = (int) $site->blog_id;
 	switch_to_blog( $site_id );
 	activate();
 	restore_current_blog();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,11 @@
 			<directory suffix=".php">./tests/phpunit/tests</directory>
 		</testsuite>
 	</testsuites>
+  <groups>
+    <exclude>
+      <group>ms-required</group>
+    </exclude>
+  </groups>
 
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,11 +18,12 @@
 			<directory suffix=".php">./tests/phpunit/tests</directory>
 		</testsuite>
 	</testsuites>
-  <groups>
-    <exclude>
-      <group>ms-required</group>
-    </exclude>
-  </groups>
+
+	<groups>
+		<exclude>
+			<group>ms-required</group>
+		</exclude>
+	</groups>
 
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">

--- a/tests/phpunit/tests/Plugin.php
+++ b/tests/phpunit/tests/Plugin.php
@@ -22,7 +22,7 @@ namespace Google\Web_Stories\Tests;
  */
 class Plugin extends \WP_UnitTestCase {
 	/**
-	 * @covers ::registerr
+	 * @covers ::register
 	 */
 	public function test_register() {
 		$plugin = new \Google\Web_Stories\Plugin();

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -289,4 +289,30 @@ class Story_Post_Type extends \WP_UnitTestCase {
 			$editor->has_cap( $cap );
 		}
 	}
+
+
+	/**
+	 * @covers ::add_caps_to_roles
+	 * @covers \Google\Web_Stories::new_site
+	 */
+	public function test_add_caps_to_roles_multisite() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Test only runs on Multisite' );
+		}
+		$blog_id = $this->factory->blog->create();
+		switch_to_blog( $blog_id );
+
+		$post_type_object = get_post_type_object( \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG );
+		$all_capabilities = array_values( (array) $post_type_object->cap );
+
+		$administrator = get_role( 'administrator' );
+		$editor        = get_role( 'editor' );
+
+		foreach ( $all_capabilities as $cap ) {
+			$administrator->has_cap( $cap );
+			$editor->has_cap( $cap );
+		}
+
+		restore_current_blog();
+	}
 }

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -293,7 +293,7 @@ class Story_Post_Type extends \WP_UnitTestCase {
 
 	/**
 	 * @covers ::add_caps_to_roles
-	 * @covers \Google\Web_Stories::new_site
+	 * @covers \Google\Web_Stories\new_site
 	 * @group ms-required
 	 */
 	public function test_add_caps_to_roles_multisite() {

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -306,8 +306,8 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		$editor        = get_role( 'editor' );
 
 		foreach ( $all_capabilities as $cap ) {
-			$administrator->has_cap( $cap );
-			$editor->has_cap( $cap );
+			$this->assertTrue( $administrator->has_cap( $cap ) );
+			$this->assertTrue( $editor->has_cap( $cap ) );
 		}
 
 		restore_current_blog();

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -285,11 +285,10 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		$editor        = get_role( 'editor' );
 
 		foreach ( $all_capabilities as $cap ) {
-			$administrator->has_cap( $cap );
-			$editor->has_cap( $cap );
+			$this->assertTrue( $administrator->has_cap( $cap ) );
+			$this->assertTrue( $editor->has_cap( $cap ) );
 		}
 	}
-
 
 	/**
 	 * @covers ::add_caps_to_roles

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -294,11 +294,9 @@ class Story_Post_Type extends \WP_UnitTestCase {
 	/**
 	 * @covers ::add_caps_to_roles
 	 * @covers \Google\Web_Stories::new_site
+	 * @group ms-required
 	 */
 	public function test_add_caps_to_roles_multisite() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Test only runs on Multisite' );
-		}
 		$blog_id = $this->factory->blog->create();
 		switch_to_blog( $blog_id );
 

--- a/tests/phpunit/tests/Uninstall.php
+++ b/tests/phpunit/tests/Uninstall.php
@@ -72,10 +72,10 @@ class Uninstall extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group ms-required
+	 */
 	public function test_delete_site_options() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Test only runs on Multisite' );
-		}
 		\Google\Web_Stories\delete_site_options();
 		$this->assertFalse( get_site_transient( 'web_stories_updater' ) );
 	}

--- a/tests/phpunit/tests/Updater.php
+++ b/tests/phpunit/tests/Updater.php
@@ -171,11 +171,10 @@ class Updater extends \WP_UnitTestCase {
 		$this->assertSame( 0, $this->request_count );
 	}
 
+	/**
+	 * @group ms-required
+	 */
 	public function test_updater_data_missing_capabilities_multisite() {
-		if ( ! is_multisite() ) {
-			$this->markTestSkipped( 'Test only runs on Multisite' );
-		}
-
 		wp_set_current_user( self::$admin_id );
 		$expected = (object) [ 'foo' => 'bar' ];
 		$actual   = ( new \Google\Web_Stories\Updater() )->updater_data( $expected );


### PR DESCRIPTION
## Summary

Hook into `wp_initialize_site` when roles are setup in new site.

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2929
