### PR TITLE
Dashboard: Dynamically Size Telemetry Banner

### DIFF
--- a/assets/src/dashboard/app/views/shared/telemetryBanner.js
+++ b/assets/src/dashboard/app/views/shared/telemetryBanner.js
@@ -17,6 +17,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import { useLayoutEffect, useRef, forwardRef } from 'react';
 import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
@@ -25,10 +26,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useLayoutEffect, useRef } from 'react';
 import { TypographyPresets, useLayoutContext } from '../../../components';
 import { Close as CloseSVG } from '../../../icons';
-import { TELEMETRY_BANNER_HEIGHT } from '../../../constants';
 import { useConfig } from '../../config';
 import useTelemetryOptIn from './useTelemetryOptIn';
 
@@ -37,10 +36,9 @@ const Banner = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: ${TELEMETRY_BANNER_HEIGHT};
   margin: 0 20px;
   padding-top: 24px;
-  background-image: url('${({ $backgroundUrl }) => $backgroundUrl}');
+  background-image: url('${({ backgroundUrl }) => backgroundUrl}');
   border-radius: 8px;
 `;
 
@@ -110,57 +108,67 @@ const ToggleButton = styled.button.attrs({
   }
 `;
 
-export function TelemetryOptInBanner({
-  visible = true,
-  disabled = false,
-  onChange = () => {},
-  onClose = () => {},
-  checked = false,
-}) {
-  const { assetsURL } = useConfig();
+export const TelemetryOptInBanner = forwardRef(
+  (
+    {
+      visible = true,
+      disabled = false,
+      onChange = () => {},
+      onClose = () => {},
+      checked = false,
+    },
+    ref
+  ) => {
+    const { assetsURL } = useConfig();
 
-  return visible ? (
-    <Banner $backgroundUrl={`${assetsURL}images/analytics-banner-bg.png`}>
-      <Header>
-        <Title>
-          {checked
-            ? __(
-                'Your selection has been updated. Thank you for helping to improve the editor!',
-                'web-stories'
-              )
-            : __('Help improve the editor!', 'web-stories')}
-        </Title>
-        <ToggleButton onClick={onClose}>
-          <CloseIcon />
-        </ToggleButton>
-      </Header>
-      <Label>
-        <CheckBox checked={checked} disabled={disabled} onChange={onChange} />
-        <LabelText aria-checked={checked}>
+    return visible ? (
+      <Banner
+        ref={ref}
+        backgroundUrl={`${assetsURL}images/analytics-banner-bg.png`}
+      >
+        <Header>
+          <Title>
+            {checked
+              ? __(
+                  'Your selection has been updated. Thank you for helping to improve the editor!',
+                  'web-stories'
+                )
+              : __('Help improve the editor!', 'web-stories')}
+          </Title>
+          <ToggleButton onClick={onClose}>
+            <CloseIcon />
+          </ToggleButton>
+        </Header>
+        <Label>
+          <CheckBox checked={checked} disabled={disabled} onChange={onChange} />
+          <LabelText aria-checked={checked}>
+            {__(
+              'Check the box to help us improve the Web Stories plugin by allowing tracking of product usage stats. All data are treated in accordance with Google Privacy Policy.',
+              'web-stories'
+            )}
+            &nbsp;
+            <a
+              href={__('https://policies.google.com/privacy', 'web-stories')}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {__('Learn more', 'web-stories')}
+              {'.'}
+            </a>
+          </LabelText>
+        </Label>
+        <VisitSettingsText>
           {__(
-            'Check the box to help us improve the Web Stories plugin by allowing tracking of product usage stats. All data are treated in accordance with Google Privacy Policy.',
+            'You can update your selection later by visiting Settings.',
             'web-stories'
           )}
-          &nbsp;
-          <a
-            href={__('https://policies.google.com/privacy', 'web-stories')}
-            rel="noreferrer"
-            target="_blank"
-          >
-            {__('Learn more', 'web-stories')}
-            {'.'}
-          </a>
-        </LabelText>
-      </Label>
-      <VisitSettingsText>
-        {__(
-          'You can update your selection later by visiting Settings.',
-          'web-stories'
-        )}
-      </VisitSettingsText>
-    </Banner>
-  ) : null;
-}
+        </VisitSettingsText>
+      </Banner>
+    ) : null;
+  }
+);
+
+TelemetryOptInBanner.displayName = 'TelemetryOptInBanner';
 
 TelemetryOptInBanner.propTypes = {
   visible: PropTypes.bool.isRequired,
@@ -178,25 +186,32 @@ export default function TelemetryBannerContainer(props) {
     disabled,
     toggleWebStoriesTrackingOptIn,
   } = useTelemetryOptIn();
+  const ref = useRef();
 
   const {
-    actions: { setTelemetryBannerOpen },
+    actions: { setTelemetryBannerOpen, setTelemetryBannerHeight },
   } = useLayoutContext();
 
   const previousBannerVisible = useRef(bannerVisible);
 
   useLayoutEffect(() => {
-    if (bannerVisible && previousBannerVisible.current === false) {
+    if (
+      bannerVisible &&
+      previousBannerVisible.current === false &&
+      ref.current
+    ) {
       setTelemetryBannerOpen(true);
+      setTelemetryBannerHeight(ref.current.offsetHeight);
       previousBannerVisible.current = true;
     } else if (!bannerVisible && previousBannerVisible.current) {
       setTelemetryBannerOpen(false);
       previousBannerVisible.current = false;
     }
-  }, [bannerVisible, setTelemetryBannerOpen]);
+  }, [bannerVisible, setTelemetryBannerOpen, setTelemetryBannerHeight]);
 
   return (
     <TelemetryOptInBanner
+      ref={ref}
       visible={bannerVisible}
       checked={optedIn}
       disabled={disabled}

--- a/assets/src/dashboard/app/views/shared/telemetryBanner.js
+++ b/assets/src/dashboard/app/views/shared/telemetryBanner.js
@@ -39,6 +39,7 @@ const Banner = styled.div`
   margin: 0 20px;
   padding-top: 24px;
   background-image: url('${({ backgroundUrl }) => backgroundUrl}');
+  background-size: cover;
   border-radius: 8px;
 `;
 

--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -30,7 +30,6 @@ import PropTypes from 'prop-types';
  */
 import { DASHBOARD_TOP_MARGIN } from '../../constants/pageStructure';
 import { clamp, throttleToAnimationFrame } from '../../utils';
-import { TELEMETRY_BANNER_HEIGHT } from '../../constants';
 
 export const SQUISH_LENGTH = DASHBOARD_TOP_MARGIN;
 export const SQUISH_CSS_VAR = '--squish-progress';
@@ -51,19 +50,20 @@ const Provider = ({ children }) => {
   const [squishContentHeight, setSquishContentHeight] = useState(0);
   const scrollFrameRef = useRef(null);
   const [telemetryBannerOpen, setTelemetryBannerOpen] = useState(false);
+  const [telemetryBannerHeight, setTelemetryBannerHeight] = useState();
   const bannerHeightIncluded = useRef(false);
 
   useLayoutEffect(() => {
     if (telemetryBannerOpen && !bannerHeightIncluded.current) {
-      setSquishContentHeight((height) => (height += TELEMETRY_BANNER_HEIGHT));
+      setSquishContentHeight((height) => (height += telemetryBannerHeight));
       bannerHeightIncluded.current = true;
     }
 
     if (!telemetryBannerOpen && bannerHeightIncluded.current) {
-      setSquishContentHeight((height) => (height -= TELEMETRY_BANNER_HEIGHT));
+      setSquishContentHeight((height) => (height -= telemetryBannerHeight));
       bannerHeightIncluded.current = false;
     }
-  }, [telemetryBannerOpen, squishContentHeight]);
+  }, [telemetryBannerOpen, squishContentHeight, telemetryBannerHeight]);
 
   useLayoutEffect(() => {
     const scrollFrameEl = scrollFrameRef.current;
@@ -141,6 +141,7 @@ const Provider = ({ children }) => {
         setSquishContentHeight,
         scrollToTop,
         setTelemetryBannerOpen,
+        setTelemetryBannerHeight,
       },
     }),
     [

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -132,9 +132,6 @@ export const TEXT_INPUT_DEBOUNCE = 300;
 export const MIN_IMG_HEIGHT = 96;
 export const MIN_IMG_WIDTH = 96;
 
-// Includes height, padding, margin
-export const TELEMETRY_BANNER_HEIGHT = 161;
-
 export * from './components';
 export * from './direction';
 export * from './pageStructure';


### PR DESCRIPTION
## Summary

This enables the banner to resize dynamically without clipping the stories (this helps account for longer translated text).

## Relevant Technical Choices

- Added a `setTelemetryBannerHeight` to the layout provider
- Forwarded a ref to the `TelemetryBanner` component that the container uses to tell the layout provider the banner's height

## User-facing changes

The banner can now be any height without clipping stories (main use cases is when the text was longer when translated, causing the height to be larger).


### Before
![before](https://user-images.githubusercontent.com/2755722/93127317-ad88aa00-f69b-11ea-82ef-b6b4d40a81dd.png)

### After
![after](https://user-images.githubusercontent.com/2755722/93127435-e88add80-f69b-11ea-879f-7bdd8b87e4a7.gif)


## Testing Instructions

Verify that the banner doesn't cut off stories

#4485 