### PR TITLE
Dashboard: Maintain grid item focus on delete

### DIFF
--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -79,6 +79,7 @@ const StoryGridView = ({
   renameStory,
   dateSettings,
   previewStory,
+  returnStoryFocusId,
 }) => {
   const { isRTL } = useConfig();
   const containerRef = useRef();
@@ -94,6 +95,12 @@ const StoryGridView = ({
     currentItemId: activeGridItemId,
     items: stories,
   });
+
+  useEffect(() => {
+    if (!activeGridItemId && returnStoryFocusId) {
+      itemRefs.current?.[returnStoryFocusId]?.children[0].focus();
+    }
+  }, [activeGridItemId, returnStoryFocusId]);
 
   // when keyboard focus changes through FocusableGridItem immediately focus the edit preview layer on top of preview
   useEffect(() => {
@@ -221,6 +228,7 @@ StoryGridView.propTypes = {
   storyMenu: StoryMenuPropType,
   renameStory: RenameStoryPropType,
   dateSettings: DateSettingsPropType,
+  returnStoryFocusId: PropTypes.number,
 };
 
 export default StoryGridView;

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -98,7 +98,7 @@ const StoryGridView = ({
 
   useEffect(() => {
     if (!activeGridItemId && returnStoryFocusId) {
-      itemRefs.current?.[returnStoryFocusId]?.children[0].focus();
+      itemRefs.current?.[returnStoryFocusId]?.children?.[0]?.focus();
     }
   }, [activeGridItemId, returnStoryFocusId]);
 


### PR DESCRIPTION
set story id in storyView state when interacting with delete dialog t…o return focus to grid on close and either move it to the previous item or keep it on the existing depending on if cancel or continue was selected

## Summary
On close of delete story dialog returns focus to that story grid item if not deleted and if it was deleted returns it to the previous grid item.

## Relevant Technical Choices

- Uses state to manage the current story id getting interacted with combined with an `isDeleted` key that signals if we need to go back an index before returning the id to focus on when the dialog is closed. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Now when you use the keyboard to open a context menu and select delete it will send your focus back to where you were (or the previous grid item) instead of back to the wordPress menu that is the beginning of the document. 

## Testing Instructions

Tab to a grid item on 'my stories' in the dashboard 
Tab to the context menu, hit enter, arrow all the way down to 'delete story', hit enter to open delete dialog. 
Tab to cancel, hit enter, see that focus returns to the story you were trying to delete and changed your mind on. 
Now open the dialog again with the keyboard and this time delete the story, see that focus is returned to the story just to the left of the one you deleted. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4198 
