### PR TITLE
Apply visibility: inherit to dropdown arrow so there's no 'ghost' arrow

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pCategories.js
@@ -78,6 +78,7 @@ const ExpandButton = styled(ArrowDown)`
   height: 32px;
   border-radius: 16px;
   ${({ isExpanded }) => isExpanded && 'transform: matrix(1, 0, 0, -1, 0, 0);'}
+  visibility: inherit;
   align-self: center;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary

Apply visibility: inherit to dropdown arrow so there's no 'ghost' arrow

## User-facing changes

This affects the Media3P pane (which is behind a feature flag).

## Testing Instructions
1. Make sure to enable all third-party media related feature flags (also gifs and videos)
2. Go to the Third-party Media tab and observe that images will be default category
3. Click on the category dropdown button to expand the category list
4. Change the third-party media category to gifs or videos
5. Category collapse button from the images list should **not** persist (potentially behind new media elements)

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4416
