### PR TITLE
Story Editor: Added Cover Text Sets

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/textSets/loadTextSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/loadTextSets.js
@@ -69,7 +69,7 @@ async function loadTextSet(name) {
 }
 
 export default async function loadTextSets() {
-  const textSets = ['editorial'];
+  const textSets = ['editorial', 'cover'];
 
   const results = await Promise.all(
     textSets.map(async (name) => {

--- a/assets/src/edit-story/components/library/panes/text/textSets/raw/cover.json
+++ b/assets/src/edit-story/components/library/panes/text/textSets/raw/cover.json
@@ -145,8 +145,8 @@
             }
           },
           "type": "shape",
-          "x": 0,
-          "y": 99,
+          "x": 33,
+          "y": 340,
           "width": 112,
           "height": 32,
           "scale": 100,
@@ -222,8 +222,8 @@
           "type": "text",
           "content": "<span style=\"font-weight: 900; color: #fff\">CATEGORY</span>",
           "fontWeight": 400,
-          "x": 0,
-          "y": 105.5,
+          "x": 33,
+          "y": 346.5,
           "width": 112,
           "height": 19,
           "scale": 100,
@@ -296,8 +296,8 @@
           "type": "text",
           "content": "<span style=\"font-weight: 700\">Ten principles for good design</span>",
           "fontWeight": 700,
-          "x": 0,
-          "y": 147,
+          "x": 33,
+          "y": 388,
           "width": 313,
           "height": 97,
           "scale": 100,
@@ -370,8 +370,8 @@
           "type": "text",
           "content": "<span style=\"font-weight: 700\">By Dieter Rams</span>\n<span style=\"font-weight: 700\">January 31, 2020</span>",
           "fontWeight": 400,
-          "x": 0,
-          "y": 259,
+          "x": 33,
+          "y": 500,
           "width": 156,
           "height": 48,
           "scale": 100,
@@ -447,8 +447,8 @@
           },
           "basedOn": "7739a64c-76d0-49d4-91fe-a177500601c7",
           "id": "e5cfb7b9-60c7-454d-8aee-9e8d9a8d0ced",
-          "x": 0,
-          "y": 125
+          "x": 33,
+          "y": 360
         },
         {
           "opacity": 100,
@@ -522,8 +522,8 @@
           "focalY": 50,
           "basedOn": "ff9919e1-95ae-4276-9330-10a36a8d51d9",
           "id": "5730a6f3-4e76-4c7f-9ce5-8316ca800339",
-          "x": 0,
-          "y": 138
+          "x": 33,
+          "y": 373
         },
         {
           "opacity": 100,
@@ -597,8 +597,8 @@
           "focalY": 50,
           "basedOn": "d774160a-9a92-4fb7-b49a-261032b332fe",
           "id": "607c25aa-8966-4232-80ac-a64ba70dd497",
-          "x": 0,
-          "y": 164
+          "x": 33,
+          "y": 399
         },
         {
           "opacity": 100,
@@ -671,8 +671,8 @@
           "marginOffset": 5.578125,
           "basedOn": "2c2855fd-d71b-4041-b5a0-bcc78c55003a",
           "id": "be8efd99-c3a7-4a43-b508-d0a5785eddc3",
-          "x": 0,
-          "y": 264
+          "x": 33,
+          "y": 499
         },
         {
           "opacity": 100,
@@ -700,8 +700,8 @@
           },
           "basedOn": "e5cfb7b9-60c7-454d-8aee-9e8d9a8d0ced",
           "id": "1f4211cc-c2bd-4b7c-a897-f3d1d1871466",
-          "x": 0,
-          "y": 256
+          "x": 33,
+          "y": 491
         },
         {
           "opacity": 100,
@@ -729,8 +729,8 @@
           },
           "basedOn": "e5cfb7b9-60c7-454d-8aee-9e8d9a8d0ced",
           "id": "e6be672d-e0cb-4d5b-aef3-a223cf9914bf",
-          "x": 0,
-          "y": 288
+          "x": 33,
+          "y": 523
         },
         {
           "opacity": 100,
@@ -758,8 +758,8 @@
           },
           "basedOn": "e5cfb7b9-60c7-454d-8aee-9e8d9a8d0ced",
           "id": "0e33182f-74b6-45fe-a6c0-7893611b182c",
-          "x": 111,
-          "y": 265
+          "x": 144,
+          "y": 500
         }
       ],
       "backgroundColor": {
@@ -880,8 +880,8 @@
           "focalY": 50,
           "basedOn": "5730a6f3-4e76-4c7f-9ce5-8316ca800339",
           "id": "ebeb00e0-5e48-4b11-b213-2500d2474bc2",
-          "x": 0,
-          "y": 265
+          "x": 33,
+          "y": 504
         },
         {
           "opacity": 100,
@@ -961,8 +961,8 @@
           "focalY": 50,
           "basedOn": "607c25aa-8966-4232-80ac-a64ba70dd497",
           "id": "41f72c82-5f33-4ec2-be22-755a93241212",
-          "x": 0,
-          "y": 69
+          "x": 33,
+          "y": 308
         },
         {
           "opacity": 100,
@@ -1043,8 +1043,8 @@
           "marginOffset": 5.578125,
           "basedOn": "be8efd99-c3a7-4a43-b508-d0a5785eddc3",
           "id": "afe7d0a5-0c85-4d3a-a34b-8a890c9e4a1a",
-          "x": 0,
-          "y": 302
+          "x": 33,
+          "y": 541
         }
       ],
       "backgroundColor": {
@@ -1113,8 +1113,8 @@
           },
           "basedOn": "e5cfb7b9-60c7-454d-8aee-9e8d9a8d0ced",
           "id": "7973cdf7-53b7-4c6c-961c-ec580ddd1974",
