### PR TITLE
Suppress PHP Lint warning

### DIFF
--- a/includes/Media.php
+++ b/includes/Media.php
@@ -242,7 +242,7 @@ class Media {
 			'compare' => 'NOT EXISTS',
 		];
 
-		$query->set( 'meta_query', $meta_query );
+		$query->set( 'meta_query', $meta_query ); // phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts
 	}
 
 	/**


### PR DESCRIPTION
## Summary
```
FILE: includes/Media.php
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 245 | WARNING | Main WP_Query is being modified without `$query->is_main_query()` check. Needs manual inspection.
     |         | (WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts)
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
This PHP error has started to appear linter and in github action. This fix simply errors it. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
