### PR TITLE
Upload tab: improve width of media types dropdown

### DIFF
--- a/assets/src/edit-story/components/form/dropDown/index.js
+++ b/assets/src/edit-story/components/form/dropDown/index.js
@@ -35,13 +35,14 @@ import {
   KEYBOARD_USER_SELECTOR,
 } from '../../../utils/keyboardOnlyOutline';
 import { Dropdown as DropdownIcon } from '../../../icons';
-import Popup from '../../popup';
+import Popup, { Placement } from '../../popup';
 import DropDownList from './list';
 
+/* same min-width as ListContainer */
 const DropDownContainer = styled.div`
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
+  min-width: 160px;
   color: ${({ theme }) => theme.colors.fg.black};
   font-family: ${({ theme }) => theme.fonts.body1.font};
 
@@ -102,7 +103,7 @@ function DropDown({
   options = [],
   disabled = false,
   lightMode = false,
-  placement = 'bottom-end',
+  placement = Placement.BOTTOM_END,
   placeholder = __('Select an option', 'web-stories'),
   ...rest
 }) {

--- a/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
@@ -51,18 +51,20 @@ import PaginatedMediaGallery from '../common/paginatedMediaGallery';
 import Flags from '../../../../../flags';
 import resourceList from '../../../../../utils/resourceList';
 import { DropDown } from '../../../../form';
+import { Placement } from '../../../../popup';
 import paneId from './paneId';
 
 export const ROOT_MARGIN = 300;
 
 const FilterArea = styled.div`
   display: flex;
+  justify-content: space-between;
   margin-top: 30px;
   padding: 0 1.5em 0 1.5em;
 `;
 
 const FILTERS = [
-  { value: '', name: __('All', 'web-stories') },
+  { value: '', name: __('All Types', 'web-stories') },
   { value: 'image', name: __('Images', 'web-stories') },
   { value: 'video', name: __('Video', 'web-stories') },
 ];
@@ -209,6 +211,7 @@ function MediaPane(props) {
               value={mediaType?.toString() || FILTERS[0].value}
               onChange={onFilter}
               options={FILTERS}
+              placement={Placement.BOTTOM_START}
             />
             <Primary onClick={openMediaPicker}>
               {__('Upload', 'web-stories')}

--- a/assets/src/edit-story/elements/video/karma/autoplay.karma.js
+++ b/assets/src/edit-story/elements/video/karma/autoplay.karma.js
@@ -45,7 +45,7 @@ describe('Autoplay video', () => {
 
   it('should autoplay on insert and on drop', async () => {
     // TODO: Switch to role selector after they are merged
-    const allFilter = fixture.screen.getByText('All');
+    const allFilter = fixture.screen.getByText('All Types');
     await fixture.events.mouse.clickOn(allFilter);
     const videoFilter = fixture.screen.getByText('Video');
     await fixture.events.mouse.clickOn(videoFilter);


### PR DESCRIPTION
## Summary

The dropdown was too wide before. Reducing width here.

## User-facing changes

<img width="390" alt="Screenshot 2020-09-08 at 19 14 30" src="https://user-images.githubusercontent.com/841956/92508019-33be6f80-f208-11ea-9e37-41150f1f6086.png">
<img width="389" alt="Screenshot 2020-09-08 at 19 14 23" src="https://user-images.githubusercontent.com/841956/92508022-34570600-f208-11ea-8fd7-f7ea719a23fb.png">

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Relates to  #4059
