### PR TITLE
Fix bundling to not drop certain CSS files

### DIFF
--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -95,6 +95,7 @@ const sharedConfig = {
       {
         test: /\.css$/,
         use: [MiniCssExtractPlugin.loader, 'css-loader'],
+        sideEffects: true,
       },
     ].filter(Boolean),
   },

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -112,6 +112,7 @@ const sharedConfig = {
     }),
   ].filter(Boolean),
   optimization: {
+    sideEffects: true,
     minimizer: [
       new TerserPlugin({
         parallel: true,


### PR DESCRIPTION
## Summary

webpack was trying to be clever and thought the calendar CSS was not used at all. By marking CSS files as side effects, webpack will not drop these again.

## Relevant Technical Choices

*  Optimized webpack config

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

No broken calendar styling anymore for production builds

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

See #1391