-          "x": 109,
-          "y": 137
+          "x": 107,
+          "y": 374
         },
         {
           "opacity": 100,
@@ -1188,8 +1188,8 @@
           "focalY": 50,
           "basedOn": "5730a6f3-4e76-4c7f-9ce5-8316ca800339",
           "id": "f77e3d81-d7d2-480a-b185-4a509a452b76",
-          "x": 153,
-          "y": 127
+          "x": 151,
+          "y": 364
         },
         {
           "opacity": 100,
@@ -1217,8 +1217,8 @@
           },
           "basedOn": "7973cdf7-53b7-4c6c-961c-ec580ddd1974",
           "id": "146eece8-418e-465e-ba9a-dfd25b1958f4",
-          "x": 275,
-          "y": 137
+          "x": 273,
+          "y": 374
         },
         {
           "opacity": 100,
@@ -1299,8 +1299,8 @@
           "marginOffset": 5.578125,
           "basedOn": "be8efd99-c3a7-4a43-b508-d0a5785eddc3",
           "id": "e7faf544-0b5e-45c0-bd52-3ebad5cc96b3",
-          "x": 145,
-          "y": 245
+          "x": 143,
+          "y": 482
         },
         {
           "opacity": 100,
@@ -1374,8 +1374,8 @@
           "focalY": 50,
           "basedOn": "41f72c82-5f33-4ec2-be22-755a93241212",
           "id": "dd4ac41c-e4fb-451d-977b-9564d3ee28d4",
-          "x": 50,
-          "y": 155
+          "x": 48,
+          "y": 392
         }
       ],
       "backgroundColor": {
@@ -1434,8 +1434,8 @@
             }
           },
           "type": "shape",
-          "x": 0,
-          "y": 0,
+          "x": 24,
+          "y": 335,
           "width": 363,
           "height": 218,
           "scale": 100,
@@ -1512,8 +1512,8 @@
           "focalY": 50,
           "basedOn": "f77e3d81-d7d2-480a-b185-4a509a452b76",
           "id": "ab4e5032-7d70-42c9-98bf-9761cb8be09b",
-          "x": 16,
-          "y": 13
+          "x": 40,
+          "y": 348
         },
         {
           "opacity": 100,
@@ -1541,8 +1541,8 @@
           },
           "basedOn": "e6be672d-e0cb-4d5b-aef3-a223cf9914bf",
           "id": "679372c2-385c-4dcc-ba9b-ebd100e813ee",
-          "x": 16,
-          "y": 53
+          "x": 40,
+          "y": 388
         },
         {
           "opacity": 100,
@@ -1610,8 +1610,8 @@
           "focalY": 50,
           "basedOn": "dd4ac41c-e4fb-451d-977b-9564d3ee28d4",
           "id": "c1b1f578-0c36-4e88-8182-7dfcfebb8b86",
-          "x": 16,
-          "y": 54
+          "x": 40,
+          "y": 389
         },
         {
           "opacity": 100,
@@ -1639,8 +1639,8 @@
           },
           "basedOn": "679372c2-385c-4dcc-ba9b-ebd100e813ee",
           "id": "da8ea483-5ce8-4443-a069-bbed22a09a6e",
-          "x": 16,
-          "y": 166
+          "x": 40,
+          "y": 501
         },
         {
           "opacity": 100,
@@ -1709,8 +1709,8 @@
           "marginOffset": 5.578125,
           "basedOn": "e7faf544-0b5e-45c0-bd52-3ebad5cc96b3",
           "id": "5df6e87c-2062-4f33-8049-608df45f5ab0",
-          "x": 16,
-          "y": 180
+          "x": 40,
+          "y": 515
         },
         {
           "opacity": 100,
@@ -1779,8 +1779,8 @@
           "marginOffset": 5.578125,
           "basedOn": "5df6e87c-2062-4f33-8049-608df45f5ab0",
           "id": "3477f800-c840-4dbd-b730-37e1597711e3",
-          "x": 225,
-          "y": 180
+          "x": 249,
+          "y": 515
         }
       ],
       "backgroundColor": {
@@ -1901,8 +1901,8 @@
           "focalY": 50,
           "basedOn": "5730a6f3-4e76-4c7f-9ce5-8316ca800339",
           "id": "7dc69555-5731-4e30-b641-1431d189cdfe",
-          "x": 0,
-          "y": 123
+          "x": 33,
+          "y": 362
         },
         {
           "opacity": 100,
@@ -1972,8 +1972,8 @@
           "focalY": 50,
           "basedOn": "607c25aa-8966-4232-80ac-a64ba70dd497",
           "id": "f8175027-5283-4bfa-abe3-0d9d8e0197bf",
-          "x": 0,
-          "y": 156
+          "x": 33,
+          "y": 395
         },
         {
           "opacity": 100,
@@ -2054,8 +2054,8 @@
           "marginOffset": 5.578125,
           "basedOn": "be8efd99-c3a7-4a43-b508-d0a5785eddc3",
           "id": "c6867853-e246-413a-b9df-29d184090da8",
-          "x": 0,
-          "y": 266
+          "x": 33,
+          "y": 505
         },
         {
           "opacity": 100,
@@ -2083,8 +2083,8 @@
           },
           "basedOn": "0e33182f-74b6-45fe-a6c0-7893611b182c",
           "id": "ee502557-00dc-4206-be40-913a8f5cbfbc",
