### PR TITLE
add keyboard navigation to provider tabs

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -194,6 +194,7 @@ describe('Media3pPane fetching', () => {
   let media3pTab;
   let unsplashSection;
   let coverrSection;
+  let media3pPane;
 
   beforeEach(async () => {
     fixture = new Fixture();
@@ -206,6 +207,7 @@ describe('Media3pPane fetching', () => {
       '#provider-bottom-wrapper-unsplash'
     );
     coverrSection = fixture.querySelector('#provider-bottom-wrapper-coverr');
+    media3pPane = fixture.querySelector('#library-pane-media3p');
   });
 
   function mockListMedia() {
@@ -339,184 +341,261 @@ describe('Media3pPane fetching', () => {
     });
   });
 
-  it('should handle pressing right when focused', async () => {
-    mockListMedia();
-    await fixture.events.click(media3pTab);
+  describe('Gallery navigation', () => {
+    it('should handle pressing right when focused', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
 
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-    let mediaElements = unsplashSection.querySelectorAll(
-      '[data-testid=mediaElement]'
-    );
+      let mediaElements = unsplashSection.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
 
-    await fixture.events.focus(mediaElements.item(0));
+      await fixture.events.focus(mediaElements.item(0));
 
-    await fixture.events.keyboard.press('ArrowRight');
+      await fixture.events.keyboard.press('ArrowRight');
 
-    expect(document.activeElement).toBe(mediaElements.item(1));
-  });
-
-  it('should handle pressing right when at the end of a row', async () => {
-    mockListMedia();
-    await fixture.events.click(media3pTab);
-
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
-
-    let mediaElements = unsplashSection.querySelectorAll(
-      '[data-testid=mediaElement]'
-    );
-
-    await fixture.events.focus(mediaElements.item(1));
-
-    await fixture.events.keyboard.press('ArrowRight');
-
-    expect(document.activeElement).toBe(mediaElements.item(2));
-  });
-
-  it('should handle pressing right when the last element is focused', async () => {
-    // Only mock 1 page.
-    spyOn(apiFetcher, 'listMedia').and.callFake(({ pageToken }) => {
-      if (!pageToken) {
-        return { media: mediaPage(1, 'unsplash'), nextPageToken: undefined };
-      }
-      throw new Error(`Unexpected pageToken: ${pageToken}`);
+      expect(document.activeElement).toBe(mediaElements.item(1));
     });
 
-    await fixture.events.click(media3pTab);
+    it('should handle pressing right when at the end of a row', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
 
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-    let mediaElements = unsplashSection.querySelectorAll(
-      '[data-testid=mediaElement]'
-    );
+      let mediaElements = unsplashSection.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
 
-    await fixture.events.focus(mediaElements.item(mediaElements.length - 1));
+      await fixture.events.focus(mediaElements.item(1));
 
-    await fixture.events.keyboard.press('ArrowRight');
+      await fixture.events.keyboard.press('ArrowRight');
 
-    expect(document.activeElement).toBe(
-      mediaElements.item(mediaElements.length - 1)
-    );
+      expect(document.activeElement).toBe(mediaElements.item(2));
+    });
+
+    it('should handle pressing right when the last element is focused', async () => {
+      // Only mock 1 page.
+      spyOn(apiFetcher, 'listMedia').and.callFake(({ pageToken }) => {
+        if (!pageToken) {
+          return { media: mediaPage(1, 'unsplash'), nextPageToken: undefined };
+        }
+        throw new Error(`Unexpected pageToken: ${pageToken}`);
+      });
+
+      await fixture.events.click(media3pTab);
+
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+
+      let mediaElements = unsplashSection.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
+
+      await fixture.events.focus(mediaElements.item(mediaElements.length - 1));
+
+      await fixture.events.keyboard.press('ArrowRight');
+
+      expect(document.activeElement).toBe(
+        mediaElements.item(mediaElements.length - 1)
+      );
+    });
+
+    it('should handle pressing left when focused', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
+
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+
+      let mediaElements = unsplashSection.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
+
+      await fixture.events.focus(mediaElements.item(1));
+
+      await fixture.events.keyboard.press('ArrowLeft');
+
+      expect(document.activeElement).toBe(mediaElements.item(0));
+    });
+
+    it('should handle pressing left at the beginning of a row', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
+
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+
+      let mediaElements = unsplashSection.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
+
+      await fixture.events.focus(mediaElements.item(2));
+
+      await fixture.events.keyboard.press('ArrowLeft');
+
+      expect(document.activeElement).toBe(mediaElements.item(1));
+    });
+
+    it('should handle pressing left when the first element is focused', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
+
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+
+      let mediaElements = unsplashSection.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
+
+      await fixture.events.focus(mediaElements.item(0));
+
+      await fixture.events.keyboard.press('ArrowLeft');
+
+      expect(document.activeElement).toBe(mediaElements.item(0));
+    });
+
+    it('should handle pressing down', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
+
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+
+      let mediaElements = unsplashSection.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
+
+      await fixture.events.focus(mediaElements.item(1));
+
+      await fixture.events.keyboard.press('ArrowDown');
+
+      expect(document.activeElement).toBe(mediaElements.item(3));
+    });
+
+    it('should handle pressing up', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
+
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+
+      let mediaElements = unsplashSection.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
+
+      await fixture.events.focus(mediaElements.item(3));
+
+      await fixture.events.keyboard.press('ArrowUp');
+
+      expect(document.activeElement).toBe(mediaElements.item(1));
+    });
+
+    it('should handle pressing Home', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
+
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+
+      let mediaElements = unsplashSection.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
+
+      await fixture.events.focus(mediaElements.item(6));
+
+      await fixture.events.keyboard.press('Home');
+
+      expect(document.activeElement).toBe(mediaElements.item(0));
+    });
+
+    it('should handle pressing End', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
+
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+
+      let mediaElements = unsplashSection.querySelectorAll(
+        '[data-testid=mediaElement]'
+      );
+
+      await fixture.events.focus(mediaElements.item(6));
+
+      await fixture.events.keyboard.press('End');
+
+      expect(document.activeElement).toBe(
+        mediaElements.item(mediaElements.length - 1)
+      );
+    });
   });
 
