### PR TITLE
Dashboard: Prevent Telemetry Banner from squishing stories

### DIFF
--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -30,11 +30,12 @@ import {
   NavMenuButton,
   StandardViewContentGutter,
 } from '../../../components';
+import { SQUISH_CSS_VAR } from '../../../components/layout';
 import TypeaheadSearch from './typeaheadSearch';
 import TelemetryBanner from './telemetryBanner';
 
 const Container = styled.div`
-  padding: 10px 0 0;
+  padding: ${cssLerp('0px', '10px', SQUISH_CSS_VAR)} 0 0;
 `;
 
 const StyledHeader = styled.h2`

--- a/assets/src/dashboard/app/views/shared/telemetryBanner.js
+++ b/assets/src/dashboard/app/views/shared/telemetryBanner.js
@@ -28,7 +28,7 @@ import { __ } from '@wordpress/i18n';
 import { useLayoutEffect, useRef } from 'react';
 import { TypographyPresets, useLayoutContext } from '../../../components';
 import { Close as CloseSVG } from '../../../icons';
-import { ICON_METRICS, TELEMETRY_BANNER_HEIGHT } from '../../../constants';
+import { TELEMETRY_BANNER_HEIGHT } from '../../../constants';
 import { useConfig } from '../../config';
 import useTelemetryOptIn from './useTelemetryOptIn';
 
@@ -79,19 +79,24 @@ const CheckBox = styled.input.attrs({
   margin: 5px 12px 0 0;
 `;
 
-const CloseIcon = styled(CloseSVG).attrs(ICON_METRICS.TELEMETRY_BANNER_EXIT)`
+const CloseIcon = styled(CloseSVG)`
   color: ${({ theme }) => theme.colors.white};
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
+  margin: 0 auto;
+  padding: 2px;
+  width: 14px;
+  height: auto;
+  display: inline-block;
 `;
 
 const ToggleButton = styled.button.attrs({
   ['aria-label']: __('Dismiss Notice', 'web-stories'),
 })`
-  border: none;
-  padding: 4px;
+  display: flex;
+  height: 16px;
+  width: 16px;
+  border: ${({ theme }) => theme.borders.transparent};
   border-radius: 50%;
+  padding: 0;
   background: ${({ theme }) => theme.colors.gray200};
   cursor: pointer;
   float: right;

--- a/assets/src/dashboard/app/views/shared/telemetryBanner.js
+++ b/assets/src/dashboard/app/views/shared/telemetryBanner.js
@@ -25,9 +25,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { TypographyPresets } from '../../../components';
+import { useLayoutEffect, useRef } from 'react';
+import { TypographyPresets, useLayoutContext } from '../../../components';
 import { Close as CloseSVG } from '../../../icons';
-import { ICON_METRICS } from '../../../constants';
+import { ICON_METRICS, TELEMETRY_BANNER_HEIGHT } from '../../../constants';
 import { useConfig } from '../../config';
 import useTelemetryOptIn from './useTelemetryOptIn';
 
@@ -36,7 +37,7 @@ const Banner = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 161px;
+  height: ${TELEMETRY_BANNER_HEIGHT};
   margin: 0 20px;
   padding-top: 24px;
   background-image: url('${({ $backgroundUrl }) => $backgroundUrl}');
@@ -172,6 +173,22 @@ export default function TelemetryBannerContainer(props) {
     disabled,
     toggleWebStoriesTrackingOptIn,
   } = useTelemetryOptIn();
