### PR TITLE
"(demo) Add originalWidth and originalHeight that can be used in absence of width/height

### DIFF
--- a/assets/src/edit-story/app/media/utils/getResourceFromMedia3p.js
+++ b/assets/src/edit-story/app/media/utils/getResourceFromMedia3p.js
@@ -94,7 +94,7 @@ function getImageUrls(m) {
 
   const sizesFromBiggest = m.imageUrls
     .sort((x, y) => y.width - x.width)
-    .map((u) => mediaUrlToImageSizeDescription(m, u));
+    .map((u) => mediaUrlToImageSizeDescription(m, u, m.imageUrls[0].width, m.imageUrls[0].height));
   const namedSizes = [
     ['full', sizesFromBiggest[0]],
     ['large', sizesFromBiggest[1]],
@@ -127,20 +127,22 @@ function getVideoUrls(m) {
 
   const sizesFromBiggest = m.videoUrls
     .sort((x, y) => y.width - x.width)
-    .map((u) => mediaUrlToImageSizeDescription(m, u));
+    .map((u) => mediaUrlToImageSizeDescription(m, u, m.videoUrls[0].width, m.videoUrls[0].height));
   return {
     full: sizesFromBiggest[0],
     preview: sizesFromBiggest[sizesFromBiggest.length - 1],
   };
 }
 
-function mediaUrlToImageSizeDescription(media, url) {
+function mediaUrlToImageSizeDescription(media, url, originalWidth, originalHeight) {
   return {
     file: media.name,
     source_url: url.url,
     mime_type: url.mimeType,
     width: url.width,
     height: url.height,
+    originalWidth,
+    originalHeight,
   };
 }
 

--- a/assets/src/edit-story/components/library/panes/media/common/mediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaGallery.js
@@ -49,8 +49,8 @@ const PhotoContainer = styled.div.attrs((props) => ({
 function MediaGallery({ resources, onInsert, providerType }) {
   const photos = resources.map((resource) => ({
     src: resource.src,
-    width: resource.width,
-    height: resource.height,
+    width: resource.width ?? resource.originalWidth,
+    height: resource.height ?? resource.originalHeight,
   }));
 
   const imageRenderer = useCallback(


### PR DESCRIPTION
## Summary

Demo of adding originalWidth and originalHeight to resource/sizes. This could be used in absence of width/height from Coverr, since MediaGallery does not require the actual width/height of each media element thumbnail.

An alternative is to add width/height to the backend, with a fixed width=640px.

