### PR TITLE
Dashboard: Make 'Open in Editor' an a-tag link

### DIFF
--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -133,7 +133,6 @@ function StoriesView({
       switch (sender.value) {
         case STORY_CONTEXT_MENU_ACTIONS.OPEN_IN_EDITOR:
           await trackEvent('open_in_editor', 'dashboard');
-          window.location.href = story.bottomTargetAction;
           break;
         case STORY_CONTEXT_MENU_ACTIONS.RENAME:
           setTitleRenameId(story.id);

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -44,13 +44,14 @@ import {
   RenameStoryPropType,
   DateSettingsPropType,
 } from '../../../types';
-import { STORY_STATUS, STORY_CONTEXT_MENU_ACTIONS } from '../../../constants';
+import { STORY_STATUS } from '../../../constants';
 import {
   getRelativeDisplayDate,
   useGridViewKeys,
   useFocusOut,
 } from '../../../utils';
 import { useConfig } from '../../config';
+import { generateStoryMenu } from '../../../components/popoverMenu/story-menu-generator';
 
 export const DetailRow = styled.div`
   display: flex;
@@ -132,13 +133,6 @@ const StoryGridView = ({
               }
             : {};
 
-          const storyMenuItems = storyMenu.menuItems.map((menuItem) => {
-            if (menuItem.value === STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK) {
-              return { ...menuItem, url: story.link };
-            }
-            return menuItem;
-          });
-
           return (
             <CardGridItem
               key={story.id}
@@ -205,7 +199,10 @@ const StoryGridView = ({
                   contextMenuId={storyMenu.contextMenuId}
                   onMenuItemSelected={storyMenu.handleMenuItemSelected}
                   story={story}
-                  menuItems={storyMenuItems}
+                  menuItems={generateStoryMenu({
+                    menuItems: storyMenu.menuItems,
+                    story,
+                  })}
                 />
               </DetailRow>
             </CardGridItem>

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -61,7 +61,6 @@ import {
   SORT_DIRECTION,
   STORY_SORT_OPTIONS,
   STORY_STATUS,
-  STORY_CONTEXT_MENU_ACTIONS,
 } from '../../../constants';
 import { FULLBLEED_RATIO } from '../../../constants/pageStructure';
 import PreviewErrorBoundary from '../../../components/previewErrorBoundary';
@@ -71,6 +70,7 @@ import {
   ArrowDownward as ArrowIconSvg,
 } from '../../../icons';
 import { getRelativeDisplayDate } from '../../../utils/';
+import { generateStoryMenu } from '../../../components/popoverMenu/story-menu-generator';
 
 const ListView = styled.div`
   width: 100%;
@@ -278,72 +278,64 @@ export default function StoryListView({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {stories.map((story) => {
-            const storyMenuItems = storyMenu.menuItems.map((menuItem) => {
-              if (
-                menuItem.value === STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK
-              ) {
-                return { ...menuItem, url: story.link };
-              }
-              return menuItem;
-            });
-
-            return (
-              <StyledTableRow key={`story-${story.id}`}>
-                <TablePreviewCell>
-                  <PreviewContainer>
-                    <PreviewErrorBoundary>
-                      <PreviewPage page={story.pages[0]} pageSize={pageSize} />
-                    </PreviewErrorBoundary>
-                  </PreviewContainer>
-                </TablePreviewCell>
-                <TableCell>
-                  <TitleTableCellContainer>
-                    {renameStory.id === story.id ? (
-                      <InlineInputForm
-                        onEditComplete={(newTitle) =>
-                          renameStory.handleOnRenameStory(story, newTitle)
-                        }
-                        onEditCancel={renameStory.handleCancelRename}
-                        value={story.title}
-                        id={story.id}
-                        label={__('Rename story', 'web-stories')}
+          {stories.map((story) => (
+            <StyledTableRow key={`story-${story.id}`}>
+              <TablePreviewCell>
+                <PreviewContainer>
+                  <PreviewErrorBoundary>
+                    <PreviewPage page={story.pages[0]} pageSize={pageSize} />
+                  </PreviewErrorBoundary>
+                </PreviewContainer>
+              </TablePreviewCell>
+              <TableCell>
+                <TitleTableCellContainer>
+                  {renameStory.id === story.id ? (
+                    <InlineInputForm
+                      onEditComplete={(newTitle) =>
+                        renameStory.handleOnRenameStory(story, newTitle)
+                      }
+                      onEditCancel={renameStory.handleCancelRename}
+                      value={story.title}
+                      id={story.id}
+                      label={__('Rename story', 'web-stories')}
+                    />
+                  ) : (
+                    <>
+                      <SelectableParagraph>
+                        {titleFormatted(story.title)}
+                      </SelectableParagraph>
+                      <StoryMenu
+                        onMoreButtonSelected={storyMenu.handleMenuToggle}
+                        contextMenuId={storyMenu.contextMenuId}
+                        onMenuItemSelected={storyMenu.handleMenuItemSelected}
+                        story={story}
+                        menuItems={generateStoryMenu({
+                          menuItems: storyMenu.menuItems,
+                          story,
+                        })}
+                        verticalAlign="center"
                       />
-                    ) : (
-                      <>
-                        <SelectableParagraph>
-                          {titleFormatted(story.title)}
-                        </SelectableParagraph>
-                        <StoryMenu
-                          onMoreButtonSelected={storyMenu.handleMenuToggle}
-                          contextMenuId={storyMenu.contextMenuId}
-                          onMenuItemSelected={storyMenu.handleMenuItemSelected}
-                          story={story}
-                          menuItems={storyMenuItems}
-                          verticalAlign="center"
-                        />
-                      </>
-                    )}
-                  </TitleTableCellContainer>
-                </TableCell>
-                <TableCell>{users[story.author]?.name || '—'}</TableCell>
-                <TableCell>
-                  {getRelativeDisplayDate(story.created, dateSettings)}
-                </TableCell>
-                <TableCell>
-                  {getRelativeDisplayDate(story.modified, dateSettings)}
-                </TableCell>
-                {storyStatus !== STORY_STATUS.DRAFT && (
-                  <TableStatusCell>
-                    {story.status === STORY_STATUS.PUBLISH &&
-                      __('Published', 'web-stories')}
-                    {story.status === STORY_STATUS.FUTURE &&
-                      __('Scheduled', 'web-stories')}
-                  </TableStatusCell>
-                )}
-              </StyledTableRow>
-            );
-          })}
+                    </>
+                  )}
+                </TitleTableCellContainer>
+              </TableCell>
+              <TableCell>{users[story.author]?.name || '—'}</TableCell>
+              <TableCell>
+                {getRelativeDisplayDate(story.created, dateSettings)}
+              </TableCell>
+              <TableCell>
+                {getRelativeDisplayDate(story.modified, dateSettings)}
+              </TableCell>
+              {storyStatus !== STORY_STATUS.DRAFT && (
+                <TableStatusCell>
+                  {story.status === STORY_STATUS.PUBLISH &&
+                    __('Published', 'web-stories')}
+                  {story.status === STORY_STATUS.FUTURE &&
+                    __('Scheduled', 'web-stories')}
+                </TableStatusCell>
+              )}
+            </StyledTableRow>
+          ))}
         </TableBody>
       </Table>
     </ListView>

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -102,8 +102,6 @@ const getActionAttributes = (targetAction) =>
     ? {
         href: resolveRoute(targetAction),
         isLink: true,
-        target: '_blank',
-        rel: 'noopener noreferrer',
       }
     : { onClick: targetAction };
 

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -99,7 +99,12 @@ const EmptyActionContainer = styled(ActionContainer)`
 
 const getActionAttributes = (targetAction) =>
   typeof targetAction === 'string'
-    ? { href: resolveRoute(targetAction), isLink: true }
+    ? {
+        href: resolveRoute(targetAction),
+        isLink: true,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      }
     : { onClick: targetAction };
 
 const CARD_STATE = {

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -161,12 +161,16 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect, ...rest }) => {
   const renderMenuItem = useCallback(
     (item, index) => {
       const itemIsDisabled = !item.value && item.value !== 0;
-      const MenuItemPropsAsLink = item.url
+      const menuItemPropsAsLink = item.url
         ? {
-            target: '_blank',
-            rel: 'noreferrer',
             href: item.url,
             as: 'a',
+            ...(item.newTab
+              ? {
+                  target: '_blank',
+                  rel: 'noreferrer',
+                }
+              : {}),
           }
         : {};
 
@@ -182,7 +186,7 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect, ...rest }) => {
             (item.separator === 'top' && 'separatorTop') ||
             (item.separator === 'bottom' && 'separatorBottom')
           }
-          {...MenuItemPropsAsLink}
+          {...menuItemPropsAsLink}
         >
           <MenuItemContent>{item.label}</MenuItemContent>
         </MenuItem>

--- a/assets/src/dashboard/components/popoverMenu/story-menu-generator.js
+++ b/assets/src/dashboard/components/popoverMenu/story-menu-generator.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { STORY_CONTEXT_MENU_ACTIONS } from '../../constants';
+
+export const generateStoryMenu = ({ menuItems, story }) =>
+  menuItems.map((menuItem) => {
+    if (menuItem.value === STORY_CONTEXT_MENU_ACTIONS.OPEN_IN_EDITOR) {
+      return { ...menuItem, url: story.bottomTargetAction };
+    } else if (menuItem.value === STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK) {
+      return { ...menuItem, url: story.link };
+    }
+    return menuItem;
+  });

--- a/assets/src/dashboard/components/popoverMenu/story-menu-generator.js
+++ b/assets/src/dashboard/components/popoverMenu/story-menu-generator.js
@@ -22,9 +22,9 @@ import { STORY_CONTEXT_MENU_ACTIONS } from '../../constants';
 export const generateStoryMenu = ({ menuItems, story }) =>
   menuItems.map((menuItem) => {
     if (menuItem.value === STORY_CONTEXT_MENU_ACTIONS.OPEN_IN_EDITOR) {
-      return { ...menuItem, url: story.bottomTargetAction };
+      return { ...menuItem, url: story.bottomTargetAction, newTab: false };
     } else if (menuItem.value === STORY_CONTEXT_MENU_ACTIONS.OPEN_STORY_LINK) {
-      return { ...menuItem, url: story.link };
+      return { ...menuItem, url: story.link, newTab: true };
     }
     return menuItem;
   });


### PR DESCRIPTION
## Summary

Makes the "Open in Editor" menu items in the Grid and List view dropdowns an `<a href` tag that opens in a new tab.

![image](https://user-images.githubusercontent.com/1738349/93128856-ba0a0400-f695-11ea-9acd-a18c49750a07.png)


## Relevant Technical Choices

- Uses a common menu function for both Grid and List View

## User-facing changes

"Open in Editor" now opens in a new tab.

## Testing Instructions

1. Visit Dashboard
2. In either the Grid or List View, see that the "Open in Editor" option in the story dropdown menu (three dots) opens the story in the editor, in a new tab.

---

<!-- Please reference the issue(s) this PR addresses. -->

#4379
