### PR TITLE
Elements: Improve position of new elements

### DIFF
--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -159,12 +159,12 @@ function getElementProperties(
   width = size.width;
   height = size.height;
 
-  // X and y defaults: in the top quarter of the page.
+  // X and y defaults: in the top corner of the page.
   if (!isNum(x)) {
-    x = (PAGE_WIDTH / 4) * Math.random();
+    x = 48;
   }
   if (!isNum(y)) {
-    y = (PAGE_HEIGHT / 4) * Math.random();
+    y = 0;
   }
   x = dataPixels(Math.min(x, PAGE_WIDTH - width));
   y = dataPixels(Math.min(y, PAGE_HEIGHT - height));


### PR DESCRIPTION
## Summary

This simply fixes the new element position to `(48,0)` rather than placing them randomly. This is used for images, videos and shapes when added by just clicking them in the library. You can still drag them in to the correct position.

NB: This is a temporary fix until proper staggering is implemented in #1206 (currently icebox'ed).

## Testing Instructions

1. Click two images to be inserted from the library
1. Observe that they're added on top of each other
---

<!-- Please reference the issue(s) this PR addresses. -->
Fixes #4413
