### PR TITLE
Dashboard: Adjust access to settings view

### DIFF
--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -49,7 +49,7 @@ import {
 } from '../components';
 import ApiProvider from './api/apiProvider';
 import { Route, RouterProvider, matchPath, useRouteHistory } from './router';
-import { ConfigProvider, useConfig } from './config';
+import { ConfigProvider } from './config';
 import {
   EditorSettingsView,
   ExploreTemplatesView,
@@ -65,9 +65,7 @@ const AppContent = () => {
     state: { currentPath },
   } = useRouteHistory();
 
-  const { capabilities: { canManageSettings } = {} } = useConfig();
-  const enableSettingsView =
-    useFeature('enableSettingsView') && canManageSettings;
+  const enableSettingsView = useFeature('enableSettingsView');
 
   useEffect(() => {
     const dynamicPageTitle = ROUTE_TITLES[currentPath] || ROUTE_TITLES.DEFAULT;

--- a/assets/src/dashboard/app/views/toaster/index.js
+++ b/assets/src/dashboard/app/views/toaster/index.js
@@ -26,6 +26,7 @@ import { useFeature } from 'flagged';
 import { Toaster, useToastContext } from '../../../components/toaster';
 import { ALERT_SEVERITY } from '../../../constants';
 import useApi from '../../api/useApi';
+import { useConfig } from '../../config';
 
 function ToasterView() {
   const { storyError, templateError, settingsError, mediaError } = useApi(
@@ -43,8 +44,10 @@ function ToasterView() {
     actions: { removeToast, addToast },
     state: { activeToasts },
   } = useToastContext();
+  const { capabilities: { canManageSettings } = {} } = useConfig();
 
-  const enableSettingsView = useFeature('enableSettingsView');
+  const enableSettingsView =
+    useFeature('enableSettingsView') && canManageSettings; // we only want to show errors about settings when users have access to managing them, otherwise they can't read settings anyways
 
   useEffect(() => {
     if (storyError?.id) {

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -100,17 +100,12 @@ export const LeftRailContainer = styled.nav.attrs({
 
 export function LeftRail() {
   const { state } = useRouteHistory();
-  const {
-    newStoryURL,
-    version,
-    capabilities: { canManageSettings } = {},
-  } = useConfig();
+  const { newStoryURL, version } = useConfig();
   const leftRailRef = useRef(null);
   const upperContentRef = useRef(null);
 
   const enableInProgressViews = useFeature('enableInProgressViews');
-  const enableSettingsViews =
-    useFeature('enableSettingsView') && canManageSettings;
+  const enableSettingsViews = useFeature('enableSettingsView');
 
   const {
     state: { sideBarVisible },


### PR DESCRIPTION
## Summary
Adjusts rules surrounding routes to get to settings so that all users have the ability to see settings when flag is true, hiding parts of settings view when not admin and cannot interact with them (API won't read).

## Relevant Technical Choices
- enabling non admin users to see settings view when `enableSettingsView` flag is true 
- Hiding toaster errors re settings when `canManageSettings` is false since that ties to reading settings data and only admin can do that at this moment

## To-do


## User-facing changes
- Now when `enableSettingsView` feature flag is true you can always navigate to settings page regardless of user's role. 
- If you are not admin, you can only see telemetry settings
- If you are admin you can see google analytics, publisher logos, and telemetry 

## Testing Instructions
- Flip `enableSettingsView` feature flag to 'true' as a logged in admin. 
- Admin should see google analytics, publisher logos, and telemetry on settings view
- Non admin (any other user role) should only see telemetry on settings view
- All users should be able to click on the 'settings' nav item (it should show up for everyone) and be able to see settings view. 

(Non admin view) 
![Screen Shot 2020-09-09 at 10 49 11 AM](https://user-images.githubusercontent.com/10720454/92638015-82165180-f28e-11ea-83a0-99d627498777.png)

(Admin view)
![Screen Shot 2020-09-09 at 10 49 42 AM](https://user-images.githubusercontent.com/10720454/92638018-82aee800-f28e-11ea-91b1-f7a9160f7c38.png)


---

<!-- Please reference the issue(s) this PR addresses. -->

Prep work to merge https://github.com/google/web-stories-wp/pull/4152
