### PR TITLE
Story Editor: Improve Keyboard Navigation on Carousel

### DIFF
--- a/assets/src/edit-story/components/canvas/carousel/compactIndicator.js
+++ b/assets/src/edit-story/components/canvas/carousel/compactIndicator.js
@@ -27,7 +27,10 @@ import { forwardRef } from 'react';
  */
 import { COMPACT_THUMB_WIDTH, COMPACT_THUMB_HEIGHT } from '../layout';
 
-function CompactIndicatorWithRef({ onClick, isActive, ariaLabel, role }, ref) {
+function CompactIndicatorWithRef(
+  { onClick, isActive, ariaLabel, role, tabIndex },
+  ref
+) {
   return (
     <Indicator
       onClick={onClick}
@@ -35,6 +38,7 @@ function CompactIndicatorWithRef({ onClick, isActive, ariaLabel, role }, ref) {
       aria-label={ariaLabel}
       role={role}
       ref={ref}
+      tabIndex={tabIndex}
     />
   );
 }
@@ -49,6 +53,11 @@ const Indicator = styled.button`
   border-radius: 6px;
   background: ${({ isActive, theme }) =>
     isActive ? theme.colors.selection : 'rgba(255, 255, 255, 0.28)'};
+
+  &:focus {
+    outline: 2px solid ${({ theme }) => theme.colors.accent.primary};
+  }
+
   ${({ isActive, isInteractive, theme }) =>
     !isActive &&
     isInteractive &&
@@ -66,6 +75,7 @@ CompactIndicator.propTypes = {
   onClick: PropTypes.func.isRequired,
   isActive: PropTypes.bool,
   ariaLabel: PropTypes.string.isRequired,
+  tabIndex: PropTypes.number,
   role: PropTypes.string,
 };
 

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -412,6 +412,7 @@ function Carousel() {
                 )}
                 <ReorderablePage position={index}>
                   <Page
+                    tabIndex={isCurrentPage && isInteractive ? 0 : -1}
                     onClick={handleClickPage(page)}
                     role="option"
                     data-page-id={page.id}

--- a/assets/src/edit-story/components/canvas/gridview/index.js
+++ b/assets/src/edit-story/components/canvas/gridview/index.js
@@ -297,6 +297,7 @@ function GridView() {
                             index + 1
                           )
                     }
+                    tabIndex={isCurrentPage && isInteractive ? 0 : -1}
                     isActive={isCurrentPage && isInteractive}
                     index={index}
                     width={width}

--- a/assets/src/edit-story/components/canvas/pagepreview/index.js
+++ b/assets/src/edit-story/components/canvas/pagepreview/index.js
@@ -83,14 +83,14 @@ function PagePreview({ index, gridRef, ...props }) {
   }));
   const page = pages[index];
   const { backgroundColor } = page;
-  const { width: thumbWidth, height: thumbHeight, tabIndex } = props;
+  const { width: thumbWidth, height: thumbHeight } = props;
   const width = thumbWidth - THUMB_FRAME_WIDTH;
   const height = thumbHeight - THUMB_FRAME_HEIGHT;
 
   return (
     <UnitsProvider pageSize={{ width, height }}>
       <TransformProvider>
-        <Page tabIndex={tabIndex} {...props}>
+        <Page {...props}>
           <PreviewWrapper background={backgroundColor}>
             {page.elements.map(({ id, ...rest }) => (
               <DisplayElement

--- a/assets/src/edit-story/components/canvas/pagepreview/index.js
+++ b/assets/src/edit-story/components/canvas/pagepreview/index.js
@@ -20,7 +20,7 @@
 import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -51,6 +51,11 @@ const Page = styled.button`
   flex: none;
   transition: width 0.2s ease, height 0.2s ease;
   outline: 0;
+
+  &:focus {
+    outline: 2px solid ${({ theme }) => theme.colors.accent.primary};
+  }
+
   ${({ isActive, isInteractive, theme }) =>
     !isActive &&
     isInteractive &&
@@ -78,25 +83,14 @@ function PagePreview({ index, gridRef, ...props }) {
   }));
   const page = pages[index];
   const { backgroundColor } = page;
-  const { width: thumbWidth, height: thumbHeight, isActive } = props;
+  const { width: thumbWidth, height: thumbHeight, tabIndex } = props;
   const width = thumbWidth - THUMB_FRAME_WIDTH;
   const height = thumbHeight - THUMB_FRAME_HEIGHT;
-  const [tabIndex, setTabIndex] = useState(isActive ? 0 : -1);
-
-  const onBlur = (e) => {
-    if (gridRef?.current?.contains(e.relatedTarget)) {
-      setTabIndex(-1);
-    }
-  };
-
-  const onFocus = () => {
-    setTabIndex(0);
-  };
 
   return (
     <UnitsProvider pageSize={{ width, height }}>
       <TransformProvider>
-        <Page tabIndex={tabIndex} onBlur={onBlur} onFocus={onFocus} {...props}>
+        <Page tabIndex={tabIndex} {...props}>
           <PreviewWrapper background={backgroundColor}>
             {page.elements.map(({ id, ...rest }) => (
               <DisplayElement
@@ -120,6 +114,7 @@ PagePreview.propTypes = {
   isInteractive: PropTypes.bool,
   isActive: PropTypes.bool,
   gridRef: PropTypes.any,
+  tabIndex: PropTypes.number,
 };
 
 PagePreview.defaultProps = {


### PR DESCRIPTION
## Summary
- Adds a focus border around page thumb in collapsed carousel, regular carousel, and page grid view.
- Updates collapsed carousel so only active page thumb is focusable.

## Relevant Technical Choices
Just made the uncollapsed page indicator behave the same as the collapsed page indicator for tabIndex. I think this offloads a little work to the browser instead of doing it manually. Happy to revert tho if there's a preference.

## User-facing changes
- Page indicators in collapsed carousel, uncollaped carousel & grid view now have a blue outline when focused
- Only active page indicator can be focused as long as there's more than 1 page indicator.

## Testing Instructions
- In story editor, tab through page and see that only active page indicator is focusable out of the page indicators, also that it's visually clear that the page indicator is focused.
- In the story editor, click the grid view. In the grid view tab through the page and see that only the active page indicator is focusable out of the page indicators and that it's visually clear that the page indicator is focused.

## Screenshots
<img width="1440" alt="Screen Shot 2020-08-26 at 2 55 56 PM" src="https://user-images.githubusercontent.com/35983235/91362829-846dab80-e7b8-11ea-9f32-98f70567f723.png">
<img width="453" alt="Screen Shot 2020-08-26 at 4 00 39 PM" src="https://user-images.githubusercontent.com/35983235/91362837-87689c00-e7b8-11ea-9fdf-c4f0fd391afe.png">
<img width="381" alt="Screen Shot 2020-08-26 at 4 02 07 PM" src="https://user-images.githubusercontent.com/35983235/91362838-87689c00-e7b8-11ea-919f-8e6f7482ffd7.png">


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4240 
