### PR TITLE
Prevent removal of amp-story that lacks mandatory attributes

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -456,14 +456,15 @@ class Story_Post_Type {
 	 */
 	public function filter_amp_story_element_validation_error_sanitized( $sanitized, $error ) {
 		if (
-			isset( $error['node_type'], $error['node_name'] )
-			&&
-			XML_ELEMENT_NODE === $error['node_type']
-			&&
-			'amp-story' === $error['node_name']
+			( isset( $error['node_type'], $error['node_name'], $error['parent_name'] ) ) &&
+			(
+				( XML_ELEMENT_NODE === $error['node_type'] && 'amp-story' === $error['node_name'] && 'body' === $error['parent_name'] ) ||
+				( XML_ATTRIBUTE_NODE === $error['node_type'] && 'poster-portrait-src' === $error['node_name'] && 'amp-story' === $error['parent_name'] )
+			)
 		) {
-			$sanitized = false;
+			return false;
 		}
+
 		return $sanitized;
 	}
 

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -178,6 +178,7 @@ class Story_Post_Type {
 
 		add_filter( 'option_amp-options', [ $this, 'filter_amp_options' ] );
 		add_filter( 'amp_supportable_post_types', [ $this, 'filter_supportable_post_types' ] );
+		add_filter( 'amp_validation_error_sanitized', [ $this, 'filter_amp_story_element_validation_error_sanitized' ], 10, 2 );
 
 		add_filter( '_wp_post_revision_fields', [ $this, 'filter_revision_fields' ], 10, 2 );
 
@@ -434,6 +435,36 @@ class Story_Post_Type {
 		}
 
 		return array_values( $post_types );
+	}
+
+	/**
+	 * Filter amp_validation_error_sanitized to prevent invalid markup removal for the amp-story element.
+	 *
+	 * Since the amp-story element requires the poster-portrait-src attribute to be valid, when this attribute is absent
+	 * the AMP plugin will try to remove the amp-story element altogether. This is not the preferred resolution! So
+	 * instead, this will force the invalid markup to be kept. When this is done, the AMP plugin in Standard mode
+	 * (which Web Stories enforces while serving singular web-story posts) will remove the amp attribute from the html
+	 * element so that the page will not be advertised as AMP. This prevents GSC from complaining about a validation
+	 * issue which we already know about.
+	 *
+	 * @since 1.0.0
+	 * @link https://github.com/ampproject/amp-wp/blob/c6aed8f/includes/validation/class-amp-validation-manager.php#L1777-L1809
+	 *
+	 * @param null|bool $sanitized Whether sanitized. Null means sanitization is not overridden.
+	 * @param array     $error Validation error being sanitized.
+	 * @return null|bool Whether sanitized.
+	 */
+	public function filter_amp_story_element_validation_error_sanitized( $sanitized, $error ) {
+		if (
+			isset( $error['node_type'], $error['node_name'] )
+			&&
+			XML_ELEMENT_NODE === $error['node_type']
+			&&
+			'amp-story' === $error['node_name']
+		) {
+			$sanitized = false;
+		}
+		return $sanitized;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

As discussed in https://github.com/google/web-stories-wp/issues/3671#issuecomment-690742964, when a user-supplied poster image is supplied, it is preferable to omit the poster altogether rather than to supply a generic fallback poster image. Nevertheless, when a story lacks a poster image (the `poster-portrait-src` attribute on `amp-story`) the AMP plugin will _remove_ the entire `amp-story` tag since this is a required attribute. (For discussion on that, see https://github.com/google/web-stories-wp/pull/4480#issuecomment-693513745.)

This PR will prevent the `amp-story` element from being removed by the AMP plugin, and it this will also result in the `amp` attribute being removed from the `html` element to avoid GSC from complaining that the page is invalid AMP (which we already know).

This is part of #4480 and it depends on https://github.com/ampproject/amp-wp/pull/5388, which will be part of v2.0.2.

## Relevant Technical Choices

What is needed is a way for the AMP plugin to serve an AMP page while keeping the `amp-story` element that is lacking the required `poster-portrait-src` attribute. One way to do this is to make use of [AMP Dev Mode](https://weston.ruter.net/2019/09/24/integrating-with-amp-dev-mode-in-wordpress/) by marking the `html` element with the `data-ampdevmode` attribute and then adding this attribute to the `amp-story` as well. Nevertheless, this is not ideal because the `html` element will still retain the `amp` attribute and GSC will complain about the page being not valid AMP. What is needed is to remove the `amp` attribute entirely, so that the page is served as AMP but it is not advertised as an AMP page, in order to prevent it from being validated as one.

One way to do this would be to extend AMP Dev Mode support in the AMP plugin to allow for AMP pages in Dev Mode to be configured to omit the `amp` attribute. This was actually discussed recently in the context of Jetpac. See https://github.com/Automattic/jetpack/pull/16901#pullrequestreview-483032801. 

Nevertheless, another option is available. The AMP plugin provides an [`amp_validation_error_sanitized`](https://github.com/ampproject/amp-wp/blob/c6aed8f66921a527911fa74188bf838a3d164f56/docs/hook/amp_validation_error_sanitized.md) filter which can be used to force the AMP plugin either to remove or keep the invalid markup causing a given validation error. When this is done on a paired AMP site (in Transitional mode or Reader mode) the effect of doing this is the AMP plugin will redirect the user to the canonical non-AMP page. However, in Standard mode the behavior different. Since no redirection is possible (as it is an AMP-first) the result is rather to remove the `amp` attribute from the `html` element. See logic:

https://github.com/ampproject/amp-wp/blob/c6aed8f66921a527911fa74188bf838a3d164f56/includes/validation/class-amp-validation-manager.php#L1777-L1809

This is exactly what we want. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Before this change, the validated AMP page appears blank (but it is _valid AMP_); after the change, the story renders and the page is not marked as AMP.

Before | After
-------|------
![Before](https://user-images.githubusercontent.com/134745/93378986-09753f00-f812-11ea-873b-2dc2efbf0f58.png) | ![After](https://user-images.githubusercontent.com/134745/93379066-2873d100-f812-11ea-888d-60711a3b0eb8.png)

The `web-story` posts will still undergo AMP validation. There will be one validation error for “Missing required attribute: `poster-portrait-src`”. Before this PR, the validation error will show up initially as unreviewed and removed. With this PR, the validation error's invalid markup will appear initially as reviewed and _kept_.

Before | After
-------|------
![before](https://user-images.githubusercontent.com/134745/93377935-93240d00-f810-11ea-95be-f3bd33ab3c59.png) | ![after](https://user-images.githubusercontent.com/134745/93377941-94553a00-f810-11ea-8690-f1f8be859db3.png)

Note that I cannot recall a situation where validation errors have been forcibly filtered to be unsanitized, so the UI doesn't exactly support this fully: if you try changing the status from kept to removed, the invalid markup will remain kept on the frontend. (We have work to do on these validation screens.)

## Testing Instructions

1. Activate the AMP plugin.
1. Ensure AMP Developer Tools are enabled in the WP user profile.
1. Create a story that lacks a poster image. (Perhaps only possible with #4480.)
1. Save the story.
1. View the story on the frontend.
1. Verify that the story looks correct and that it is not marked as an AMP page.
1. Find the story in the AMP Validated URLs screen and verify that the `poster-portrait-src` attribute is marked as kept and reviewed.

---

<!-- Please reference the issue(s) this PR addresses. -->

See #3671.
