### PR TITLE
3P Media: fix strange resizing of width of gallery

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
@@ -73,6 +73,7 @@ const ProviderMediaCategoriesWrapper = styled.div`
   flex-direction: column;
   height: 100%;
   min-height: 100px;
+  max-width: 100%;
   top: 0;
   left: 0;
   &.provider-selected {


### PR DESCRIPTION
## Summary

When you've loaded 2 or more provider tabs (eg: unsplash and coverr) and you select Unsplash, the Coverr tab continuously resizes for some reason, which triggers re-rendering of the media elements. Setting a max-width on this container avoids this issue.

Fixes #4434
