### PR TITLE
Workspace: SafeZone Toggle/Button A11y Improvements

### DIFF
--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -132,6 +132,10 @@ const StyledGridViewButton = styled(GridViewButton).attrs(buttonDimensions)``;
 //   margin-bottom: 12px;
 // `;
 
+const SafeZoneToggle = styled(ToggleButton).attrs(buttonDimensions)`
+  margin-bottom: 12px;
+`;
+
 const PageList = styled(Reorderable).attrs({
   area: 'carousel',
   role: 'listbox',
@@ -477,7 +481,7 @@ function Carousel() {
               }
               placement="left"
             >
-              <ToggleButton
+              <SafeZoneToggle
                 icon={<SafeZone />}
                 value={showSafeZone}
                 onChange={() => setShowSafeZone((current) => !current)}

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -119,11 +119,15 @@ const OverflowButtons = styled.div`
   }
 `;
 
-const buttonDimensions = { width: '24', height: '24' };
+const StyledGridViewButton = styled(GridViewButton).attrs({
+  width: '24',
+  height: '24',
+})``;
 
-const StyledGridViewButton = styled(GridViewButton).attrs(buttonDimensions)``;
-
-const SafeZoneToggle = styled(ToggleButton).attrs(buttonDimensions)`
+const SafeZoneToggle = styled(ToggleButton).attrs({
+  iconWidth: 24,
+  iconHeight: 24,
+})`
   margin-bottom: 12px;
 `;
 
@@ -476,8 +480,8 @@ function Carousel() {
                 icon={<SafeZone />}
                 value={showSafeZone}
                 onChange={setShowSafeZone}
-                iconHeight={24}
-                iconWidth={24}
+                // iconHeight={24}
+                // iconWidth={24}
                 aria-label={
                   showSafeZone
                     ? __('Disable Safe Zone', 'web-stories')

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -36,7 +36,6 @@ import {
   RightArrow,
   GridView as GridViewButton,
   Keyboard as KeyboardShortcutsButton,
-  SafeZone,
   Plain,
 } from '../../button';
 import {
@@ -61,6 +60,8 @@ import { PAGE_WIDTH, PAGE_HEIGHT, SCROLLBAR_WIDTH } from '../../../constants';
 
 import useCanvas from '../useCanvas';
 import WithTooltip from '../../tooltip';
+import { ToggleButton } from '../../form';
+import { SafeZone } from '../../../icons';
 import CompactIndicator from './compactIndicator';
 import useCarouselKeys from './useCarouselKeys';
 
@@ -122,14 +123,14 @@ const buttonDimensions = { width: '24', height: '24' };
 
 const StyledGridViewButton = styled(GridViewButton).attrs(buttonDimensions)``;
 
-const SafeZoneButton = styled(SafeZone).attrs(buttonDimensions)`
-  ${({ active, theme }) =>
-    active &&
-    css`
-      background: ${rgba(theme.colors.bg.white, 0.1)};
-    `}
-  margin-bottom: 12px;
-`;
+// const SafeZoneButton = styled(SafeZone).attrs(buttonDimensions)`
+//   ${({ active, theme }) =>
+//     active &&
+//     css`
+//       background: ${rgba(theme.colors.bg.white, 0.1)};
+//     `}
+//   margin-bottom: 12px;
+// `;
 
 const PageList = styled(Reorderable).attrs({
   area: 'carousel',
@@ -476,9 +477,12 @@ function Carousel() {
               }
               placement="left"
             >
-              <SafeZoneButton
-                active={showSafeZone}
-                onClick={() => setShowSafeZone((current) => !current)}
+              <ToggleButton
+                icon={<SafeZone />}
+                value={showSafeZone}
+                onChange={() => setShowSafeZone((current) => !current)}
+                iconHeight={24}
+                iconWidth={24}
                 aria-label={
                   showSafeZone
                     ? __('Disable Safe Zone', 'web-stories')

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -123,15 +123,6 @@ const buttonDimensions = { width: '24', height: '24' };
 
 const StyledGridViewButton = styled(GridViewButton).attrs(buttonDimensions)``;
 
-// const SafeZoneButton = styled(SafeZone).attrs(buttonDimensions)`
-//   ${({ active, theme }) =>
-//     active &&
-//     css`
-//       background: ${rgba(theme.colors.bg.white, 0.1)};
-//     `}
-//   margin-bottom: 12px;
-// `;
-
 const SafeZoneToggle = styled(ToggleButton).attrs(buttonDimensions)`
   margin-bottom: 12px;
 `;

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -475,7 +475,7 @@ function Carousel() {
               <SafeZoneToggle
                 icon={<SafeZone />}
                 value={showSafeZone}
-                onChange={() => setShowSafeZone((current) => !current)}
+                onChange={setShowSafeZone}
                 iconHeight={24}
                 iconWidth={24}
                 aria-label={

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -120,15 +120,23 @@ const OverflowButtons = styled.div`
 `;
 
 const StyledGridViewButton = styled(GridViewButton).attrs({
-  width: '24',
   height: '24',
+  width: '24',
 })``;
 
 const SafeZoneToggle = styled(ToggleButton).attrs({
-  iconWidth: 24,
   iconHeight: 24,
+  iconWidth: 24,
 })`
+  height: 24px;
+  width: 24px;
   margin-bottom: 12px;
+
+  & label {
+    height: 24px;
+    width: 24px;
+    border-radius: 2px;
+  }
 `;
 
 const PageList = styled(Reorderable).attrs({
@@ -480,8 +488,6 @@ function Carousel() {
                 icon={<SafeZone />}
                 value={showSafeZone}
                 onChange={setShowSafeZone}
-                // iconHeight={24}
-                // iconWidth={24}
                 aria-label={
                   showSafeZone
                     ? __('Disable Safe Zone', 'web-stories')


### PR DESCRIPTION
## Summary

Switch the SafeZone toggle from a Button to a Checkbox to improve A11y for screen readers. (Validated using WAVE extension for parity with other ToggleButton (checkbox buttons) in the editor)

## Relevant Technical Choices

Swapped using our default `Button` component to using our `ToggleButton` component (the same which is used in the design panel for bold/italic/underline toggles - thanks for the suggestion @barklund)


## User-facing changes

None

## Testing Instructions

- Validate that the toggle works correctly


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4245 
