### PR TITLE
Dashboard: Enable keyboard navigation for publisher logos grid

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -104,6 +104,10 @@ export const UploadedContainer = styled.div`
   padding-bottom: 24px;
 `;
 
+export const GridItemContainer = styled.div`
+  position: relative;
+`;
+
 export const GridItemButton = styled.button`
   position: relative;
   display: block;

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import { rgba } from 'polished';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ import {
 } from '../../../components';
 import { visuallyHiddenStyles } from '../../../utils/visuallyHiddenStyles';
 import { Link } from '../../../components/link';
+import { KEYBOARD_USER_SELECTOR } from '../../../constants';
 
 export const Wrapper = styled.div`
   margin: 0 107px;
@@ -102,6 +104,24 @@ export const UploadedContainer = styled.div`
   padding-bottom: 24px;
 `;
 
+export const GridItemButton = styled.button`
+  position: relative;
+  display: block;
+  background-color: transparent;
+  border: ${({ theme }) => theme.borders.transparent};
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+  border-width: 2px;
+  padding: 0;
+
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    border-color: ${({ theme }) => rgba(theme.colors.bluePrimary, 0.85)};
+    border-width: 2px;
+    outline: none;
+  }
+`;
+
 export const Logo = styled.img`
   object-fit: cover;
   width: 100%;
@@ -110,13 +130,13 @@ export const Logo = styled.img`
 `;
 
 export const RemoveLogoButton = styled.button`
-  position: relative;
+  position: absolute;
   left: 2px;
-  bottom: 30px;
+  bottom: 2px;
   width: 24px;
   height: 24px;
   text-align: center;
-
+  padding: 0;
   color: ${({ theme }) => theme.colors.white};
   background: ${({ theme }) => theme.colors.gray700};
   border-radius: 50%;
@@ -124,9 +144,16 @@ export const RemoveLogoButton = styled.button`
   cursor: pointer;
 
   & > svg {
+    padding: 6px;
     width: 100%;
     height: 100%;
     display: block;
+  }
+
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    border-color: ${({ theme }) => rgba(theme.colors.bluePrimary, 0.85)};
+    border-width: 2px;
+    outline: none;
   }
 `;
 

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -152,14 +152,14 @@ function EditorSettings() {
     [maxUpload, maxUploadFormatted, uploadMedia]
   );
 
-  const isActiveRemoveLogoDialog = Boolean(
-    activeDialog === ACTIVE_DIALOG_REMOVE_LOGO && activeLogo
-  );
-
   const handleRemoveLogo = useCallback((media) => {
     setActiveDialog(ACTIVE_DIALOG_REMOVE_LOGO);
     setActiveLogo(media.id);
   }, []);
