### PR TITLE
Make stack traces more readable

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -110,6 +110,10 @@ const sharedConfig = {
         sourceMap: false,
         cache: true,
         terserOptions: {
+          // We preserve function names that start with capital letters as
+          // they're _likely_ component names, and these are useful to have
+          // in tracebacks and error messages.
+          keep_fnames: /__|_x|_n|_nx|sprintf|^[A-Z].+$/,
           output: {
             comments: /translators:/i,
           },


### PR DESCRIPTION
## Summary

Amend webpack config like so:
```
terserOptions: {
	[...]
	// We preserve function names that start with capital letters as
	// they're _likely_ component names, and these are useful to have
	// in tracebacks and error messages.
	keep_fnames: /__|_x|_n|_nx|sprintf|^[A-Z].+$/,
}
```

Site Kit uses this: google/site-kit-wp#976

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3694
