### PR TITLE
Media: Add srcset to cropbox when editing images

### DIFF
--- a/assets/src/edit-story/elements/media/edit.js
+++ b/assets/src/edit-story/elements/media/edit.js
@@ -110,6 +110,9 @@ function MediaEdit({ element, box }) {
     [id, updateElementById]
   );
 
+  const isImage = 'image' === type;
+  const isVideo = 'video' === type;
+
   const mediaProps = getMediaSizePositionProps(
     resource,
     width,
@@ -137,8 +140,11 @@ function MediaEdit({ element, box }) {
     ...mediaProps,
   };
 
-  const isImage = 'image' === type;
-  const isVideo = 'video' === type;
+  const srcSet = calculateSrcSet(element.resource);
+  if (isImage && srcSet) {
+    cropMediaProps.srcSet = srcSet;
+  }
+
   return (
     <Element>
       {isImage && (


### PR DESCRIPTION
## Summary

Add srcset to cropbox when available so the cropped scaled image displays similarly to the canvas display one.

## Testing Instructions

Follow the steps in #4051

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4051
