### PR TITLE
Dashboard: Rename story text box is cut off

### DIFF
--- a/assets/src/dashboard/components/input/index.js
+++ b/assets/src/dashboard/components/input/index.js
@@ -26,6 +26,7 @@ import { TypographyPresets } from '../typography';
 
 export const TextInput = styled.input`
   ${TypographyPresets.Small};
+  width: 100%;
   margin: 0;
   padding: 1px 8px;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
Makes sure the rename input spans the width of the available space.

## Relevant Technical Choices
- input was missing `width` to control the space the input would take up.

## To-do

N/A

## User-facing changes

- Rename input should now not be cut off in any browser.
Safari:  
![input - safari](https://user-images.githubusercontent.com/10720454/90568640-28c07400-e161-11ea-8451-2aa2960ea9bf.png)
Firefox:
![input - firefox](https://user-images.githubusercontent.com/10720454/90568641-29590a80-e161-11ea-9f34-5886ee82cbeb.png)
Chrome:
![input - chrome](https://user-images.githubusercontent.com/10720454/90568643-29f1a100-e161-11ea-9abf-dcc4d1c0682d.png)


## Testing Instructions

- Go to Dashboard -> My Stories and rename a story in different browsers. Input should not be cut off anymore.

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4053 
