### PR TITLE
Added excerpt panel to document inspector

### DIFF
--- a/assets/src/edit-story/components/form/index.js
+++ b/assets/src/edit-story/components/form/index.js
@@ -27,6 +27,7 @@ export { default as Row } from './row';
 export { default as Spacer } from './spacer';
 export { default as Switch } from './switch';
 export { default as TextInput } from './text';
+export { default as TextArea } from './textArea';
 export { default as Toggle } from './toggle';
 export { default as ToggleButton } from './toggleButton';
 export { default as usePresubmitHandler } from './usePresubmitHandler';

--- a/assets/src/edit-story/components/form/stories/textArea.js
+++ b/assets/src/edit-story/components/form/stories/textArea.js
@@ -18,31 +18,38 @@
  * External dependencies
  */
 import { useState } from 'react';
-import { boolean, text } from '@storybook/addon-knobs';
+import { number, boolean, text } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
  */
-import Switch from '../switch';
+import TextArea from '../textArea';
 
 export default {
-  title: 'Stories Editor/Components/Form/Switch',
-  component: Switch,
+  title: 'Stories Editor/Components/Form/TextArea',
+  component: TextArea,
 };
 
 export const _default = () => {
-  const onLabel = text('OnLabel', 'Fit to Device');
-  const offLabel = text('OffLabel', 'Do not format');
-  const disabled = boolean('Disabled', false);
-  const [value, setValue] = useState(true);
+  const [value, setValue] = useState('');
+
+  const placeholder = text('Placeholder', 'Write some text');
+  const maxLength = number('Max Character Count', 100);
+  const rows = number('Text Rows', 4);
+  const showTextLimit = boolean('Toggle Character Limit Label', true);
 
   return (
-    <Switch
-      value={value}
-      onLabel={onLabel}
-      offLabel={offLabel}
-      onChange={setValue}
-      disabled={disabled}
-    />
+    <div
+      style={{ width: '300px', backgroundColor: '#444', borderRadius: '4px' }}
+    >
+      <TextArea
+        value={value}
+        onTextChange={setValue}
+        placeholder={placeholder}
+        maxLength={maxLength}
+        rows={rows}
+        showTextLimit={showTextLimit}
+      />
+    </div>
   );
 };

--- a/assets/src/edit-story/components/form/textArea.js
+++ b/assets/src/edit-story/components/form/textArea.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { rgba } from 'polished';
@@ -50,8 +50,8 @@ const Container = styled.div`
 
   ${({ disabled, readOnly }) => (disabled || readOnly) && `opacity: 0.3`};
 
-  padding: 6px 12px;
-  padding-right: 6px;
+  padding: 6px;
+  padding-left: 12px;
   border-radius: 4px;
   border: 1px solid transparent;
   &:focus-within {
@@ -81,14 +81,8 @@ function TextArea({
   onBlur,
   ...rest
 }) {
-  const hasMaxLength = useMemo(() => typeof maxLength === 'number', [
-    maxLength,
-  ]);
-
-  const showCounter = useMemo(() => showTextLimit && hasMaxLength, [
-    showTextLimit,
-    hasMaxLength,
-  ]);
+  const hasMaxLength = typeof maxLength === 'number';
+  const showCounter = showTextLimit && hasMaxLength;
 
   const handleChange = useCallback(
     (e) => {

--- a/assets/src/edit-story/components/form/textArea.js
+++ b/assets/src/edit-story/components/form/textArea.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo } from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { rgba } from 'polished';
+
+const StyledTextArea = styled.textarea`
+  width: 100%;
+  padding: 0;
+  border: none;
+  appearance: none;
+  box-shadow: none !important;
+  outline: none;
+  background-color: transparent;
+  color: ${({ theme }) => theme.colors.fg.white};
+  font-family: ${({ theme }) => theme.fonts.body2.family};
+  font-size: ${({ theme }) => theme.fonts.body2.size};
+  line-height: ${({ theme }) => theme.fonts.body2.lineHeight};
+  letter-spacing: ${({ theme }) => theme.fonts.body2.letterSpacing};
+  resize: ${({ resizeable }) => (resizeable ? 'auto' : 'none')};
+
+  &:disabled {
+    background-color: transparent;
+    color: ${({ theme }) => theme.colors.fg.white};
+  }
+`;
+
+const Container = styled.div`
+  width: 100%;
+  color: ${({ theme }) => rgba(theme.colors.fg.white, 0.3)};
+  background-color: ${({ theme }) => rgba(theme.colors.bg.black, 0.3)};
+
+  ${({ disabled, readOnly }) => (disabled || readOnly) && `opacity: 0.3`};
+
+  padding: 6px 12px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  &:focus-within {
+    border-color: ${({ theme }) => theme.colors.whiteout} !important;
+  }
+`;
+
+const Counter = styled.div`
+  font-family: ${({ theme }) => theme.fonts.body2.family};
+  font-size: ${({ theme }) => theme.fonts.tab.size};
+  text-align: right;
+  line-height: 1;
+`;
+
+function TextArea({
+  className,
+  placeholder,
+  value,
+  maxLength,
+  readOnly,
+  disabled,
+  resizeable,
+  showTextLimit,
+  rows,
+  onTextChange,
+  onBlur,
+  ...rest
+}) {
+  const hasMaxLength = useMemo(() => typeof maxLength === 'number', [
+    maxLength,
+  ]);
+
+  const showCounter = useMemo(() => showTextLimit && hasMaxLength, [
+    showTextLimit,
+    hasMaxLength,
+  ]);
+
+  const handleChange = useCallback(
+    (e) => {
+      const str = e.target.value || '';
+      const text = hasMaxLength ? str.slice(0, maxLength) : str;
+
+      onTextChange(text, e);
+    },
+    [onTextChange, hasMaxLength, maxLength]
+  );
+
+  const handleBlur = useCallback(
+    (e) => {
+      if (e.target.form) {
+        e.target.form.dispatchEvent(
+          new window.Event('submit', { cancelable: true })
+        );
+      }
+
+      if (onBlur) {
+        onBlur(e);
+      }
+    },
+    [onBlur]
+  );
+
+  return (
+    <Container className={className}>
+      <StyledTextArea
+        placeholder={placeholder}
+        maxLength={maxLength}
+        disabled={disabled}
+        readOnly={readOnly}
+        resizeable={resizeable}
+        rows={rows}
+        value={value}
+        {...rest}
+        onChange={handleChange}
+        onBlur={handleBlur}
+      />
+      {showCounter && <Counter>{`${value.length}/${maxLength}`}</Counter>}
+    </Container>
+  );
+}
+
+TextArea.propTypes = {
+  className: PropTypes.string,
+  placeholder: PropTypes.string,
+  value: PropTypes.string.isRequired,
+  maxLength: PropTypes.number,
+  readOnly: PropTypes.bool,
+  disabled: PropTypes.bool,
+  resizeable: PropTypes.bool,
+  showTextLimit: PropTypes.bool,
+  rows: PropTypes.number,
+  onTextChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func,
+};
+
+TextArea.defaultProps = {
+  showTextLimit: true,
+  rows: 2,
+};
+
+export default TextArea;

--- a/assets/src/edit-story/components/form/textArea.js
+++ b/assets/src/edit-story/components/form/textArea.js
@@ -51,6 +51,7 @@ const Container = styled.div`
   ${({ disabled, readOnly }) => (disabled || readOnly) && `opacity: 0.3`};
 
   padding: 6px 12px;
