### PR TITLE
Dashboard: Focused grid items no longer initially cut off

### DIFF
--- a/assets/src/dashboard/app/views/myStories/header/index.js
+++ b/assets/src/dashboard/app/views/myStories/header/index.js
@@ -128,6 +128,11 @@ function Header({
     [scrollToTop, sort]
   );
 
+  const onLayoutChange = useCallback(() => {
+    scrollToTop();
+    view.toggleStyle();
+  }, [scrollToTop, view]);
+
   const [debouncedTypeaheadChange] = useDebouncedCallback(async (value) => {
     await trackEvent('search_stories', 'dashboard', '', '', {
       search_term: value,
@@ -151,7 +156,7 @@ function Header({
         showSortDropdown
         resultsLabel={resultsLabel}
         layoutStyle={view.style}
-        handleLayoutSelect={view.toggleStyle}
+        handleLayoutSelect={onLayoutChange}
         currentSort={sort.value}
         pageSortOptions={STORY_SORT_MENU_ITEMS}
         handleSortChange={onSortChange}

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -55,7 +55,6 @@ import {
   MoreVerticalButton,
   InlineInputForm,
   Paragraph2,
-  useLayoutContext,
 } from '../../../components';
 import {
   ORDER_BY_SORT,
@@ -64,11 +63,7 @@ import {
   STORY_STATUS,
   STORY_CONTEXT_MENU_ACTIONS,
 } from '../../../constants';
-import {
-  FULLBLEED_RATIO,
-  DASHBOARD_TOP_MARGIN,
-  DEFAULT_DASHBOARD_TOP_SPACE,
-} from '../../../constants/pageStructure';
+import { FULLBLEED_RATIO } from '../../../constants/pageStructure';
 import PreviewErrorBoundary from '../../../components/previewErrorBoundary';
 import {
   ArrowAlphaAscending as ArrowAlphaAscendingSvg,
@@ -177,15 +172,6 @@ export default function StoryListView({
   users,
   dateSettings,
 }) {
-  const {
-    state: { squishContentHeight },
-  } = useLayoutContext();
-
-  // get sticky position from the squishContentHeight (header area),
-  // subtract top margin of header which is only relevant until scrolling and the fixed table header is on scroll & add default top padding.
-  const stickyTopPosition =
-    squishContentHeight - DASHBOARD_TOP_MARGIN + DEFAULT_DASHBOARD_TOP_SPACE;
-
   const onSortTitleSelected = useCallback(
     (newStorySort) => {
       if (newStorySort !== storySort) {
@@ -210,7 +196,7 @@ export default function StoryListView({
   return (
     <ListView data-testid="story-list-view">
       <Table>
-        <StickyTableHeader top={stickyTopPosition}>
+        <StickyTableHeader>
           <TableRow>
             <TablePreviewHeaderCell
               onClick={() => onSortTitleSelected(STORY_SORT_OPTIONS.NAME)}

--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -52,6 +52,7 @@ export const LayoutContext = createContext(null);
 
 const Provider = ({ children }) => {
   const [squishContentHeight, setSquishContentHeight] = useState(0);
+  const [squishContainerHeight, setSquishContainerHeight] = useState(0);
   const scrollFrameRef = useRef(null);
   const [telemetryBannerOpen, setTelemetryBannerOpen] = useState(false);
   const [telemetryBannerHeight, setTelemetryBannerHeight] = useState();
@@ -125,6 +126,7 @@ const Provider = ({ children }) => {
     () => ({
       state: {
         scrollFrameRef,
+        squishContainerHeight,
         squishContentHeight,
         telemetryBannerOpen,
       },
@@ -143,17 +145,18 @@ const Provider = ({ children }) => {
          */
         removeSquishListener,
         setSquishContentHeight,
+        setSquishContainerHeight,
         scrollToTop,
         setTelemetryBannerOpen,
         setTelemetryBannerHeight,
       },
     }),
     [
-      setTelemetryBannerOpen,
+      squishContainerHeight,
+      squishContentHeight,
       telemetryBannerOpen,
       addSquishListener,
       removeSquishListener,
-      squishContentHeight,
       scrollToTop,
     ]
   );

--- a/assets/src/dashboard/components/layout/scrollable.js
+++ b/assets/src/dashboard/components/layout/scrollable.js
@@ -26,7 +26,7 @@ import useLayoutContext from './useLayoutContext';
 
 const ScrollContent = styled.div`
   position: absolute;
-  top: 0;
+  top: ${(props) => props.topOffset || 0}px;
   right: 0;
   bottom: 0;
   left: 0;
@@ -42,7 +42,6 @@ const ScrollContent = styled.div`
 
 const Inner = styled.div`
   position: relative;
-  padding-top: ${(props) => props.paddingTop || 0}px;
   width: ${({ scrollbarWidth }) => `calc(100% + ${scrollbarWidth}px)`};
 `;
 
@@ -52,7 +51,7 @@ Inner.propTypes = {
 
 const Scrollable = ({ children }) => {
   const {
-    state: { scrollFrameRef, squishContentHeight },
+    state: { scrollFrameRef, squishContainerHeight },
   } = useLayoutContext();
 
   const scrollbarWidth = scrollFrameRef?.current
@@ -60,10 +59,8 @@ const Scrollable = ({ children }) => {
     : 0;
 
   return (
-    <ScrollContent ref={scrollFrameRef}>
-      <Inner scrollbarWidth={scrollbarWidth} paddingTop={squishContentHeight}>
-        {children}
-      </Inner>
+    <ScrollContent ref={scrollFrameRef} topOffset={squishContainerHeight}>
+      <Inner scrollbarWidth={scrollbarWidth}>{children}</Inner>
     </ScrollContent>
   );
 };

--- a/assets/src/dashboard/components/layout/squishable.js
+++ b/assets/src/dashboard/components/layout/squishable.js
@@ -16,7 +16,7 @@
 /**
  * External dependencies
  */
-import { useLayoutEffect, useRef } from 'react';
+import { useLayoutEffect, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 /**
@@ -52,7 +52,12 @@ const Squishable = ({ children }) => {
   useAddSquishVar(rootRef);
 
   const {
-    actions: { setSquishContentHeight },
+    actions: {
+      setSquishContentHeight,
+      setSquishContainerHeight,
+      addSquishListener,
+      removeSquishListener,
+    },
   } = useLayoutContext();
 
   useLayoutEffect(() => {
@@ -61,7 +66,24 @@ const Squishable = ({ children }) => {
       return;
     }
     setSquishContentHeight(contentEl.offsetHeight + SQUISH_LENGTH);
-  }, [setSquishContentHeight]);
+  }, [setSquishContentHeight, setSquishContainerHeight]);
+
+  // update squishContainerHeight when children of squishContainer change (which updates the height of the container)
+  useEffect(() => {
+    if (children) {
+      setSquishContainerHeight(rootRef?.current.offsetHeight);
+    }
+  }, [children, setSquishContainerHeight]);
+
+  useEffect(() => {
+    const adjustHeight = () =>
+      setSquishContainerHeight(rootRef?.current.offsetHeight);
+
+    addSquishListener(adjustHeight);
+    return () => {
+      removeSquishListener(adjustHeight);
+    };
+  }, [addSquishListener, removeSquishListener, setSquishContainerHeight]);
 
   return (
     <Squish ref={rootRef}>

--- a/assets/src/dashboard/components/table/index.js
+++ b/assets/src/dashboard/components/table/index.js
@@ -51,7 +51,7 @@ export const StickyTableHeader = styled(TableHeader)`
     border-bottom: ${({ theme }) => theme.table.border};
     position: sticky;
     z-index: ${Z_INDEX.STICKY_TABLE};
-    top: ${({ top }) => `${top}px` || 0};
+    top: 0;
   }
 `;
 StickyTableHeader.propTypes = {


### PR DESCRIPTION
## Summary
- prevents scrollable content being focused behind squishable content (headers)
- Builds on PR #4488 

## Relevant Technical Choices
- Adds a new value to LayoutProvider to track the vertical space taken up by the dashboard header in the `Squishable` component. 
- This value is updated when the Squishable children change and when scrolled so that we have the proper vertical pixel size that the header is taking up and can use it as the scrollable component's top position to keep scrollable content from reaching the actual top of the browser window. 
- Eliminates my early PR calculating the space to set table header to be sticky - now that can just be top: 0 which feels way better. 

## To-do
- The trade off here is that now the popover menus inside of the scrollable container get cut off on overflow:scroll, but without the update to control the top we are back tot he focused items being under the header

## User-facing changes
- When you use the keyboard to tab into a grid it should no longer scroll up slightly, the entire grid should remain in view.
- When you scroll down and then swap to list view on my stories you should get sent back to the top of the page (and vice versa)


## Testing Instructions
- Verify that focusing on grid items is no longer out of view when using a keyboard 
- Verify that when you switch layout views on my stories while scrolled down on the page that you get sent to the top of the view 
- Verify that table headers in list view of my stories are still fixed to the top available space on scroll 
- Verify all of the above without the telemetry banner and with it. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4470 
