### PR TITLE
Workspace: Adds ability to generate a cover image from the current canvas

### DIFF
--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -190,10 +190,10 @@ function CanvasProvider({ children }) {
       editingElement,
       editingElementState,
       lastSelectionEvent,
-      pageSize,
       showSafeZone,
-      setPageContainer,
-      setFullbleedContainer,
+      pageSize,
+      displayLinkGuidelines,
+      pageAttachmentContainer,
       getNodeForElement,
       setNodeForElement,
       setEditingElementWithoutState,
@@ -201,12 +201,6 @@ function CanvasProvider({ children }) {
       clearEditing,
       handleSelectElement,
       selectIntersection,
-      setPageSize,
-      setShowSafeZone,
-      displayLinkGuidelines,
-      setDisplayLinkGuidelines,
-      pageAttachmentContainer,
-      setPageAttachmentContainer,
     ]
   );
   return (

--- a/assets/src/edit-story/components/canvas/selectionCanvas.js
+++ b/assets/src/edit-story/components/canvas/selectionCanvas.js
@@ -19,7 +19,7 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useEffect, useRef } from 'react';
+import { forwardRef, useEffect, useRef } from 'react';
 
 /**
  * Internal dependencies
@@ -57,7 +57,7 @@ const Lasso = styled.div`
   z-index: 1;
 `;
 
-function SelectionCanvas({ children }) {
+const SelectionCanvas = forwardRef(({ children }, ref) => {
   const { selectedElements, currentPage, clearSelection } = useStory(
     ({
       state: { selectedElements, currentPage },
@@ -199,6 +199,7 @@ function SelectionCanvas({ children }) {
 
   return (
     <Container
+      ref={ref}
       onMouseDown={onMouseDown}
       onMouseMove={onMouseMove}
       onMouseUp={onMouseUp}
@@ -209,8 +210,9 @@ function SelectionCanvas({ children }) {
       </InOverlay>
     </Container>
   );
-}
+});
 
+SelectionCanvas.displayName = 'SelectionCanvas';
 SelectionCanvas.propTypes = {
   children: PropTypes.node,
 };

--- a/assets/src/edit-story/components/inspector/document/publish/index.js
+++ b/assets/src/edit-story/components/inspector/document/publish/index.js
@@ -20,7 +20,6 @@
 import { useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
-import html2canvas from 'html2canvas';
 
 /**
  * WordPress dependencies
@@ -70,15 +69,22 @@ function PublishPanel() {
     featuredMediaUrl,
     publisherLogoUrl,
     updateStory,
+    storyId,
   } = useStory(
     ({
       state: {
         meta: { isSaving },
-        story: { author = '', featuredMediaUrl = '', publisherLogoUrl = '' },
+        story: {
+          storyId = '',
+          author = '',
+          featuredMediaUrl = '',
+          publisherLogoUrl = '',
+        },
       },
       actions: { updateStory },
     }) => {
       return {
+        storyId,
         isSaving,
         author,
         featuredMediaUrl,
@@ -115,6 +121,7 @@ function PublishPanel() {
 
   const generateCanvas = useCallback(async () => {
     try {
+      const html2canvas = (await import('html2canvas')).default;
       const canvas = await html2canvas(fullbleedContainer);
       const blob = await new Promise((resolve, reject) =>
         canvas.toBlob(
@@ -123,7 +130,9 @@ function PublishPanel() {
         )
       );
       const { id, media_details, source_url } = await uploadFile(
-        new File([blob], 'cover-image.jpg', { type: 'image/jpeg' })
+        new File([blob], `web-story-${storyId}-cover-generated.jpg`, {
+          type: 'image/jpeg',
+        })
       );
       updateStory({
         properties: {
@@ -136,7 +145,7 @@ function PublishPanel() {
         message: __('Could not generate a cover image.', 'web-stories'),
       });
     }
-  }, [fullbleedContainer, uploadFile, showSnackbar, updateStory]);
+  }, [fullbleedContainer, uploadFile, storyId, updateStory, showSnackbar]);
 
   // @todo Enforce square image while selecting in Media Library.
   const handleChangePublisherLogo = useCallback(

--- a/assets/src/edit-story/components/inspector/document/publish/index.js
+++ b/assets/src/edit-story/components/inspector/document/publish/index.js
@@ -121,7 +121,7 @@ function PublishPanel() {
 
   const generateCanvas = useCallback(async () => {
     try {
-      const html2canvas = (await import('html2canvas')).default;
+      const html2canvas = (await import(/* webpackChunkName: "html2canvas" */ 'html2canvas')).default;
       const canvas = await html2canvas(fullbleedContainer);
       const blob = await new Promise((resolve, reject) =>
         canvas.toBlob(

--- a/assets/src/edit-story/components/inspector/document/publish/index.js
+++ b/assets/src/edit-story/components/inspector/document/publish/index.js
@@ -40,6 +40,7 @@ import Button from '../../../form/button';
 import { useCanvas } from '../../../canvas';
 import useUploader from '../../../../app/uploader/useUploader';
 import useSnackbar from '../../../../app/snackbar/useSnackbar';
+import { useAPI } from '../../../../app/api';
 import PublishTime from './publishTime';
 
 const LabelWrapper = styled.div`
@@ -62,6 +63,9 @@ function PublishPanel() {
 
   const { showSnackbar } = useSnackbar();
   const { uploadFile } = useUploader();
+  const {
+    actions: { updateMedia },
+  } = useAPI();
 
   const {
     isSaving,
@@ -121,7 +125,9 @@ function PublishPanel() {
 
   const generateCanvas = useCallback(async () => {
     try {
-      const html2canvas = (await import(/* webpackChunkName: "html2canvas" */ 'html2canvas')).default;
+      const html2canvas = (
+        await import(/* webpackChunkName: "html2canvas" */ 'html2canvas')
+      ).default;
       const canvas = await html2canvas(fullbleedContainer);
       const blob = await new Promise((resolve, reject) =>
         canvas.toBlob(
@@ -134,6 +140,11 @@ function PublishPanel() {
           type: 'image/jpeg',
         })
       );
+      await updateMedia(id, {
+        meta: {
+          web_stories_is_poster: true,
+        },
+      });
       updateStory({
         properties: {
           featuredMedia: id,
@@ -145,7 +156,14 @@ function PublishPanel() {
         message: __('Could not generate a cover image.', 'web-stories'),
       });
     }
-  }, [fullbleedContainer, uploadFile, storyId, updateStory, showSnackbar]);
+  }, [
+    fullbleedContainer,
+    uploadFile,
+    storyId,
+    updateMedia,
+    updateStory,
+    showSnackbar,
+  ]);
 
   // @todo Enforce square image while selecting in Media Library.
   const handleChangePublisherLogo = useCallback(

--- a/package-lock.json
+++ b/package-lock.json
@@ -13974,6 +13974,21 @@
         "timsort": "^0.3.0"
       }
     },
+    "css-line-break": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-1.1.1.tgz",
+      "integrity": "sha512-1feNVaM4Fyzdj4mKPIQNL2n70MmuYzAXZ1aytlROFX1JsOo070OsugwGjj7nl6jnDJWHDM8zRZswkmeYVWZJQA==",
+      "requires": {
+        "base64-arraybuffer": "^0.2.0"
+      },
+      "dependencies": {
+        "base64-arraybuffer": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+          "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
+        }
+      }
+    },
     "css-loader": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-4.2.2.tgz",
@@ -18436,6 +18451,14 @@
             "object.getownpropertydescriptors": "^2.0.3"
           }
         }
+      }
+    },
+    "html2canvas": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.0.0-rc.7.tgz",
+      "integrity": "sha512-yvPNZGejB2KOyKleZspjK/NruXVQuowu8NnV2HYG7gW7ytzl+umffbtUI62v2dCHQLDdsK6HIDtyJZ0W3neerA==",
+      "requires": {
+        "css-line-break": "1.1.1"
       }
     },
     "htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "draftjs-filters": "^2.3.0",
     "flagged": "^2.0.1",
     "history": "^5.0.0",
+    "html2canvas": "^1.0.0-rc.7",
     "mockdate": "^3.0.2",
     "moment": "^2.27.0",
     "moment-timezone": "^0.5.31",


### PR DESCRIPTION
## Summary

![image](https://user-images.githubusercontent.com/1738349/92254130-04b99e00-ee96-11ea-9aff-deda47c1a55e.png)

The `html2canvas` likely does not understand how the SVG shape clippings work. It might be better to have it rasterize the AMP output instead. This PR is to get feedback right now and start a conversation about either using the AMP output or opting for a different pacakge.

## Relevant Technical Choices

- Use current `uploadFile` hook to upload then update the cover image of the story.

## To-do

- Code split out `html2canvas` or whatever eventual package we use.
- Fix shapes from not being turned into squares. 

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Edit a story in the editor
2. Select the Document panel on the right
3. Click generate cover image and see a new cover image show up
4. Save & Refresh and see it's still there!

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3671
