### PR TITLE
3P Media: Improve layout issues when there is no media

### DIFF
--- a/assets/src/edit-story/components/library/libraryLayout.js
+++ b/assets/src/edit-story/components/library/libraryLayout.js
@@ -41,17 +41,17 @@ const Layout = styled.section.attrs({
   flex-direction: column;
   background-color: ${({ theme }) => theme.colors.bg.panel};
   color: ${({ theme }) => theme.colors.fg.white};
+  max-height: 100%;
 `;
 
 // @todo Verify that L10N works with the translation happening here.
 const TabsArea = styled.nav.attrs({
   'aria-label': __('Library tabs', 'web-stories'),
-})`
-  grid-area: tabs;
-`;
+})``;
 
 const LibraryPaneContainer = styled.div`
   overflow: auto;
+  flex: 1 1 auto;
 `;
 
 function LibraryLayout() {

--- a/assets/src/edit-story/components/library/panes/media/common/styles.js
+++ b/assets/src/edit-story/components/library/panes/media/common/styles.js
@@ -39,7 +39,7 @@ export const MediaGalleryContainer = styled.div`
   margin-top: 1em;
   position: relative;
   width: 100%;
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   min-height: 100px;
 `;
 

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
@@ -30,12 +30,12 @@ import CategoryPill from './categoryPill';
 // Pills have a margin of 4, so the l/r padding is 24-4=20.
 const CategorySection = styled.div`
   background-color: ${({ theme }) => theme.colors.bg.v3};
-  min-height: 94px;
+  ${({ hasCategories }) => (hasCategories ? '' : 'min-height: 104px;')}
   padding: 30px 20px 10px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  flex: 1 0 auto;
+  flex: 0 1 auto;
 `;
 
 // This hides the category pills unless expanded
@@ -107,24 +107,31 @@ const Media3pCategories = ({
     }
   }, [containerRef, innerContainerRef, isExpanded]);
 
-  return categories.length ? (
-    <CategorySection aria-expanded={isExpanded}>
-      <CategoryPillContainer
-        ref={containerRef}
-        isExpanded={isExpanded}
-        role="tablist"
-      >
-        <CategoryPillInnerContainer ref={innerContainerRef}>
-          {renderCategories()}
-        </CategoryPillInnerContainer>
-      </CategoryPillContainer>
-      <ExpandButton
-        onClick={() => setIsExpanded(!isExpanded)}
-        isExpanded={isExpanded}
-        visible={!selectedCategoryId}
-      />
+  return (
+    <CategorySection
+      aria-expanded={isExpanded}
+      hasCategories={Boolean(categories.length)}
+    >
+      {categories.length ? (
+        <>
+          <CategoryPillContainer
+            ref={containerRef}
+            isExpanded={isExpanded}
+            role="tablist"
+          >
+            <CategoryPillInnerContainer ref={innerContainerRef}>
+              {renderCategories()}
+            </CategoryPillInnerContainer>
+          </CategoryPillContainer>
+          <ExpandButton
+            onClick={() => setIsExpanded(!isExpanded)}
+            isExpanded={isExpanded}
+            visible={!selectedCategoryId}
+          />
+        </>
+      ) : null}
     </CategorySection>
-  ) : null;
+  );
 };
 
 Media3pCategories.propTypes = {

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
@@ -60,7 +60,7 @@ const MediaSubheading = styled.div`
 const PaneBottom = styled.div`
   position: relative;
   height: 100%;
-  flex: 0 1 auto;
+  flex: 1 1 auto;
   min-height: 0;
 `;
 
@@ -69,8 +69,10 @@ const ProviderMediaCategoriesWrapper = styled.div`
   visibility: hidden;
   display: flex;
   flex-direction: column;
-  max-height: 100%;
+  height: 100%;
   min-height: 100px;
+  top: 0;
+  left: 0;
   &.provider-selected {
     position: relative;
     visibility: visible;


### PR DESCRIPTION
## Summary

Fixes a series of flex issues with the library tab collapsing when there's litte to no media. These changes make it take 100% and so the attribution always displays at the bottom.

![Screen Shot 2020-08-17 at 6 14 56 pm](https://user-images.githubusercontent.com/512647/90374126-57354500-e0b6-11ea-928d-4681a6ad0ca3.png)

![Screen Shot 2020-08-17 at 6 17 12 pm](https://user-images.githubusercontent.com/512647/90374106-50a6cd80-e0b6-11ea-959d-bf2e67437b4b.png)

Fixes #3896