### PR TITLE
Dashboard: Use Keydown Event to Trigger Sort in List View 

### DIFF
--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -889,6 +889,177 @@ describe('List view', () => {
         storieModifiedSortedByModified.reverse()
       );
     });
+
+    it('should sort by Title in List View with keyboard', async () => {
+      const listViewButton = fixture.screen.getByLabelText(
+        new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
+      );
+
+      await fixture.events.focus(listViewButton);
+      await fixture.events.keyboard.press('Enter');
+
+      // There is a second hidden span with the same text
+      const titleHeader = fixture.screen.getAllByText(/^Title/)[0];
+
+      await fixture.events.focus(titleHeader);
+      await fixture.events.keyboard.press('Enter');
+      // drop the header row using slice
+      let rows = fixture.screen.getAllByRole('row').slice(1);
+
+      const { stories, storiesOrderById } = await getStoriesState();
+
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      const storieTitlesSortedByTitle = storiesOrderById.map(
+        (id) => stories[id].title
+      );
+
+      // title is the second column
+      let rowTitles = rows.map((row) => row.children[1].innerText);
+
+      expect(rowTitles).toEqual(storieTitlesSortedByTitle);
+
+      // sort by descending
+      await fixture.events.keyboard.press('Enter');
+
+      rows = fixture.screen.getAllByRole('row').slice(1);
+
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      // title is the second column
+      rowTitles = rows.map((row) => row.children[1].innerText);
+
+      expect(rowTitles).toEqual(storieTitlesSortedByTitle.reverse());
+    });
+
+    it('should sort by Author in List View with keyboard', async () => {
+      const listViewButton = fixture.screen.getByLabelText(
+        new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
+      );
+
+      await fixture.events.focus(listViewButton);
+      await fixture.events.keyboard.press('Enter');
+
+      const authorHeader = fixture.screen.getByText(/^Author/);
+
+      await fixture.events.focus(authorHeader);
+      await fixture.events.keyboard.press('Enter');
+
+      // drop the header row using slice
+      let rows = fixture.screen.getAllByRole('row').slice(1);
+
+      const { stories, storiesOrderById } = await getStoriesState();
+
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      const users = await getUsers();
+
+      const storieAuthorsSortedByAuthor = storiesOrderById.map(
+        (id) => users[stories[id].author].name
+      );
+
+      // author is the third column
+      let rowAuthors = rows.map((row) => row.children[2].innerText);
+
+      expect(rowAuthors).toEqual(storieAuthorsSortedByAuthor);
+
+      // sort by descending
+      await fixture.events.keyboard.press('Enter');
+
+      rows = fixture.screen.getAllByRole('row').slice(1);
+
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      // author is the third column
+      rowAuthors = rows.map((row) => row.children[2].innerText);
+
+      expect(rowAuthors).toEqual(storieAuthorsSortedByAuthor.reverse());
+    });
+
+    it('should sort by Date Created in List View with keyboard', async () => {
+      const listViewButton = fixture.screen.getByLabelText(
+        new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
+      );
+
+      await fixture.events.focus(listViewButton);
+      await fixture.events.keyboard.press('Enter');
+
+      const dateCreatedHeader = fixture.screen.getByText(/^Date Created/);
+
+      await fixture.events.focus(dateCreatedHeader);
+      await fixture.events.keyboard.press('Enter');
+
+      // drop the header row using slice
+      let rows = fixture.screen.getAllByRole('row').slice(1);
+
+      const { stories, storiesOrderById } = await getStoriesState();
+
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      const storiesDateCreatedSortedByDateCreated = storiesOrderById.map((id) =>
+        getRelativeDisplayDate(stories[id].created, fillerDateSettingsObject)
+      );
+
+      let rowDateCreatedValues = rows.map((row) => row.children[3].innerText);
+
+      expect(rowDateCreatedValues).toEqual(
+        storiesDateCreatedSortedByDateCreated
+      );
+
+      // sort by ascending
+      await fixture.events.keyboard.press('Enter');
+
+      rows = fixture.screen.getAllByRole('row').slice(1);
+
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      // author is the fourth column
+      rowDateCreatedValues = rows.map((row) => row.children[3].innerText);
+
+      expect(rowDateCreatedValues).toEqual(
+        storiesDateCreatedSortedByDateCreated.reverse()
+      );
+    });
+
+    it('should sort by Last Modified in List View with keyboard', async () => {
+      // last modified desc is the default sort
+      const listViewButton = fixture.screen.getByLabelText(
+        new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
+      );
+
+      await fixture.events.focus(listViewButton);
+      await fixture.events.keyboard.press('Enter');
+
+      // drop the header row using slice
+      let rows = fixture.screen.getAllByRole('row').slice(1);
+
+      const { stories, storiesOrderById } = await getStoriesState();
+
+      expect(rows.length).toEqual(storiesOrderById.length);
+
+      const storieModifiedSortedByModified = storiesOrderById.map((id) =>
+        getRelativeDisplayDate(stories[id].modified, fillerDateSettingsObject)
+      );
+
+      // Last Modified is the fifth column
+      let rowModifiedValues = rows.map((row) => row.children[4].innerText);
+
+      expect(rowModifiedValues).toEqual(storieModifiedSortedByModified);
+
+      // sort ascending
+      const lastModifiedHeader = fixture.screen.getByText(/^Last Modified/);
+
+      await fixture.events.focus(lastModifiedHeader);
+      await fixture.events.keyboard.press('Enter');
+
+      rows = fixture.screen.getAllByRole('row').slice(1);
+
+      rowModifiedValues = rows.map((row) => row.children[4].innerText);
+
+      expect(rowModifiedValues).toEqual(
+        storieModifiedSortedByModified.reverse()
+      );
+    });
   });
 
   describe('CUJ: Creator can view their stories in list view: Go to WP list view to do any action', () => {

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -162,6 +162,15 @@ export default function StoryListView({
     },
     [handleSortDirectionChange, handleSortChange, storySort, sortDirection]
   );
+
+  const onKeyDownSort = useCallback(
+    ({ key }, sortBy) => {
+      if (key === 'Enter') {
+        onSortTitleSelected(sortBy);
+      }
+    },
+    [onSortTitleSelected]
+  );
   return (
     <ListView data-testid="story-list-view">
       <Table>
@@ -169,11 +178,13 @@ export default function StoryListView({
           <TableRow>
             <TablePreviewHeaderCell
               onClick={() => onSortTitleSelected(STORY_SORT_OPTIONS.NAME)}
+              onKeyDown={(e) => onKeyDownSort(e, STORY_SORT_OPTIONS.NAME)}
             >
               <SelectableTitle>{__('Title', 'web-stories')}</SelectableTitle>
             </TablePreviewHeaderCell>
             <TableTitleHeaderCell
               onClick={() => onSortTitleSelected(STORY_SORT_OPTIONS.NAME)}
+              onKeyDown={(e) => onKeyDownSort(e, STORY_SORT_OPTIONS.NAME)}
             >
               <SelectableTitle>{__('Title', 'web-stories')}</SelectableTitle>
               <ArrowIcon active={storySort === STORY_SORT_OPTIONS.NAME}>
@@ -188,6 +199,9 @@ export default function StoryListView({
               <SelectableTitle
                 onClick={() =>
                   onSortTitleSelected(STORY_SORT_OPTIONS.CREATED_BY)
+                }
+                onKeyDown={(e) =>
+                  onKeyDownSort(e, STORY_SORT_OPTIONS.CREATED_BY)
                 }
               >
                 {__('Author', 'web-stories')}
@@ -207,30 +221,36 @@ export default function StoryListView({
                 onClick={() =>
                   onSortTitleSelected(STORY_SORT_OPTIONS.DATE_CREATED)
                 }
+                onKeyDown={(e) =>
+                  onKeyDownSort(e, STORY_SORT_OPTIONS.DATE_CREATED)
+                }
               >
                 {__('Date Created', 'web-stories')}
-                <ArrowIconWithTitle
-                  active={storySort === STORY_SORT_OPTIONS.DATE_CREATED}
-                  asc={sortDirection === SORT_DIRECTION.ASC}
-                >
-                  <ArrowIconSvg />
-                </ArrowIconWithTitle>
               </SelectableTitle>
+              <ArrowIconWithTitle
+                active={storySort === STORY_SORT_OPTIONS.DATE_CREATED}
+                asc={sortDirection === SORT_DIRECTION.ASC}
+              >
+                <ArrowIconSvg />
+              </ArrowIconWithTitle>
             </TableDateHeaderCell>
             <TableDateHeaderCell>
               <SelectableTitle
                 onClick={() =>
                   onSortTitleSelected(STORY_SORT_OPTIONS.LAST_MODIFIED)
                 }
+                onKeyDown={(e) =>
+                  onKeyDownSort(e, STORY_SORT_OPTIONS.LAST_MODIFIED)
+                }
               >
                 {__('Last Modified', 'web-stories')}
-                <ArrowIconWithTitle
-                  active={storySort === STORY_SORT_OPTIONS.LAST_MODIFIED}
-                  asc={sortDirection === SORT_DIRECTION.ASC}
-                >
-                  <ArrowIconSvg />
-                </ArrowIconWithTitle>
               </SelectableTitle>
+              <ArrowIconWithTitle
+                active={storySort === STORY_SORT_OPTIONS.LAST_MODIFIED}
+                asc={sortDirection === SORT_DIRECTION.ASC}
+              >
+                <ArrowIconSvg />
+              </ArrowIconWithTitle>
             </TableDateHeaderCell>
             {storyStatus !== STORY_STATUS.DRAFT && <TableStatusHeaderCell />}
           </TableRow>


### PR DESCRIPTION
## Summary

Adds the ability to trigger list view sorting via `Enter` with keydown event. 

![list view sort with keydown](https://user-images.githubusercontent.com/10720454/91219084-f073e500-e6ce-11ea-89ec-b5d995a6c3e4.gif)

## Relevant Technical Choices

- Adding an onKeyDown event handler to the focusable parts of the table header that make up the list view so that when they get focus we can sort when users keydown on enter. 
- While in here tabbing through, I noticed that for the alpha sorts the icons were not part of the focusable title while for dates they were. Opted, for the sake of the dual title headers to make this consistent by moving the date sort icons out of the focusable spans that make up the visible title. 
- Karma tests updated to include sort functionality based on keyboard

## To-do

- N/A

## User-facing changes

- Should be able to change my stories list view sort with `Enter` now. 

## Testing Instructions

- Navigate to Dashboard -> My Stories -> List View and use the keyboard to focus on table headers, when you focus on a table header and hit `Enter` it should re-sort the view as it would with a click. 
---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4199 
