### PR TITLE
Workspace: Update panel divider color from blue to gray

### DIFF
--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -51,7 +51,7 @@ function getBackgroundColor(isPrimary, isSecondary, theme) {
 const Header = styled.h2`
   background-color: ${({ isPrimary, isSecondary, theme }) =>
     getBackgroundColor(isPrimary, isSecondary, theme)};
-  border: 0 solid ${({ theme }) => theme.colors.fg.gray16};
+  border: 0 solid ${({ theme }) => rgba(theme.colors.fg.gray16, 0.6)};
   border-top-width: ${({ isPrimary, isSecondary }) =>
     isPrimary || isSecondary ? 0 : '1px'};
   color: ${({ theme }) => rgba(theme.colors.fg.white, 0.84)};

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -51,7 +51,7 @@ function getBackgroundColor(isPrimary, isSecondary, theme) {
 const Header = styled.h2`
   background-color: ${({ isPrimary, isSecondary, theme }) =>
     getBackgroundColor(isPrimary, isSecondary, theme)};
-  border: 0 solid ${({ theme }) => theme.colors.bg.v9};
+  border: 0 solid ${({ theme }) => theme.colors.fg.gray16};
   border-top-width: ${({ isPrimary, isSecondary }) =>
     isPrimary || isSecondary ? 0 : '1px'};
   color: ${({ theme }) => rgba(theme.colors.fg.white, 0.84)};


### PR DESCRIPTION
## Summary
Update panel divider color from blue to gray

## Relevant Technical Choices

Use `theme.colors.fg.gray16` for the divider color.


## User-facing changes

Divider panel colors change from blue to gray.

## Testing Instructions

Verify these dividers are gray

![panel](https://user-images.githubusercontent.com/2755722/91228872-f7aee900-e6f6-11ea-8942-14fb35fec6fa.png)



---


#4063 