-  it('should handle pressing left when focused', async () => {
-    mockListMedia();
-    await fixture.events.click(media3pTab);
+  describe('Provider navigation', () => {
+    it('should handle pressing Right', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
 
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-    let mediaElements = unsplashSection.querySelectorAll(
-      '[data-testid=mediaElement]'
-    );
+      let providerTabs = media3pPane.querySelectorAll(
+        '[data-testid=providerTab]'
+      );
 
-    await fixture.events.focus(mediaElements.item(1));
+      await fixture.events.focus(providerTabs.item(0));
 
-    await fixture.events.keyboard.press('ArrowLeft');
+      await fixture.events.keyboard.press('ArrowRight');
 
-    expect(document.activeElement).toBe(mediaElements.item(0));
-  });
+      expect(document.activeElement).toBe(providerTabs.item(1));
+      await expectMediaElements(coverrSection, MEDIA_PER_PAGE);
+    });
 
-  it('should handle pressing left at the beginning of a row', async () => {
-    mockListMedia();
-    await fixture.events.click(media3pTab);
+    it('should handle pressing Right when no more providers', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
 
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-    let mediaElements = unsplashSection.querySelectorAll(
-      '[data-testid=mediaElement]'
-    );
+      let providerTabs = media3pPane.querySelectorAll(
+        '[data-testid=providerTab]'
+      );
 
-    await fixture.events.focus(mediaElements.item(2));
+      await fixture.events.focus(providerTabs.item(providerTabs.length - 1));
 
-    await fixture.events.keyboard.press('ArrowLeft');
+      await fixture.events.keyboard.press('ArrowRight');
 
-    expect(document.activeElement).toBe(mediaElements.item(1));
-  });
+      expect(document.activeElement).toBe(
+        providerTabs.item(providerTabs.length - 1)
+      );
+    });
 
-  it('should handle pressing left when the first element is focused', async () => {
-    mockListMedia();
-    await fixture.events.click(media3pTab);
+    it('should handle pressing Left', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
 
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-    let mediaElements = unsplashSection.querySelectorAll(
-      '[data-testid=mediaElement]'
-    );
+      let providerTabs = media3pPane.querySelectorAll(
+        '[data-testid=providerTab]'
+      );
 
-    await fixture.events.focus(mediaElements.item(0));
+      await fixture.events.focus(providerTabs.item(providerTabs.length - 1));
 
-    await fixture.events.keyboard.press('ArrowLeft');
+      await fixture.events.keyboard.press('ArrowRight');
 
-    expect(document.activeElement).toBe(mediaElements.item(0));
-  });
+      expect(document.activeElement).toBe(
+        providerTabs.item(providerTabs.length - 2)
+      );
+    });
 
