### PR TITLE
Dashboard: Settings Publisher Logo UI 

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -96,7 +96,6 @@ export const UploadedContainer = styled.div`
   padding-bottom: 24px;
 `;
 
-export const LogoContainer = styled.div``;
 export const Logo = styled.img`
   object-fit: cover;
   width: 100%;

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -101,6 +101,7 @@ export const Logo = styled.img`
   object-fit: cover;
   width: 100%;
   height: 100%;
+  border-radius: 4px;
 `;
 
 export const DeleteLogoButton = styled.button`

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -91,8 +91,9 @@ export const FinePrintHelperText = styled.p`
 export const UploadedContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, 56px);
-  grid-template-rows: 56px;
+  grid-auto-rows: 56px;
   grid-column-gap: 12px;
+  grid-row-gap: 20px;
   padding-bottom: 24px;
 `;
 

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { TypographyPresets, FileUpload } from '../../../components';
+import { TypographyPresets } from '../../../components';
 import { visuallyHiddenStyles } from '../../../utils/visuallyHiddenStyles';
 
 export const Wrapper = styled.div`
@@ -32,17 +32,11 @@ export const Header = styled.header`
   padding-top: 100px;
 `;
 
-export const Heading = styled.h1`
+export const Heading = styled.h2`
   ${TypographyPresets.ExtraExtraLarge};
-  font-size: 50.67px;
-  line-height: 140%;
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
+  color: ${({ theme }) => theme.colors.black};
   padding: 0;
-  font-weight: bold;
-  color: ${({ theme }) => theme.colors.gray800};
-
-  @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {
-    font-size: 40.67px;
-  }
 `;
 
 export const Main = styled.main`
@@ -65,12 +59,11 @@ export const SettingForm = styled.form`
   }
 `;
 
-export const SettingHeading = styled.h2`
-  ${TypographyPresets.Large};
-  font-size: 18.667px;
+export const SettingHeading = styled.h3`
+  ${TypographyPresets.Small};
   font-weight: ${({ theme }) => theme.typography.weight.bold};
-  line-height: 140%;
-  color: ${({ theme }) => theme.colors.gray600};
+  color: ${({ theme }) => theme.colors.black};
+  padding-bottom: 8px;
 `;
 
 export const FormContainer = styled.div`
@@ -80,28 +73,55 @@ export const FormContainer = styled.div`
   }
 `;
 
-export const TextInputHelperText = styled.p`
+export const HelperText = styled.p`
   ${TypographyPresets.Small};
-  padding-top: 10px;
-  color: ${({ theme }) => theme.colors.gray500};
+  color: ${({ theme }) => theme.colors.gray200};
 `;
 
-export const FileUploadHelperText = styled.p`
-  ${TypographyPresets.Small};
-  font-size: 15px;
-  padding-bottom: 10px;
-  color: ${({ theme }) => theme.colors.gray500};
-  font-weight: 600;
+export const TextInputHelperText = styled(HelperText)`
+  padding-top: 10px;
 `;
 
 export const FinePrintHelperText = styled.p`
   ${TypographyPresets.ExtraSmall};
   padding-top: 10px;
