### PR TITLE
Removed `isBold` from text style preset (using only `fontWeight`)

### DIFF
--- a/assets/src/edit-story/components/panels/preset/test/utils.js
+++ b/assets/src/edit-story/components/panels/preset/test/utils.js
@@ -275,7 +275,7 @@ describe('Panels/StylePreset/utils', () => {
     expect(presets).toStrictEqual(expected);
   });
 
-  it('should get corect font weight for text preset', () => {
+  it('should get correct font weight for text preset', () => {
     const elements = [
       {
         type: 'text',

--- a/assets/src/edit-story/components/panels/preset/test/utils.js
+++ b/assets/src/edit-story/components/panels/preset/test/utils.js
@@ -188,7 +188,6 @@ describe('Panels/StylePreset/utils', () => {
           color: TEST_COLOR,
           font: TEXT_ELEMENT_DEFAULT_FONT,
           fontWeight: 400,
-          isBold: false,
           isItalic: false,
           isUnderline: false,
           letterSpacing: 0,
@@ -206,7 +205,6 @@ describe('Panels/StylePreset/utils', () => {
             family: 'Foo',
           },
           fontWeight: 700,
-          isBold: true,
           isItalic: true,
           isUnderline: false,
           letterSpacing: 0,
@@ -243,7 +241,6 @@ describe('Panels/StylePreset/utils', () => {
     const stylePreset = {
       ...STYLE_PRESET,
       fontWeight: 400,
-      isBold: false,
       isItalic: false,
       isUnderline: false,
       letterSpacing: 0,
@@ -278,11 +275,41 @@ describe('Panels/StylePreset/utils', () => {
     expect(presets).toStrictEqual(expected);
   });
 
+  it('should get corect font weight for text preset', () => {
+    const elements = [
+      {
+        type: 'text',
+        backgroundTextMode: BACKGROUND_TEXT_MODE.NONE,
+        font: TEXT_ELEMENT_DEFAULT_FONT,
+        content: '<span style="font-weight: 600">Semi-bold</span>',
+      },
+    ];
+    const stylePresets = {
+      textStyles: [],
+      colors: [],
+    };
+    const expected = {
+      colors: [],
+      textStyles: [
+        {
+          backgroundTextMode: BACKGROUND_TEXT_MODE.NONE,
+          font: TEXT_ELEMENT_DEFAULT_FONT,
+          color: { color: { r: 0, g: 0, b: 0 } },
+          fontWeight: 600,
+          isItalic: false,
+          isUnderline: false,
+          letterSpacing: 0,
+        },
+      ],
+    };
+    const presets = getTextPresets(elements, stylePresets, 'style');
+    expect(presets).toStrictEqual(expected);
+  });
+
   it('should default to null/false when adding text style preset for mixed inline styles', () => {
     const stylePreset = {
       ...STYLE_PRESET,
       fontWeight: null,
-      isBold: false,
       isItalic: false,
       isUnderline: false,
       letterSpacing: null,

--- a/assets/src/edit-story/components/panels/preset/useApplyPreset.js
+++ b/assets/src/edit-story/components/panels/preset/useApplyPreset.js
@@ -76,7 +76,6 @@ function useApplyPreset(isColor, pushUpdate) {
       handleClickUnderline,
       handleClickItalic,
       handleSelectFontWeight,
-      handleClickBold,
     },
   } = useRichTextFormatting(selectedElements, push);
 
@@ -90,7 +89,6 @@ function useApplyPreset(isColor, pushUpdate) {
         const {
           color,
           fontWeight,
-          isBold,
           isItalic,
           isUnderline,
           letterSpacing,
@@ -102,7 +100,6 @@ function useApplyPreset(isColor, pushUpdate) {
         handleSelectFontWeight(fontWeight);
         handleClickUnderline(isUnderline);
         handleClickItalic(isItalic);
-        handleClickBold(isBold);
       } else if (isBackground) {
         updateCurrentPageProperties({
           properties: { backgroundColor: preset },
@@ -126,7 +123,6 @@ function useApplyPreset(isColor, pushUpdate) {
       handleClickUnderline,
       handleClickItalic,
       handleSelectFontWeight,
-      handleClickBold,
     ]
   );
   return handleApplyPreset;

--- a/assets/src/edit-story/components/panels/preset/utils.js
+++ b/assets/src/edit-story/components/panels/preset/utils.js
@@ -116,7 +116,6 @@ function getTextInlineStyles(content) {
   const {
     color,
     fontWeight,
-    isBold,
     isItalic,
     isUnderline,
     letterSpacing,
@@ -124,7 +123,6 @@ function getTextInlineStyles(content) {
   return {
     color: color !== MULTIPLE_VALUE ? color : createSolid(0, 0, 0),
     fontWeight: getExtractedInlineValue(fontWeight),
-    isBold: getExtractedInlineValue(isBold),
     isItalic: getExtractedInlineValue(isItalic),
     isUnderline: getExtractedInlineValue(isUnderline),
     letterSpacing: getExtractedInlineValue(letterSpacing),


### PR DESCRIPTION
## Summary

Both `isBold` and `fontWeight` was saved as a style preset - however the former shaded the real value of the latter, so now only `fontWeight` is saved, which will correctly set bold setting as well.

## Relevant Technical Choices

* Remove any notion of `isBold` from style presets and tests
* Add a test for correct font weight being detected

## User-facing changes

* Bug fixed

## Testing Instructions

* Add a text field
* Change the font-weight to Semi-Bold or Black
* Save as a style preset
* Apply the same style preset to the text field itself
* Observe that font-weight is preserved

---

<!-- Please reference the issue(s) this PR addresses. -->
Fixes #4526