-          "x": 126,
-          "y": 269
+          "x": 159,
+          "y": 508
         }
       ],
       "backgroundColor": {
@@ -2198,8 +2198,8 @@
           "focalY": 50,
           "basedOn": "f8175027-5283-4bfa-abe3-0d9d8e0197bf",
           "id": "1e7b6aad-8cc7-4404-a538-fbf9c9232588",
-          "x": 54,
-          "y": 101
+          "x": 50,
+          "y": 340
         },
         {
           "opacity": 100,
@@ -2272,8 +2272,8 @@
           "focalY": 50,
           "basedOn": "1e7b6aad-8cc7-4404-a538-fbf9c9232588",
           "id": "7754cac3-e8a6-49bb-9b4e-9a67164f479a",
-          "x": 50,
-          "y": 97
+          "x": 46,
+          "y": 336
         },
         {
           "opacity": 100,
@@ -2354,8 +2354,8 @@
           "marginOffset": 5.578125,
           "basedOn": "e7faf544-0b5e-45c0-bd52-3ebad5cc96b3",
           "id": "bbd94bfc-49d5-4280-b25d-df97697225e6",
-          "x": 127,
-          "y": 209
+          "x": 123,
+          "y": 448
         },
         {
           "opacity": 100,
@@ -2435,8 +2435,8 @@
           "focalY": 50,
           "basedOn": "7dc69555-5731-4e30-b641-1431d189cdfe",
           "id": "fff8ea88-c2fc-417e-8489-b88f887718ff",
-          "x": 115,
-          "y": 277
+          "x": 111,
+          "y": 516
         },
         {
           "opacity": 100,
@@ -2454,8 +2454,8 @@
             }
           },
           "type": "shape",
-          "x": 128,
-          "y": 269,
+          "x": 124,
+          "y": 508,
           "width": 4,
           "height": 40,
           "scale": 100,
@@ -2492,8 +2492,8 @@
           },
           "basedOn": "49aa3fb2-bc63-41ac-810f-d961a96d9f47",
           "id": "87750f85-c55c-478a-b7f1-fd60b48e3e9e",
-          "x": 285,
-          "y": 269
+          "x": 281,
+          "y": 508
         },
         {
           "opacity": 100,
@@ -2521,8 +2521,8 @@
           },
           "basedOn": "87750f85-c55c-478a-b7f1-fd60b48e3e9e",
           "id": "0d7ac44c-8fd5-4383-bf39-d325ffcfc8fa",
-          "x": 128,
-          "y": 269
+          "x": 124,
+          "y": 508
         },
         {
           "opacity": 100,
@@ -2550,8 +2550,8 @@
           },
           "basedOn": "0d7ac44c-8fd5-4383-bf39-d325ffcfc8fa",
           "id": "ea329f35-fc03-4a8c-b8fc-5b9441d8d039",
-          "x": 128,
-          "y": 305
+          "x": 124,
+          "y": 544
         }
       ],
       "backgroundColor": {
@@ -2620,8 +2620,8 @@
           },
           "basedOn": "3dd28357-58fb-45fc-b7df-4873dbb58806",
           "id": "39dd9085-76df-462d-9ca0-f09f3040fe18",
-          "x": 16,
-          "y": 11
+          "x": 14,
+          "y": 306
         },
         {
           "opacity": 100,
@@ -2649,8 +2649,8 @@
           },
           "basedOn": "39dd9085-76df-462d-9ca0-f09f3040fe18",
           "id": "e92fc3f9-3b43-4697-8201-392a09e3f9aa",
-          "x": 395,
-          "y": 11
+          "x": 393,
+          "y": 306
         },
         {
           "opacity": 100,
@@ -2678,8 +2678,8 @@
           },
           "basedOn": "3dd28357-58fb-45fc-b7df-4873dbb58806",
           "id": "ed41ddcd-8d01-42b7-a6a9-d36ef18b9553",
-          "x": 16,
-          "y": 11
+          "x": 14,
+          "y": 306
         },
         {
           "opacity": 100,
@@ -2707,8 +2707,8 @@
           },
           "basedOn": "ed41ddcd-8d01-42b7-a6a9-d36ef18b9553",
           "id": "1ef48d77-a32f-4a85-8c75-d132a2ab04b6",
-          "x": 16,
-          "y": 283
+          "x": 14,
+          "y": 578
         },
         {
           "opacity": 100,
@@ -2784,8 +2784,8 @@
           "focalY": 50,
           "basedOn": "7754cac3-e8a6-49bb-9b4e-9a67164f479a",
           "id": "0f5f6273-994d-45d6-923d-100b88051129",
-          "x": 79,
-          "y": 55
+          "x": 77,
+          "y": 350
         },
         {
           "opacity": 100,
@@ -2813,8 +2813,8 @@
           },
           "basedOn": "7973cdf7-53b7-4c6c-961c-ec580ddd1974",
           "id": "5bde3567-9a2a-44e4-a183-4c8b62aae675",
