### PR TITLE
Dashboard: Added tab support to story list view

### DIFF
--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -1086,7 +1086,7 @@ describe('List view', () => {
     });
   });
 
-  describe('CUJ: Creator can navigate list view using keyboard', () => {
+  describe('CUJ: Creator can navigate list view using keyboard: Tab through each story in the list', () => {
     let storiesSortedByModified = [];
 
     beforeEach(async () => {

--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -497,6 +497,14 @@ describe('List view', () => {
     return users;
   }
 
+  function isElementVisible(element) {
+    return Boolean(
+      element.offsetWidth ||
+        element.offsetHeight ||
+        element.getClientRects().length
+    );
+  }
+
   describe('CUJ: Creator can view their stories in list view: See stories in list view', () => {
     it('should switch to List View', async () => {
       const listViewButton = fixture.screen.getByLabelText(
@@ -1075,6 +1083,69 @@ describe('List view', () => {
       });
 
       expect(wpListViewLink).toBeTruthy();
+    });
+  });
+
+  describe('CUJ: Creator can navigate list view using keyboard', () => {
+    let storiesSortedByModified = [];
+
+    beforeEach(async () => {
+      const { stories, storiesOrderById } = await getStoriesState();
+      storiesSortedByModified = storiesOrderById.map((id) => stories[id]);
+
+      const listViewButton = fixture.screen.getByLabelText(
+        new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
+      );
+
+      // switch to list view
+      await fixture.events.click(listViewButton);
+
+      // place focus on last modified header
+      const lastModifiedHeader = fixture.screen.getByText(/^Last Modified/);
+      await fixture.events.focus(lastModifiedHeader);
+    });
+
+    it('should be able to tab to story title', async () => {
+      // tabbing from Last Modified should get us to title
+      await fixture.events.keyboard.press('Tab');
+
+      const title = await document.activeElement.innerText;
+      expect(title).toContain(storiesSortedByModified[0].title);
+    });
+
+    it('should be able to tab to story menu control', async () => {
+      // drop the header row using slice
+      const rows = fixture.screen.getAllByRole('row').slice(1);
+      const { getByText } = within(rows[0]);
+
+      // Rename shouldn't be found until menu is open
+      expect(isElementVisible(getByText(/^Rename/))).toBeFalse();
+
+      // tabbing from Last Modified should get us to title
+      await fixture.events.keyboard.press('Tab');
+
+      // tabbing from title should move to menu control
+      await fixture.events.keyboard.press('Tab');
+
+      // hitting enter should open menu
+      await fixture.events.keyboard.press('Enter');
+
+      // Rename should be findable
+      expect(isElementVisible(getByText(/^Rename/))).toBeTrue();
+    });
+
+    it('should be able to tab to another story title', async () => {
+      // tabbing from Last Modified should get us to title
+      await fixture.events.keyboard.press('Tab');
+
+      // tabbing from title should move to menu control
+      await fixture.events.keyboard.press('Tab');
+
+      // tabbing from menu control should move to next story title
+      await fixture.events.keyboard.press('Tab');
+
+      const title = await document.activeElement.innerText;
+      expect(title).toContain(storiesSortedByModified[1].title);
     });
   });
 });

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -116,6 +116,18 @@ const SelectableTitle = styled.span.attrs({ tabIndex: 0 })`
   cursor: pointer;
 `;
 
+const SelectableParagraph = styled(Paragraph2).attrs({
+  tabIndex: 0,
+  onFocus: onFocusSelectAll,
+  onBlur: onBlurDeselectAll,
+})``;
+
+const StyledTableRow = styled(TableRow)`
+  &:hover ${MoreVerticalButton}, &:focus-within ${MoreVerticalButton} {
+    opacity: 1;
+  }
+`;
+
 const TitleTableCellContainer = styled.div`
   display: flex;
   align-items: center;
@@ -135,9 +147,18 @@ const toggleSortLookup = {
   [SORT_DIRECTION.ASC]: SORT_DIRECTION.DESC,
 };
 
-const titleFormatted = (rawTitle) => {
+function titleFormatted(rawTitle) {
   return rawTitle === '' ? __('(no title)', 'web-stories') : rawTitle;
-};
+}
+
+function onFocusSelectAll(e) {
+  window.getSelection().selectAllChildren(e.target);
+}
+
+function onBlurDeselectAll() {
+  window.getSelection().removeAllRanges();
+}
+
 export default function StoryListView({
   handleSortChange,
   handleSortDirectionChange,
@@ -171,6 +192,7 @@ export default function StoryListView({
     },
     [onSortTitleSelected]
   );
+
   return (
     <ListView data-testid="story-list-view">
       <Table>
@@ -267,7 +289,7 @@ export default function StoryListView({
             });
 
             return (
-              <TableRow key={`story-${story.id}`}>
+              <StyledTableRow key={`story-${story.id}`}>
                 <TablePreviewCell>
                   <PreviewContainer>
                     <PreviewErrorBoundary>
@@ -289,7 +311,9 @@ export default function StoryListView({
                       />
                     ) : (
                       <>
-                        <Paragraph2>{titleFormatted(story.title)}</Paragraph2>
+                        <SelectableParagraph>
+                          {titleFormatted(story.title)}
+                        </SelectableParagraph>
                         <StoryMenu
                           onMoreButtonSelected={storyMenu.handleMenuToggle}
                           contextMenuId={storyMenu.contextMenuId}
@@ -317,7 +341,7 @@ export default function StoryListView({
                       __('Scheduled', 'web-stories')}
                   </TableStatusCell>
                 )}
-              </TableRow>
+              </StyledTableRow>
             );
           })}
         </TableBody>

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -24,9 +24,11 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { KEYS } from '../../constants';
+import { KEYS, STORY_CONTEXT_MENU_ACTIONS } from '../../constants';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
 import { TypographyPresets } from '../typography';
+
+const CLOSE_MENU_ACTION = { value: STORY_CONTEXT_MENU_ACTIONS.CLOSE };
 
 export const MenuContainer = styled.ul`
   align-items: flex-start;
@@ -75,7 +77,7 @@ export const MenuItem = styled.li`
     &:focus, &:active, &:hover {
       color: ${isDisabled ? theme.colors.gray400 : theme.colors.gray700};
     }
-  
+
   `}
 `;
 
@@ -130,7 +132,7 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
             event.preventDefault();
             if (onSelect) {
               // Close menu
-              onSelect(-1);
+              onSelect(CLOSE_MENU_ACTION);
             }
             break;
 

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -20,6 +20,7 @@
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
+
 /**
  * Internal dependencies
  */
@@ -47,6 +48,7 @@ export const MenuContainer = styled.ul`
     }
   }
 `;
+
 MenuContainer.propTypes = {
   isOpen: PropTypes.bool,
 };
@@ -121,6 +123,14 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
             event.preventDefault();
             if (onSelect) {
               onSelect(items[hoveredIndex]);
+            }
+            break;
+
+          case KEYS.ESC:
+            event.preventDefault();
+            if (onSelect) {
+              // Close menu
+              onSelect(-1);
             }
             break;
 

--- a/assets/src/dashboard/components/storyMenu/index.js
+++ b/assets/src/dashboard/components/storyMenu/index.js
@@ -59,6 +59,7 @@ const MenuContainer = styled.div`
     margin: 0; /* 0 out margin that is needed by default on other instances of popover menus */
   }
 `;
+
 MenuContainer.propTypes = {
   verticalAlign: PropTypes.oneOf(['center', 'flex-start', 'flex-end']),
 };

--- a/assets/src/dashboard/constants/components.js
+++ b/assets/src/dashboard/constants/components.js
@@ -44,6 +44,7 @@ export const DROPDOWN_TYPES = {
 
 export const KEYS = {
   ENTER: 'Enter',
+  ESC: 'Escape',
   UP: 'ArrowUp',
   DOWN: 'ArrowDown',
 };

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -30,6 +30,7 @@ export const STORY_CONTEXT_MENU_ACTIONS = {
   DELETE: 'delete-story-action',
   COPY_STORY_LINK: 'copy-story-link',
   OPEN_STORY_LINK: 'open-story-link',
+  CLOSE: 'close-menu',
 };
 
 export const STORY_CONTEXT_MENU_ITEMS = [

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -104,7 +104,7 @@ export const StoryMenuPropType = PropTypes.shape({
   menuItems: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,
-      value: PropTypes.oneOfType[(PropTypes.string, PropTypes.bool)],
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
       url: PropTypes.string,
     })
   ),
@@ -134,6 +134,6 @@ export const ToastMessagesPropType = PropTypes.arrayOf(ToastMessagePropType);
 export const DateSettingsPropType = PropTypes.shape({
   dateFormat: PropTypes.string,
   timeFormat: PropTypes.string,
-  gmtOffset: PropTypes.number,
+  gmtOffset: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   timezone: PropTypes.string,
 });

--- a/assets/src/date/getRelativeDisplayDate.js
+++ b/assets/src/date/getRelativeDisplayDate.js
@@ -64,5 +64,5 @@ export function getRelativeDisplayDate(
 
   const fmt = new DateFormatter();
 
-  return fmt.formatDate(date.toDate(), dateSettings.dateFormat);
+  return fmt.formatDate(displayDate.toDate(), dateSettings.dateFormat);
 }

--- a/assets/src/date/test/getRelativeDisplayDate.js
+++ b/assets/src/date/test/getRelativeDisplayDate.js
@@ -157,6 +157,18 @@ describe('date/getRelativeDisplayDate', () => {
     expect(formattedDate).toBe('Sat 05 02 2020');
   });
 
+  it('should correctly format a string date', () => {
+    const dateString = '2020-05-02T10:47:26';
+    const formattedDate = getRelativeDisplayDate(dateString, {
+      dateFormat: 'm/d/Y',
+      gmtOffset: -7,
+      timeFormat: 'g:i A',
+      timezone: 'America/Los_Angeles',
+    });
+
+    expect(formattedDate).toBe('05/02/2020');
+  });
+
   it('should return an empty string with a null date', () => {
     const formattedDate = getRelativeDisplayDate(null, {
       dateFormat: 'F j, Y',


### PR DESCRIPTION
## Summary

This PR adds keyboard navigation to the Dashboard list view page.

## Relevant Technical Choices

I decided to make only the `title` and `option menu` tab-able because it didn't seem as useful to be able to tab through to the author, date created, or last modified (especially if you want to tab through the list, having to tab 5 times to get to the next story didn't seem to make sense).  However, if y'all think we should make the other columns tab-able, let me know, it'll be quick to add.

I also added a little logic so when you tab into the `title` field, the title is auto-selected so a user can easily tab into a title, click `cmd + c` and voila, title copied to clipboard!

And finally, I added in some karma tests to showcase the tabbing support.

## User-facing changes

When viewing "My Stories" in the list view, you should be able to click `tab` to tab through all the stories in the table.

## Testing Instructions

1.) Go to "My Stories".
2.) Click on the "Switch to List View" button.
3.) Click `tab` a bunch and see that you can navigate into each story.

- If you tab into a title, the title should be auto-selected for easy copying
- If you tab into the option menu, clicking `enter` should open the menu (up/down arrows navigate the menu, enter selects the option, and hitting `esc` with the menu open, closes it).
- You should be able to tab all the way to the bottom and force more stories to load until all stories are loaded.

Fixes #4200 

## Screenshot

Tabbing through and opening/closing option menu:
![list_view_tab](https://user-images.githubusercontent.com/40646372/92008285-d43dfc80-ecfb-11ea-9f97-f6a7de7cfdf9.gif)

