### PR TITLE
Display fallback message if JavaScript is disabled

### DIFF
--- a/assets/src/dashboard/style.css
+++ b/assets/src/dashboard/style.css
@@ -26,11 +26,12 @@ body {
 }
 
 #screen-meta,
-#screen-meta ~ :not(#web-stories-dashboard):not(.clear) {
+#screen-meta
+  ~ :not(#web-stories-dashboard):not(.clear):not(#stories-dashboard-no-js) {
   display: none;
 }
 
-body.web-story_page_stories-dashboard {
+body.web-story_page_stories-dashboard.js {
   position: relative;
 }
 
@@ -38,8 +39,8 @@ body.web-story_page_stories-dashboard {
   z-index: 4;
 }
 
-body.web-story_page_stories-dashboard #wpwrap,
-body.web-story_page_stories-dashboard #wpbody-content {
+body.web-story_page_stories-dashboard.js #wpwrap,
+body.web-story_page_stories-dashboard.js #wpbody-content {
   position: absolute;
   overflow: hidden;
   top: 0;
@@ -50,22 +51,37 @@ body.web-story_page_stories-dashboard #wpbody-content {
   padding: 0;
 }
 
-body.web-story_page_stories-dashboard #wpcontent,
-body.web-story_page_stories-dashboard #wpbody-content {
+body.web-story_page_stories-dashboard.js #wpcontent,
+body.web-story_page_stories-dashboard.js #wpbody-content {
   padding: 0;
 }
 
-body.web-story_page_stories-dashboard #wpbody {
+body.web-story_page_stories-dashboard.js #wpbody {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-body.web-story_page_stories-dashboard #web-stories-dashboard .loading-message {
+body.web-story_page_stories-dashboard.js
+  #web-stories-dashboard
+  .loading-message {
   text-align: center;
 }
 
-body.web-story_page_stories-dashboard #wpfooter {
+body.web-story_page_stories-dashboard.no-js
+  #web-stories-dashboard
+  .loading-message {
+  display: none;
+}
+body.web-story_page_stories-dashboard #stories-editor-no-js {
+  display: none;
+}
+
+body.web-story_page_stories-dashboard.no-js #stories-editor-no-js {
+  display: block;
+}
+
+body.web-story_page_stories-dashboard.js #wpfooter {
   display: none;
 }
 

--- a/assets/src/dashboard/style.css
+++ b/assets/src/dashboard/style.css
@@ -27,11 +27,11 @@ body {
 
 #screen-meta,
 #screen-meta
-  ~ :not(#web-stories-dashboard):not(.clear):not(#stories-dashboard-no-js) {
+  ~ :not(#web-stories-dashboard):not(.clear):not(#web-stories-no-js) {
   display: none;
 }
 
-body.web-story_page_stories-dashboard.js {
+body.web-story_page_stories-dashboard {
   position: relative;
 }
 
@@ -39,8 +39,8 @@ body.web-story_page_stories-dashboard.js {
   z-index: 4;
 }
 
-body.web-story_page_stories-dashboard.js #wpwrap,
-body.web-story_page_stories-dashboard.js #wpbody-content {
+body.web-story_page_stories-dashboard #wpwrap,
+body.web-story_page_stories-dashboard #wpbody-content {
   position: absolute;
   overflow: hidden;
   top: 0;
@@ -51,37 +51,22 @@ body.web-story_page_stories-dashboard.js #wpbody-content {
   padding: 0;
 }
 
-body.web-story_page_stories-dashboard.js #wpcontent,
-body.web-story_page_stories-dashboard.js #wpbody-content {
+body.web-story_page_stories-dashboard #wpcontent,
+body.web-story_page_stories-dashboard #wpbody-content {
   padding: 0;
 }
 
-body.web-story_page_stories-dashboard.js #wpbody {
+body.web-story_page_stories-dashboard #wpbody {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-body.web-story_page_stories-dashboard.js
-  #web-stories-dashboard
-  .loading-message {
+body.web-story_page_stories-dashboard #web-stories-dashboard .loading-message {
   text-align: center;
 }
 
-body.web-story_page_stories-dashboard.no-js
-  #web-stories-dashboard
-  .loading-message {
-  display: none;
-}
-body.web-story_page_stories-dashboard #stories-editor-no-js {
-  display: none;
-}
-
-body.web-story_page_stories-dashboard.no-js #stories-editor-no-js {
-  display: block;
-}
-
-body.web-story_page_stories-dashboard.js #wpfooter {
+body.web-story_page_stories-dashboard #wpfooter {
   display: none;
 }
 