-          "x": 106,
-          "y": 167
+          "x": 104,
+          "y": 462
         },
         {
           "opacity": 100,
@@ -2890,8 +2890,8 @@
           "focalY": 50,
           "basedOn": "f77e3d81-d7d2-480a-b185-4a509a452b76",
           "id": "9bd0f726-0d83-4066-a154-f6e415c3593d",
-          "x": 150,
-          "y": 157
+          "x": 148,
+          "y": 452
         },
         {
           "opacity": 100,
@@ -2919,8 +2919,8 @@
           },
           "basedOn": "146eece8-418e-465e-ba9a-dfd25b1958f4",
           "id": "a5beb228-301e-478b-bda4-daf8d1294720",
-          "x": 272,
-          "y": 167
+          "x": 270,
+          "y": 462
         },
         {
           "opacity": 100,
@@ -2987,8 +2987,8 @@
           "marginOffset": 5.578125,
           "basedOn": "bbd94bfc-49d5-4280-b25d-df97697225e6",
           "id": "249be185-abeb-4282-8f56-4a61ab112160",
-          "x": 126.5,
-          "y": 198
+          "x": 124.5,
+          "y": 493
         }
       ],
       "backgroundColor": {

--- a/assets/src/edit-story/components/library/panes/text/textSets/raw/cover.json
+++ b/assets/src/edit-story/components/library/panes/text/textSets/raw/cover.json
@@ -1,0 +1,3005 @@
+{
+  "current": "7cf5cb87-0090-4ef4-b047-a745f8f6bfbe",
+  "selection": [],
+  "story": {
+    "stylePresets": {
+      "colors": [
+        {
+          "color": {
+            "r": 33,
+            "g": 33,
+            "b": 33
+          }
+        },
+        {
+          "color": {
+            "r": 0,
+            "g": 92,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 61,
+            "g": 46,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 200,
+            "g": 122,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 163,
+            "b": 214
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 187,
+            "b": 196
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 187,
+            "b": 196,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 246,
+            "g": 147,
+            "b": 147,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 240,
+            "g": 176,
+            "b": 119,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 220,
+            "g": 211,
+            "b": 67,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 153,
+            "g": 199,
+            "b": 39,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 119,
+            "g": 151,
+            "b": 18,
+            "a": 0.6
+          }
+        }
+      ],
+      "textStyles": []
+    }
+  },
+  "version": 24,
+  "pages": [
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "ca669203-934f-44e3-a94f-a04e4892c9e4"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "x": 0,
+          "y": 99,
+          "width": 112,
+          "height": 32,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "id": "7739a64c-76d0-49d4-91fe-a177500601c7"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 16,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 900; color: #fff\">CATEGORY</span>",
+          "fontWeight": 400,
+          "x": 0,
+          "y": 105.5,
+          "width": 112,
+          "height": 19,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "ff9919e1-95ae-4276-9330-10a36a8d51d9"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 43,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">Ten principles for good design</span>",
+          "fontWeight": 700,
+          "x": 0,
+          "y": 147,
+          "width": 313,
+          "height": 97,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "d774160a-9a92-4fb7-b49a-261032b332fe"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">By Dieter Rams</span>\n<span style=\"font-weight: 700\">January 31, 2020</span>",
+          "fontWeight": 400,
+          "x": 0,
+          "y": 259,
+          "width": 156,
+          "height": 48,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "2c2855fd-d71b-4041-b5a0-bcc78c55003a",
+          "marginOffset": 5.578125
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "e54fe990-3dbf-4d29-b64d-f862ff237392"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "14f53574-3915-4c23-927c-bf9ff0319aca"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 332,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "7739a64c-76d0-49d4-91fe-a177500601c7",
+          "id": "e5cfb7b9-60c7-454d-8aee-9e8d9a8d0ced",
+          "x": 0,
+          "y": 125
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 600; letter-spacing: 0.05em\">CATEGORY</span>",
+          "fontWeight": 400,
+          "width": 112,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "ff9919e1-95ae-4276-9330-10a36a8d51d9",
+          "id": "5730a6f3-4e76-4c7f-9ce5-8316ca800339",
+          "x": 0,
+          "y": 138
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 36,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 600\">Ten principles for good design</span>",
+          "fontWeight": 700,
+          "width": 313,
+          "height": 84,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "d774160a-9a92-4fb7-b49a-261032b332fe",
+          "id": "607c25aa-8966-4232-80ac-a64ba70dd497",
+          "x": 0,
+          "y": 164
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Lato",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 300, 400, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [0, 900],
+              [1, 100],
+              [1, 300],
+              [1, 400],
+              [1, 700],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 2000,
+              "asc": 1974,
+              "des": -426,
+              "tAsc": 1610,
+              "tDes": -390,
+              "tLGap": 400,
+              "wAsc": 1974,
+              "wDes": 426,
+              "xH": 1013,
+              "capH": 1433,
+              "yMin": -365,
+              "yMax": 1837,
+              "hAsc": 1974,
+              "hDes": -426,
+              "lGap": 0
+            }
+          },
+          "fontSize": 14,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "By Dieter Rams &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;January 31, 2020",
+          "fontWeight": 400,
+          "width": 342,
+          "height": 16,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 5.578125,
+          "basedOn": "2c2855fd-d71b-4041-b5a0-bcc78c55003a",
+          "id": "be8efd99-c3a7-4a43-b508-d0a5785eddc3",
+          "x": 0,
+          "y": 264
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 332,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "e5cfb7b9-60c7-454d-8aee-9e8d9a8d0ced",
+          "id": "1f4211cc-c2bd-4b7c-a897-f3d1d1871466",
+          "x": 0,
+          "y": 256
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 332,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "e5cfb7b9-60c7-454d-8aee-9e8d9a8d0ced",
+          "id": "e6be672d-e0cb-4d5b-aef3-a223cf9914bf",
+          "x": 0,
+          "y": 288
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 1,
+          "height": 14,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "e5cfb7b9-60c7-454d-8aee-9e8d9a8d0ced",
+          "id": "0e33182f-74b6-45fe-a6c0-7893611b182c",
+          "x": 111,
+          "y": 265
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "92b7301d-85c4-41b6-aba0-387d66ea9ee9"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "bf62d480-6490-451d-9ec8-1a403e8a24d3"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Poppins",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1050,
+              "des": -350,
+              "tAsc": 1050,
+              "tDes": -350,
+              "tLGap": 100,
+              "wAsc": 1135,
+              "wDes": 627,
+              "xH": 548,
+              "capH": 698,
+              "yMin": -572,
+              "yMax": 1065,
+              "hAsc": 1050,
+              "hDes": -350,
+              "lGap": 100
+            }
+          },
+          "fontSize": 24,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; letter-spacing: 0.03em\">CATEGORY</span>",
+          "fontWeight": 400,
+          "width": 140,
+          "height": 33,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5730a6f3-4e76-4c7f-9ce5-8316ca800339",
+          "id": "ebeb00e0-5e48-4b11-b213-2500d2474bc2",
+          "x": 0,
+          "y": 265
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Poppins",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1050,
+              "des": -350,
+              "tAsc": 1050,
+              "tDes": -350,
+              "tLGap": 100,
+              "wAsc": 1135,
+              "wDes": 627,
+              "xH": 548,
+              "capH": 698,
+              "yMin": -572,
+              "yMax": 1065,
+              "hAsc": 1050,
+              "hDes": -350,
+              "lGap": 100
+            }
+          },
+          "fontSize": 43,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; letter-spacing: 0.03em\">TEN&nbsp;</span>\n<span style=\"font-weight: 700; letter-spacing: 0.03em\">PRINCIPLES</span>\n<span style=\"font-weight: 700; letter-spacing: 0.03em\">FOR GOOD</span>\n<span style=\"font-weight: 700; letter-spacing: 0.03em\">DESIGN</span>",
+          "fontWeight": 700,
+          "width": 313,
+          "height": 201,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "607c25aa-8966-4232-80ac-a64ba70dd497",
+          "id": "41f72c82-5f33-4ec2-be22-755a93241212",
+          "x": 0,
+          "y": 69
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Poppins",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1050,
+              "des": -350,
+              "tAsc": 1050,
+              "tDes": -350,
+              "tLGap": 100,
+              "wAsc": 1135,
+              "wDes": 627,
+              "xH": 548,
+              "capH": 698,
+              "yMin": -572,
+              "yMax": 1065,
+              "hAsc": 1050,
+              "hDes": -350,
+              "lGap": 100
+            }
+          },
+          "fontSize": 14,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.4,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "By Dieter Rams\nJanuary 31, 2020",
+          "fontWeight": 400,
+          "width": 122,
+          "height": 38,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 5.578125,
+          "basedOn": "be8efd99-c3a7-4a43-b508-d0a5785eddc3",
+          "id": "afe7d0a5-0c85-4d3a-a34b-8a890c9e4a1a",
+          "x": 0,
+          "y": 302
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "37304213-5ef8-4083-91e0-9f349ced3cbb"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "392150a7-487e-4910-ba2d-cb23dc592332"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 32,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "e5cfb7b9-60c7-454d-8aee-9e8d9a8d0ced",
+          "id": "7973cdf7-53b7-4c6c-961c-ec580ddd1974",
+          "x": 109,
+          "y": 137
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Playfair Display",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1082,
+              "des": -251,
+              "tAsc": 1082,
+              "tDes": -251,
+              "tLGap": 0,
+              "wAsc": 1159,
+              "wDes": 251,
+              "xH": 514,
+              "capH": 708,
+              "yMin": -241,
+              "yMax": 1159,
+              "hAsc": 1082,
+              "hDes": -251,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; letter-spacing: 0.1em\">CATEGORY</span>",
+          "fontWeight": 400,
+          "width": 112,
+          "height": 23,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5730a6f3-4e76-4c7f-9ce5-8316ca800339",
+          "id": "f77e3d81-d7d2-480a-b185-4a509a452b76",
+          "x": 153,
+          "y": 127
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 32,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "7973cdf7-53b7-4c6c-961c-ec580ddd1974",
+          "id": "146eece8-418e-465e-ba9a-dfd25b1958f4",
+          "x": 275,
+          "y": 137
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Poppins",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1050,
+              "des": -350,
+              "tAsc": 1050,
+              "tDes": -350,
+              "tLGap": 100,
+              "wAsc": 1135,
+              "wDes": 627,
+              "xH": 548,
+              "capH": 698,
+              "yMin": -572,
+              "yMax": 1065,
+              "hAsc": 1050,
+              "hDes": -350,
+              "lGap": 100
+            }
+          },
+          "fontSize": 14,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.4,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "By Dieter Rams\nJanuary 31, 2020",
+          "fontWeight": 400,
+          "width": 122,
+          "height": 38,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 5.578125,
+          "basedOn": "be8efd99-c3a7-4a43-b508-d0a5785eddc3",
+          "id": "e7faf544-0b5e-45c0-bd52-3ebad5cc96b3",
+          "x": 145,
+          "y": 245
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Playfair Display",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1082,
+              "des": -251,
+              "tAsc": 1082,
+              "tDes": -251,
+              "tLGap": 0,
+              "wAsc": 1159,
+              "wDes": 251,
+              "xH": 514,
+              "capH": 708,
+              "yMin": -241,
+              "yMax": 1159,
+              "hAsc": 1082,
+              "hDes": -251,
+              "lGap": 0
+            }
+          },
+          "fontSize": 31,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; letter-spacing: 0.04em\">TEN&nbsp;PRINCIPLES</span>\n<span style=\"font-weight: 700; letter-spacing: 0.04em\">FOR GOOD DESIGN</span>",
+          "fontWeight": 700,
+          "width": 313,
+          "height": 77,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "41f72c82-5f33-4ec2-be22-755a93241212",
+          "id": "dd4ac41c-e4fb-451d-977b-9564d3ee28d4",
+          "x": 50,
+          "y": 155
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "1385a801-9bda-4720-8450-492ece575d7e"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "08de681c-ecaf-4f97-9bbe-fce65b589fdb"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "x": 0,
+          "y": 0,
+          "width": 363,
+          "height": 218,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "id": "cc7c5a89-9bec-4ba5-bf42-19ca9172942a"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Oswald",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 500, 600, 700],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1193,
+              "des": -289,
+              "tAsc": 1193,
+              "tDes": -289,
+              "tLGap": 0,
+              "wAsc": 1325,
+              "wDes": 377,
+              "xH": 578,
+              "capH": 810,
+              "yMin": -287,
+              "yMax": 1297,
+              "hAsc": 1193,
+              "hDes": -289,
+              "lGap": 0
+            }
+          },
+          "fontSize": 24,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 300; color: #fff\">Category</span>",
+          "fontWeight": 400,
+          "width": 112,
+          "height": 35,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "f77e3d81-d7d2-480a-b185-4a509a452b76",
+          "id": "ab4e5032-7d70-42c9-98bf-9761cb8be09b",
+          "x": 16,
+          "y": 13
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "e6be672d-e0cb-4d5b-aef3-a223cf9914bf",
+          "id": "679372c2-385c-4dcc-ba9b-ebd100e813ee",
+          "x": 16,
+          "y": 53
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Oswald",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 500, 600, 700],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1193,
+              "des": -289,
+              "tAsc": 1193,
+              "tDes": -289,
+              "tLGap": 0,
+              "wAsc": 1325,
+              "wDes": 377,
+              "xH": 578,
+              "capH": 810,
+              "yMin": -287,
+              "yMax": 1297,
+              "hAsc": 1193,
+              "hDes": -289,
+              "lGap": 0
+            }
+          },
+          "fontSize": 43,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 500; color: #fff\">TEN&nbsp;PRINCIPLES</span>\n<span style=\"font-weight: 500; color: #fff\">FOR GOOD DESIGN</span>",
+          "fontWeight": 700,
+          "width": 313,
+          "height": 111,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "dd4ac41c-e4fb-451d-977b-9564d3ee28d4",
+          "id": "c1b1f578-0c36-4e88-8182-7dfcfebb8b86",
+          "x": 16,
+          "y": 54
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "679372c2-385c-4dcc-ba9b-ebd100e813ee",
+          "id": "da8ea483-5ce8-4443-a069-bbed22a09a6e",
+          "x": 16,
+          "y": 166
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [1, 300],
+              [1, 400],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #fff\">By Dieter Rams</span>",
+          "fontWeight": 400,
+          "width": 122,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 5.578125,
+          "basedOn": "e7faf544-0b5e-45c0-bd52-3ebad5cc96b3",
+          "id": "5df6e87c-2062-4f33-8049-608df45f5ab0",
+          "x": 16,
+          "y": 180
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [1, 300],
+              [1, 400],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #fff\">January 31, 2020</span>",
+          "fontWeight": 400,
+          "width": 122,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 5.578125,
+          "basedOn": "5df6e87c-2062-4f33-8049-608df45f5ab0",
+          "id": "3477f800-c840-4dbd-b730-37e1597711e3",
+          "x": 225,
+          "y": 180
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "160e8c18-f3be-43fd-acdb-40f88066574b"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "7f46527b-f6d9-427e-8a97-bb77e4dabdf1"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Raleway",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 940,
+              "des": -234,
+              "tAsc": 940,
+              "tDes": -234,
+              "tLGap": 0,
+              "wAsc": 1154,
+              "wDes": 234,
+              "xH": 519,
+              "capH": 710,
+              "yMin": -223,
+              "yMax": 1151,
+              "hAsc": 940,
+              "hDes": -234,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.4,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; letter-spacing: 0.05em\">CATEGORY</span>",
+          "fontWeight": 400,
+          "width": 112,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5730a6f3-4e76-4c7f-9ce5-8316ca800339",
+          "id": "7dc69555-5731-4e30-b641-1431d189cdfe",
+          "x": 0,
+          "y": 123
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Merriweather",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [300, 400, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [0, 900],
+              [1, 300],
+              [1, 400],
+              [1, 700],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 984,
+              "des": -273,
+              "tAsc": 984,
+              "tDes": -273,
+              "tLGap": 0,
+              "wAsc": 1065,
+              "wDes": 273,
+              "xH": 555,
+              "capH": 743,
+              "yMin": -272,
+              "yMax": 1055,
+              "hAsc": 984,
+              "hDes": -273,
+              "lGap": 0
+            }
+          },
+          "fontSize": 36,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 300\">Ten principles for good design</span>",
+          "fontWeight": 700,
+          "width": 313,
+          "height": 91,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "607c25aa-8966-4232-80ac-a64ba70dd497",
+          "id": "f8175027-5283-4bfa-abe3-0d9d8e0197bf",
+          "x": 0,
+          "y": 156
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Raleway",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 940,
+              "des": -234,
+              "tAsc": 940,
+              "tDes": -234,
+              "tLGap": 0,
+              "wAsc": 1154,
+              "wDes": 234,
+              "xH": 519,
+              "capH": 710,
+              "yMin": -223,
+              "yMax": 1151,
+              "hAsc": 940,
+              "hDes": -234,
+              "lGap": 0
+            }
+          },
+          "fontSize": 16,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.4,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "By Dieter Rams &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; January 31, 2020",
+          "fontWeight": 400,
+          "width": 342,
+          "height": 18,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 5.578125,
+          "basedOn": "be8efd99-c3a7-4a43-b508-d0a5785eddc3",
+          "id": "c6867853-e246-413a-b9df-29d184090da8",
+          "x": 0,
+          "y": 266
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 1,
+          "height": 14,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "0e33182f-74b6-45fe-a6c0-7893611b182c",
+          "id": "ee502557-00dc-4206-be40-913a8f5cbfbc",
+          "x": 126,
+          "y": 269
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "b0a31c77-faa8-47b3-8a5e-ac0ee0944fea"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "5c52917f-60d1-43d1-a909-69fbc89f1f08"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Titillium Web",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1133,
+              "des": -388,
+              "tAsc": 1133,
+              "tDes": -388,
+              "tLGap": 0,
+              "wAsc": 1133,
+              "wDes": 388,
+              "xH": 500,
+              "capH": 692,
+              "yMin": -285,
+              "yMax": 1082,
+              "hAsc": 1133,
+              "hDes": -388,
+              "lGap": 0
+            }
+          },
+          "fontSize": 43,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 900; color: rgba(0,0,0,0.15)\">Ten principles for good design</span>",
+          "fontWeight": 700,
+          "width": 313,
+          "height": 113,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "f8175027-5283-4bfa-abe3-0d9d8e0197bf",
+          "id": "1e7b6aad-8cc7-4404-a538-fbf9c9232588",
+          "x": 54,
+          "y": 101
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Titillium Web",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1133,
+              "des": -388,
+              "tAsc": 1133,
+              "tDes": -388,
+              "tLGap": 0,
+              "wAsc": 1133,
+              "wDes": 388,
+              "xH": 500,
+              "capH": 692,
+              "yMin": -285,
+              "yMax": 1082,
+              "hAsc": 1133,
+              "hDes": -388,
+              "lGap": 0
+            }
+          },
+          "fontSize": 43,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 900\">Ten principles for good design</span>",
+          "fontWeight": 700,
+          "width": 313,
+          "height": 113,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "1e7b6aad-8cc7-4404-a538-fbf9c9232588",
+          "id": "7754cac3-e8a6-49bb-9b4e-9a67164f479a",
+          "x": 50,
+          "y": 97
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Work Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 930,
+              "des": -243,
+              "tAsc": 930,
+              "tDes": -243,
+              "tLGap": 0,
+              "wAsc": 1105,
+              "wDes": 343,
+              "xH": 500,
+              "capH": 660,
+              "yMin": -337,
+              "yMax": 1100,
+              "hAsc": 930,
+              "hDes": -243,
+              "lGap": 0
+            }
+          },
+          "fontSize": 16,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "By Dieter Rams\nJanuary 31, 2020",
+          "fontWeight": 400,
+          "width": 159,
+          "height": 42,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 5.578125,
+          "basedOn": "e7faf544-0b5e-45c0-bd52-3ebad5cc96b3",
+          "id": "bbd94bfc-49d5-4280-b25d-df97697225e6",
+          "x": 127,
+          "y": 209
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Montserrat",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 968,
+              "des": -251,
+              "tAsc": 968,
+              "tDes": -251,
+              "tLGap": 0,
+              "wAsc": 1109,
+              "wDes": 270,
+              "xH": 525,
+              "capH": 700,
+              "yMin": -262,
+              "yMax": 1043,
+              "hAsc": 968,
+              "hDes": -251,
+              "lGap": 0
+            }
+          },
+          "fontSize": 20,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; letter-spacing: 0.01em\">CATEGORY</span>",
+          "fontWeight": 400,
+          "width": 184,
+          "height": 24,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "7dc69555-5731-4e30-b641-1431d189cdfe",
+          "id": "fff8ea88-c2fc-417e-8489-b88f887718ff",
+          "x": 115,
+          "y": 277
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "x": 128,
+          "y": 269,
+          "width": 4,
+          "height": 40,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "id": "49aa3fb2-bc63-41ac-810f-d961a96d9f47"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 4,
+          "height": 40,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "49aa3fb2-bc63-41ac-810f-d961a96d9f47",
+          "id": "87750f85-c55c-478a-b7f1-fd60b48e3e9e",
+          "x": 285,
+          "y": 269
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 161,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "87750f85-c55c-478a-b7f1-fd60b48e3e9e",
+          "id": "0d7ac44c-8fd5-4383-bf39-d325ffcfc8fa",
+          "x": 128,
+          "y": 269
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 161,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "0d7ac44c-8fd5-4383-bf39-d325ffcfc8fa",
+          "id": "ea329f35-fc03-4a8c-b8fc-5b9441d8d039",
+          "x": 128,
+          "y": 305
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "5dde9e25-8bc2-4584-ae74-87935dcb09fb"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "0479e630-5db5-4c64-9a5e-13caa114be88"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 1,
+          "height": 273,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "3dd28357-58fb-45fc-b7df-4873dbb58806",
+          "id": "39dd9085-76df-462d-9ca0-f09f3040fe18",
+          "x": 16,
+          "y": 11
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 1,
+          "height": 273,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "39dd9085-76df-462d-9ca0-f09f3040fe18",
+          "id": "e92fc3f9-3b43-4697-8201-392a09e3f9aa",
+          "x": 395,
+          "y": 11
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 380,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "3dd28357-58fb-45fc-b7df-4873dbb58806",
+          "id": "ed41ddcd-8d01-42b7-a6a9-d36ef18b9553",
+          "x": 16,
+          "y": 11
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 380,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "ed41ddcd-8d01-42b7-a6a9-d36ef18b9553",
+          "id": "1ef48d77-a32f-4a85-8c75-d132a2ab04b6",
+          "x": 16,
+          "y": 283
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Nunito",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1011,
+              "des": -353,
+              "tAsc": 1011,
+              "tDes": -353,
+              "tLGap": 0,
+              "wAsc": 1092,
+              "wDes": 281,
+              "xH": 487,
+              "capH": 705,
+              "yMin": -275,
+              "yMax": 1081,
+              "hAsc": 1011,
+              "hDes": -353,
+              "lGap": 0
+            }
+          },
+          "fontSize": 36,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 200\">Ten principles for good design</span>",
+          "fontWeight": 700,
+          "width": 254,
+          "height": 89,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "7754cac3-e8a6-49bb-9b4e-9a67164f479a",
+          "id": "0f5f6273-994d-45d6-923d-100b88051129",
+          "x": 79,
+          "y": 55
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 32,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "7973cdf7-53b7-4c6c-961c-ec580ddd1974",
+          "id": "5bde3567-9a2a-44e4-a183-4c8b62aae675",
+          "x": 106,
+          "y": 167
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Nunito",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1011,
+              "des": -353,
+              "tAsc": 1011,
+              "tDes": -353,
+              "tLGap": 0,
+              "wAsc": 1092,
+              "wDes": 281,
+              "xH": 487,
+              "capH": 705,
+              "yMin": -275,
+              "yMax": 1081,
+              "hAsc": 1011,
+              "hDes": -353,
+              "lGap": 0
+            }
+          },
+          "fontSize": 16,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"letter-spacing: 0.2em\">CATEGORY</span>",
+          "fontWeight": 400,
+          "width": 112,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "f77e3d81-d7d2-480a-b185-4a509a452b76",
+          "id": "9bd0f726-0d83-4066-a154-f6e415c3593d",
+          "x": 150,
+          "y": 157
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 32,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "146eece8-418e-465e-ba9a-dfd25b1958f4",
+          "id": "a5beb228-301e-478b-bda4-daf8d1294720",
+          "x": 272,
+          "y": 167
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 700],
+              [1, 400],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 15,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.4,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "By Dieter Rams\nJanuary 31, 2020",
+          "fontWeight": 400,
+          "width": 159,
+          "height": 37,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 5.578125,
+          "basedOn": "bbd94bfc-49d5-4280-b25d-df97697225e6",
+          "id": "249be185-abeb-4282-8f56-4a61ab112160",
+          "x": 126.5,
+          "y": 198
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "7cf5cb87-0090-4ef4-b047-a745f8f6bfbe"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds text sets under `Cover` category in this design file:
https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Design-System?node-id=837%3A3585

## User-facing changes
NA

## Testing Instructions
Enable the text sets flag in experiments and see the new text sets in the story editor.

## Screenshots
<img width="348" alt="Screen Shot 2020-09-16 at 2 08 37 PM" src="https://user-images.githubusercontent.com/35983235/93388002-4d267380-f827-11ea-9614-f0044a915408.png">


---

<!-- Please reference the issue(s) this PR addresses. -->

Partial for #4078 