+
+  const {
+    actions: { setTelemetryBannerOpen },
+  } = useLayoutContext();
+
+  const previousBannerVisible = useRef(bannerVisible);
+
+  useLayoutEffect(() => {
+    if (bannerVisible && previousBannerVisible.current === false) {
+      setTelemetryBannerOpen(true);
+      previousBannerVisible.current = true;
+    } else if (!bannerVisible && previousBannerVisible.current) {
+      setTelemetryBannerOpen(false);
+      previousBannerVisible.current = false;
+    }
+  }, [bannerVisible, setTelemetryBannerOpen]);
 
   return (
     <TelemetryOptInBanner

--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -30,6 +30,7 @@ import PropTypes from 'prop-types';
  */
 import { DASHBOARD_TOP_MARGIN } from '../../constants/pageStructure';
 import { clamp, throttleToAnimationFrame } from '../../utils';
+import { TELEMETRY_BANNER_HEIGHT } from '../../constants';
 
 export const SQUISH_LENGTH = DASHBOARD_TOP_MARGIN;
 export const SQUISH_CSS_VAR = '--squish-progress';
@@ -49,6 +50,20 @@ export const LayoutContext = createContext(null);
 const Provider = ({ children }) => {
   const [squishContentHeight, setSquishContentHeight] = useState(0);
   const scrollFrameRef = useRef(null);
+  const [telemetryBannerOpen, setTelemetryBannerOpen] = useState(false);
+  const bannerHeightIncluded = useRef(false);
+
+  useLayoutEffect(() => {
+    if (telemetryBannerOpen && !bannerHeightIncluded.current) {
+      setSquishContentHeight((height) => (height += TELEMETRY_BANNER_HEIGHT));
+      bannerHeightIncluded.current = true;
+    }
+
+    if (!telemetryBannerOpen && bannerHeightIncluded.current) {
+      setSquishContentHeight((height) => (height -= TELEMETRY_BANNER_HEIGHT));
+      bannerHeightIncluded.current = false;
+    }
+  }, [telemetryBannerOpen, squishContentHeight]);
 
   useLayoutEffect(() => {
     const scrollFrameEl = scrollFrameRef.current;
@@ -107,6 +122,7 @@ const Provider = ({ children }) => {
       state: {
         scrollFrameRef,
         squishContentHeight,
+        telemetryBannerOpen,
       },
       actions: {
         /**
@@ -124,9 +140,17 @@ const Provider = ({ children }) => {
         removeSquishListener,
         setSquishContentHeight,
         scrollToTop,
+        setTelemetryBannerOpen,
       },
     }),
-    [addSquishListener, removeSquishListener, squishContentHeight, scrollToTop]
+    [
+      setTelemetryBannerOpen,
+      telemetryBannerOpen,
+      addSquishListener,
+      removeSquishListener,
+      squishContentHeight,
+      scrollToTop,
+    ]
   );
 
   return (

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -132,6 +132,9 @@ export const TEXT_INPUT_DEBOUNCE = 300;
 export const MIN_IMG_HEIGHT = 96;
 export const MIN_IMG_WIDTH = 96;
 
+// Includes height, padding, margin
+export const TELEMETRY_BANNER_HEIGHT = 161;
+
 export * from './components';
 export * from './direction';
 export * from './pageStructure';


### PR DESCRIPTION
## Summary

This fixes the bug where when the Telemetry Banner is open stories were being squished/cut off.

## Relevant Technical Choices

I integrated the LayoutProvider context with the TelemetryBanner container - when the Banner is visible the layout provider will factor in the banners height to `squishContentHeight`.

## User-facing changes

Stories should no longer be squished or cut off when the telemetry banner is open.

## Testing Instructions

- Make sure localStorage is cleared (`localStorage.clear() in the dev console) and make sure Data Sharing Opt In is unchecked on the Editor Settings page - these are the conditions to display the banner.
- Refresh/load My Stories and verify that the banner is displayed and stories aren't cut off

### Before
![before](https://user-images.githubusercontent.com/2755722/92937522-6c816300-f419-11ea-8a0b-bb45d909af84.png)

### After
![after](https://user-images.githubusercontent.com/2755722/92937455-596e9300-f419-11ea-8162-e02b57838426.png)


<!-- Please reference the issue(s) this PR addresses. -->

#4449 