+
+  const isActiveRemoveLogoDialog = Boolean(
+    activeDialog === ACTIVE_DIALOG_REMOVE_LOGO && activeLogo
+  );
 
   const orderedPublisherLogos = useMemo(() => {
     if (Object.keys(mediaById).length <= 0) {

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -166,14 +166,16 @@ function EditorSettings() {
       return [];
     }
 
-    return publisherLogoIds.map((publisherLogoId) => {
-      if (mediaById[publisherLogoId]) {
-        return publisherLogoId === activePublisherLogoId
-          ? { ...mediaById[publisherLogoId], isActive: true }
-          : mediaById[publisherLogoId];
-      }
-      return undefined; // this is a safeguard against edge cases where a user has > 100 publisher logos, which is more than we're loading
-    });
+    return publisherLogoIds
+      .map((publisherLogoId) => {
+        if (mediaById[publisherLogoId]) {
+          return publisherLogoId === activePublisherLogoId
+            ? { ...mediaById[publisherLogoId], isActive: true }
+            : mediaById[publisherLogoId];
+        }
+        return {}; // this is a safeguard against edge cases where a user has > 100 publisher logos, which is more than we're loading
+      })
+      .filter((logo) => logo?.id);
   }, [activePublisherLogoId, publisherLogoIds, mediaById]);
 
   return (

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -152,16 +152,14 @@ function EditorSettings() {
     [maxUpload, maxUploadFormatted, uploadMedia]
   );
 
-  const handleRemoveLogo = useCallback((e, media) => {
-    e.preventDefault();
-
-    setActiveDialog(ACTIVE_DIALOG_REMOVE_LOGO);
-    setActiveLogo(media.id);
-  }, []);
-
   const isActiveRemoveLogoDialog = Boolean(
     activeDialog === ACTIVE_DIALOG_REMOVE_LOGO && activeLogo
   );
+
+  const handleRemoveLogo = useCallback((media) => {
+    setActiveDialog(ACTIVE_DIALOG_REMOVE_LOGO);
+    setActiveLogo(media.id);
+  }, []);
 
   const orderedPublisherLogos = useMemo(() => {
     if (Object.keys(mediaById).length <= 0) {

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -31,6 +31,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
   Error,
   GridItemButton,
+  GridItemContainer,
   Logo,
   RemoveLogoButton,
   SettingForm,
@@ -146,7 +147,7 @@ function PublisherLogoSettings({
         <SettingHeading>{TEXT.SECTION_HEADING}</SettingHeading>
         <HelperText>{TEXT.CONTEXT}</HelperText>
       </div>
-      <div ref={containerRef}>
+      <div ref={containerRef} data-testid="publisher-logos-container">
         {publisherLogos.length > 0 && (
           <UploadedContainer ref={gridRef}>
             {publisherLogos.map((publisherLogo, idx) => {
@@ -157,14 +158,14 @@ function PublisherLogoSettings({
               const isActive = activePublisherLogo === publisherLogo.id;
 
               return (
-                <div
+                <GridItemContainer
                   key={`${publisherLogo.title}_${idx}`}
-                  data-testid={`publisher-logo-${idx}`}
                   ref={(el) => {
                     itemRefs.current[publisherLogo.id] = el;
                   }}
                 >
                   <GridItemButton
+                    data-testid={`publisher-logo-${idx}`}
                     isSelected={isActive}
                     tabIndex={isActive ? 0 : -1}
                     onClick={(e) => {
@@ -172,34 +173,42 @@ function PublisherLogoSettings({
                       e.stopPropagation();
                       setActivePublisherLogoId(publisherLogo.id);
                     }}
-                    aria-label={sprintf(
-                      /* translators: %s: logo number. */
-                      __(
-                        'Publisher Logo %s (currently selected)',
-                        'web-stories'
-                      ),
-                      idx + 1
-                    )}
+                    aria-label={
+                      isActive
+                        ? sprintf(
+                            /* translators: %s: logo number.*/
+                            __(
+                              'Publisher Logo %s (currently selected)',
+                              'web-stories'
+                            ),
+                            idx + 1
+                          )
+                        : sprintf(
+                            /* translators: %s: logo number.*/
+                            __('Publisher Logo %s', 'web-stories'),
+                            idx + 1
+                          )
+                    }
                   >
                     <Logo src={publisherLogo.src} alt={publisherLogo.title} />
-                    {!publisherLogo.isActive && (
-                      <RemoveLogoButton
-                        tabIndex={isActive ? 0 : -1}
-                        data-testid={`remove-publisher-logo-${idx}`}
-                        aria-label={sprintf(
-                          /* translators: %s: logo title */
-                          __('Remove %s as a publisher logo', 'web-stories'),
-                          publisherLogo.title
-                        )}
-                        onClick={(e) =>
-                          onRemoveLogoClick(e, { publisherLogo, idx })
-                        }
-                      >
-                        <RemoveIcon aria-hidden="true" />
-                      </RemoveLogoButton>
-                    )}
                   </GridItemButton>
-                </div>
+                  {!publisherLogo.isActive && (
+                    <RemoveLogoButton
+                      tabIndex={isActive ? 0 : -1}
+                      data-testid={`remove-publisher-logo-${idx}`}
+                      aria-label={sprintf(
+                        /* translators: %s: logo title */
+                        __('Remove %s as a publisher logo', 'web-stories'),
+                        publisherLogo.title
+                      )}
+                      onClick={(e) =>
+                        onRemoveLogoClick(e, { publisherLogo, idx })
+                      }
+                    >
+                      <RemoveIcon aria-hidden="true" />
+                    </RemoveLogoButton>
+                  )}
+                </GridItemContainer>
               );
             })}
           </UploadedContainer>

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -41,7 +41,7 @@ import { FileUpload } from '../../../../components';
 import { Close as RemoveIcon } from '../../../../icons';
 
 export const TEXT = {
-  SECTION_HEADING: __('Published Logo', 'web-stories'),
+  SECTION_HEADING: __('Publisher Logo', 'web-stories'),
   CONTEXT: __(
     'Upload your logos here and they will become available to any stories you create.',
     'web-stories'

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -84,9 +84,7 @@ function PublisherLogoSettings({
     publisherLogos,
   ]);
 
-  const [publisherLogoCount, setPublisherLogoCount] = useState(
-    publisherLogosById.length
-  );
+  const publisherLogoCount = useRef(publisherLogosById.length);
 
   const onRemoveLogoClick = useCallback(
     (e, { publisherLogo, idx }) => {
@@ -94,7 +92,7 @@ function PublisherLogoSettings({
 
       handleRemoveLogo(publisherLogo);
       setIndexRemoved(idx);
-      setPublisherLogoCount(publisherLogosById.length);
+      publisherLogoCount.current = publisherLogosById.length;
     },
     [handleRemoveLogo, publisherLogosById.length]
   );
@@ -114,7 +112,7 @@ function PublisherLogoSettings({
   useEffect(() => {
     if (
       Boolean(indexRemoved?.toString()) &&
-      publisherLogosById.length !== publisherLogoCount
+      publisherLogosById.length !== publisherLogoCount.current
     ) {
       if (publisherLogosById.length === 0) {
         // if the user has removed their last publisher logo, the logo grid will not render
@@ -140,7 +138,6 @@ function PublisherLogoSettings({
   }, [
     activePublisherLogo,
     indexRemoved,
-    publisherLogoCount,
     publisherLogosById,
     setActivePublisherLogoId,
   ]);

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -75,7 +75,9 @@ function PublisherLogoSettings({
   const containerRef = useRef();
   const gridRef = useRef();
   const itemRefs = useRef({});
+
   const [activePublisherLogo, _setActivePublisherLogoId] = useState(null);
+
   const publisherLogosById = useMemo(() => publisherLogos.map(({ id }) => id), [
     publisherLogos,
   ]);

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -91,7 +91,6 @@ function PublisherLogoSettings({
   const onRemoveLogoClick = useCallback(
     (e, { publisherLogo, idx }) => {
       e.preventDefault();
-      e.stopPropagation();
 
       handleRemoveLogo(publisherLogo);
       setIndexRemoved(idx);
@@ -128,13 +127,13 @@ function PublisherLogoSettings({
           .focus();
       }
 
-      const moveFocusByIndex =
+      const moveItemFocusByIndex =
         indexRemoved > 0
           ? publisherLogosById[indexRemoved - 1]
           : publisherLogosById[0];
 
-      setActivePublisherLogoId(moveFocusByIndex);
-      itemRefs.current[moveFocusByIndex].firstChild.focus();
+      setActivePublisherLogoId(moveItemFocusByIndex);
+      itemRefs.current[moveItemFocusByIndex].firstChild.focus();
       return setIndexRemoved(null);
     }
     return undefined;
@@ -143,7 +142,6 @@ function PublisherLogoSettings({
     indexRemoved,
     publisherLogoCount,
     publisherLogosById,
-    publisherLogosById.length,
     setActivePublisherLogoId,
   ]);
 
@@ -185,7 +183,6 @@ function PublisherLogoSettings({
                     tabIndex={isActive ? 0 : -1}
                     onClick={(e) => {
                       e.preventDefault();
-                      e.stopPropagation();
                       setActivePublisherLogoId(publisherLogo.id);
                     }}
                     aria-label={

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -75,7 +75,6 @@ function PublisherLogoSettings({
   const containerRef = useRef();
   const gridRef = useRef();
   const itemRefs = useRef({});
-  const isInteractive = publisherLogos.length > 1;
   const [activePublisherLogo, _setActivePublisherLogoId] = useState(null);
   const publisherLogosById = useMemo(() => publisherLogos.map(({ id }) => id), [
     publisherLogos,
@@ -84,28 +83,16 @@ function PublisherLogoSettings({
   const onRemoveLogoClick = useCallback(
     (e, { publisherLogo, idx }) => {
       e.preventDefault();
-      const moveFocusByIndex =
-        idx > 1 ? publisherLogosById[idx - 1] : publisherLogosById[0];
+      e.stopPropagation();
+
       handleRemoveLogo(publisherLogo);
 
-      // need to delete the removed logo from itemRefs & move focus to moveFocusByIndex value
-      const currentCopy = { ...itemRefs.current };
-      itemRefs.current = Object.keys(currentCopy).reduce((acc, itemId) => {
-        if (itemId === publisherLogo.id.toString()) {
-          return acc;
-        }
-
-        return {
-          ...acc,
-          [itemId]: currentCopy[itemId],
-        };
-      }, {});
-
-      itemRefs.current[moveFocusByIndex].focus();
-
-      setActivePublisherLogoId(moveFocusByIndex);
+      const moveFocusByIndex =
+        idx > 1 ? publisherLogosById[idx - 1] : publisherLogosById[0];
+      _setActivePublisherLogoId(moveFocusByIndex);
+      itemRefs.current[moveFocusByIndex].firstChild.focus();
     },
-    [handleRemoveLogo, publisherLogosById, setActivePublisherLogoId]
+    [handleRemoveLogo, publisherLogosById]
   );
 
   const setActivePublisherLogoId = useCallback((id) => {
@@ -126,6 +113,7 @@ function PublisherLogoSettings({
     currentItemId: activePublisherLogo,
     items: publisherLogos,
   });
+
   return (
     <SettingForm>
       <div>
@@ -140,8 +128,7 @@ function PublisherLogoSettings({
                 return null;
               }
 
-              const isCurrentLogo = activePublisherLogo === publisherLogo.id;
-              const isActive = isCurrentLogo && isInteractive;
+              const isActive = activePublisherLogo === publisherLogo.id;
 
               return (
                 <div
@@ -152,7 +139,7 @@ function PublisherLogoSettings({
                   }}
                 >
                   <GridItemButton
-                    isSelected={isCurrentLogo}
+                    isSelected={isActive}
                     tabIndex={isActive ? 0 : -1}
                     onClick={(e) => {
                       e.preventDefault();

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -80,21 +80,28 @@ function PublisherLogoSettings({
   const publisherLogosById = useMemo(() => publisherLogos.map(({ id }) => id), [
     publisherLogos,
   ]);
-  console.log('publisherLogosById', publisherLogosById);
-  console.log(itemRefs.current);
+
   const onRemoveLogoClick = useCallback(
     (e, { publisherLogo, idx }) => {
       e.preventDefault();
-      e.stopPropagation();
-      console.log('delete index: ', idx);
       const moveFocusByIndex =
         idx > 1 ? publisherLogosById[idx - 1] : publisherLogosById[0];
-      console.log('move to this focus: ', moveFocusByIndex);
       handleRemoveLogo(publisherLogo);
 
-      delete itemRefs.current[publisherLogo.id];
+      // need to delete the removed logo from itemRefs & move focus to moveFocusByIndex value
+      const currentCopy = { ...itemRefs.current };
+      itemRefs.current = Object.keys(currentCopy).reduce((acc, itemId) => {
+        if (itemId === publisherLogo.id.toString()) {
+          return acc;
+        }
 
-      // itemRefs.current[moveFocusByIndex].focus();
+        return {
+          ...acc,
+          [itemId]: currentCopy[itemId],
+        };
+      }, {});
+
+      itemRefs.current[moveFocusByIndex].focus();
 
       setActivePublisherLogoId(moveFocusByIndex);
     },
@@ -102,13 +109,11 @@ function PublisherLogoSettings({
   );
 
   const setActivePublisherLogoId = useCallback((id) => {
-    console.log('????? ', id);
     _setActivePublisherLogoId(id);
   }, []);
 
   useEffect(() => {
     if (publisherLogos.length > 0 && !activePublisherLogo) {
-      console.log('SET ACTIVE PUBLISHER LOGO ', activePublisherLogo);
       setActivePublisherLogoId(publisherLogos?.[0].id);
     }
   }, [activePublisherLogo, publisherLogos, setActivePublisherLogoId]);
@@ -121,7 +126,6 @@ function PublisherLogoSettings({
     currentItemId: activePublisherLogo,
     items: publisherLogos,
   });
-  console.log('focus: ', activePublisherLogo);
   return (
     <SettingForm>
       <div>

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -77,7 +77,7 @@ function PublisherLogoSettings({
   const gridRef = useRef();
   const itemRefs = useRef({});
 
-  const [activePublisherLogo, _setActivePublisherLogoId] = useState(null);
+  const [activePublisherLogo, setActivePublisherLogoId] = useState(null);
   const [indexRemoved, setIndexRemoved] = useState(null);
 
   const publisherLogosById = useMemo(() => publisherLogos.map(({ id }) => id), [
@@ -96,10 +96,6 @@ function PublisherLogoSettings({
     },
     [handleRemoveLogo, publisherLogosById.length]
   );
-
-  const setActivePublisherLogoId = useCallback((id) => {
-    _setActivePublisherLogoId(id);
-  }, []);
 
   // set active logo when first painting
   useEffect(() => {
@@ -120,9 +116,7 @@ function PublisherLogoSettings({
         // upload will always be present unless upload is not enabled.
         // currently only admin can get to settings, which means they have upload ability
         // checking for current and firstElementChild are safeguards
-        return containerRef.current?.firstElementChild
-          ?.getElementsByTagName('input')[0]
-          .focus();
+        return containerRef.current?.getElementsByTagName('input')[0].focus();
       }
 
       const moveItemFocusByIndex =

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -113,16 +113,31 @@ function PublisherLogoSettings({
 
   // Update publisher logo focus when logo is removed
   useEffect(() => {
-    if (indexRemoved && publisherLogosById.length !== publisherLogoCount) {
+    if (
+      Boolean(indexRemoved?.toString()) &&
+      publisherLogosById.length !== publisherLogoCount
+    ) {
+      if (publisherLogosById.length === 0) {
+        // if the user has removed their last publisher logo, the logo grid will not render
+        // the first element child of containerRef becomes the input upload
+        // upload will always be present unless upload is not enabled.
+        // currently only admin can get to settings, which means they have upload ability
+        // checking for current and firstElementChild are safeguards
+        return containerRef.current?.firstElementChild
+          ?.getElementsByTagName('input')[0]
+          .focus();
+      }
+
       const moveFocusByIndex =
-        indexRemoved > 1
+        indexRemoved > 0
           ? publisherLogosById[indexRemoved - 1]
           : publisherLogosById[0];
 
       setActivePublisherLogoId(moveFocusByIndex);
       itemRefs.current[moveFocusByIndex].firstChild.focus();
-      setIndexRemoved(null);
+      return setIndexRemoved(null);
     }
+    return undefined;
   }, [
     activePublisherLogo,
     indexRemoved,

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -77,10 +77,15 @@ function PublisherLogoSettings({
   const itemRefs = useRef({});
 
   const [activePublisherLogo, _setActivePublisherLogoId] = useState(null);
+  const [indexRemoved, setIndexRemoved] = useState(null);
 
   const publisherLogosById = useMemo(() => publisherLogos.map(({ id }) => id), [
     publisherLogos,
   ]);
+
+  const [publisherLogoCount, setPublisherLogoCount] = useState(
+    publisherLogosById.length
+  );
 
   const onRemoveLogoClick = useCallback(
     (e, { publisherLogo, idx }) => {
@@ -88,24 +93,43 @@ function PublisherLogoSettings({
       e.stopPropagation();
 
       handleRemoveLogo(publisherLogo);
-
-      const moveFocusByIndex =
-        idx > 1 ? publisherLogosById[idx - 1] : publisherLogosById[0];
-      _setActivePublisherLogoId(moveFocusByIndex);
-      itemRefs.current[moveFocusByIndex].firstChild.focus();
+      setIndexRemoved(idx);
+      setPublisherLogoCount(publisherLogosById.length);
     },
-    [handleRemoveLogo, publisherLogosById]
+    [handleRemoveLogo, publisherLogosById.length]
   );
 
   const setActivePublisherLogoId = useCallback((id) => {
     _setActivePublisherLogoId(id);
   }, []);
 
+  // set active logo when first painting
   useEffect(() => {
     if (publisherLogos.length > 0 && !activePublisherLogo) {
       setActivePublisherLogoId(publisherLogos?.[0].id);
     }
   }, [activePublisherLogo, publisherLogos, setActivePublisherLogoId]);
+
+  // Update publisher logo focus when logo is removed
+  useEffect(() => {
+    if (indexRemoved && publisherLogosById.length !== publisherLogoCount) {
+      const moveFocusByIndex =
+        indexRemoved > 1
+          ? publisherLogosById[indexRemoved - 1]
+          : publisherLogosById[0];
+
+      setActivePublisherLogoId(moveFocusByIndex);
+      itemRefs.current[moveFocusByIndex].firstChild.focus();
+      setIndexRemoved(null);
+    }
+  }, [
+    activePublisherLogo,
+    indexRemoved,
+    publisherLogoCount,
+    publisherLogosById,
+    publisherLogosById.length,
+    setActivePublisherLogoId,
+  ]);
 
   useGridViewKeys({
     containerRef,
@@ -145,6 +169,7 @@ function PublisherLogoSettings({
                     tabIndex={isActive ? 0 : -1}
                     onClick={(e) => {
                       e.preventDefault();
+                      e.stopPropagation();
                       setActivePublisherLogoId(publisherLogo.id);
                     }}
                     aria-label={sprintf(

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -162,7 +162,7 @@ function PublisherLogoSettings({
       </div>
       <div ref={containerRef} data-testid="publisher-logos-container">
         {publisherLogos.length > 0 && (
-          <UploadedContainer ref={gridRef}>
+          <UploadedContainer ref={gridRef} role="list">
             {publisherLogos.map((publisherLogo, idx) => {
               if (!publisherLogo) {
                 return null;
@@ -176,6 +176,7 @@ function PublisherLogoSettings({
                   ref={(el) => {
                     itemRefs.current[publisherLogo.id] = el;
                   }}
+                  role="listitem"
                 >
                   <GridItemButton
                     data-testid={`publisher-logo-${idx}`}

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/stories/index.js
@@ -62,8 +62,7 @@ export const _default = () => {
     });
   }, []);
 
-  const handleRemoveLogo = useCallback((e, deleteLogo) => {
-    e.preventDefault();
+  const handleRemoveLogo = useCallback((deleteLogo) => {
     action('onDelete fired')(deleteLogo);
 
     setUploadedContent((existingUploadedContent) => {

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/test/publisherLogo.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/test/publisherLogo.js
@@ -60,7 +60,7 @@ describe('PublisherLogo', () => {
   });
 
   it('should render an image for each publisherLogo in the array', () => {
-    const { queryAllByTestId } = renderWithTheme(
+    const { queryAllByRole } = renderWithTheme(
       <PublisherLogoSettings
         handleAddLogos={mockHandleAddLogos}
         handleRemoveLogo={mockHandleRemoveLogo}
@@ -69,9 +69,7 @@ describe('PublisherLogo', () => {
       />
     );
 
-    expect(queryAllByTestId(/^publisher-logo/)).toHaveLength(
-      formattedPublisherLogos.length
-    );
+    expect(queryAllByRole('img')).toHaveLength(formattedPublisherLogos.length);
   });
 
   it('should render a button to remove publisherLogos aside from the default logo', () => {

--- a/assets/src/dashboard/app/views/editorSettings/test/editorSettings.js
+++ b/assets/src/dashboard/app/views/editorSettings/test/editorSettings.js
@@ -132,7 +132,7 @@ describe('Editor Settings: <Editor Settings />', function () {
         logos={rawPublisherLogos}
       />
     );
-    expect(queryAllByTestId(/^publisher-logo/)).toHaveLength(
+    expect(queryAllByTestId(/^publisher-logo-/)).toHaveLength(
       publisherLogoIds.length
     );
 

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -167,7 +167,6 @@ function CardGallery({ story, isRTL, galleryLabel }) {
                 width={miniWrapperSize.width}
               >
                 <MiniCardButton
-                  gridRef={gridRef}
                   isSelected={isCurrentPage}
                   tabIndex={isActive ? 0 : -1}
                   {...miniWrapperSize}


### PR DESCRIPTION
## Summary

Allows easy traversing of publisher logos grid on settings page of dashboard. Previously, you would get to the uploaded logos and have to tab through each 'remove' button to get to the upload component. Now the logos exist as a single group. You tab to the group and use the arrow keys to navigate through the logos, hitting 'enter' or 'space' will focus into that logo and allow you to 'tab' to the remove button. This increases accessibility through labels, clears the path for more complicated navigation as we build on options to edit or replace a logo not just remove, and ensures that focus doesn't get trapped or require excessive tabbing.  

## Relevant Technical Choices

- uses shared util `useGridViewKeys` established from edit-story when adding keyboard nav to detail template gallery view. 
- updates css positioning to allow each grid item to be a button without nesting buttons 
- fixes issue with `undefined` `orderedPublisherLogos` getting sent to `<PublisherLogos />` by filtering after mapping - depending on how many logos a user has it won't return all of them which can cause some 'undefined' mapping. 
- inside of `PublisherLogos` I am storing a memoized `publisherLogosById` because i want to store the length of that array as state and update it accordingly to decide when to actually adjust  the logo focus if an item is removed or not since there's a confirmation dialog. There's a change that the action is cancelled and the focus should stay put. using the length of `publisherLogosById` and the `indexRemoved` from the initial action of starting the remove process signal the `useEffect` hook that focus should be moved. Then that memoized array of logo ids is used to update where the focus is for the `itemRefs.current` object. That's the only weird thing here. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

User can now navigate through publisher logos using arrow keys and tab to exit the grid without reaching the end of the uploaded logos 

## Testing Instructions

- Karma and unit tests are updated, validate that they run locally. 
- Storybook is updated, see that keyboard functionality is present here: Dashboard/Views/EditorSettings/PublisherLogo/Default (dashboard-views-editorsettings-publisherlogo--default) 
- Enable the `enableSettingsView` flag and log in as an admin to the dashboard, see that you can use arrow keys to traverse your uploaded publisher logos. 

Functionality should be: 
- Tab to the grid of uploaded logos 
- Tab again, go to the upload component (out of the uploaded logos grid) 
- Shift + Tab, go back to the first uploaded logo (if you have a default set logo, there isn't a remove button on it, default logo should be the first logo in the grid if one is set) 
- Use your arrow keys to move around the logos. If you have more than 1 row of logos in the grid you can use the arrowDown button to get to that second row, etc. 
- Land on a logo, hit 'enter' or 'space' to update focus to that grid item. Now you can hit 'tab' again and the keyboard focus moves inside the logo to the remove button. Now you can hit 'enter' or 'space' again and the remove dialog will appear. 
- If you 'cancel' the removal the dialog will close and the focus will remain on that button you just hit 'enter' or 'space' on. 
- If you continue and click 'remove logo' then the dialog will close and the logo will remove and your focus will shift to the logo preceding the one you just deleted. 
- If you delete the first logo (in cases where you have no default logo set) and it is your only logo then the focus will move to the file upload input.
- If you delete the first logo (in cases where you have no default logo set) and there's another logo after it, that logo will get the focus. 
- Also, if you only have 1 logo then when you tab from the logo itself it'll tab to the delete button since there's no group for it to assert itself into. 

![safari keyboard remove logo](https://user-images.githubusercontent.com/10720454/91884222-83b29a80-ec3a-11ea-9667-f6627eef288b.gif)



---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4203 
