### PR TITLE
Add key accidentally removed in #3780

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/mediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaGallery.js
@@ -46,6 +46,7 @@ function MediaGallery({ resources, onInsert, providerType }) {
   const imageRenderer = useCallback(
     ({ index, photo }) => (
       <MediaElement
+        key={index}
         index={index}
         margin={PHOTO_MARGIN + 'px'}
         resource={resources[index]}


### PR DESCRIPTION
Fixes a React warning:

```
react.development.js:315 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `Gallery`. See https://fb.me/react-warning-keys for more information.
    in MediaElement (at mediaGallery.js:48)
    in Gallery
    in Gallery (at mediaGallery.js:63)
    in div (at mediaGallery.js:62)
    in MediaGallery (at paginatedMediaGallery.js:171)
...
```