### PR TITLE
Fix element links being removed incorrectly

### DIFF
--- a/assets/src/edit-story/output/page.js
+++ b/assets/src/edit-story/output/page.js
@@ -53,7 +53,7 @@ function OutputPage({ page, autoAdvance, defaultPageDuration }) {
 
   // Remove invalid links, @todo this should come from the pre-publish checklist in the future.
   const validElements = regularElements.map((element) =>
-    hasPageAttachment && !isElementBelowLimit(element)
+    !hasPageAttachment || !isElementBelowLimit(element)
       ? element
       : {
           ...element,

--- a/assets/src/edit-story/output/test/page.js
+++ b/assets/src/edit-story/output/test/page.js
@@ -410,6 +410,57 @@ describe('Page output', () => {
   });
 
   describe('pageAttachment', () => {
+    const BACKGROUND_ELEMENT = {
+      isBackground: true,
+      id: 'baz',
+      type: 'image',
+      mimeType: 'image/png',
+      origRatio: 1,
+      x: 50,
+      y: 100,
+      scale: 1,
+      rotationAngle: 0,
+      width: 1,
+      height: 1,
+      resource: {
+        type: 'image',
+        mimeType: 'image/png',
+        id: 123,
+        src: 'https://example.com/image.png',
+        poster: 'https://example.com/poster.png',
+        height: 1,
+        width: 1,
+      },
+    };
+
+    const TEXT_ELEMENT = {
+      id: 'baz',
+      type: 'text',
+      content: 'Hello, link!',
+      x: 50,
+      y: PAGE_HEIGHT,
+      height: 300,
+      width: 100,
+      rotationAngle: 10,
+      padding: {
+        vertical: 0,
+        horizontal: 0,
+      },
+      fontSize: 30,
+      font: {
+        family: 'Roboto',
+        service: 'fonts.google.com',
+      },
+      color: {
+        color: {
+          r: 255,
+          g: 255,
+          b: 255,
+          a: 0.5,
+        },
+      },
+    };
+
     it('should output page attachment if the URL is set', async () => {
       const props = {
         id: '123',
@@ -468,56 +519,11 @@ describe('Page output', () => {
         page: {
           id: '123',
           elements: [
+            BACKGROUND_ELEMENT,
             {
-              isBackground: true,
-              id: 'baz',
-              type: 'image',
-              mimeType: 'image/png',
-              origRatio: 1,
-              x: 50,
-              y: 100,
-              scale: 1,
-              rotationAngle: 0,
-              width: 1,
-              height: 1,
-              resource: {
-                type: 'image',
-                mimeType: 'image/png',
-                id: 123,
-                src: 'https://example.com/image.png',
-                poster: 'https://example.com/poster.png',
-                height: 1,
-                width: 1,
-              },
-            },
-            {
-              id: 'baz',
-              type: 'text',
-              content: 'Hello, link!',
-              x: 50,
-              y: PAGE_HEIGHT,
-              height: 300,
-              width: 100,
-              rotationAngle: 10,
-              padding: {
-                vertical: 0,
-                horizontal: 0,
-              },
+              ...TEXT_ELEMENT,
               link: {
                 url: 'http://shouldremove.com',
-              },
-              fontSize: 30,
-              font: {
-                family: 'Roboto',
-                service: 'fonts.google.com',
-              },
-              color: {
-                color: {
-                  r: 255,
-                  g: 255,
-                  b: 255,
-                  a: 0.5,
-                },
               },
             },
           ],
@@ -542,57 +548,14 @@ describe('Page output', () => {
         page: {
           id: '123',
           elements: [
+            BACKGROUND_ELEMENT,
             {
-              isBackground: true,
-              id: 'baz',
-              type: 'image',
-              mimeType: 'image/png',
-              origRatio: 1,
-              x: 50,
-              y: 100,
-              scale: 1,
-              rotationAngle: 0,
-              width: 1,
-              height: 1,
-              resource: {
-                type: 'image',
-                mimeType: 'image/png',
-                id: 123,
-                src: 'https://example.com/image.png',
-                poster: 'https://example.com/poster.png',
-                height: 1,
-                width: 1,
-              },
-            },
-            {
-              id: 'baz',
-              type: 'text',
-              content: 'Hello, link!',
-              x: 50,
-              y: 0,
-              height: 100,
-              width: 250,
-              rotationAngle: 10,
-              padding: {
-                vertical: 0,
-                horizontal: 0,
-              },
+              ...TEXT_ELEMENT,
               link: {
                 url: 'http://shouldoutput.com',
               },
-              fontSize: 30,
-              font: {
-                family: 'Roboto',
-                service: 'fonts.google.com',
-              },
-              color: {
-                color: {
-                  r: 255,
-                  g: 255,
-                  b: 255,
-                  a: 0.5,
-                },
-              },
+              y: 0,
+              height: 100,
             },
           ],
           pageAttachment: {
@@ -616,56 +579,11 @@ describe('Page output', () => {
         page: {
           id: '123',
           elements: [
+            BACKGROUND_ELEMENT,
             {
-              isBackground: true,
-              id: 'baz',
-              type: 'image',
-              mimeType: 'image/png',
-              origRatio: 1,
-              x: 50,
-              y: 100,
-              scale: 1,
-              rotationAngle: 0,
-              width: 1,
-              height: 1,
-              resource: {
-                type: 'image',
-                mimeType: 'image/png',
-                id: 123,
-                src: 'https://example.com/image.png',
-                poster: 'https://example.com/poster.png',
-                height: 1,
-                width: 1,
-              },
-            },
-            {
-              id: 'baz',
-              type: 'text',
-              content: 'Hello, link!',
-              x: 50,
-              y: PAGE_HEIGHT,
-              height: 300,
-              width: 100,
-              rotationAngle: 10,
-              padding: {
-                vertical: 0,
-                horizontal: 0,
-              },
+              ...TEXT_ELEMENT,
               link: {
                 url: 'http://shouldoutput.com',
-              },
-              fontSize: 30,
-              font: {
-                family: 'Roboto',
-                service: 'fonts.google.com',
-              },
-              color: {
-                color: {
-                  r: 255,
-                  g: 255,
-                  b: 255,
-                  a: 0.5,
-                },
               },
             },
           ],

--- a/assets/src/edit-story/output/test/page.js
+++ b/assets/src/edit-story/output/test/page.js
@@ -534,6 +534,77 @@ describe('Page output', () => {
       expect(content).toContain('Hello, link');
       expect(content).not.toContain('http://shouldremove.com');
     });
+
+    it('should output a link in page attachment area if page attachment is not set', () => {
+      const props = {
+        id: '123',
+        backgroundColor: { color: { r: 255, g: 255, b: 255 } },
+        page: {
+          id: '123',
+          elements: [
+            {
+              isBackground: true,
+              id: 'baz',
+              type: 'image',
+              mimeType: 'image/png',
+              origRatio: 1,
+              x: 50,
+              y: 100,
+              scale: 1,
+              rotationAngle: 0,
+              width: 1,
+              height: 1,
+              resource: {
+                type: 'image',
+                mimeType: 'image/png',
+                id: 123,
+                src: 'https://example.com/image.png',
+                poster: 'https://example.com/poster.png',
+                height: 1,
+                width: 1,
+              },
+            },
+            {
+              id: 'baz',
+              type: 'text',
+              content: 'Hello, link!',
+              x: 50,
+              y: PAGE_HEIGHT,
+              height: 300,
+              width: 100,
+              rotationAngle: 10,
+              padding: {
+                vertical: 0,
+                horizontal: 0,
+              },
+              link: {
+                url: 'http://shouldoutput.com',
+              },
+              fontSize: 30,
+              font: {
+                family: 'Roboto',
+                service: 'fonts.google.com',
+              },
+              color: {
+                color: {
+                  r: 255,
+                  g: 255,
+                  b: 255,
+                  a: 0.5,
+                },
+              },
+            },
+          ],
+          pageAttachment: null,
+        },
+        autoAdvance: false,
+        defaultPageDuration: 7,
+      };
+
+      const content = renderToStaticMarkup(<PageOutput {...props} />);
+      expect(content).toContain('Hello, link');
+      expect(content).toContain('http://shouldoutput.com');
+    });
   });
 
   describe('AMP validation', () => {

--- a/assets/src/edit-story/output/test/page.js
+++ b/assets/src/edit-story/output/test/page.js
@@ -535,6 +535,80 @@ describe('Page output', () => {
       expect(content).not.toContain('http://shouldremove.com');
     });
 
+    it('should output a link outside of page attachment area', () => {
+      const props = {
+        id: '123',
+        backgroundColor: { color: { r: 255, g: 255, b: 255 } },
+        page: {
+          id: '123',
+          elements: [
+            {
+              isBackground: true,
+              id: 'baz',
+              type: 'image',
+              mimeType: 'image/png',
+              origRatio: 1,
+              x: 50,
+              y: 100,
+              scale: 1,
+              rotationAngle: 0,
+              width: 1,
+              height: 1,
+              resource: {
+                type: 'image',
+                mimeType: 'image/png',
+                id: 123,
+                src: 'https://example.com/image.png',
+                poster: 'https://example.com/poster.png',
+                height: 1,
+                width: 1,
+              },
+            },
+            {
+              id: 'baz',
+              type: 'text',
+              content: 'Hello, link!',
+              x: 50,
+              y: 0,
+              height: 100,
+              width: 250,
+              rotationAngle: 10,
+              padding: {
+                vertical: 0,
+                horizontal: 0,
+              },
+              link: {
+                url: 'http://shouldoutput.com',
+              },
+              fontSize: 30,
+              font: {
+                family: 'Roboto',
+                service: 'fonts.google.com',
+              },
+              color: {
+                color: {
+                  r: 255,
+                  g: 255,
+                  b: 255,
+                  a: 0.5,
+                },
+              },
+            },
+          ],
+          pageAttachment: {
+            url: 'http://example.com',
+            ctaText: 'Click me!',
+          },
+        },
+        autoAdvance: false,
+        defaultPageDuration: 7,
+      };
+
+      const content = renderToStaticMarkup(<PageOutput {...props} />);
+      expect(content).toContain('Hello, link');
+      expect(content).toContain('http://shouldoutput.com');
+    });
+
     it('should output a link in page attachment area if page attachment is not set', () => {
       const props = {
         id: '123',


### PR DESCRIPTION
## Summary
- Adds unit tests to verify the links are output if there's no page attachment / if there is one but the element is out of its area
- Fixes the incorrect condition always removing links if page attachment is not present.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
I
1. Add a link
2. Verify that it shows up in the front-end (is clickable)

II
1. Add a link
2. Add a Page attachment
3. Ensure the link is outside of the Page Attachment area
4. Save and verify that the link shows up in the front-end as well

III
1. Add a link to the bottom of the page (needs to be in the Page Attachment area)
2. Add a Page attachment
3. Save and verify that the link is not clickable in the front-end

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4318 
