### PR TITLE
Media: Remove crossorigin attribute from videos to fix poster caching

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
@@ -406,8 +406,6 @@ function getInnerElement(
           aria-label={alt}
           muted
           onClick={onClick(poster)}
-          // crossorigin='anonymous' is required to play videos from other domains.
-          crossOrigin="anonymous"
           {...dropTargetsBindings(poster)}
         >
           <source

--- a/assets/src/edit-story/elements/video/display.js
+++ b/assets/src/edit-story/elements/video/display.js
@@ -90,8 +90,6 @@ function VideoDisplay({ previewMode, box: { width, height }, element }) {
           {...videoProps}
           loop={loop}
           preload="none"
-          // crossorigin='anonymous' is required to play videos from other domains.
-          crossOrigin="anonymous"
           ref={ref}
         >
           <source src={resource.src} type={resource.mimeType} />

--- a/assets/src/edit-story/elements/video/output.js
+++ b/assets/src/edit-story/elements/video/output.js
@@ -45,11 +45,7 @@ function VideoOutput({ element, box }) {
   // crossorigin='anonymous' is required to play videos from other domains.
   return (
     <MediaOutput element={element} box={box}>
-      <amp-video
-        {...props}
-        id={`el-${element.id}-media`}
-        crossorigin="anonymous"
-      >
+      <amp-video {...props} id={`el-${element.id}-media`}>
         <source {...sourceProps} />
       </amp-video>
     </MediaOutput>

--- a/assets/src/edit-story/output/test/page.js
+++ b/assets/src/edit-story/output/test/page.js
@@ -351,7 +351,6 @@ describe('Page output', () => {
         <amp-video
           artwork="https://example.com/poster.png"
           autoplay="autoplay"
-          crossorigin="anonymous"
           id="el-baz-media"
           layout="fill"
           poster="https://example.com/poster.png"


### PR DESCRIPTION
## Summary

Remove crossorigin attribute from videos, to fix Coverr video poster caching.

## Relevant Technical Choices

A combination of the 301 redirect and 'crossorigin' <video> attribute causes caching to stop working for video posters. crossorigin was added to allow videos to be played from non-origin sites (ie. Coverr), but this doesn't seem to be needed now.

## User-facing changes

Faster loading of Coverr videos.

## Testing Instructions

* Make sure Coverr and locally uploaded videos can still be previewed in the gallery, previewed on the canvas and played back in AMP.
* Tested on Chrome, Firefox, Safari and Microsoft Edge.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4208
