### PR TITLE
Enforce webpackChunkName comments for dynamic imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -73,6 +73,9 @@
         "from": "./assets/src/edit-story/utils/useWhyDidYouUpdate.js"
       } ]
     } ],
+    "import/dynamic-import-chunkname": [ "error", {
+      "webpackChunknameFormat": "[0-9a-zA-Z-_/.[\\]]+"
+    } ],
     "no-restricted-properties": "error",
     "no-return-assign": "error",
     "no-return-await": "error",

--- a/assets/src/edit-story/components/library/panes/text/textSets/getTextSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/getTextSets.js
@@ -32,7 +32,9 @@ function updateMinMax(minMax, element) {
 }
 
 async function loadTextSet(name) {
-  const data = await import(`./raw/${name}.json`);
+  const data = await import(
+    /* webpackChunkName: "chunk-web-stories-textset-[index]" */ `./raw/${name}.json`
+  );
   const migrated = migrate(data, data.version);
 
   const textSets = migrated.pages.reduce((sets, page) => {


### PR DESCRIPTION
## Summary

Avoids meaningless chunk file names and comments like these (because they change all the time):

<img width="619" alt="Screenshot 2020-09-10 at 14 48 36" src="https://user-images.githubusercontent.com/841956/92730965-c9770d80-f374-11ea-97b7-b67233843747.png">

