### PR TITLE
Bug: Tooltip Text Wrapping & Improvements

### DIFF
--- a/assets/src/edit-story/components/panels/stylePreset/presets.js
+++ b/assets/src/edit-story/components/panels/stylePreset/presets.js
@@ -138,7 +138,6 @@ function Presets({
         (isText && presetHasGradient(color)));
     let tooltip = null;
     if (disabled) {
-      // However, due to bug with Tooltips/Popup, the text flows out of the screen.
       tooltip = isBackground
         ? __('Page background colors can not have an opacity.', 'web-stories')
         : __('Gradient not allowed for Text', 'web-stories');

--- a/assets/src/edit-story/components/panels/stylePreset/presets.js
+++ b/assets/src/edit-story/components/panels/stylePreset/presets.js
@@ -139,7 +139,7 @@ function Presets({
     let tooltip = null;
     if (disabled) {
       tooltip = isBackground
-        ? __('Page background colors can not have an opacity.', 'web-stories')
+        ? __('Page background colors cannot have an opacity.', 'web-stories')
         : __('Gradient not allowed for Text', 'web-stories');
     }
     return (

--- a/assets/src/edit-story/components/panels/stylePreset/presets.js
+++ b/assets/src/edit-story/components/panels/stylePreset/presets.js
@@ -138,10 +138,9 @@ function Presets({
         (isText && presetHasGradient(color)));
     let tooltip = null;
     if (disabled) {
-      // @todo The correct text here should be: Page background colors can not have an opacity.
       // However, due to bug with Tooltips/Popup, the text flows out of the screen.
       tooltip = isBackground
-        ? __('Opacity not allowed for Page', 'web-stories')
+        ? __('Page background colors can not have an opacity.', 'web-stories')
         : __('Gradient not allowed for Text', 'web-stories');
     }
     return (

--- a/assets/src/edit-story/components/popup/index.js
+++ b/assets/src/edit-story/components/popup/index.js
@@ -58,7 +58,8 @@ export const Placement = {
 const Container = styled.div.attrs(
   ({ x, y, width, height, fillWidth, fillHeight }) => ({
     style: {
-      left: `${x}px`,
+      left: '0px',
+      transform: `translateX(${x}px)`,
       top: `${y}px`,
       ...(fillWidth ? { width: `${width}px` } : {}),
       ...(fillHeight ? { height: `${height}px` } : {}),
@@ -67,7 +68,6 @@ const Container = styled.div.attrs(
 )`
   position: fixed;
   z-index: 2;
-  ${({ placement }) => getTransforms(placement)}
 
   /*
    * Custom gray scrollbars for Chromium & Firefox.
@@ -96,6 +96,10 @@ const Container = styled.div.attrs(
   }
 `;
 
+const Content = styled.div`
+  ${({ placement }) => getTransforms(placement)}
+`;
+
 function Popup({
   anchor,
   dock,
@@ -121,7 +125,6 @@ function Popup({
       if (evt?.target?.nodeType && popup.current?.contains(evt.target)) {
         return;
       }
-
       setPopupState({
         offset: getOffset(placement, spacing, anchor, dock, popup),
       });
@@ -153,11 +156,12 @@ function Popup({
           {...popupState.offset}
           fillWidth={fillWidth}
           fillHeight={fillHeight}
-          placement={placement}
         >
-          {renderContents
-            ? renderContents({ propagateDimensionChange: positionPopup })
-            : children}
+          <Content placement={placement}>
+            {renderContents
+              ? renderContents({ propagateDimensionChange: positionPopup })
+              : children}
+          </Content>
         </Container>,
         document.body
       )

--- a/assets/src/edit-story/components/popup/index.js
+++ b/assets/src/edit-story/components/popup/index.js
@@ -63,7 +63,6 @@ const Container = styled.div.attrs(
   top: 0px;
   position: fixed;
   z-index: 2;
-  background-color: tomato;
 
   /*
    * Custom gray scrollbars for Chromium & Firefox.

--- a/assets/src/edit-story/components/popup/index.js
+++ b/assets/src/edit-story/components/popup/index.js
@@ -126,14 +126,16 @@ function Popup({
 
   useLayoutEffect(() => {
     setMounted(true);
+    if (!isOpen) {
+      return () => {};
+    }
+    positionPopup();
     // Adjust the position when scrolling.
     document.addEventListener('scroll', positionPopup, true);
     return () => {
       document.removeEventListener('scroll', positionPopup, true);
     };
-  }, [positionPopup]);
-
-  useLayoutEffect(positionPopup, [positionPopup, isOpen]);
+  }, [isOpen, positionPopup]);
 
   useLayoutEffect(onPositionUpdate, [popupState, onPositionUpdate]);
 

--- a/assets/src/edit-story/components/popup/utils.js
+++ b/assets/src/edit-story/components/popup/utils.js
@@ -57,9 +57,9 @@ export function getTransforms(placement) {
   if (!xTransforms && !yTransforms) {
     return '';
   }
-  return `transform: ${
-    xTransforms ? `translateX(${xTransforms * 100}%)` : ``
-  } ${yTransforms ? `translateY(${yTransforms * 100}%)` : ``};`;
+  return `translate(${(xTransforms || 0) * 100}%, ${
+    (yTransforms || 0) * 100
+  }%)`;
 }
 
 export function getXOffset(
@@ -147,7 +147,7 @@ export function getOffset(placement, spacing, anchor, dock, popup) {
   const maxOffsetX = bodyRect.width - width - getXTransforms(placement) * width;
   // Vertical
   const offsetY = getYOffset(placement, spacingV, anchorRect);
-  const maxOffsetY = bodyRect.height - height - spacingV;
+  const maxOffsetY = bodyRect.height + bodyRect.y - height;
   // Clamp values
   return {
     x: Math.max(0, Math.min(offsetX, maxOffsetX)),

--- a/assets/src/edit-story/components/popup/utils.js
+++ b/assets/src/edit-story/components/popup/utils.js
@@ -22,7 +22,7 @@ import { Placement } from '.';
 export function getXTransforms(placement) {
   // left & right
   if (placement.startsWith('left')) {
-    return `-100%`;
+    return -1;
   } else if (placement.startsWith('right')) {
     return null;
   }
@@ -30,9 +30,9 @@ export function getXTransforms(placement) {
   if (placement.endsWith('-start')) {
     return null;
   } else if (placement.endsWith('-end')) {
-    return `-100%`;
+    return -1;
   }
-  return `-50%`;
+  return -0.5;
 }
 
 export function getYTransforms(placement) {
@@ -41,10 +41,10 @@ export function getYTransforms(placement) {
     placement === Placement.RIGHT_END ||
     placement === Placement.LEFT_END
   ) {
-    return `-100%`;
+    return -1;
   }
   if (placement === Placement.RIGHT || placement === Placement.LEFT) {
-    return `-50%`;
+    return -0.5;
   }
   return null;
 }
@@ -57,9 +57,9 @@ export function getTransforms(placement) {
   if (!xTransforms && !yTransforms) {
     return '';
   }
-  return `transform: ${xTransforms ? `translateX(${xTransforms})` : ``} ${
-    yTransforms ? `translateY(${yTransforms})` : ``
-  };`;
+  return `transform: ${
+    xTransforms ? `translateX(${xTransforms * 100}%)` : ``
+  } ${yTransforms ? `translateY(${yTransforms * 100}%)` : ``};`;
 }
 
 export function getXOffset(
@@ -133,7 +133,7 @@ export function getOffset(placement, spacing, anchor, dock, popup) {
     popupRect.width = Math.max(popupRect.width, popup.current?.scrollWidth);
   }
 
-  const { height = 0 } = popupRect || {};
+  const { height = 0, width = 0 } = popupRect || {};
   const { x: spacingH = 0, y: spacingV = 0 } = spacing || {};
 
   // Horizontal
@@ -144,7 +144,7 @@ export function getOffset(placement, spacing, anchor, dock, popup) {
     dockRect,
     bodyRect
   );
-  const maxOffsetX = bodyRect.width - spacingH;
+  const maxOffsetX = bodyRect.width - width - getXTransforms(placement) * width;
   // Vertical
   const offsetY = getYOffset(placement, spacingV, anchorRect);
   const maxOffsetY = bodyRect.height - height - spacingV;

--- a/assets/src/edit-story/components/tooltip/index.js
+++ b/assets/src/edit-story/components/tooltip/index.js
@@ -52,7 +52,7 @@ const Tooltip = styled.div`
   align-items: center;
   text-align: center;
   flex-direction: row;
-  max-width: 12em;
+  max-width: 13em;
   transition: 0.4s opacity;
   opacity: ${({ shown }) => (shown ? 1 : 0)};
   pointer-events: ${({ shown }) => (shown ? 'all' : 'none')};

--- a/assets/src/edit-story/components/tooltip/index.js
+++ b/assets/src/edit-story/components/tooltip/index.js
@@ -36,20 +36,23 @@ const Wrapper = styled.div`
 `;
 
 const Tooltip = styled.div`
-  background-color: ${({ theme }) => theme.colors.bg.black};
-  color: ${({ theme }) => theme.colors.fg.white};
-  font-family: ${({ theme }) => theme.fonts.body1.family};
-  font-size: 12px;
-  line-height: ${({ theme }) => theme.fonts.body1.lineHeight};
-  letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing};
+  ${({ theme }) => css`
+    background-color: ${theme.colors.bg.black};
+    color: ${theme.colors.fg.white};
+    font-family: ${theme.fonts.tab.family};
+    font-size: ${theme.fonts.tab.size};
+    line-height: ${theme.fonts.tab.lineHeight};
+    letter-spacing: ${theme.fonts.tab.letterSpacing};
+    box-shadow: 0px 6px 10px ${rgba(theme.colors.bg.black, 0.1)};
+  `}
   padding: ${PADDING}px ${PADDING * 2}px;
   border-radius: 6px;
-  box-shadow: 0px 6px 10px ${({ theme }) => rgba(theme.colors.bg.black, 0.1)};
   display: flex;
   justify-content: center;
   align-items: center;
+  text-align: center;
   flex-direction: row;
-  max-width: 180px;
+  max-width: 12em;
   transition: 0.4s opacity;
   opacity: ${({ shown }) => (shown ? 1 : 0)};
   pointer-events: ${({ shown }) => (shown ? 'all' : 'none')};

--- a/assets/src/edit-story/components/tooltip/index.js
+++ b/assets/src/edit-story/components/tooltip/index.js
@@ -20,7 +20,7 @@
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
-import { useState, useRef, useMemo, useEffect } from 'react';
+import { useState, useRef, useMemo, useCallback } from 'react';
 
 /**
  * Internal dependencies
@@ -131,7 +131,7 @@ function WithTooltip({
       x:
         placement.startsWith('left') || placement.startsWith('right')
           ? SPACING
-          : tooltipRef.current?.getBoundingClientRect().width,
+          : 0,
       y:
         placement.startsWith('top') || placement.startsWith('bottom')
           ? SPACING
@@ -140,24 +140,18 @@ function WithTooltip({
     [placement]
   );
 
-  useEffect(() => {
-    const id = setTimeout(() => {
-      const anchorElBoundingBox = anchorRef.current?.getBoundingClientRect();
-      const tooltipElBoundingBox = tooltipRef.current?.getBoundingClientRect();
-      if (!shown || !tooltipElBoundingBox || !anchorElBoundingBox) {
-        return;
-      }
-      const delta =
-        getBoundingBoxCenter(anchorElBoundingBox) -
-        getBoundingBoxCenter(tooltipElBoundingBox);
+  const postionArrow = useCallback(() => {
+    const anchorElBoundingBox = anchorRef.current?.getBoundingClientRect();
+    const tooltipElBoundingBox = tooltipRef.current?.getBoundingClientRect();
+    if (!tooltipElBoundingBox || !anchorElBoundingBox) {
+      return;
+    }
+    const delta =
+      getBoundingBoxCenter(anchorElBoundingBox) -
+      getBoundingBoxCenter(tooltipElBoundingBox);
 
-      setArrowDelta(delta);
-    }, 0);
-
-    return () => {
-      clearTimeout(id);
-    };
-  }, [shown]);
+    setArrowDelta(delta);
+  }, []);
 
   return (
     <>
@@ -188,12 +182,13 @@ function WithTooltip({
         placement={placement}
         spacing={spacing}
         isOpen={Boolean(shown && (shortcut || title))}
+        onPositionUpdate={postionArrow}
       >
         <Tooltip
           ref={tooltipRef}
           arrow={arrow}
           placement={placement}
-          shown={shown && !isNaN(arrowDelta)}
+          shown={shown}
         >
           {shortcut ? `${title} (${prettifyShortcut(shortcut)})` : title}
           <TooltipArrow placement={placement} translateX={arrowDelta} />

--- a/assets/src/edit-story/components/tooltip/index.js
+++ b/assets/src/edit-story/components/tooltip/index.js
@@ -49,8 +49,7 @@ const Tooltip = styled.div`
   justify-content: center;
   align-items: center;
   flex-direction: row;
-  white-space: nowrap;
-  will-change: transform;
+  max-width: 180px;
   transition: 0.4s opacity;
   opacity: ${({ shown }) => (shown ? 1 : 0)};
   pointer-events: ${({ shown }) => (shown ? 'all' : 'none')};
@@ -120,12 +119,14 @@ function WithTooltip({
 }) {
   const [shown, setShown] = useState(false);
   const ref = useRef(null);
+  const tooltipRef = useRef(null);
+
   const spacing = useMemo(
     () => ({
       x:
         placement.startsWith('left') || placement.startsWith('right')
           ? SPACING
-          : 0,
+          : tooltipRef.current?.getBoundingClientRect().width,
       y:
         placement.startsWith('top') || placement.startsWith('bottom')
           ? SPACING
@@ -164,7 +165,12 @@ function WithTooltip({
         spacing={spacing}
         isOpen={Boolean(shown && (shortcut || title))}
       >
-        <Tooltip arrow={arrow} placement={placement} shown={shown}>
+        <Tooltip
+          ref={tooltipRef}
+          arrow={arrow}
+          placement={placement}
+          shown={shown}
+        >
           {shortcut ? `${title} (${prettifyShortcut(shortcut)})` : title}
           <TooltipArrow placement={placement} />
         </Tooltip>

--- a/assets/src/edit-story/components/tooltip/index.js
+++ b/assets/src/edit-story/components/tooltip/index.js
@@ -18,9 +18,9 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
-import { useState, useRef, useMemo } from 'react';
+import { useState, useRef, useMemo, useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -61,30 +61,32 @@ const TRANSPARENT_BORDER = `6px solid transparent`;
 const TooltipArrow = styled.div`
   position: absolute;
   box-shadow: 0px 6px 10px ${({ theme }) => rgba(theme.colors.bg.black, 0.1)};
-  ${({ placement, theme }) => {
+  ${({ placement, theme, translateX }) => {
     switch (placement) {
       case Placement.TOP:
       case Placement.TOP_START:
       case Placement.TOP_END:
-        return `
+        return css`
           bottom: -6px;
           border-top: 6px solid ${theme.colors.bg.black};
           border-left: ${TRANSPARENT_BORDER};
           border-right: ${TRANSPARENT_BORDER};
+          transform: translateX(${translateX}px);
         `;
       case Placement.BOTTOM:
       case Placement.BOTTOM_START:
       case Placement.BOTTOM_END:
-        return `
+        return css`
           top: -6px;
           border-bottom: 6px solid ${theme.colors.bg.black};
           border-left: ${TRANSPARENT_BORDER};
           border-right: ${TRANSPARENT_BORDER};
+          transform: translateX(${translateX}px);
         `;
       case Placement.LEFT:
       case Placement.LEFT_START:
       case Placement.LEFT_END:
-        return `
+        return css`
           right: -6px;
           border-top: ${TRANSPARENT_BORDER};
           border-bottom: ${TRANSPARENT_BORDER};
@@ -93,7 +95,7 @@ const TooltipArrow = styled.div`
       case Placement.RIGHT:
       case Placement.RIGHT_START:
       case Placement.RIGHT_END:
-        return `
+        return css`
           left: -6px;
           border-top: ${TRANSPARENT_BORDER};
           border-bottom: ${TRANSPARENT_BORDER};
@@ -104,6 +106,8 @@ const TooltipArrow = styled.div`
     }
   }}
 `;
+
+const getBoundingBoxCenter = ({ x, width }) => x + width / 2;
 
 function WithTooltip({
   title,
@@ -118,7 +122,8 @@ function WithTooltip({
   ...props
 }) {
   const [shown, setShown] = useState(false);
-  const ref = useRef(null);
+  const [arrowDelta, setArrowDelta] = useState(null);
+  const anchorRef = useRef(null);
   const tooltipRef = useRef(null);
 
   const spacing = useMemo(
@@ -134,6 +139,25 @@ function WithTooltip({
     }),
     [placement]
   );
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      const anchorElBoundingBox = anchorRef.current?.getBoundingClientRect();
+      const tooltipElBoundingBox = tooltipRef.current?.getBoundingClientRect();
+      if (!shown || !tooltipElBoundingBox || !anchorElBoundingBox) {
+        return;
+      }
+      const delta =
+        getBoundingBoxCenter(anchorElBoundingBox) -
+        getBoundingBoxCenter(tooltipElBoundingBox);
+
+      setArrowDelta(delta);
+    }, 0);
+
+    return () => {
+      clearTimeout(id);
+    };
+  }, [shown]);
 
   return (
     <>
@@ -154,13 +178,13 @@ function WithTooltip({
           setShown(false);
           onBlur(e);
         }}
-        ref={ref}
+        ref={anchorRef}
         {...props}
       >
         {children}
       </Wrapper>
       <Popup
-        anchor={ref}
+        anchor={anchorRef}
         placement={placement}
         spacing={spacing}
         isOpen={Boolean(shown && (shortcut || title))}
@@ -169,10 +193,10 @@ function WithTooltip({
           ref={tooltipRef}
           arrow={arrow}
           placement={placement}
-          shown={shown}
+          shown={shown && !isNaN(arrowDelta)}
         >
           {shortcut ? `${title} (${prettifyShortcut(shortcut)})` : title}
-          <TooltipArrow placement={placement} />
+          <TooltipArrow placement={placement} translateX={arrowDelta} />
         </Tooltip>
       </Popup>
     </>


### PR DESCRIPTION
## Summary
This PR fixes the following bugs:
- Sizes popover to size of contents
- Updates tooltip to have `max-width` of `180px` & allows for text wrapping after text exceeds `180px`. We can alter this to a different `px` value or use `em` if we'd prefer a max character length here.
- Adds dynamic arrow positioning for top and bottom positioned tooltips so that tooltips aren't extremely smooshed and still visually map to corresponding anchor element
- Corrects upper bounds of popover for both horizontal & vertical positioning
- Fixes when tooltips are spaced to be whenever body resizes instead of trying to infer this through a resize event & several other metrics. This should fix a flash that occasionally happens on first hover.
- Updates no opacity allowed text to requested text in comment above now that tooltip allows for wrapping

## Relevant Technical Choices
Updated popover positioning from resize & other metrics to a callback in a resize observer observing the body size changes. This primarily fixes a first render being off bug that was causing small flashes between popover positions on initial hover.

Also tried to alter existing approach as little as possible while still fixing a couple issues.

## To-do
NA

## User-facing changes
Popovers should no longer go off screen as describe in [the issue this addresses](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/2343). 
Also should see dynamic arrow for tooltip that doesn't only appear in the center of the tooltip when getting close to off screen.

## Testing Instructions
Follow steps described in [issue ticket](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/2343) to reproduce tooltip going outside of screen. Verify that it doesn't go out of the screen anymore and looks nice.

In the story editor for any story, hover over grid view and see that the tooltip now lines up properly to the icon it's pointing to.

## Screenshots
<img width="159" alt="Screen Shot 2020-08-25 at 5 31 09 PM" src="https://user-images.githubusercontent.com/35983235/91238916-5ece9c80-e6fb-11ea-8c7d-b2d1f0857c9b.png">
<img width="226" alt="Screen Shot 2020-08-25 at 5 31 18 PM" src="https://user-images.githubusercontent.com/35983235/91238920-5f673300-e6fb-11ea-8737-d8a7ca8dec39.png">
<img width="342" alt="Screen Shot 2020-08-25 at 5 31 24 PM" src="https://user-images.githubusercontent.com/35983235/91238921-5f673300-e6fb-11ea-866c-44c2008e7ec5.png">


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2343
