### PR TITLE
Animation: Timeline Keyboard Controls

### DIFF
--- a/assets/src/edit-story/components/animationTimeline/index.js
+++ b/assets/src/edit-story/components/animationTimeline/index.js
@@ -61,7 +61,7 @@ export default function AnimationTimeline({
           >
             <TimingBar
               label={animation.label}
-              offset={animation.offset}
+              delay={animation.delay}
               duration={animation.duration}
               maxDuration={duration}
               onUpdateAnimation={(delta) => onUpdateAnimation(animation, delta)}

--- a/assets/src/edit-story/components/animationTimeline/stories/index.js
+++ b/assets/src/edit-story/components/animationTimeline/stories/index.js
@@ -36,17 +36,17 @@ export const _default = () => {
       acc[id] = {
         id,
         duration: 500,
-        offset: id % 2 ? 100 : 0,
+        delay: id % 2 ? 100 : 0,
         label: `Animation ${id}`,
       };
       return acc;
     }, {})
   );
 
-  const handleUpdateAnimation = useCallback(({ id }, { duration, offset }) => {
+  const handleUpdateAnimation = useCallback(({ id }, { duration, delay }) => {
     setAnimations((a) => {
       a[id].duration = duration;
-      a[id].offset = offset;
+      a[id].delay = delay;
       return { ...a };
     });
   }, []);

--- a/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
+++ b/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import React from 'react';
+import { act, fireEvent } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -49,13 +50,63 @@ describe('<AnimationTimeline />', function () {
     );
   });
 
-  it('should update the offset when a timing bar is adjusted to the right', async function () {
-    const { queryAllByTestId } = renderWithTheme(
+  it('should update the offset when a timing bar is adjusted to the right', function () {
+    const updaterFn = jest.fn();
+    const { getByTestId } = renderWithTheme(
       <AnimationTimeline
         animations={Object.values(animations)}
         duration={6000}
-        onUpdateAnimation={() => {}}
+        onUpdateAnimation={updaterFn}
       />
+    );
+
+    const endHandle = getByTestId('end-animation-handle-Animation 0');
+    endHandle.focus();
+
+    act(() => {
+      fireEvent.keyDown(endHandle, {
+        key: 'ArrowRight',
+        which: 39,
+      });
+    });
+
+    /**
+     * Starting duration was 500ms, one right key press moves 100ms,
+     * so the new duration should be 600ms.
+     */
+    expect(updaterFn).toHaveBeenCalledWith(
+      { duration: 500, id: 0, label: 'Animation 0', offset: 0 },
+      { duration: 600, offset: 0 }
+    );
+  });
+
+  it('should update the offset when a timing bar is adjusted to the left', function () {
+    const updaterFn = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <AnimationTimeline
+        animations={Object.values(animations)}
+        duration={6000}
+        onUpdateAnimation={updaterFn}
+      />
+    );
+
+    const endHandle = getByTestId('end-animation-handle-Animation 0');
+    endHandle.focus();
+
+    act(() => {
+      fireEvent.keyDown(endHandle, {
+        key: 'ArrowLeft',
+        which: 37,
+      });
+    });
+
+    /**
+     * Starting duration was 500ms, one left key press moves -100ms,
+     * so the new duration should be 400ms.
+     */
+    expect(updaterFn).toHaveBeenCalledWith(
+      { duration: 500, id: 0, label: 'Animation 0', offset: 0 },
+      { duration: 400, offset: 0 }
     );
   });
 });

--- a/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
+++ b/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
@@ -50,7 +50,7 @@ describe('<AnimationTimeline />', function () {
     );
   });
 
