### PR TITLE
Suppress key listener when on clickable target

### DIFF
--- a/assets/src/edit-story/components/canvas/useCanvasKeys.js
+++ b/assets/src/edit-story/components/canvas/useCanvasKeys.js
@@ -168,7 +168,7 @@ function useCanvasKeys(ref) {
 
   // Edit mode
   useGlobalKeyDownEffect(
-    'enter',
+    { key: 'enter', clickable: false },
     () => {
       if (selectedElements.length !== 1) {
         return;

--- a/assets/src/edit-story/components/form/dropDown/index.js
+++ b/assets/src/edit-story/components/form/dropDown/index.js
@@ -36,7 +36,6 @@ import {
 } from '../../../utils/keyboardOnlyOutline';
 import { Dropdown as DropdownIcon } from '../../../icons';
 import Popup from '../../popup';
-import { useKeyDownEffect } from '../../keyboard';
 import DropDownList from './list';
 
 const DropDownContainer = styled.div`
@@ -144,12 +143,6 @@ function DropDown({
     e.preventDefault();
     setIsOpen(!isOpen);
   };
-
-  // We unfortunately have to manually assign this listener, as it would be default behaviour
-  // if it wasn't for our listener further up the stack interpreting enter as "enter edit mode"
-  // for text elements. For non-text element selection, this does nothing, that default beviour
-  // wouldn't do.
-  useKeyDownEffect(selectRef, 'enter', handleSelectClick, [isOpen]);
 
   return (
     <DropDownContainer>

--- a/assets/src/edit-story/components/form/switch.js
+++ b/assets/src/edit-story/components/form/switch.js
@@ -124,10 +124,12 @@ function Switch({ value, disabled, onChange, onLabel, offLabel }) {
     [onChange]
   );
   const ref = useRef();
-  useKeyDownEffect(ref, ['left', 'right'], () => handleChange(!value), [
-    handleChange,
-    value,
-  ]);
+  useKeyDownEffect(
+    ref,
+    ['space', 'enter', 'left', 'right'],
+    () => handleChange(!value),
+    [handleChange, value]
+  );
 
   return (
     <SwitchContainer ref={ref}>

--- a/assets/src/edit-story/components/form/switch.js
+++ b/assets/src/edit-story/components/form/switch.js
@@ -124,12 +124,10 @@ function Switch({ value, disabled, onChange, onLabel, offLabel }) {
     [onChange]
   );
   const ref = useRef();
-  useKeyDownEffect(
-    ref,
-    ['space', 'enter', 'left', 'right'],
-    () => handleChange(!value),
-    [handleChange, value]
-  );
+  useKeyDownEffect(ref, ['left', 'right'], () => handleChange(!value), [
+    handleChange,
+    value,
+  ]);
 
   return (
     <SwitchContainer ref={ref}>

--- a/assets/src/edit-story/components/form/toggle.js
+++ b/assets/src/edit-story/components/form/toggle.js
@@ -25,6 +25,7 @@ import { Fragment, useRef, forwardRef, useImperativeHandle } from 'react';
  * Internal dependencies
  */
 import { KEYBOARD_USER_SELECTOR } from '../../utils/keyboardOnlyOutline';
+import { useKeyDownEffect } from '../keyboard';
 import WithTooltip from '../tooltip';
 
 // Class should contain "mousetrap" to enable keyboard shortcuts on inputs.
@@ -101,6 +102,8 @@ function Toggle(
   const inputRef = useRef();
   useImperativeHandle(ref, () => inputRef.current);
   const toggle = () => onChange(!value);
+  // <enter> doesn't normally toggle checkboxes, but we'd like it to
+  useKeyDownEffect(inputRef, 'enter', toggle, [toggle]);
 
   return (
     <Wrapper>

--- a/assets/src/edit-story/components/form/toggle.js
+++ b/assets/src/edit-story/components/form/toggle.js
@@ -25,7 +25,6 @@ import { Fragment, useRef, forwardRef, useImperativeHandle } from 'react';
  * Internal dependencies
  */
 import { KEYBOARD_USER_SELECTOR } from '../../utils/keyboardOnlyOutline';
-import { useKeyDownEffect } from '../keyboard';
 import WithTooltip from '../tooltip';
 
 // Class should contain "mousetrap" to enable keyboard shortcuts on inputs.
@@ -102,12 +101,6 @@ function Toggle(
   const inputRef = useRef();
   useImperativeHandle(ref, () => inputRef.current);
   const toggle = () => onChange(!value);
-
-  // We unfortunately have to manually assign this listener, as it would be default behaviour
-  // if it wasn't for our listener further up the stack interpreting enter as "enter edit mode"
-  // for text elements. For non-text element selection, this does nothing, that default beviour
-  // wouldn't do.
-  useKeyDownEffect(inputRef, 'enter', toggle, [toggle]);
 
   return (
     <Wrapper>

--- a/assets/src/edit-story/components/form/toggleButton.js
+++ b/assets/src/edit-story/components/form/toggleButton.js
@@ -20,11 +20,13 @@
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { rgba } from 'polished';
+import { useRef } from 'react';
 
 /**
  * Internal dependencies
  */
 import { KEYBOARD_USER_SELECTOR } from '../../utils/keyboardOnlyOutline';
+import { useKeyDownEffect } from '../keyboard';
 import MULTIPLE_VALUE from './multipleValue';
 
 // Class should contain "mousetrap" to enable keyboard shortcuts on inputs.
@@ -108,6 +110,9 @@ function ToggleButton({
   ...rest
 }) {
   const toggle = () => onChange(!value);
+  const inputRef = useRef();
+  // <enter> doesn't normally toggle checkboxes, but we'd like it to
+  useKeyDownEffect(inputRef, 'enter', toggle, [toggle]);
 
   value = value === MULTIPLE_VALUE ? '' : value;
   return (
@@ -119,6 +124,7 @@ function ToggleButton({
         iconHeight={iconHeight}
       >
         <CheckBoxInput
+          ref={inputRef}
           checked={value}
           onChange={toggle}
           disabled={disabled}

--- a/assets/src/edit-story/components/form/toggleButton.js
+++ b/assets/src/edit-story/components/form/toggleButton.js
@@ -24,9 +24,7 @@ import { rgba } from 'polished';
 /**
  * Internal dependencies
  */
-import { useRef } from 'react';
 import { KEYBOARD_USER_SELECTOR } from '../../utils/keyboardOnlyOutline';
-import { useKeyDownEffect } from '../keyboard';
 import MULTIPLE_VALUE from './multipleValue';
 
 // Class should contain "mousetrap" to enable keyboard shortcuts on inputs.
@@ -111,13 +109,6 @@ function ToggleButton({
 }) {
   const toggle = () => onChange(!value);
 
-  // We unfortunately have to manually assign this listener, as it would be default behaviour
-  // if it wasn't for our listener further up the stack interpreting enter as "enter edit mode"
-  // for text elements. For non-text element selection, this does nothing, that default beviour
-  // wouldn't do.
-  const inputRef = useRef();
-  useKeyDownEffect(inputRef, 'enter', toggle, [toggle]);
-
   value = value === MULTIPLE_VALUE ? '' : value;
   return (
     <Container className={className}>
@@ -128,7 +119,6 @@ function ToggleButton({
         iconHeight={iconHeight}
       >
         <CheckBoxInput
-          ref={inputRef}
           checked={value}
           onChange={toggle}
           disabled={disabled}

--- a/assets/src/edit-story/components/keyboard/index.js
+++ b/assets/src/edit-story/components/keyboard/index.js
@@ -39,6 +39,15 @@ const NON_EDITABLE_INPUT_TYPES = [
   'reset',
   'hidden',
 ];
+const CLICKABLE_INPUT_TYPES = [
+  'submit',
+  'button',
+  'checkbox',
+  'radio',
+  'image',
+  'file',
+  'reset',
+];
 
 const globalRef = createRef();
 
@@ -247,6 +256,7 @@ function resolveKeySpec(keyDict, keyNameOrSpec) {
     key: keyOrArray,
     shift = false,
     repeat = true,
+    clickable = true,
     editable = false,
     dialog = false,
   } = keySpec;
@@ -255,7 +265,7 @@ function resolveKeySpec(keyDict, keyNameOrSpec) {
     .map((key) => keyDict[key] || key)
     .flat();
   const allKeys = addMods(mappedKeys, shift);
-  return { key: allKeys, shift, repeat, editable, dialog };
+  return { key: allKeys, shift, clickable, repeat, editable, dialog };
 }
 
 function addMods(keys, shift) {
@@ -267,7 +277,12 @@ function addMods(keys, shift) {
 
 function createKeyHandler(
   keyTarget,
-  { repeat: repeatAllowed, editable: editableAllowed, dialog: dialogAllowed },
+  {
+    repeat: repeatAllowed,
+    editable: editableAllowed,
+    clickable: clickableAllowed,
+    dialog: dialogAllowed,
+  },
   callback
 ) {
   return (evt) => {
@@ -278,6 +293,9 @@ function createKeyHandler(
     if (!editableAllowed && isEditableTarget(target)) {
       return undefined;
     }
+    if (!clickableAllowed && isClickableTarget(target)) {
+      return undefined;
+    }
     if (!dialogAllowed && crossesDialogBoundary(target, keyTarget)) {
       return undefined;
     }
@@ -286,6 +304,16 @@ function createKeyHandler(
     // and default behavior.
     return false;
   };
+}
+
+function isClickableTarget({ tagName, type }) {
+  if (['BUTTON', 'A'].includes(tagName)) {
+    return true;
+  }
+  if (tagName === 'INPUT') {
+    return CLICKABLE_INPUT_TYPES.includes(type);
+  }
+  return false;
 }
 
 function isEditableTarget({ tagName, isContentEditable, type, readOnly }) {

--- a/assets/src/edit-story/components/panels/alignment/alignment.js
+++ b/assets/src/edit-story/components/panels/alignment/alignment.js
@@ -61,7 +61,7 @@ const ElementRow = styled.div`
   overflow: overlay;
 `;
 
-const IconButton = styled.button.attrs({
+const Icon = styled.button.attrs({
   type: 'button',
 })`
   display: flex;
@@ -116,25 +116,6 @@ const PAGE_RECT = {
   endY: PAGE_HEIGHT,
   width: PAGE_WIDTH,
   height: PAGE_HEIGHT,
-};
-
-function Icon({ onClick, children, ...rest }) {
-  // We unfortunately have to manually assign this listener, as it would be default behaviour
-  // if it wasn't for our listener further up the stack interpreting enter as "enter edit mode"
-  // for text elements. For non-text element selection, this does nothing, that default beviour
-  // wouldn't do.
-  const ref = useRef();
-  useKeyDownEffect(ref, 'enter', onClick, [onClick]);
-  return (
-    <IconButton ref={ref} onClick={onClick} {...rest}>
-      {children}
-    </IconButton>
-  );
-}
-
-Icon.propTypes = {
-  children: PropTypes.node.isRequired,
-  onClick: PropTypes.func.isRequired,
 };
 
 function ElementAlignmentPanel({ selectedElements, pushUpdate }) {

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -19,7 +19,7 @@
  */
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { useCallback, useRef, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { rgba } from 'polished';
 
 /**
@@ -35,7 +35,6 @@ import panelContext from '../context';
 import { Arrow } from '../../../../icons';
 import { PANEL_COLLAPSED_THRESHOLD } from '../panel';
 import { useContext } from '../../../../utils/context';
-import { useKeyDownEffect } from '../../../keyboard';
 import DragHandle from './handle';
 
 function getBackgroundColor(isPrimary, isSecondary, theme) {
@@ -104,15 +103,8 @@ const Collapse = styled.button`
 `;
 
 function Toggle({ children, toggle, ...rest }) {
-  // We unfortunately have to manually assign this listener, as it would be default behaviour
-  // if it wasn't for our listener further up the stack interpreting enter as "enter edit mode"
-  // for text elements. For non-text element selection, this does nothing, that default beviour
-  // wouldn't do.
-  const ref = useRef();
-  useKeyDownEffect(ref, 'enter', toggle, [toggle]);
   return (
     <Collapse
-      ref={ref}
       onClick={(evt) => {
         evt.stopPropagation();
         toggle();

--- a/assets/src/edit-story/components/panels/stylePreset/colorPresetActions.js
+++ b/assets/src/edit-story/components/panels/stylePreset/colorPresetActions.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import styled from 'styled-components';
 import { rgba } from 'polished';
 
@@ -31,7 +31,6 @@ import { __ } from '@wordpress/i18n';
  */
 import { useStory } from '../../../app/story';
 import { PatternPropType } from '../../../types';
-import { useKeyDownEffect } from '../../keyboard';
 import { findMatchingColor } from './utils';
 
 const ActionsWrapper = styled.div`
@@ -62,8 +61,6 @@ function ColorPresetActions({ color }) {
 
   const { colors } = stylePresets;
 
-  const linkRef = useRef();
-
   // @todo This will change with the missing multi-selection handling.
   const isText =
     selectedElements.length > 0 &&
@@ -91,16 +88,9 @@ function ColorPresetActions({ color }) {
     [stylePresets, isText, colors, updateStory]
   );
 
-  useKeyDownEffect(
-    linkRef,
-    { key: ['space', 'enter'] },
-    () => handleAddColorPreset(color),
-    [color, handleAddColorPreset]
-  );
-
   return (
     <ActionsWrapper>
-      <AddColorPreset ref={linkRef} onClick={() => handleAddColorPreset(color)}>
+      <AddColorPreset onClick={() => handleAddColorPreset(color)}>
         {__('+ Add to Color Preset', 'web-stories')}
       </AddColorPreset>
     </ActionsWrapper>

--- a/assets/src/edit-story/components/panels/stylePreset/header.js
+++ b/assets/src/edit-story/components/panels/stylePreset/header.js
@@ -20,7 +20,6 @@
 import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
 import PropTypes from 'prop-types';
-import { useRef } from 'react';
 
 /**
  * WordPress dependencies
@@ -32,7 +31,6 @@ import { __ } from '@wordpress/i18n';
  */
 import { Add, EditPencil } from '../../../icons';
 import { StylePresetPropType } from '../../../types';
-import { useKeyDownEffect } from '../../keyboard';
 import { PanelTitle } from '../panel';
 
 const buttonCSS = css`
@@ -76,26 +74,6 @@ const EditMode = styled.button`
         `}
 `;
 
-function Button({ onClick, Icon, children, ...rest }) {
-  // We unfortunately have to manually assign this listener, as it would be default behaviour
-  // if it wasn't for our listener further up the stack interpreting enter as "enter edit mode"
-  // for text elements. For non-text element selection, this does nothing, that default beviour
-  // wouldn't do.
-  const ref = useRef();
-  useKeyDownEffect(ref, 'enter', onClick, [onClick]);
-  return (
-    <Icon ref={ref} onClick={onClick} {...rest}>
-      {children}
-    </Icon>
-  );
-}
-
-Button.propTypes = {
-  children: PropTypes.node.isRequired,
-  Icon: PropTypes.elementType.isRequired,
-  onClick: PropTypes.func.isRequired,
-};
-
 function PresetsHeader({
   handleAddColorPreset,
   isEditMode,
@@ -110,8 +88,7 @@ function PresetsHeader({
     return (
       <>
         {hasPresets && (
-          <Button
-            Icon={EditMode}
+          <EditMode
             onClick={(evt) => {
               evt.stopPropagation();
               setIsEditMode(!isEditMode);
@@ -124,16 +101,15 @@ function PresetsHeader({
             isEditMode={isEditMode}
           >
             {isEditMode ? __('Exit', 'web-stories') : <EditPencil />}
-          </Button>
+          </EditMode>
         )}
         {!isEditMode && (
-          <Button
-            Icon={AddColorPresetButton}
+          <AddColorPresetButton
             onClick={handleAddColorPreset}
             aria-label={__('Add preset', 'web-stories')}
           >
             <Add />
-          </Button>
+          </AddColorPresetButton>
         )}
       </>
     );

--- a/assets/src/edit-story/components/panels/stylePreset/presets.js
+++ b/assets/src/edit-story/components/panels/stylePreset/presets.js
@@ -19,7 +19,6 @@
  */
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
-import { useRef } from 'react';
 
 /**
  * WordPress dependencies
@@ -34,7 +33,6 @@ import generatePatternStyles from '../../../utils/generatePatternStyles';
 import { PanelContent } from '../panel';
 import { StylePresetPropType } from '../../../types';
 import WithTooltip from '../../tooltip';
-import { useKeyDownEffect } from '../../keyboard';
 import PresetGroup from './presetGroup';
 import { presetHasOpacity, presetHasGradient } from './utils';
 
@@ -89,7 +87,7 @@ const ColorWrapper = styled.div`
   }
 `;
 
-const ColorButton = styled.button.attrs({ type: 'button' })`
+const Color = styled.button.attrs({ type: 'button' })`
   ${presetCSS}
   ${({ color }) => generatePatternStyles(color)}
 
@@ -97,20 +95,6 @@ const ColorButton = styled.button.attrs({ type: 'button' })`
     outline: none !important;
   }
 `;
-
-function Color({ onClick, children, ...rest }) {
-  // We unfortunately have to manually assign this listener, as it would be default behaviour
-  // if it wasn't for our listener further up the stack interpreting enter as "enter edit mode"
-  // for text elements. For non-text element selection, this does nothing, that default beviour
-  // wouldn't do.
-  const ref = useRef();
-  useKeyDownEffect(ref, 'enter', onClick, [onClick]);
-  return (
-    <ColorButton ref={ref} onClick={onClick} {...rest}>
-      {children}
-    </ColorButton>
-  );
-}
 
 Color.propTypes = {
   children: PropTypes.node.isRequired,


### PR DESCRIPTION
## Summary

This fixes the global <kbd>enter</kbd> listener on the canvas to ignore instances where the focus is on a clickable target - in such a case we need browser default behaviour to kick in instead.

Also, this behaviour was manually re-implemented in a number of components using an explicit listener - this has now been removed (leading to a net reduction of code in this PR - yay 🎉 ).

This makes sure that all clickable targets can be correctly clicked using the keyboard - and, in particular, ensures that all WP links (in the menu and topbar) can be correctly navigated.

**NB:** @miina did [suggest this](https://github.com/google/web-stories-wp/pull/2879#discussion_r450094108) when I implemented the feature in the first place, but I somehow assumed it to be harder to do than it was. 🙇  

## Relevant Technical Choices

* Add new `clickable` flag to event listener logic, defaulting to `true`
* If false, ignore clickable targets (buttons, links, some inputs) when assigning the listener

## To-do

* We could potentially add checks for clickable roles (`button`, `option`, `menuitem`), but I'm not sure it's necessary.

## User-facing changes

* WP menu options in can now be navigated to using keyboard

## Testing Instructions

1. Tab to a menu item in the WP left-hand menu.
1. Press enter to navigate to the link target and observe that something actually happens (whereas before, nothing happened)

Fixes #4239 
