### PR TITLE
Fix local media pagination karma test flakiness

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -31,6 +31,8 @@ describe('MediaPane fetching', () => {
   let localPane;
 
   beforeEach(async () => {
+    jasmine.clock().install();
+
     fixture = new Fixture();
     await fixture.render();
 
@@ -38,6 +40,7 @@ describe('MediaPane fetching', () => {
   });
 
   afterEach(() => {
+    jasmine.clock().uninstall();
     fixture.restore();
   });
 
@@ -50,6 +53,7 @@ describe('MediaPane fetching', () => {
           `Not ready: ${mediaElements?.length} != ${expectedCount}`
         );
       }
+      jasmine.clock().tick(10);
     });
     expect(mediaElements.length).toBe(expectedCount);
   }
@@ -65,6 +69,7 @@ describe('MediaPane fetching', () => {
       0,
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
     );
+    jasmine.clock().tick(500);
 
     await expectMediaElements(MEDIA_PER_PAGE * 2);
   });

--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -199,6 +199,8 @@ describe('Media3pPane fetching', () => {
     fixture = new Fixture();
     fixture.setFlags({ media3pTab: true, showCoverrTab: true });
 
+    jasmine.clock().install();
+
     await fixture.render();
 
     media3pTab = fixture.querySelector('#library-tab-media3p');
@@ -206,6 +208,11 @@ describe('Media3pPane fetching', () => {
       '#provider-bottom-wrapper-unsplash'
     );
     coverrSection = fixture.querySelector('#provider-bottom-wrapper-coverr');
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    fixture.restore();
   });
 
   function mockListMedia() {
@@ -248,6 +255,7 @@ describe('Media3pPane fetching', () => {
           `Not ready: ${mediaElements?.length} != ${expectedCount}`
         );
       }
+      jasmine.clock().tick(10);
     });
     expect(mediaElements.length).toBe(expectedCount);
   }
@@ -299,6 +307,7 @@ describe('Media3pPane fetching', () => {
       0,
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
     );
+    jasmine.clock().tick(500);
     await expectMediaElements(unsplashSection, MEDIA_PER_PAGE * 2);
   });
 
@@ -327,6 +336,7 @@ describe('Media3pPane fetching', () => {
       0,
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
     );
+    jasmine.clock().tick(500);
     await expectMediaElements(unsplashSection, MEDIA_PER_PAGE * 2);
 
     const mediaCategories = unsplashSection.querySelectorAll(


### PR DESCRIPTION
## Summary

Fix local media pagination test flakiness in karma by using jasmine.clock().

## Relevant Technical Choices

This is to avoid this sleep from causing test flakiness:

https://github.com/google/web-stories-wp/blob/16309f7c6f805c38c5c57ab19863aa3c3f1591f9/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js#L134

The sleep is unfortunately required to avoid evaluating the scroll position while <Gallery> is performing a render cycle.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4003
