### PR TITLE
[WIP] Implemented correct layout for story title input

### DIFF
--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -76,7 +76,7 @@ const Layer = styled.section`
 
   display: grid;
   grid:
-    'head      head      head      head      head    ' ${HEADER_HEIGHT}px
+    '.         .         head      head      head    ' ${HEADER_HEIGHT}px
     '.         .         .         .         .       ' minmax(16px, 1fr)
     '.         prev      page      next      .       ' var(
       --fullbleed-height-px

--- a/assets/src/edit-story/components/header/buttons.js
+++ b/assets/src/edit-story/components/header/buttons.js
@@ -44,7 +44,7 @@ const PREVIEW_TARGET = 'story-preview';
 const ButtonList = styled.nav`
   display: flex;
   justify-content: flex-end;
-  padding: 1em;
+  padding: 1em 1em 1em 40px;
   height: 100%;
 `;
 

--- a/assets/src/edit-story/components/header/headerLayout.js
+++ b/assets/src/edit-story/components/header/headerLayout.js
@@ -34,11 +34,12 @@ const Background = styled.header`
 
 const Head = styled.div`
   flex: 1 1 auto;
-  padding: 1em;
+  overflow: hidden;
+  padding: 1em 0;
 `;
 
 const ButtonCell = styled.div`
-  grid-area: buttons;
+  flex: 0 0 auto;
 `;
 
 function HeaderLayout() {

--- a/assets/src/edit-story/theme.js
+++ b/assets/src/edit-story/theme.js
@@ -158,6 +158,11 @@ const theme = {
       lineHeight: '24px',
       weight: 'bold',
     },
+    storyTitle: {
+      family: 'Roboto',
+      size: '16px',
+      lineHeight: '20px',
+    },
     body1: {
       family: 'Roboto',
       size: '16px',


### PR DESCRIPTION
## Summary

Implementation of story title layout as per Figma (ignoring dropdown as it's not relevant until post-stable).

Awaiting UX confirmation of current implementation.

## Relevant Technical Choices

* Move things around in CSS mostly, but added extra wrapper of title input.
* Added a `ResizeObserver` to handle the proper width settings of input and wrapper.

## To-do

* [ ] Await confirmation from UX requested [here](https://github.com/google/web-stories-wp/issues/41#issuecomment-674291609).

## User-facing changes

* Story title input is placed about page
* On all but the narrowest view, story title is centered
* On wide views, the story title input has the same width as the page, otherwise it's only 94px.

## Testing Instructions

* Observe story title input changing width and location based off of screen width

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #41
