### PR TITLE
Added karma tests and storybook entry for Keyboard Shortcuts menu

### DIFF
--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -496,7 +496,6 @@ function Carousel() {
               placement="left"
             >
               <SafeZoneToggle
-                data-testid={'safe-zone-toggle'}
                 icon={<SafeZone />}
                 value={showSafeZone}
                 onChange={setShowSafeZone}

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/index.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/index.js
@@ -72,7 +72,6 @@ function KeyboardShortcutsMenu({ onMenuToggled }) {
         placement={Placement.LEFT}
       >
         <KeyboardShortcutsButton
-          data-testid={'keyboard-shortcuts-toggle'}
           ref={anchorRef}
           width="24"
           height="24"
@@ -83,7 +82,11 @@ function KeyboardShortcutsMenu({ onMenuToggled }) {
           onClick={toggleMenu}
         />
       </WithTooltip>
-      <Modal open={isOpen} onClose={toggleMenu}>
+      <Modal
+        contentLabel={__('Keyboard Shortcuts Menu', 'web-stories')}
+        open={isOpen}
+        onClose={toggleMenu}
+      >
         <ShortcutMenu toggleMenu={toggleMenu} />
       </Modal>
     </>

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { within } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+
+describe('Keyboard Shortcuts Menu', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    fixture.setFlags({ showKeyboardShortcutsButton: true });
+
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  describe('CUJ: User can interact with menu using mouse: Click toggle button to open, click close button to close menu', () => {
+    it('should be able to open menu by clicking on keyboard shortcut button', async () => {
+      const hiddenMenu = await fixture.screen.queryByTestId(
+        'keyboard-shortcuts-menu'
+      );
+      // Menu should be closed
+      expect(hiddenMenu).toBeNull();
+
+      const menuToggle = fixture.screen.getByTestId(
+        'keyboard-shortcuts-toggle'
+      );
+
+      await fixture.events.click(menuToggle);
+
+      const openMenu = await fixture.screen.queryByTestId(
+        'keyboard-shortcuts-menu'
+      );
+
+      expect(openMenu).toBeTruthy();
+    });
+
+    describe('when menu is open', () => {
+      beforeEach(async () => {
+        const menuToggle = fixture.screen.getByTestId(
+          'keyboard-shortcuts-toggle'
+        );
+
+        await fixture.events.click(menuToggle);
+      });
+
+      it('should be able to close menu by clicking on close button', async () => {
+        const openMenu = await fixture.screen.getByTestId(
+          'keyboard-shortcuts-menu'
+        );
+        expect(openMenu).toBeTruthy();
+
+        const closeButton = fixture.screen.queryByRole('button', {
+          name: /^Close menu$/,
+        });
+        await fixture.events.click(closeButton);
+        // Give time for menu to close
+        await fixture.events.sleep(100);
+
+        const closedMenu = await fixture.screen.queryByTestId(
+          'keyboard-shortcuts-menu'
+        );
+
+        expect(closedMenu).toBeNull();
+      });
+
+      it('should be able to close menu by clicking outside the menu', async () => {
+        const openMenu = await fixture.screen.getByTestId(
+          'keyboard-shortcuts-menu'
+        );
+        expect(openMenu).toBeTruthy();
+
+        // Click outside menu
+        await fixture.events.mouse.clickOn(openMenu, -10, -10);
+        // Give time for menu to close
+        await fixture.events.sleep(100);
+
+        const closedMenu = await fixture.screen.queryByTestId(
+          'keyboard-shortcuts-menu'
+        );
+
+        expect(closedMenu).toBeNull();
+      });
+
+      it('should not close menu when clicking inside the menu', async () => {
+        const openMenu = await fixture.screen.getByTestId(
+          'keyboard-shortcuts-menu'
+        );
+        expect(openMenu).toBeTruthy();
+
+        // Click inside menu
+        await fixture.events.mouse.clickOn(openMenu, 10, 10);
+
+        const menuItem = await within(openMenu).queryAllByRole('listitem')[0];
+        // Click on element inside menu
+        await fixture.events.click(menuItem);
+        // Give time for menu to process clicks
+        await fixture.events.sleep(100);
+
+        const menu = await fixture.screen.queryByTestId(
+          'keyboard-shortcuts-menu'
+        );
+
+        // Menu should still be open
+        expect(menu).toBeTruthy();
+      });
+    });
+  });
+
+  describe('CUJ: User can interact with menu using keyboard: Tab to menu, enter to open, esc to close', () => {
+    it('should be able to tab to keyboard shortcuts button', async () => {
+      const safeZone = fixture.screen.getByTestId('safe-zone-toggle');
+
+      await fixture.events.focus(safeZone);
+
+      await fixture.events.keyboard.down('Shift');
+      await fixture.events.keyboard.press('Tab');
+      await fixture.events.keyboard.up('Shift');
+
+      const focusElement = document.activeElement;
+      const keyboardShortcutsToggle = fixture.screen.getByTestId(
+        'keyboard-shortcuts-toggle'
+      );
+
+      expect(focusElement).toEqual(keyboardShortcutsToggle);
+    });
+
+    it('should be able to toggle menu open with Enter key', async () => {
+      const hiddenMenu = await fixture.screen.queryByTestId(
+        'keyboard-shortcuts-menu'
+      );
+      // Menu should be closed
+      expect(hiddenMenu).toBeNull();
+
+      const menuToggle = fixture.screen.getByTestId(
+        'keyboard-shortcuts-toggle'
+      );
+
+      await fixture.events.focus(menuToggle);
+      await fixture.events.keyboard.press('Enter');
+
+      const openMenu = await fixture.screen.queryByTestId(
+        'keyboard-shortcuts-menu'
+      );
+
+      expect(openMenu).toBeTruthy();
+    });
+
+    describe('when menu is open', () => {
+      beforeEach(async () => {
+        const menuToggle = fixture.screen.getByTestId(
+          'keyboard-shortcuts-toggle'
+        );
+
+        await fixture.events.focus(menuToggle);
+        await fixture.events.keyboard.press('Enter');
+      });
+
+      it('should be able to close open menu using Esc key', async () => {
+        const openMenu = fixture.screen.getByTestId('keyboard-shortcuts-menu');
+        expect(openMenu).toBeTruthy();
+
+        await fixture.events.keyboard.press('Escape');
+        // Give time for menu to close
+        await fixture.events.sleep(100);
+
+        const closedMenu = await fixture.screen.queryByTestId(
+          'keyboard-shortcuts-menu'
+        );
+
+        expect(closedMenu).toBeNull();
+      });
+
+      it('should place focus on close button when menu opens', () => {
+        const openMenu = fixture.screen.getByTestId('keyboard-shortcuts-menu');
+        expect(openMenu).toBeTruthy();
+
+        const closeButton = fixture.screen.queryByRole('button', {
+          name: /^Close menu$/,
+        });
+
+        expect(document.activeElement).toEqual(closeButton);
+      });
+
+      it('should be able to close menu with close button', async () => {
+        const openMenu = fixture.screen.getByTestId('keyboard-shortcuts-menu');
+        expect(openMenu).toBeTruthy();
+
+        const closeButton = fixture.screen.queryByRole('button', {
+          name: /^Close menu$/,
+        });
+
+        await fixture.events.focus(closeButton);
+        await fixture.events.keyboard.press('Enter');
+        // Give time for menu to close
+        await fixture.events.sleep(100);
+
+        const closedMenu = await fixture.screen.queryByTestId(
+          'keyboard-shortcuts-menu'
+        );
+
+        expect(closedMenu).toBeNull();
+      });
+    });
+  });
+});

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
@@ -40,58 +40,59 @@ describe('Keyboard Shortcuts Menu', () => {
 
   describe('CUJ: User can interact with menu using mouse: Click toggle button to open, click close button to close menu', () => {
     it('should be able to open menu by clicking on keyboard shortcut button', async () => {
-      const hiddenMenu = await fixture.screen.queryByTestId(
-        'keyboard-shortcuts-menu'
-      );
+      const hiddenMenu = fixture.screen.queryByRole('dialog', {
+        name: /^Keyboard Shortcuts Menu$/,
+      });
       // Menu should be closed
       expect(hiddenMenu).toBeNull();
 
-      const menuToggle = fixture.screen.getByTestId(
-        'keyboard-shortcuts-toggle'
-      );
+      const menuToggle = fixture.editor.getByRole('button', {
+        name: /^Open Keyboard Shortcuts$/,
+      });
 
       await fixture.events.click(menuToggle);
 
-      const openMenu = await fixture.screen.queryByTestId(
-        'keyboard-shortcuts-menu'
-      );
+      const openMenu = fixture.screen.getByRole('dialog', {
+        name: /^Keyboard Shortcuts Menu$/,
+      });
 
       expect(openMenu).toBeTruthy();
     });
 
     describe('when menu is open', () => {
       beforeEach(async () => {
-        const menuToggle = fixture.screen.getByTestId(
-          'keyboard-shortcuts-toggle'
-        );
+        const menuToggle = fixture.editor.getByRole('button', {
+          name: /^Open Keyboard Shortcuts$/,
+        });
 
         await fixture.events.click(menuToggle);
       });
 
       it('should be able to close menu by clicking on close button', async () => {
-        const openMenu = await fixture.screen.getByTestId(
-          'keyboard-shortcuts-menu'
-        );
+        const openMenu = fixture.screen.getByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
         expect(openMenu).toBeTruthy();
 
-        const closeButton = fixture.screen.queryByRole('button', {
+        const menu = within(openMenu);
+        const closeButton = menu.getByRole('button', {
           name: /^Close menu$/,
         });
         await fixture.events.click(closeButton);
         // Give time for menu to close
         await fixture.events.sleep(100);
 
-        const closedMenu = await fixture.screen.queryByTestId(
-          'keyboard-shortcuts-menu'
-        );
+        const closedMenu = fixture.screen.queryByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
 
         expect(closedMenu).toBeNull();
       });
 
       it('should be able to close menu by clicking outside the menu', async () => {
-        const openMenu = await fixture.screen.getByTestId(
-          'keyboard-shortcuts-menu'
-        );
+        const openMenu = fixture.screen.getByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
         expect(openMenu).toBeTruthy();
 
         // Click outside menu
@@ -99,107 +100,112 @@ describe('Keyboard Shortcuts Menu', () => {
         // Give time for menu to close
         await fixture.events.sleep(100);
 
-        const closedMenu = await fixture.screen.queryByTestId(
-          'keyboard-shortcuts-menu'
-        );
+        const closedMenu = fixture.screen.queryByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
 
         expect(closedMenu).toBeNull();
       });
 
       it('should not close menu when clicking inside the menu', async () => {
-        const openMenu = await fixture.screen.getByTestId(
-          'keyboard-shortcuts-menu'
-        );
+        const openMenu = fixture.screen.getByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
         expect(openMenu).toBeTruthy();
 
         // Click inside menu
         await fixture.events.mouse.clickOn(openMenu, 10, 10);
 
-        const menuItem = await within(openMenu).queryAllByRole('listitem')[0];
+        const menu = within(openMenu);
+        const menuItem = await menu.queryAllByRole('listitem')[0];
         // Click on element inside menu
         await fixture.events.click(menuItem);
         // Give time for menu to process clicks
         await fixture.events.sleep(100);
 
-        const menu = await fixture.screen.queryByTestId(
-          'keyboard-shortcuts-menu'
-        );
+        const stillOpenMenu = fixture.screen.getByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
 
         // Menu should still be open
-        expect(menu).toBeTruthy();
+        expect(stillOpenMenu).toBeTruthy();
       });
     });
   });
 
   describe('CUJ: User can interact with menu using keyboard: Tab to menu, enter to open, esc to close', () => {
     it('should be able to tab to keyboard shortcuts button', async () => {
-      const safeZone = fixture.screen.getByTestId('safe-zone-toggle');
+      const safeZone = fixture.editor.getByRole('checkbox', {
+        name: /^Disable Safe Zone$/,
+      });
 
       await fixture.events.focus(safeZone);
-
-      await fixture.events.keyboard.down('Shift');
-      await fixture.events.keyboard.press('Tab');
-      await fixture.events.keyboard.up('Shift');
+      await fixture.events.keyboard.shortcut('Shift+Tab');
 
       const focusElement = document.activeElement;
-      const keyboardShortcutsToggle = fixture.screen.getByTestId(
-        'keyboard-shortcuts-toggle'
-      );
+      const menuToggle = fixture.editor.getByRole('button', {
+        name: /^Open Keyboard Shortcuts$/,
+      });
 
-      expect(focusElement).toEqual(keyboardShortcutsToggle);
+      expect(focusElement).toEqual(menuToggle);
     });
 
     it('should be able to toggle menu open with Enter key', async () => {
-      const hiddenMenu = await fixture.screen.queryByTestId(
-        'keyboard-shortcuts-menu'
-      );
+      const hiddenMenu = fixture.screen.queryByRole('dialog', {
+        name: /^Keyboard Shortcuts Menu$/,
+      });
       // Menu should be closed
       expect(hiddenMenu).toBeNull();
 
-      const menuToggle = fixture.screen.getByTestId(
-        'keyboard-shortcuts-toggle'
-      );
+      const menuToggle = fixture.editor.getByRole('button', {
+        name: /^Open Keyboard Shortcuts$/,
+      });
 
       await fixture.events.focus(menuToggle);
       await fixture.events.keyboard.press('Enter');
 
-      const openMenu = await fixture.screen.queryByTestId(
-        'keyboard-shortcuts-menu'
-      );
+      const openMenu = fixture.screen.getByRole('dialog', {
+        name: /^Keyboard Shortcuts Menu$/,
+      });
 
       expect(openMenu).toBeTruthy();
     });
 
     describe('when menu is open', () => {
       beforeEach(async () => {
-        const menuToggle = fixture.screen.getByTestId(
-          'keyboard-shortcuts-toggle'
-        );
+        const menuToggle = fixture.editor.getByRole('button', {
+          name: /^Open Keyboard Shortcuts$/,
+        });
 
         await fixture.events.focus(menuToggle);
         await fixture.events.keyboard.press('Enter');
       });
 
       it('should be able to close open menu using Esc key', async () => {
-        const openMenu = fixture.screen.getByTestId('keyboard-shortcuts-menu');
+        const openMenu = fixture.screen.getByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
         expect(openMenu).toBeTruthy();
 
         await fixture.events.keyboard.press('Escape');
         // Give time for menu to close
         await fixture.events.sleep(100);
 
-        const closedMenu = await fixture.screen.queryByTestId(
-          'keyboard-shortcuts-menu'
-        );
+        const closedMenu = fixture.screen.queryByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
 
         expect(closedMenu).toBeNull();
       });
 
       it('should place focus on close button when menu opens', () => {
-        const openMenu = fixture.screen.getByTestId('keyboard-shortcuts-menu');
+        const openMenu = fixture.screen.getByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
         expect(openMenu).toBeTruthy();
 
-        const closeButton = fixture.screen.queryByRole('button', {
+        const menu = within(openMenu);
+        const closeButton = menu.getByRole('button', {
           name: /^Close menu$/,
         });
 
@@ -207,10 +213,13 @@ describe('Keyboard Shortcuts Menu', () => {
       });
 
       it('should be able to close menu with close button', async () => {
-        const openMenu = fixture.screen.getByTestId('keyboard-shortcuts-menu');
+        const openMenu = fixture.screen.getByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
         expect(openMenu).toBeTruthy();
 
-        const closeButton = fixture.screen.queryByRole('button', {
+        const menu = within(openMenu);
+        const closeButton = menu.getByRole('button', {
           name: /^Close menu$/,
         });
 
@@ -219,9 +228,9 @@ describe('Keyboard Shortcuts Menu', () => {
         // Give time for menu to close
         await fixture.events.sleep(100);
 
-        const closedMenu = await fixture.screen.queryByTestId(
-          'keyboard-shortcuts-menu'
-        );
+        const closedMenu = fixture.screen.queryByRole('dialog', {
+          name: /^Keyboard Shortcuts Menu$/,
+        });
 
         expect(closedMenu).toBeNull();
       });

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
@@ -27,6 +27,18 @@ import { Fixture } from '../../../karma';
 describe('Keyboard Shortcuts Menu', () => {
   let fixture;
 
+  const getKeyboardShortcutsMenu = () => {
+    return fixture.screen.queryByRole('dialog', {
+      name: /^Keyboard Shortcuts Menu$/,
+    });
+  };
+
+  const getKeyboardShortcutsToggle = () => {
+    return fixture.editor.getByRole('button', {
+      name: /^Open Keyboard Shortcuts$/,
+    });
+  };
+
   beforeEach(async () => {
     fixture = new Fixture();
     fixture.setFlags({ showKeyboardShortcutsButton: true });
@@ -40,38 +52,28 @@ describe('Keyboard Shortcuts Menu', () => {
 
   describe('CUJ: User can interact with menu using mouse: Click toggle button to open, click close button to close menu', () => {
     it('should be able to open menu by clicking on keyboard shortcut button', async () => {
-      const hiddenMenu = fixture.screen.queryByRole('dialog', {
-        name: /^Keyboard Shortcuts Menu$/,
-      });
+      const hiddenMenu = getKeyboardShortcutsMenu();
       // Menu should be closed
       expect(hiddenMenu).toBeNull();
 
-      const menuToggle = fixture.editor.getByRole('button', {
-        name: /^Open Keyboard Shortcuts$/,
-      });
+      const menuToggle = getKeyboardShortcutsToggle();
 
       await fixture.events.click(menuToggle);
 
-      const openMenu = fixture.screen.getByRole('dialog', {
-        name: /^Keyboard Shortcuts Menu$/,
-      });
+      const openMenu = getKeyboardShortcutsMenu();
 
       expect(openMenu).toBeTruthy();
     });
 
     describe('when menu is open', () => {
       beforeEach(async () => {
-        const menuToggle = fixture.editor.getByRole('button', {
-          name: /^Open Keyboard Shortcuts$/,
-        });
+        const menuToggle = getKeyboardShortcutsToggle();
 
         await fixture.events.click(menuToggle);
       });
 
       it('should be able to close menu by clicking on close button', async () => {
-        const openMenu = fixture.screen.getByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const openMenu = getKeyboardShortcutsMenu();
         expect(openMenu).toBeTruthy();
 
         const menu = within(openMenu);
@@ -82,17 +84,13 @@ describe('Keyboard Shortcuts Menu', () => {
         // Give time for menu to close
         await fixture.events.sleep(100);
 
-        const closedMenu = fixture.screen.queryByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const closedMenu = getKeyboardShortcutsMenu();
 
         expect(closedMenu).toBeNull();
       });
 
       it('should be able to close menu by clicking outside the menu', async () => {
-        const openMenu = fixture.screen.getByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const openMenu = getKeyboardShortcutsMenu();
         expect(openMenu).toBeTruthy();
 
         // Click outside menu
@@ -100,17 +98,13 @@ describe('Keyboard Shortcuts Menu', () => {
         // Give time for menu to close
         await fixture.events.sleep(100);
 
-        const closedMenu = fixture.screen.queryByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const closedMenu = getKeyboardShortcutsMenu();
 
         expect(closedMenu).toBeNull();
       });
 
       it('should not close menu when clicking inside the menu', async () => {
-        const openMenu = fixture.screen.getByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const openMenu = getKeyboardShortcutsMenu();
         expect(openMenu).toBeTruthy();
 
         // Click inside menu
@@ -123,9 +117,7 @@ describe('Keyboard Shortcuts Menu', () => {
         // Give time for menu to process clicks
         await fixture.events.sleep(100);
 
-        const stillOpenMenu = fixture.screen.getByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const stillOpenMenu = getKeyboardShortcutsMenu();
 
         // Menu should still be open
         expect(stillOpenMenu).toBeTruthy();
@@ -143,65 +135,49 @@ describe('Keyboard Shortcuts Menu', () => {
       await fixture.events.keyboard.shortcut('Shift+Tab');
 
       const focusElement = document.activeElement;
-      const menuToggle = fixture.editor.getByRole('button', {
-        name: /^Open Keyboard Shortcuts$/,
-      });
+      const menuToggle = getKeyboardShortcutsToggle();
 
       expect(focusElement).toEqual(menuToggle);
     });
 
     it('should be able to toggle menu open with Enter key', async () => {
-      const hiddenMenu = fixture.screen.queryByRole('dialog', {
-        name: /^Keyboard Shortcuts Menu$/,
-      });
+      const hiddenMenu = getKeyboardShortcutsMenu();
       // Menu should be closed
       expect(hiddenMenu).toBeNull();
 
-      const menuToggle = fixture.editor.getByRole('button', {
-        name: /^Open Keyboard Shortcuts$/,
-      });
+      const menuToggle = getKeyboardShortcutsToggle();
 
       await fixture.events.focus(menuToggle);
       await fixture.events.keyboard.press('Enter');
 
-      const openMenu = fixture.screen.getByRole('dialog', {
-        name: /^Keyboard Shortcuts Menu$/,
-      });
+      const openMenu = getKeyboardShortcutsMenu();
 
       expect(openMenu).toBeTruthy();
     });
 
     describe('when menu is open', () => {
       beforeEach(async () => {
-        const menuToggle = fixture.editor.getByRole('button', {
-          name: /^Open Keyboard Shortcuts$/,
-        });
+        const menuToggle = getKeyboardShortcutsToggle();
 
         await fixture.events.focus(menuToggle);
         await fixture.events.keyboard.press('Enter');
       });
 
       it('should be able to close open menu using Esc key', async () => {
-        const openMenu = fixture.screen.getByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const openMenu = getKeyboardShortcutsMenu();
         expect(openMenu).toBeTruthy();
 
         await fixture.events.keyboard.press('Escape');
         // Give time for menu to close
         await fixture.events.sleep(100);
 
-        const closedMenu = fixture.screen.queryByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const closedMenu = getKeyboardShortcutsMenu();
 
         expect(closedMenu).toBeNull();
       });
 
       it('should place focus on close button when menu opens', () => {
-        const openMenu = fixture.screen.getByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const openMenu = getKeyboardShortcutsMenu();
         expect(openMenu).toBeTruthy();
 
         const menu = within(openMenu);
@@ -213,9 +189,7 @@ describe('Keyboard Shortcuts Menu', () => {
       });
 
       it('should be able to close menu with close button', async () => {
-        const openMenu = fixture.screen.getByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const openMenu = getKeyboardShortcutsMenu();
         expect(openMenu).toBeTruthy();
 
         const menu = within(openMenu);
@@ -228,9 +202,7 @@ describe('Keyboard Shortcuts Menu', () => {
         // Give time for menu to close
         await fixture.events.sleep(100);
 
-        const closedMenu = fixture.screen.queryByRole('dialog', {
-          name: /^Keyboard Shortcuts Menu$/,
-        });
+        const closedMenu = getKeyboardShortcutsMenu();
 
         expect(closedMenu).toBeNull();
       });

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/shortcutMenu.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/shortcutMenu.js
@@ -137,7 +137,12 @@ function ShortcutMenu({ toggleMenu }) {
   ]);
 
   return (
-    <Container ref={containerRef} role="list" aria-labelledby={headerLabels}>
+    <Container
+      data-testid={'keyboard-shortcuts-menu'}
+      ref={containerRef}
+      role="list"
+      aria-labelledby={headerLabels}
+    >
       <CloseButton
         ref={closeRef}
         onClick={handleCloseClick}

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/shortcutMenu.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/shortcutMenu.js
@@ -137,12 +137,7 @@ function ShortcutMenu({ toggleMenu }) {
   ]);
 
   return (
-    <Container
-      data-testid={'keyboard-shortcuts-menu'}
-      ref={containerRef}
-      role="list"
-      aria-labelledby={headerLabels}
-    >
+    <Container ref={containerRef} role="list" aria-labelledby={headerLabels}>
       <CloseButton
         ref={closeRef}
         onClick={handleCloseClick}

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/stories/index.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/stories/index.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import ShortcutMenu from '../shortcutMenu';
+
+export default {
+  title: 'Stories Editor/Components/Keyboard Shortcuts Menu',
+  component: ShortcutMenu,
+};
+
+export const _default = () => {
+  return <ShortcutMenu />;
+};


### PR DESCRIPTION
## Summary

This PR just adds a few karma tests to test our the Keyboard Shortcuts menu.  I test interactions with keyboard and mouse 😎 

I've also added a storybook entry of the full menu so we can have it in our library.

## User-facing changes

None.

## Testing Instructions

1.) Make sure the karma tests run and pass.
2.) Open up Storybook and go to: "Stories Editor ->Components -> Keyboard Shortcuts Menu" and make sure the menu appears in all its glory.

Fixes #359 

## Screenshots

Storybook pic:
<img src="https://user-images.githubusercontent.com/40646372/92976258-07d8ff00-f43f-11ea-8ecc-4aab093c60c4.png" height="500">
