### PR TITLE
Animation: Resizable and Draggable Animation Bar

### DIFF
--- a/assets/src/edit-story/components/animationTimeline/components.js
+++ b/assets/src/edit-story/components/animationTimeline/components.js
@@ -28,7 +28,7 @@ const TIMELINE_HEIGHT = 180;
 export const TimelineContainer = styled.div`
   display: flex;
   box-sizing: border-box;
-  font-family: Roboto;
+  font-family: Roboto, sans-serif;
   height: ${TIMELINE_HEIGHT}px;
   background: ${({ theme }) => theme.colors.bg.v16};
   color: ${({ theme }) => theme.colors.fg.white};

--- a/assets/src/edit-story/components/animationTimeline/components.js
+++ b/assets/src/edit-story/components/animationTimeline/components.js
@@ -28,7 +28,7 @@ const TIMELINE_HEIGHT = 180;
 export const TimelineContainer = styled.div`
   display: flex;
   box-sizing: border-box;
-  font-family: Roboto, sans-serif;
+  font-family: ${({ theme }) => theme.fonts.label.family};
   height: ${TIMELINE_HEIGHT}px;
   background: ${({ theme }) => theme.colors.bg.v16};
   color: ${({ theme }) => theme.colors.fg.white};

--- a/assets/src/edit-story/components/animationTimeline/components.js
+++ b/assets/src/edit-story/components/animationTimeline/components.js
@@ -64,6 +64,8 @@ export const TimelineTitleBar = styled.div`
 `;
 
 export const TimelineRow = styled.div`
+  display: flex;
+  align-items: center;
   height: ${ROW_HEIGHT}px;
   min-width: 100%;
   ${({ alternating, theme }) =>

--- a/assets/src/edit-story/components/animationTimeline/index.js
+++ b/assets/src/edit-story/components/animationTimeline/index.js
@@ -60,8 +60,10 @@ export default function AnimationTimeline({
             alternating={Boolean(index % 2)}
           >
             <TimingBar
+              label={animation.label}
               offset={animation.offset}
               duration={animation.duration}
+              maxDuration={duration}
               onUpdateAnimation={(delta) => onUpdateAnimation(animation, delta)}
             />
           </TimelineRow>

--- a/assets/src/edit-story/components/animationTimeline/index.js
+++ b/assets/src/edit-story/components/animationTimeline/index.js
@@ -31,6 +31,7 @@ import {
   TimelineRow,
 } from './components';
 import AnimationRuler from './ruler';
+import TimingBar from './timingBar';
 
 export default function AnimationTimeline({ animations, duration }) {
   return (
@@ -53,7 +54,9 @@ export default function AnimationTimeline({ animations, duration }) {
             data-testid="timeline-animation-item"
             key={`timeline-animation-item-${animation.id}`}
             alternating={Boolean(index % 2)}
-          />
+          >
+            <TimingBar duration={animation.duration} />
+          </TimelineRow>
         ))}
       </TimelineTimingContainer>
     </TimelineContainer>

--- a/assets/src/edit-story/components/animationTimeline/index.js
+++ b/assets/src/edit-story/components/animationTimeline/index.js
@@ -33,7 +33,11 @@ import {
 import AnimationRuler from './ruler';
 import TimingBar from './timingBar';
 
-export default function AnimationTimeline({ animations, duration }) {
+export default function AnimationTimeline({
+  animations,
+  duration,
+  onUpdateAnimation,
+}) {
   return (
     <TimelineContainer>
       <TimelineLegend>
@@ -66,4 +70,5 @@ export default function AnimationTimeline({ animations, duration }) {
 AnimationTimeline.propTypes = {
   animations: propTypes.arrayOf(propTypes.object).isRequired,
   duration: propTypes.number.isRequired,
+  onUpdateAnimation: propTypes.func.isRequired,
 };

--- a/assets/src/edit-story/components/animationTimeline/index.js
+++ b/assets/src/edit-story/components/animationTimeline/index.js
@@ -59,7 +59,11 @@ export default function AnimationTimeline({
             key={`timeline-animation-item-${animation.id}`}
             alternating={Boolean(index % 2)}
           >
-            <TimingBar duration={animation.duration} />
+            <TimingBar
+              offset={animation.offset}
+              duration={animation.duration}
+              onUpdateAnimation={(delta) => onUpdateAnimation(animation, delta)}
+            />
           </TimelineRow>
         ))}
       </TimelineTimingContainer>

--- a/assets/src/edit-story/components/animationTimeline/ruler.js
+++ b/assets/src/edit-story/components/animationTimeline/ruler.js
@@ -34,7 +34,7 @@ const Path = styled.path`
 `;
 
 const Text = styled.text`
