### PR TITLE
Enable React apps to use  dynamic imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -195,7 +195,8 @@
     "window": true,
     "document": true,
     "wp": "readonly",
-    "process": "readonly"
+    "process": "readonly",
+    "__webpack_public_path__": true
   },
   "settings": {
     "jsdoc": {

--- a/assets/src/activation-notice/index.js
+++ b/assets/src/activation-notice/index.js
@@ -26,6 +26,8 @@ import { render } from 'react-dom';
 import { initializeTracking } from '../tracking';
 import App from './app';
 
+__webpack_public_path__ = global.webStoriesActivationSettings.publicPath;
+
 /**
  * Initializes the Web Stories dashboard screen.
  *

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -207,13 +207,13 @@ const useTemplateApi = (dataAdapter, config) => {
   }, []);
 
   const fetchExternalTemplates = useCallback(
-    (filters) => {
+    async (filters) => {
       dispatch({
         type: TEMPLATE_ACTION_TYPES.LOADING_TEMPLATES,
         payload: true,
       });
 
-      const reshapedTemplates = getAllTemplates({ assetsURL }).map(
+      const reshapedTemplates = (await getAllTemplates({ assetsURL })).map(
         reshapeTemplateObject(false)
       );
       dispatch({

--- a/assets/src/dashboard/index.js
+++ b/assets/src/dashboard/index.js
@@ -29,6 +29,8 @@ import { initializeTracking } from '../tracking';
 import App from './app';
 import './style.css'; // This way the general dashboard styles are loaded before all the component styles.
 
+__webpack_public_path__ = global.webStoriesDashboardSettings.publicPath;
+
 /**
  * Initializes the Web Stories dashboard screen.
  *

--- a/assets/src/dashboard/templates/index.js
+++ b/assets/src/dashboard/templates/index.js
@@ -27,8 +27,8 @@ import getTemplates from './getTemplates';
 
 const memoizedGetTemplates = memoize(getTemplates);
 
-export default function ({ assetsURL }) {
-  const templates = memoizedGetTemplates(assetsURL);
+export default async function ({ assetsURL }) {
+  const templates = await memoizedGetTemplates(assetsURL);
 
   const globalConfig = {
     createdBy: 'Google Web Stories',

--- a/assets/src/edit-story/index.js
+++ b/assets/src/edit-story/index.js
@@ -28,6 +28,8 @@ import { initializeTracking } from '../tracking';
 import App from './app';
 import './style.css'; // This way the general editor styles are loaded before all the component styles.
 
+__webpack_public_path__ = global.webStoriesEditorSettings.publicPath;
+
 /**
  * Initializes the web stories editor.
  *

--- a/assets/src/story-embed-block/index.js
+++ b/assets/src/story-embed-block/index.js
@@ -25,6 +25,8 @@ import { registerBlockType } from '@wordpress/blocks';
 import { initializeTracking } from '../tracking';
 import { name, settings } from './block';
 
+__webpack_public_path__ = global.webStoriesEmbedBlockSettings.publicPath;
+
 registerBlockType(name, settings);
 
 initializeTracking('Embed Block', false);

--- a/includes/Activation_Notice.php
+++ b/includes/Activation_Notice.php
@@ -130,14 +130,15 @@ class Activation_Notice {
 		$demo_story_url = 'https://google.github.io/web-stories-wp/beta/tips.html';
 
 		return [
-			'id'     => 'web-stories-plugin-activation-notice',
-			'config' => [
+			'id'         => 'web-stories-plugin-activation-notice',
+			'config'     => [
 				'isRTL'        => is_rtl(),
 				'assetsURL'    => trailingslashit( WEBSTORIES_ASSETS_URL ),
 				'demoStoryURL' => $demo_story_url,
 				'newStoryURL'  => $new_story_url,
 				'dashboardURL' => $dashboard_url,
 			],
+			'publicPath' => WEBSTORIES_PLUGIN_DIR_URL . 'assets/js/',
 		];
 	}
 

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -247,8 +247,8 @@ class Dashboard {
 		}
 
 		$settings = [
-			'id'     => 'web-stories-dashboard',
-			'config' => [
+			'id'         => 'web-stories-dashboard',
+			'config'     => [
 				'isRTL'        => is_rtl(),
 				'dateFormat'   => get_option( 'date_format' ),
 				'timeFormat'   => get_option( 'time_format' ),
@@ -273,10 +273,11 @@ class Dashboard {
 					'canUploadFiles'    => current_user_can( 'upload_files' ),
 				],
 			],
-			'flags'  => array_merge(
+			'flags'      => array_merge(
 				$this->experiments->get_experiment_statuses( 'general' ),
 				$this->experiments->get_experiment_statuses( 'dashboard' )
 			),
+			'publicPath' => WEBSTORIES_PLUGIN_DIR_URL . 'assets/js/',
 		];
 
 		/**

--- a/includes/Embed_Block.php
+++ b/includes/Embed_Block.php
@@ -56,6 +56,12 @@ class Embed_Block {
 		$this->register_script( self::SCRIPT_HANDLE, [ 'standalone-amp-story-player', Tracking::SCRIPT_HANDLE ] );
 		$this->register_style( self::SCRIPT_HANDLE, [ 'standalone-amp-story-player' ] );
 
+		wp_localize_script(
+			self::SCRIPT_HANDLE,
+			'webStoriesEmbedBlockSettings',
+			$this->get_script_settings()
+		);
+
 		// todo: use register_block_type_from_metadata() once generally available.
 
 		// Note: does not use 'script' and 'style' args, and instead uses 'render_callback'
@@ -94,6 +100,17 @@ class Embed_Block {
 		);
 
 		add_filter( 'wp_kses_allowed_html', [ $this, 'filter_kses_allowed_html' ], 10, 2 );
+	}
+
+	/**
+	 * Returns script settings.
+	 *
+	 * @return array Script settings.
+	 */
+	private function get_script_settings() {
+		return [
+			'publicPath' => WEBSTORIES_PLUGIN_DIR_URL . 'assets/js/',
+		];
 	}
 
 	/**

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -586,10 +586,9 @@ class Story_Post_Type {
 			'preview_nonce' => wp_create_nonce( 'post_preview_' . $story_id ),
 		];
 
-
 		$settings = [
-			'id'     => 'edit-story',
-			'config' => [
+			'id'         => 'edit-story',
+			'config'     => [
 				'autoSaveInterval' => defined( 'AUTOSAVE_INTERVAL' ) ? AUTOSAVE_INTERVAL : null,
 				'isRTL'            => is_rtl(),
 				'dateFormat'       => get_option( 'date_format' ),
@@ -618,10 +617,11 @@ class Story_Post_Type {
 					'fallbackPoster'  => plugins_url( 'assets/images/fallback-poster.png', WEBSTORIES_PLUGIN_FILE ),
 				],
 			],
-			'flags'  => array_merge(
+			'flags'      => array_merge(
 				$this->experiments->get_experiment_statuses( 'general' ),
 				$this->experiments->get_experiment_statuses( 'editor' )
 			),
+			'publicPath' => WEBSTORIES_PLUGIN_DIR_URL . 'assets/js/',
 		];
 
 		/**

--- a/tests/e2e/specs/dashboard/templates/useTemplate.js
+++ b/tests/e2e/specs/dashboard/templates/useTemplate.js
@@ -39,11 +39,12 @@ describe('Template', () => {
 
     await expect(page).toMatch('Viewing all templates');
 
-    await percySnapshot(page, 'Explore Templates');
-
     const firstTemplate = await expect(page).toMatchElement(
       '[data-testid="template-grid-item-1"]'
     );
+
+    await percySnapshot(page, 'Explore Templates');
+
     await expect(firstTemplate).toClick('button', { text: 'Use template' });
     await page.waitForNavigation();
 

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -56,6 +56,14 @@ const sharedConfig = {
     path: path.resolve(process.cwd(), 'assets', 'js'),
     filename: '[name].js',
     chunkFilename: '[name].js',
+    publicPath: '',
+    /**
+     * If multiple webpack runtimes (from different compilations) are used on the same webpage,
+     * there is a risk of conflicts of on-demand chunks in the global namespace.
+     *
+     * @see (@link https://webpack.js.org/configuration/output/#outputjsonpfunction)
+     */
+    jsonpFunction: '__webStories_webpackJsonp',
   },
   module: {
     rules: [


### PR DESCRIPTION
## Summary

Sets `__webpack_public_path__` for all apps (dashboard, editor, plugin activation notice, embed block) so that webpack can correctly infer the URLs for dynamic imports.

## Relevant Technical Choices

* Set `__webpack_public_path__` for all apps
* Verify implementation by loading templates using dynamic imports, thus reducing the main bundle size

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

No visual changes, only (perceived) performance changes.

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3509