-  it('should handle pressing down', async () => {
-    mockListMedia();
-    await fixture.events.click(media3pTab);
+    it('should handle pressing Left when at the beginning', async () => {
+      mockListMedia();
+      await fixture.events.click(media3pTab);
 
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-    let mediaElements = unsplashSection.querySelectorAll(
-      '[data-testid=mediaElement]'
-    );
+      let providerTabs = media3pPane.querySelectorAll(
+        '[data-testid=providerTab]'
+      );
 
-    await fixture.events.focus(mediaElements.item(1));
+      await fixture.events.focus(providerTabs.item(0));
 
-    await fixture.events.keyboard.press('ArrowDown');
+      await fixture.events.keyboard.press('ArrowRight');
 
-    expect(document.activeElement).toBe(mediaElements.item(3));
-  });
-
-  it('should handle pressing up', async () => {
-    mockListMedia();
-    await fixture.events.click(media3pTab);
-
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
-
-    let mediaElements = unsplashSection.querySelectorAll(
-      '[data-testid=mediaElement]'
-    );
-
-    await fixture.events.focus(mediaElements.item(3));
-
-    await fixture.events.keyboard.press('ArrowUp');
-
-    expect(document.activeElement).toBe(mediaElements.item(1));
-  });
-
-  it('should handle pressing Home', async () => {
-    mockListMedia();
-    await fixture.events.click(media3pTab);
-
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
-
-    let mediaElements = unsplashSection.querySelectorAll(
-      '[data-testid=mediaElement]'
-    );
-
-    await fixture.events.focus(mediaElements.item(6));
-
-    await fixture.events.keyboard.press('Home');
-
-    expect(document.activeElement).toBe(mediaElements.item(0));
-  });
-
-  it('should handle pressing End', async () => {
-    mockListMedia();
-    await fixture.events.click(media3pTab);
-
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
-
-    let mediaElements = unsplashSection.querySelectorAll(
-      '[data-testid=mediaElement]'
-    );
-
-    await fixture.events.focus(mediaElements.item(6));
-
-    await fixture.events.keyboard.press('End');
-
-    expect(document.activeElement).toBe(
-      mediaElements.item(mediaElements.length - 1)
-    );
+      expect(document.activeElement).toBe(providerTabs.item(0));
+    });
   });
 });

