### PR TITLE
Animation: Adding Animation panel to Editor

### DIFF
--- a/assets/src/animation/constants.js
+++ b/assets/src/animation/constants.js
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 export const BEZIER = {
   linear: 'linear',
   inQuad: 'cubic-bezier(0.55, 0.085, 0.68, 0.53)',
@@ -52,15 +57,21 @@ export const ANIMATION_TYPES = {
 };
 
 export const ANIMATION_EFFECTS = {
-  DROP: 'effect-drop',
-  FADE_IN: 'effect-fade-in',
-  FLY_IN: 'effect-fly-in',
-  PAN: 'effect-pan',
-  PULSE: 'effect-pulse',
-  TWIRL_IN: 'effect-twirl-in',
-  WHOOSH_IN: 'effect-whoosh-in',
-  ZOOM: 'effect-zoom',
-  ROTATE_IN: 'effect-rotate-in',
+  DROP: { value: 'effect-drop', name: __('Drop', 'web-stories') },
+  FADE_IN: { value: 'effect-fade-in', name: __('Fade In', 'web-stories') },
+  FLY_IN: { value: 'effect-fly-in', name: __('Fly In', 'web-stories') },
+  PAN: { value: 'effect-pan', name: __('Pan', 'web-stories') },
+  PULSE: { value: 'effect-pulse', name: __('Pulse', 'web-stories') },
+  TWIRL_IN: { value: 'effect-twirl-in', name: __('Twirl In', 'web-stories') },
+  WHOOSH_IN: {
+    value: 'effect-whoosh-in',
+    name: __('Whoosh In', 'web-stories'),
+  },
+  ZOOM: { value: 'effect-zoom', name: __('Zoom', 'web-stories') },
+  ROTATE_IN: {
+    value: 'effect-rotate-in',
+    name: __('Rotate In', 'web-stories'),
+  },
 };
 
 export const DIRECTION = {

--- a/assets/src/animation/effects/flyIn/animationProps.js
+++ b/assets/src/animation/effects/flyIn/animationProps.js
@@ -15,12 +15,18 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { FIELD_TYPES, DIRECTION } from '../../constants';
 
 export default {
   flyInDir: {
+    label: __('Direction', 'web-stories'),
     type: FIELD_TYPES.DROPDOWN,
     values: [
       DIRECTION.TOP_TO_BOTTOM,

--- a/assets/src/animation/effects/pan/animationProps.js
+++ b/assets/src/animation/effects/pan/animationProps.js
@@ -20,9 +20,19 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
  * Internal dependencies
  */
 import { FIELD_TYPES, DIRECTION } from '../../constants';
+import { AnimationInputPropTypes } from '../types';
+
+export const PanEffectInputPropTypes = {
+  panDir: PropTypes.shape(AnimationInputPropTypes),
+};
 
 export default {
   panDir: {

--- a/assets/src/animation/effects/pulse/animationProps.js
+++ b/assets/src/animation/effects/pulse/animationProps.js
@@ -20,9 +20,20 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
  * Internal dependencies
  */
 import { FIELD_TYPES } from '../../constants';
+import { AnimationInputPropTypes } from '../types';
+
+export const PulseEffectInputPropTypes = {
+  scale: PropTypes.shape(AnimationInputPropTypes),
+  iterations: PropTypes.shape(AnimationInputPropTypes),
+};
 
 export default {
   scale: {

--- a/assets/src/animation/effects/pulse/animationProps.js
+++ b/assets/src/animation/effects/pulse/animationProps.js
@@ -15,14 +15,25 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { FIELD_TYPES } from '../../constants';
 
 export default {
   scale: {
+    label: __('Scale', 'web-stories'),
     tooltip: 'Valid values are greater than or equal to 0',
     type: FIELD_TYPES.FLOAT,
     defaultValue: 0.5,
+  },
+  iterations: {
+    label: __('# of Pulses', 'web-stories'),
+    type: FIELD_TYPES.NUMBER,
+    defaultValue: 1,
   },
 };

--- a/assets/src/animation/effects/rotateIn/animationProps.js
+++ b/assets/src/animation/effects/rotateIn/animationProps.js
@@ -20,9 +20,21 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
  * Internal dependencies
  */
 import { FIELD_TYPES, DIRECTION } from '../../constants';
+import { AnimationInputPropTypes } from '../types';
+
+export const RotateInEffectInputPropTypes = {
+  rotateInDir: PropTypes.shape(AnimationInputPropTypes),
+  stopAngle: PropTypes.shape(AnimationInputPropTypes),
+  numberOfRotations: PropTypes.shape(AnimationInputPropTypes),
+};
 
 export default {
   rotateInDir: {

--- a/assets/src/animation/effects/rotateIn/animationProps.js
+++ b/assets/src/animation/effects/rotateIn/animationProps.js
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
@@ -20,15 +26,18 @@ import { FIELD_TYPES, DIRECTION } from '../../constants';
 
 export default {
   rotateInDir: {
+    label: __('Direction', 'web-stories'),
     type: FIELD_TYPES.DROPDOWN,
     values: [DIRECTION.LEFT_TO_RIGHT, DIRECTION.RIGHT_TO_LEFT],
     defaultValue: DIRECTION.LEFT_TO_RIGHT,
   },
   stopAngle: {
+    label: __('Stop Angle', 'web-stories'),
     type: FIELD_TYPES.NUMBER,
     defaultValue: 0,
   },
   numberOfRotations: {
+    label: __('# of Rotations', 'web-stories'),
     type: FIELD_TYPES.NUMBER,
     defaultValue: 1,
   },

--- a/assets/src/animation/effects/types.js
+++ b/assets/src/animation/effects/types.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * External dependencies
  */
 import PropTypes from 'prop-types';
@@ -27,23 +22,17 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES, DIRECTION } from '../../constants';
-import { AnimationInputPropTypes } from '../types';
+import { FIELD_TYPES } from '../constants';
 
-export const FlyInEffectInputPropTypes = {
-  flyInDir: PropTypes.shape(AnimationInputPropTypes),
-};
-
-export default {
-  flyInDir: {
-    label: __('Direction', 'web-stories'),
-    type: FIELD_TYPES.DROPDOWN,
-    values: [
-      DIRECTION.TOP_TO_BOTTOM,
-      DIRECTION.BOTTOM_TO_TOP,
-      DIRECTION.LEFT_TO_RIGHT,
-      DIRECTION.RIGHT_TO_LEFT,
-    ],
-    defaultValue: DIRECTION.BOTTOM_TO_TOP,
-  },
+export const AnimationInputPropTypes = {
+  type: PropTypes.oneOf([...Object.values(FIELD_TYPES)]).isRequired,
+  label: PropTypes.string,
+  tooltip: PropTypes.string,
+  unit: PropTypes.string,
+  values: PropTypes.array,
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
+  ]),
 };

--- a/assets/src/animation/effects/whooshIn/animationProps.js
+++ b/assets/src/animation/effects/whooshIn/animationProps.js
@@ -15,12 +15,18 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { FIELD_TYPES, DIRECTION } from '../../constants';
 
 export default {
   whooshInDir: {
+    label: __('Direction', 'web-stories'),
     type: FIELD_TYPES.DROPDOWN,
     values: [DIRECTION.LEFT_TO_RIGHT, DIRECTION.RIGHT_TO_LEFT],
     defaultValue: DIRECTION.LEFT_TO_RIGHT,

--- a/assets/src/animation/effects/whooshIn/animationProps.js
+++ b/assets/src/animation/effects/whooshIn/animationProps.js
@@ -20,9 +20,19 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
  * Internal dependencies
  */
 import { FIELD_TYPES, DIRECTION } from '../../constants';
+import { AnimationInputPropTypes } from '../types';
+
+export const WhooshInEffectInputPropTypes = {
+  whooshInDir: PropTypes.shape(AnimationInputPropTypes),
+};
 
 export default {
   whooshInDir: {

--- a/assets/src/animation/effects/zoom/animationProps.js
+++ b/assets/src/animation/effects/zoom/animationProps.js
@@ -20,9 +20,20 @@
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
  * Internal dependencies
  */
 import { FIELD_TYPES } from '../../constants';
+import { AnimationInputPropTypes } from '../types';
+
+export const ZoomEffectInputPropTypes = {
+  zoomFrom: PropTypes.shape(AnimationInputPropTypes),
+  zoomTo: PropTypes.shape(AnimationInputPropTypes),
+};
 
 export default {
   zoomFrom: {

--- a/assets/src/animation/effects/zoom/animationProps.js
+++ b/assets/src/animation/effects/zoom/animationProps.js
@@ -27,13 +27,13 @@ import { FIELD_TYPES } from '../../constants';
 export default {
   zoomFrom: {
     label: __('From', 'web-stories'),
-    tooltip: 'Valid values range from 0 to 1',
+    tooltip: __('Valid values range from 0 to 1', 'web-stories'),
     type: FIELD_TYPES.FLOAT,
     defaultValue: 0,
   },
   zoomTo: {
     label: __('To', 'web-stories'),
-    tooltip: 'Valid values range from 0 to 1',
+    tooltip: __('Valid values range from 0 to 1', 'web-stories'),
     type: FIELD_TYPES.FLOAT,
     defaultValue: 1,
   },

--- a/assets/src/animation/effects/zoom/animationProps.js
+++ b/assets/src/animation/effects/zoom/animationProps.js
@@ -22,18 +22,19 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES, DIRECTION } from '../../constants';
+import { FIELD_TYPES } from '../../constants';
 
 export default {
-  panDir: {
-    label: __('Direction', 'web-stories'),
-    type: FIELD_TYPES.DROPDOWN,
-    values: [
-      DIRECTION.TOP_TO_BOTTOM,
-      DIRECTION.BOTTOM_TO_TOP,
-      DIRECTION.LEFT_TO_RIGHT,
-      DIRECTION.RIGHT_TO_LEFT,
-    ],
-    defaultValue: DIRECTION.BOTTOM_TO_TOP,
+  zoomFrom: {
+    label: __('From', 'web-stories'),
+    tooltip: 'Valid values range from 0 to 1',
+    type: FIELD_TYPES.FLOAT,
+    defaultValue: 0,
+  },
+  zoomTo: {
+    label: __('To', 'web-stories'),
+    tooltip: 'Valid values range from 0 to 1',
+    type: FIELD_TYPES.FLOAT,
+    defaultValue: 1,
   },
 };

--- a/assets/src/animation/parts/defaultAnimationProps.js
+++ b/assets/src/animation/parts/defaultAnimationProps.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __, _x } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import {
@@ -23,6 +28,21 @@ import {
   FIELD_TYPES,
   BEZIER,
 } from '../constants';
+
+export const basicAnimationProps = {
+  duration: {
+    label: __('Duration', 'web-stories'),
+    type: FIELD_TYPES.NUMBER,
+    unit: _x('ms', 'Time in milliseconds ', 'web-stories'),
+    defaultValue: 1000,
+  },
+  delay: {
+    label: __('Delay', 'web-stories'),
+    type: FIELD_TYPES.NUMBER,
+    unit: _x('ms', 'Time in milliseconds ', 'web-stories'),
+    defaultValue: 0,
+  },
+};
 
 export default {
   id: {
@@ -33,19 +53,10 @@ export default {
     type: FIELD_TYPES.DROPDOWN,
     values: [
       ...Object.values(ANIMATION_TYPES),
-      ...Object.values(ANIMATION_EFFECTS),
+      ...Object.values(ANIMATION_EFFECTS).map((o) => o.value),
     ],
   },
-  duration: {
-    label: 'Duration (ms)',
-    type: FIELD_TYPES.NUMBER,
-    defaultValue: 1000,
-  },
-  delay: {
-    label: 'Delay (ms)',
-    type: FIELD_TYPES.NUMBER,
-    defaultValue: 0,
-  },
+  ...basicAnimationProps,
   direction: {
     type: FIELD_TYPES.DROPDOWN,
     values: ['normal', 'reverse', 'alternate', 'alternate-reverse'],

--- a/assets/src/animation/parts/defaultAnimationProps.js
+++ b/assets/src/animation/parts/defaultAnimationProps.js
@@ -20,6 +20,11 @@
 import { __, _x } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
  * Internal dependencies
  */
 import {
@@ -28,6 +33,12 @@ import {
   FIELD_TYPES,
   BEZIER,
 } from '../constants';
+import { AnimationInputPropTypes } from '../effects/types';
+
+export const BasicAnimationInputPropTypes = {
+  duration: PropTypes.shape(AnimationInputPropTypes),
+  delay: PropTypes.shape(AnimationInputPropTypes),
+};
 
 export const basicAnimationProps = {
   duration: {

--- a/assets/src/animation/parts/index.js
+++ b/assets/src/animation/parts/index.js
@@ -152,6 +152,7 @@ export function GetAnimationEffectProps(type) {
     type,
     props: {
       // This order is important.
+      // We want custom props to appear above default props
       ...(customProps[type] || {}),
       ...basicAnimationProps,
     },

--- a/assets/src/animation/parts/index.js
+++ b/assets/src/animation/parts/index.js
@@ -35,7 +35,9 @@ import { EffectRotateIn } from '../effects/rotateIn';
 import flyInProps from '../effects/flyIn/animationProps';
 import panProps from '../effects/pan/animationProps';
 import pulseProps from '../effects/pulse/animationProps';
+import rotateInProps from '../effects/rotateIn/animationProps';
 import whooshInProps from '../effects/whooshIn/animationProps';
+import zoomEffectProps from '../effects/zoom/animationProps';
 
 import { AnimationBounce } from './bounce';
 import { AnimationBlinkOn } from './blinkOn';
@@ -47,7 +49,9 @@ import { AnimationPulse } from './pulse';
 import { AnimationSpin } from './spin';
 import { AnimationZoom } from './zoom';
 
-import defaultAnimationProps from './defaultAnimationProps';
+import defaultAnimationProps, {
+  basicAnimationProps,
+} from './defaultAnimationProps';
 import blinkOnProps from './blinkOn/animationProps';
 import fadeProps from './fade/animationProps';
 import flipProps from './flip/animationProps';
@@ -86,15 +90,15 @@ export function AnimationPart(type, args) {
       [ANIMATION_TYPES.PULSE]: AnimationPulse,
       [ANIMATION_TYPES.SPIN]: AnimationSpin,
       [ANIMATION_TYPES.ZOOM]: AnimationZoom,
-      [ANIMATION_EFFECTS.FADE_IN]: EffectFadeIn,
-      [ANIMATION_EFFECTS.FLY_IN]: EffectFlyIn,
-      [ANIMATION_EFFECTS.PAN]: EffectPan,
-      [ANIMATION_EFFECTS.PULSE]: EffectPulse,
-      [ANIMATION_EFFECTS.TWIRL_IN]: EffectTwirlIn,
-      [ANIMATION_EFFECTS.WHOOSH_IN]: EffectWhooshIn,
-      [ANIMATION_EFFECTS.ZOOM]: EffectZoom,
-      [ANIMATION_EFFECTS.DROP]: EffectDrop,
-      [ANIMATION_EFFECTS.ROTATE_IN]: EffectRotateIn,
+      [ANIMATION_EFFECTS.FADE_IN.value]: EffectFadeIn,
+      [ANIMATION_EFFECTS.FLY_IN.value]: EffectFlyIn,
+      [ANIMATION_EFFECTS.PAN.value]: EffectPan,
+      [ANIMATION_EFFECTS.PULSE.value]: EffectPulse,
+      [ANIMATION_EFFECTS.TWIRL_IN.value]: EffectTwirlIn,
+      [ANIMATION_EFFECTS.WHOOSH_IN.value]: EffectWhooshIn,
+      [ANIMATION_EFFECTS.ZOOM.value]: EffectZoom,
+      [ANIMATION_EFFECTS.DROP.value]: EffectDrop,
+      [ANIMATION_EFFECTS.ROTATE_IN.value]: EffectRotateIn,
     }[type] || throughput;
 
   args.easing = args.easing || BEZIER[args.easingPreset];
@@ -112,10 +116,12 @@ export function GetAnimationProps(type) {
     [ANIMATION_TYPES.MOVE]: moveProps,
     [ANIMATION_TYPES.SPIN]: spinProps,
     [ANIMATION_TYPES.ZOOM]: zoomProps,
-    [ANIMATION_EFFECTS.FLY_IN]: flyInProps,
-    [ANIMATION_EFFECTS.PAN]: panProps,
-    [ANIMATION_EFFECTS.PULSE]: pulseProps,
-    [ANIMATION_EFFECTS.WHOOSH_IN]: whooshInProps,
+    [ANIMATION_EFFECTS.FLY_IN.value]: flyInProps,
+    [ANIMATION_EFFECTS.PAN.value]: panProps,
+    [ANIMATION_EFFECTS.PULSE.value]: pulseProps,
+    [ANIMATION_EFFECTS.ROTATE_IN.value]: rotateInProps,
+    [ANIMATION_EFFECTS.WHOOSH_IN.value]: whooshInProps,
+    [ANIMATION_EFFECTS.ZOOM.value]: zoomProps,
   };
 
   const { type: animationType, ...remaining } = defaultAnimationProps;
@@ -128,6 +134,26 @@ export function GetAnimationProps(type) {
       type: animationType,
       ...(customProps[type] || {}),
       ...remaining,
+    },
+  };
+}
+
+export function GetAnimationEffectProps(type) {
+  const customProps = {
+    [ANIMATION_EFFECTS.FLY_IN.value]: flyInProps,
+    [ANIMATION_EFFECTS.PAN.value]: panProps,
+    [ANIMATION_EFFECTS.PULSE.value]: pulseProps,
+    [ANIMATION_EFFECTS.ROTATE_IN.value]: rotateInProps,
+    [ANIMATION_EFFECTS.WHOOSH_IN.value]: whooshInProps,
+    [ANIMATION_EFFECTS.ZOOM.value]: zoomEffectProps,
+  };
+
+  return {
+    type,
+    props: {
+      // This order is important.
+      ...(customProps[type] || {}),
+      ...basicAnimationProps,
     },
   };
 }

--- a/assets/src/animation/parts/index.js
+++ b/assets/src/animation/parts/index.js
@@ -23,6 +23,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { ANIMATION_TYPES, ANIMATION_EFFECTS, BEZIER } from '../constants';
+import getDefaultFieldValue from '../utils/getDefaultFieldValue';
 import { EffectDrop } from '../effects/drop';
 import { EffectFadeIn } from '../effects/fadeIn';
 import { EffectFlyIn } from '../effects/flyIn';
@@ -107,7 +108,7 @@ export function AnimationPart(type, args) {
   return generator(args);
 }
 
-export function GetAnimationProps(type) {
+export function getAnimationProps(type) {
   const customProps = {
     [ANIMATION_TYPES.BLINK_ON]: blinkOnProps,
     [ANIMATION_TYPES.FADE]: fadeProps,
@@ -138,7 +139,7 @@ export function GetAnimationProps(type) {
   };
 }
 
-export function GetAnimationEffectProps(type) {
+export function getAnimationEffectProps(type) {
   const customProps = {
     [ANIMATION_EFFECTS.FLY_IN.value]: flyInProps,
     [ANIMATION_EFFECTS.PAN.value]: panProps,
@@ -157,6 +158,20 @@ export function GetAnimationEffectProps(type) {
       ...basicAnimationProps,
     },
   };
+}
+
+export function getAnimationEffectDefaults(type) {
+  const { props: effectProps } = getAnimationEffectProps(type);
+
+  return Object.keys(effectProps).reduce(
+    (acc, key) => ({
+      ...acc,
+      [key]:
+        effectProps[key].defaultValue ??
+        getDefaultFieldValue(effectProps[key].type),
+    }),
+    {}
+  );
 }
 
 export * from './types';

--- a/assets/src/animation/parts/types.js
+++ b/assets/src/animation/parts/types.js
@@ -41,7 +41,7 @@ export const AnimationProps = {
   id: PropTypes.string.isRequired,
   type: PropTypes.oneOf([
     ...Object.values(ANIMATION_TYPES),
-    ...Object.values(ANIMATION_EFFECTS),
+    ...Object.values(ANIMATION_EFFECTS).map((o) => o.value),
   ]),
   targets: PropTypes.arrayOf(PropTypes.string),
   ...GeneralAnimationPropTypes,

--- a/assets/src/animation/types.js
+++ b/assets/src/animation/types.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { FlyInEffectInputPropTypes } from './effects/flyIn/animationProps';
+import { PanEffectInputPropTypes } from './effects/pan/animationProps';
+import { PulseEffectInputPropTypes } from './effects/pulse/animationProps';
+import { RotateInEffectInputPropTypes } from './effects/rotateIn/animationProps';
+import { WhooshInEffectInputPropTypes } from './effects/whooshIn/animationProps';
+import { ZoomEffectInputPropTypes } from './effects/zoom/animationProps';
+import { BasicAnimationInputPropTypes } from './parts/defaultAnimationProps';
+
+export const AnimationFormPropTypes = PropTypes.shape({
+  ...FlyInEffectInputPropTypes,
+  ...PanEffectInputPropTypes,
+  ...PulseEffectInputPropTypes,
+  ...RotateInEffectInputPropTypes,
+  ...WhooshInEffectInputPropTypes,
+  ...ZoomEffectInputPropTypes,
+  ...BasicAnimationInputPropTypes,
+});

--- a/assets/src/animation/utils/getDefaultFieldValue.js
+++ b/assets/src/animation/utils/getDefaultFieldValue.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES } from '../constants';
+
+const getDefaultFieldValue = (fieldType) => {
+  switch (fieldType) {
+    case FIELD_TYPES.CHECKBOX:
+      return false;
+    case FIELD_TYPES.NUMBER:
+    case FIELD_TYPES.FLOAT:
+      return 0;
+    default:
+      return '';
+  }
+};
+
+export default getDefaultFieldValue;

--- a/assets/src/dashboard/app/views/storyAnimTool/timeline/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/timeline/index.js
@@ -24,7 +24,7 @@ import { v4 as uuidv4 } from 'uuid';
  * Internal dependencies
  */
 import {
-  GetAnimationProps,
+  getAnimationProps,
   ANIMATION_TYPES,
   FIELD_TYPES,
 } from '../../../../../animation';
@@ -134,7 +134,7 @@ function Timeline({
   const [formFields, setFormFields] = useState({});
 
   const { type: selectedAnimationType, props: animationProps } = useMemo(
-    () => GetAnimationProps(formFields.type || animationTypes[0]),
+    () => getAnimationProps(formFields.type || animationTypes[0]),
     [formFields.type]
   );
 

--- a/assets/src/edit-story/app/story/storyProvider.js
+++ b/assets/src/edit-story/app/story/storyProvider.js
@@ -74,7 +74,12 @@ function StoryProvider({ storyId, children }) {
   }, [pages, current]);
 
   // Generate selection info
-  const { selectedElementIds, selectedElements, hasSelection } = useMemo(() => {
+  const {
+    selectedElementIds,
+    selectedElements,
+    selectedElementAnimations,
+    hasSelection,
+  } = useMemo(() => {
     if (!currentPage) {
       return {
         selectedElements: [],
@@ -82,10 +87,23 @@ function StoryProvider({ storyId, children }) {
         hasSelection: false,
       };
     }
+
     const els = currentPage.elements.filter(({ id }) => selection.includes(id));
+    const animations = (currentPage.animations || []).reduce(
+      (acc, { targets, ...properties }) => {
+        if (targets.some((id) => selection.includes(id))) {
+          return [...acc, { ...properties }];
+        }
+
+        return acc;
+      },
+      []
+    );
+
     return {
       selectedElementIds: selection,
       selectedElements: els,
+      selectedElementAnimations: animations,
       hasSelection: els.length > 0,
     };
   }, [currentPage, selection]);
@@ -124,6 +142,7 @@ function StoryProvider({ storyId, children }) {
       currentPage,
       selectedElementIds,
       selectedElements,
+      selectedElementAnimations,
       hasSelection,
       story,
       animationState,

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/deleteElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/deleteElements.js
@@ -81,9 +81,16 @@ function deleteElements(state, { elementIds }) {
     newElements = [oldPage.defaultBackgroundElement, ...newElements];
   }
 
+  // Remove animations associated with elements
+  const oldAnimations = oldPage.animations || [];
+  const newAnimations = oldAnimations.filter((anim) =>
+    anim.targets.some((elementId) => !validDeletionIds.includes(elementId))
+  );
+
   const newPage = {
     ...oldPage,
     elements: newElements,
+    ...(oldAnimations.length > 0 ? { animations: newAnimations } : {}),
   };
 
   const newPages = [

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/updateElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/updateElements.js
@@ -18,7 +18,7 @@
  * Internal dependencies
  */
 import { STORY_ANIMATION_STATE } from '../../../../../animation';
-import { updateElementWithUpdater, intersect } from './utils';
+import { updateElementWithUpdater, updateAnimations, intersect } from './utils';
 
 /**
  * Update elements by the given list of ids with the given properties.
@@ -70,16 +70,51 @@ function updateElements(
     return state;
   }
 
-  const updatedElements = oldPage.elements.map((element) => {
-    if (!idsToUpdate.includes(element.id)) {
-      return element;
+  const {
+    animationLookup,
+    elements: updatedElements,
+  } = oldPage.elements.reduce(
+    ({ animationLookup, elements }, element) => {
+      if (!idsToUpdate.includes(element.id)) {
+        return {
+          animationLookup,
+          elements: [...elements, element],
+        };
+      }
+
+      const { animation, ...elem } = updateElementWithUpdater(
+        element,
+        propertiesOrUpdater,
+        pageIndex
+      );
+
+      const animLookup = animation
+        ? { [animation.id]: { ...animation, targets: [elem.id] } }
+        : {};
+
+      return {
+        animationLookup: {
+          ...animationLookup,
+          ...animLookup,
+        },
+        elements: [...elements, elem],
+      };
+    },
+    {
+      animationLookup: {},
+      elements: [],
     }
-    return updateElementWithUpdater(element, propertiesOrUpdater, pageIndex);
-  });
+  );
+
+  const newAnimations =
+    Object.keys(animationLookup).length > 0
+      ? updateAnimations(oldPage.animations || [], animationLookup)
+      : oldPage.animations;
 
   const newPage = {
     ...oldPage,
     elements: updatedElements,
+    ...(newAnimations ? { animations: newAnimations } : {}),
   };
 
   const newPages = [

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/utils.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/utils.js
@@ -91,3 +91,28 @@ export function updateElementWithUpdater(element, properties) {
   }
   return { ...element, ...allowedProperties };
 }
+
+export function updateAnimations(oldAnimations, animationUpdates) {
+  const newAnimations = oldAnimations.reduce((animations, animation) => {
+    const updatedAnimation = animationUpdates[animation.id];
+
+    // remove animation from lookup
+    delete animationUpdates[animation.id];
+
+    if (updatedAnimation?.delete) {
+      // delete animation
+      return animations;
+    } else if (updatedAnimation) {
+      // update animation
+      return [...animations, updatedAnimation];
+    } else {
+      // No updates
+      return [...animations, animation];
+    }
+  }, []);
+
+  // add animations
+  Object.values(animationUpdates).forEach((a) => newAnimations.push(a));
+
+  return newAnimations;
+}

--- a/assets/src/edit-story/components/form/index.js
+++ b/assets/src/edit-story/components/form/index.js
@@ -21,6 +21,7 @@ export { default as Input } from './input';
 export { default as Label } from './label';
 export { default as Media } from './media';
 export { default as Numeric } from './numeric';
+export { default as BoxedNumeric } from './shared/boxedNumeric';
 export { default as Row } from './row';
 export { default as Spacer } from './spacer';
 export { default as Switch } from './switch';

--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -31,6 +31,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { defaultUnit } from '../../../animation/utils/defaultUnit';
 import useFocusAndSelect from '../../utils/useFocusAndSelect';
 import { useKeyDownEffect } from '../keyboard';
 import Input from './input';
@@ -60,7 +61,7 @@ const Container = styled.div`
   justify-content: center;
   align-items: center;
   background-color: ${({ theme }) => rgba(theme.colors.bg.black, 0.3)};
-  flex-basis: ${({ flexBasis }) => flexBasis}px;
+  flex-basis: ${({ flexBasis }) => defaultUnit(flexBasis, 'px')};
   border: 1px solid;
   border-color: ${({ theme, focused }) =>
     focused ? theme.colors.whiteout : 'transparent'};
@@ -206,7 +207,7 @@ Numeric.propTypes = {
   suffix: PropTypes.any,
   disabled: PropTypes.bool,
   symbol: PropTypes.string,
-  flexBasis: PropTypes.number,
+  flexBasis: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   textCenter: PropTypes.bool,
   float: PropTypes.bool,
   min: PropTypes.number,

--- a/assets/src/edit-story/components/form/shared/boxedNumeric.js
+++ b/assets/src/edit-story/components/form/shared/boxedNumeric.js
@@ -15,25 +15,18 @@
  */
 
 /**
- * WordPress dependencies
+ * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import styled from 'styled-components';
 
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES, DIRECTION } from '../../constants';
+import { Numeric } from '../index';
 
-export default {
-  panDir: {
-    label: __('Direction', 'web-stories'),
-    type: FIELD_TYPES.DROPDOWN,
-    values: [
-      DIRECTION.TOP_TO_BOTTOM,
-      DIRECTION.BOTTOM_TO_TOP,
-      DIRECTION.LEFT_TO_RIGHT,
-      DIRECTION.RIGHT_TO_LEFT,
-    ],
-    defaultValue: DIRECTION.BOTTOM_TO_TOP,
-  },
-};
+const BoxedNumeric = styled(Numeric)`
+  padding: 6px 6px;
+  border-radius: 4px;
+`;
+
+export default BoxedNumeric;

--- a/assets/src/edit-story/components/form/shared/boxedNumeric.js
+++ b/assets/src/edit-story/components/form/shared/boxedNumeric.js
@@ -22,7 +22,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { Numeric } from '../index';
+import Numeric from '../numeric';
 
 const BoxedNumeric = styled(Numeric)`
   padding: 6px 6px;

--- a/assets/src/edit-story/components/inspector/design/useDesignPanels.js
+++ b/assets/src/edit-story/components/inspector/design/useDesignPanels.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { useCallback, useEffect, useMemo } from 'react';
+import { useFeatures } from 'flagged';
 
 /**
  * Internal dependencies
@@ -31,25 +32,34 @@ function useDesignPanels() {
   const {
     selectedElementIds,
     selectedElements,
+    selectedElementAnimations,
     deleteSelectedElements,
     updateElementsById,
   } = useStory(
     ({
-      state: { selectedElementIds, selectedElements },
+      state: {
+        selectedElementIds,
+        selectedElements,
+        selectedElementAnimations,
+      },
       actions: { deleteSelectedElements, updateElementsById },
     }) => {
       return {
         selectedElementIds,
         selectedElements,
+        selectedElementAnimations,
         deleteSelectedElements,
         updateElementsById,
       };
     }
   );
 
-  const panels = useMemo(() => getPanels(selectedElements), [selectedElements]);
+  const flags = useFeatures();
+  const panels = useMemo(() => getPanels(selectedElements, flags), [
+    selectedElements,
+    flags,
+  ]);
   const [submitHandlers, registerSubmitHandler] = useHandlers();
-
   const onSetProperties = useCallback(
     (newPropertiesOrUpdater) => {
       updateElementsById({
@@ -98,6 +108,7 @@ function useDesignPanels() {
       onSetProperties,
       deleteSelectedElements,
       selectedElements,
+      selectedElementAnimations,
     },
   };
 }

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -25,13 +25,13 @@ import PropTypes from 'prop-types';
 import { FIELD_TYPES } from '../../../../animation/constants';
 import { DropDown, BoxedNumeric } from '../../form';
 
-function EffectInput({ effectProps, effectConfig, field }) {
+function EffectInput({ effectProps, effectConfig, field, onChange }) {
   switch (effectProps[field].type) {
     case FIELD_TYPES.DROPDOWN:
       return (
         <DropDown
           value={effectConfig[field] || effectProps[field].defaultValue}
-          onChange={() => {}}
+          onChange={onChange}
           options={effectProps[field].values.map((v) => ({
             value: v,
             name: v,
@@ -46,8 +46,9 @@ function EffectInput({ effectProps, effectConfig, field }) {
           symbol={effectProps[field].unit}
           value={effectConfig[field] || effectProps[field].defaultValue}
           min={0}
-          onChange={() => {}}
+          onChange={onChange}
           canBeNegative={false}
+          float={effectProps[field].type === FIELD_TYPES.FLOAT}
           flexBasis={'100%'}
         />
       );
@@ -58,6 +59,7 @@ EffectInput.propTypes = {
   effectProps: PropTypes.object,
   effectConfig: PropTypes.object,
   field: PropTypes.string,
+  onChange: PropTypes.func,
 };
 
 export default EffectInput;

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -33,7 +33,7 @@ function EffectInput({ effectProps, effectConfig, field, onChange }) {
       return (
         <DropDown
           value={effectConfig[field] || effectProps[field].defaultValue}
-          onChange={onChange}
+          onChange={(value) => onChange(value, true)}
           options={effectProps[field].values.map((v) => ({
             value: v,
             name: v,

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES } from '../../../../animation/constants';
+import { DropDown, BoxedNumeric } from '../../form';
+
+function EffectInput({ effectProps, effectConfig, field }) {
+  switch (effectProps[field].type) {
+    case FIELD_TYPES.DROPDOWN:
+      return (
+        <DropDown
+          value={effectConfig[field] || effectProps[field].defaultValue}
+          onChange={() => {}}
+          options={effectProps[field].values.map((v) => ({
+            value: v,
+            name: v,
+          }))}
+        />
+      );
+    default:
+      return (
+        <BoxedNumeric
+          aria-label={effectProps[field].label}
+          suffix={effectProps[field].label}
+          symbol={effectProps[field].unit}
+          value={effectConfig[field] || effectProps[field].defaultValue}
+          min={0}
+          onChange={() => {}}
+          canBeNegative={false}
+          flexBasis={'100%'}
+        />
+      );
+  }
+}
+
+EffectInput.propTypes = {
+  effectProps: PropTypes.object,
+  effectConfig: PropTypes.object,
+  field: PropTypes.string,
+};
+
+export default EffectInput;

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -23,6 +23,8 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { FIELD_TYPES } from '../../../../animation/constants';
+import { GeneralAnimationPropTypes } from '../../../../animation/outputs/types';
+import { AnimationFormPropTypes } from '../../../../animation/types';
 import { DropDown, BoxedNumeric } from '../../form';
 
 function EffectInput({ effectProps, effectConfig, field, onChange }) {
@@ -56,10 +58,10 @@ function EffectInput({ effectProps, effectConfig, field, onChange }) {
 }
 
 EffectInput.propTypes = {
-  effectProps: PropTypes.object,
-  effectConfig: PropTypes.object,
-  field: PropTypes.string,
-  onChange: PropTypes.func,
+  effectProps: AnimationFormPropTypes.isRequired,
+  effectConfig: PropTypes.shape(GeneralAnimationPropTypes).isRequired,
+  field: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default EffectInput;

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -24,8 +24,10 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { ANIMATION_EFFECTS } from '../../../../animation/constants';
-import { AnimationProps } from '../../../../animation/parts/types';
-import { GetAnimationEffectProps } from '../../../../animation/parts';
+import {
+  GetAnimationEffectProps,
+  AnimationProps,
+} from '../../../../animation/parts';
 import { Row } from '../../form';
 import { Panel, PanelTitle, PanelContent } from '../panel';
 import EffectInput from './effectInput';

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 /**
@@ -35,12 +36,29 @@ function getEffectName(type) {
   );
 }
 
-function EffectPanel({ animation: { id, type, ...config } }) {
+function EffectPanel({ animation: { id, type, ...config }, onChange }) {
   const { props } = GetAnimationEffectProps(type);
+
+  const handleInputChange = useCallback(
+    (updates) => {
+      onChange({
+        id,
+        type,
+        ...config,
+        ...updates,
+      });
+    },
+    [id, type, config, onChange]
+  );
 
   const content = Object.keys(props).map((field) => (
     <Row key={field} expand>
-      <EffectInput effectProps={props} effectConfig={config} field={field} />
+      <EffectInput
+        effectProps={props}
+        effectConfig={config}
+        field={field}
+        onChange={(value) => handleInputChange({ [field]: value })}
+      />
     </Row>
   ));
 
@@ -54,6 +72,7 @@ function EffectPanel({ animation: { id, type, ...config } }) {
 
 EffectPanel.propTypes = {
   animation: PropTypes.shape(AnimationProps),
+  onChange: PropTypes.func.isRequired,
 };
 
 export default EffectPanel;

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { ANIMATION_EFFECTS } from '../../../../animation/constants';
+import { AnimationProps } from '../../../../animation/parts/types';
+import { GetAnimationEffectProps } from '../../../../animation/parts';
+import { Row } from '../../form';
+import { Panel, PanelTitle, PanelContent } from '../panel';
+import EffectInput from './effectInput';
+
+function getEffectName(type) {
+  return (
+    Object.values(ANIMATION_EFFECTS).find((o) => o.value === type)?.name || ''
+  );
+}
+
+function EffectPanel({ animation: { id, type, ...config } }) {
+  const { props } = GetAnimationEffectProps(type);
+
+  const content = Object.keys(props).map((field) => (
+    <Row key={field} expand>
+      <EffectInput effectProps={props} effectConfig={config} field={field} />
+    </Row>
+  ));
+
+  return (
+    <Panel key={id} name={type}>
+      <PanelTitle>{getEffectName(type)}</PanelTitle>
+      <PanelContent>{content}</PanelContent>
+    </Panel>
+  );
+}
+
+EffectPanel.propTypes = {
+  animation: PropTypes.shape(AnimationProps),
+};
+
+export default EffectPanel;

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * External dependencies
  */
 import { useCallback } from 'react';
@@ -28,7 +33,7 @@ import {
   GetAnimationEffectProps,
   AnimationProps,
 } from '../../../../animation/parts';
-import { Row } from '../../form';
+import { Row, Button } from '../../form';
 import { Panel, PanelTitle, PanelContent } from '../panel';
 import EffectInput from './effectInput';
 
@@ -38,7 +43,11 @@ function getEffectName(type) {
   );
 }
 
-function EffectPanel({ animation: { id, type, ...config }, onChange }) {
+function EffectPanel({
+  animation: { id, type, ...config },
+  onChange,
+  onRemove,
+}) {
   const { props } = GetAnimationEffectProps(type);
 
   const handleInputChange = useCallback(
@@ -53,6 +62,15 @@ function EffectPanel({ animation: { id, type, ...config }, onChange }) {
     [id, type, config, onChange]
   );
 
+  const handleRemoveClick = useCallback(() => {
+    onRemove({
+      id,
+      type,
+      ...config,
+      delete: true,
+    });
+  }, [id, type, config, onRemove]);
+
   const content = Object.keys(props).map((field) => (
     <Row key={field} expand>
       <EffectInput
@@ -66,7 +84,15 @@ function EffectPanel({ animation: { id, type, ...config }, onChange }) {
 
   return (
     <Panel key={id} name={type}>
-      <PanelTitle>{getEffectName(type)}</PanelTitle>
+      <PanelTitle
+        secondaryAction={
+          <Button onClick={handleRemoveClick}>
+            {__('Delete', 'web-stories')}
+          </Button>
+        }
+      >
+        {getEffectName(type)}
+      </PanelTitle>
       <PanelContent>{content}</PanelContent>
     </Panel>
   );
@@ -75,6 +101,7 @@ function EffectPanel({ animation: { id, type, ...config }, onChange }) {
 EffectPanel.propTypes = {
   animation: PropTypes.shape(AnimationProps),
   onChange: PropTypes.func.isRequired,
+  onRemove: PropTypes.func.isRequired,
 };
 
 export default EffectPanel;

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -30,7 +30,7 @@ import PropTypes from 'prop-types';
  */
 import { ANIMATION_EFFECTS } from '../../../../animation/constants';
 import {
-  GetAnimationEffectProps,
+  getAnimationEffectProps,
   AnimationProps,
 } from '../../../../animation/parts';
 import { Row, Button } from '../../form';
@@ -48,16 +48,19 @@ function EffectPanel({
   onChange,
   onRemove,
 }) {
-  const { props } = GetAnimationEffectProps(type);
+  const { props } = getAnimationEffectProps(type);
 
   const handleInputChange = useCallback(
-    (updates) => {
-      onChange({
-        id,
-        type,
-        ...config,
-        ...updates,
-      });
+    (updates, submitArg) => {
+      onChange(
+        {
+          id,
+          type,
+          ...config,
+          ...updates,
+        },
+        submitArg
+      );
     },
     [id, type, config, onChange]
   );
@@ -77,7 +80,9 @@ function EffectPanel({
         effectProps={props}
         effectConfig={config}
         field={field}
-        onChange={(value) => handleInputChange({ [field]: value })}
+        onChange={(value, submitArg) =>
+          handleInputChange({ [field]: value }, submitArg)
+        }
       />
     </Row>
   ));

--- a/assets/src/edit-story/components/panels/animation/index.js
+++ b/assets/src/edit-story/components/panels/animation/index.js
@@ -14,26 +14,4 @@
  * limitations under the License.
  */
 
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
-import { FIELD_TYPES, DIRECTION } from '../../constants';
-
-export default {
-  panDir: {
-    label: __('Direction', 'web-stories'),
-    type: FIELD_TYPES.DROPDOWN,
-    values: [
-      DIRECTION.TOP_TO_BOTTOM,
-      DIRECTION.BOTTOM_TO_TOP,
-      DIRECTION.LEFT_TO_RIGHT,
-      DIRECTION.RIGHT_TO_LEFT,
-    ],
-    defaultValue: DIRECTION.BOTTOM_TO_TOP,
-  },
-};
+export { default } from './panel';

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -17,15 +17,12 @@
 /**
  * WordPress dependencies
  */
-/**
- * External dependencies
- */
-import { useCallback, useMemo } from 'react';
 import { __ } from '@wordpress/i18n';
 
 /**
  * External dependencies
  */
+import { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 /**

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -52,15 +52,24 @@ function AnimationPanel({
     [pushUpdateForObject]
   );
 
+  const handleRemoveEffect = useCallback(
+    (animation) => {
+      pushUpdateForObject('animation', animation, null, true);
+    },
+    [pushUpdateForObject]
+  );
+
   const updatedAnimations = useMemo(() => {
     // Combining local element updates with the
     // page level applied updates
     const updated = selectedElements
       .map((element) => element.animation)
       .filter(Boolean);
-    return selectedElementAnimations.map((anim) => ({
-      ...(updated.find((a) => a.id === anim.id) || anim),
-    }));
+    return selectedElementAnimations
+      .map((anim) => ({
+        ...(updated.find((a) => a.id === anim.id) || anim),
+      }))
+      .filter((a) => !a.delete);
   }, [selectedElements, selectedElementAnimations]);
 
   return selectedElements.length > 1 ? (
@@ -83,6 +92,7 @@ function AnimationPanel({
           key={animation.id}
           animation={animation}
           onChange={handlePanelChange}
+          onRemove={handleRemoveEffect}
         />
       ))}
     </>

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+// import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import {
+  ANIMATION_EFFECTS,
+  FIELD_TYPES,
+} from '../../../../animation/constants';
+import { GetAnimationEffectProps } from '../../../../animation/parts';
+import StoryPropTypes, { AnimationPropType } from '../../../types';
+import { Row, DropDown, BoxedNumeric } from '../../form';
+import { SimplePanel, Panel, PanelTitle, PanelContent } from '../panel';
+import { Note } from '../shared';
+
+const ANIMATION_OPTIONS = [
+  { value: '', name: __('Add Effect', 'web-stories') },
+  ...Object.values(ANIMATION_EFFECTS),
+];
+
+function getEffectName(type) {
+  return (
+    Object.values(ANIMATION_EFFECTS).find((o) => o.value === type)?.name || ''
+  );
+}
+
+function renderEffectInput(effectProps, effectConfig, field) {
+  switch (effectProps[field].type) {
+    case FIELD_TYPES.DROPDOWN:
+      return (
+        <DropDown
+          value={effectConfig[field] || effectProps[field].defaultValue}
+          onChange={() => {}}
+          options={effectProps[field].values.map((v) => ({
+            value: v,
+            name: v,
+          }))}
+        />
+      );
+    default:
+      return (
+        <BoxedNumeric
+          aria-label={effectProps[field].label}
+          suffix={effectProps[field].label}
+          symbol={effectProps[field].unit}
+          value={effectConfig[field] || effectProps[field].defaultValue}
+          min={0}
+          onChange={() => {}}
+          canBeNegative={false}
+          flexBasis={'100%'}
+        />
+      );
+  }
+}
+
+function renderEffectsPanel({ id, type, ...config }) {
+  const { props } = GetAnimationEffectProps(type);
+
+  const content = Object.keys(props).map((field) => (
+    <Row key={field} expand>
+      {renderEffectInput(props, config, field)}
+    </Row>
+  ));
+
+  return (
+    <Panel key={id} name={type}>
+      <PanelTitle>{getEffectName(type)}</PanelTitle>
+      <PanelContent>{content}</PanelContent>
+    </Panel>
+  );
+}
+
+function AnimationPanel({ selectedElements, selectedElementAnimations }) {
+  return selectedElements.length > 1 ? (
+    <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
+      <Row>
+        <Note>{'Group animation support coming soon.'}</Note>
+      </Row>
+    </SimplePanel>
+  ) : (
+    <>
+      <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
+        <DropDown
+          value={ANIMATION_OPTIONS[0].value}
+          onChange={() => {}}
+          options={ANIMATION_OPTIONS}
+        />
+      </SimplePanel>
+      {selectedElementAnimations.map((animation) =>
+        renderEffectsPanel(animation)
+      )}
+    </>
+  );
+}
+
+AnimationPanel.propTypes = {
+  selectedElements: PropTypes.arrayOf(StoryPropTypes.element),
+  selectedElementAnimations: PropTypes.arrayOf(AnimationPropType),
+};
+
+export default AnimationPanel;

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -23,83 +23,27 @@ import { __ } from '@wordpress/i18n';
  * External dependencies
  */
 import PropTypes from 'prop-types';
-// import styled from 'styled-components';
 
 /**
  * Internal dependencies
  */
-import {
-  ANIMATION_EFFECTS,
-  FIELD_TYPES,
-} from '../../../../animation/constants';
-import { GetAnimationEffectProps } from '../../../../animation/parts';
+import { ANIMATION_EFFECTS } from '../../../../animation/constants';
 import StoryPropTypes, { AnimationPropType } from '../../../types';
-import { Row, DropDown, BoxedNumeric } from '../../form';
-import { SimplePanel, Panel, PanelTitle, PanelContent } from '../panel';
+import { Row, DropDown } from '../../form';
+import { SimplePanel } from '../panel';
 import { Note } from '../shared';
+import EffectPanel from './effectPanel';
 
 const ANIMATION_OPTIONS = [
   { value: '', name: __('Add Effect', 'web-stories') },
   ...Object.values(ANIMATION_EFFECTS),
 ];
 
-function getEffectName(type) {
-  return (
-    Object.values(ANIMATION_EFFECTS).find((o) => o.value === type)?.name || ''
-  );
-}
-
-function renderEffectInput(effectProps, effectConfig, field) {
-  switch (effectProps[field].type) {
-    case FIELD_TYPES.DROPDOWN:
-      return (
-        <DropDown
-          value={effectConfig[field] || effectProps[field].defaultValue}
-          onChange={() => {}}
-          options={effectProps[field].values.map((v) => ({
-            value: v,
-            name: v,
-          }))}
-        />
-      );
-    default:
-      return (
-        <BoxedNumeric
-          aria-label={effectProps[field].label}
-          suffix={effectProps[field].label}
-          symbol={effectProps[field].unit}
-          value={effectConfig[field] || effectProps[field].defaultValue}
-          min={0}
-          onChange={() => {}}
-          canBeNegative={false}
-          flexBasis={'100%'}
-        />
-      );
-  }
-}
-
-function renderEffectsPanel({ id, type, ...config }) {
-  const { props } = GetAnimationEffectProps(type);
-
-  const content = Object.keys(props).map((field) => (
-    <Row key={field} expand>
-      {renderEffectInput(props, config, field)}
-    </Row>
-  ));
-
-  return (
-    <Panel key={id} name={type}>
-      <PanelTitle>{getEffectName(type)}</PanelTitle>
-      <PanelContent>{content}</PanelContent>
-    </Panel>
-  );
-}
-
 function AnimationPanel({ selectedElements, selectedElementAnimations }) {
   return selectedElements.length > 1 ? (
     <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
       <Row>
-        <Note>{'Group animation support coming soon.'}</Note>
+        <Note>{__('Group animation support coming soon.', 'web-stories')}</Note>
       </Row>
     </SimplePanel>
   ) : (
@@ -111,9 +55,9 @@ function AnimationPanel({ selectedElements, selectedElementAnimations }) {
           options={ANIMATION_OPTIONS}
         />
       </SimplePanel>
-      {selectedElementAnimations.map((animation) =>
-        renderEffectsPanel(animation)
-      )}
+      {selectedElementAnimations.map((animation) => (
+        <EffectPanel key={animation.id} animation={animation} />
+      ))}
     </>
   );
 }

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -17,6 +17,10 @@
 /**
  * WordPress dependencies
  */
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo } from 'react';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -39,7 +43,29 @@ const ANIMATION_OPTIONS = [
   ...Object.values(ANIMATION_EFFECTS),
 ];
 
-function AnimationPanel({ selectedElements, selectedElementAnimations }) {
+function AnimationPanel({
+  selectedElements,
+  selectedElementAnimations,
+  pushUpdateForObject,
+}) {
+  const handlePanelChange = useCallback(
+    (animation) => {
+      pushUpdateForObject('animation', animation, null, false);
+    },
+    [pushUpdateForObject]
+  );
+
+  const updatedAnimations = useMemo(() => {
+    // Combining local element updates with the
+    // page level applied updates
+    const updated = selectedElements
+      .map((element) => element.animation)
+      .filter(Boolean);
+    return selectedElementAnimations.map((anim) => ({
+      ...(updated.find((a) => a.id === anim.id) || anim),
+    }));
+  }, [selectedElements, selectedElementAnimations]);
+
   return selectedElements.length > 1 ? (
     <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
       <Row>
@@ -55,16 +81,21 @@ function AnimationPanel({ selectedElements, selectedElementAnimations }) {
           options={ANIMATION_OPTIONS}
         />
       </SimplePanel>
-      {selectedElementAnimations.map((animation) => (
-        <EffectPanel key={animation.id} animation={animation} />
+      {updatedAnimations.map((animation) => (
+        <EffectPanel
+          key={animation.id}
+          animation={animation}
+          onChange={handlePanelChange}
+        />
       ))}
     </>
   );
 }
 
 AnimationPanel.propTypes = {
-  selectedElements: PropTypes.arrayOf(StoryPropTypes.element),
+  selectedElements: PropTypes.arrayOf(StoryPropTypes.element).isRequired,
   selectedElementAnimations: PropTypes.arrayOf(AnimationPropType),
+  pushUpdateForObject: PropTypes.func.isRequired,
 };
 
 export default AnimationPanel;

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -24,11 +24,13 @@ import { __ } from '@wordpress/i18n';
  */
 import { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
 
 /**
  * Internal dependencies
  */
 import { ANIMATION_EFFECTS } from '../../../../animation/constants';
+import { getAnimationEffectDefaults } from '../../../../animation/parts';
 import StoryPropTypes, { AnimationPropType } from '../../../types';
 import { Row, DropDown } from '../../form';
 import { SimplePanel } from '../panel';
@@ -40,21 +42,44 @@ const ANIMATION_OPTIONS = [
   ...Object.values(ANIMATION_EFFECTS),
 ];
 
+const ANIMATION_PROPERTY = 'animation';
+
 function AnimationPanel({
   selectedElements,
   selectedElementAnimations,
   pushUpdateForObject,
 }) {
   const handlePanelChange = useCallback(
-    (animation) => {
-      pushUpdateForObject('animation', animation, null, false);
+    (animation, submitArg = false) => {
+      pushUpdateForObject(ANIMATION_PROPERTY, animation, null, submitArg);
     },
     [pushUpdateForObject]
   );
 
   const handleRemoveEffect = useCallback(
     (animation) => {
-      pushUpdateForObject('animation', animation, null, true);
+      pushUpdateForObject(ANIMATION_PROPERTY, animation, null, true);
+    },
+    [pushUpdateForObject]
+  );
+
+  const handleAddEffect = useCallback(
+    (type) => {
+      if (!type) {
+        return;
+      }
+
+      const defaults = getAnimationEffectDefaults(type);
+      pushUpdateForObject(
+        ANIMATION_PROPERTY,
+        {
+          id: uuidv4(),
+          type,
+          ...defaults,
+        },
+        null,
+        true
+      );
     },
     [pushUpdateForObject]
   );
@@ -83,7 +108,7 @@ function AnimationPanel({
       <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
         <DropDown
           value={ANIMATION_OPTIONS[0].value}
-          onChange={() => {}}
+          onChange={handleAddEffect}
           options={ANIMATION_OPTIONS}
         />
       </SimplePanel>

--- a/assets/src/edit-story/components/panels/index.js
+++ b/assets/src/edit-story/components/panels/index.js
@@ -18,6 +18,7 @@
  * Internal dependencies
  */
 import { elementTypes } from '../../elements';
+import AnimationPanel from './animation';
 import BackgroundSizePositionPanel from './backgroundSizePosition';
 import BackgroundOverlayPanel from './backgroundOverlay';
 import ImageAccessibilityPanel from './imageAccessibility';
@@ -34,6 +35,7 @@ import VideoOptionsPanel from './videoOptions';
 import StylePresetPanel from './stylePreset';
 export { default as LayerPanel } from './layer';
 
+const ANIMATION = 'animation';
 const BACKGROUND_SIZE_POSITION = 'backgroundSizePosition';
 const BACKGROUND_OVERLAY = 'backgroundOverlay';
 const STYLE_PRESETS = 'stylePresets';
@@ -65,6 +67,7 @@ export const PanelTypes = {
   VIDEO_OPTIONS,
   IMAGE_ACCESSIBILITY,
   VIDEO_ACCESSIBILITY,
+  ANIMATION,
 };
 
 const ALL = Object.values(PanelTypes);
@@ -73,7 +76,9 @@ function intersect(a, b) {
   return a.filter((v) => b.includes(v));
 }
 
-export function getPanels(elements) {
+export function getPanels(elements, options = {}) {
+  const { enableAnimation } = options;
+
   if (elements.length === 0) {
     return [{ type: NO_SELECTION, Panel: NoSelectionPanel }];
   }
@@ -118,6 +123,8 @@ export function getPanels(elements) {
     .reduce((commonPanels, panels) => intersect(commonPanels, panels), ALL)
     .map((type) => {
       switch (type) {
+        case ANIMATION:
+          return enableAnimation ? { type, Panel: AnimationPanel } : null;
         case BACKGROUND_SIZE_POSITION:
           // Only display when isBackground.
           return null;

--- a/assets/src/edit-story/components/panels/layerStyle.js
+++ b/assets/src/edit-story/components/panels/layerStyle.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 
 /**
  * WordPress dependencies
@@ -29,14 +28,9 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import clamp from '../../utils/clamp';
-import { Row, Numeric, usePresubmitHandler } from '../form';
+import { Row, BoxedNumeric, usePresubmitHandler } from '../form';
 import { SimplePanel } from './panel';
 import { getCommonValue } from './utils';
-
-const BoxedNumeric = styled(Numeric)`
-  padding: 6px 6px;
-  border-radius: 4px;
-`;
 
 const MIN_MAX = {
   OPACITY: {

--- a/assets/src/edit-story/components/panels/sizePosition.js
+++ b/assets/src/edit-story/components/panels/sizePosition.js
@@ -30,9 +30,9 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import {
+  BoxedNumeric,
   Button,
   Row,
-  Numeric,
   Toggle,
   usePresubmitHandler,
   MULTIPLE_VALUE,
@@ -63,11 +63,6 @@ const MIN_MAX = {
     MAX: 1000,
   },
 };
-
-const BoxedNumeric = styled(Numeric)`
-  padding: 6px 6px;
-  border-radius: 4px;
-`;
 
 const StyledToggle = styled(Toggle)`
   margin: 0 10px;

--- a/assets/src/edit-story/elements/media/index.js
+++ b/assets/src/edit-story/elements/media/index.js
@@ -80,4 +80,5 @@ export const MEDIA_PANELS = [
   PanelTypes.BACKGROUND_SIZE_POSITION,
   PanelTypes.LAYER_STYLE,
   PanelTypes.SIZE_POSITION,
+  PanelTypes.ANIMATION,
 ];

--- a/assets/src/edit-story/elements/shape/index.js
+++ b/assets/src/edit-story/elements/shape/index.js
@@ -53,4 +53,5 @@ export const panels = [
   PanelTypes.LAYER_STYLE,
   PanelTypes.LINK,
   PanelTypes.SHAPE_STYLE,
+  PanelTypes.ANIMATION,
 ];

--- a/assets/src/edit-story/elements/text/index.js
+++ b/assets/src/edit-story/elements/text/index.js
@@ -71,4 +71,5 @@ export const panels = [
   PanelTypes.LAYER_STYLE,
   PanelTypes.TEXT_STYLE,
   PanelTypes.LINK,
+  PanelTypes.ANIMATION,
 ];

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -192,6 +192,8 @@ StoryPropTypes.elements.media = PropTypes.oneOfType([
   StoryPropTypes.elements.video,
 ]);
 
+export const AnimationPropType = PropTypes.shape(AnimationProps);
+
 export const FontPropType = PropTypes.shape({
   family: PropTypes.string,
   service: PropTypes.string,


### PR DESCRIPTION
## Summary

This PR lays down the foundation for editing animations within the editor using animation panels!  You can `Add`, `Update`, and `Remove` animation effects using the animation panels in the editor.

## Relevant Technical Choices

We currently store `animation` data in an array at the `page` level, but the existing editor panel code is setup to easily update properties within an element.  So, instead of adding in a bunch of extra code to specifically update animations as a separate thing, I decided to treat animations as a property of an element so animation data can be pushed up like any other element data.

## To-do

Coming soon in another PR:
- Tests (karma and other tests).
- Logic to handle animation panels when multiple elements are selected.
- Some sort of support for `Animation Parts` (so far I'm specifically just supporting `Animation Effects`, which are the animations we want users to specifically use).
- Update the panel styles to appear like the mocks but that's going to be part of the greater editor design update.

## User-facing changes

None.

## Testing Instructions

1.) Enable animations
2.) Go to a story (or create a new one).
3.) Select an element (only 1 element at a time) and the "Animation" panel should appear in the panel list.
4.) Select an effect from the drop down to apply the effect (with default values) to the selected element.
5.) Add more effects, remove some, have fun.
6.) Click the play button under the editor page area and see the animations come to life!

## Screenshot

![image](https://user-images.githubusercontent.com/40646372/90823822-55a09280-e2eb-11ea-9a58-9beacd46a5b2.png)
