### PR TITLE
Fixed range handle color

### DIFF
--- a/assets/src/edit-story/components/rangeInput/index.js
+++ b/assets/src/edit-story/components/rangeInput/index.js
@@ -30,14 +30,14 @@ const rangeThumb = css`
   appearance: none;
   width: ${({ thumbSize = 16 }) => thumbSize}px;
   height: ${({ thumbSize = 16 }) => thumbSize}px;
-  background-color: ${({ theme }) => theme.colors.fg.v1};
+  background-color: ${({ theme }) => theme.colors.fg.white};
   cursor: pointer;
   border-radius: 50px;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
 `;
 
 const focusedRangeThumb = css`
-  background-color: ${({ theme }) => theme.colors.action};
+  background-color: ${({ theme }) => theme.colors.accent.primary};
 `;
 
 const Input = styled.input.attrs({


### PR DESCRIPTION
## Summary

I found a bug where the range handle wasn't correctly colored due to bad merge after first visual color pass combined with a11y optimizations.

This happens to also fix an old ticket in #1425.

## Relevant Technical Choices

* Use proper color names (maybe we should start throwing errors for invalid color names?)

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

* Sliders / range inputs now have a white color when unfocused and blue when focused.

## Testing Instructions

#### Document page advancement time

1. Go to the document panel and scroll down
1. Make sure page advancement is set to manual
1. Observe that range slider handle is white
1. Drag range slider handle to change value
1. Observe that while focused range slider handle is blue

#### Image size slider

1. Add an image to a page
1. Double click image to edit
1. Observe that range slider handle is white
1. Drag range slider handle to change value
1. Observe that while focused range slider handle is blue

#### Page grid thumbnail size slider

1. Click the button next to the page carousel to enter page grid view
1. Observe that range slider handle is white
1. Drag range slider handle to change value
1. Observe that while focused range slider handle is blue

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1425
