### PR TITLE
3P Media: reset pagetoken on category deselection

### DIFF
--- a/assets/src/edit-story/app/media/media3p/providerReducer.js
+++ b/assets/src/edit-story/app/media/media3p/providerReducer.js
@@ -76,6 +76,16 @@ function providerReducer(state = INITIAL_STATE, { type, payload }) {
       };
     }
 
+    case categoryTypes.DESELECT_CATEGORY: {
+      // This is called only for the provider in the payload, so it clears
+      // out only that provider's pageToken and nextPageToken.
+      return {
+        ...state,
+        pageToken: undefined,
+        nextPageToken: undefined,
+      };
+    }
+
     default:
       return state;
   }

--- a/assets/src/edit-story/app/media/media3p/test/providerReducer.js
+++ b/assets/src/edit-story/app/media/media3p/test/providerReducer.js
@@ -121,4 +121,41 @@ describe('providerReducer', () => {
       })
     );
   });
+
+  it('should reset {next}pageToken when the category is deselected', () => {
+    const { result } = renderHook(() =>
+      useMediaReducer(providerReducer, {
+        ...actionsToWrap,
+        ...paginationActionsToWrap,
+        ...categoryActionsToWrap,
+      })
+    );
+
+    act(() => {
+      result.current.actions.fetchMediaSuccess({
+        provider: 'provider',
+        media: [{ id: 'id' }],
+        nextPageToken: 'page2',
+      });
+    });
+
+    act(() => {
+      result.current.actions.setNextPage({ provider: 'provider' });
+    });
+
+    expect(result.current.state).toStrictEqual(
+      expect.objectContaining({ pageToken: 'page2', nextPageToken: 'page2' })
+    );
+
+    act(() => {
+      result.current.actions.deselectCategory({ categoryId: 'lala' });
+    });
+
+    expect(result.current.state).toStrictEqual(
+      expect.objectContaining({
+        pageToken: undefined,
+        nextPageToken: undefined,
+      })
+    );
+  });
 });


### PR DESCRIPTION
Reset pagetoken when deselecting a category.

Fixes #4297