+  padding-right: 6px;
   border-radius: 4px;
   border: 1px solid transparent;
   &:focus-within {
@@ -63,6 +64,7 @@ const Counter = styled.div`
   font-size: ${({ theme }) => theme.fonts.tab.size};
   text-align: right;
   line-height: 1;
+  padding-right: 6px;
 `;
 
 function TextArea({

--- a/assets/src/edit-story/components/inspector/document/documentInspector.js
+++ b/assets/src/edit-story/components/inspector/document/documentInspector.js
@@ -18,6 +18,7 @@
  * Internal dependencies
  */
 import PublishPanel from './publish';
+import ExcerptPanel from './excerpt';
 import SlugPanel from './slug';
 import StatusPanel from './status';
 import PageAdvancement from './pageAdvancement';
@@ -27,6 +28,7 @@ function DocumentInspector() {
     <>
       <StatusPanel />
       <PublishPanel />
+      <ExcerptPanel />
       <SlugPanel />
       <PageAdvancement />
     </>

--- a/assets/src/edit-story/components/inspector/document/excerpt.js
+++ b/assets/src/edit-story/components/inspector/document/excerpt.js
@@ -32,7 +32,7 @@ import { Row, TextArea } from '../../form';
 import { useStory } from '../../../app/story';
 import Note from '../../panels/shared/note';
 
-const EXCERPT_MAX_LENGTH = 200;
+export const EXCERPT_MAX_LENGTH = 200;
 
 function ExcerptPanel() {
   const { excerpt, updateStory } = useStory(

--- a/assets/src/edit-story/components/inspector/document/excerpt.js
+++ b/assets/src/edit-story/components/inspector/document/excerpt.js
@@ -32,7 +32,7 @@ import { Row, TextArea } from '../../form';
 import { useStory } from '../../../app/story';
 import Note from '../../panels/shared/note';
 
-const EXCERPT_MAX_LENGTH = 100;
+const EXCERPT_MAX_LENGTH = 200;
 
 function ExcerptPanel() {
   const { excerpt, updateStory } = useStory(

--- a/assets/src/edit-story/components/inspector/document/excerpt.js
+++ b/assets/src/edit-story/components/inspector/document/excerpt.js
@@ -15,14 +15,14 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * External dependencies
  */
 import { useCallback } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/components/inspector/document/excerpt.js
+++ b/assets/src/edit-story/components/inspector/document/excerpt.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { SimplePanel } from '../../panels/panel';
+import { Row, TextArea } from '../../form';
+import { useStory } from '../../../app/story';
+import Note from '../../panels/shared/note';
+
+const EXCERPT_MAX_LENGTH = 100;
+
+function ExcerptPanel() {
+  const { excerpt, updateStory } = useStory(
+    ({
+      state: {
+        story: { excerpt = '' },
+      },
+      actions: { updateStory },
+    }) => ({ excerpt, updateStory })
+  );
+
+  const handleTextChange = useCallback(
+    (text) => {
+      updateStory({
+        properties: { excerpt: text },
+      });
+    },
+    [updateStory]
+  );
+
+  return (
+    <SimplePanel name="excerpt" title={__('Excerpt', 'web-stories')}>
+      <Row>
+        <TextArea
+          value={excerpt}
+          onTextChange={handleTextChange}
+          placeholder={__('Write an excerpt', 'web-stories')}
+          aria-label={__('Edit: Story Excerpt', 'web-stories')}
+          maxLength={EXCERPT_MAX_LENGTH}
+          rows={4}
+        />
+      </Row>
+      <Row>
+        <Note>
+          {__(
+            'Stories with an excerpt tend to do better on search and have a wider reach.',
+            'web-stories'
+          )}
+        </Note>
+      </Row>
+    </SimplePanel>
+  );
+}
+
+export default ExcerptPanel;

--- a/assets/src/edit-story/components/inspector/document/test/excerpt.js
+++ b/assets/src/edit-story/components/inspector/document/test/excerpt.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import StoryContext from '../../../../app/story/context';
+import ExcerptPanel, { EXCERPT_MAX_LENGTH } from '../excerpt';
+import { renderWithTheme } from '../../../../testUtils';
+
+function setupPanel() {
+  const updateStory = jest.fn();
+
+  const storyContextValue = {
+    state: {
+      story: {
+        excerpt: 'This is the story excerpt.',
+      },
+    },
+    actions: { updateStory },
+  };
+
+  const { getByRole } = renderWithTheme(
+    <StoryContext.Provider value={storyContextValue}>
+      <ExcerptPanel />
+    </StoryContext.Provider>
+  );
+
+  return {
+    getByRole,
+    updateStory,
+  };
+}
+
+describe('ExcerptPanel', () => {
+  it('should render Excerpt Panel', () => {
+    const { getByRole } = setupPanel();
+    const element = getByRole('button', { name: 'Excerpt' });
+    expect(element).toBeDefined();
+  });
+
+  it('should display textbox', () => {
+    const { getByRole } = setupPanel();
+    const input = getByRole('textbox', { name: 'Edit: Story Excerpt' });
+    expect(input).toBeDefined();
+  });
+
+  it('should respect excerpt character limit', async () => {
+    const { getByRole, updateStory } = setupPanel();
+    const input = getByRole('textbox', { name: 'Edit: Story Excerpt' });
+
+    const bigExcerpt = ''.padStart(EXCERPT_MAX_LENGTH + 10, '1');
+
+    fireEvent.change(input, {
+      target: { value: bigExcerpt },
+    });
+
+    await waitFor(() =>
+      expect(updateStory).toHaveBeenCalledWith({
+        properties: {
+          excerpt: bigExcerpt.slice(0, EXCERPT_MAX_LENGTH),
+        },
+      })
+    );
+
+    fireEvent.change(input, {
+      target: { value: 'This is the excerpt.' },
+    });
+
+    await waitFor(() =>
+      expect(updateStory).toHaveBeenCalledWith({
+        properties: {
+          excerpt: 'This is the excerpt.',
+        },
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds the Excerpt Panel to the document inspector.  It also adds a `TextArea` Storybook sample and `ExcerptPanel` tests.

## Relevant Technical Choices

The [figma design](https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories---Stable-Release?node-id=1%3A68068) displays a 100 character limit, but I choose to up it to 200 characters based on Pascal's suggestion (it follows how Twitter does it) in the main ticket (#490).

## User-facing changes

The "Excerpt Panel" will now appear within the "Document" tab for the entire story (above the "Permalink Panel").

## Testing Instructions

1.) Open up a new or existing story in the Editor.
2.) Click on "Document" in the panel to the right to revel the document inspector.
3.) Scroll down the document inspector to find the "Excerpt" panel.  It should be located below "Publishing" and above "Permalink".
4.) In the Excerpt panel you should be able to do the following:
- Type up a small excerpt.  Click save.  Refresh the page and notice that the excerpt remains (meanings it was saved off with the story).
- You should be able to remove the excerpt and save with an empty excerpt.
- Type in or copy-n-paste a message _over_ 200 characters and it should be auto-truncated to 200 chars.

Fixes #490 

## Screenshots

Empty Excerpt panel:
<img src="https://user-images.githubusercontent.com/40646372/91605884-08917180-e926-11ea-907b-348dac740bfb.png" height="300">

Nicely filled Excerpt panel:
<img src="https://user-images.githubusercontent.com/40646372/91605850-fd3e4600-e925-11ea-9ce1-5db1f45ebf92.png" height="300">

