### PR TITLE
Fix gallery warning caused by missing MediaElement key

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/mediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaGallery.js
@@ -46,6 +46,7 @@ function MediaGallery({ resources, onInsert, providerType }) {
   const imageRenderer = useCallback(
     ({ index, photo }) => (
       <MediaElement
+        key={index}
         index={index}
         margin={PHOTO_MARGIN + 'px'}
         resource={resources[index]}


### PR DESCRIPTION
## Summary

Fix gallery warning caused by missing MediaElement key.

The warning was introduced in https://github.com/google/web-stories-wp/issues/3780.

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4044
