### PR TITLE
Remove `amp` attribute when no poster is set

### DIFF
--- a/includes/Story_Renderer/HTML.php
+++ b/includes/Story_Renderer/HTML.php
@@ -358,6 +358,18 @@ class HTML {
 		foreach ( $poster_images as $attr => $url ) {
 			$story_element->setAttribute( $attr, esc_url( $url ) );
 		}
+
+		// Without a poster, a story becomes invalid AMP.
+		// Remove the 'amp' attribute to not mark it as an AMP document anymore,
+		// preventing errors from showing up in GSC and other tools.
+		if ( ! $story_element->getAttribute( 'poster-portrait-src' ) ) {
+			/* @var DOMElement $html The <html> element */
+			$html = $this->get_element_by_tag_name( 'html' );
+
+			if ( $html ) {
+				$html->removeAttribute( 'amp' );
+			}
+		}
 	}
 
 	/**

--- a/tests/phpunit/tests/Story_Renderer/HTML.php
+++ b/tests/phpunit/tests/Story_Renderer/HTML.php
@@ -57,7 +57,7 @@ class HTML extends \WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			[
 				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
-				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
+				'post_content' => '<html><head></head><body><amp-story poster-portrait-src="https://example.com/poster.png"></amp-story></body></html>',
 			]
 		);
 
@@ -172,6 +172,22 @@ class HTML extends \WP_UnitTestCase {
 		$this->assertNotContains( 'poster-portrait-src=', $rendered );
 		$this->assertNotContains( 'poster-square-src=', $rendered );
 		$this->assertNotContains( 'poster-landscape-src=', $rendered );
+	}
+
+	/**
+	 * @covers ::add_poster_images
+	 */
+	public function test_add_poster_images_no_poster_no_amp() {
+		$post = self::factory()->post->create_and_get(
+			[
+				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
+			]
+		);
+
+		$rendered = $this->setup_renderer( $post );
+
+		$this->assertNotContains( 'amp=', $rendered );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This is a quick follow-up to #3767 

We need to remove the `amp` attribute from the `<html>` tag to prevent GSC from complaining about known invalid AMP documents when there is no poster.

## Relevant Technical Choices

N/A

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

1. Publish a story without a poster
1. Verify there's no `amp` attribute present on the `<html>` element

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3671
