### PR TITLE
Improves flaky tests from #4218 (text staggering)

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/karma/textPane.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/karma/textPane.karma.js
@@ -92,7 +92,7 @@ describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => 
 
     // @todo Remove this once #4094 gets fixed!
     // Wait until the history has changed to its initial (incorrect due to a bug) position.
-    await fixture.events.sleep(300);
+    await fixture.events.sleep(500);
 
     // Stagger all different text presets.
 

--- a/assets/src/edit-story/components/library/panes/text/karma/textPane.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/karma/textPane.karma.js
@@ -41,6 +41,10 @@ describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => 
 
   it('should add text presets below each other if added consecutively', async () => {
     await fixture.editor.library.textTab.click();
+    // @todo Remove this once #4094 gets fixed!
+    // Wait until the history has changed to its initial (incorrect due to a bug) position.
+    await fixture.events.sleep(300);
+
     await fixture.events.click(fixture.editor.library.text.preset('Heading 1'));
     await fixture.events.click(fixture.editor.library.text.preset('Heading 3'));
     await fixture.events.click(fixture.editor.library.text.preset('Paragraph'));

--- a/assets/src/edit-story/components/library/panes/text/karma/textPane.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/karma/textPane.karma.js
@@ -54,6 +54,8 @@ describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => 
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
     let lastY;
     let lastHeight;
+    let nextY;
+    let nextHeight;
     let storyContext;
 
     const verifyDefaultPosition = async (name, content) => {
@@ -64,29 +66,37 @@ describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => 
         const preset = PRESETS.find(({ title }) => name === title);
         expect(element.y).toEqual(preset.element.y);
       });
-      lastY = element.y;
-      lastHeight = element.height;
+      nextY = element.y;
+      nextHeight = element.height;
     };
 
     const verifyStaggeredPosition = async (content) => {
+      // Store both last and next value to ensure incorrect value isn't used within waitFor.
+      lastY = nextY;
+      lastHeight = nextHeight;
       storyContext = await fixture.renderHook(() => useStory());
       const element = storyContext.state.selectedElements[0];
       await waitFor(() => {
         expect(stripHTML(element.content)).toEqual(content);
         expect(element.y).toEqual(lastY + lastHeight + POSITION_MARGIN);
       });
-      lastY = element.y;
-      lastHeight = element.height;
+      nextY = element.y;
+      nextHeight = element.height;
     };
 
     await fixture.editor.library.textTab.click();
+
+    // @todo Remove this once #4094 gets fixed!
+    // Wait until the history has changed to its initial (incorrect due to a bug) position.
+    await fixture.events.sleep(300);
+
     // Stagger all different text presets.
 
     await fixture.events.click(fixture.editor.library.text.preset('Heading 1'));
     await verifyDefaultPosition('Heading 1', 'Heading 1');
 
     await fixture.events.click(fixture.editor.library.text.preset('Paragraph'));
-    await verifyStaggeredPosition('Paragraph');
+    await verifyStaggeredPosition(PARAGRAPH_TEXT);
 
     await fixture.events.click(fixture.editor.library.text.preset('Heading 2'));
     await verifyStaggeredPosition('Heading 2');


### PR DESCRIPTION
## Summary
- Compares the `y` values to ensure the correct value is used.
- Adds a `sleep` to ensure the history has "settled down" before starting staggering -- needed due to history bug (reported in #4094 

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!-- Please describe your changes. -->

## Testing Instructions
N/A
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
