### PR TITLE
RegisterUsage on useInsertElement (not drag/click)

### DIFF
--- a/assets/src/edit-story/components/canvas/test/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/test/useInsertElement.js
@@ -29,7 +29,7 @@ import { useLocalMedia, useStory } from '../../../app';
 jest.mock('../../../app/media/media3p/api/useMedia3pApi');
 jest.mock('../../../app');
 
-const TYPE = 'image';
+const IMAGE_TYPE = 'image';
 
 const PROPS_LOCAL = {
   resource: {
@@ -95,7 +95,7 @@ const PROPS_M3P_WITH_ATTRIBUTION = {
   height: 353,
 };
 
-const registerUsageUrl = 'https://registerUsageUrl.com/register';
+const REGISTER_USAGE_URL = 'https://registerUsageUrl.com/register';
 
 describe('useInsertElement', () => {
   const registerUsage = jest.fn();
@@ -122,16 +122,16 @@ describe('useInsertElement', () => {
     it('should be called for external resources with registerUsageUrl', () => {
       const { result } = renderHook(() => useInsertElement());
       act(() => {
-        result.current(TYPE, PROPS_M3P_WITH_ATTRIBUTION);
+        result.current(IMAGE_TYPE, PROPS_M3P_WITH_ATTRIBUTION);
       });
 
-      expect(registerUsage).toHaveBeenCalledWith({ registerUsageUrl });
+      expect(registerUsage).toHaveBeenCalledWith({ REGISTER_USAGE_URL });
     });
 
     it('should not be called for local resources', () => {
       const { result } = renderHook(() => useInsertElement());
       act(() => {
-        result.current(TYPE, PROPS_LOCAL);
+        result.current(IMAGE_TYPE, PROPS_LOCAL);
       });
       expect(registerUsage).not.toHaveBeenCalled();
     });

--- a/assets/src/edit-story/components/canvas/test/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/test/useInsertElement.js
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useInsertElement from '../useInsertElement';
+import useMedia3pApi from '../../../app/media/media3p/api/useMedia3pApi';
+import { useLocalMedia, useStory } from '../../../app';
+
+jest.mock('../../../app/media/media3p/api/useMedia3pApi');
+jest.mock('../../../app');
+
+const TYPE = 'image';
+
+const PROPS_LOCAL = {
+  resource: {
+    type: 'image',
+    mimeType: 'image/jpeg',
+    creationDate: '2020-08-10T03:42:08',
+    src: 'http://local_url/wp-content/uploads/2020/08/local_image.jpg',
+    width: 1920,
+    height: 1080,
+    posterId: 0,
+    id: 211,
+    title: 'local_image',
+    alt: 'local_image',
+    local: false,
+    sizes: {
+      full: {
+        file: 'local_image.jpg',
+        width: 1920,
+        height: 1080,
+        mime_type: 'image/jpeg',
+        source_url:
+          'http://wp.local/wp-content/uploads/2020/08/local_image.jpg',
+      },
+    },
+  },
+  x: 126,
+  y: 512,
+  width: 354,
+  height: 199,
+};
+
+const PROPS_M3P_WITH_ATTRIBUTION = {
+  resource: {
+    type: 'image',
+    mimeType: 'image/jpeg',
+    creationDate: '2020-08-14T19:43:09Z',
+    src: 'https://images.url.com/photo-fake-url',
+    width: 2400,
+    height: 3620,
+    title: 'Pictures of dogs',
+    alt: null,
+    local: false,
+    sizes: {
+      full: {
+        file: 'media/provider:TZ2tVEJx2aA',
+        source_url: 'https://source_url.com',
+        mime_type: 'image/jpeg',
+        width: 2400,
+        height: 3620,
+      },
+    },
+    attribution: {
+      author: {
+        displayName: 'Photographer Name',
+        url: 'https://author.url',
+      },
+      registerUsageUrl: 'https://registerUsageUrl.com/register',
+    },
+  },
+  x: 28,
+  y: 401,
+  width: 233,
+  height: 353,
+};
+
+const registerUsageUrl = 'https://registerUsageUrl.com/register';
+
+describe('useInsertElement', () => {
+  const registerUsage = jest.fn();
+
+  beforeAll(() => {
+    useMedia3pApi.mockReturnValue({
+      actions: { registerUsage },
+    });
+
+    useStory.mockReturnValue({
+      addElement: jest.fn(),
+    });
+
+    useLocalMedia.mockReturnValue({
+      uploadVideoPoster: jest.fn(),
+    });
+  });
+
+  describe('register usage function', () => {
+    beforeEach(() => {
+      registerUsage.mockClear();
+    });
+
+    it('should be called for external resources with registerUsageUrl', () => {
+      const { result } = renderHook(() => useInsertElement());
+      act(() => {
+        result.current(TYPE, PROPS_M3P_WITH_ATTRIBUTION);
+      });
+
+      expect(registerUsage).toHaveBeenCalledWith({ registerUsageUrl });
+    });
+
+    it('should not be called for local resources', () => {
+      const { result } = renderHook(() => useInsertElement());
+      act(() => {
+        result.current(TYPE, PROPS_LOCAL);
+      });
+      expect(registerUsage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/assets/src/edit-story/components/canvas/test/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/test/useInsertElement.js
@@ -125,7 +125,9 @@ describe('useInsertElement', () => {
         result.current(IMAGE_TYPE, PROPS_M3P_WITH_ATTRIBUTION);
       });
 
-      expect(registerUsage).toHaveBeenCalledWith({ REGISTER_USAGE_URL });
+      expect(registerUsage).toHaveBeenCalledWith({
+        registerUsageUrl: REGISTER_USAGE_URL,
+      });
     });
 
     it('should not be called for local resources', () => {

--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -64,8 +64,7 @@ function useInsertElement() {
    * If the resource has a register usage url then the fact that it's been
    * inserted needs to be registered as per API provider policies.
    *
-   * @param {Object} resource The resource to verify/update.
-   * is complete.
+   * @param {Object} resource The resource to attempt to register usage.
    */
   const handleRegisterUsage = useCallback(
     (resource) => {

--- a/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
@@ -30,7 +30,6 @@ import { useDropTargets } from '../../../../../app';
 import DropDownMenu from '../local/dropDownMenu';
 import { KEYBOARD_USER_SELECTOR } from '../../../../../utils/keyboardOnlyOutline';
 import { useKeyDownEffect } from '../../../../keyboard';
-import { useMedia3pApi } from '../../../../../app/media/media3p/api';
 import getThumbnailUrl from '../../../../../elements/media/util';
 import useRovingTabIndex from './useRovingTabIndex';
 import Attribution from './attribution';
@@ -166,22 +165,6 @@ const MediaElement = ({
     actions: { handleDrag, handleDrop, setDraggingResource },
   } = useDropTargets();
 
-  const {
-    actions: { registerUsage },
-  } = useMedia3pApi();
-
-  const handleRegisterUsage = useCallback(() => {
-    if (
-      providerType !== 'local' &&
-      resource.attribution &&
-      resource.attribution.registerUsageUrl
-    ) {
-      registerUsage({
-        registerUsageUrl: resource.attribution.registerUsageUrl,
-      });
-    }
-  }, [providerType, resource, registerUsage]);
-
   const measureMediaElement = () =>
     mediaElement?.current?.getBoundingClientRect();
 
@@ -208,11 +191,10 @@ const MediaElement = ({
       onDragEnd: (e) => {
         e.preventDefault();
         setDraggingResource(null);
-        handleRegisterUsage();
         handleDrop(resource);
       },
     }),
-    [setDraggingResource, resource, handleDrag, handleDrop, handleRegisterUsage]
+    [setDraggingResource, resource, handleDrag, handleDrop]
   );
 
   const makeActive = useCallback(() => setActive(true), []);
@@ -255,7 +237,6 @@ const MediaElement = ({
   }, [isMenuOpen, active, type]);
 
   const onClick = () => {
-    handleRegisterUsage();
     onInsert(resource, width, height);
   };
 


### PR DESCRIPTION
## Summary

Moving the registerUsage functions from being triggered on UI interactions (i.e. on click or on dragend of elements from mediaPane) to being triggered when useInsertElement() is triggered with a media3p resource with a registerUsageUrl.

The issue with previous approach was that the registerUsage call is triggered on the interactions regardless of whether the element was inserted. This PR fixes that.

## User-facing changes

None

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3998 
