### PR TITLE
Dashboard:  Confirmation dialog before removing logos

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -85,7 +85,7 @@ function EditorSettings() {
   } = useConfig();
 
   const [activeDialog, setActiveDialog] = useState('');
-  const [activeLogo, setActiveLogo] = useState(null);
+  const [activeLogo, setActiveLogo] = useState('');
   const [mediaError, setMediaError] = useState('');
   /**
    * WP settings references publisher logos by ID.

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -211,7 +211,10 @@ function EditorSettings() {
             'Dialog to confirm removing a publisher logo',
             'web-stories'
           )}
-          title={__('Remove Publisher Logo', 'web-stories')}
+          title={__(
+            'Are you sure you want to remove this logo?',
+            'web-stories'
+          )}
           onClose={() => setActiveDialog('')}
           actions={
             <>
@@ -233,7 +236,10 @@ function EditorSettings() {
             </>
           }
         >
-          {__('Are you sure you want to remove this logo?', 'web-stories')}
+          {__(
+            'This will affect any stories that currently use it as their publisher logo.',
+            'web-stories'
+          )}
         </Dialog>
       )}
     </Layout.Provider>

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -159,8 +159,9 @@ function EditorSettings() {
     setActiveLogo(media.id);
   }, []);
 
-  const isActiveRemoveLogoDialog =
-    activeDialog === ACTIVE_DIALOG_REMOVE_LOGO && activeLogo;
+  const isActiveRemoveLogoDialog = Boolean(
+    activeDialog === ACTIVE_DIALOG_REMOVE_LOGO && activeLogo
+  );
 
   const orderedPublisherLogos = useMemo(() => {
     if (Object.keys(mediaById).length <= 0) {
@@ -204,44 +205,39 @@ function EditorSettings() {
         </Layout.Scrollable>
       </Wrapper>
 
-      {isActiveRemoveLogoDialog && (
-        <Dialog
-          isOpen={true}
-          contentLabel={__(
-            'Dialog to confirm removing a publisher logo',
-            'web-stories'
-          )}
-          title={__(
-            'Are you sure you want to remove this logo?',
-            'web-stories'
-          )}
-          onClose={() => setActiveDialog('')}
-          actions={
-            <>
-              <Button
-                type={BUTTON_TYPES.DEFAULT}
-                onClick={() => setActiveDialog('')}
-              >
-                {__('Cancel', 'web-stories')}
-              </Button>
-              <Button
-                type={BUTTON_TYPES.DEFAULT}
-                onClick={() => {
-                  updateSettings({ publisherLogoIdToRemove: activeLogo });
-                  setActiveDialog('');
-                }}
-              >
-                {__('Remove Logo', 'web-stories')}
-              </Button>
-            </>
-          }
-        >
-          {__(
-            'This will affect any stories that currently use it as their publisher logo.',
-            'web-stories'
-          )}
-        </Dialog>
-      )}
+      <Dialog
+        isOpen={isActiveRemoveLogoDialog}
+        contentLabel={__(
+          'Dialog to confirm removing a publisher logo',
+          'web-stories'
+        )}
+        title={__('Are you sure you want to remove this logo?', 'web-stories')}
+        onClose={() => setActiveDialog('')}
+        actions={
+          <>
+            <Button
+              type={BUTTON_TYPES.DEFAULT}
+              onClick={() => setActiveDialog('')}
+            >
+              {__('Cancel', 'web-stories')}
+            </Button>
+            <Button
+              type={BUTTON_TYPES.DEFAULT}
+              onClick={() => {
+                updateSettings({ publisherLogoIdToRemove: activeLogo });
+                setActiveDialog('');
+              }}
+            >
+              {__('Remove Logo', 'web-stories')}
+            </Button>
+          </>
+        }
+      >
+        {__(
+          'This will affect any stories that currently use it as their publisher logo.',
+          'web-stories'
+        )}
+      </Dialog>
     </Layout.Provider>
   );
 }

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -28,12 +28,15 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import useApi from '../../api/useApi';
-import { Layout } from '../../../components';
+import { Layout, Dialog, Button } from '../../../components';
+import { BUTTON_TYPES } from '../../../constants';
 import { useConfig } from '../../config';
 import { PageHeading } from '../shared';
 import GoogleAnalyticsSettings from './googleAnalytics';
 import { Main, Wrapper } from './components';
 import PublisherLogoSettings from './publisherLogo';
+
+const ACTIVE_DIALOG_REMOVE_LOGO = 'REMOVE_LOGO';
 
 function EditorSettings() {
   const {
@@ -81,6 +84,8 @@ function EditorSettings() {
     maxUploadFormatted,
   } = useConfig();
 
+  const [activeDialog, setActiveDialog] = useState('');
+  const [activeLogo, setActiveLogo] = useState(null);
   const [mediaError, setMediaError] = useState('');
   /**
    * WP settings references publisher logos by ID.
@@ -147,13 +152,15 @@ function EditorSettings() {
     [maxUpload, maxUploadFormatted, uploadMedia]
   );
 
-  const handleRemoveLogo = useCallback(
-    (e, media) => {
-      e.preventDefault();
-      updateSettings({ publisherLogoIdToRemove: media.id });
-    },
-    [updateSettings]
-  );
+  const handleRemoveLogo = useCallback((e, media) => {
+    e.preventDefault();
+
+    setActiveDialog(ACTIVE_DIALOG_REMOVE_LOGO);
+    setActiveLogo(media.id);
+  }, []);
+
+  const isActiveRemoveLogoDialog =
+    activeDialog === ACTIVE_DIALOG_REMOVE_LOGO && activeLogo;
 
   const orderedPublisherLogos = useMemo(() => {
     if (Object.keys(mediaById).length <= 0) {
@@ -196,6 +203,39 @@ function EditorSettings() {
           </Main>
         </Layout.Scrollable>
       </Wrapper>
+
+      {isActiveRemoveLogoDialog && (
+        <Dialog
+          isOpen={true}
+          contentLabel={__(
+            'Dialog to confirm removing a publisher logo',
+            'web-stories'
+          )}
+          title={__('Remove Publisher Logo', 'web-stories')}
+          onClose={() => setActiveDialog('')}
+          actions={
+            <>
+              <Button
+                type={BUTTON_TYPES.DEFAULT}
+                onClick={() => setActiveDialog('')}
+              >
+                {__('Cancel', 'web-stories')}
+              </Button>
+              <Button
+                type={BUTTON_TYPES.DEFAULT}
+                onClick={() => {
+                  updateSettings({ publisherLogoIdToRemove: activeLogo });
+                  setActiveDialog('');
+                }}
+              >
+                {__('Remove Logo', 'web-stories')}
+              </Button>
+            </>
+          }
+        >
+          {__('Are you sure you want to remove this logo?', 'web-stories')}
+        </Dialog>
+      )}
     </Layout.Provider>
   );
 }

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -84,7 +84,7 @@ function EditorSettings() {
     maxUploadFormatted,
   } = useConfig();
 
-  const [activeDialog, setActiveDialog] = useState('');
+  const [activeDialog, setActiveDialog] = useState(null);
   const [activeLogo, setActiveLogo] = useState('');
   const [mediaError, setMediaError] = useState('');
   /**
@@ -212,12 +212,12 @@ function EditorSettings() {
           'web-stories'
         )}
         title={__('Are you sure you want to remove this logo?', 'web-stories')}
-        onClose={() => setActiveDialog('')}
+        onClose={() => setActiveDialog(null)}
         actions={
           <>
             <Button
               type={BUTTON_TYPES.DEFAULT}
-              onClick={() => setActiveDialog('')}
+              onClick={() => setActiveDialog(null)}
             >
               {__('Cancel', 'web-stories')}
             </Button>
@@ -225,7 +225,7 @@ function EditorSettings() {
               type={BUTTON_TYPES.DEFAULT}
               onClick={() => {
                 updateSettings({ publisherLogoIdToRemove: activeLogo });
-                setActiveDialog('');
+                setActiveDialog(null);
               }}
             >
               {__('Remove Logo', 'web-stories')}

--- a/assets/src/dashboard/app/views/editorSettings/karma/editorSettings.karma.js
+++ b/assets/src/dashboard/app/views/editorSettings/karma/editorSettings.karma.js
@@ -131,6 +131,12 @@ describe('Settings View', () => {
 
     await fixture.events.click(RemovePublisherLogoButton);
 
+    const confirmRemoveButton = fixture.screen.getByRole('button', {
+      name: /^Remove Logo$/,
+    });
+
+    await fixture.events.click(confirmRemoveButton);
+
     const UpdatedPublisherLogos = within(
       await fixture.screen.getByTestId('editor-settings')
     ).queryAllByTestId(/^publisher-logo/);
@@ -154,6 +160,13 @@ describe('Settings View', () => {
     expect(RemovePublisherLogoButton).toBeTruthy();
 
     await fixture.events.focus(RemovePublisherLogoButton);
+    await fixture.events.keyboard.press('Enter');
+
+    const confirmRemoveButton = fixture.screen.getByRole('button', {
+      name: /^Remove Logo$/,
+    });
+
+    await fixture.events.focus(confirmRemoveButton);
     await fixture.events.keyboard.press('Enter');
 
     const UpdatedPublisherLogos = within(

--- a/assets/src/dashboard/app/views/editorSettings/test/editorSettings.js
+++ b/assets/src/dashboard/app/views/editorSettings/test/editorSettings.js
@@ -142,7 +142,7 @@ describe('Editor Settings: <Editor Settings />', function () {
   });
 
   it('should call mockUpdateSettings when a logo is removed', function () {
-    const { getByTestId } = renderWithTheme(
+    const { getByTestId, getByText } = renderWithTheme(
       <SettingsWrapper
         googleAnalyticsId="UA-098909-05"
         canUploadFiles={true}
@@ -157,6 +157,11 @@ describe('Editor Settings: <Editor Settings />', function () {
     expect(RemoveLogoButton).toBeDefined();
 
     fireEvent.click(RemoveLogoButton);
+
+    const ConfirmRemoveLogoButton = getByText('Remove Logo');
+
+    fireEvent.click(ConfirmRemoveLogoButton);
+
     expect(mockUpdateSettings).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

Adds a confirmation dialog on Dashboard/Settings to verify that user wants to remove a publisher logo. 

## Relevant Technical Choices

- Just adds a new dialog in the same fashion as the remove story dialog 

## User-facing changes

When the `enableSettingsView` feature flag is true and you navigate to Dashboard/Settings and remove a publisher logo (just not the default, which has no 'x' and cannot currently be removed from this view) you will be prompted with a dialog (see screenshot) to confirm that you really do want to remove this logo. 

![Screen Shot 2020-08-28 at 2 28 55 PM](https://user-images.githubusercontent.com/10720454/91617431-ea833b80-e93c-11ea-8ccc-db9ddaf06f56.png)

## Testing Instructions

- Enable `enableSettingsView` feature flag 
- Click an 'x' button on a publisher logo (again, not the default (first) logo in the list) and see that a dialog pops up. 
- If you click 'cancel' the dialog closes and the logo who's button you clicked will still be there. 
- If you click 'Remove Logo' the dialog will close and the logo will be removed. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4149 
