### PR TITLE
Workspace: Gridview Page Preview Focus Style

### DIFF
--- a/assets/src/edit-story/components/canvas/pagepreview/index.js
+++ b/assets/src/edit-story/components/canvas/pagepreview/index.js
@@ -50,7 +50,6 @@ const Page = styled.button`
   width: ${({ width }) => width}px;
   flex: none;
   transition: width 0.2s ease, height 0.2s ease;
-  outline: 0;
   ${({ isActive, isInteractive, theme }) =>
     !isActive &&
     isInteractive &&


### PR DESCRIPTION
## Summary

Allows the browser to use the default user agent outline styles for focused buttons (Page Previews are buttons) to make it more clear what's in focus.

## Relevant Technical Choices

Removed `outline: 0` on the Card Preview

## User-facing changes

Card Previews should now have focus outlines in GridView and the Carousel.

### Gridview
![active](https://user-images.githubusercontent.com/2755722/90679638-71922e80-e22e-11ea-8c3d-beb97c4b0df7.png)

![non-active-focus](https://user-images.githubusercontent.com/2755722/90679657-7951d300-e22e-11ea-9456-52c25b2cbc97.png)


### Carousel 
![Carousel](https://user-images.githubusercontent.com/2755722/90679598-6212e580-e22e-11ea-89bc-36addc7de9e7.png)


## Testing Instructions

1. Tab to focus on the page previews in the carousel to see focus outline (use arrow keys to see focus change between page previews)
2. Launch Grid view tab to focus on the active page (use arrow keys to see focus change between page previews)

#3653 
