### PR TITLE
Dashboard: Prevent focus on menu separator lines 

### DIFF
--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -53,7 +53,7 @@ MenuContainer.propTypes = {
 
 export const MenuItem = styled.li`
   ${TypographyPresets.Small};
-  ${({ theme, isDisabled, isHovering }) => `
+  ${({ theme, isDisabled, isHovering, separator }) => `
     margin-bottom: 0; /* override common js */
     padding: 5px 25px;
     background: ${isHovering && !isDisabled ? theme.colors.gray25 : 'none'};
@@ -64,6 +64,13 @@ export const MenuItem = styled.li`
 
     &:focus, &:active, &:hover {
       color: ${isDisabled ? theme.colors.gray400 : theme.colors.gray700};
+    }
+    
+    ${
+      separator === 'top' &&
+      `
+        border-top: 1px solid ${theme.colors.gray50};
+      `
     }
   `}
 `;
@@ -77,13 +84,6 @@ const MenuItemContent = styled.span`
   align-self: flex-start;
   height: 100%;
   margin: auto 0;
-`;
-
-const Separator = styled.li`
-  height: 1px;
-  background: ${({ theme }) => theme.colors.gray50};
-  width: 100%;
-  margin: 6px 0;
 `;
 
 const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
@@ -158,6 +158,7 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
           onClick={() => !itemIsDisabled && onSelect && onSelect(item)}
           onMouseEnter={() => setHoveredIndex(index)}
           isDisabled={itemIsDisabled}
+          separator={item.separator}
           {...MenuItemPropsAsLink}
         >
           <MenuItemContent>{item.label}</MenuItemContent>
@@ -167,18 +168,9 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
     [hoveredIndex, onSelect]
   );
 
-  const renderSeparator = useCallback((index) => {
-    return <Separator key={`separator-${index}`} />;
-  }, []);
-
   return (
     <MenuContainer ref={listRef}>
-      {items.map((item, index) => {
-        if (item.separator) {
-          return renderSeparator(index);
-        }
-        return renderMenuItem(item, index);
-      })}
+      {items.map((item, index) => renderMenuItem(item, index))}
     </MenuContainer>
   );
 };

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -67,10 +67,19 @@ export const MenuItem = styled.li`
     }
     
     ${
-      separator === 'top' &&
-      `
+      separator === 'top'
+        ? `
         border-top: 1px solid ${theme.colors.gray50};
       `
+        : ''
+    }
+
+    ${
+      separator === 'bottom'
+        ? `
+        border-bottom: 1px solid ${theme.colors.gray50};
+      `
+        : ''
     }
   `}
 `;

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -53,7 +53,7 @@ MenuContainer.propTypes = {
 
 export const MenuItem = styled.li`
   ${TypographyPresets.Small};
-  ${({ theme, isDisabled, isHovering, separator }) => `
+  ${({ theme, isDisabled, isHovering }) => `
     margin-bottom: 0; /* override common js */
     padding: 5px 25px;
     background: ${isHovering && !isDisabled ? theme.colors.gray25 : 'none'};
@@ -62,25 +62,18 @@ export const MenuItem = styled.li`
     display: flex;
     width: 100%;
 
+    &.separatorTop {
+      border-top: 1px solid ${theme.colors.gray50};
+    }
+
+    &.separatorBottom {
+      border-bottom: 1px solid ${theme.colors.gray50};
+    }
+
     &:focus, &:active, &:hover {
       color: ${isDisabled ? theme.colors.gray400 : theme.colors.gray700};
     }
-    
-    ${
-      separator === 'top'
-        ? `
-        border-top: 1px solid ${theme.colors.gray50};
-      `
-        : ''
-    }
-
-    ${
-      separator === 'bottom'
-        ? `
-        border-bottom: 1px solid ${theme.colors.gray50};
-      `
-        : ''
-    }
+  
   `}
 `;
 
@@ -167,7 +160,10 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
           onClick={() => !itemIsDisabled && onSelect && onSelect(item)}
           onMouseEnter={() => setHoveredIndex(index)}
           isDisabled={itemIsDisabled}
-          separator={item.separator}
+          className={
+            (item.separator === 'top' && 'separatorTop') ||
+            (item.separator === 'bottom' && 'separatorBottom')
+          }
           {...MenuItemPropsAsLink}
         >
           <MenuItemContent>{item.label}</MenuItemContent>

--- a/assets/src/dashboard/components/popoverMenu/stories/index.js
+++ b/assets/src/dashboard/components/popoverMenu/stories/index.js
@@ -30,7 +30,7 @@ const demoItems = [
   { value: '1', label: 'one' },
   { value: 'foo', label: 'two' },
   { value: false, label: 'invalid option' },
-  { value: 'bar', label: 'three' },
+  { value: 'bar', label: 'three', separator: 'top' },
   {
     value: 'link',
     label: 'i am a link!',
@@ -39,7 +39,11 @@ const demoItems = [
   {
     value: 'edge_case',
     label: 'i am a very very very very very very very long label',
+    separator: 'bottom',
   },
+  { value: 'lions', label: 'lions' },
+  { value: 'tigers', label: 'tigers', separator: 'top' },
+  { value: 'bears', label: 'bears' },
 ];
 
 export default {

--- a/assets/src/dashboard/components/types.js
+++ b/assets/src/dashboard/components/types.js
@@ -23,7 +23,7 @@ export const DROPDOWN_ITEM_PROP_TYPE = PropTypes.shape({
   label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]).isRequired,
   selected: PropTypes.bool,
-  separator: PropTypes.bool,
+  separator: PropTypes.oneOf(['top', 'bottom']),
   disabled: PropTypes.bool,
   url: PropTypes.string,
 });

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -50,10 +50,10 @@ export const STORY_CONTEXT_MENU_ITEMS = [
     label: __('Copy Story URL', 'web-stories'),
     value: STORY_CONTEXT_MENU_ACTIONS.COPY_STORY_LINK,
   },
-  { label: null, value: false, separator: true },
   {
     label: __('Rename', 'web-stories'),
     value: STORY_CONTEXT_MENU_ACTIONS.RENAME,
+    separator: 'top',
   },
   {
     label: __('Duplicate', 'web-stories'),
@@ -64,10 +64,10 @@ export const STORY_CONTEXT_MENU_ITEMS = [
     value: STORY_CONTEXT_MENU_ACTIONS.CREATE_TEMPLATE,
     inProgress: true,
   },
-  { label: null, value: false, separator: true },
   {
     label: __('Delete Story', 'web-stories'),
     value: STORY_CONTEXT_MENU_ACTIONS.DELETE,
+    separator: 'top',
   },
 ];
 


### PR DESCRIPTION
## Summary
Updates structure of story context menu items so that separators are borders not line items to prevent them being focusable. 

## Relevant Technical Choices

- moving separator lines to menu items as top border to prevent them becoming list items (also tightens up the space a little bit on the menu)

## User-facing changes

-The separator line items in story context menus are no longer focusable. 

## Testing Instructions

- Open a story's context menu and use the arrow keys to select an item, notice that the focus never disappears (where it would focus on the separator line itself). 
- Updated popover menu in storybook too: `story/dashboard-components-popovermenu--default`

![context menu keyboard nav](https://user-images.githubusercontent.com/10720454/91613907-5497e280-e935-11ea-8e40-e9b8d7d82ba7.gif)


---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4197 
