### PR TITLE
Fixes for Safari, and for weird autoloading edge case

### DIFF
--- a/assets/src/edit-story/components/library/libraryLayout.js
+++ b/assets/src/edit-story/components/library/libraryLayout.js
@@ -50,8 +50,8 @@ const TabsArea = styled.nav.attrs({
 })``;
 
 const LibraryPaneContainer = styled.div`
-  overflow: auto;
-  flex: 1 1 auto;
+  height: 100%;
+  min-height: 0;
 `;
 
 function LibraryLayout() {

--- a/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/assets/src/edit-story/components/library/panes/media/common/paginatedMediaGallery.js
@@ -92,6 +92,7 @@ function PaginatedMediaGallery({
   const loadNextPageIfNeeded = useCallback(() => {
     const node = refContainer.current;
     if (
+      !resources.length ||
       !node ||
       // This condition happens when the component is hidden, and causes the
       // calculation below to load a new page in error.
@@ -117,7 +118,7 @@ function PaginatedMediaGallery({
       setNextPage();
       return;
     }
-  }, [hasMore, isMediaLoaded, isMediaLoading, setNextPage]);
+  }, [resources, hasMore, isMediaLoaded, isMediaLoading, setNextPage]);
 
   // Scroll to the top when the searchTerm or selected category changes.
   useEffect(() => {

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
@@ -36,11 +36,13 @@ import CategoryPill from './categoryPill';
 const CategorySection = styled.div`
   background-color: ${({ theme }) => theme.colors.bg.v3};
   ${({ hasCategories }) => (hasCategories ? '' : 'min-height: 104px;')}
+  ${({ hasCategories }) =>
+    hasCategories ? '' : 'max-height: 104px;'}
   padding: 30px 20px 10px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  flex: 0 1 auto;
+  flex: 1 0 auto;
 `;
 
 // This hides the category pills unless expanded


### PR DESCRIPTION
## Summary

This fixes some layout issues for Safari, where apparently flexbox behaves very differently than in Chrome.

This also fixes an edge case that sometimes occurs where when the editor loads, it triggers an effect that loads another page even though there are no resources yet rendered.

Verified in both Chrome and Safari.

<img width="412" alt="Screen Shot 2020-08-20 at 11 04 17 pm" src="https://user-images.githubusercontent.com/512647/90773626-87d8e100-e339-11ea-944d-1fcddbc0b9a8.png">

