### PR TITLE
Fix flex issues in Safari

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
@@ -136,6 +136,8 @@ const Media3pCategories = ({
         CATEGORY_BOTTOM_MARGIN
       }px`;
     }
+    // Safari has some strange issues with flex-shrink that require setting
+    // min-height as well.
     categorySectionRef.current.style.height = height;
     categorySectionRef.current.style.minHeight = height;
   }, [categorySectionRef, innerContainerRef, isExpanded]);

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { useLayoutEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { rgba } from 'polished';
@@ -32,29 +32,29 @@ import { __ } from '@wordpress/i18n';
  */
 import { ArrowDown } from '../../../../button';
 import CategoryPill from './categoryPill';
+import { PILL_HEIGHT } from './pill';
+
+const CATEGORY_TOP_MARGIN = 16;
+const CATEGORY_BOTTOM_MARGIN = 30;
+const CATEGORY_COLLAPSED_FULL_HEIGHT =
+  PILL_HEIGHT + CATEGORY_TOP_MARGIN + CATEGORY_BOTTOM_MARGIN;
 
 const CategorySection = styled.div`
+  height: ${CATEGORY_COLLAPSED_FULL_HEIGHT}px;
+  min-height: ${CATEGORY_COLLAPSED_FULL_HEIGHT}px;
   background-color: ${({ theme }) => rgba(theme.colors.bg.workspace, 0.8)};
-  padding: 16px 12px 30px 24px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  flex: 1 0 auto;
+  flex: 0 1 auto;
   position: relative;
-
-  ${({ hasCategories }) =>
-    !hasCategories &&
-    css`
-      min-height: 104px;
-      max-height: 104px;
-    `}
+  transition: height 0.2s, min-height 0.2s;
 `;
 
 // This hides the category pills unless expanded
 const CategoryPillContainer = styled.div`
-  height: 36px;
   overflow: hidden;
-  transition: height 0.2s;
+  margin: ${CATEGORY_TOP_MARGIN}px 12px ${CATEGORY_BOTTOM_MARGIN}px 24px;
 `;
 
 const CategoryPillInnerContainer = styled.div`
@@ -117,29 +117,38 @@ const Media3pCategories = ({
     });
   }
 
-  const containerRef = useRef();
+  const categorySectionRef = useRef();
   const innerContainerRef = useRef();
 
   // We calculate the actual height of the categories list, and set its explicit
   // height if it's expanded, in order to have a CSS height transition.
   useLayoutEffect(() => {
-    if (!containerRef.current || !innerContainerRef.current) {
+    if (!categorySectionRef.current || !innerContainerRef.current) {
       return;
     }
+    let height;
     if (!isExpanded) {
-      containerRef.current.style.height = '36px';
+      height = `${CATEGORY_COLLAPSED_FULL_HEIGHT}px`;
     } else {
-      containerRef.current.style.height = `${innerContainerRef.current.offsetHeight}px`;
+      height = `${
+        innerContainerRef.current.offsetHeight +
+        CATEGORY_TOP_MARGIN +
+        CATEGORY_BOTTOM_MARGIN
+      }px`;
     }
-  }, [containerRef, innerContainerRef, isExpanded]);
+    categorySectionRef.current.style.height = height;
+    categorySectionRef.current.style.minHeight = height;
+  }, [categorySectionRef, innerContainerRef, isExpanded]);
 
   return (
-    <CategorySection hasCategories={Boolean(categories.length)}>
+    <CategorySection
+      ref={categorySectionRef}
+      hasCategories={Boolean(categories.length)}
+    >
       {categories.length ? (
         <>
           <CategoryPillContainer
             id="category-pill-container"
-            ref={containerRef}
             isExpanded={isExpanded}
             role="tablist"
           >

--- a/assets/src/edit-story/components/library/panes/media/media3p/pill.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/pill.js
@@ -18,11 +18,13 @@
  */
 import { css } from 'styled-components';
 
+export const PILL_HEIGHT = 36;
+
 export const pill = css`
   border: 1px solid transparent;
   margin-right: 12px;
   padding: 7px 16px 8px;
-  height: 36px;
+  height: ${PILL_HEIGHT}px;
   border-radius: 18px;
   font-size: 14px;
   line-height: 20px;


### PR DESCRIPTION
## Summary

We were using flex-grow for the categories container which is incorrect, because we want it to shrink as much as possible and have the media section grow (eg: when there are no media results).
This PR changes to flex-shrink instead.

## Relevant Technical Choices

Safari has some very weird edge cases with flex-shrink that causes it to not adapt to its contents correctly. This PR explicitly set the height AND min-height which resolves the issue. Additionally, the outer container is animated instead of the inner one, because Safari doesn't make the parent change size correctly as well.

## User-facing changes

Safari and Chrome now display the categories section correctly in expanded and collapsed mode with media results and without.

Fixes #4177
