### PR TITLE
Dashboard: enable arrow key navigation on stories grid

### DIFF
--- a/assets/src/dashboard/app/views/myStories/content/stories/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/stories/index.js
@@ -25,7 +25,7 @@ import { FlagsProvider } from 'flagged';
 /**
  * Internal dependencies
  */
-import { Layout } from '../../../../../components';
+import { Layout, ToastProvider } from '../../../../../components';
 import {
   STORY_SORT_OPTIONS,
   SORT_DIRECTION,
@@ -106,20 +106,24 @@ export const _default = () => {
 
   return (
     <FlagsProvider features={{ enableInProgressStoryActions: false }}>
-      <Layout.Provider>
-        <StorybookLayoutContainer>
-          <Content {...defaultProps} view={{ ...view, pageSize }} />
-        </StorybookLayoutContainer>
-      </Layout.Provider>
+      <ToastProvider>
+        <Layout.Provider>
+          <StorybookLayoutContainer>
+            <Content {...defaultProps} view={{ ...view, pageSize }} />
+          </StorybookLayoutContainer>
+        </Layout.Provider>
+      </ToastProvider>
     </FlagsProvider>
   );
 };
 
 export const NoStories = () => (
   <Layout.Provider>
-    <StorybookLayoutContainer>
-      <Content {...defaultProps} stories={[]} />
-    </StorybookLayoutContainer>
+    <ToastProvider>
+      <StorybookLayoutContainer>
+        <Content {...defaultProps} stories={[]} />
+      </StorybookLayoutContainer>
+    </ToastProvider>
   </Layout.Provider>
 );
 
@@ -129,15 +133,17 @@ export const AllDataFetched = () => {
   });
   return (
     <FlagsProvider features={{ enableInProgressStoryActions: false }}>
-      <Layout.Provider>
-        <StorybookLayoutContainer>
-          <Content
-            {...defaultProps}
-            allPagesFetched={true}
-            view={{ ...view, pageSize }}
-          />
-        </StorybookLayoutContainer>
-      </Layout.Provider>
+      <ToastProvider>
+        <Layout.Provider>
+          <StorybookLayoutContainer>
+            <Content
+              {...defaultProps}
+              allPagesFetched={true}
+              view={{ ...view, pageSize }}
+            />
+          </StorybookLayoutContainer>
+        </Layout.Provider>
+      </ToastProvider>
     </FlagsProvider>
   );
 };
@@ -148,44 +154,50 @@ export const AllDataFetchedAsList = () => {
   });
   return (
     <FlagsProvider features={{ enableInProgressStoryActions: false }}>
-      <Layout.Provider>
-        <StorybookLayoutContainer>
-          <Content
-            {...defaultProps}
-            allPagesFetched={true}
-            view={{ ...view, style: VIEW_STYLE.LIST, pageSize }}
-          />
-        </StorybookLayoutContainer>
-      </Layout.Provider>
+      <ToastProvider>
+        <Layout.Provider>
+          <StorybookLayoutContainer>
+            <Content
+              {...defaultProps}
+              allPagesFetched={true}
+              view={{ ...view, style: VIEW_STYLE.LIST, pageSize }}
+            />
+          </StorybookLayoutContainer>
+        </Layout.Provider>
+      </ToastProvider>
     </FlagsProvider>
   );
 };
 
 export const _StoriesViewGrid = () => (
   <FlagsProvider features={{ enableInProgressStoryActions: false }}>
-    <StoriesView
-      filterValue={STORY_STATUS.ALL}
-      sort={sort}
-      storyActions={storyActions}
-      stories={formattedStoriesArray}
-      users={formattedUsersObject}
-      view={view}
-      dateSettings={fillerDateSettingsObject}
-    />
+    <ToastProvider>
+      <StoriesView
+        filterValue={STORY_STATUS.ALL}
+        sort={sort}
+        storyActions={storyActions}
+        stories={formattedStoriesArray}
+        users={formattedUsersObject}
+        view={view}
+        dateSettings={fillerDateSettingsObject}
+      />
+    </ToastProvider>
   </FlagsProvider>
 );
 
 export const _StoriesViewList = () => (
   <FlagsProvider features={{ enableInProgressStoryActions: false }}>
-    <StoriesView
-      filterValue={STORY_STATUS.ALL}
-      sort={sort}
-      storyActions={storyActions}
-      stories={formattedStoriesArray}
-      users={formattedUsersObject}
-      view={{ ...view, style: VIEW_STYLE.LIST }}
-      dateSettings={fillerDateSettingsObject}
-    />
+    <ToastProvider>
+      <StoriesView
+        filterValue={STORY_STATUS.ALL}
+        sort={sort}
+        storyActions={storyActions}
+        stories={formattedStoriesArray}
+        users={formattedUsersObject}
+        view={{ ...view, style: VIEW_STYLE.LIST }}
+        dateSettings={fillerDateSettingsObject}
+      />
+    </ToastProvider>
   </FlagsProvider>
 );
 

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -140,9 +140,6 @@ function StoriesView({
           });
           break;
 
