### PR TITLE
Add delay before preloading preview videos

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
@@ -34,6 +34,8 @@ import { getSmallestUrlForWidth } from '../../../../../elements/media/util';
 import useRovingTabIndex from './useRovingTabIndex';
 import Attribution from './attribution';
 
+const AUTOPLAY_PREVIEW_VIDEO_DELAY_MS = 600;
+
 const styledTiles = css`
   width: 100%;
   cursor: pointer;
@@ -206,6 +208,10 @@ const MediaElement = ({
     setActive(false);
   }, []);
 
+  const [hoverTimer, setHoverTimer] = useState(null);
+  const activeRef = useRef(active);
+  activeRef.current = active;
+
   useEffect(() => {
     if (type === 'video') {
       if (isMenuOpen) {
@@ -216,16 +222,25 @@ const MediaElement = ({
       } else {
         if (active) {
           setShowVideoDetail(false);
-          if (mediaElement.current) {
+          if (mediaElement.current && hoverTimer == null) {
+            const timer = setTimeout(() => {
+              if (activeRef.current) {
+                const playPromise = mediaElement.current.play();
+                if (playPromise) {
+                  // All supported browsers return promise but unit test runner does not.
+                  playPromise.catch(() => {});
+                }
+              }
+            }, AUTOPLAY_PREVIEW_VIDEO_DELAY_MS);
+            setHoverTimer(timer);
             // Pointer still in the media element, continue the video.
-            const playPromise = mediaElement.current.play();
-            if (playPromise) {
-              // All supported browsers return promise but unit test runner does not.
-              playPromise.catch(() => {});
-            }
           }
         } else {
           setShowVideoDetail(true);
+          if (hoverTimer != null) {
+            clearTimeout(hoverTimer);
+            setHoverTimer(null);
+          }
           if (mediaElement.current) {
             // Stop video and reset position.
             mediaElement.current.pause();
@@ -234,7 +249,13 @@ const MediaElement = ({
         }
       }
     }
-  }, [isMenuOpen, active, type]);
+    return () => {
+      if (hoverTimer != null) {
+        clearTimeout(hoverTimer);
+        setHoverTimer(null);
+      }
+    };
+  }, [isMenuOpen, active, type, hoverTimer, setHoverTimer, activeRef]);
 
   const onClick = () => {
     onInsert(resource, width, height);

--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -385,6 +385,30 @@ describe('Media3pPane fetching', () => {
     });
   });
 
+  it('should have a delay before autoplaying videos', async () => {
+    mockListMedia();
+    await fixture.events.click(media3pTab);
+
+    const coverrTab = fixture.querySelector('#provider-tab-coverr');
+
+    await fixture.events.click(coverrTab);
+    await expectMediaElements(coverrSection, MEDIA_PER_PAGE);
+
+    let mediaElements = coverrSection.querySelectorAll(
+      '[data-testid=mediaElement]'
+    );
+
+    const firstMediaElement = mediaElements.item(0);
+    await fixture.events.focus(firstMediaElement);
+    const video = firstMediaElement.querySelector('video');
+
+    expect(video.paused).toBe(true);
+
+    jasmine.clock().tick(700);
+
+    expect(video.paused).toBe(false);
+  });
+
   describe('Gallery navigation', () => {
     it('should handle pressing right when focused', async () => {
       mockListMedia();


### PR DESCRIPTION
## Summary

This PR adds a 600ms delay before preloading videos on hover in the media gallery. This fixes an issue where hovering around the gallery would suddenly start preloading tens of videos which is super wasteful.

## Relevant Technical Choices

State for the timer, and a ref to ensure we can get the current value of "active" inside the callback (and not whichever was in the closure).

## User-facing changes

When hover over videos, the preloading waits a bit before starting.

## Testing Instructions

Verify that hovering over videos to see a preview works, albeit with a small delay before starting.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4110