@@ -89,4 +74,8 @@ body.web-story_page_stories-dashboard.js #wpfooter {
 
 button {
   font-size: inherit;
+}
+
+#web-stories-no-js {
+  margin: 25px 20px 0px 20px;
 }

--- a/assets/src/edit-story/style.css
+++ b/assets/src/edit-story/style.css
@@ -22,33 +22,44 @@
 
 #screen-meta,
 #screen-meta-links,
-#screen-meta-links ~ :not(#edit-story):not(.clear) {
+#screen-meta-links ~ :not(#edit-story):not(.clear):not(#stories-editor-no-js) {
   display: none;
 }
 
-body.edit-story #wpcontent,
-body.edit-story #wpbody-content {
+body.edit-story.js #wpcontent,
+body.edit-story.js #wpbody-content {
   padding: 0;
 }
 
-body.edit-story #edit-story {
+body.edit-story.js #edit-story {
   background-color: #1b1d1c; /* theme.colors.bg.workspace */
   position: relative;
   height: calc(100vh - 32px); /* ADMIN_TOOLBAR_HEIGHT = 32 */
 }
 
-body.edit-story .loading-message {
+body.edit-story.js .loading-message {
   color: #fff;
   text-align: center;
   margin: 0;
   padding: 0.67em 0;
 }
 
-body.edit-story #wpfooter {
+body.edit-story.no-js .loading-message {
+  display: none;
+}
+body.edit-story #stories-editor-no-js {
   display: none;
 }
 
-body.edit-story #edit-story .components-spinner {
+body.edit-story.no-js #stories-editor-no-js {
+  display: block;
+}
+
+body.edit-story.js #wpfooter {
+  display: none;
+}
+
+body.edit-story.js #edit-story .components-spinner {
   float: none;
   margin: 0 11px;
 }

--- a/assets/src/edit-story/style.css
+++ b/assets/src/edit-story/style.css
@@ -22,44 +22,33 @@
 
 #screen-meta,
 #screen-meta-links,
-#screen-meta-links ~ :not(#edit-story):not(.clear):not(#stories-editor-no-js) {
+#screen-meta-links ~ :not(#edit-story):not(.clear):not(#web-stories-no-js) {
   display: none;
 }
 
-body.edit-story.js #wpcontent,
-body.edit-story.js #wpbody-content {
+body.edit-story #wpcontent,
+body.edit-story #wpbody-content {
   padding: 0;
 }
 
-body.edit-story.js #edit-story {
+body.edit-story #edit-story {
   background-color: #1b1d1c; /* theme.colors.bg.workspace */
   position: relative;
   height: calc(100vh - 32px); /* ADMIN_TOOLBAR_HEIGHT = 32 */
 }
 
-body.edit-story.js .loading-message {
+body.edit-story .loading-message {
   color: #fff;
   text-align: center;
   margin: 0;
   padding: 0.67em 0;
 }
 
-body.edit-story.no-js .loading-message {
-  display: none;
-}
-body.edit-story #stories-editor-no-js {
+body.edit-story #wpfooter {
   display: none;
 }
 
-body.edit-story.no-js #stories-editor-no-js {
-  display: block;
-}
-
-body.edit-story.js #wpfooter {
-  display: none;
-}
-
-body.edit-story.js #edit-story .components-spinner {
+body.edit-story #edit-story .components-spinner {
   float: none;
   margin: 0 11px;
 }
@@ -68,4 +57,8 @@ body.edit-story.js #edit-story .components-spinner {
 
 button {
   font-size: inherit;
+}
+
+#web-stories-no-js {
+  margin: 25px 20px 0px 20px;
 }

