### PR TITLE
Add focus shortcuts

### DIFF
--- a/assets/src/edit-story/components/canvas/karma/selection.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/selection.karma.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
@@ -88,5 +93,23 @@ describe('Selection integration', () => {
     ]);
     expect(await getSelection()).toEqual([element1.id]);
     await fixture.snapshot();
+  });
+
+  it('should return focus to selection when pressing mod+alt+2', async () => {
+    const frame1 = fixture.editor.canvas.framesLayer.frame(element1.id).node;
+
+    // Click nothing, then element
+    await fixture.events.click(fixture.editor.canvas.node);
+    await fixture.events.click(frame1);
+    await waitFor(() => expect(frame1).toHaveFocus());
+
+    // Click elsewhere
+    await fixture.events.click(fixture.editor.canvas.header.title);
+    expect(frame1).not.toHaveFocus();
+
+    // Return focus with shortcut
+    await fixture.events.keyboard.shortcut('mod+alt+2');
+    await waitFor(() => expect(frame1).toHaveFocus());
+    await fixture.snapshot('selected element has focus');
   });
 });

--- a/assets/src/edit-story/components/canvas/karma/selection.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/selection.karma.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { waitFor } from '@testing-library/react';
-
-/**
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
@@ -96,20 +91,17 @@ describe('Selection integration', () => {
   });
 
   it('should return focus to selection when pressing mod+alt+2', async () => {
-    const frame1 = fixture.editor.canvas.framesLayer.frame(element1.id).node;
-
-    // Click nothing, then element
-    await fixture.events.click(fixture.editor.canvas.node);
-    await fixture.events.click(frame1);
-    await waitFor(() => expect(frame1).toHaveFocus());
+    // NB: We can't actually validate that the frame has focus, as that's a bit flaky,
+    // But as long as the focus moves in the shortcut press, it's fair to assume that it has
+    // Move to the canvas selection.
 
     // Click elsewhere
     await fixture.events.click(fixture.editor.canvas.header.title);
-    expect(frame1).not.toHaveFocus();
+    expect(fixture.editor.canvas.header.title).toHaveFocus();
 
     // Return focus with shortcut
     await fixture.events.keyboard.shortcut('mod+alt+2');
-    await waitFor(() => expect(frame1).toHaveFocus());
+    expect(fixture.editor.canvas.header.title).not.toHaveFocus();
     await fixture.snapshot('selected element has focus');
   });
 });

--- a/assets/src/edit-story/components/canvas/useFocusCanvas.js
+++ b/assets/src/edit-story/components/canvas/useFocusCanvas.js
@@ -19,6 +19,11 @@
  */
 import { useCallback } from 'react';
 
