### PR TITLE
Dashboard: Remove fixed height on preview cards

### DIFF
--- a/assets/src/dashboard/components/cardGallery/components.js
+++ b/assets/src/dashboard/components/cardGallery/components.js
@@ -50,20 +50,19 @@ export const MiniCardWrapper = styled.div`
 `;
 
 export const MiniCard = styled.div(
-  ({ width, containerHeight, theme }) => `
+  ({ width, theme }) => `
     position: relative;
     width: ${width}px;
-    height: ${containerHeight}px;
     cursor: pointer;
     border: ${theme.storyPreview.border};
   `
 );
 
 export const ActiveCard = styled.div(
-  ({ width, containerHeight, theme }) => `
+  ({ width, theme }) => `
     position: relative;
+    box-sizing: border-box;
     width: ${width}px;
-    height: ${containerHeight}px;
     border: ${theme.storyPreview.border};
     box-shadow: ${theme.storyPreview.shadow};
   `


### PR DESCRIPTION
## Summary

Fixes the missing bottom borders for preview cards on template details

<img width="657" alt="Screen Shot 2020-08-24 at 9 52 11 AM" src="https://user-images.githubusercontent.com/1738349/91059553-7e789e80-e5ef-11ea-85f8-dad9977fdd07.png">


## Relevant Technical Choices

The updated `<PreviewElements />` with the background no longer needs a set height on the parent container. This drops it which shows the bottom border which was now being clipped.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

The bottom border now works again

## Testing Instructions

1. Visit Explore Templates on Dashboard
2. Click View to see any Template
3. See the bottom border shows up again

---

<!-- Please reference the issue(s) this PR addresses. -->

#4183 
