### PR TITLE
Fix fullbleedRef console warning

### DIFF
--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -240,7 +240,10 @@ PageArea.propTypes = {
   children: PropTypes.node,
   showSafeZone: PropTypes.bool,
   showOverflow: PropTypes.bool,
-  fullbleedRef: PropTypes.object,
+  fullbleedRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.elementType }),
+  ]),
   overlay: PropTypes.node,
   background: PropTypes.object,
 };


### PR DESCRIPTION
## Summary

Fix fullbleedRef console warning by adding a more specific PropTypes for ref.

Fixes #4042
