### PR TITLE
Embed block: explicitly set dimensions in AMP context

### DIFF
--- a/includes/Story_Renderer/Embed.php
+++ b/includes/Story_Renderer/Embed.php
@@ -73,15 +73,29 @@ class Embed {
 		$player_style = sprintf( 'width: %dpx;height: %dpx;margin: %s', absint( $args['width'] ), absint( $args['height'] ), esc_attr( $margin ) );
 		$poster_style = ! empty( $poster ) ? sprintf( '--story-player-poster: url(%s)', $poster ) : '';
 
-		if ( ! function_exists( 'is_amp_endpoint' ) || ! is_amp_endpoint() ) {
-			wp_enqueue_style( 'standalone-amp-story-player' );
-			wp_enqueue_script( 'standalone-amp-story-player' );
+		ob_start();
+
+		if (
+			( function_exists( 'amp_is_request' ) && amp_is_request() ) ||
+			( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() )
+		) {
+			$player_style = sprintf( 'margin: %s', esc_attr( $margin ) );
+			?>
+			<div class="wp-block-web-stories-embed <?php echo esc_attr( $align ); ?>">
+				<amp-story-player width="<?php echo esc_attr( absint( $args['width'] ) ); ?>" height="<?php echo esc_attr( absint( $args['height'] ) ); ?>" style="<?php echo esc_attr( $player_style ); ?>">
+					<a href="<?php echo esc_url( $url ); ?>" style="<?php echo esc_attr( $poster_style ); ?>"><?php echo esc_html( $title ); ?></a>
+				</amp-story-player>
+			</div>
+			<?php
+
+			return (string) ob_get_clean();
 		}
 
-		ob_start();
+		wp_enqueue_style( 'standalone-amp-story-player' );
+		wp_enqueue_script( 'standalone-amp-story-player' );
 		?>
 		<div class="wp-block-web-stories-embed <?php echo esc_attr( $align ); ?>">
-			<amp-story-player style="<?php echo esc_attr( $player_style ); ?>" data-testid="amp-story-player">
+			<amp-story-player style="<?php echo esc_attr( $player_style ); ?>">
 				<a href="<?php echo esc_url( $url ); ?>" style="<?php echo esc_attr( $poster_style ); ?>"><?php echo esc_html( $title ); ?></a>
 			</amp-story-player>
 		</div>

--- a/includes/Story_Renderer/Embed.php
+++ b/includes/Story_Renderer/Embed.php
@@ -82,7 +82,7 @@ class Embed {
 			$player_style = sprintf( 'margin: %s', esc_attr( $margin ) );
 			?>
 			<div class="wp-block-web-stories-embed <?php echo esc_attr( $align ); ?>">
-				<amp-story-player width="<?php echo esc_attr( absint( $args['width'] ) ); ?>" height="<?php echo esc_attr( absint( $args['height'] ) ); ?>" style="<?php echo esc_attr( $player_style ); ?>">
+				<amp-story-player width="<?php echo esc_attr( $args['width'] ); ?>" height="<?php echo esc_attr( $args['height'] ); ?>" style="<?php echo esc_attr( $player_style ); ?>">
 					<a href="<?php echo esc_url( $url ); ?>" style="<?php echo esc_attr( $poster_style ); ?>"><?php echo esc_html( $title ); ?></a>
 				</amp-story-player>
 			</div>

--- a/includes/plugin-compat/amp.php
+++ b/includes/plugin-compat/amp.php
@@ -39,3 +39,17 @@ if ( ! function_exists( '\is_amp_endpoint' ) ) {
 		return is_singular( Story_Post_Type::POST_TYPE_SLUG );
 	}
 }
+
+if ( ! function_exists( '\amp_is_request' ) ) {
+	/**
+	 * Determine whether the current response being served as AMP.
+	 *
+	 * Polyfill to ensure compatibility with plugins checking for AMP
+	 * when the AMP plugin itself is not available.
+	 *
+	 * @return bool Whether it is singular story post (and thus an AMP endpoint).
+	 */
+	function amp_is_request() {
+		return is_amp_endpoint();
+	}
+}


### PR DESCRIPTION
## Summary

Just like other AMP components, the `amp-story-player` **AMP component** (not the standalone one) requires the `width` and `height` attributes to be set explicitly.

## Relevant Technical Choices

* Adds polyfill for `amp_is_request()` (new in AMP plugin 2.0)

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

Use Embed block when the AMP plugin is active.

E2E tests will be added in #3261 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3992