--- a/includes/templates/admin/dashboard.php
+++ b/includes/templates/admin/dashboard.php
@@ -30,7 +30,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-
+<div id="stories-dashboard-no-js" class="wrap">
+	<div class="notice notice-error notice-alt">
+		<p><?php esc_html_e( 'The Web Stories dashboard requires JavaScript. Please enable JavaScript in your browser settings.', 'web-stories' ); ?></p>
+	</div>
+</div>
 <div id="web-stories-dashboard">
 	<h1 class="loading-message"><?php esc_html_e( 'Please wait...', 'web-stories' ); ?></h1>
 </div>

--- a/includes/templates/admin/dashboard.php
+++ b/includes/templates/admin/dashboard.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div id="stories-dashboard-no-js" class="wrap">
 	<div class="notice notice-error notice-alt">
-		<p><?php esc_html_e( 'The Web Stories dashboard requires JavaScript. Please enable JavaScript in your browser settings.', 'web-stories' ); ?></p>
+		<p><?php esc_html_e( 'Web Stories for WordPress requires JavaScript. Please enable JavaScript in your browser settings.', 'web-stories' ); ?></p>
 	</div>
 </div>
 <div id="web-stories-dashboard">

--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -78,7 +78,7 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 <div id="stories-editor-no-js" class="wrap">
 	<div class="notice notice-error notice-alt">
-		<p><?php esc_html_e( 'The Web Stories editor requires JavaScript. Please enable JavaScript in your browser settings.', 'web-stories' ); ?></p>
+		<p><?php esc_html_e( 'Web Stories for WordPress requires JavaScript. Please enable JavaScript in your browser settings.', 'web-stories' ); ?></p>
 	</div>
 </div>
 

--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -73,15 +73,9 @@ wp_add_inline_script(
 );
 
 require_once ABSPATH . 'wp-admin/admin-header.php';
-
+require_once __DIR__ . '/error-no-js.php';
 ?>
 
-<div id="stories-editor-no-js" class="wrap">
-	<div class="notice notice-error notice-alt">
-		<p><?php esc_html_e( 'Web Stories for WordPress requires JavaScript. Please enable JavaScript in your browser settings.', 'web-stories' ); ?></p>
-	</div>
-</div>
-
-<div id="edit-story">
+<div id="edit-story" class="hide-if-no-js">
 	<h1 class="loading-message"><?php esc_html_e( 'Please wait...', 'web-stories' ); ?></h1>
 </div>

--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -76,6 +76,12 @@ require_once ABSPATH . 'wp-admin/admin-header.php';
 
 ?>
 
+<div id="stories-editor-no-js" class="wrap">
+	<div class="notice notice-error notice-alt">
+		<p><?php esc_html_e( 'The Web Stories editor requires JavaScript. Please enable JavaScript in your browser settings.', 'web-stories' ); ?></p>
+	</div>
+</div>
+
 <div id="edit-story">
 	<h1 class="loading-message"><?php esc_html_e( 'Please wait...', 'web-stories' ); ?></h1>
 </div>

--- a/includes/templates/admin/error-no-js.php
+++ b/includes/templates/admin/error-no-js.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Stories dashboard.
+ * Stories no js error.
  *
  * @package   Google\Web_Stories
  * @copyright 2020 Google LLC
@@ -29,10 +29,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-require_once __DIR__ . '/error-no-js.php';
-
 ?>
-
-<div id="web-stories-dashboard" class="hide-if-no-js">
-	<h1 class="loading-message"><?php esc_html_e( 'Please wait...', 'web-stories' ); ?></h1>
+<div id="web-stories-no-js" class="wrap hide-if-js">
+	<div class="notice notice-error notice-alt">
+		<p><?php esc_html_e( 'Web Stories for WordPress requires JavaScript. Please enable JavaScript in your browser settings.', 'web-stories' ); ?></p>
+	</div>
 </div>


### PR DESCRIPTION
## Summary

Display a fallback message if javascript is disabled.

## Relevant Technical Choices

<!-- Please describe your changes. -->
I hide the loading message if js is disabled. It now requires js / no js classes on the body. Which may mean a little more jumpy load in. But I didn't notice anything in my testing.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3132
