### PR TITLE
Align Snackbar colors with Figma

### DIFF
--- a/assets/src/edit-story/app/snackbar/snackbar.js
+++ b/assets/src/edit-story/app/snackbar/snackbar.js
@@ -27,7 +27,7 @@ const Container = styled.div`
 const Main = styled.div`
   background-color: ${({ theme }) => theme.colors.fg.primary};
   border-radius: 4px;
-  color: ${({ theme }) => theme.colors.fg.white};
+  color: ${({ theme }) => theme.colors.fg.black};
   max-width: 456px;
   display: flex;
   flex-grow: 1;
@@ -62,7 +62,7 @@ const ActionButton = styled.button`
   justify-content: center;
   font-size: ${({ theme }) => theme.fonts.body2.size};
   line-height: ${({ theme }) => theme.fonts.body2.lineHeight};
-  color: ${({ theme }) => theme.colors.accent.primary};
+  color: ${({ theme }) => theme.colors.fg.tertiary};
   outline: none;
   border: 0;
   cursor: pointer;

--- a/assets/src/edit-story/theme.js
+++ b/assets/src/edit-story/theme.js
@@ -116,6 +116,7 @@ const theme = {
       black: '#000000',
       white: '#FFFFFF',
       primary: '#EDEFEC',
+      tertiary: '#767570',
       gray24: '#5E615C',
       gray16: '#414442',
       gray8: '#2F3131',


### PR DESCRIPTION
## Summary

Fixes the message color for the bright background and button color.

![image](https://user-images.githubusercontent.com/21036224/91743807-b025d280-ebb8-11ea-9426-5c88d39fbe3a.png)


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

The snackbar message should be readable (on a bright background).

## Testing Instructions

Trigger any message (e.g. drop an unsupported file on canvas/media library) and check if it's readable.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