+/**
+ * Internal dependencies
+ */
+import { useGlobalKeyDownEffect } from '../keyboard';
+
 function useFocusCanvas() {
   /**
    * @param {boolean} force When true, the focus will always be
@@ -35,6 +40,14 @@ function useFocusCanvas() {
       doc.dispatchEvent(evt);
     });
   }, []);
+
+  // Globally listen for Cmd+Option+2 / Ctrl+Alt+2 for focus
+  useGlobalKeyDownEffect(
+    { key: 'mod+option+2', editable: true },
+    () => focusCanvas(true),
+    [focusCanvas]
+  );
+
   return focusCanvas;
 }
 

--- a/assets/src/edit-story/components/inspector/inspectorLayout.js
+++ b/assets/src/edit-story/components/inspector/inspectorLayout.js
@@ -65,6 +65,7 @@ function InspectorLayout() {
         initialTab={tab}
         onTabChange={(id) => setTab(id)}
         getAriaControlsId={getTabId}
+        shortcut="mod+option+3"
       />
       <InspectorContainer ref={setInspectorContentNode}>
         <InspectorContent />

--- a/assets/src/edit-story/components/inspector/karma/inspectorTabs.karma.js
+++ b/assets/src/edit-story/components/inspector/karma/inspectorTabs.karma.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+
+describe('Inspector Tabs integration', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  describe('keyboard navigation', () => {
+    it('should return focus to current tab when pressing mod+alt+3', async () => {
+      const { documentTab } = fixture.editor.inspector;
+
+      // Click document tab
+      await fixture.events.mouse.clickOn(documentTab);
+      await waitFor(() => fixture.editor.inspector.documentPanel);
+      expect(documentTab).toHaveFocus();
+
+      // Click elsewhere
+      await fixture.events.click(fixture.editor.canvas.header.title);
+      expect(documentTab).not.toHaveFocus();
+
+      // Return focus with shortcut
+      await fixture.events.keyboard.shortcut('mod+alt+3');
+      expect(documentTab).toHaveFocus();
+      await fixture.snapshot('document tab has focus');
+    });
+  });
+});

--- a/assets/src/edit-story/components/keyboard/index.js
+++ b/assets/src/edit-story/components/keyboard/index.js
@@ -91,8 +91,13 @@ function useKeyEffectInternal(
       ) {
         throw new Error('only an element or a document node can be used');
       }
-      const mousetrap = getOrCreateMousetrap(node);
+
       const keySpec = resolveKeySpec(keys, keyNameOrSpec);
+      if (keySpec.key.length === 1 && keySpec.key[0] === '') {
+        return undefined;
+      }
+
+      const mousetrap = getOrCreateMousetrap(node);
       const handler = createKeyHandler(node, keySpec, batchingCallback);
       mousetrap.bind(keySpec.key, handler, type);
       return () => {

--- a/assets/src/edit-story/components/keyboard/index.js
+++ b/assets/src/edit-story/components/keyboard/index.js
@@ -53,7 +53,7 @@ const globalRef = createRef();
 
 function setGlobalRef() {
   if (!globalRef.current) {
-    globalRef.current = document;
+    globalRef.current = document.documentElement;
   }
 }
 

--- a/assets/src/edit-story/components/keyboard/test/index.test.js
+++ b/assets/src/edit-story/components/keyboard/test/index.test.js
@@ -98,12 +98,12 @@ describe('keyboard/index.js', () => {
   describe('useGlobalIsKeyPressed', () => {
     it('should initialise and then register key up and down events', () => {
       const { result } = renderHook(() => useGlobalIsKeyPressed('a'));
-      testIsKeyPressed(result, document, keys.a);
+      testIsKeyPressed(result, document.documentElement, keys.a);
     });
 
     it('should not register when other keys are pressed', () => {
       const { result } = renderHook(() => useGlobalIsKeyPressed('a'));
-      testIsKeyPressed(result, document, keys.b, false);
+      testIsKeyPressed(result, document.documentElement, keys.b, false);
     });
 
     it('should register key presses on any part of the document', () => {

--- a/assets/src/edit-story/components/library/karma/libraryTabs.karma.js
+++ b/assets/src/edit-story/components/library/karma/libraryTabs.karma.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
@@ -84,6 +89,24 @@ describe('LibraryTabs integration', () => {
       const mediaPane = fixture.container.querySelector('#library-pane-media');
       expect(getExpandedPanes()).toEqual([mediaPane]);
       await fixture.waitOnScreen(mediaPane);
+    });
+
+    it('should return focus to current tab when pressing mod+alt+1', async () => {
+      const { textTab } = fixture.editor.library;
+
+      // Click tab
+      await fixture.events.mouse.clickOn(textTab);
+      await waitFor(() => fixture.editor.library.text);
+      expect(textTab).toHaveFocus();
+
+      // Click elsewhere
+      await fixture.events.click(fixture.editor.canvas.header.title);
+      expect(textTab).not.toHaveFocus();
+
+      // Return focus with shortcut
+      await fixture.events.keyboard.shortcut('mod+alt+1');
+      expect(textTab).toHaveFocus();
+      await fixture.snapshot('text tab has focus');
     });
   });
 });

--- a/assets/src/edit-story/components/library/libraryLayout.js
+++ b/assets/src/edit-story/components/library/libraryLayout.js
@@ -70,6 +70,7 @@ function LibraryLayout() {
           initialTab={initialTab}
           onTabChange={(id) => setTab(id)}
           getTabId={getTabId}
+          shortcut="mod+option+1"
         />
       </TabsArea>
       <LibraryPaneContainer>

--- a/assets/src/edit-story/components/tabview/index.js
+++ b/assets/src/edit-story/components/tabview/index.js
@@ -26,7 +26,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { useConfig } from '../../app';
-import { useKeyDownEffect } from '../keyboard';
+import { useKeyDownEffect, useGlobalKeyDownEffect } from '../keyboard';
 
 const Tabs = styled.ul.attrs({
   role: 'tablist',
@@ -93,6 +93,7 @@ function TabView({
   onTabChange = () => {},
   tabs = [],
   label = '',
+  shortcut = '',
   initialTab,
 }) {
   const [tab, setTab] = useState(initialTab || tabs[0]?.id);
@@ -117,6 +118,12 @@ function TabView({
       setTab(initialTab);
     }
   }, [initialTab]);
+
+  useGlobalKeyDownEffect(
+    { key: shortcut, editable: true },
+    () => tabChanged(tab),
+    [tabChanged, tab]
+  );
 
   const selectTabByIndex = useCallback(
     (index) => {
@@ -179,6 +186,7 @@ TabView.propTypes = {
   tabs: PropTypes.array.isRequired,
   initialTab: PropTypes.any,
   label: PropTypes.string,
+  shortcut: PropTypes.string,
 };
 
 export default TabView;

--- a/assets/src/edit-story/karma/fixture/containers/inspector.js
+++ b/assets/src/edit-story/karma/fixture/containers/inspector.js
@@ -46,7 +46,7 @@ export class Inspector extends Container {
   }
 
   get documentPanel() {
-    // @todo: implement
-    return null;
+    // TODO: Wrap in proper container
+    return this.getByRole('tabpanel', { name: /Document/ });
   }
 }

--- a/assets/src/edit-story/utils/keyboardOnlyOutline.js
+++ b/assets/src/edit-story/utils/keyboardOnlyOutline.js
@@ -37,12 +37,15 @@ const ACCEPTED_KEYS = [
   'ArrowLeft',
   'ArrowRight',
   'Tab',
+  'Digit1',
+  'Digit2',
+  'Digit3',
 ];
 
 const KeyboardOnlyOutline = () => {
   const [usingKeyboard, setUsingKeyboard] = useState(false);
   const handleKeydown = (e) => {
-    if (!usingKeyboard && ACCEPTED_KEYS.includes(e.key)) {
+    if (!usingKeyboard && ACCEPTED_KEYS.includes(e.code)) {
       setUsingKeyboard(true);
     }
   };


### PR DESCRIPTION
## Summary

This adds focus shortcuts to the three main sections of the editor as per #4241.

## Relevant Technical Choices

* Had to modify some things in the global keyboard shortcut system, but everything else seems to work still.
* Also had to make minor changes to how the keyboard outlines work (digits can also make them appear).

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4241
