### PR TITLE
E2E Tests: reduce flakiness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10394,17 +10394,6 @@
         }
       }
     },
-    "@wordpress/keycodes": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.14.0.tgz",
-      "integrity": "sha512-R/0orMutajuQ1d1kFFIvksXKR5C5TtszEkbnxSfdNlKaOW7p9Srv8+8m2QqM+AKNvEGMaq6cn7BfDtTbZ33Dbw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "@wordpress/i18n": "^3.14.0",
-        "lodash": "^4.17.15"
-      }
-    },
     "@wordpress/notices": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-2.9.0.tgz",
@@ -10499,18 +10488,6 @@
       "requires": {
         "@babel/runtime": "^7.9.2",
         "lodash": "^4.17.19"
-      }
-    },
-    "@wordpress/url": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.17.0.tgz",
-      "integrity": "sha512-4OBUy8IKZlobXe41GASw+p5xP/Nvh+HSzfhTN+BU0OggnIsXvZpf0iBYRYGp6M60ne8MkeEoQg9rMM22Osh9Cg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.9.2",
-        "lodash": "^4.17.15",
-        "qs": "^6.5.2",
-        "react-native-url-polyfill": "^1.1.2"
       }
     },
     "@wordpress/viewport": {

--- a/patches/puppeteer+5.2.1.patch
+++ b/patches/puppeteer+5.2.1.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js b/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js
+index d819547..b833ddb 100644
+--- a/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js
++++ b/node_modules/puppeteer/lib/cjs/puppeteer/common/ExecutionContext.js
+@@ -213,8 +213,10 @@ class ExecutionContext {
+             throw error;
+         }
+         const { exceptionDetails, result: remoteObject, } = await callFunctionOnPromise.catch(rewriteError);
+-        if (exceptionDetails)
++        if (exceptionDetails) {
++          console.log(functionText, exceptionDetails);
+             throw new Error('Evaluation failed: ' + helper_js_1.helper.getExceptionMessage(exceptionDetails));
++        }
+         return returnByValue
+             ? helper_js_1.helper.valueFromRemoteObject(remoteObject)
+             : JSHandle_js_1.createJSHandle(this, remoteObject);

--- a/tests/e2e/specs/editor/publishingFlow.js
+++ b/tests/e2e/specs/editor/publishingFlow.js
@@ -17,18 +17,16 @@
 /**
  * WordPress dependencies
  */
-import {
-  getEditedPostContent,
-  publishPostWithPrePublishChecksDisabled,
-  arePrePublishChecksEnabled,
-  disablePrePublishChecks,
-  enablePrePublishChecks,
-} from '@wordpress/e2e-test-utils';
+import { getEditedPostContent } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
-import { createNewStory, addRequestInterception } from '../../utils';
+import {
+  createNewStory,
+  addRequestInterception,
+  publishPost,
+} from '../../utils';
 
 describe('Publishing Flow', () => {
   let stopRequestInterception;
@@ -82,18 +80,10 @@ describe('Publishing Flow', () => {
 
     expect(await getEditedPostContent()).toMatchSnapshot();
 
-    const werePrePublishChecksEnabled = await arePrePublishChecksEnabled();
+    const postPermalink = await publishPost();
 
-    if (werePrePublishChecksEnabled) {
-      await disablePrePublishChecks();
-    }
-
-    await publishPostWithPrePublishChecksDisabled();
-    await enablePrePublishChecks();
-
-    const postPermalink = await page.evaluate(() =>
-      wp.data.select('core/editor').getPermalink()
-    );
+    expect(postPermalink).not.toBeNull();
+    expect(postPermalink).toStrictEqual(expect.any(String));
 
     await Promise.all([page.goto(postPermalink), page.waitForNavigation()]);
 

--- a/tests/e2e/specs/wordpress/embedBlock.js
+++ b/tests/e2e/specs/wordpress/embedBlock.js
@@ -21,10 +21,6 @@ import {
   activatePlugin,
   deactivatePlugin,
   createNewPost,
-  arePrePublishChecksEnabled,
-  disablePrePublishChecks,
-  publishPostWithPrePublishChecksDisabled,
-  enablePrePublishChecks,
   insertBlock,
   setPostContent,
 } from '@wordpress/e2e-test-utils';
@@ -34,6 +30,7 @@ import {
  */
 import {
   addRequestInterception,
+  publishPost,
   withDisabledToolbarOnFrontend,
 } from '../../utils';
 
@@ -103,18 +100,10 @@ describe('Embed Block', () => {
 
       await setPostContent(EMBED_BLOCK_CONTENT);
 
-      const werePrePublishChecksEnabled = await arePrePublishChecksEnabled();
+      const postPermalink = await publishPost();
 
-      if (werePrePublishChecksEnabled) {
-        await disablePrePublishChecks();
-      }
-
-      await publishPostWithPrePublishChecksDisabled();
-      await enablePrePublishChecks();
-
-      const postPermalink = await page.evaluate(() =>
-        wp.data.select('core/editor').getPermalink()
-      );
+      expect(postPermalink).not.toBeNull();
+      expect(postPermalink).toStrictEqual(expect.any(String));
 
       const ampPostPermaLink = postPermalink.includes('?')
         ? `${postPermalink}&amp`

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -20,3 +20,4 @@ export { default as visitDashboard } from './visitDashboard';
 export { default as addRequestInterception } from './addRequestInterception';
 export { default as withExperimentalFeatures } from './experimentalFeatures';
 export { default as withDisabledToolbarOnFrontend } from './toolbarProfileOption';
+export { default as publishPost } from './publishPost';

--- a/tests/e2e/utils/publishPost.js
+++ b/tests/e2e/utils/publishPost.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import {
+  arePrePublishChecksEnabled,
+  publishPostWithPrePublishChecksDisabled,
+  publishPost as _publishPost,
+} from '@wordpress/e2e-test-utils';
+
+/**
+ * Custom helper function to publish posts in Gutenberg.
+ *
+ * Avoid using disablePrePublishChecks.
+ *
+ * The main reason for this is that it calls toggleScreenOption,
+ * which itself is rather flaky and sometimes
+ * doesn't find the requested element, causing JS errors.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/f96bd6b6fdfca02d47edce8c2f0d68dccf3a37be/packages/e2e-test-utils/src/toggle-screen-option.js#L20-L23
+ *
+ * @return {Promise<string>} The post's permalink.
+ */
+async function publishPost() {
+  const prePublishChecksEnabled = await arePrePublishChecksEnabled();
+
+  if (prePublishChecksEnabled) {
+    await _publishPost();
+  } else {
+    await publishPostWithPrePublishChecksDisabled();
+  }
+
+  // Wait until the selector returns a truthy value.
+  await page.waitForFunction(() =>
+    wp.data.select('core/editor').getPermalink()
+  );
+
+  return page.evaluate(() => wp.data.select('core/editor').getPermalink());
+}
+
+export default publishPost;


### PR DESCRIPTION
Makes e2e tests a bit more robust

- Ensures `wp.data.select('core/editor').getPermalink()` will return a string
- Prevent JS errors caused by `disablePrePublishChecks`