### PR TITLE
Dashboard: keep grid top in view of initial focus

### DIFF
--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -37,6 +37,7 @@ const DashboardGrid = styled.div(
   grid-template-columns:
     repeat(auto-fill, ${columnWidth}px);
   grid-template-rows: minmax(${columnHeight}px, auto);
+  scroll-margin-top: 50vh;
   margin-top: 2px; // this is for keyboard focus 
 
   ${theme.breakpoint.tablet} {


### PR DESCRIPTION

## Summary
Keeps the grid top in view to not cut off grid items when keyboard is used to focus on the grid in dashboard. 
[Bug screenshot](https://camo.githubusercontent.com/f0a45807dfdaa623081a84a423e97c7919d04866/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3565613038356534373034653732633061393963363939372f30656364383364612d333532322d343830662d393432622d316335363839656237643261)

## Relevant Technical Choices
Taking advantage of `scroll-margin-top` in css - https://css-tricks.com/almanac/properties/s/scroll-margin/ 
This value has really good support. Safari's a little behind but implementation has been requested and is being tracked: https://bugs.webkit.org/show_bug.cgi?id=189265 

When supported this prevents the scroll that the browser does by default on focus from going to the top of the page (here we use 50vh, somewhat arbitrarily). The grid items themselves retain their on focus scroll that the browser does by default, this is just for the grid container (which has to be focusable for keyboard users). 

Even though this is fixing the issue for everyone outside of Safari, I still think this is the best approach since it's more of an enhancement than something that blocks a user from interacting with the dashboard. Were we to take another approach this would look less like a bug and more like a feature as it would require rethinking the dashboard header's squishable functionality. 

## User-facing changes
Grid should not cut off top row on initial focus with keyboard if not in Safari. 

## Testing Instructions
- Tab through my stories and templates grids on Dashboard - see that when you get to the grid (it's got that blue outline surrounding all grid items) the scroll on focus of the browser does not cut off the first row of items.

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4470 