### PR TITLE
Media: Compare aspect ratios instead of just orientations

### DIFF
--- a/assets/src/edit-story/elements/media/test/util.js
+++ b/assets/src/edit-story/elements/media/test/util.js
@@ -61,7 +61,7 @@ describe('util', () => {
           size3: {
             source_url: 'URL3',
             width: 400,
-            height: 400,
+            height: 410,
           },
         },
       };
@@ -114,9 +114,9 @@ describe('util', () => {
         width: 400,
         height: 200,
         sizes: {
-          img1: { width: 200, height: 1, source_url: 'full-url' },
-          img2: { width: 300, height: 1, source_url: 'med-url' },
-          img3: { width: 400, height: 1, source_url: 'large-url' },
+          img1: { width: 200, height: 100, source_url: 'full-url' },
+          img2: { width: 300, height: 150, source_url: 'med-url' },
+          img3: { width: 400, height: 200, source_url: 'large-url' },
         },
       };
       expect(getSmallestUrlForWidth(210, resource)).toBe('med-url');
@@ -129,15 +129,15 @@ describe('util', () => {
         width: 400,
         height: 200,
         sizes: {
-          img1: { width: 200, height: 1, source_url: 'full-url' },
-          img2: { width: 300, height: 1, source_url: 'med-url' },
-          img3: { width: 400, height: 1, source_url: 'large-url' },
+          img1: { width: 200, height: 100, source_url: 'full-url' },
+          img2: { width: 300, height: 150, source_url: 'med-url' },
+          img3: { width: 400, height: 200, source_url: 'large-url' },
         },
       };
       expect(getSmallestUrlForWidth(160, resource)).toBe('large-url');
     });
 
-    it('should return an image with the same orientation', () => {
+    it('should return an image with the same aspect ratio', () => {
       const resource = {
         src: 'default-url',
         width: 400,
@@ -145,8 +145,8 @@ describe('util', () => {
         sizes: {
           img1: { width: 200, height: 500, source_url: 'portrait-url' },
           img2: { width: 250, height: 250, source_url: 'square-url' },
-          img3: { width: 300, height: 1, source_url: 'med-url' },
-          img4: { width: 400, height: 1, source_url: 'large-url' },
+          img3: { width: 300, height: 150, source_url: 'med-url' },
+          img4: { width: 400, height: 200, source_url: 'large-url' },
         },
       };
       expect(getSmallestUrlForWidth(150, resource)).toBe('med-url');

--- a/assets/src/edit-story/elements/media/util.js
+++ b/assets/src/edit-story/elements/media/util.js
@@ -32,19 +32,8 @@ export function getMediaWithScaleCss({ width, height, offsetX, offsetY }) {
   return `width:${width}px; height:${height}px; left:${-offsetX}px; top:${-offsetY}px;`;
 }
 
-const getOrientation = (obj) => {
-  if (obj.width / obj.height > 1) {
-    return Orientation.LANDSCAPE;
-  } else if (obj.width / obj.height < 1) {
-    return Orientation.PORTRAIT;
-  }
-  return Orientation.SQUARE;
-};
-
-const Orientation = {
-  PORTRAIT: 'portrait',
-  LANDSCAPE: 'landscape',
-  SQUARE: 'square',
+const aspectRatiosApproximatelyMatch = (obj1, obj2) => {
+  return Math.abs(obj1.width / obj1.height - obj2.width / obj2.height) < 0.01;
 };
 
 /**
@@ -62,7 +51,7 @@ export function calculateSrcSet(resource) {
   return (
     Object.values(resource.sizes)
       .sort((s1, s2) => s2.width - s1.width)
-      .filter((s) => getOrientation(s) === getOrientation(resource))
+      .filter((s) => aspectRatiosApproximatelyMatch(s, resource))
       // Remove duplicates. Given it's already ordered in descending width order, we can be
       // more efficient and just check the last item in each reduction.
       .reduce(
@@ -89,7 +78,7 @@ export function getSmallestUrlForWidth(minWidth, resource) {
   if (resource.sizes) {
     const smallestMedia = Object.values(resource.sizes)
       .sort((s1, s2) => s1.width - s2.width)
-      .filter((s) => getOrientation(s) === getOrientation(resource))
+      .filter((s) => aspectRatiosApproximatelyMatch(s, resource))
       .find((s) => s.width >= minWidth * window.devicePixelRatio);
     if (smallestMedia) {
       return smallestMedia.source_url;


### PR DESCRIPTION
## Summary

Only use images whose aspect ratio matches the one of the original resource. This fixes an issue where some autogenerated images that matched the orientation of the original resource but didn't match its aspect ratio were being used in the srcset.

## Relevant Technical Choices

The aspect ratios are compares with 0.01 of leeway (to account for rounding errors).

Fixes #4360
