### PR TITLE
Dashboard: Add copy story URL and open story menu action items

### DIFF
--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -40,6 +40,7 @@ jest.mock('../wpAdapter', () => ({
           id: 123,
           status: 'publish',
           author: 1,
+          link: 'https://www.story-link.com',
           title: { rendered: 'Carlos', raw: 'Carlos' },
           story_data: { pages: [{ id: 1, elements: [] }] },
           modified_gmt: '1970-01-01T00:00:00.000Z',
@@ -57,6 +58,7 @@ jest.mock('../wpAdapter', () => ({
       story_data: { pages: [{ id: 1, elements: [] }] },
       modified_gmt: '1970-01-01T00:00:00.000Z',
       date_gmt: '1970-01-01T00:00:00.000Z',
+      link: 'https://www.story-link.com',
     });
   },
   deleteRequest: (path, { data }) =>
@@ -67,6 +69,7 @@ jest.mock('../wpAdapter', () => ({
       story_data: { pages: [{ id: 1, elements: [] }] },
       modified_gmt: '1970-01-01T00:00:00.000Z',
       date_gmt: '1970-01-01T00:00:00.000Z',
+      link: 'https://www.story-link.com',
     }),
 }));
 
@@ -96,12 +99,14 @@ describe('ApiProvider', () => {
         modified: moment.parseZone('1970-01-01T00:00:00.000Z'),
         created: moment.parseZone('1970-01-01T00:00:00.000Z'),
         author: 1,
+        link: 'https://www.story-link.com',
         originalStoryData: {
           id: 123,
           modified_gmt: '1970-01-01T00:00:00.000Z',
           date_gmt: '1970-01-01T00:00:00.000Z',
           status: 'publish',
           author: 1,
+          link: 'https://www.story-link.com',
           story_data: {
             pages: [
               {
@@ -155,6 +160,7 @@ describe('ApiProvider', () => {
         ],
         status: 'publish',
         title: 'New Title',
+        link: 'https://www.story-link.com',
       });
     });
 
@@ -167,12 +173,14 @@ describe('ApiProvider', () => {
         modified: moment.parseZone('1970-01-01T00:00:00.000Z'),
         created: moment.parseZone('1970-01-01T00:00:00.000Z'),
         author: 1,
+        link: 'https://www.story-link.com',
         originalStoryData: {
           id: 123,
           modified_gmt: '1970-01-01T00:00:00.000Z',
           date_gmt: '1970-01-01T00:00:00.000Z',
           status: 'publish',
           author: 1,
+          link: 'https://www.story-link.com',
           story_data: {
             pages: [
               {
@@ -225,7 +233,9 @@ describe('ApiProvider', () => {
         status: 'publish',
         title: 'Carlos',
         author: 1,
+        link: 'https://www.story-link.com',
         originalStoryData: {
+          link: 'https://www.story-link.com',
           story_data: {
             author: 1,
             pages: [
@@ -251,12 +261,14 @@ describe('ApiProvider', () => {
         modified: moment.parseZone('1970-01-01T00:00:00.000Z'),
         created: moment.parseZone('1970-01-01T00:00:00.000Z'),
         author: 1,
+        link: 'https://www.story-link.com',
         originalStoryData: {
           id: 123,
           modified_gmt: '1970-01-01T00:00:00.000Z',
           date_gmt: '1970-01-01T00:00:00.000Z',
           status: 'publish',
           author: 1,
+          link: 'https://www.story-link.com',
           story_data: {
             pages: [
               {
@@ -287,12 +299,14 @@ describe('ApiProvider', () => {
         modified: moment.parseZone('1970-01-01T00:00:00.000Z'),
         created: moment.parseZone('1970-01-01T00:00:00.000Z'),
         author: 1,
+        link: 'https://www.story-link.com',
         originalStoryData: {
           id: 456,
           modified_gmt: '1970-01-01T00:00:00.000Z',
           date_gmt: '1970-01-01T00:00:00.000Z',
           status: 'publish',
           author: 1,
+          link: 'https://www.story-link.com',
           story_data: {
             pages: [
               {

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -121,9 +121,8 @@ const AppContent = () => {
           component={<StoryAnimTool />}
         />
       </PageContent>
-      <ToastProvider>
-        <ToasterView />
-      </ToastProvider>
+
+      <ToasterView />
     </AppFrame>
   );
 };
@@ -139,7 +138,9 @@ function App({ config }) {
               <RouterProvider>
                 <GlobalStyle />
                 <KeyboardOnlyOutline />
-                <AppContent />
+                <ToastProvider>
+                  <AppContent />
+                </ToastProvider>
               </RouterProvider>
             </NavProvider>
           </ApiProvider>

--- a/assets/src/dashboard/app/serializers/stories.js
+++ b/assets/src/dashboard/app/serializers/stories.js
@@ -33,6 +33,7 @@ export default function reshapeStoryObject(editStoryURL) {
       status,
       date_gmt,
       author,
+      link,
       story_data: storyData,
     } = originalStoryData;
     if (
@@ -59,6 +60,7 @@ export default function reshapeStoryObject(editStoryURL) {
       centerTargetAction: '',
       bottomTargetAction: `${editStoryURL}&post=${id}`,
       editStoryLink: `${editStoryURL}&post=${id}`,
+      link,
       originalStoryData,
     };
   };

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -110,6 +110,14 @@ function StoriesView({
           setActiveDialog(ACTIVE_DIALOG_DELETE_STORY);
           break;
 
+        case STORY_CONTEXT_MENU_ACTIONS.COPY_STORY_LINK:
+          global.navigator.clipboard.writeText(story.link);
+          break;
+
+        case STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK:
+          window.open(story.link, '_blank');
+          break;
+
         default:
           break;
       }

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -114,10 +114,6 @@ function StoriesView({
           global.navigator.clipboard.writeText(story.link);
           break;
 
-        case STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK:
-          window.open(story.link, '_blank');
-          break;
-
         default:
           break;
       }

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -39,13 +39,14 @@ import {
   SortPropTypes,
   ViewPropTypes,
 } from '../../../../../utils/useStoryView';
-import { Button, Dialog } from '../../../../../components';
+import { Button, Dialog, useToastContext } from '../../../../../components';
 import {
   VIEW_STYLE,
   STORY_ITEM_CENTER_ACTION_LABELS,
   STORY_CONTEXT_MENU_ACTIONS,
   STORY_CONTEXT_MENU_ITEMS,
   BUTTON_TYPES,
+  ALERT_SEVERITY,
 } from '../../../../../constants';
 import { StoryGridView, StoryListView } from '../../../shared';
 
@@ -69,6 +70,9 @@ function StoriesView({
   const [activeDialog, setActiveDialog] = useState('');
   const [activeStory, setActiveStory] = useState(null);
 
+  const {
+    actions: { addToast },
+  } = useToastContext();
   const isActiveDeleteStoryDialog =
     activeDialog === ACTIVE_DIALOG_DELETE_STORY && activeStory;
 
@@ -112,13 +116,35 @@ function StoriesView({
 
         case STORY_CONTEXT_MENU_ACTIONS.COPY_STORY_LINK:
           global.navigator.clipboard.writeText(story.link);
+
+          addToast({
+            message: {
+              title: __('URL copied', 'web-stories'),
+              body:
+                story.title.length > 0
+                  ? sprintf(
+                      /* translators: %s is the story title. */
+                      __(
+                        '%s has been copied to your clipboard.',
+                        'web-stories'
+                      ),
+                      story.title
+                    )
+                  : __(
+                      '(no title) has been copied to your clipboard.',
+                      'web-stories'
+                    ),
+            },
+            severity: ALERT_SEVERITY.SUCCESS,
+            id: Date.now(),
+          });
           break;
 
         default:
           break;
       }
     },
-    [storyActions]
+    [addToast, storyActions]
   );
 
   const enabledMenuItems = useMemo(() => {

--- a/assets/src/dashboard/app/views/myStories/content/test/content.js
+++ b/assets/src/dashboard/app/views/myStories/content/test/content.js
@@ -22,6 +22,7 @@ import formattedUsersObject from '../../../../../dataUtils/formattedUsersObject'
 
 import { VIEW_STYLE, STORY_STATUSES } from '../../../../../constants';
 import LayoutProvider from '../../../../../components/layout/provider';
+import { ToastProvider } from '../../../../../components';
 import Content from '../';
 
 const fakeStories = [
@@ -66,27 +67,29 @@ describe('My Stories <Content />', function () {
 
   it('should render the content grid with the correct story count.', function () {
     const { getAllByTestId } = renderWithThemeAndFlagsProvider(
-      <LayoutProvider>
-        <Content
-          filter={STORY_STATUSES[0]}
-          search={{ keyword: '' }}
-          stories={fakeStories}
-          users={formattedUsersObject}
-          page={{
-            requestNextPage: jest.fn,
-          }}
-          view={{
-            style: VIEW_STYLE.GRID,
-            pageSize: { width: 200, height: 300 },
-          }}
-          storyActions={{
-            createTemplateFromStory: jest.fn,
-            duplicateStory: jest.fn,
-            trashStory: jest.fn,
-            updateStory: jest.fn,
-          }}
-        />
-      </LayoutProvider>,
+      <ToastProvider>
+        <LayoutProvider>
+          <Content
+            filter={STORY_STATUSES[0]}
+            search={{ keyword: '' }}
+            stories={fakeStories}
+            users={formattedUsersObject}
+            page={{
+              requestNextPage: jest.fn,
+            }}
+            view={{
+              style: VIEW_STYLE.GRID,
+              pageSize: { width: 200, height: 300 },
+            }}
+            storyActions={{
+              createTemplateFromStory: jest.fn,
+              duplicateStory: jest.fn,
+              trashStory: jest.fn,
+              updateStory: jest.fn,
+            }}
+          />
+        </LayoutProvider>
+      </ToastProvider>,
       { enableInProgressStoryActions: false }
     );
 
@@ -95,27 +98,29 @@ describe('My Stories <Content />', function () {
 
   it('should show "Create a story to get started!" if no stories are present.', function () {
     const { getByText } = renderWithThemeAndFlagsProvider(
-      <LayoutProvider>
-        <Content
-          filter={STORY_STATUSES[0]}
-          search={{ keyword: '' }}
-          stories={[]}
-          users={{}}
-          page={{
-            requestNextPage: jest.fn,
-          }}
-          view={{
-            style: VIEW_STYLE.GRID,
-            pageSize: { width: 200, height: 300 },
-          }}
-          storyActions={{
-            createTemplateFromStory: jest.fn,
-            duplicateStory: jest.fn,
-            trashStory: jest.fn,
-            updateStory: jest.fn,
-          }}
-        />
-      </LayoutProvider>,
+      <ToastProvider>
+        <LayoutProvider>
+          <Content
+            filter={STORY_STATUSES[0]}
+            search={{ keyword: '' }}
+            stories={[]}
+            users={{}}
+            page={{
+              requestNextPage: jest.fn,
+            }}
+            view={{
+              style: VIEW_STYLE.GRID,
+              pageSize: { width: 200, height: 300 },
+            }}
+            storyActions={{
+              createTemplateFromStory: jest.fn,
+              duplicateStory: jest.fn,
+              trashStory: jest.fn,
+              updateStory: jest.fn,
+            }}
+          />
+        </LayoutProvider>
+      </ToastProvider>,
       { enableInProgressStoryActions: false }
     );
 
@@ -124,27 +129,29 @@ describe('My Stories <Content />', function () {
 
   it('should show "Sorry, we couldn\'t find any results matching "scooby dooby doo" if no stories are found for a search query are present.', function () {
     const { getByText } = renderWithThemeAndFlagsProvider(
-      <LayoutProvider>
-        <Content
-          filter={STORY_STATUSES[0]}
-          search={{ keyword: 'scooby dooby doo' }}
-          stories={[]}
-          users={{}}
-          page={{
-            requestNextPage: jest.fn,
-          }}
-          view={{
-            style: VIEW_STYLE.GRID,
-            pageSize: { width: 200, height: 300 },
-          }}
-          storyActions={{
-            createTemplateFromStory: jest.fn,
-            duplicateStory: jest.fn,
-            trashStory: jest.fn,
-            updateStory: jest.fn,
-          }}
-        />
-      </LayoutProvider>,
+      <ToastProvider>
+        <LayoutProvider>
+          <Content
+            filter={STORY_STATUSES[0]}
+            search={{ keyword: 'scooby dooby doo' }}
+            stories={[]}
+            users={{}}
+            page={{
+              requestNextPage: jest.fn,
+            }}
+            view={{
+              style: VIEW_STYLE.GRID,
+              pageSize: { width: 200, height: 300 },
+            }}
+            storyActions={{
+              createTemplateFromStory: jest.fn,
+              duplicateStory: jest.fn,
+              trashStory: jest.fn,
+              updateStory: jest.fn,
+            }}
+          />
+        </LayoutProvider>
+      </ToastProvider>,
       { enableInProgressStoryActions: false }
     );
 

--- a/assets/src/dashboard/app/views/myStories/content/test/storiesView.js
+++ b/assets/src/dashboard/app/views/myStories/content/test/storiesView.js
@@ -19,7 +19,7 @@
  */
 import { fillerDateSettingsObject } from '../../../../../dataUtils/dateSettings';
 import { renderWithThemeAndFlagsProvider } from '../../../../../testUtils';
-
+import { ToastProvider } from '../../../../../components';
 import {
   STORY_SORT_OPTIONS,
   SORT_DIRECTION,
@@ -60,26 +60,28 @@ const fakeStories = [
 describe('My Stories <StoriesView />', function () {
   it(`should render stories as a grid when view is ${VIEW_STYLE.GRID}`, function () {
     const { getAllByTestId } = renderWithThemeAndFlagsProvider(
-      <StoriesView
-        filterValue="all"
-        sort={{
-          value: STORY_SORT_OPTIONS.NAME,
-          direction: SORT_DIRECTION.ASC,
-        }}
-        storyActions={{
-          createTemplateFromStory: jest.fn,
-          duplicateStory: jest.fn,
-          trashStory: jest.fn,
-          updateStory: jest.fn,
-        }}
-        dateSettings={fillerDateSettingsObject}
-        stories={fakeStories}
-        users={{}}
-        view={{
-          style: VIEW_STYLE.GRID,
-          pageSize: { width: 210, height: 316 },
-        }}
-      />,
+      <ToastProvider>
+        <StoriesView
+          filterValue="all"
+          sort={{
+            value: STORY_SORT_OPTIONS.NAME,
+            direction: SORT_DIRECTION.ASC,
+          }}
+          storyActions={{
+            createTemplateFromStory: jest.fn,
+            duplicateStory: jest.fn,
+            trashStory: jest.fn,
+            updateStory: jest.fn,
+          }}
+          dateSettings={fillerDateSettingsObject}
+          stories={fakeStories}
+          users={{}}
+          view={{
+            style: VIEW_STYLE.GRID,
+            pageSize: { width: 210, height: 316 },
+          }}
+        />
+      </ToastProvider>,
       { enableInProgressStoryActions: false }
     );
 

--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -140,7 +140,9 @@ describe('Grid view', () => {
 
     utils = within(firstStory);
 
-    expect(utils.getByText(/Copy/)).toBeTruthy();
+    const copiedStory = utils.queryAllByText(/Copy/)[0];
+
+    expect(copiedStory.text.includes('(Copy)')).toBeTruthy();
   });
 
   it('should Delete a story', async () => {
@@ -624,7 +626,9 @@ describe('List view', () => {
 
       utils = within(rows[0]);
 
-      expect(utils.getByText(/Copy/)).toBeTruthy();
+      const copiedStory = utils.queryAllByText(/Copy/)[0];
+
+      expect(copiedStory).toBeTruthy();
     });
 
     it('should Delete a story', async () => {

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -42,7 +42,7 @@ import {
   RenameStoryPropType,
   DateSettingsPropType,
 } from '../../../types';
-import { STORY_STATUS } from '../../../constants';
+import { STORY_STATUS, STORY_CONTEXT_MENU_ACTIONS } from '../../../constants';
 import { getRelativeDisplayDate } from '../../../utils';
 
 export const DetailRow = styled.div`
@@ -84,6 +84,13 @@ const StoryGridView = ({
               onEditCancel: renameStory?.handleCancelRename,
             }
           : {};
+
+        const storyMenuItems = storyMenu.menuItems.map((menuItem) => {
+          if (menuItem.value === STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK) {
+            return { ...menuItem, url: story.link };
+          }
+          return menuItem;
+        });
 
         return (
           <CardGridItem
@@ -127,7 +134,7 @@ const StoryGridView = ({
                 contextMenuId={storyMenu.contextMenuId}
                 onMenuItemSelected={storyMenu.handleMenuItemSelected}
                 story={story}
-                menuItems={storyMenu.menuItems}
+                menuItems={storyMenuItems}
               />
             </DetailRow>
           </CardGridItem>

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -61,6 +61,7 @@ import {
   SORT_DIRECTION,
   STORY_SORT_OPTIONS,
   STORY_STATUS,
+  STORY_CONTEXT_MENU_ACTIONS,
 } from '../../../constants';
 import { FULLBLEED_RATIO } from '../../../constants/pageStructure';
 import PreviewErrorBoundary from '../../../components/previewErrorBoundary';
@@ -235,59 +236,70 @@ export default function StoryListView({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {stories.map((story) => (
-            <TableRow key={`story-${story.id}`}>
-              <TablePreviewCell>
-                <PreviewContainer>
-                  <PreviewErrorBoundary>
-                    <PreviewPage page={story.pages[0]} pageSize={pageSize} />
-                  </PreviewErrorBoundary>
-                </PreviewContainer>
-              </TablePreviewCell>
-              <TableCell>
-                <TitleTableCellContainer>
-                  {renameStory.id === story.id ? (
-                    <InlineInputForm
-                      onEditComplete={(newTitle) =>
-                        renameStory.handleOnRenameStory(story, newTitle)
-                      }
-                      onEditCancel={renameStory.handleCancelRename}
-                      value={story.title}
-                      id={story.id}
-                      label={__('Rename story', 'web-stories')}
-                    />
-                  ) : (
-                    <>
-                      <Paragraph2>{titleFormatted(story.title)}</Paragraph2>
-                      <StoryMenu
-                        onMoreButtonSelected={storyMenu.handleMenuToggle}
-                        contextMenuId={storyMenu.contextMenuId}
-                        onMenuItemSelected={storyMenu.handleMenuItemSelected}
-                        story={story}
-                        menuItems={storyMenu.menuItems}
-                        verticalAlign="center"
+          {stories.map((story) => {
+            const storyMenuItems = storyMenu.menuItems.map((menuItem) => {
+              if (
+                menuItem.value === STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK
+              ) {
+                return { ...menuItem, url: story.link };
+              }
+              return menuItem;
+            });
+
+            return (
+              <TableRow key={`story-${story.id}`}>
+                <TablePreviewCell>
+                  <PreviewContainer>
+                    <PreviewErrorBoundary>
+                      <PreviewPage page={story.pages[0]} pageSize={pageSize} />
+                    </PreviewErrorBoundary>
+                  </PreviewContainer>
+                </TablePreviewCell>
+                <TableCell>
+                  <TitleTableCellContainer>
+                    {renameStory.id === story.id ? (
+                      <InlineInputForm
+                        onEditComplete={(newTitle) =>
+                          renameStory.handleOnRenameStory(story, newTitle)
+                        }
+                        onEditCancel={renameStory.handleCancelRename}
+                        value={story.title}
+                        id={story.id}
+                        label={__('Rename story', 'web-stories')}
                       />
-                    </>
-                  )}
-                </TitleTableCellContainer>
-              </TableCell>
-              <TableCell>{users[story.author]?.name || '—'}</TableCell>
-              <TableCell>
-                {getRelativeDisplayDate(story.created, dateSettings)}
-              </TableCell>
-              <TableCell>
-                {getRelativeDisplayDate(story.modified, dateSettings)}
-              </TableCell>
-              {storyStatus !== STORY_STATUS.DRAFT && (
-                <TableStatusCell>
-                  {story.status === STORY_STATUS.PUBLISH &&
-                    __('Published', 'web-stories')}
-                  {story.status === STORY_STATUS.FUTURE &&
-                    __('Scheduled', 'web-stories')}
-                </TableStatusCell>
-              )}
-            </TableRow>
-          ))}
+                    ) : (
+                      <>
+                        <Paragraph2>{titleFormatted(story.title)}</Paragraph2>
+                        <StoryMenu
+                          onMoreButtonSelected={storyMenu.handleMenuToggle}
+                          contextMenuId={storyMenu.contextMenuId}
+                          onMenuItemSelected={storyMenu.handleMenuItemSelected}
+                          story={story}
+                          menuItems={storyMenuItems}
+                          verticalAlign="center"
+                        />
+                      </>
+                    )}
+                  </TitleTableCellContainer>
+                </TableCell>
+                <TableCell>{users[story.author]?.name || '—'}</TableCell>
+                <TableCell>
+                  {getRelativeDisplayDate(story.created, dateSettings)}
+                </TableCell>
+                <TableCell>
+                  {getRelativeDisplayDate(story.modified, dateSettings)}
+                </TableCell>
+                {storyStatus !== STORY_STATUS.DRAFT && (
+                  <TableStatusCell>
+                    {story.status === STORY_STATUS.PUBLISH &&
+                      __('Published', 'web-stories')}
+                    {story.status === STORY_STATUS.FUTURE &&
+                      __('Scheduled', 'web-stories')}
+                  </TableStatusCell>
+                )}
+              </TableRow>
+            );
+          })}
         </TableBody>
       </Table>
     </ListView>

--- a/assets/src/dashboard/components/alert/components.js
+++ b/assets/src/dashboard/components/alert/components.js
@@ -80,8 +80,8 @@ export const AlertTitle = styled.span`
 export const DismissButton = styled.button`
   align-self: center;
   margin: 0 0 0 auto;
-  width: 25px;
-  height: 25px;
+  width: 36px;
+  height: 36px;
   background-color: transparent;
   color: ${({ theme }) => theme.colors.white};
   border: ${({ theme }) => theme.borders.transparent};

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -38,6 +38,14 @@ export const MenuContainer = styled.ul`
   overflow: hidden;
   padding: 5px 0;
   pointer-events: auto;
+
+  & > a {
+    background-color: none;
+    text-decoration: none;
+    &:focus {
+      box-shadow: none; /*override common js */
+    }
+  }
 `;
 MenuContainer.propTypes = {
   isOpen: PropTypes.bool,
@@ -52,6 +60,10 @@ export const MenuItem = styled.li`
     cursor: ${isDisabled ? 'default' : 'pointer'};
     display: flex;
     width: 100%;
+
+    &:focus, &:active, &:hover {
+      color: ${isDisabled ? theme.colors.gray400 : theme.colors.gray700};
+    }
   `}
 `;
 
@@ -128,6 +140,16 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
   const renderMenuItem = useCallback(
     (item, index) => {
       const itemIsDisabled = !item.value && item.value !== 0;
+      const MenuItemPropsAsLink =
+        item.renderItemAs === 'a'
+          ? {
+              target: '_blank',
+              rel: 'noreferrer',
+              href: item.url,
+              as: item.renderItemAs,
+            }
+          : {};
+
       return (
         <MenuItem
           key={`${item.value}_${index}`}
@@ -135,6 +157,7 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
           onClick={() => !itemIsDisabled && onSelect && onSelect(item)}
           onMouseEnter={() => setHoveredIndex(index)}
           isDisabled={itemIsDisabled}
+          {...MenuItemPropsAsLink}
         >
           <MenuItemContent>{item.label}</MenuItemContent>
         </MenuItem>

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -54,6 +54,7 @@ MenuContainer.propTypes = {
 export const MenuItem = styled.li`
   ${TypographyPresets.Small};
   ${({ theme, isDisabled, isHovering }) => `
+    margin-bottom: 0; /* override common js */
     padding: 5px 25px;
     background: ${isHovering && !isDisabled ? theme.colors.gray25 : 'none'};
     color: ${isDisabled ? theme.colors.gray400 : theme.colors.gray700};
@@ -82,6 +83,7 @@ const Separator = styled.li`
   height: 1px;
   background: ${({ theme }) => theme.colors.gray50};
   width: 100%;
+  margin: 6px 0;
 `;
 
 const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -140,15 +140,14 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
   const renderMenuItem = useCallback(
     (item, index) => {
       const itemIsDisabled = !item.value && item.value !== 0;
-      const MenuItemPropsAsLink =
-        item.renderItemAs === 'a'
-          ? {
-              target: '_blank',
-              rel: 'noreferrer',
-              href: item.url,
-              as: item.renderItemAs,
-            }
-          : {};
+      const MenuItemPropsAsLink = item.url
+        ? {
+            target: '_blank',
+            rel: 'noreferrer',
+            href: item.url,
+            as: 'a',
+          }
+        : {};
 
       return (
         <MenuItem

--- a/assets/src/dashboard/components/popoverMenu/stories/index.js
+++ b/assets/src/dashboard/components/popoverMenu/stories/index.js
@@ -32,6 +32,12 @@ const demoItems = [
   { value: false, label: 'invalid option' },
   { value: 'bar', label: 'three' },
   {
+    value: 'link',
+    label: 'i am a link!',
+    renderItemAs: 'a',
+    url: 'https://www.google.com/',
+  },
+  {
     value: 'edge_case',
     label: 'i am a very very very very very very very long label',
   },

--- a/assets/src/dashboard/components/popoverMenu/stories/index.js
+++ b/assets/src/dashboard/components/popoverMenu/stories/index.js
@@ -34,7 +34,6 @@ const demoItems = [
   {
     value: 'link',
     label: 'i am a link!',
-    renderItemAs: 'a',
     url: 'https://www.google.com/',
   },
   {

--- a/assets/src/dashboard/components/popoverMenu/test/popover-menu.js
+++ b/assets/src/dashboard/components/popoverMenu/test/popover-menu.js
@@ -34,7 +34,6 @@ describe('PopoverMenu', () => {
     {
       value: 'link',
       label: 'i am a link!',
-      renderItemAs: 'a',
       url: 'https://www.google.com/',
     },
   ];

--- a/assets/src/dashboard/components/popoverMenu/test/popover-menu.js
+++ b/assets/src/dashboard/components/popoverMenu/test/popover-menu.js
@@ -31,6 +31,12 @@ describe('PopoverMenu', () => {
     { value: 'foo', label: 'two' },
     { value: false, label: 'invalid option' },
     { value: 'bar', label: 'three' },
+    {
+      value: 'link',
+      label: 'i am a link!',
+      renderItemAs: 'a',
+      url: 'https://www.google.com/',
+    },
   ];
   const onClickMock = jest.fn();
 
@@ -64,5 +70,14 @@ describe('PopoverMenu', () => {
     fireEvent.click(menuItem);
 
     expect(onClickMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render one anchor and 4 list items', () => {
+    const { queryAllByRole } = renderWithTheme(
+      <PopoverMenu onSelect={onClickMock} items={demoItems} isOpen />
+    );
+
+    expect(queryAllByRole('listitem')).toHaveLength(4);
+    expect(queryAllByRole('link')).toHaveLength(1);
   });
 });

--- a/assets/src/dashboard/components/types.js
+++ b/assets/src/dashboard/components/types.js
@@ -25,7 +25,6 @@ export const DROPDOWN_ITEM_PROP_TYPE = PropTypes.shape({
   selected: PropTypes.bool,
   separator: PropTypes.bool,
   disabled: PropTypes.bool,
-  renderItemAs: PropTypes.string,
   url: PropTypes.string,
 });
 

--- a/assets/src/dashboard/components/types.js
+++ b/assets/src/dashboard/components/types.js
@@ -25,6 +25,8 @@ export const DROPDOWN_ITEM_PROP_TYPE = PropTypes.shape({
   selected: PropTypes.bool,
   separator: PropTypes.bool,
   disabled: PropTypes.bool,
+  renderItemAs: PropTypes.string,
+  url: PropTypes.string,
 });
 
 export const ColorType = PropTypes.shape({

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -45,6 +45,7 @@ export const STORY_CONTEXT_MENU_ITEMS = [
   {
     label: __('Open in new tab', 'web-stories'),
     value: STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK,
+    renderItemAs: 'a',
   },
   {
     label: __('Copy Story URL', 'web-stories'),

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -45,7 +45,6 @@ export const STORY_CONTEXT_MENU_ITEMS = [
   {
     label: __('Open in new tab', 'web-stories'),
     value: STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK,
-    renderItemAs: 'a',
   },
   {
     label: __('Copy Story URL', 'web-stories'),

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -28,6 +28,8 @@ export const STORY_CONTEXT_MENU_ACTIONS = {
   DUPLICATE: 'duplicate-action',
   CREATE_TEMPLATE: 'create-template-action',
   DELETE: 'delete-story-action',
+  COPY_STORY_LINK: 'copy-story-link',
+  OPEN_STORY_LINK: 'open-story-link',
 };
 
 export const STORY_CONTEXT_MENU_ITEMS = [
@@ -39,6 +41,14 @@ export const STORY_CONTEXT_MENU_ITEMS = [
     label: __('Preview', 'web-stories'),
     value: STORY_CONTEXT_MENU_ACTIONS.PREVIEW,
     inProgress: true,
+  },
+  {
+    label: __('Open in new tab', 'web-stories'),
+    value: STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK,
+  },
+  {
+    label: __('Copy Story URL', 'web-stories'),
+    value: STORY_CONTEXT_MENU_ACTIONS.COPY_STORY_LINK,
   },
   { label: null, value: false, separator: true },
   {

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -105,6 +105,8 @@ export const StoryMenuPropType = PropTypes.shape({
     PropTypes.shape({
       label: PropTypes.string,
       value: PropTypes.oneOfType[(PropTypes.string, PropTypes.bool)],
+      renderItemAs: PropTypes.string,
+      url: PropTypes.string,
     })
   ),
 });

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -105,7 +105,6 @@ export const StoryMenuPropType = PropTypes.shape({
     PropTypes.shape({
       label: PropTypes.string,
       value: PropTypes.oneOfType[(PropTypes.string, PropTypes.bool)],
-      renderItemAs: PropTypes.string,
       url: PropTypes.string,
     })
   ),


### PR DESCRIPTION
## Summary

Adds two new context menu items to a story menu

- Copy the story URL to the clipboard "Copy Story URL"
- Open the story URL in a new tab "Open in new tab"

<img width="460" alt="Screen Shot 2020-08-20 at 1 06 02 PM" src="https://user-images.githubusercontent.com/10720454/90820222-ebd1ba00-e2e5-11ea-9dc9-d4a45abd5c13.png">

![Screen Shot 2020-08-24 at 10 58 42 AM](https://user-images.githubusercontent.com/10720454/91079833-7160ad00-e5f9-11ea-9fcb-58a36b901b6c.png)



## Relevant Technical Choices

- Added two new menu items in the same style as other context menu items. 
- Tweaks to story menu item constant as well as popover menu to allow list items to be rendered as anchors. 
- Moves `ToastProvider` up to encompass `<AppContent />` not just the `ToasterView` now that we're not just using it for state errors generated from context. This allows us to easily wire up any kind of toast.

## To-do

N/A

## User-facing changes

- 2 new action items in the story context menus of the dashboard to copy story url or open story in new tab. 
- Alert 'X' dismiss button is a bit larger to identify it from message body text.

## Testing Instructions

Go to dashboard and see the two new options.
- validate that the copy link copies the link (you will also get a success toast)
- validate that open in new tab opens a new tab with the story

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4101 
