### PR TITLE
Dashboard: Handle stories with no titles in list view and search dropdown

### DIFF
--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -134,6 +134,9 @@ const toggleSortLookup = {
   [SORT_DIRECTION.ASC]: SORT_DIRECTION.DESC,
 };
 
+const titleFormatted = (rawTitle) => {
+  return rawTitle === '' ? __('(no title)', 'web-stories') : rawTitle;
+};
 export default function StoryListView({
   handleSortChange,
   handleSortDirectionChange,
@@ -255,7 +258,7 @@ export default function StoryListView({
                     />
                   ) : (
                     <>
-                      <Paragraph2>{story.title}</Paragraph2>
+                      <Paragraph2>{titleFormatted(story.title)}</Paragraph2>
                       <StoryMenu
                         onMoreButtonSelected={storyMenu.handleMenuToggle}
                         contextMenuId={storyMenu.contextMenuId}

--- a/assets/src/dashboard/app/views/shared/typeaheadSearch.js
+++ b/assets/src/dashboard/app/views/shared/typeaheadSearch.js
@@ -33,7 +33,7 @@ export default function TypeaheadSearch({
   const typeaheadMenuOptions = useMemo(() => {
     // todo add different option sets, value and label won't always be the same
     return stories.reduce((acc, story) => {
-      if (!story.title) {
+      if (!story.title || story.title.trim().length <= 0) {
         return acc;
       }
       return [

--- a/assets/src/dashboard/app/views/shared/typeaheadSearch.js
+++ b/assets/src/dashboard/app/views/shared/typeaheadSearch.js
@@ -32,12 +32,18 @@ export default function TypeaheadSearch({
 }) {
   const typeaheadMenuOptions = useMemo(() => {
     // todo add different option sets, value and label won't always be the same
-    return stories.map((story) => {
-      return {
-        label: story.title,
-        value: story.title,
-      };
-    });
+    return stories.reduce((acc, story) => {
+      if (!story.title) {
+        return acc;
+      }
+      return [
+        ...acc,
+        {
+          label: story.title,
+          value: story.title,
+        },
+      ];
+    }, []);
   }, [stories]);
 
   return (


### PR DESCRIPTION
# Summary
Updating story list view to show (no title) like grid [(update missed when handling stories with no titles](https://github.com/google/web-stories-wp/pull/3918)), and reducing typeahead dropdown items to show only those with organic titles for continuity with the (no title) update.

From this: 
![Screen Shot 2020-08-17 at 3 51 26 PM](https://user-images.githubusercontent.com/10720454/90452741-bc336f80-e0a3-11ea-8482-e15079406375.png)

To this: 
![Screen Shot 2020-08-17 at 4 10 33 PM](https://user-images.githubusercontent.com/10720454/90452943-3663f400-e0a4-11ea-9488-dfc9c8f5e218.png)



## Relevant Technical Choices
N/A

## To-do
None

## User-facing changes
Now when a story is untitled, it will show the same `(no title)` in the story list view as it does in the grid from this update: 
And when you search, empty titles don't render in the dropdown list. 

## Testing Instructions
Create a story with no title, see that it's "title" in the dashboard/my stories view is `(no title)`. Now open the search dropdown and see that no empty titles render. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
