### PR TITLE
Dashboard A11y: Focus on preview close

### DIFF
--- a/assets/src/dashboard/app/views/myStories/content/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/index.js
@@ -62,6 +62,7 @@ function Content({
   users,
   view,
   dateSettings,
+  initialFocusStoryId,
 }) {
   return (
     <Layout.Scrollable>
@@ -83,6 +84,7 @@ function Content({
                   users={users}
                   view={view}
                   dateSettings={dateSettings}
+                  initialFocusStoryId={initialFocusStoryId}
                 />
                 <InfiniteScroller
                   canLoadMore={!allPagesFetched}
@@ -112,6 +114,7 @@ Content.propTypes = {
   users: UsersPropType,
   view: ViewPropTypes,
   dateSettings: DateSettingsPropType,
+  initialFocusStoryId: PropTypes.number,
 };
 
 export default Content;

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -59,6 +59,7 @@ function StoriesView({
   users,
   view,
   dateSettings,
+  initialFocusStoryId = null,
 }) {
   const [contextMenuId, setContextMenuId] = useState(-1);
   const [titleRenameId, setTitleRenameId] = useState(-1);
@@ -232,6 +233,7 @@ function StoriesView({
         users={users}
         dateSettings={dateSettings}
         returnStoryFocusId={returnStoryFocusId}
+        initialFocusStoryId={initialFocusStoryId}
       />
     );
 
@@ -290,5 +292,6 @@ StoriesView.propTypes = {
   users: UsersPropType,
   view: ViewPropTypes,
   dateSettings: DateSettingsPropType,
+  initialFocusStoryId: PropTypes.number,
 };
 export default StoriesView;

--- a/assets/src/dashboard/app/views/myStories/index.js
+++ b/assets/src/dashboard/app/views/myStories/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useEffect, useMemo, useCallback } from 'react';
+import { useEffect, useMemo, useCallback, useState } from 'react';
 
 /**
  * Internal dependencies
@@ -109,6 +109,8 @@ function MyStories() {
     view.style,
   ]);
 
+  const [lastActiveStoryId, setLastActiveStoryId] = useState(null);
+
   const orderedStories = useMemo(() => {
     return storiesOrderById.map((storyId) => {
       return stories[storyId];
@@ -118,16 +120,21 @@ function MyStories() {
   const handlePreviewStory = useCallback(
     (e, story) => {
       activePreview.set(e, story);
+      setLastActiveStoryId(story?.id);
+    },
+    [activePreview]
+  );
+
+  const handleClose = useCallback(
+    (e) => {
+      activePreview.set(e, undefined);
     },
     [activePreview]
   );
 
   if (activePreview.value) {
     return (
-      <PreviewStoryView
-        story={activePreview.value}
-        handleClose={handlePreviewStory}
-      />
+      <PreviewStoryView story={activePreview.value} handleClose={handleClose} />
     );
   }
 
@@ -161,6 +168,7 @@ function MyStories() {
         }}
         users={users}
         view={view}
+        initialFocusStoryId={lastActiveStoryId}
       />
 
       <Layout.Fixed>

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -80,12 +80,13 @@ const StoryGridView = ({
   dateSettings,
   previewStory,
   returnStoryFocusId,
+  initialFocusStoryId = null,
 }) => {
   const { isRTL } = useConfig();
   const containerRef = useRef();
   const gridRef = useRef();
   const itemRefs = useRef({});
-  const [activeGridItemId, setActiveGridItemId] = useState(null);
+  const [activeGridItemId, setActiveGridItemId] = useState(initialFocusStoryId);
 
   useGridViewKeys({
     containerRef,
@@ -231,6 +232,7 @@ StoryGridView.propTypes = {
   renameStory: RenameStoryPropType,
   dateSettings: DateSettingsPropType,
   returnStoryFocusId: PropTypes.number,
+  initialFocusStoryId: PropTypes.number,
 };
 
 export default StoryGridView;


### PR DESCRIPTION
## Summary
refocuses on story grid item after previewing that story grid item.

## Relevant Technical Choices
Prop drilling 🔨 

## User-facing changes
When you preview story from my stories, exit out and story item should now regain focus.

## Testing Instructions
**Note** must enable `Story Previews`

In `My Stories`, use keyboard to get to the `preview` button on any story, press enter. Now that you're in the preview mode, use your keyboard to get to the `x` and press enter to exit out of the preview. The grid story item you used to open up the preview should be focused.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4205 
