### PR TITLE
Dashboard: Add checks for logos dimensions

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -37,8 +37,8 @@ import { Main, Wrapper } from './components';
 import PublisherLogoSettings from './publisherLogo';
 
 const ACTIVE_DIALOG_REMOVE_LOGO = 'REMOVE_LOGO';
-const minHeight = 96;
-const minWidth = 96;
+const MIN_IMG_HEIGHT = 96;
+const MIN_IMG_WIDTH = 96;
 
 function EditorSettings() {
   const {
@@ -184,7 +184,8 @@ function EditorSettings() {
       }
 
       const allFileDimensionsValid = images.every(
-        ({ height, width }) => height >= minHeight && width >= minWidth
+        ({ height, width }) =>
+          height >= MIN_IMG_HEIGHT && width >= MIN_IMG_WIDTH
       );
 
       if (!allFileDimensionsValid) {
@@ -196,8 +197,8 @@ function EditorSettings() {
                   "Sorry, this file's dimensions are too small. Make sure your logo is larger than %1$dx%2$d.",
                   'web-stories'
                 ),
-                minWidth,
-                minHeight
+                MIN_IMG_WIDTH,
+                MIN_IMG_HEIGHT
               )
             : sprintf(
                 /* translators: 1 = minimum width, 2 = minimum height */
@@ -205,8 +206,8 @@ function EditorSettings() {
                   "Sorry, one or more of these files dimension's are too small. Make sure your logos are all larger than %1$dx%2$d.",
                   'web-stories'
                 ),
-                minWidth,
-                minHeight
+                MIN_IMG_WIDTH,
+                MIN_IMG_HEIGHT
               );
         return setMediaError(errorText);
       }

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -201,13 +201,12 @@ function EditorSettings() {
                 MIN_IMG_HEIGHT
               )
             : sprintf(
-                /* translators: 1 = minimum width, 2 = minimum height */
+                /* translators: %s: image dimensions in pixels. */
                 __(
-                  "Sorry, one or more of these files dimension's are too small. Make sure your logos are all larger than %1$dx%2$d.",
+                  'Sorry, one or more files are too small. Make sure your logos are all larger than %s.',
                   'web-stories'
                 ),
-                MIN_IMG_WIDTH,
-                MIN_IMG_HEIGHT
+                sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)
               );
         return setMediaError(errorText);
       }

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -194,11 +194,10 @@ function EditorSettings() {
             ? sprintf(
                 /* translators: 1 = minimum width, 2 = minimum height */
                 __(
-                  "Sorry, this file's dimensions are too small. Make sure your logo is larger than %1$dx%2$d.",
+                  'Sorry, this file is too small. Make sure your logo is larger than %s.",
                   'web-stories'
                 ),
-                MIN_IMG_WIDTH,
-                MIN_IMG_HEIGHT
+                sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)
               )
             : sprintf(
                 /* translators: %s: image dimensions in pixels. */

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -124,7 +124,6 @@ function EditorSettings() {
   const handleAddLogos = useCallback(
     async (files) => {
       let allFileSizesWithinMaxUpload = true;
-      let allFileDimensionsWithinMinSize = true;
       let errorProcessingImages = false;
       let imagePromises = [];
 
@@ -184,13 +183,11 @@ function EditorSettings() {
         return setMediaError(errorText);
       }
 
-      allFileDimensionsWithinMinSize =
-        allFileDimensionsWithinMinSize &&
-        images.every(
-          ({ height, width }) => height >= minHeight && width >= minWidth
-        );
+      const allFileDimensionsValid = images.every(
+        ({ height, width }) => height >= minHeight && width >= minWidth
+      );
 
-      if (!allFileDimensionsWithinMinSize) {
+      if (!allFileDimensionsValid) {
         const errorText =
           files.length === 1
             ? sprintf(

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -29,7 +29,11 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import useApi from '../../api/useApi';
 import { Layout, Dialog, Button } from '../../../components';
-import { BUTTON_TYPES } from '../../../constants';
+import {
+  BUTTON_TYPES,
+  MIN_IMG_WIDTH,
+  MIN_IMG_HEIGHT,
+} from '../../../constants';
 import { useConfig } from '../../config';
 import { PageHeading } from '../shared';
 import GoogleAnalyticsSettings from './googleAnalytics';
@@ -37,8 +41,6 @@ import { Main, Wrapper } from './components';
 import PublisherLogoSettings from './publisherLogo';
 
 const ACTIVE_DIALOG_REMOVE_LOGO = 'REMOVE_LOGO';
-const MIN_IMG_HEIGHT = 96;
-const MIN_IMG_WIDTH = 96;
 
 function EditorSettings() {
   const {
@@ -194,7 +196,7 @@ function EditorSettings() {
             ? sprintf(
                 /* translators: 1 = minimum width, 2 = minimum height */
                 __(
-                  'Sorry, this file is too small. Make sure your logo is larger than %s.",
+                  'Sorry, this file is too small. Make sure your logo is larger than %s.',
                   'web-stories'
                 ),
                 sprintf('%1$dx%2$dpx', MIN_IMG_WIDTH, MIN_IMG_HEIGHT)

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -126,6 +126,9 @@ export const STORIES_PER_REQUEST = 24;
 
 export const DEFAULT_DATE_FORMAT = 'Y-m-d';
 
+export const MIN_IMG_HEIGHT = 96;
+export const MIN_IMG_WIDTH = 96;
+
 export * from './components';
 export * from './direction';
 export * from './pageStructure';


### PR DESCRIPTION
## Summary

Adds error messages in the case that uploaded logos are smaller than 96x96.

## User-facing changes

- If you upload one image, and it is smaller than 96x96, the following error message will display: `Sorry, this file's dimensions are too small. Make sure your logo is larger than 96x96.`
- If you upload two or more images, and one or more are smaller than 96x96, the following error message will display: `Sorry, one or more of these files dimension's are too small. Make sure your logos are all larger than 96x96.`

## Testing Instructions

- Upload a single image that is smaller than 96x96 and verify that you see the first error message above.
- Upload two or more images, where at least one is smaller than 96x96, and verify that you see the second 


<!-- Please reference the issue(s) this PR addresses. -->

#4147 
