### PR TITLE
Media: populate sizes when images are uploaded via cop/paste or drag/drop

### DIFF
--- a/assets/src/edit-story/components/canvas/useUploadWithPreview.js
+++ b/assets/src/edit-story/components/canvas/useUploadWithPreview.js
@@ -58,6 +58,7 @@ function useUploadWithPreview() {
       const blobUrl = element.resource.src;
       const keysToUpdate = objectPick(resource, [
         'src',
+        'sizes',
         'width',
         'height',
         'length',


### PR DESCRIPTION
## Summary

Ensure we populate the `sizes` field when local files are uploaded via drag n drop and copy/paste.

## User-facing changes

Images added to the canvas via drag n drop or copy/paste should now display with srcset in the canvas and AMP output.

## Testing Instructions

Add images to canvas via drag n drop / copy paste and ensure srcset is used.

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #3905