-  color: ${({ theme }) => theme.colors.gray500};
+  color: ${({ theme }) => theme.colors.gray200};
 `;
 
-export const UploadContainer = styled(FileUpload)`
-  min-height: 153px;
+export const UploadedContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 56px);
+  grid-template-rows: 56px;
+  grid-column-gap: 12px;
+  padding-bottom: 24px;
+`;
+
+export const LogoContainer = styled.div``;
+export const Logo = styled.img`
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+`;
+
+export const DeleteLogoButton = styled.button`
+  position: relative;
+  left: 2px;
+  bottom: 30px;
+  width: 24px;
+  height: 24px;
+  text-align: center;
+
+  color: ${({ theme }) => theme.colors.white};
+  background: ${({ theme }) => theme.colors.gray700};
+  border-radius: 50%;
+  border: ${({ theme }) => theme.borders.transparent};
+  cursor: pointer;
+
+  & > svg {
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
 `;
 
 export const VisuallyHiddenDescription = styled.span(visuallyHiddenStyles);

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -31,7 +31,6 @@ import { useCallback } from 'react';
 import { getResourceFromLocalFile } from '../../../../utils';
 import {
   Logo,
-  LogoContainer,
   DeleteLogoButton,
   SettingForm,
   HelperText,
@@ -84,9 +83,7 @@ function PublisherLogoSettings({ onUpdatePublisherLogo, publisherLogos }) {
   return (
     <SettingForm>
       <div>
-        <SettingHeading htmlFor="publisherLogo">
-          {TEXT.SECTION_HEADING}
-        </SettingHeading>
+        <SettingHeading>{TEXT.SECTION_HEADING}</SettingHeading>
         <HelperText>{TEXT.CONTEXT}</HelperText>
       </div>
       <div>
@@ -94,7 +91,7 @@ function PublisherLogoSettings({ onUpdatePublisherLogo, publisherLogos }) {
           <UploadedContainer>
             {publisherLogos.map((publisherLogo, idx) => {
               return (
-                <LogoContainer
+                <div
                   key={`${publisherLogo.title}_${idx}`}
                   data-testid={`remove-publisher-logo-${idx}`}
                 >
@@ -109,7 +106,7 @@ function PublisherLogoSettings({ onUpdatePublisherLogo, publisherLogos }) {
                   >
                     <DeleteIcon aria-hidden="true" />
                   </DeleteLogoButton>
-                </LogoContainer>
+                </div>
               );
             })}
           </UploadedContainer>

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -43,7 +43,7 @@ import { FileUpload } from '../../../../components';
 import { Close as DeleteIcon } from '../../../../icons';
 
 export const TEXT = {
-  SECTION_HEADING: __('Publisher Logo', 'web-stories'),
+  SECTION_HEADING: __('Published Logo', 'web-stories'),
   CONTEXT: __(
     'Upload your logos here and they will become available to any stories you create.',
     'web-stories'
@@ -120,7 +120,7 @@ function PublisherLogoSettings({ onUpdatePublisherLogo, publisherLogos }) {
           label={TEXT.SUBMIT}
           isMultiple
           ariaLabel={TEXT.ARIA_LABEL}
-          emptyDragHelperText={TEXT.HELPER_UPLOAD}
+          instructionalText={TEXT.HELPER_UPLOAD}
         />
         <FinePrintHelperText>{TEXT.INSTRUCTIONS}</FinePrintHelperText>
       </div>

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -17,7 +17,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -30,12 +30,17 @@ import { useCallback } from 'react';
  */
 import { getResourceFromLocalFile } from '../../../../utils';
 import {
+  Logo,
+  LogoContainer,
+  DeleteLogoButton,
   SettingForm,
-  FileUploadHelperText,
+  HelperText,
   FinePrintHelperText,
-  UploadContainer,
+  UploadedContainer,
   SettingHeading,
 } from '../components';
+import { FileUpload } from '../../../../components';
+import { Close as DeleteIcon } from '../../../../icons';
 
 const TEXT = {
   SECTION_HEADING: __('Publisher Logo', 'web-stories'),
@@ -44,12 +49,15 @@ const TEXT = {
     'web-stories'
   ),
   INSTRUCTIONS: __(
-    'Click on upload or drag a jpg, png, or static gif in the box above. Avoid vector files, such as svg or eps. Logos should be at least 96x96 pixels and a perfect square. The background should not be transparent.',
+    'Avoid vector files, such as svg or eps. Logos should be at least 96x96 pixels and a perfect square. The background should not be transparent.',
     'web-stories'
   ),
-  SUBMIT: __('Upload', 'web-stories'),
+  SUBMIT: __('Upload logo', 'web-stories'),
   ARIA_LABEL: __('Click to upload a new logo', 'web-stories'),
-  HELPER_UPLOAD: __('You can also drag your logo here', 'web-stories'),
+  HELPER_UPLOAD: __(
+    'Drag a jpg, png, or static gif in this box. Or click “Upload logo” below.',
+    'web-stories'
+  ),
 };
 
 function PublisherLogoSettings({ onUpdatePublisherLogo, publisherLogos }) {
@@ -75,19 +83,41 @@ function PublisherLogoSettings({ onUpdatePublisherLogo, publisherLogos }) {
 
   return (
     <SettingForm>
-      <SettingHeading htmlFor="publisherLogo">
-        {TEXT.SECTION_HEADING}
-      </SettingHeading>
       <div>
-        <FileUploadHelperText>{TEXT.CONTEXT}</FileUploadHelperText>
-        <UploadContainer
+        <SettingHeading htmlFor="publisherLogo">
+          {TEXT.SECTION_HEADING}
+        </SettingHeading>
+        <HelperText>{TEXT.CONTEXT}</HelperText>
+      </div>
+      <div>
+        {publisherLogos.length > 0 && (
+          <UploadedContainer>
+            {publisherLogos.map((publisherLogo, idx) => {
+              return (
+                <LogoContainer key={`${publisherLogo.title}_${idx}`}>
+                  <Logo src={publisherLogo.src} alt={publisherLogo.title} />
+                  <DeleteLogoButton
+                    aria-label={sprintf(
+                      /* translators: %s: uploaded logo title */
+                      __('delete %s as a publisher logo', 'web-stories'),
+                      publisherLogo.title
+                    )}
+                    onClick={(e) => onSubmitDeleteFile(e, publisherLogo)}
+                  >
+                    <DeleteIcon aria-hidden="true" />
+                  </DeleteLogoButton>
+                </LogoContainer>
+              );
+            })}
+          </UploadedContainer>
+        )}
+        <FileUpload
           onSubmit={onSubmitNewFile}
           onDelete={onSubmitDeleteFile}
           id="settings_publisher_logos"
           label={TEXT.SUBMIT}
           isMultiple
           ariaLabel={TEXT.ARIA_LABEL}
-          uploadedContent={publisherLogos}
           emptyDragHelperText={TEXT.HELPER_UPLOAD}
         />
         <FinePrintHelperText>{TEXT.INSTRUCTIONS}</FinePrintHelperText>

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -42,7 +42,7 @@ import {
 import { FileUpload } from '../../../../components';
 import { Close as DeleteIcon } from '../../../../icons';
 
-const TEXT = {
+export const TEXT = {
   SECTION_HEADING: __('Publisher Logo', 'web-stories'),
   CONTEXT: __(
     'Upload your logos here and they will become available to any stories you create.',
@@ -94,7 +94,10 @@ function PublisherLogoSettings({ onUpdatePublisherLogo, publisherLogos }) {
           <UploadedContainer>
             {publisherLogos.map((publisherLogo, idx) => {
               return (
-                <LogoContainer key={`${publisherLogo.title}_${idx}`}>
+                <LogoContainer
+                  key={`${publisherLogo.title}_${idx}`}
+                  data-testid={`remove-publisher-logo-${idx}`}
+                >
                   <Logo src={publisherLogo.src} alt={publisherLogo.title} />
                   <DeleteLogoButton
                     aria-label={sprintf(
@@ -113,7 +116,6 @@ function PublisherLogoSettings({ onUpdatePublisherLogo, publisherLogos }) {
         )}
         <FileUpload
           onSubmit={onSubmitNewFile}
-          onDelete={onSubmitDeleteFile}
           id="settings_publisher_logos"
           label={TEXT.SUBMIT}
           isMultiple

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/stories/index.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { useState, useCallback } from 'react';
 import { action } from '@storybook/addon-actions';
 
 /**
@@ -30,12 +31,41 @@ export default {
 };
 
 export const _default = () => {
+  const [uploadedContent, setUploadedContent] = useState([]);
+
+  const handleSubmit = useCallback(({ newPublisherLogos, deleteLogo }) => {
+    if (newPublisherLogos) {
+      action('onSubmit fired')(newPublisherLogos);
+
+      setUploadedContent((existingUploads) => {
+        const newUploads = newPublisherLogos.map(({ file, localResource }) => {
+          return {
+            src: localResource.src,
+            title: file.name,
+            alt: localResource.alt,
+          };
+        });
+
+        return [...existingUploads, ...newUploads];
+      });
+    }
+
+    if (deleteLogo) {
+      action('onDelete fired')(deleteLogo);
+
+      setUploadedContent((existingUploadedContent) => {
+        const revisedMockUploads = existingUploadedContent.filter(
+          (uploadedLogo) => uploadedLogo.title !== deleteLogo.title
+        );
+        return revisedMockUploads;
+      });
+    }
+  }, []);
+
   return (
     <PublisherLogoSettings
-      onUpdatePublisherLogo={(newFiles) => {
-        action('update publisher logo clicked')(newFiles);
-      }}
-      publisherLogos={[]}
+      onUpdatePublisherLogo={handleSubmit}
+      publisherLogos={uploadedContent}
     />
   );
 };

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/test/publisherLogo.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/test/publisherLogo.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { renderWithTheme } from '../../../../../testUtils';
+
+import PublisherLogoSettings, { TEXT } from '..';
+
+describe('PublisherLogo', () => {
+  const mockUpdatePublisherLogo = jest.fn();
+  it('should render a fileUpload container and helper text by default', () => {
+    const { getByTestId, getByText } = renderWithTheme(
+      <PublisherLogoSettings
+        onUpdatePublisherLogo={mockUpdatePublisherLogo}
+        publisherLogos={[]}
+      />
+    );
+
+    expect(getByTestId('upload-file-input')).toBeInTheDocument();
+    expect(getByText(TEXT.SECTION_HEADING)).toBeInTheDocument();
+  });
+
+  it('should trigger onUpdatePublisherLogo when delete button is clicked on an uploaded file', () => {
+    const { getByTestId } = renderWithTheme(
+      <PublisherLogoSettings
+        onUpdatePublisherLogo={mockUpdatePublisherLogo}
+        publisherLogos={[
+          {
+            src: 'source-that-displays-an-image',
+            title: 'mockfile.png',
+            alt: 'mockfile.png',
+          },
+        ]}
+      />
+    );
+
+    const DeleteFileButton = getByTestId('remove-publisher-logo-0').lastChild;
+    expect(DeleteFileButton).toBeDefined();
+    fireEvent.click(DeleteFileButton);
+    expect(mockUpdatePublisherLogo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assets/src/dashboard/components/fileUpload/index.js
+++ b/assets/src/dashboard/components/fileUpload/index.js
@@ -67,6 +67,10 @@ const UploadLabelAsCta = styled(DefaultButton).attrs({
   z-index: 10;
   font-size: 14px;
   line-height: 16px;
+
+  &:focus-within {
+    border: ${({ theme }) => theme.borders.action};
+  }
 `;
 
 function disableDefaults(e) {

--- a/assets/src/dashboard/components/fileUpload/index.js
+++ b/assets/src/dashboard/components/fileUpload/index.js
@@ -17,7 +17,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -31,7 +31,6 @@ import styled from 'styled-components';
 import { DEFAULT_FILE_UPLOAD_TYPES } from '../../constants';
 import { visuallyHiddenStyles } from '../../utils/visuallyHiddenStyles';
 import { DefaultButton } from '../button';
-import { Close as _DeleteIcon, UploadIcon as _UploadIcon } from '../../icons';
 import { TypographyPresets } from '../typography';
 
 const Input = styled.input(visuallyHiddenStyles);
@@ -43,103 +42,23 @@ const UploadFormArea = styled.div`
   justify-content: flex-end;
   width: 100%;
   min-height: 153px;
-  padding: 36px 36px 10px;
+  padding: 40px 0;
   border-radius: 4px;
   border: ${({ isDragging, theme }) =>
-    isDragging ? theme.borders.bluePrimary : theme.borders.transparent};
-  border-width: 2px;
-  background-color: ${({ theme }) => theme.colors.gray25};
+    isDragging ? theme.borders.bluePrimary : theme.borders.gray100};
+  border-style: dashed;
 
   transition: border-color 300ms ease-in;
 `;
 
-const StaticUploadArea = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  color: ${({ theme }) => theme.colors.gray500};
-  z-index: 0;
-`;
-
-const StaticAreaText = styled.span`
-  ${TypographyPresets.Medium};
-  margin: 0 auto 20px;
-`;
-
-const StaticAreaIcon = styled(_UploadIcon)`
-  width: 52px;
-  height: 52px;
-`;
-const UploadedContentContainer = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-self: flex-start;
-`;
-
-const DeleteButton = styled.button`
-  position: absolute;
-  z-index: 10;
-  border-radius: 100%;
-  width: 30px;
-  height: 30px;
-  margin-top: -10px;
-  margin-left: -10px;
-  background-color: ${({ theme }) => theme.colors.gray75};
-  color: ${({ theme }) => theme.colors.gray500};
-  border: ${({ theme }) => theme.borders.transparent};
-  opacity: 1;
-
-  transition: opacity 300ms ease-in-out;
-`;
-
-const UploadedContent = styled.div`
-  width: 60px;
-  margin: 0 15px 10px 0;
-
-  ${DeleteButton} {
-    opacity: 0;
-    visibility: none;
-  }
-
-  &:hover,
-  &:focus {
-    ${DeleteButton} {
-      opacity: 1;
-      visibility: visible;
-    }
-  }
-`;
-
-const DisplayImage = styled.img`
-  width: 100%;
-  height: 60px;
-  margin-bottom: 5px;
-  object-fit: cover;
-`;
-
-const DeleteIcon = styled(_DeleteIcon)`
-  width: 100%;
-  height: 100%;
-`;
-
-const DisplayTitle = styled.span`
+const UploadHelperText = styled.span`
   ${TypographyPresets.ExtraSmall};
-  display: inline-block;
-  width: 100%;
-  margin-right: 0.5em;
-  white-space: normal;
-  word-break: break-word;
+  margin: 0 auto 16px;
+  padding: 0 20%;
+  color: ${({ theme }) => theme.colors.gray200};
 `;
 
+/* TODO: new button styles */
 const UploadLabelAsCta = styled(DefaultButton).attrs({
   as: 'label',
 })`
@@ -158,13 +77,10 @@ function disableDefaults(e) {
 const FileUpload = ({
   id,
   label,
-  onDelete,
   onSubmit,
-  isFileNameVisible,
   isMultiple,
   ariaLabel,
-  emptyDragHelperText = __('You can also drag your file here', 'web-stories'),
-  uploadedContent = [],
+  instructionalText = __('You can also drag your file here', 'web-stories'),
   acceptableFormats = DEFAULT_FILE_UPLOAD_TYPES,
 }) => {
   const uploadFileContainer = useRef(null);
@@ -211,13 +127,6 @@ const FileUpload = ({
     [isDragging]
   );
 
-  const handleDeleteFile = useCallback(
-    (index, fileData) => {
-      onDelete(index, fileData);
-    },
-    [onDelete]
-  );
-
   useEffect(() => {
     if (!fileInputRef?.current) {
       return;
@@ -229,7 +138,6 @@ const FileUpload = ({
     };
   }, [handleChange]);
 
-  const hasUploadedContent = uploadedContent.length > 0;
   return (
     <UploadFormArea
       ref={uploadFileContainer}
@@ -240,38 +148,7 @@ const FileUpload = ({
       onDragOver={disableDefaults}
       data-testid="file-upload-drop-area"
     >
-      {hasUploadedContent ? (
-        <UploadedContentContainer data-testid="file-upload-content-container">
-          {uploadedContent.map((file, idx) => (
-            <UploadedContent key={idx}>
-              {Boolean(onDelete) && (
-                <DeleteButton
-                  data-testid={`file-upload-delete-button_${idx}`}
-                  onClick={() => handleDeleteFile(idx, file)}
-                  aria-label={sprintf(
-                    /* translators: %s is the file name to delete */
-                    __('Delete %s', 'web-stories'),
-                    file.title
-                  )}
-                >
-                  <DeleteIcon />
-                </DeleteButton>
-              )}
-              <DisplayImage
-                alt={file.title}
-                title={file.title}
-                src={file.src}
-              />
-              {isFileNameVisible && <DisplayTitle>{file.title}</DisplayTitle>}
-            </UploadedContent>
-          ))}
-        </UploadedContentContainer>
-      ) : (
-        <StaticUploadArea aria-hidden={true}>
-          <StaticAreaIcon />
-          <StaticAreaText>{emptyDragHelperText}</StaticAreaText>
-        </StaticUploadArea>
-      )}
+      <UploadHelperText>{instructionalText}</UploadHelperText>
 
       <UploadLabelAsCta htmlFor={id} aria-label={ariaLabel}>
         {label}
@@ -291,16 +168,11 @@ const FileUpload = ({
 FileUpload.propTypes = {
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   label: PropTypes.string.isRequired,
-  onDelete: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,
   isMultiple: PropTypes.bool,
-  isFileNameVisible: PropTypes.bool,
   ariaLabel: PropTypes.string,
   acceptableFormats: PropTypes.arrayOf(PropTypes.string),
-  uploadedContent: PropTypes.arrayOf(
-    PropTypes.shape({ src: PropTypes.string, name: PropTypes.string })
-  ),
-  emptyDragHelperText: PropTypes.string,
+  instructionalText: PropTypes.string,
 };
 
 export default FileUpload;

--- a/assets/src/dashboard/components/fileUpload/stories/index.js
+++ b/assets/src/dashboard/components/fileUpload/stories/index.js
@@ -46,7 +46,7 @@ export const _default = () => {
         ariaLabel={'Click to upload a file'}
         instructionalText={text(
           'instructionalText',
-          'You can also drag your logo here'
+          'Drag a jpg, png, or static gif in this box. Or click “Upload logo” below.'
         )}
       />
     </Container>

--- a/assets/src/dashboard/components/fileUpload/stories/index.js
+++ b/assets/src/dashboard/components/fileUpload/stories/index.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import { useState, useCallback } from 'react';
 import styled from 'styled-components';
 import { text, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
@@ -26,7 +25,6 @@ import { action } from '@storybook/addon-actions';
  * Internal dependencies
  */
 import FileUpload from '../';
-import { getResourceFromLocalFile } from '../../../utils';
 
 const Container = styled.div`
   width: 600px;
@@ -37,51 +35,17 @@ export default {
 };
 
 export const _default = () => {
-  const [uploadedContent, setUploadedContent] = useState([]);
-
-  const formatFiles = async (files) => {
-    action('onSubmit fired')(files);
-    const resources = await Promise.all(
-      files.map(async (file) => ({
-        localResource: await getResourceFromLocalFile(file),
-        file,
-      }))
-    );
-    setUploadedContent((existingUploads) => {
-      const newUploads = resources.map(({ file, localResource }) => {
-        return {
-          src: localResource.src,
-          title: file.name,
-          alt: localResource.alt,
-        };
-      });
-
-      return [...existingUploads, ...newUploads];
-    });
-  };
-
-  const deleteUploadedContent = useCallback((index, fileData) => {
-    action('onDelete fired')(index, fileData);
-    setUploadedContent((existingUploadedContent) => {
-      existingUploadedContent.splice(index, 1);
-      return [...existingUploadedContent];
-    });
-  }, []);
-
   return (
     <Container>
       <FileUpload
         acceptableFormats={['.jpg', '.jpeg', '.png', '.gif']}
-        onSubmit={formatFiles}
-        onDelete={deleteUploadedContent}
+        onSubmit={action('files uploaded')}
         id={'898989'}
         label={text('label', 'Upload')}
         isMultiple={boolean('isMultiple', true)}
-        isFileNameVisible={boolean('isFileNameVisible', false)}
         ariaLabel={'Click to upload a file'}
-        uploadedContent={uploadedContent}
-        emptyDragHelperText={text(
-          'emptyDragHelperText',
+        instructionalText={text(
+          'instructionalText',
           'You can also drag your logo here'
         )}
       />

--- a/assets/src/dashboard/components/fileUpload/test/fileUpload.js
+++ b/assets/src/dashboard/components/fileUpload/test/fileUpload.js
@@ -97,30 +97,4 @@ describe('FileUpload', () => {
 
     expect(onSubmitMock).toHaveBeenCalledTimes(1);
   });
-
-  it('should trigger onDelete when delete button is clicked on an uploaded file', () => {
-    const onDeleteMock = jest.fn();
-
-    const { getByTestId } = renderWithTheme(
-      <FileUpload
-        onSubmit={jest.fn}
-        onDelete={onDeleteMock}
-        id={'898989'}
-        label="Upload"
-        ariaLabel="Click to upload a file"
-        uploadedContent={[
-          {
-            src: 'source-that-displays-an-image',
-            title: 'mockfile.png',
-            alt: 'mockfile.png',
-          },
-        ]}
-      />
-    );
-
-    const DeleteFileButton = getByTestId('file-upload-delete-button_0');
-    expect(DeleteFileButton).toBeDefined();
-    fireEvent.click(DeleteFileButton);
-    expect(onDeleteMock).toHaveBeenCalledTimes(1);
-  });
 });

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -70,6 +70,8 @@ const colors = {
   selection: '#44aaff',
   warning: '#FF9800',
   success: '#4CAF4F',
+  // Updated design colors
+  black: '#000',
   // todo
   placeholder: '#d9dbdd',
   storyPreviewBackground: '#202125',
@@ -176,11 +178,11 @@ const theme = {
     presets: {
       xxl: {
         family: themeFonts.primary,
-        size: 32,
+        size: 36,
         minSize: 18,
-        lineHeight: 53,
-        minLineHeight: 43,
-        letterSpacing: -0.005,
+        lineHeight: 40,
+        minLineHeight: 40,
+        letterSpacing: -0.01,
         minLetterSpacing: -0.01,
       },
       xl: {


### PR DESCRIPTION
## Summary
- Moves closer to updated design specs. Pending some shared resources with colors and buttons. New designs are here: https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Stories-Stable?node-id=521%3A839 
- Moves container to show uploaded files into publisher logos component instead of file uploader, which makes more sense and allows flexibility of potential reuse. 
- Text updates per design specs to publisher logos section 
<img width="1082" alt="Screen Shot 2020-08-12 at 1 32 25 PM" src="https://user-images.githubusercontent.com/10720454/90064893-46dd2e80-dca0-11ea-9f88-64c270f1b587.png">


## Relevant Technical Choices
- Show publisher logos when they are present
- Nothing too technical, just moving functionality that had been in the fileUpload component up to prep for connecting API.

## To-do
- Rest of design updates (later)
- connect API (will happen next) 

## User-facing changes
None

## Testing Instructions
Look at storybook Dashboard > Views > EditorSettings > PublisherLogo and see updates. You can upload/remove images here too if you want - it's just local. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #3854 