-  it('should update the offset when a timing bar is adjusted to the right', function () {
+  it('should update the duration when the end timing bar is adjusted to the right', function () {
     const updaterFn = jest.fn();
     const { getByTestId } = renderWithTheme(
       <AnimationTimeline
@@ -80,7 +80,7 @@ describe('<AnimationTimeline />', function () {
     );
   });
 
-  it('should update the offset when a timing bar is adjusted to the left', function () {
+  it('should update the duration when the end timing bar is adjusted to the left', function () {
     const updaterFn = jest.fn();
     const { getByTestId } = renderWithTheme(
       <AnimationTimeline
@@ -107,6 +107,126 @@ describe('<AnimationTimeline />', function () {
     expect(updaterFn).toHaveBeenCalledWith(
       { duration: 500, id: 0, label: 'Animation 0', offset: 0 },
       { duration: 400, offset: 0 }
+    );
+  });
+
+  it('should update the offset and duration when the start timing bar is adjusted to the left', function () {
+    const updaterFn = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <AnimationTimeline
+        animations={Object.values(animations)}
+        duration={6000}
+        onUpdateAnimation={updaterFn}
+      />
+    );
+
+    const startHandle = getByTestId('start-animation-handle-Animation 1');
+    startHandle.focus();
+
+    act(() => {
+      fireEvent.keyDown(startHandle, {
+        key: 'ArrowLeft',
+        which: 37,
+      });
+    });
+
+    /**
+     * Starting duration was 500ms with a 100ms, one left key press moves -100ms,
+     * so the new duration should be 600ms with an offset of 0s.
+     */
+    expect(updaterFn).toHaveBeenCalledWith(
+      { duration: 500, id: 1, label: 'Animation 1', offset: 100 },
+      { duration: 600, offset: 0 }
+    );
+  });
+
+  it('should update the offset and duration when the start timing bar is adjusted to the right', function () {
+    const updaterFn = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <AnimationTimeline
+        animations={Object.values(animations)}
+        duration={6000}
+        onUpdateAnimation={updaterFn}
+      />
+    );
+
+    const startHandle = getByTestId('start-animation-handle-Animation 1');
+    startHandle.focus();
+
+    act(() => {
+      fireEvent.keyDown(startHandle, {
+        key: 'ArrowRight',
+        which: 39,
+      });
+    });
+
+    /**
+     * Starting duration was 500ms with a 100ms, one right key press moves 100ms,
+     * so the new duration should be 400ms with an offset of 200ms.
+     */
+    expect(updaterFn).toHaveBeenCalledWith(
+      { duration: 500, id: 1, label: 'Animation 1', offset: 100 },
+      { duration: 400, offset: 200 }
+    );
+  });
+
+  it('should update the offset when the location timing bar is adjusted to the right', function () {
+    const updaterFn = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <AnimationTimeline
+        animations={Object.values(animations)}
+        duration={6000}
+        onUpdateAnimation={updaterFn}
+      />
+    );
+
+    const startHandle = getByTestId('location-animation-handle-Animation 1');
+    startHandle.focus();
+
+    act(() => {
+      fireEvent.keyDown(startHandle, {
+        key: 'ArrowRight',
+        which: 39,
+      });
+    });
+
+    /**
+     * Starting duration was 500ms with a 100ms, one right key press moves 100ms,
+     * so the new duration should be 500ms with an offset of 200ms.
+     */
+    expect(updaterFn).toHaveBeenCalledWith(
+      { duration: 500, id: 1, label: 'Animation 1', offset: 100 },
+      { duration: 500, offset: 200 }
+    );
+  });
+
+  it('should update the offset when the location timing bar is adjusted to the left', function () {
+    const updaterFn = jest.fn();
+    const { getByTestId } = renderWithTheme(
+      <AnimationTimeline
+        animations={Object.values(animations)}
+        duration={6000}
+        onUpdateAnimation={updaterFn}
+      />
+    );
+
+    const startHandle = getByTestId('location-animation-handle-Animation 1');
+    startHandle.focus();
+
+    act(() => {
+      fireEvent.keyDown(startHandle, {
+        key: 'ArrowLeft',
+        which: 37,
+      });
+    });
+
+    /**
+     * Starting duration was 500ms with a 100ms, one right key press moves 100ms,
+     * so the new duration should be 500ms with an offset of 0s.
+     */
+    expect(updaterFn).toHaveBeenCalledWith(
+      { duration: 500, id: 1, label: 'Animation 1', offset: 100 },
+      { duration: 500, offset: 0 }
     );
   });
 });

--- a/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
+++ b/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
@@ -15,21 +15,47 @@
  */
 
 /**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
  * Internal dependencies
  */
 import AnimationTimeline from '..';
 import { renderWithTheme } from '../../../testUtils';
 
+const animations = Array.from(Array(10).keys()).reduce((acc, id) => {
+  acc[id] = {
+    id,
+    duration: 500,
+    offset: id % 2 ? 100 : 0,
+    label: `Animation ${id}`,
+  };
+  return acc;
+}, {});
+
 describe('<AnimationTimeline />', function () {
   it('should generate the number of rows for animations provided.', function () {
-    const animations = Array.from(Array(10).keys()).map((id) => ({
-      id,
-    }));
     const { queryAllByTestId } = renderWithTheme(
-      <AnimationTimeline animations={animations} duration={6000} />
+      <AnimationTimeline
+        animations={Object.values(animations)}
+        duration={6000}
+        onUpdateAnimation={() => {}}
+      />
     );
     expect(queryAllByTestId('timeline-animation-item')).toHaveLength(
-      animations.length
+      Object.values(animations).length
+    );
+  });
+
+  it('should update the offset when a timing bar is adjusted to the right', async function () {
+    const { queryAllByTestId } = renderWithTheme(
+      <AnimationTimeline
+        animations={Object.values(animations)}
+        duration={6000}
+        onUpdateAnimation={() => {}}
+      />
     );
   });
 });

--- a/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
+++ b/assets/src/edit-story/components/animationTimeline/test/animationTimeline.test.js
@@ -30,7 +30,7 @@ const animations = Array.from(Array(10).keys()).reduce((acc, id) => {
   acc[id] = {
     id,
     duration: 500,
-    offset: id % 2 ? 100 : 0,
+    delay: id % 2 ? 100 : 0,
     label: `Animation ${id}`,
   };
   return acc;
@@ -75,8 +75,8 @@ describe('<AnimationTimeline />', function () {
      * so the new duration should be 600ms.
      */
     expect(updaterFn).toHaveBeenCalledWith(
-      { duration: 500, id: 0, label: 'Animation 0', offset: 0 },
-      { duration: 600, offset: 0 }
+      { duration: 500, id: 0, label: 'Animation 0', delay: 0 },
+      { duration: 600, delay: 0 }
     );
   });
 
@@ -105,12 +105,12 @@ describe('<AnimationTimeline />', function () {
      * so the new duration should be 400ms.
      */
     expect(updaterFn).toHaveBeenCalledWith(
-      { duration: 500, id: 0, label: 'Animation 0', offset: 0 },
-      { duration: 400, offset: 0 }
+      { duration: 500, id: 0, label: 'Animation 0', delay: 0 },
+      { duration: 400, delay: 0 }
     );
   });
 
-  it('should update the offset and duration when the start timing bar is adjusted to the left', function () {
+  it('should update the delay and duration when the start timing bar is adjusted to the left', function () {
     const updaterFn = jest.fn();
     const { getByTestId } = renderWithTheme(
       <AnimationTimeline
@@ -132,15 +132,15 @@ describe('<AnimationTimeline />', function () {
 
     /**
      * Starting duration was 500ms with a 100ms, one left key press moves -100ms,
-     * so the new duration should be 600ms with an offset of 0s.
+     * so the new duration should be 600ms with an delay of 0s.
      */
     expect(updaterFn).toHaveBeenCalledWith(
-      { duration: 500, id: 1, label: 'Animation 1', offset: 100 },
-      { duration: 600, offset: 0 }
+      { duration: 500, id: 1, label: 'Animation 1', delay: 100 },
+      { duration: 600, delay: 0 }
     );
   });
 
-  it('should update the offset and duration when the start timing bar is adjusted to the right', function () {
+  it('should update the delay and duration when the start timing bar is adjusted to the right', function () {
     const updaterFn = jest.fn();
     const { getByTestId } = renderWithTheme(
       <AnimationTimeline
@@ -162,15 +162,15 @@ describe('<AnimationTimeline />', function () {
 
     /**
      * Starting duration was 500ms with a 100ms, one right key press moves 100ms,
-     * so the new duration should be 400ms with an offset of 200ms.
+     * so the new duration should be 400ms with an delay of 200ms.
      */
     expect(updaterFn).toHaveBeenCalledWith(
-      { duration: 500, id: 1, label: 'Animation 1', offset: 100 },
-      { duration: 400, offset: 200 }
+      { duration: 500, id: 1, label: 'Animation 1', delay: 100 },
+      { duration: 400, delay: 200 }
     );
   });
 
-  it('should update the offset when the location timing bar is adjusted to the right', function () {
+  it('should update the delay when the location timing bar is adjusted to the right', function () {
     const updaterFn = jest.fn();
     const { getByTestId } = renderWithTheme(
       <AnimationTimeline
@@ -192,15 +192,15 @@ describe('<AnimationTimeline />', function () {
 
     /**
      * Starting duration was 500ms with a 100ms, one right key press moves 100ms,
-     * so the new duration should be 500ms with an offset of 200ms.
+     * so the new duration should be 500ms with an delay of 200ms.
      */
     expect(updaterFn).toHaveBeenCalledWith(
-      { duration: 500, id: 1, label: 'Animation 1', offset: 100 },
-      { duration: 500, offset: 200 }
+      { duration: 500, id: 1, label: 'Animation 1', delay: 100 },
+      { duration: 500, delay: 200 }
     );
   });
 
-  it('should update the offset when the location timing bar is adjusted to the left', function () {
+  it('should update the delay when the location timing bar is adjusted to the left', function () {
     const updaterFn = jest.fn();
     const { getByTestId } = renderWithTheme(
       <AnimationTimeline
@@ -222,11 +222,11 @@ describe('<AnimationTimeline />', function () {
 
     /**
      * Starting duration was 500ms with a 100ms, one right key press moves 100ms,
-     * so the new duration should be 500ms with an offset of 0s.
+     * so the new duration should be 500ms with an delay of 0s.
      */
     expect(updaterFn).toHaveBeenCalledWith(
-      { duration: 500, id: 1, label: 'Animation 1', offset: 100 },
-      { duration: 500, offset: 0 }
+      { duration: 500, id: 1, label: 'Animation 1', delay: 100 },
+      { duration: 500, delay: 0 }
     );
   });
 });

--- a/assets/src/edit-story/components/animationTimeline/timingBar.js
+++ b/assets/src/edit-story/components/animationTimeline/timingBar.js
@@ -25,9 +25,12 @@ import Moveable from 'react-moveable';
 /**
  * Internal dependencies
  */
+import { useKeyDownEffect } from '../../components/keyboard';
 import { MARK_OFFSET, MS_DIVISOR } from './ruler';
 
 const BAR_HEIGHT = 24;
+const KEY_OFFSET_MS = 100;
+const MIN_ANIMATION_MS = 100;
 
 const Bar = styled.div`
   position: relative;
@@ -79,9 +82,9 @@ export default function TimingBar({
   label,
   onUpdateAnimation,
 }) {
-  const [leftRef, setLeftRef] = useState(null);
-  const [middleRef, setMiddleRef] = useState(null);
-  const [rightRef, setRightRef] = useState(null);
+  const [leftRef, setLeftRef] = useState();
+  const [middleRef, setMiddleRef] = useState();
+  const [rightRef, setRightRef] = useState();
   const dragStart = useRef(0);
   const startingDuration = useRef(0);
   const startingOffset = useRef(0);
@@ -138,6 +141,40 @@ export default function TimingBar({
       setDuration(movedMilliseconds + startingDuration.current);
     },
     [maxDuration]
+  );
+
+  useKeyDownEffect(
+    leftRef,
+    { key: ['left', 'right'] },
+    ({ key }) => {
+      setDuration(internalDuration + (key === 'ArrowLeft' ? -100 : 100));
+      handleDragEnd();
+    },
+    [leftRef, handleDragEnd, internalDuration]
+  );
+
+  useKeyDownEffect(
+    rightRef,
+    { key: ['left', 'right'] },
+    ({ key }) => {
+      switch (key) {
+        case 'ArrowRight':
+          setDuration(
+            Math.min(internalDuration + KEY_OFFSET_MS, maxDuration - offset)
+          );
+          break;
+        case 'ArrowLeft':
+          setDuration(
+            Math.max(internalDuration - KEY_OFFSET_MS, MIN_ANIMATION_MS)
+          );
+          break;
+        default:
+          break;
+      }
+
+      handleDragEnd();
+    },
+    [rightRef, handleDragEnd, internalDuration, maxDuration, duration, offset]
   );
 
   return (

--- a/assets/src/edit-story/components/animationTimeline/timingBar.js
+++ b/assets/src/edit-story/components/animationTimeline/timingBar.js
@@ -78,7 +78,7 @@ const commonMovableProps = {
 export default function TimingBar({
   duration,
   maxDuration,
-  offset,
+  delay,
   label,
   onUpdateAnimation,
 }) {
@@ -87,19 +87,19 @@ export default function TimingBar({
   const rightRef = useRef();
   const dragStart = useRef(0);
   const startingDuration = useRef(0);
-  const startingOffset = useRef(0);
+  const startingDelay = useRef(0);
   const [mountMovable, setMountMovable] = useState(false);
 
   const [internalDuration, setDuration] = useState(duration);
-  const [internalOffset, setOffset] = useState(offset);
+  const [internalDelay, setDelay] = useState(delay);
 
   const handleDragStart = useCallback(
     ({ clientX }) => {
       dragStart.current = clientX;
       startingDuration.current = duration;
-      startingOffset.current = offset;
+      startingDelay.current = delay;
     },
-    [duration, offset]
+    [duration, delay]
   );
 
   useEffect(() => {
@@ -107,30 +107,30 @@ export default function TimingBar({
   }, []);
 
   const handleDragEnd = useCallback(() => {
-    onUpdateAnimation({ duration: internalDuration, offset: internalOffset });
-  }, [internalDuration, internalOffset, onUpdateAnimation]);
+    onUpdateAnimation({ duration: internalDuration, delay: internalDelay });
+  }, [internalDuration, internalDelay, onUpdateAnimation]);
 
   const handleDragLeft = useCallback(({ clientX }) => {
     const movedMilliseconds = Math.max(
       ((clientX - dragStart.current) / MARK_OFFSET) * MS_DIVISOR,
-      -startingOffset.current
+      -startingDelay.current
     );
-    setOffset(Math.max(0, movedMilliseconds + startingOffset.current));
+    setDelay(Math.max(0, movedMilliseconds + startingDelay.current));
     setDuration(startingDuration.current - movedMilliseconds);
   }, []);
 
   const handleDragMiddle = useCallback(
     ({ clientX }) => {
       const stop =
-        maxDuration - (startingOffset.current + startingDuration.current);
+        maxDuration - (startingDelay.current + startingDuration.current);
       const movedMilliseconds = Math.min(
         Math.max(
           ((clientX - dragStart.current) / MARK_OFFSET) * MS_DIVISOR,
-          -startingOffset.current
+          -startingDelay.current
         ),
         stop
       );
-      setOffset(movedMilliseconds + startingOffset.current);
+      setDelay(movedMilliseconds + startingDelay.current);
     },
     [maxDuration]
   );
@@ -138,7 +138,7 @@ export default function TimingBar({
   const handleDragRight = useCallback(
     ({ clientX }) => {
       const stop =
-        maxDuration - (startingOffset.current + startingDuration.current);
+        maxDuration - (startingDelay.current + startingDuration.current);
       const movedMilliseconds = Math.min(
         ((clientX - dragStart.current) / MARK_OFFSET) * MS_DIVISOR,
         stop
@@ -153,24 +153,24 @@ export default function TimingBar({
     { key: ['left', 'right'] },
     ({ key }) => {
       let updatedDuration;
-      let updatedOffset;
+      let updatedDelay;
       switch (key) {
         case 'ArrowRight':
-          updatedOffset = Math.min(
-            internalOffset + KEY_OFFSET_MS,
-            internalDuration + internalOffset - MIN_ANIMATION_MS
+          updatedDelay = Math.min(
+            internalDelay + KEY_OFFSET_MS,
+            internalDuration + internalDelay - MIN_ANIMATION_MS
           );
           updatedDuration = Math.max(
             internalDuration - KEY_OFFSET_MS,
             MIN_ANIMATION_MS
           );
-          setOffset(updatedOffset);
+          setDelay(updatedDelay);
           setDuration(updatedDuration);
           break;
         case 'ArrowLeft':
-          updatedOffset = Math.max(internalOffset - KEY_OFFSET_MS, 0);
-          setOffset(updatedOffset);
-          if (internalOffset === 0) {
+          updatedDelay = Math.max(internalDelay - KEY_OFFSET_MS, 0);
+          setDelay(updatedDelay);
+          if (internalDelay === 0) {
             break;
           }
           updatedDuration = internalDuration + KEY_OFFSET_MS;
@@ -182,7 +182,7 @@ export default function TimingBar({
 
       onUpdateAnimation({
         duration: updatedDuration || internalDuration,
-        offset: updatedOffset,
+        delay: updatedDelay,
       });
     },
     [
@@ -190,8 +190,8 @@ export default function TimingBar({
       handleDragEnd,
       internalDuration,
       maxDuration,
-      offset,
-      internalOffset,
+      delay,
+      internalDelay,
       duration,
       onUpdateAnimation,
     ]
@@ -206,7 +206,7 @@ export default function TimingBar({
         case 'ArrowRight':
           updatedDuration = Math.min(
             internalDuration + KEY_OFFSET_MS,
-            maxDuration - offset
+            maxDuration - delay
           );
           setDuration(updatedDuration);
           break;
@@ -221,7 +221,7 @@ export default function TimingBar({
           break;
       }
 
-      onUpdateAnimation({ duration: updatedDuration, offset: internalOffset });
+      onUpdateAnimation({ duration: updatedDuration, delay: internalDelay });
     },
     [
       rightRef,
@@ -229,8 +229,8 @@ export default function TimingBar({
       internalDuration,
       maxDuration,
       duration,
-      offset,
-      internalOffset,
+      delay,
+      internalDelay,
       onUpdateAnimation,
     ]
   );
@@ -239,24 +239,24 @@ export default function TimingBar({
     middleRef,
     { key: ['left', 'right'] },
     ({ key }) => {
-      let updatedOffset;
+      let updatedDelay;
       switch (key) {
         case 'ArrowRight':
-          updatedOffset = Math.min(
-            internalOffset + KEY_OFFSET_MS,
+          updatedDelay = Math.min(
+            internalDelay + KEY_OFFSET_MS,
             maxDuration - internalDuration
           );
-          setOffset(updatedOffset);
+          setDelay(updatedDelay);
           break;
         case 'ArrowLeft':
-          updatedOffset = Math.max(internalOffset - KEY_OFFSET_MS, 0);
-          setOffset(updatedOffset);
+          updatedDelay = Math.max(internalDelay - KEY_OFFSET_MS, 0);
+          setDelay(updatedDelay);
           break;
         default:
           break;
       }
 
-      onUpdateAnimation({ duration: internalDuration, offset: updatedOffset });
+      onUpdateAnimation({ duration: internalDuration, delay: updatedDelay });
     },
     [
       middleRef,
@@ -264,8 +264,8 @@ export default function TimingBar({
       internalDuration,
       maxDuration,
       duration,
-      offset,
-      internalOffset,
+      delay,
+      internalDelay,
       onUpdateAnimation,
     ]
   );
@@ -274,7 +274,7 @@ export default function TimingBar({
     <Bar
       style={{
         width: (internalDuration / MS_DIVISOR) * MARK_OFFSET,
-        left: (internalOffset / MS_DIVISOR) * MARK_OFFSET,
+        left: (internalDelay / MS_DIVISOR) * MARK_OFFSET,
       }}
     >
       <Handle ref={leftRef} data-testid={`start-animation-handle-${label}`}>
@@ -318,7 +318,7 @@ export default function TimingBar({
 TimingBar.propTypes = {
   duration: propTypes.number.isRequired,
   maxDuration: propTypes.number.isRequired,
-  offset: propTypes.number.isRequired,
+  delay: propTypes.number.isRequired,
   label: propTypes.string.isRequired,
   onUpdateAnimation: propTypes.func.isRequired,
 };

--- a/assets/src/edit-story/components/animationTimeline/timingBar.js
+++ b/assets/src/edit-story/components/animationTimeline/timingBar.js
@@ -147,10 +147,40 @@ export default function TimingBar({
     leftRef,
     { key: ['left', 'right'] },
     ({ key }) => {
-      setDuration(internalDuration + (key === 'ArrowLeft' ? -100 : 100));
+      switch (key) {
+        case 'ArrowRight':
+          setOffset(
+            Math.min(
+              internalOffset + KEY_OFFSET_MS,
+              internalDuration + internalOffset - MIN_ANIMATION_MS
+            )
+          );
+          setDuration(
+            Math.max(internalDuration - KEY_OFFSET_MS, MIN_ANIMATION_MS)
+          );
+          break;
+        case 'ArrowLeft':
+          setOffset(Math.max(internalOffset - KEY_OFFSET_MS, 0));
+          if (internalOffset === 0) {
+            break;
+          }
+          setDuration(internalDuration + KEY_OFFSET_MS);
+          break;
+        default:
+          break;
+      }
+
       handleDragEnd();
     },
-    [leftRef, handleDragEnd, internalDuration]
+    [
+      leftRef,
+      handleDragEnd,
+      internalDuration,
+      maxDuration,
+      offset,
+      internalOffset,
+      duration,
+    ]
   );
 
   useKeyDownEffect(

--- a/assets/src/edit-story/components/animationTimeline/timingBar.js
+++ b/assets/src/edit-story/components/animationTimeline/timingBar.js
@@ -25,7 +25,7 @@ import Moveable from 'react-moveable';
 /**
  * Internal dependencies
  */
-import { useKeyDownEffect } from '../../components/keyboard';
+import { useKeyDownEffect } from '../keyboard';
 import { MARK_OFFSET, MS_DIVISOR } from './ruler';
 
 const BAR_HEIGHT = 24;
@@ -205,6 +205,39 @@ export default function TimingBar({
       handleDragEnd();
     },
     [rightRef, handleDragEnd, internalDuration, maxDuration, duration, offset]
+  );
+
+  useKeyDownEffect(
+    middleRef,
+    { key: ['left', 'right'] },
+    ({ key }) => {
+      switch (key) {
+        case 'ArrowRight':
+          setOffset(
+            Math.min(
+              internalOffset + KEY_OFFSET_MS,
+              maxDuration - internalDuration
+            )
+          );
+          break;
+        case 'ArrowLeft':
+          setOffset(Math.max(internalOffset - KEY_OFFSET_MS, 0));
+          break;
+        default:
+          break;
+      }
+
+      handleDragEnd();
+    },
+    [
+      middleRef,
+      handleDragEnd,
+      internalDuration,
+      maxDuration,
+      duration,
+      offset,
+      internalOffset,
+    ]
   );
 
   return (

--- a/assets/src/edit-story/components/animationTimeline/timingBar.js
+++ b/assets/src/edit-story/components/animationTimeline/timingBar.js
@@ -49,7 +49,7 @@ const Bar = styled.div`
   overflow: hidden;
 `;
 
-const Handle = styled.div`
+const Handle = styled.div.attrs({ tabIndex: 0 })`
   background-color: white;
   width: 14px;
   height: 14px;
@@ -58,7 +58,7 @@ const Handle = styled.div`
   cursor: ew-resize;
 `;
 
-const Label = styled.div`
+const Label = styled.div.attrs({ tabIndex: 0 })`
   font-family: ${({ theme }) => theme.fonts.label.family};
   flex: 1;
   font-weight: bold;

--- a/assets/src/edit-story/components/keyboard/index.js
+++ b/assets/src/edit-story/components/keyboard/index.js
@@ -69,9 +69,6 @@ function useKeyEffectInternal(
   const batchingCallback = useBatchingCallback(callback, deps || []);
   useEffect(
     () => {
-      if (!refOrNode) {
-        return undefined;
-      }
       const node =
         typeof refOrNode.current !== 'undefined'
           ? refOrNode.current

--- a/assets/src/edit-story/components/keyboard/index.js
+++ b/assets/src/edit-story/components/keyboard/index.js
@@ -69,6 +69,9 @@ function useKeyEffectInternal(
   const batchingCallback = useBatchingCallback(callback, deps || []);
   useEffect(
     () => {
+      if (!refOrNode) {
+        return undefined;
+      }
       const node =
         typeof refOrNode.current !== 'undefined'
           ? refOrNode.current


### PR DESCRIPTION
## Summary

Adds focus and a11y keyboard controls to the start, location, and stop controls of the Timeline Bar.

![Kapture 2020-08-18 at 20 36 17](https://user-images.githubusercontent.com/1738349/90582168-aea8e300-e192-11ea-860a-1076d2b478fb.gif)


## Relevant Technical Choices

Uses key down hook to add key controls to the timing events.

## To-do

Add tests

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

#3444 
