### PR TITLE
3P Media: Fix refreshing on updated search terms

### DIFF
--- a/assets/src/edit-story/app/media/media3p/providerReducer.js
+++ b/assets/src/edit-story/app/media/media3p/providerReducer.js
@@ -61,6 +61,7 @@ function providerReducer(state = INITIAL_STATE, { type, payload }) {
       // clears out the pageToken and nextPageToken for all providers.
       return {
         ...state,
+        isMediaLoaded: false,
         pageToken: undefined,
         nextPageToken: undefined,
       };

--- a/assets/src/edit-story/app/media/media3p/test/providerReducer.js
+++ b/assets/src/edit-story/app/media/media3p/test/providerReducer.js
@@ -70,7 +70,11 @@ describe('providerReducer', () => {
     });
 
     expect(result.current.state).toStrictEqual(
-      expect.objectContaining({ pageToken: 'page2', nextPageToken: 'page2' })
+      expect.objectContaining({
+        isMediaLoaded: true,
+        pageToken: 'page2',
+        nextPageToken: 'page2',
+      })
     );
 
     act(() => {
@@ -79,6 +83,7 @@ describe('providerReducer', () => {
 
     expect(result.current.state).toStrictEqual(
       expect.objectContaining({
+        isMediaLoaded: false,
         pageToken: undefined,
         nextPageToken: undefined,
       })


### PR DESCRIPTION
## Summary

Set isMediaLoading=false to refresh on a new search term.

This causes media to be re-fetched when the media3p tab is changed:
https://github.com/google/web-stories-wp/blob/9cd13ee04a8ec6240017e2fdd513fe3b45720e23/assets/src/edit-story/app/media/media3p/useFetchMediaEffect.js#L121

## Alternatives Considered

We could also set media=[] to save memory in the state for the other providers that are going to re-load their media anyway, but decided against this for a couple of reasons:
1. This causes the media list to be cleared momentarily while loading new results.
2. If the user loses internet connection when changing tabs, it may be desirable to continue showing the previous list of results.

This has the minor downside of showing 'cats' momentarily when switching tabs before showing results for 'dogs'.

## User-facing changes

This causes media to be updated when the search term has updated and the tab is changed.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4071
