### PR TITLE
Updated text preset settings to match designs

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/textPresets.js
+++ b/assets/src/edit-story/components/library/panes/text/textPresets.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { PAGE_HEIGHT, PAGE_WIDTH } from '../../../../constants';
+import { PAGE_HEIGHT, PAGE_WIDTH, FONT_WEIGHT } from '../../../../constants';
 import { dataFontEm } from '../../../../units';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../../app/font/defaultFonts';
 
@@ -33,6 +33,7 @@ const DEFAULT_LEFT_MARGIN = 40;
 
 const DEFAULT_PRESET = {
   content: __('Fill in some text', 'web-stories'),
+  fontWeight: FONT_WEIGHT.NORMAL,
   fontSize: dataFontEm(1.2),
   lineHeight: 1.5,
   x: DEFAULT_LEFT_MARGIN,
@@ -46,10 +47,11 @@ const PRESETS = [
   {
     title: __('Heading 1', 'web-stories'),
     element: {
-      content: `<span style="font-weight: 700">${__(
+      content: `<span style="font-weight: ${FONT_WEIGHT.BOLD}">${__(
         'Heading 1',
         'web-stories'
       )}</span>`,
+      fontWeight: FONT_WEIGHT.BOLD,
       fontSize: dataFontEm(2.7),
       lineHeight: 1.1,
       x: DEFAULT_LEFT_MARGIN,
@@ -61,10 +63,11 @@ const PRESETS = [
   {
     title: __('Heading 2', 'web-stories'),
     element: {
-      content: `<span style="font-weight: 700">${__(
+      content: `<span style="font-weight: ${FONT_WEIGHT.BOLD}">${__(
         'Heading 2',
         'web-stories'
       )}</span>`,
+      fontWeight: FONT_WEIGHT.BOLD,
       fontSize: dataFontEm(2),
       lineHeight: 1.2,
       x: DEFAULT_LEFT_MARGIN,
@@ -76,10 +79,11 @@ const PRESETS = [
   {
     title: __('Heading 3', 'web-stories'),
     element: {
-      content: `<span style="font-weight: 700">${__(
+      content: `<span style="font-weight: ${FONT_WEIGHT.BOLD}">${__(
         'Heading 3',
         'web-stories'
       )}</span>`,
+      fontWeight: FONT_WEIGHT.BOLD,
       fontSize: dataFontEm(1.6),
       lineHeight: 1.3,
       x: DEFAULT_LEFT_MARGIN,
@@ -95,6 +99,7 @@ const PRESETS = [
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
         'web-stories'
       ),
+      fontWeight: FONT_WEIGHT.NORMAL,
       fontSize: dataFontEm(1.3),
       lineHeight: 1.5,
       x: DEFAULT_LEFT_MARGIN,
@@ -107,6 +112,7 @@ const PRESETS = [
     title: __('Caption', 'web-stories'),
     element: {
       content: __('Caption', 'web-stories'),
+      fontWeight: FONT_WEIGHT.NORMAL,
       fontSize: dataFontEm(1),
       lineHeight: 1.5,
       x: DEFAULT_LEFT_MARGIN,
@@ -119,6 +125,7 @@ const PRESETS = [
     title: __('OVERLINE', 'web-stories'),
     element: {
       content: __('OVERLINE', 'web-stories'),
+      fontWeight: FONT_WEIGHT.NORMAL,
       fontSize: dataFontEm(0.9),
       lineHeight: 1.5,
       x: DEFAULT_LEFT_MARGIN,

--- a/assets/src/edit-story/components/library/panes/text/textPresets.js
+++ b/assets/src/edit-story/components/library/panes/text/textPresets.js
@@ -50,10 +50,10 @@ const PRESETS = [
         'Heading 1',
         'web-stories'
       )}</span>`,
-      fontSize: dataFontEm(2),
-      lineHeight: 1.5,
+      fontSize: dataFontEm(2.7),
+      lineHeight: 1.1,
       x: DEFAULT_LEFT_MARGIN,
-      y: (PAGE_HEIGHT - dataFontEm(2)) / 2,
+      y: (PAGE_HEIGHT - dataFontEm(2.7)) / 2,
       font: TEXT_ELEMENT_DEFAULT_FONT,
       width: DEFAULT_ELEMENT_WIDTH,
     },
@@ -61,14 +61,14 @@ const PRESETS = [
   {
     title: __('Heading 2', 'web-stories'),
     element: {
-      content: `<span style="font-weight: 600">${__(
+      content: `<span style="font-weight: 700">${__(
         'Heading 2',
         'web-stories'
       )}</span>`,
-      fontSize: dataFontEm(1.5),
-      lineHeight: 1.5,
+      fontSize: dataFontEm(2),
+      lineHeight: 1.2,
       x: DEFAULT_LEFT_MARGIN,
-      y: (PAGE_HEIGHT - dataFontEm(1.5)) / 2,
+      y: (PAGE_HEIGHT - dataFontEm(2)) / 2,
       font: TEXT_ELEMENT_DEFAULT_FONT,
       width: DEFAULT_ELEMENT_WIDTH,
     },
@@ -76,14 +76,14 @@ const PRESETS = [
   {
     title: __('Heading 3', 'web-stories'),
     element: {
-      content: `<span style="font-weight: 500">${__(
+      content: `<span style="font-weight: 700">${__(
         'Heading 3',
         'web-stories'
       )}</span>`,
-      fontSize: dataFontEm(1),
-      lineHeight: 1,
+      fontSize: dataFontEm(1.6),
+      lineHeight: 1.3,
       x: DEFAULT_LEFT_MARGIN,
-      y: (PAGE_HEIGHT - dataFontEm(1)) / 2,
+      y: (PAGE_HEIGHT - dataFontEm(1.6)) / 2,
       font: TEXT_ELEMENT_DEFAULT_FONT,
       width: DEFAULT_ELEMENT_WIDTH,
     },
@@ -95,10 +95,10 @@ const PRESETS = [
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
         'web-stories'
       ),
-      fontSize: dataFontEm(1.2),
+      fontSize: dataFontEm(1.3),
       lineHeight: 1.5,
       x: DEFAULT_LEFT_MARGIN,
-      y: (PAGE_HEIGHT - dataFontEm(1.5)) / 2,
+      y: (PAGE_HEIGHT - dataFontEm(1.3)) / 2,
       font: TEXT_ELEMENT_DEFAULT_FONT,
       width: DEFAULT_ELEMENT_WIDTH,
     },
@@ -110,7 +110,7 @@ const PRESETS = [
       fontSize: dataFontEm(1),
       lineHeight: 1.5,
       x: DEFAULT_LEFT_MARGIN,
-      y: (PAGE_HEIGHT - dataFontEm(1.5)) / 2,
+      y: (PAGE_HEIGHT - dataFontEm(1)) / 2,
       font: TEXT_ELEMENT_DEFAULT_FONT,
       width: DEFAULT_ELEMENT_WIDTH,
     },
@@ -119,10 +119,10 @@ const PRESETS = [
     title: __('OVERLINE', 'web-stories'),
     element: {
       content: __('OVERLINE', 'web-stories'),
-      fontSize: dataFontEm(1),
+      fontSize: dataFontEm(0.9),
       lineHeight: 1.5,
       x: DEFAULT_LEFT_MARGIN,
-      y: (PAGE_HEIGHT - dataFontEm(1.5)) / 2,
+      y: (PAGE_HEIGHT - dataFontEm(0.9)) / 2,
       font: TEXT_ELEMENT_DEFAULT_FONT,
       width: DEFAULT_ELEMENT_WIDTH,
     },

--- a/assets/src/edit-story/components/library/text/fontPreview.js
+++ b/assets/src/edit-story/components/library/text/fontPreview.js
@@ -40,6 +40,7 @@ const Preview = styled.button`
   width: 100%;
   border: none;
   cursor: pointer;
+  text-align: left;
 `;
 
 const Text = styled.span`

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -74,3 +74,8 @@ export const BACKGROUND_TEXT_MODE = {
   FILL: 'FILL',
   HIGHLIGHT: 'HIGHLIGHT',
 };
+
+export const FONT_WEIGHT = {
+  NORMAL: 400,
+  BOLD: 700,
+};


### PR DESCRIPTION
## Summary

This is a quick PR to update the text preset settings to better match the mocks.

## User-facing changes

The text tab in the Editor has the following changes:
- Presets are now `left` aligned:
<img src="https://user-images.githubusercontent.com/40646372/91362719-ec6bc400-e7af-11ea-90e9-2835f21f41aa.png" height="300">

The presets should have the following properties:

- **Heading 1**:
Font: `Roboto`
Weight: `Bold`
Size: `36px`
Line Height: `1.1`

- **Heading 2**:
Font: `Roboto`
Weight: `Bold`
Size: `27px`
Line Height: `1.2`

- **Heading 3**:
Font: `Roboto`
Weight: `Bold`
Size: `22px`
Line Height: `1.3`

- **Paragraph**:
Font: `Roboto`
Weight: `Regular`
Size: `18px`
Line Height: `1.5`

- **Caption**:
Font: `Roboto`
Weight: `Regular`
Size: `14px`
Line Height: `1.5`

- **Overline**:
Font: `Roboto`
Weight: `Regular`
Size: `12px`
Line Height: `1.5`


## Testing Instructions

1.) Go to a new or existing story in Editor.
2.) Click on "T" to make the text tab active.
3.) Ensure that each preset is left-aligned.
4.) Click on each preset and double check that each text sample that appears has the properties set to the above.

Fixes #3639 

## Screenshots

![image](https://user-images.githubusercontent.com/40646372/91363589-cc3d0480-e7b1-11ea-9603-a8d6b55df943.png)

