### PR TITLE
Media: Improve "No media found" message

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/styles.js
+++ b/assets/src/edit-story/components/library/panes/media/common/styles.js
@@ -71,8 +71,14 @@ export const MediaGalleryLoadingPill = styled.div`
 
 export const MediaGalleryMessage = styled.div`
   color: ${({ theme }) => theme.colors.fg.white};
-  font-size: 16px;
   padding: 1em;
+  font-family: ${({ theme }) => theme.fonts.mediaError.family};
+  font-style: ${({ theme }) => theme.fonts.mediaError.style};
+  line-height: ${({ theme }) => theme.fonts.mediaError.lineHeight};
+  font-weight: ${({ theme }) => theme.fonts.mediaError.weight};
+  font-size: ${({ theme }) => theme.fonts.mediaError.size};
+  text-align: ${({ theme }) => theme.fonts.mediaError.textAlign};
+  opacity: 0.54;
 `;
 
 export const StyledPane = styled(Pane)`

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
@@ -54,7 +54,7 @@ const ProviderTabSection = styled.div`
 const MediaSubheading = styled.div`
   margin-top: 24px;
   padding: 0 24px;
-  visibility: ${(props) => (props.shouldDisplay ? 'inherit' : 'hidden')};
+  ${(props) => props.shouldDisplay || 'display: none;'}
 `;
 
 const PaneBottom = styled.div`

--- a/assets/src/edit-story/components/library/panes/media/media3p/test/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/test/media3pPane.js
@@ -151,7 +151,7 @@ describe('Media3pPane', () => {
     const { queryByText } = renderWithTheme(<Media3pPane isActive={true} />);
 
     expect(queryByText('No media found')).toBeDefined();
-    expect(getComputedStyle(queryByText('Trending')).visibility).toBe('hidden');
+    expect(getComputedStyle(queryByText('Trending')).display).toBe('none');
   });
 
   it('should render <Media3pPane /> with no "Trending" text while media is being loaded', () => {
@@ -160,7 +160,7 @@ describe('Media3pPane', () => {
     useMediaResult.media3p.PROVIDER_1.state.media = [];
     const { queryByText } = renderWithTheme(<Media3pPane isActive={true} />);
 
-    expect(getComputedStyle(queryByText('Trending')).visibility).toBe('hidden');
+    expect(getComputedStyle(queryByText('Trending')).display).toBe('none');
   });
 
   it('should render <Media3pPane /> with the "Trending" text while a new page is being loaded', () => {
@@ -189,8 +189,8 @@ describe('Media3pPane', () => {
 
     expect(queryByTestId('media-subheading')).toBeDefined();
     expect(
-      getComputedStyle(queryByTestId('media-subheading')).visibility
-    ).not.toBe('hidden');
+      getComputedStyle(queryByTestId('media-subheading')).display
+    ).not.toBe('none');
     expect(queryByTestId('media-subheading')).toHaveTextContent(
       'Tiny dogs for provider 1'
     );

--- a/assets/src/edit-story/components/library/panes/media/media3p/test/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/test/media3pPane.js
@@ -169,9 +169,7 @@ describe('Media3pPane', () => {
     useMediaResult.media3p.PROVIDER_1.state.media = MEDIA;
     const { queryByText } = renderWithTheme(<Media3pPane isActive={true} />);
 
-    expect(getComputedStyle(queryByText('Trending')).visibility).not.toBe(
-      'hidden'
-    );
+    expect(getComputedStyle(queryByText('Trending')).display).not.toBe('none');
   });
 
   it('should render <Media3pPane /> with the "Trending" text', () => {
@@ -179,9 +177,7 @@ describe('Media3pPane', () => {
     useMediaResult.media3p.PROVIDER_1.state.media = MEDIA;
     const { queryByText } = renderWithTheme(<Media3pPane isActive={true} />);
 
-    expect(getComputedStyle(queryByText('Trending')).visibility).not.toBe(
-      'hidden'
-    );
+    expect(getComputedStyle(queryByText('Trending')).display).not.toBe('none');
   });
 
   it('should render <Media3pPane /> with the category display name when selected', () => {

--- a/assets/src/edit-story/theme.js
+++ b/assets/src/edit-story/theme.js
@@ -206,7 +206,7 @@ const theme = {
       lineHeight: '24px',
     },
     mediaError: {
-      font: 'Roboto',
+      family: 'Roboto',
       style: 'italic',
       weight: 'normal',
       size: '16px',

--- a/assets/src/edit-story/theme.js
+++ b/assets/src/edit-story/theme.js
@@ -205,6 +205,14 @@ const theme = {
       size: '13px',
       lineHeight: '24px',
     },
+    mediaError: {
+      font: 'Roboto',
+      style: 'italic',
+      weight: 'normal',
+      size: '16px',
+      lineHeight: '24px',
+      textAlign: 'center',
+    },
   },
 };
 


### PR DESCRIPTION
## Summary

Fix "no media found" error message to fit mocks. 

For MediaSubheading "visibility:hidden" only "hides" the content, but the actual padding/height of the content remains. Hence, changing that to "display:none" fixes the alignment issue for "no media found" message.

## User-facing changes

<img width="321" alt="Screen Shot 2020-08-20 at 3 29 14 PM" src="https://user-images.githubusercontent.com/13947816/90720587-33624100-e2fa-11ea-8e81-b4e65ee84a57.png">


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3899