--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -301,8 +301,9 @@ describe('Media3pPane fetching', () => {
     mockListCategories();
     await fixture.events.click(media3pTab);
 
-    await fixture.events.keyboard.press('tab');
-    await fixture.events.keyboard.press('tab');
+    await fixture.events.focus(
+      fixture.querySelectorAll('[data-testid="mediaCategory"]')[0]
+    );
     expect(document.activeElement.textContent).toBe('Sustainability');
 
     await fixture.events.keyboard.press('ArrowRight');

--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -574,7 +574,7 @@ describe('Media3pPane fetching', () => {
 
       await fixture.events.focus(providerTabs.item(providerTabs.length - 1));
 
-      await fixture.events.keyboard.press('ArrowRight');
+      await fixture.events.keyboard.press('ArrowLeft');
 
       expect(document.activeElement).toBe(
         providerTabs.item(providerTabs.length - 2)
@@ -593,7 +593,7 @@ describe('Media3pPane fetching', () => {
 
       await fixture.events.focus(providerTabs.item(0));
 
-      await fixture.events.keyboard.press('ArrowRight');
+      await fixture.events.keyboard.press('ArrowLeft');
 
       expect(document.activeElement).toBe(providerTabs.item(0));
     });

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
@@ -137,13 +137,6 @@ function Media3pPane(props) {
 
   const paneBottomRef = useRef();
 
-  const onProviderTabClick = useCallback(
-    (providerType) => {
-      setSelectedProvider({ provider: providerType });
-    },
-    [setSelectedProvider]
-  );
-
   const features = useFeatures();
   const enabledProviders = Object.keys(PROVIDERS).filter(
     (p) => !PROVIDERS[p].featureName || features[PROVIDERS[p].featureName]
@@ -222,13 +215,16 @@ function Media3pPane(props) {
             />
           </SearchInputContainer>
           <ProviderTabSection>
-            {enabledProviders.map((providerType) => (
+            {enabledProviders.map((providerType, index) => (
               <ProviderTab
                 key={`provider-tab-${providerType}`}
+                index={index}
+                data-testid={'providerTab'}
                 id={`provider-tab-${providerType}`}
                 name={PROVIDERS[providerType].displayName}
                 active={selectedProvider === providerType}
-                onClick={() => onProviderTabClick(providerType)}
+                providerType={providerType}
+                setSelectedProvider={setSelectedProvider}
               />
             ))}
           </ProviderTabSection>

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
@@ -219,7 +219,6 @@ function Media3pPane(props) {
               <ProviderTab
                 key={`provider-tab-${providerType}`}
                 index={index}
-                data-testid={'providerTab'}
                 id={`provider-tab-${providerType}`}
                 name={PROVIDERS[providerType].displayName}
                 active={selectedProvider === providerType}

--- a/assets/src/edit-story/components/library/panes/media/media3p/providerTab.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/providerTab.js
@@ -81,6 +81,7 @@ function ProviderTab({
     <Tab
       ref={ref}
       tabIndex={index == 0 ? 0 : -1}
+      data-testid={'providerTab'}
       onClick={() => setSelectedProvider({ provider: providerType })}
       data-provider-type={providerType}
       active={active}

--- a/assets/src/edit-story/components/library/panes/media/media3p/providerTab.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/providerTab.js
@@ -18,6 +18,12 @@
  */
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+/**
+ * Internal dependencies
+ */
+import { useCallback, useRef } from 'react';
+import { useKeyDownEffect } from '../../../../keyboard';
+import { useConfig } from '../../../../../app/config';
 
 const Tab = styled.span`
   cursor: pointer;
@@ -30,19 +36,68 @@ const Tab = styled.span`
   }
 `;
 
-function ProviderTab(props) {
+function ProviderTab({
+  id,
+  index,
+  name,
+  providerType,
+  active,
+  setSelectedProvider,
+}) {
+  const { isRTL } = useConfig();
+  const ref = useRef();
+
+  const onKeyDown = useCallback(
+    ({ key }) => {
+      if (!ref.current) {
+        return;
+      }
+      ref.current.tabIndex = -1;
+      const siblingSelector =
+        (key === 'ArrowRight' && !isRTL) || (key === 'ArrowLeft' && isRTL)
+          ? 'nextSibling'
+          : 'previousSibling';
+      const sibling = ref.current[siblingSelector];
+      if (sibling) {
+        sibling.tabIndex = 0;
+        sibling.focus();
+        const newProvider = sibling.dataset.providerType;
+        setSelectedProvider({ provider: newProvider });
+      }
+    },
+    [ref, isRTL, setSelectedProvider]
+  );
+
+  useKeyDownEffect(
+    ref,
+    {
+      key: ['left', 'right'],
+    },
+    onKeyDown,
+    [ref, onKeyDown]
+  );
+
   return (
-    <Tab onClick={props.onClick} active={props.active} id={props.id}>
-      {props.name}
+    <Tab
+      ref={ref}
+      tabIndex={index == 0 ? 0 : -1}
+      onClick={() => setSelectedProvider({ provider: providerType })}
+      data-provider-type={providerType}
+      active={active}
+      id={id}
+    >
+      {name}
     </Tab>
   );
 }
 
 ProviderTab.propTypes = {
   id: PropTypes.string.isRequired,
+  index: PropTypes.number.isRequired,
   name: PropTypes.string.isRequired,
-  onClick: PropTypes.func.isRequired,
+  providerType: PropTypes.string.isRequired,
   active: PropTypes.bool.isRequired,
+  setSelectedProvider: PropTypes.func.isRequired,
 };
 
 export default ProviderTab;


### PR DESCRIPTION
Simply handling left/right to automatically load the tabs as you focus them.

![028d185f-f72a-4b23-ab46-e4a23fc0795f](https://user-images.githubusercontent.com/512647/90368405-4fbd6e00-e0ad-11ea-906d-c09ef9ba4891.gif)

Fixes #4006