### PR TITLE
3P Media: Categories Animations

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/media3p/categoryPill.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/categoryPill.js
@@ -37,6 +37,10 @@ const PillContainer = styled.button`
   color: ${({ theme }) => theme.colors.fg.primary};
   user-select: none;
   background-clip: padding-box;
+  transition: opacity 0.2s;
+  &.invisible {
+    opacity: 0;
+  }
 `;
 
 PillContainer.propTypes = {
@@ -45,6 +49,7 @@ PillContainer.propTypes = {
 
 const CategoryPill = ({
   index,
+  categoryId,
   title,
   isSelected,
   isExpanded,
@@ -74,6 +79,8 @@ const CategoryPill = ({
       role="tab"
       aria-selected={isSelected}
       data-testid="mediaCategory"
+      className="categoryPill"
+      data-category-id={categoryId}
     >
       {title}
     </PillContainer>
@@ -82,6 +89,7 @@ const CategoryPill = ({
 
 CategoryPill.propTypes = {
   index: PropTypes.number,
+  categoryId: PropTypes.string,
   isSelected: PropTypes.bool,
   isExpanded: PropTypes.bool,
   setIsExpanded: PropTypes.func,

--- a/assets/src/edit-story/components/library/panes/media/media3p/categoryPill.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/categoryPill.js
@@ -71,16 +71,16 @@ const CategoryPill = ({
   return (
     <PillContainer
       ref={ref}
+      className="categoryPill"
+      data-testid="mediaCategory"
+      data-category-id={categoryId}
+      role="tab"
+      aria-selected={isSelected}
       // The first or selected category will be in focus for roving
       // (arrow-based) navigation initially.
       tabIndex={index === 0 || isSelected ? 0 : -1}
       isSelected={isSelected}
       onClick={onClick}
-      role="tab"
-      aria-selected={isSelected}
-      data-testid="mediaCategory"
-      className="categoryPill"
-      data-category-id={categoryId}
     >
       {title}
     </PillContainer>

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
@@ -61,6 +61,8 @@ const CategoryPillInnerContainer = styled.div`
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
+  position: relative;
+  transition: transform 0.2s;
 `;
 
 // Flips the button upside down when expanded;
@@ -91,10 +93,7 @@ const Media3pCategories = ({
   const [isExpanded, setIsExpanded] = useState(false);
 
   function renderCategories() {
-    return (selectedCategoryId
-      ? [categories.find((e) => e.id === selectedCategoryId)]
-      : categories
-    ).map((e, i) => {
+    return categories.map((e, i) => {
       const selected = e.id === selectedCategoryId;
       return (
         <CategoryPill
@@ -103,6 +102,7 @@ const Media3pCategories = ({
           isExpanded={isExpanded}
           setIsExpanded={setIsExpanded}
           key={e.id}
+          categoryId={e.id}
           title={e.displayName}
           onClick={() => {
             if (selected) {
@@ -120,6 +120,9 @@ const Media3pCategories = ({
   const containerRef = useRef();
   const innerContainerRef = useRef();
 
+  const [focusedRowOffset, setFocusedRowOffset] = useState(0);
+
+  // Handles expand and contract animation.
   // We calculate the actual height of the categories list, and set its explicit
   // height if it's expanded, in order to have a CSS height transition.
   useLayoutEffect(() => {
@@ -130,8 +133,52 @@ const Media3pCategories = ({
       containerRef.current.style.height = '36px';
     } else {
       containerRef.current.style.height = `${innerContainerRef.current.offsetHeight}px`;
+      setFocusedRowOffset(0);
     }
   }, [containerRef, innerContainerRef, isExpanded]);
+
+  // Handles setting which row will be seen, by manipulating translateY.
+  useLayoutEffect(() => {
+    if (!innerContainerRef.current) {
+      return;
+    }
+    const categoryPills = Array.from(
+      innerContainerRef.current.querySelectorAll('.categoryPill')
+    );
+    const selectedCategoryPill = selectedCategoryId
+      ? categoryPills.find((p) => p.dataset.categoryId == selectedCategoryId)
+      : null;
+    const selectedCategoryPillOffsetTop = selectedCategoryPill?.offsetTop || 0;
+
+    if (selectedCategoryPillOffsetTop) {
+      setFocusedRowOffset(selectedCategoryPillOffsetTop);
+    }
+  }, [innerContainerRef, isExpanded, selectedCategoryId]);
+
+  // Handles fading category rows in and out depending on the selected category.
+  useLayoutEffect(() => {
+    if (!innerContainerRef.current) {
+      return;
+    }
+    const categoryPills = Array.from(
+      innerContainerRef.current.querySelectorAll('.categoryPill')
+    );
+    const selectedCategoryPill = selectedCategoryId
+      ? categoryPills.find((p) => p.dataset.categoryId == selectedCategoryId)
+      : null;
+    const selectedCategoryPillOffsetTop = selectedCategoryPill?.offsetTop || 0;
+
+    for (let categoryPill of categoryPills) {
+      const isSameRow =
+        selectedCategoryPill &&
+        categoryPill.offsetTop == selectedCategoryPillOffsetTop;
+      if (selectedCategoryPill && !isSameRow) {
+        categoryPill.classList.add('invisible');
+      } else {
+        categoryPill.classList.remove('invisible');
+      }
+    }
+  }, [innerContainerRef, isExpanded, selectedCategoryId]);
 
   return (
     <CategorySection hasCategories={Boolean(categories.length)}>
@@ -143,7 +190,10 @@ const Media3pCategories = ({
             isExpanded={isExpanded}
             role="tablist"
           >
-            <CategoryPillInnerContainer ref={innerContainerRef}>
+            <CategoryPillInnerContainer
+              ref={innerContainerRef}
+              style={{ transform: `translateY(-${focusedRowOffset}px` }}
+            >
               {renderCategories()}
             </CategoryPillInnerContainer>
           </CategoryPillContainer>

--- a/assets/src/edit-story/components/library/panes/media/media3p/test/media3pCategories.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/test/media3pCategories.js
@@ -92,8 +92,8 @@ describe('Media3pCategories', () => {
     const categoryPill3 = queryByRole('tab', { name: 'Category 3' });
 
     expect(categoryPill1).toHaveAttribute('aria-selected', 'true');
-    expect(categoryPill2).toBeNull();
-    expect(categoryPill3).toBeNull();
+    expect(categoryPill2).toHaveAttribute('aria-selected', 'false');
+    expect(categoryPill3).toHaveAttribute('aria-selected', 'false');
   });
 
   it('should render <Media3pCategories /> with and allow selection', () => {

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -382,6 +382,7 @@ class Experiments {
 				'label'       => __( 'Third-Party Media', 'web-stories' ),
 				'description' => __( 'Enable third-party media tab', 'web-stories' ),
 				'group'       => 'editor',
+				'default'     => true,
 			],
 			/**
 			 * Description: Flag for showing the Coverr Media3p subtab.
@@ -394,6 +395,7 @@ class Experiments {
 				'label'       => __( 'Coverr', 'web-stories' ),
 				'description' => __( 'Enable the Coverr tab in the Third-party media tab.', 'web-stories' ),
 				'group'       => 'editor',
+				'default'     => true,
 			],
 		];
 	}

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -382,7 +382,6 @@ class Experiments {
 				'label'       => __( 'Third-Party Media', 'web-stories' ),
 				'description' => __( 'Enable third-party media tab', 'web-stories' ),
 				'group'       => 'editor',
-				'default'     => true,
 			],
 			/**
 			 * Description: Flag for showing the Coverr Media3p subtab.
@@ -395,7 +394,6 @@ class Experiments {
 				'label'       => __( 'Coverr', 'web-stories' ),
 				'description' => __( 'Enable the Coverr tab in the Third-party media tab.', 'web-stories' ),
 				'group'       => 'editor',
-				'default'     => true,
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

This PR adds the necessary animations as per spec, see the attached issue. This includes "scrolling" to show the row with the selected category and fading in/out the rows that don't correspond to the currently selected category.

![3aaff3b2-8b77-42d3-800a-259e39ce3b4f](https://user-images.githubusercontent.com/512647/91116517-e43c5780-e6cf-11ea-8f81-bcc73b2fcf90.gif)

Fixes #2364