### PR TITLE
Layer Panel: Accessibility improvements

### DIFF
--- a/assets/src/edit-story/components/keyboardShortcutsMenu/constants.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/constants.js
@@ -34,4 +34,6 @@ export const SPECIAL_KEYS = {
   OPTION: { symbol: '⌥', title: __('Option', 'web-stories') },
   ALT: 'Alt',
   DELETE: __('Delete', 'web-stories'),
+  UP: { symbol: '⬆', title: __('Up arrow', 'web-stories') },
+  DOWN: { symbol: '⬇', title: __('Down arrow', 'web-stories') },
 };

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/getKeyboardShortcuts.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/getKeyboardShortcuts.js
@@ -127,8 +127,30 @@ function getKeyboardShortcuts() {
             ],
           },
           {
+            label: __('Move layer forward or backward', 'web-stories'),
+            shortcut: [
+              cmdOrCtrl,
+              SPECIAL_KEYS.UP,
+              { label: __('or', 'web-stories') },
+              SPECIAL_KEYS.DOWN,
+            ],
+          },
+          {
+            label: __('Move layer to front or back', 'web-stories'),
+            shortcut: [
+              cmdOrCtrl,
+              SPECIAL_KEYS.SHIFT,
+              SPECIAL_KEYS.UP,
+              { label: __('or', 'web-stories') },
+              SPECIAL_KEYS.DOWN,
+            ],
+          },
+          {
             label: __('Enter crop/edit mode', 'web-stories'),
-            shortcut: [SPECIAL_KEYS.ENTER],
+            shortcut: [
+              SPECIAL_KEYS.ENTER,
+              { label: __('or double-click', 'web-stories') },
+            ],
           },
           {
             label: __('Delete', 'web-stories'),
@@ -141,10 +163,7 @@ function getKeyboardShortcuts() {
             shortcut: [cmdOrCtrl, 'K'],
           },
           {
-            label: __(
-              'Disable snapping during move/rotate/resize',
-              'web-stories'
-            ),
+            label: __('Disable snapping during drag', 'web-stories'),
             shortcut: [cmdOrCtrl],
           },
         ],

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/getKeyboardShortcuts.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/getKeyboardShortcuts.js
@@ -127,7 +127,7 @@ function getKeyboardShortcuts() {
             ],
           },
           {
-            label: __('Move layer forward or backward', 'web-stories'),
+            label: __('Move forward or backward', 'web-stories'),
             shortcut: [
               cmdOrCtrl,
               SPECIAL_KEYS.UP,
@@ -136,7 +136,7 @@ function getKeyboardShortcuts() {
             ],
           },
           {
-            label: __('Move layer to front or back', 'web-stories'),
+            label: __('Move to front or back', 'web-stories'),
             shortcut: [
               cmdOrCtrl,
               SPECIAL_KEYS.SHIFT,
@@ -163,7 +163,7 @@ function getKeyboardShortcuts() {
             shortcut: [cmdOrCtrl, 'K'],
           },
           {
-            label: __('Disable snapping during drag', 'web-stories'),
+            label: __('Disable snapping while moving', 'web-stories'),
             shortcut: [cmdOrCtrl],
           },
         ],

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/styled.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/styled.js
@@ -30,7 +30,7 @@ export const Container = styled.div`
   width: 100%;
   max-width: 625px;
   min-width: 300px;
-  max-height: 625px;
+  max-height: 675px;
   border-radius: 4px;
   padding: 24px;
   padding-bottom: 0;
@@ -91,11 +91,15 @@ export const SectionHeader = styled.h2(
 export const SectionWrapper = styled.div`
   width: 100%;
   margin-bottom: 60px;
+
+  &:last-child {
+    margin-bottom: 24px;
+  }
 `;
 
 export const SectionContent = styled.dl`
   display: grid;
-  grid-template-columns: 1fr 0.75fr;
+  grid-template-columns: 1fr 1fr;
   row-gap: 12px;
   column-gap: 5px;
   align-items: center;

--- a/assets/src/edit-story/components/panels/layer/layer.js
+++ b/assets/src/edit-story/components/panels/layer/layer.js
@@ -38,6 +38,8 @@ const LayerButton = styled.button.attrs({
   type: 'button',
   tabIndex: -1,
   role: 'option',
+  // Because the layer panel is aria-hidden, we need something else to select by
+  'data-testid': 'layer-option',
 })`
   display: flex;
   border: 0;

--- a/assets/src/edit-story/components/panels/layer/panel.js
+++ b/assets/src/edit-story/components/panels/layer/panel.js
@@ -41,7 +41,7 @@ function LayerPanel() {
         window.innerHeight / 3
       )}
       resizeable
-      aria-hidden
+      ariaHidden
     >
       <PanelTitle isSecondary isResizable>
         {__('Layers', 'web-stories')}

--- a/assets/src/edit-story/components/panels/layer/panel.js
+++ b/assets/src/edit-story/components/panels/layer/panel.js
@@ -41,6 +41,7 @@ function LayerPanel() {
         window.innerHeight / 3
       )}
       resizeable
+      aria-hidden
     >
       <PanelTitle isSecondary isResizable>
         {__('Layers', 'web-stories')}

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -42,6 +42,7 @@ function Panel({
   canCollapse = true,
   initialHeight = null,
   ariaLabel = null,
+  ...rest
 }) {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [expandToHeight, setExpandToHeight] = useState(initialHeight);
@@ -144,7 +145,7 @@ function Panel({
   );
 
   return (
-    <Wrapper {...wrapperProps}>
+    <Wrapper {...wrapperProps} {...rest}>
       <ContextProvider value={contextValue}>{children}</ContextProvider>
     </Wrapper>
   );

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -42,7 +42,7 @@ function Panel({
   canCollapse = true,
   initialHeight = null,
   ariaLabel = null,
-  ...rest
+  ariaHidden = false,
 }) {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [expandToHeight, setExpandToHeight] = useState(initialHeight);
@@ -123,6 +123,7 @@ function Panel({
       panelContentId,
       panelTitleId,
       panelTitleReadable,
+      ariaHidden,
     },
     actions: {
       setHeight: manuallySetHeight,
@@ -145,7 +146,7 @@ function Panel({
   );
 
   return (
-    <Wrapper {...wrapperProps} {...rest}>
+    <Wrapper {...wrapperProps} aria-hidden={ariaHidden}>
       <ContextProvider value={contextValue}>{children}</ContextProvider>
     </Wrapper>
   );
@@ -158,6 +159,7 @@ Panel.propTypes = {
   resizeable: PropTypes.bool,
   canCollapse: PropTypes.bool,
   ariaLabel: PropTypes.string,
+  ariaHidden: PropTypes.bool,
 };
 
 export default Panel;

--- a/assets/src/edit-story/components/panels/panel/shared/handle.js
+++ b/assets/src/edit-story/components/panels/panel/shared/handle.js
@@ -50,9 +50,7 @@ const Handle = styled.div`
   width: 100%;
 `;
 
-const Bar = styled.div.attrs({
-  tabIndex: 0,
-})`
+const Bar = styled.div`
   width: 100%;
   height: 4px;
 
@@ -70,6 +68,7 @@ function DragHandle({
   handleExpandToHeightChange,
   handleDoubleClick,
   position,
+  ...rest
 }) {
   const handle = useRef();
   useDragHandlers(handle, handleHeightChange, handleExpandToHeightChange);
@@ -84,6 +83,7 @@ function DragHandle({
         aria-valuemin={minHeight}
         aria-valuemax={maxHeight}
         aria-label={__('Set panel height', 'web-stories')}
+        {...rest}
       />
     </Handle>
   );

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -138,6 +138,7 @@ function Title({
       panelContentId,
       panelTitleId,
       panelTitleReadable,
+      ariaHidden,
     },
     actions: {
       collapse,
@@ -200,6 +201,7 @@ function Title({
           handleHeightChange={handleHeightChange}
           handleExpandToHeightChange={handleExpandToHeightChange}
           handleDoubleClick={resetHeight}
+          tabIndex={ariaHidden ? -1 : 0}
         />
       )}
       <HeaderButton onClick={onToggle}>
@@ -213,6 +215,7 @@ function Title({
               aria-label={titleLabel}
               aria-expanded={!isCollapsed}
               aria-controls={panelContentId}
+              tabIndex={ariaHidden ? -1 : 0}
             >
               <Arrow />
             </Toggle>

--- a/assets/src/edit-story/karma/fixture/containers/container.js
+++ b/assets/src/edit-story/karma/fixture/containers/container.js
@@ -19,7 +19,6 @@
  */
 import {
   getByRole,
-  getByLabelText,
   getAllByRole,
   queryByRole,
   waitFor,
@@ -71,17 +70,6 @@ export class Container {
         throw new Error(`Focus is not set within the <${this._path}> yet`);
       }
     });
-  }
-
-  /**
-   * See https://testing-library.com/docs/dom-testing-library/api-queries#bylabeltext
-   *
-   * @param {Matcher} label Label name.
-   * @param {ByRoleOptions} options Options.
-   * @return {HTMLElement} The found element.
-   */
-  getByLabelText(label, options) {
-    return getByLabelText(this._node, label, options);
   }
 
   /**

--- a/assets/src/edit-story/karma/fixture/containers/container.js
+++ b/assets/src/edit-story/karma/fixture/containers/container.js
@@ -19,6 +19,7 @@
  */
 import {
   getByRole,
+  getByLabelText,
   getAllByRole,
   queryByRole,
   waitFor,
@@ -70,6 +71,17 @@ export class Container {
         throw new Error(`Focus is not set within the <${this._path}> yet`);
       }
     });
+  }
+
+  /**
+   * See https://testing-library.com/docs/dom-testing-library/api-queries#bylabeltext
+   *
+   * @param {Matcher} label Label name.
+   * @param {ByRoleOptions} options Options.
+   * @return {HTMLElement} The found element.
+   */
+  getByLabelText(label, options) {
+    return getByLabelText(this._node, label, options);
   }
 
   /**

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/index.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/index.js
@@ -116,10 +116,8 @@ export class DesignPanel extends Container {
   }
 
   get layerPanel() {
-    return this._get(
-      this.getByRole('region', { name: /layers/i }),
-      'layerPanel',
-      Layers
-    );
+    // The whole panel is aria-hidden now for accessibiility reasons
+    // thus it cannot be accessed by role:
+    return this._get(this.getByLabelText('Layers'), 'layerPanel', Layers);
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/index.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/index.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { getByLabelText } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
 import { Container } from '../container';
@@ -118,6 +123,10 @@ export class DesignPanel extends Container {
   get layerPanel() {
     // The whole panel is aria-hidden now for accessibiility reasons
     // thus it cannot be accessed by role:
-    return this._get(this.getByLabelText('Layers'), 'layerPanel', Layers);
+    return this._get(
+      getByLabelText(this._node, 'Layers'),
+      'layerPanel',
+      Layers
+    );
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/layers.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/layers.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { getByLabelText, getAllByTestId } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
 import { AbstractPanel } from './abstractPanel';
@@ -28,16 +33,10 @@ export class Layers extends AbstractPanel {
   }
 
   get layersList() {
-    return this.getByRoleIn(this.node.ownerDocument, 'listbox', {
-      name: /layers list/i,
-    });
+    return getByLabelText(this.node.ownerDocument, /layers list/i);
   }
 
   get layers() {
-    return this.getAllByRoleIn(this.layersList, 'option');
-  }
-
-  layer(name) {
-    return this.getByRoleIn(this.layersList, 'option', { name });
+    return getAllByTestId(this.layersList, 'layer-option');
   }
 }


### PR DESCRIPTION
## Summary

1. Hides layer panel from screen readers
1. Adds layer manipulation shortcuts to shortcut modal.

Please see #4432 for arguments.

## Testing Instructions

1. Open keyboard shortcut modal
1. See new shortcuts listed

---

<!-- Please reference the issue(s) this PR addresses. -->
Fixes #4432 