-  font-family: Roboto, sans-serif;
+  font-family: ${({ theme }) => theme.fonts.label.family};
   font-size: 13px;
   fill: ${({ theme }) => rgba(theme.colors.fg.white, 0.8)};
 `;

--- a/assets/src/edit-story/components/animationTimeline/ruler.js
+++ b/assets/src/edit-story/components/animationTimeline/ruler.js
@@ -40,12 +40,14 @@ const Text = styled.text`
 `;
 
 export const MARK_OFFSET = 40.0;
+export const MS_DIVISOR = 100.0;
+
 const RULER_HEIGHT = 24.0;
 
 const isMajor = (index) => index % 10 === 0;
 
 export default function AnimationRuler({ duration }) {
-  const numberOfMarks = Math.ceil(duration / 100);
+  const numberOfMarks = Math.ceil(duration / MS_DIVISOR);
   const range = [...Array(numberOfMarks).keys()];
   return (
     <svg

--- a/assets/src/edit-story/components/animationTimeline/ruler.js
+++ b/assets/src/edit-story/components/animationTimeline/ruler.js
@@ -34,12 +34,12 @@ const Path = styled.path`
 `;
 
 const Text = styled.text`
-  font-family: Roboto;
+  font-family: Roboto, sans-serif;
   font-size: 13px;
   fill: ${({ theme }) => rgba(theme.colors.fg.white, 0.8)};
 `;
 
-const MARK_OFFSET = 40.0;
+export const MARK_OFFSET = 40.0;
 const RULER_HEIGHT = 24.0;
 
 const isMajor = (index) => index % 10 === 0;

--- a/assets/src/edit-story/components/animationTimeline/ruler.js
+++ b/assets/src/edit-story/components/animationTimeline/ruler.js
@@ -58,7 +58,7 @@ export default function AnimationRuler({ duration }) {
         {range.map((value, index) => {
           const isValueMajor = isMajor(index);
           return (
-            <>
+            <React.Fragment key={`ruler-mark-${value}`}>
               {isValueMajor && (
                 <Text x={value * MARK_OFFSET + 5} y={20}>
                   {sprintf(
@@ -75,7 +75,7 @@ export default function AnimationRuler({ duration }) {
                   isValueMajor ? 8 : 18
                 },${RULER_HEIGHT} Z`}
               />
-            </>
+            </React.Fragment>
           );
         })}
       </g>

