### PR TITLE
Dashboard: Enforce outline on CTA buttons

### DIFF
--- a/assets/src/dashboard/components/button/index.js
+++ b/assets/src/dashboard/components/button/index.js
@@ -96,6 +96,10 @@ export const DefaultButton = styled(StyledButton)`
 const CtaButton = styled(StyledButton)`
   background-color: ${({ theme }) => theme.colors.bluePrimary};
   opacity: 1;
+
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    outline: ${({ theme }) => theme.borders.action};
+  }
 `;
 
 const SecondaryButton = styled(StyledButton)`

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -185,7 +185,7 @@ export function LeftRail() {
         </Content>
         <Content>
           <NavButton
-            type={BUTTON_TYPES.CTA}
+            type={BUTTON_TYPES.PRIMARY}
             href={newStoryURL}
             isLink
             onClick={onCreateNewStoryClick}

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -185,7 +185,7 @@ export function LeftRail() {
         </Content>
         <Content>
           <NavButton
-            type={BUTTON_TYPES.PRIMARY}
+            type={BUTTON_TYPES.CTA}
             href={newStoryURL}
             isLink
             onClick={onCreateNewStoryClick}


### PR DESCRIPTION
## Summary
We have 2 CTAs in use on the dashboard, the 'Create New Story' button on the left side nav and the "Use Template" button on the top nav of the template detail view. When you tab through the given components it has been really hard to tell when the button's focused because it's nearly the same blue as the action border is. Now the browser based outline is restored to these buttons with the action color. 

## Relevant Technical Choices
- added outline color to CTA buttons to override `outline:0` when `KEYBOARD_USER_SELECTOR` class is present

## To-do

- The button styles on the whole are about to change with the new design system. Focus styles will be consistent at that point.

## User-facing changes
Now when you use a keyboard and tab through the side nav menu and template detail nav you see an outline when focused on the 'create new story' and 'use template' buttons. 
![use template cta](https://user-images.githubusercontent.com/10720454/91620451-d7746980-e944-11ea-916b-1df34d2fc4dc.gif)
![create new story cta](https://user-images.githubusercontent.com/10720454/91620457-de02e100-e944-11ea-8411-6c08a1c49ab8.gif)


## Testing Instructions

- Navigate to Dashboard/MyStories and tab through to the side nav, see that it's clear that the "Create New Story" button is focused when you are using a keyboard. Also see that when you use a cursor to interact with the button the outline is not present. 

- Navigate to a detail template view from Dashboard/ExploreTemplates and tab through the menu. See that there's an outline when the "use template" button is focused and you are using a keyboard. See that there is no outline present when you interact with it with a cursor. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4196 