### PR TITLE
Media: Fix issue where images from the WP media modal are broken

### DIFF
--- a/assets/src/edit-story/app/media/utils/createResource.js
+++ b/assets/src/edit-story/app/media/utils/createResource.js
@@ -62,6 +62,16 @@ import getTypeFromMime from './getTypeFromMime';
  */
 
 /**
+ * ResourceSize object
+ *
+ * @typedef {ResourceSize} ResourceSize
+ * @property {number} width The width of the ResourceSize.
+ * @property {number} height The height of the ResourceSize.
+ * @property {string} source_url The URL pointing to the resource for this size.
+ * @property {string|null} mimeType The mimeType of this ResourceSize.
+ */
+
+/**
  * Resource object.
  *
  * TODO: Try to remove posterId (poster should be enough?)
@@ -86,7 +96,7 @@ import getTypeFromMime from './getTypeFromMime';
  * resource.
  * @property {boolean} local Whether the resource has been already uploaded to
  * the server.
- * @property {Object} sizes Object of image sizes.
+ * @property {Object.<string, ResourceSize>} sizes Object of image sizes.
  * @property {Attribution|null} attribution An optional attribution for the
  * resource.
  */

--- a/assets/src/edit-story/app/media/utils/getResourceFromMediaPicker.js
+++ b/assets/src/edit-story/app/media/utils/getResourceFromMediaPicker.js
@@ -46,8 +46,18 @@ const getResourceFromMediaPicker = (mediaPickerEl) => {
       generated: posterGenerated,
     } = '',
     fileLength: lengthFormatted,
-    sizes,
+    sizes: mediaPickerSizes,
   } = mediaPickerEl;
+  const sizes = Object.fromEntries(
+    Object.entries(mediaPickerSizes).map(([k, size]) => [
+      k,
+      {
+        width: size.width,
+        height: size.height,
+        source_url: size.url,
+      },
+    ])
+  );
   return createResource({
     mimeType,
     uploadDate: date,


### PR DESCRIPTION
## Summary

Fixes the issue where images added from the WP media gallery don't display (due to the `sizes` missing source_url).

## Relevant Technical Choices

The getResourceFromMediaPicker was passing the `sizes` object directly from the picker, which uses `url` instead of the expected `source_url`.

## Testing Instructions

This should fix #4023 so following the steps outlined there should suffice.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4023