--- a/assets/src/edit-story/components/animationTimeline/stories/index.js
+++ b/assets/src/edit-story/components/animationTimeline/stories/index.js
@@ -27,6 +27,7 @@ export default {
 
 const animations = Array.from(Array(10).keys()).map((id) => ({
   id,
+  duration: id * 10 + 20,
 }));
 
 export const _default = () => {

--- a/assets/src/edit-story/components/animationTimeline/stories/index.js
+++ b/assets/src/edit-story/components/animationTimeline/stories/index.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import React, { useCallback, useState } from 'react';
+
+/**
  * Internal dependencies
  */
 
@@ -25,21 +30,46 @@ export default {
   component: AnimationTimeline,
 };
 
-const animations = Array.from(Array(10).keys()).map((id) => ({
-  id,
-  duration: id * 10 + 20,
-}));
-
 export const _default = () => {
+  const [animations, setAnimations] = useState(
+    Array.from(Array(10).keys()).reduce((acc, id) => {
+      acc[id] = {
+        id,
+        duration: 1000,
+        offset: id % 2 ? 500 : 0,
+      };
+      return acc;
+    }, {})
+  );
+
+  const handleUpdateAnimation = useCallback(({ id }, { duration, offset }) => {
+    setAnimations((a) => {
+      a[id].duration = duration;
+      a[id].offset = offset;
+      return { ...a };
+    });
+  }, []);
+
   return (
     <AnimationTimeline
-      animations={animations}
+      animations={Object.values(animations)}
       duration={3500}
-      onUpdateAnimation={() => {}}
+      onUpdateAnimation={handleUpdateAnimation}
     />
   );
 };
 
 export const noAnimations = () => {
-  return <AnimationTimeline animations={[]} duration={5000} />;
+  const animations = Array.from(Array(10).keys()).map((id) => ({
+    id,
+    duration: id * 100 + 20,
+  }));
+
+  return (
+    <AnimationTimeline
+      animations={[]}
+      duration={5000}
+      onUpdateAnimation={() => {}}
+    />
+  );
 };

--- a/assets/src/edit-story/components/animationTimeline/stories/index.js
+++ b/assets/src/edit-story/components/animationTimeline/stories/index.js
@@ -31,7 +31,13 @@ const animations = Array.from(Array(10).keys()).map((id) => ({
 }));
 
 export const _default = () => {
-  return <AnimationTimeline animations={animations} duration={3500} />;
+  return (
+    <AnimationTimeline
+      animations={animations}
+      duration={3500}
+      onUpdateAnimation={() => {}}
+    />
+  );
 };
 
 export const noAnimations = () => {

--- a/assets/src/edit-story/components/animationTimeline/stories/index.js
+++ b/assets/src/edit-story/components/animationTimeline/stories/index.js
@@ -35,8 +35,9 @@ export const _default = () => {
     Array.from(Array(10).keys()).reduce((acc, id) => {
       acc[id] = {
         id,
-        duration: 1000,
-        offset: id % 2 ? 500 : 0,
+        duration: 500,
+        offset: id % 2 ? 100 : 0,
+        label: `Animation ${id}`,
       };
       return acc;
     }, {})
@@ -53,18 +54,13 @@ export const _default = () => {
   return (
     <AnimationTimeline
       animations={Object.values(animations)}
-      duration={3500}
+      duration={1500}
       onUpdateAnimation={handleUpdateAnimation}
     />
   );
 };
 
 export const noAnimations = () => {
-  const animations = Array.from(Array(10).keys()).map((id) => ({
-    id,
-    duration: id * 100 + 20,
-  }));
-
   return (
     <AnimationTimeline
       animations={[]}

--- a/assets/src/edit-story/components/animationTimeline/timingBar.js
+++ b/assets/src/edit-story/components/animationTimeline/timingBar.js
@@ -17,14 +17,19 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import React, { useRef, useState } from 'react';
 import propTypes from 'prop-types';
 import styled from 'styled-components';
+import Moveable from 'react-moveable';
 
 const BAR_HEIGHT = 24;
 
 const Bar = styled.div`
   position: relative;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
   background-color: #3988f7;
   width: ${({ width }) => (width / 10) * 40}px;
   height: ${BAR_HEIGHT}px;
@@ -39,17 +44,59 @@ const Bar = styled.div`
   );
 `;
 
-const Handle = styled.div``;
+const Handle = styled.div`
+  background-color: white;
+  width: 14px;
+  height: 14px;
+  transform: rotate(45deg);
+  margin: 6px;
+`;
+
+const Label = styled.span`
+  font-weight: bold;
+`;
+
+const commonMovableProps = {
+  originDraggable: false,
+  origin: false,
+  draggable: true,
+};
 
 export default function TimingBar({ duration }) {
+  const [leftRef, setLeftRef] = useState(null);
+  const [rightRef, setRightRef] = useState(null);
   return (
     <Bar width={duration}>
-      <Handle position="left" />
-      <Handle position="right" />
+      <Handle ref={setLeftRef}>
+        <Moveable
+          target={leftRef}
+          onDragStart={({ target, clientX, clientY }) => {
+            console.log('onDragStart', target);
+          }}
+          onDrag={({ target, clientX, clientY }) => {
+            console.log('onDragStart', target);
+          }}
+          {...commonMovableProps}
+        />
+      </Handle>
+      <Label>Hi</Label>
+      <Handle ref={setRightRef}>
+        <Moveable
+          target={rightRef}
+          onDragStart={({ target, clientX, clientY }) => {
+            console.log('onDragStart', target);
+          }}
+          onDrag={({ target, clientX, clientY }) => {
+            console.log('onDragStart', target);
+          }}
+          {...commonMovableProps}
+        />
+      </Handle>
     </Bar>
   );
 }
 
 TimingBar.propTypes = {
   duration: propTypes.number.isRequired,
+  onUpdateAnimation: propTypes.func.isRequired,
 };

--- a/assets/src/edit-story/components/animationTimeline/timingBar.js
+++ b/assets/src/edit-story/components/animationTimeline/timingBar.js
@@ -25,7 +25,7 @@ import Moveable from 'react-moveable';
 /**
  * Internal dependencies
  */
-import { MARK_OFFSET } from './ruler';
+import { MARK_OFFSET, MS_DIVISOR } from './ruler';
 
 const BAR_HEIGHT = 24;
 
@@ -46,6 +46,7 @@ const Bar = styled.div`
     0% 50%,
     ${BAR_HEIGHT / 2}px 0
   );
+  overflow: hidden;
 `;
 
 const Handle = styled.div`
@@ -54,14 +55,14 @@ const Handle = styled.div`
   height: 14px;
   transform: rotate(45deg);
   margin: 6px;
-  cursor: pointer;
+  cursor: ew-resize;
 `;
 
 const Label = styled.div`
   flex: 1;
   font-weight: bold;
   font-size: 12px;
-  cursor: pointer;
+  cursor: grabbing;
 `;
 
 const commonMovableProps = {
@@ -102,7 +103,7 @@ export default function TimingBar({
 
   const handleDragLeft = useCallback(({ clientX }) => {
     const movedMilliseconds = Math.max(
-      ((clientX - dragStart.current) / MARK_OFFSET) * 100,
+      ((clientX - dragStart.current) / MARK_OFFSET) * MS_DIVISOR,
       -startingOffset.current
     );
     setOffset(Math.max(0, movedMilliseconds + startingOffset.current));
@@ -115,7 +116,7 @@ export default function TimingBar({
         maxDuration - (startingOffset.current + startingDuration.current);
       const movedMilliseconds = Math.min(
         Math.max(
-          ((clientX - dragStart.current) / MARK_OFFSET) * 100,
+          ((clientX - dragStart.current) / MARK_OFFSET) * MS_DIVISOR,
           -startingOffset.current
         ),
         stop
@@ -130,7 +131,7 @@ export default function TimingBar({
       const stop =
         maxDuration - (startingOffset.current + startingDuration.current);
       const movedMilliseconds = Math.min(
-        ((clientX - dragStart.current) / MARK_OFFSET) * 100,
+        ((clientX - dragStart.current) / MARK_OFFSET) * MS_DIVISOR,
         stop
       );
       setDuration(movedMilliseconds + startingDuration.current);
@@ -141,8 +142,8 @@ export default function TimingBar({
   return (
     <Bar
       style={{
-        width: (internalDuration / 100) * MARK_OFFSET,
-        left: (internalOffset / 100) * MARK_OFFSET,
+        width: (internalDuration / MS_DIVISOR) * MARK_OFFSET,
+        left: (internalOffset / MS_DIVISOR) * MARK_OFFSET,
       }}
     >
       <Handle ref={setLeftRef}>

--- a/assets/src/edit-story/components/animationTimeline/timingBar.js
+++ b/assets/src/edit-story/components/animationTimeline/timingBar.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import propTypes from 'prop-types';
 import styled from 'styled-components';
 import Moveable from 'react-moveable';
@@ -65,17 +65,24 @@ const commonMovableProps = {
 export default function TimingBar({ duration }) {
   const [leftRef, setLeftRef] = useState(null);
   const [rightRef, setRightRef] = useState(null);
+
+  const dragStart = useRef(0);
+
+  const handleDragStart = useCallback(({ clientX }) => {
+    dragStart.current = clientX;
+  }, []);
+
+  const handleDrag = useCallback(({ clientX }) => {
+    console.log(clientX - dragStart.current);
+  }, []);
+
   return (
     <Bar width={duration}>
       <Handle ref={setLeftRef}>
         <Moveable
           target={leftRef}
-          onDragStart={({ target, clientX, clientY }) => {
-            console.log('onDragStart', target);
-          }}
-          onDrag={({ target, clientX, clientY }) => {
-            console.log('onDragStart', target);
-          }}
+          onDragStart={handleDragStart}
+          onDrag={handleDrag}
           {...commonMovableProps}
         />
       </Handle>
@@ -83,12 +90,8 @@ export default function TimingBar({ duration }) {
       <Handle ref={setRightRef}>
         <Moveable
           target={rightRef}
-          onDragStart={({ target, clientX, clientY }) => {
-            console.log('onDragStart', target);
-          }}
-          onDrag={({ target, clientX, clientY }) => {
-            console.log('onDragStart', target);
-          }}
+          onDragStart={handleDragStart}
+          onDrag={handleDrag}
           {...commonMovableProps}
         />
       </Handle>

--- a/assets/src/edit-story/components/animationTimeline/timingBar.js
+++ b/assets/src/edit-story/components/animationTimeline/timingBar.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import * as React from 'react';
+import propTypes from 'prop-types';
+import styled from 'styled-components';
+
+const BAR_HEIGHT = 24;
+
+const Bar = styled.div`
+  position: relative;
+  background-color: #3988f7;
+  width: ${({ width }) => (width / 10) * 40}px;
+  height: ${BAR_HEIGHT}px;
+  text-align: center;
+  clip-path: polygon(
+    calc(100% - ${BAR_HEIGHT / 2}px) 0,
+    100% 50%,
+    calc(100% - ${BAR_HEIGHT / 2}px) 100%,
+    ${BAR_HEIGHT / 2}px 100%,
+    0% 50%,
+    ${BAR_HEIGHT / 2}px 0
+  );
+`;
+
+const Handle = styled.div``;
+
+export default function TimingBar({ duration }) {
+  return (
+    <Bar width={duration}>
+      <Handle position="left" />
+      <Handle position="right" />
+    </Bar>
+  );
+}
+
+TimingBar.propTypes = {
+  duration: propTypes.number.isRequired,
+};

--- a/assets/src/edit-story/components/animationTimeline/timingBar.js
+++ b/assets/src/edit-story/components/animationTimeline/timingBar.js
@@ -59,6 +59,7 @@ const Handle = styled.div`
 `;
 
 const Label = styled.div`
+  font-family: ${({ theme }) => theme.fonts.label.family};
   flex: 1;
   font-weight: bold;
   font-size: 12px;


### PR DESCRIPTION
## Summary

Adds an animation bar that can be resized either by start or end or moved across the timeline.

The animation bar shows the correct cursor if you are grabbing to move or resizing the end or start points.
The bar cannot be moved or re-sized beyond the bounds of the overall timeline duration.

<img width="1041" alt="Screen Shot 2020-08-14 at 9 28 58 AM" src="https://user-images.githubusercontent.com/1738349/90260765-9727ce00-de11-11ea-9fc7-8688add17a66.png">

![Kapture 2020-08-14 at 9 32 40](https://user-images.githubusercontent.com/1738349/90260951-e3730e00-de11-11ea-9a73-d01ba4003420.gif)



## Relevant Technical Choices

- Uses the already included `react-movable` package to add the resize/drag handling
- Commits changes to the data source on drag complete to improve performance
- Scalable metrics so the overall timeline can change units and zoom-levels 

## To-do

- Keyboard commands and focus elements

## User-facing changes

- Nothing in the app. Currently all in Storybook.

## Testing Instructions

- Launch Storybook
- Timeline > Default
- Drag, resize, and move animation bars
---

<!-- Please reference the issue(s) this PR addresses. -->

#3444 
