### PR TITLE
Fixed font-size in layer panel

### DIFF
--- a/assets/src/edit-story/components/panels/layer/layer.js
+++ b/assets/src/edit-story/components/panels/layer/layer.js
@@ -84,6 +84,8 @@ const LayerDescription = styled.div`
   margin-left: 0;
   text-align: left;
   color: ${({ theme }) => theme.colors.fg.white};
+  font-family: ${({ theme }) => theme.fonts.description.family};
+  font-size: ${({ theme }) => theme.fonts.description.size};
 `;
 
 const LockedIcon = styled(Locked)`

--- a/assets/src/edit-story/elements/shape/layer.js
+++ b/assets/src/edit-story/elements/shape/layer.js
@@ -34,6 +34,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: center;
+  align-items: center;
 `;
 
 const ShapePreview = styled.div`


### PR DESCRIPTION
## Summary

This PR ensures that all element text in the "Layers" panel is uniform at `font-size: 13px` and `font-family: Roboto` (before the font-size and family varied on the element type).

## User-facing changes

The text in the "Layers" panel should be consistent font size (13px) and family (Roboto).

## Testing Instructions

1.) Open up a story in the Editor.
2.) Make sure the current page has at least one text element, one shape element, and one image element.
3.) Double check that the label for each element (if a text label exists) is of `font-size: 13px` and `font-family: Roboto` (this includes the locked Background element text too).

Fixes #2014 

## Screenshot

Consistent font-size and font-family for all element types 😎 
![image](https://user-images.githubusercontent.com/40646372/90923392-72e46800-e3a2-11ea-957a-7666df9472f5.png)

