### PR TITLE
Dashboard: A11y - Add ability to tab to/from story preview iframe

### DIFF
--- a/assets/src/dashboard/app/views/previewStory/index.js
+++ b/assets/src/dashboard/app/views/previewStory/index.js
@@ -68,6 +68,7 @@ const IframeContainer = styled.div`
 
   &:focus {
     border: ${({ theme }) => theme.borders.bluePrimary};
+    border-width: 2px;
   }
 `;
 

--- a/assets/src/dashboard/app/views/previewStory/index.js
+++ b/assets/src/dashboard/app/views/previewStory/index.js
@@ -22,7 +22,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -65,6 +65,10 @@ const IframeContainer = styled.div`
   height: ${({ dimensions }) =>
     `${dimensions.height - CLOSE_BUTTON_SIZE.HEIGHT}px`};
   min-height: 90vh;
+
+  &:focus {
+    border: ${({ theme }) => theme.borders.bluePrimary};
+  }
 `;
 
 const HelperText = styled.p`
@@ -109,6 +113,7 @@ const PreviewStory = ({ story, handleClose }) => {
   );
 
   const containerRef = useRef(document.getElementById(WPBODY_ID));
+  const iframeContainerRef = useRef();
 
   const [modalDimensions, setModalDimensions] = useState({
     width: containerRef.current?.offsetWidth || window.innerWidth,
@@ -122,6 +127,8 @@ const PreviewStory = ({ story, handleClose }) => {
       let iframe = document.createElement('iframe');
       iframeContainer.appendChild(iframe);
       iframe.setAttribute('style', 'height:100%;width:100%;border:none;');
+      iframe.setAttribute('title', __('AMP preview', 'web-stories'));
+      iframe.setAttribute('tabindex', 0);
       iframe.contentWindow.document.open();
       iframe.contentWindow.document.write(previewMarkup);
       iframe.contentWindow.document.close();
@@ -158,6 +165,17 @@ const PreviewStory = ({ story, handleClose }) => {
     [setModalDimensions]
   );
 
+  const handleIframeFocus = useCallback(({ key, shiftKey }) => {
+    if (key.toLowerCase() !== 'tab') {
+      return false;
+    }
+    if (!shiftKey && iframeContainerRef?.current) {
+      // Force focus within the iframe to circumnavigate browser settings
+      return iframeContainerRef?.current.firstChild.contentWindow.document.body.focus();
+    }
+    return containerRef.current.focus();
+  }, []);
+
   return (
     <Modal
       contentLabel={
@@ -186,16 +204,19 @@ const PreviewStory = ({ story, handleClose }) => {
       <>
         <CloseButton
           onClick={handleClose}
-          aria-label={__('close', 'web-stories')}
+          aria-label={__('close preview', 'web-stories')}
         >
           <CloseIcon aria-hidden={true} />
         </CloseButton>
 
         {!previewError && (
           <IframeContainer
+            ref={iframeContainerRef}
             dimensions={modalDimensions}
             id={PREVIEW_CONTAINER_ID}
             data-testid="preview-iframe"
+            onKeyDown={(e) => handleIframeFocus(e)}
+            tabIndex={0}
           />
         )}
 

--- a/assets/src/dashboard/app/views/previewStory/index.js
+++ b/assets/src/dashboard/app/views/previewStory/index.js
@@ -215,7 +215,7 @@ const PreviewStory = ({ story, handleClose }) => {
             dimensions={modalDimensions}
             id={PREVIEW_CONTAINER_ID}
             data-testid="preview-iframe"
-            onKeyDown={(e) => handleIframeFocus(e)}
+            onKeyDown={handleIframeFocus}
             tabIndex={0}
           />
         )}


### PR DESCRIPTION
## Summary
Allows a user to use the keyboard to tab through story/template previews and interact with the preview iframe itself with just a keyboard. 

## Relevant Technical Choices
- Make iframe container focusable and add focus style. 
- Set iframe title for a11y and tabindex - firefox and chrome are fine without setting tabindex, safari does not allow focus into iframe without this.  
- Control onKeyDown of iframe container to transfer and regain focus to and from iFrame by referencing  boolean in event handler. 
- In handleIframeFocus check to see that the key in question is 'tab', when it is check to see if the shift key was also pressed. 
  - If shiftkey is true, we want to reverse the focus (close button).
  - If shiftkey is false, we want to tab into the iframe. 
- Had to get a little creative with focusing the iframe - Chrome and Firefox are fine with just .current.firstChild (or any of the other ways to get to it from .current) but safari does not like it one bit! Need to force our way in passed the iframe and into the actual document body for safari to let the focus into the iframe with the keyboard. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
User can now tab through story/template previews that are embedded in the page (not a new tab) 

## Testing Instructions

Make sure the enableStoryPreviews or enableTemplatePreviews feature flags are true so you can access previews. For stories, click on the "preview" or "view" button that is exposed when you hover or focus on a story in the grid. For templates, click on the preview. 
Once you've got a preview open, use your keyboard and tab through the page, see that you can now get into the iframe and control the pagination, pause and share like you can if it was its own page.  See that both tab and tab + shift work as expected (tab = forward, tab + shift = reverse). 
Since it's a modal you have to close the modal to get out of the modal and into the browser bar. 

Also as a note, if you're focused in the iframe, we can't control anything. So if you hit 'esc' while focused _inside_ the iframe, it won't close the modal. 


---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4204 
