### PR TITLE
Story Editor: Carousel Page Preview Aria Labels

### DIFF
--- a/assets/src/edit-story/components/canvas/carousel/compactIndicator.js
+++ b/assets/src/edit-story/components/canvas/carousel/compactIndicator.js
@@ -25,27 +25,7 @@ import { rgba } from 'polished';
  */
 import { COMPACT_THUMB_WIDTH, COMPACT_THUMB_HEIGHT } from '../layout';
 
-<<<<<<< HEAD
-function CompactIndicatorWithRef(
-  { onClick, isActive, ariaLabel, role, tabIndex },
-  ref
-) {
-  return (
-    <Indicator
-      onClick={onClick}
-      isActive={isActive}
-      aria-label={ariaLabel}
-      role={role}
-      ref={ref}
-      tabIndex={tabIndex}
-    />
-  );
-}
-
-const Indicator = styled.button`
-=======
 const CompactIndicator = styled.button`
->>>>>>> clean up
   display: block;
   width: ${COMPACT_THUMB_WIDTH}px;
   height: ${COMPACT_THUMB_HEIGHT}px;
@@ -71,19 +51,4 @@ const CompactIndicator = styled.button`
     `}
 `;
 
-<<<<<<< HEAD
-const CompactIndicator = forwardRef(CompactIndicatorWithRef);
-
-CompactIndicator.propTypes = {
-  onClick: PropTypes.func.isRequired,
-  isActive: PropTypes.bool,
-  ariaLabel: PropTypes.string.isRequired,
-  tabIndex: PropTypes.number,
-  role: PropTypes.string,
-};
-
-CompactIndicatorWithRef.propTypes = CompactIndicator.propTypes;
-
-=======
->>>>>>> clean up
 export default CompactIndicator;

--- a/assets/src/edit-story/components/canvas/carousel/compactIndicator.js
+++ b/assets/src/edit-story/components/canvas/carousel/compactIndicator.js
@@ -17,16 +17,15 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
-import { forwardRef } from 'react';
 
 /**
  * Internal dependencies
  */
 import { COMPACT_THUMB_WIDTH, COMPACT_THUMB_HEIGHT } from '../layout';
 
+<<<<<<< HEAD
 function CompactIndicatorWithRef(
   { onClick, isActive, ariaLabel, role, tabIndex },
   ref
@@ -44,6 +43,9 @@ function CompactIndicatorWithRef(
 }
 
 const Indicator = styled.button`
+=======
+const CompactIndicator = styled.button`
+>>>>>>> clean up
   display: block;
   width: ${COMPACT_THUMB_WIDTH}px;
   height: ${COMPACT_THUMB_HEIGHT}px;
@@ -69,6 +71,7 @@ const Indicator = styled.button`
     `}
 `;
 
+<<<<<<< HEAD
 const CompactIndicator = forwardRef(CompactIndicatorWithRef);
 
 CompactIndicator.propTypes = {
@@ -81,4 +84,6 @@ CompactIndicator.propTypes = {
 
 CompactIndicatorWithRef.propTypes = CompactIndicator.propTypes;
 
+=======
+>>>>>>> clean up
 export default CompactIndicator;

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -424,7 +424,7 @@ function Carousel() {
                     onClick={handleClickPage(page)}
                     role="option"
                     data-page-id={page.id}
-                    ariaLabel={
+                    aria-label={
                       isCurrentPage
                         ? sprintf(
                             /* translators: %s: page number. */

--- a/assets/src/edit-story/components/canvas/pagepreview/index.js
+++ b/assets/src/edit-story/components/canvas/pagepreview/index.js
@@ -108,7 +108,6 @@ function PagePreview({ index, gridRef, ...props }) {
 }
 
 PagePreview.propTypes = {
-  ariaLabel: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,

--- a/assets/src/edit-story/components/canvas/pagepreview/index.js
+++ b/assets/src/edit-story/components/canvas/pagepreview/index.js
@@ -108,6 +108,7 @@ function PagePreview({ index, gridRef, ...props }) {
 }
 
 PagePreview.propTypes = {
+  ariaLabel: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,


### PR DESCRIPTION
## Summary
Small one. aria labels were already getting created here, just weren't applied properly to the non collapsed page previews. This just fixes that real quick.

## User-facing changes
Page aria labels should now be on non-collapsed page preview thumbs in story editor carousel & grid view (they were already being applied to the collapsed ones, so didn't need to change anything)

## Testing Instructions
Open up a story in the story editor. Inspect the page preview buttons on the uncollapsed carousel & the grid view. See that they have aria-labels designating them as `Page <index>`.

---

Fixes #4244 
