### PR TITLE
Editor: Enable Keyboard Shortcut Menu

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -306,6 +306,7 @@ class Experiments {
 				'label'       => __( 'Keyboard Shortcuts', 'web-stories' ),
 				'description' => __( 'Enable keyboard shortcuts button', 'web-stories' ),
 				'group'       => 'editor',
+				'default'     => true,
 			],
 			/**
 			 * Author: @dmmulroy


### PR DESCRIPTION
## Summary

Super small PR to enable the keyboard shortcut menu.

## User-facing changes

Yes.  The little keyboard icon to open the menu should appear in the editor:
![image](https://user-images.githubusercontent.com/40646372/92799941-12c16000-f369-11ea-97d0-c8291f17e222.png)

## Testing Instructions

1.) Go to the Experiments page and make sure "Keyboard Shortcuts" is auto-enabled (checked in with a disabled box):
![image](https://user-images.githubusercontent.com/40646372/92800008-27055d00-f369-11ea-97a1-5dbb33ee3441.png)

2.) Go to editor and see that the keyboard menu button appears.  Toggle the menu open and closed.

Fixes #4455 

Menu opened in all its glory:
<img src="https://user-images.githubusercontent.com/40646372/92800179-4a300c80-f369-11ea-8fe3-de3a9251a88e.png" height="500">

