### PR TITLE
Add karma spec reporter

### DIFF
--- a/karma-dashboard.config.cjs
+++ b/karma-dashboard.config.cjs
@@ -28,6 +28,7 @@ module.exports = function (config) {
       'karma-jasmine',
       'karma-sourcemap-loader',
       'karma-webpack',
+      'karma-spec-reporter',
       'karma-coverage-istanbul-reporter',
       require('./karma/karma-puppeteer-launcher/index.cjs'),
       require('./karma/karma-puppeteer-client/index.cjs'),
@@ -80,7 +81,7 @@ module.exports = function (config) {
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
     reporters: [
-      'progress',
+      'spec',
       config.coverage && 'cuj',
       config.coverage && 'coverage-istanbul',
     ].filter(Boolean),

--- a/karma-edit-story.config.cjs
+++ b/karma-edit-story.config.cjs
@@ -28,6 +28,7 @@ module.exports = function (config) {
       'karma-jasmine',
       'karma-sourcemap-loader',
       'karma-webpack',
+      'karma-spec-reporter',
       'karma-coverage-istanbul-reporter',
       require('./karma/karma-puppeteer-launcher/index.cjs'),
       require('./karma/karma-puppeteer-client/index.cjs'),
@@ -80,7 +81,7 @@ module.exports = function (config) {
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
     reporters: [
-      'progress',
+      'spec',
       config.coverage && 'cuj',
       config.coverage && 'coverage-istanbul',
     ].filter(Boolean),

--- a/package-lock.json
+++ b/package-lock.json
@@ -23996,6 +23996,15 @@
         "graceful-fs": "^4.1.2"
       }
     },
+    "karma-spec-reporter": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.32.tgz",
+      "integrity": "sha1-LpxyB+pyZ3EmAln4K+y1QyCeRAo=",
+      "dev": true,
+      "requires": {
+        "colors": "^1.1.2"
+      }
+    },
     "karma-webpack": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "karma-coverage-istanbul-reporter": "^3.0.3",
     "karma-jasmine": "^4.0.1",
     "karma-sourcemap-loader": "^0.3.8",
+    "karma-spec-reporter": "0.0.32",
     "karma-webpack": "^4.0.2",
     "lint-staged": "^10.3.0",
     "markdown-table": "^2.0.0",


### PR DESCRIPTION
Makes it a bit easier to see which test caused failure.

Explored this while looking into #4364

Screenshot:

<img width="1322" alt="Screenshot 2020-09-09 at 16 16 25" src="https://user-images.githubusercontent.com/841956/92610286-d550ca00-f2b7-11ea-9daa-3643798f6043.png">

[**(example run)**](https://github.com/google/web-stories-wp/pull/4393/checks?check_run_id=1091492987)