-        case STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK:
-          window.open(sender.url, '_blank', 'noopener');
-          break;
         default:
           break;
       }

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -140,6 +140,9 @@ function StoriesView({
           });
           break;
 
+        case STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK:
+          window.open(sender.url, '_blank', 'noopener');
+          break;
         default:
           break;
       }

--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -390,31 +390,12 @@ describe('Grid view', () => {
       await fixture.render();
     });
 
-    it('should trigger template preview when user clicks a card', async () => {
-      const { storiesOrderById } = await getStoriesState();
-
-      const currentCard = await getGridElementById(storiesOrderById[1]);
-      const utils = within(currentCard);
-
-      const activeCard = utils.getByTestId('card-action-container');
-      expect(activeCard).toBeTruthy();
-
-      const { x, y } = activeCard.getBoundingClientRect();
-
-      // We need to click slightly above the center of the card to avoid clicking 'View'
-      await fixture.events.mouse.click(x - 20, y);
-
-      const viewPreviewStory = await fixture.screen.queryByTestId(
-        'preview-iframe'
-      );
-
-      expect(viewPreviewStory).toBeTruthy();
-    });
-
     it('should trigger story preview when user presses Enter while focused on a card', async () => {
       const gridContainer = fixture.screen.getByTestId('dashboard-grid-list');
 
       await fixture.events.focus(gridContainer);
+
+      await fixture.events.keyboard.press('right');
 
       await fixture.events.keyboard.press('tab');
 
@@ -591,11 +572,17 @@ describe('List view', () => {
 
       const storiesSortedByModified = storiesOrderById.map((id) => stories[id]);
 
+      const gridContainer = fixture.screen.getByTestId('dashboard-grid-list');
+
+      await fixture.events.focus(gridContainer);
+
       const listViewButton = fixture.screen.getByLabelText(
         new RegExp(`^${VIEW_STYLE_LABELS[VIEW_STYLE.GRID]}$`)
       );
 
       expect(listViewButton).toBeTruthy();
+
+      await fixture.events.hover(listViewButton);
 
       await fixture.events.click(listViewButton);
 

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -145,10 +145,13 @@ const StoryGridView = ({
                 }}
                 isSelected={isActive}
                 tabIndex={tabIndex}
-                ariaLabelledBy={`${story.id}_story`}
+                title={sprintf(
+                  /* translators: %s: story title.*/
+                  __('Press Enter to explore details about %s', 'web-stories'),
+                  story.title
+                )}
               />
               <CardPreviewContainer
-                id={`${story.id}_story`}
                 ariaLabel={sprintf(
                   /* translators: %s: story title.*/
                   __('preview of %s', 'web-stories'),

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -79,6 +79,7 @@ const StoryGridView = ({
   renameStory,
   dateSettings,
   previewStory,
+  returnStoryFocusId,
 }) => {
   const { isRTL } = useConfig();
   const containerRef = useRef();
@@ -94,6 +95,12 @@ const StoryGridView = ({
     currentItemId: activeGridItemId,
     items: stories,
   });
+
+  useEffect(() => {
+    if (!activeGridItemId && returnStoryFocusId) {
+      itemRefs.current?.[returnStoryFocusId]?.children[0].focus();
+    }
+  }, [activeGridItemId, returnStoryFocusId]);
 
   // when keyboard focus changes through FocusableGridItem immediately focus the edit preview layer on top of preview
   useEffect(() => {
@@ -221,6 +228,7 @@ StoryGridView.propTypes = {
   storyMenu: StoryMenuPropType,
   renameStory: RenameStoryPropType,
   dateSettings: DateSettingsPropType,
+  returnStoryFocusId: PropTypes.number,
 };
 
 export default StoryGridView;

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -45,8 +45,11 @@ import {
   DateSettingsPropType,
 } from '../../../types';
 import { STORY_STATUS, STORY_CONTEXT_MENU_ACTIONS } from '../../../constants';
-import { getRelativeDisplayDate, useGridViewKeys } from '../../../utils';
-
+import {
+  getRelativeDisplayDate,
+  useGridViewKeys,
+  useFocusOut,
+} from '../../../utils';
 import { useConfig } from '../../config';
 
 export const DetailRow = styled.div`
@@ -99,11 +102,7 @@ const StoryGridView = ({
     }
   }, [activeGridItemId]);
 
-  // useEffect(() => {
-  //   document.addEventListener('keydown', (e) => {
-  //     console.log(document.activeElement, e.currentTarget);
-  //   });
-  // }, []);
+  useFocusOut(containerRef, () => setActiveGridItemId(null), []);
 
   return (
     <div ref={containerRef}>

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -109,6 +109,7 @@ const StoryGridView = ({
       <StoryGrid
         pageSize={pageSize}
         ref={gridRef}
+        role="list"
         ariaLabel={__('Viewing stories', 'web-stories')}
       >
         {stories.map((story) => {
@@ -134,6 +135,7 @@ const StoryGridView = ({
             <CardGridItem
               key={story.id}
               data-testid={`story-grid-item-${story.id}`}
+              role="listitem"
               ref={(el) => {
                 itemRefs.current[story.id] = el;
               }}

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -98,7 +98,7 @@ const StoryGridView = ({
 
   useEffect(() => {
     if (!activeGridItemId && returnStoryFocusId) {
-      itemRefs.current?.[returnStoryFocusId]?.children[0].focus();
+      itemRefs.current?.[returnStoryFocusId]?.children?.[0]?.focus();
     }
   }, [activeGridItemId, returnStoryFocusId]);
 

--- a/assets/src/dashboard/components/cardGrid/stories/index.js
+++ b/assets/src/dashboard/components/cardGrid/stories/index.js
@@ -64,6 +64,7 @@ const StorybookGridItem = (
       displayDate={moment().subtract(2, 'minutes')}
       onEditCancel={() => {}}
       onEditComplete={() => {}}
+      tabIndex={0}
     />
   </CardGridItem>
 );

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -80,6 +80,7 @@ const CardTitle = ({
   editMode,
   onEditComplete,
   onEditCancel,
+  tabIndex,
 }) => {
   const displayDateText = useMemo(() => {
     if (!displayDate) {
@@ -124,7 +125,7 @@ const CardTitle = ({
           label={__('Rename story', 'web-stories')}
         />
       ) : (
-        <TitleStoryLink href={titleLink}>
+        <TitleStoryLink href={titleLink} tabIndex={tabIndex}>
           {titleFormatted(title)}
         </TitleStoryLink>
       )}
@@ -149,6 +150,7 @@ CardTitle.propTypes = {
   displayDate: PropTypes.string,
   onEditComplete: PropTypes.func,
   onEditCancel: PropTypes.func,
+  tabIndex: PropTypes.number,
 };
 
 export default CardTitle;

--- a/assets/src/dashboard/components/cardGridItem/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/cardTitle.js
@@ -125,7 +125,15 @@ const CardTitle = ({
           label={__('Rename story', 'web-stories')}
         />
       ) : (
-        <TitleStoryLink href={titleLink} tabIndex={tabIndex}>
+        <TitleStoryLink
+          href={titleLink}
+          tabIndex={tabIndex}
+          aria-label={sprintf(
+            /* translators: %s: title*/
+            __('Open %s in editor', 'web-stories'),
+            title
+          )}
+        >
           {titleFormatted(title)}
         </TitleStoryLink>
       )}

--- a/assets/src/dashboard/components/cardGridItem/stories/index.js
+++ b/assets/src/dashboard/components/cardGridItem/stories/index.js
@@ -71,6 +71,7 @@ export const _default = () => {
           status={STORY_STATUS.DRAFT}
           onEditCancel={() => {}}
           onEditComplete={() => {}}
+          tabIndex={0}
         />
       </CardGridItem>
     </CardGrid>
@@ -102,6 +103,7 @@ export const _publishedStory = () => {
           status={STORY_STATUS.PUBLISH}
           onEditCancel={() => {}}
           onEditComplete={() => {}}
+          tabIndex={0}
         />
       </CardGridItem>
     </CardGrid>

--- a/assets/src/dashboard/components/cardGridItem/test/cardTitle.js
+++ b/assets/src/dashboard/components/cardGridItem/test/cardTitle.js
@@ -35,6 +35,7 @@ describe('CardTitle', () => {
         onEditCancel={jest.fn}
         onEditComplete={jest.fn}
         editMode={false}
+        tabIndex={0}
       />
     );
 
@@ -51,6 +52,7 @@ describe('CardTitle', () => {
         onEditComplete={jest.fn}
         editMode={true}
         id="sampleStoryId"
+        tabIndex={0}
       />
     );
     const titleInput = getByDisplayValue('Sample Story');
@@ -69,6 +71,7 @@ describe('CardTitle', () => {
         onEditCancel={jest.fn}
         onEditComplete={jest.fn}
         editMode={false}
+        tabIndex={0}
       />
     );
 
@@ -84,6 +87,7 @@ describe('CardTitle', () => {
         onEditCancel={jest.fn}
         onEditComplete={jest.fn}
         editMode={false}
+        tabIndex={0}
       />
     );
 
@@ -99,6 +103,7 @@ describe('CardTitle', () => {
         onEditCancel={jest.fn}
         onEditComplete={jest.fn}
         editMode={false}
+        tabIndex={0}
       />
     );
 
@@ -113,6 +118,7 @@ describe('CardTitle', () => {
         displayDate={moment('01/20/2020', 'MM/DD/YYYY')}
         onEditCancel={jest.fn}
         onEditComplete={jest.fn}
+        tabIndex={0}
       />
     );
 

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -97,6 +97,7 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
   useEffect(() => {
     if (isOpen) {
       const handleKeyDown = (event) => {
+        event.stopPropagation();
         switch (event.key) {
           case KEYS.UP:
             event.preventDefault();
@@ -137,7 +138,7 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
 
   useEffect(() => {
     if (listRef.current && isOpen) {
-      listRef.current[currentValueIndex]?.focus();
+      listRef.current?.children[0].focus();
     }
     setHoveredIndex(currentValueIndex);
   }, [currentValueIndex, isOpen]);
@@ -176,7 +177,11 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
   );
 
   return (
-    <MenuContainer ref={listRef}>
+    <MenuContainer
+      tabIndex={0}
+      ref={listRef}
+      onKeyDown={(e) => e.stopPropagation()}
+    >
       {items.map((item, index) => renderMenuItem(item, index))}
     </MenuContainer>
   );

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -138,7 +138,7 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
 
   useEffect(() => {
     if (listRef.current && isOpen) {
-      listRef.current?.children[0].focus();
+      listRef.current?.children[currentValueIndex].focus();
     }
     setHoveredIndex(currentValueIndex);
   }, [currentValueIndex, isOpen]);

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -120,9 +120,12 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect }) => {
             break;
 
           case KEYS.ENTER:
-            event.preventDefault();
-            if (onSelect) {
-              onSelect(items[hoveredIndex]);
+            // let anchor items be handled natively by browser
+            if (!items[hoveredIndex].url) {
+              event.preventDefault();
+              if (onSelect) {
+                onSelect(items[hoveredIndex]);
+              }
             }
             break;
 

--- a/assets/src/dashboard/components/storyMenu/index.js
+++ b/assets/src/dashboard/components/storyMenu/index.js
@@ -35,7 +35,7 @@ export const MoreVerticalButton = styled.button`
   border: none;
   background: transparent;
   padding: 0 8px;
-  opacity: ${({ menuOpen }) => (menuOpen ? 1 : 0)};
+  opacity: ${({ menuOpen, isVisible }) => (menuOpen || isVisible ? 1 : 0)};
   transition: opacity ease-in-out 300ms;
   cursor: pointer;
   color: ${({ theme }) => theme.colors.gray900};
@@ -70,6 +70,8 @@ export default function StoryMenu({
   story,
   verticalAlign,
   menuItems,
+  itemActive,
+  tabIndex,
 }) {
   const containerRef = useRef(null);
 
@@ -85,9 +87,13 @@ export default function StoryMenu({
   return (
     <MenuContainer ref={containerRef} verticalAlign={verticalAlign}>
       <MoreVerticalButton
+        tabIndex={tabIndex}
         menuOpen={isPopoverMenuOpen}
+        isVisible={itemActive}
         aria-label="More Options"
-        onClick={() => onMoreButtonSelected(isPopoverMenuOpen ? -1 : story.id)}
+        onClick={() => {
+          onMoreButtonSelected(isPopoverMenuOpen ? -1 : story.id);
+        }}
       >
         <MoreVerticalSvg />
       </MoreVerticalButton>
@@ -101,6 +107,8 @@ export default function StoryMenu({
 }
 
 StoryMenu.propTypes = {
+  itemActive: PropTypes.bool,
+  tabIndex: PropTypes.number,
   story: StoryPropType,
   onMoreButtonSelected: PropTypes.func.isRequired,
   onMenuItemSelected: PropTypes.func.isRequired,

--- a/assets/src/dashboard/components/storyMenu/index.js
+++ b/assets/src/dashboard/components/storyMenu/index.js
@@ -91,9 +91,7 @@ export default function StoryMenu({
         menuOpen={isPopoverMenuOpen}
         isVisible={itemActive}
         aria-label="More Options"
-        onClick={() => {
-          onMoreButtonSelected(isPopoverMenuOpen ? -1 : story.id);
-        }}
+        onClick={() => onMoreButtonSelected(isPopoverMenuOpen ? -1 : story.id)}
       >
         <MoreVerticalSvg />
       </MoreVerticalButton>

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -118,8 +118,8 @@ export const STORY_STATUS = {
 };
 
 export const STORY_ITEM_CENTER_ACTION_LABELS = {
-  [STORY_STATUS.PUBLISH]: __('View', 'web-stories'),
-  [STORY_STATUS.FUTURE]: __('View', 'web-stories'),
+  [STORY_STATUS.PUBLISH]: __('Preview', 'web-stories'),
+  [STORY_STATUS.FUTURE]: __('Preview', 'web-stories'),
   [STORY_STATUS.DRAFT]: __('Preview', 'web-stories'),
 };
 


### PR DESCRIPTION
## Summary
Allows users to key into the my stories grid and use arrow keys to navigate.

## Relevant Technical Choices

- Follows same pattern as here: [#4303](https://github.com/google/web-stories-wp/pull/4303) and here: [#4317 ](https://github.com/google/web-stories-wp/pull/4317)
- Adds an invisible button to each grid item that will transfer focus to grid items according to useGridViewKeys without interrupting the grid structure and preventing nested buttons.
when new FocusableGridItem is set a useEffect hook immediately updates the focus to the actual grid item.
- Adds stopProp and/or preventDefault to keyDown handlers and onClick (for native buttons) to prevent bubbling up of events that are nested inside of the grid item so that they don't cause the grid item focus to adjust 
- Adds some extra aria labels to card items

## To-do

- return focus to proper item after closing the preview dialog
- loading more stories could be more graceful, right now you have to tab one extra time to get the loading to trigger since it's based on the loading component being visible, but think this could be done later.

## User-facing changes

Now when you are on my templates and tab to the grid you can enter the grid items by using arrow keys or tab again to exit the grid and, if you are not at the top of the browser window, jump into the scroll to top button.

Updates display text to open the preview text updated to always say "preview" not "view" if story is published, per conversation with @samitron7 9/2/2020


## Testing Instructions

- Navigate to 'My Stories' in dashboard
- Use 'Tab' to change focused element until you get to the grid. The grid should have a blue outline now.
  - Hit tab again to exit the entire grid (this can be tricky to see if the scroll to top button is not in view, but it should go there).
  - Hit the right arrow key and enter into the grid. 
    - Now you're focused on that first template
      - tab again,  the 'preview' button gains focus
      - tab again, the 'open in editor' button gains focus
      - tab again, the card title link gains focus 
      - tab again,  the context menu button gains focus
      - Hit enter to open the menu or the right arrow to move to the next grid item
      - If you open the menu, it'll gain focus. You can use the up/down arrow keys to navigate the menu. 
      - One thing to note here is right now you have to select an item to close the menu, Mariano made an update for that ( [here](https://github.com/google/web-stories-wp/pull/4309) ) which will resolve this.
- If you exit the grid and hit shift + tab, focus will be regained to whatever grid item you left off on.
- Ability to interact with grid items with a cursor should persist. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4296 
