### PR TITLE
Prefix Composer Dependencies

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,6 +10,7 @@ assets/testjs
 bin
 build
 docs
+includes/composer.json
 karma
 node_modules
 patches
@@ -17,6 +18,8 @@ plugin-assets
 public
 static
 tests
+third-party/composer.json
+/vendor
 web-stories-scraper
 .browserslistrc
 .DS_Store
@@ -57,6 +60,7 @@ phpunit.xml.dist
 phpunit-multisite.xml
 phpunit-multisite.xml.dist
 README.md
+scoper.inc.php
 SECURITY.md
 webpack.config.cjs
 webpack.config.test.cjs

--- a/.github/workflows/continuous-integration-unit-php.yml
+++ b/.github/workflows/continuous-integration-unit-php.yml
@@ -45,23 +45,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: mysql
-          coverage: xdebug
-          tools: composer, cs2pr
-
-      - name: Shutdown default MySQL service
-        run: sudo service mysql stop
-
-      - name: Verify MariaDB connection
-        run: |
-          while ! mysqladmin ping -h"127.0.0.1" -P"${{ job.services.mysql.ports[3306] }}" --silent; do
-            sleep 1
-          done
-
       - name: Get Composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
@@ -75,8 +58,42 @@ jobs:
             ${{ runner.os }}-composer-
             ${{ runner.os }}-
 
+      # PHP-Scoper only works on PHP 7.2+ and we need to prefix our dependencies to accurately test them.
+      # So we temporarily switch PHP versions, do a full install and then remove the package.
+      # Then switch back to the PHP version we want to test and delete the vendor directory.
+
+      - name: Setup PHP 7.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: composer
+
+      - name: Install prefixed dependencies
+        run: |
+          composer install --prefer-dist --no-suggest --no-progress --no-interaction
+          rm -rf vendor/*
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mysql
+          coverage: xdebug
+          tools: composer, cs2pr
+
       - name: Install dependencies
-        run: composer install --prefer-dist --no-suggest --no-progress --no-interaction
+        run: |
+          composer install --prefer-dist --no-suggest --no-progress --no-interaction --no-scripts
+          composer dump-autoload --no-interaction
+
+      - name: Shutdown default MySQL service
+        run: sudo service mysql stop
+
+      - name: Verify MariaDB connection
+        run: |
+          while ! mysqladmin ping -h"127.0.0.1" -P"${{ job.services.mysql.ports[3306] }}" --silent; do
+            sleep 1
+          done
 
       - name: Set up tests
         run: bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1:${{ job.services.mysql.ports['3306'] }} ${{ matrix.wp }} true

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,12 @@ node_modules
 /build
 /bin/build
 /bin/local-env/data
+/includes/vendor
+/includes/composer.json
 /plugin-assets
 /public
 /static
+/third-party
 /vendor
 phpcs.xml
 phpunit.xml

--- a/bin/utils/createBuild.js
+++ b/bin/utils/createBuild.js
@@ -15,18 +15,10 @@
  */
 
 /**
- * External dependencies
- */
-import { execSync } from 'child_process';
-
-/**
  * Internal dependencies
  */
 import copyFiles from './copyFiles.js';
 import getIgnoredFiles from './getIgnoredFiles.js';
-
-const composerArgs =
-  '--optimize-autoloader --no-interaction --prefer-dist --no-suggest --quiet';
 
 /**
  * Main function to bundle the plugin.
@@ -36,23 +28,15 @@ const composerArgs =
  * @param {boolean} [composer=false] Create Composer-ready ZIP file without PHP autoloader.
  */
 function createBuild(source, target, composer = false) {
-  if (!composer) {
-    execSync(`composer update --no-dev ${composerArgs}`);
-  }
-
   const ignoredFiles = getIgnoredFiles(source);
+
   if (composer) {
-    ignoredFiles.push('vendor/');
+    ignoredFiles.push('includes/vendor/');
   } else {
     ignoredFiles.push('composer.json');
   }
-  copyFiles(source, target, ignoredFiles);
 
-  if (!composer) {
-    execSync(
-      `composer update ${composerArgs}; git checkout composer.lock --quiet; composer install ${composerArgs}`
-    );
-  }
+  copyFiles(source, target, ignoredFiles);
 }
 
 export default createBuild;

--- a/bin/utils/test/createBuild.js
+++ b/bin/utils/test/createBuild.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import { __setMockFiles } from 'fs';
-import { execSync } from 'child_process';
 
 /**
  * Internal dependencies
@@ -27,7 +26,6 @@ import createBuild from '../createBuild';
 import copyFiles from '../copyFiles';
 
 jest.mock('fs');
-jest.mock('child_process');
 
 jest.mock('../getIgnoredFiles', () => jest.fn(() => ['bar.txt', 'baz/']));
 jest.mock('../copyFiles');
@@ -56,24 +54,12 @@ describe('createBuild', () => {
     ]);
   });
 
-  it('should ignore vendor folder for composer builds', () => {
+  it('should ignore third-party folder for composer builds', () => {
     createBuild('/foo', '/foo/build/web-stories', true);
     expect(copyFiles).toHaveBeenCalledWith('/foo', '/foo/build/web-stories', [
       'bar.txt',
       'baz/',
-      'vendor/',
+      'includes/vendor/',
     ]);
-  });
-
-  it('should run composer update for non-composer builds', () => {
-    createBuild('/foo', '/foo/build', false);
-    expect(execSync).toHaveBeenNthCalledWith(
-      1,
-      expect.stringContaining('composer update --no-dev')
-    );
-    expect(execSync).toHaveBeenNthCalledWith(
-      2,
-      expect.stringContaining('composer update')
-    );
   });
 });

--- a/codecov.yml
+++ b/codecov.yml
@@ -78,6 +78,7 @@ comment:
 # See https://docs.codecov.io/docs/ignoring-paths
 ignore:
   - bin/commander.js
+  - scoper.inc.php
   - web-stories.php
   - uninstall.php
   - includes/namespace.php

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
   },
   "require-dev": {
     "automattic/vipwpcs": "^2.1",
+    "civicrm/composer-downloads-plugin": "^2.1",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "php-stubs/wordpress-stubs": "^5.5",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
@@ -41,6 +42,11 @@
       "phpstan": {
         "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
         "path": "vendor/bin/phpstan",
+        "type": "phar"
+      },
+      "php-scoper": {
+        "url": "https://github.com/humbug/php-scoper/releases/latest/download/php-scoper.phar",
+        "path": "vendor/bin/php-scoper",
         "type": "phar"
       }
     },
@@ -76,7 +82,20 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "scripts": {
+    "post-install-cmd": [
+      "@prefix-dependencies"
+    ],
+    "post-update-cmd": [
+      "@prefix-dependencies"
+    ],
     "phpcs": "phpcs",
-    "phpstan": "phpstan analyse --memory-limit=512M"
+    "phpstan": "phpstan analyse --memory-limit=512M",
+    "prefix-dependencies": [
+      "php-scoper add-prefix --output-dir=./third-party --force --quiet",
+      "echo '{ \"autoload\": { \"classmap\": [\"\"] } }' > ./third-party/composer.json",
+      "@composer dump-autoload --working-dir ./third-party --no-dev --classmap-authoritative",
+      "echo '{ \"autoload\": { \"classmap\": [\"\"] } }' > ./includes/composer.json",
+      "@composer dump-autoload --working-dir ./includes --no-dev --classmap-authoritative"
+    ]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -94,8 +94,10 @@
       "php-scoper add-prefix --output-dir=./third-party --force --quiet",
       "echo '{ \"autoload\": { \"classmap\": [\"\"] } }' > ./third-party/composer.json",
       "@composer dump-autoload --working-dir ./third-party --no-dev --classmap-authoritative",
+      "sed -i'.bak' -e 's/Composer\\\\Autoload/Google_Web_Stories_Composer\\\\Autoload/' third-party/vendor/composer/*.php && rm -rf third-party/vendor/composer/*.php.bak",
       "echo '{ \"autoload\": { \"classmap\": [\"\"] } }' > ./includes/composer.json",
-      "@composer dump-autoload --working-dir ./includes --no-dev --classmap-authoritative"
+      "@composer dump-autoload --working-dir ./includes --no-dev --classmap-authoritative",
+      "sed -i'.bak' -e 's/Composer\\\\Autoload/Google_Web_Stories_Composer\\\\Autoload/' includes/vendor/composer/*.php && rm -rf includes/vendor/composer/*.php.bak"
     ]
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3925ca06f4956517fd5546c52868737b",
+    "content-hash": "53b1d091b718211173fba382d450d68c",
     "packages": [
         {
             "name": "ampproject/amp-wp",

--- a/includes/AMP/Canonical_Sanitizer.php
+++ b/includes/AMP/Canonical_Sanitizer.php
@@ -26,8 +26,9 @@
 
 namespace Google\Web_Stories\AMP;
 
-use AmpProject\Attribute;
-use AmpProject\Tag;
+use Google\Web_Stories_Dependencies\AMP_Base_Sanitizer;
+use Google\Web_Stories_Dependencies\AmpProject\Attribute;
+use Google\Web_Stories_Dependencies\AmpProject\Tag;
 use DOMElement;
 
 /**
@@ -44,7 +45,7 @@ use DOMElement;
  *
  * @since 1.0.0
  */
-class Canonical_Sanitizer extends \AMP_Base_Sanitizer {
+class Canonical_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Sanitize the HTML contained in the DOMDocument received by the constructor.
 	 *

--- a/includes/AMP/Meta_Sanitizer.php
+++ b/includes/AMP/Meta_Sanitizer.php
@@ -26,9 +26,9 @@
 
 namespace Google\Web_Stories\AMP;
 
-use AmpProject\Attribute;
-use AmpProject\Tag;
-use AMP_Meta_Sanitizer;
+use Google\Web_Stories_Dependencies\AmpProject\Attribute;
+use Google\Web_Stories_Dependencies\AmpProject\Tag;
+use Google\Web_Stories_Dependencies\AMP_Meta_Sanitizer;
 
 /**
  * Meta sanitizer.

--- a/includes/AMP/Optimization.php
+++ b/includes/AMP/Optimization.php
@@ -26,19 +26,19 @@
 
 namespace Google\Web_Stories\AMP;
 
-use AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest;
-use AmpProject\AmpWP\RemoteRequest\WpHttpRemoteGetRequest;
-use AmpProject\Dom\Document;
-use AmpProject\Optimizer\Configuration;
-use AmpProject\Optimizer\Error;
-use AmpProject\Optimizer\ErrorCollection;
-use AmpProject\Optimizer\LocalFallback;
-use AmpProject\Optimizer\TransformationEngine;
-use AmpProject\Optimizer\Transformer\AmpRuntimeCss;
-use AmpProject\Optimizer\Transformer\ServerSideRendering;
-use AmpProject\Optimizer\Transformer\TransformedIdentifier;
-use AmpProject\RemoteRequest\FallbackRemoteGetRequest;
-use AmpProject\RemoteRequest\FilesystemRemoteGetRequest;
+use Google\Web_Stories_Dependencies\AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest;
+use Google\Web_Stories_Dependencies\AmpProject\AmpWP\RemoteRequest\WpHttpRemoteGetRequest;
+use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Configuration;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Error;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\ErrorCollection;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\LocalFallback;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\TransformationEngine;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\AmpRuntimeCss;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\ServerSideRendering;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\TransformedIdentifier;
+use Google\Web_Stories_Dependencies\AmpProject\RemoteRequest\FallbackRemoteGetRequest;
+use Google\Web_Stories_Dependencies\AmpProject\RemoteRequest\FilesystemRemoteGetRequest;
 
 /**
  * Optimization class.

--- a/includes/AMP/Sanitization.php
+++ b/includes/AMP/Sanitization.php
@@ -26,18 +26,18 @@
 
 namespace Google\Web_Stories\AMP;
 
-use AMP_Allowed_Tags_Generated;
-use AMP_Content_Sanitizer;
-use AMP_DOM_Utils;
-use AMP_Layout_Sanitizer;
-use AMP_Script_Sanitizer;
-use AMP_Style_Sanitizer;
-use AMP_Tag_And_Attribute_Sanitizer;
-use AmpProject\Amp;
-use AmpProject\Attribute;
-use AmpProject\Dom\Document;
-use AmpProject\Extension;
-use AmpProject\Tag;
+use Google\Web_Stories_Dependencies\AMP_Allowed_Tags_Generated;
+use Google\Web_Stories_Dependencies\AMP_Content_Sanitizer;
+use Google\Web_Stories_Dependencies\AMP_DOM_Utils;
+use Google\Web_Stories_Dependencies\AMP_Layout_Sanitizer;
+use Google\Web_Stories_Dependencies\AMP_Script_Sanitizer;
+use Google\Web_Stories_Dependencies\AMP_Style_Sanitizer;
+use Google\Web_Stories_Dependencies\AMP_Tag_And_Attribute_Sanitizer;
+use Google\Web_Stories_Dependencies\AmpProject\Amp;
+use Google\Web_Stories_Dependencies\AmpProject\Attribute;
+use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
+use Google\Web_Stories_Dependencies\AmpProject\Extension;
+use Google\Web_Stories_Dependencies\AmpProject\Tag;
 use DOMElement;
 
 /**

--- a/includes/AMP/Story_Sanitizer.php
+++ b/includes/AMP/Story_Sanitizer.php
@@ -26,7 +26,7 @@
 
 namespace Google\Web_Stories\AMP;
 
-use AMP_Base_Sanitizer;
+use Google\Web_Stories_Dependencies\AMP_Base_Sanitizer;
 
 /**
  * Story sanitizer.

--- a/includes/Story_Renderer/HTML.php
+++ b/includes/Story_Renderer/HTML.php
@@ -26,7 +26,7 @@
 
 namespace Google\Web_Stories\Story_Renderer;
 
-use AmpProject\Dom\Document;
+use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
 use DOMElement;
 use Google\Web_Stories\AMP\Optimization;
 use Google\Web_Stories\AMP\Sanitization;
@@ -91,6 +91,11 @@ class HTML {
 			);
 		}
 
+		/**
+		 * Document instance.
+		 *
+		 * @var Document $document
+		 */
 		$this->document = $document;
 
 		// Run all further transformations on the Document instance.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -77,6 +77,7 @@
 	<exclude-pattern>*/build/*</exclude-pattern>
 	<exclude-pattern>*/data/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/third-party/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>assets/js/*.asset.php</exclude-pattern>
 	<exclude-pattern>tests/phpstan/*</exclude-pattern>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,11 +18,16 @@ parameters:
   checkMissingIterableValueType: false
   paths:
     - includes/
+  excludes_analyse:
+    - includes/vendor/*
+  scanDirectories:
+    - third-party
+  scanFiles:
+    - web-stories.php
   bootstrapFiles:
     - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
     - tests/phpstan/stubs/wordpress-defines.php
     - tests/phpstan/bootstrap.php
-    - includes/namespace.php
   dynamicConstantNames:
     - WP_DEBUG
     - WP_DEBUG_LOG
@@ -45,3 +50,11 @@ parameters:
     - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
     # False positive for wp_unslash()
     - '#^Cannot cast array<string>\|string to string.$#'
+    # AMP PHP Library files
+    # TODO: Actually fix this.
+    -
+      message: '#^Class Google\\Web_Stories_Dependencies\\AMP_Base_Sanitizer not found#'
+      path: includes/AMP
+    -
+      message: '#^Class Google\\Web_Stories_Dependencies\\AMP_Meta_Sanitizer not found#'
+      path: includes/AMP

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,6 +35,7 @@
 				<directory suffix=".php">node_modules</directory>
 				<directory suffix=".php">tests</directory>
 				<directory suffix=".php">vendor</directory>
+				<file>scoper.inc.php</file>
 				<file>web-stories.php</file>
 				<file>uninstall.php</file>
 				<file>includes/namespace.php</file>

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,239 @@
+<?php
+/**
+ * PHP-Scoper configuration file.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+return [
+	'prefix'                     => 'Google\\Web_Stories_Dependencies',
+
+	// See: https://github.com/humbug/php-scoper#finders-and-paths.
+	'finders'                    => [
+		// Main AMP PHP Library.
+		Finder::create()
+			->files()
+			->ignoreVCS( true )
+			->ignoreDotFiles( true )
+			->name( '*.php' )
+			->name( 'class-amp-base-sanitizer.php' )
+			->notName(
+				[
+					'amp.php',
+					'amp-enabled-classic-editor-toggle.php',
+					'amp-frontend-actions.php',
+					'amp-helper-functions.php',
+					'amp-paired-browsing.php',
+					'amp-post-template-functions.php',
+					'class-amp-autoloader.php',
+					'class-amp-comment-walker.php',
+					'class-amp-content.php',
+					'class-amp-html-utils.php',
+					'class-amp-http.php',
+					'class-amp-post-template.php',
+					'class-amp-post-type-support.php',
+					'class-amp-service-worker.php',
+					'class-amp-theme-support.php',
+					'class-amp-validated-url-post-type.php',
+					'class-amp-validation-callback-wrapper.php',
+					'deprecated.php',
+					'reader-template-loader.php',
+				]
+			)
+			->exclude(
+				[
+					'admin',
+					'assets',
+					'back-compat',
+					'bin',
+					'cli',
+					'docs',
+					'embeds',
+					'includes/admin',
+					'includes/cli',
+					'includes/embeds',
+					'includes/options',
+					'includes/settings',
+					'includes/validation',
+					'includes/widgets',
+					'options',
+					'patches',
+					'sanitizers',
+					'settings',
+					'src',
+					'templates',
+					'tests',
+					'vendor',
+					'widgets',
+					'wp-assets',
+					'tests',
+				]
+			)
+			->in(
+				[
+					'vendor/ampproject/amp-wp/includes',
+					'vendor/ampproject/amp-wp/src/RemoteRequest',
+				]
+			)
+			->append(
+				[
+					'vendor/ampproject/amp-wp/includes/sanitizers/class-amp-allowed-tags-generated.php',
+					'vendor/ampproject/amp-wp/includes/sanitizers/class-amp-base-sanitizer.php',
+					'vendor/ampproject/amp-wp/includes/sanitizers/class-amp-layout-sanitizer.php',
+					'vendor/ampproject/amp-wp/includes/sanitizers/class-amp-meta-sanitizer.php',
+					'vendor/ampproject/amp-wp/includes/sanitizers/class-amp-rule-spec.php',
+					'vendor/ampproject/amp-wp/includes/sanitizers/class-amp-script-sanitizer.php',
+					'vendor/ampproject/amp-wp/includes/sanitizers/class-amp-style-sanitizer.php',
+					'vendor/ampproject/amp-wp/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php',
+					'vendor/ampproject/amp-wp/includes/sanitizers/trait-amp-noscript-fallback.php',
+					'vendor/ampproject/amp-wp/includes/templates/class-amp-content-sanitizer.php',
+				]
+			)
+			->append( [ 'vendor/ampproject/amp-wp/composer.json' ] ),
+
+		// AMP Common + Optimizer.
+		Finder::create()
+			->files()
+			->ignoreVCS( true )
+			->ignoreDotFiles( true )
+			->name( '*.php' )
+			->exclude(
+				[
+					'bin',
+					'tests',
+				]
+			)
+			->in(
+				[
+					'vendor/ampproject/amp-wp/lib',
+				]
+			),
+
+		// FasterImage (used by AMP_Img_Sanitizer).
+		Finder::create()
+			->files()
+			->ignoreVCS( true )
+			->ignoreDotFiles( true )
+			->name( '*.php' )
+			->exclude(
+				[
+					'tests',
+				]
+			)
+			->in( 'vendor/fasterimage/fasterimage' )
+			->append( [ 'vendor/fasterimage/fasterimage/composer.json' ] ),
+
+		// PHP-CSS-Parser (used by AMP_Style_Sanitizer).
+		Finder::create()
+			->files()
+			->ignoreVCS( true )
+			->ignoreDotFiles( true )
+			->name( '*.php' )
+			->exclude(
+				[
+					'tests',
+				]
+			)
+			->in( 'vendor/sabberworm/php-css-parser' )
+			->append( [ 'vendor/sabberworm/php-css-parser/composer.json' ] ),
+
+		// Main composer.json file so that we can build a classmap.
+		Finder::create()
+			->append( [ 'composer.json' ] ),
+	],
+
+	// See: https://github.com/humbug/php-scoper#patchers.
+	'patchers'                   => [
+		function ( $file_path, $prefix, $contents ) {
+			/*
+			 * There is currently no easy way to simply whitelist all global WordPress functions.
+			 *
+			 * This list here is a manual attempt after scanning through the AMP plugin, which means
+			 * it needs to be maintained and kept in sync with any changes to the dependency.
+			 *
+			 * As long as there's no built-in solution in PHP-Scoper for this, an alternative could be
+			 * to generate a list based on php-stubs/wordpress-stubs. devowlio/wp-react-starter/ seems
+			 * to be doing just this successfully.
+			 *
+			 * @see https://github.com/humbug/php-scoper/issues/303
+			 * @see https://github.com/php-stubs/wordpress-stubs
+			 * @see https://github.com/devowlio/wp-react-starter/
+			 */
+			$contents = str_replace( "\\$prefix\\_doing_it_wrong", '\\_doing_it_wrong', $contents );
+			$contents = str_replace( "\\$prefix\\__", '\\__', $contents );
+			$contents = str_replace( "\\$prefix\\esc_html_e", '\\esc_html_e', $contents );
+			$contents = str_replace( "\\$prefix\\esc_html", '\\esc_html', $contents );
+			$contents = str_replace( "\\$prefix\\esc_attr", '\\esc_attr', $contents );
+			$contents = str_replace( "\\$prefix\\esc_url", '\\esc_url', $contents );
+			$contents = str_replace( "\\$prefix\\do_action", '\\do_action', $contents );
+			$contents = str_replace( "\\$prefix\\site_url", '\\site_url', $contents );
+			$contents = str_replace( "\\$prefix\\wp_guess_url", '\\wp_guess_url', $contents );
+			$contents = str_replace( "\\$prefix\\untrailingslashit", '\\untrailingslashit', $contents );
+			$contents = str_replace( "\\$prefix\\WP_CONTENT_URL", '\\WP_CONTENT_URL', $contents );
+			$contents = str_replace( "\\$prefix\\wp_list_pluck", '\\wp_list_pluck', $contents );
+			$contents = str_replace( "\\$prefix\\is_customize_preview", '\\is_customize_preview', $contents );
+			$contents = str_replace( "\\$prefix\\do_action", '\\do_action', $contents );
+			$contents = str_replace( "\\$prefix\\trailingslashit", '\\trailingslashit', $contents );
+			$contents = str_replace( "\\$prefix\\get_template_directory_uri", '\\get_template_directory_uri', $contents );
+			$contents = str_replace( "\\$prefix\\get_stylesheet_directory_uri", '\\get_stylesheet_directory_uri', $contents );
+			$contents = str_replace( "\\$prefix\\includes_url", '\\includes_url', $contents );
+			$contents = str_replace( "\\$prefix\\wp_styles", '\\wp_styles', $contents );
+			$contents = str_replace( "\\$prefix\\get_stylesheet", '\\get_stylesheet', $contents );
+			$contents = str_replace( "\\$prefix\\get_template", '\\get_template', $contents );
+			$contents = str_replace( "\\$prefix\\wp_parse_url", '\\wp_parse_url', $contents );
+			$contents = str_replace( "\\$prefix\\is_wp_error", '\\is_wp_error', $contents );
+			$contents = str_replace( "\\$prefix\\content_url", '\\content_url', $contents );
+			$contents = str_replace( "\\$prefix\\get_admin_url", '\\get_admin_url', $contents );
+			$contents = str_replace( "\\$prefix\\WP_CONTENT_DIR", '\\WP_CONTENT_DIR', $contents );
+			$contents = str_replace( "\\$prefix\\ABSPATH", '\\ABSPATH', $contents );
+			$contents = str_replace( "\\$prefix\\WPINC", '\\WPINC', $contents );
+			$contents = str_replace( "\\$prefix\\home_url", '\\home_url', $contents );
+			$contents = str_replace( "\\$prefix\\__", '\\__', $contents );
+			$contents = str_replace( "\\$prefix\\wp_array_slice_assoc", '\\wp_array_slice_assoc', $contents );
+			$contents = str_replace( "\\$prefix\\wp_json_encode", '\\wp_json_encode', $contents );
+			$contents = str_replace( "\\$prefix\\get_transient", '\\get_transient', $contents );
+			$contents = str_replace( "\\$prefix\\wp_cache_get", '\\wp_cache_get', $contents );
+			$contents = str_replace( "\\$prefix\\set_transient", '\\set_transient', $contents );
+			$contents = str_replace( "\\$prefix\\wp_cache_set", '\\wp_cache_set', $contents );
+			$contents = str_replace( "\\$prefix\\wp_using_ext_object_cache", '\\wp_using_ext_object_cache', $contents );
+			$contents = str_replace( "\\$prefix\\_doing_it_wrong", '\\_doing_it_wrong', $contents );
+			$contents = str_replace( "\\$prefix\\plugin_dir_url", '\\plugin_dir_url', $contents );
+			$contents = str_replace( "\\$prefix\\is_admin_bar_showing", '\\is_admin_bar_showing', $contents );
+			$contents = str_replace( "\\$prefix\\get_bloginfo", '\\get_bloginfo', $contents );
+			$contents = str_replace( "\\$prefix\\add_filter", '\\add_filter', $contents );
+			$contents = str_replace( "\\$prefix\\apply_filters", '\\apply_filters', $contents );
+			$contents = str_replace( "\\$prefix\\add_query_arg", '\\add_query_arg', $contents );
+			$contents = str_replace( "\\$prefix\\remove_query_arg", '\\remove_query_arg', $contents );
+			$contents = str_replace( "\\$prefix\\get_post", '\\get_post', $contents );
+			$contents = str_replace( "\\$prefix\\wp_scripts", '\\wp_scripts', $contents );
+			$contents = str_replace( "\\$prefix\\wp_styles", '\\wp_styles', $contents );
+			$contents = str_replace( "\\$prefix\\wp_style_is", '\\wp_style_is', $contents );
+			$contents = str_replace( "\\$prefix\\WP_PLUGIN_URL", '\\WP_PLUGIN_URL', $contents );
+			$contents = str_replace( "\\$prefix\\WPMU_PLUGIN_URL", '\\WPMU_PLUGIN_URL', $contents );
+			$contents = str_replace( "\\$prefix\\wp_list_pluck", '\\wp_list_pluck', $contents );
+			$contents = str_replace( "\\$prefix\\wp_array_slice_assoc", '\\wp_array_slice_assoc', $contents );
+			$contents = str_replace( "\\$prefix\\wp_json_encode", '\\wp_json_encode', $contents );
+			$contents = str_replace( "\\$prefix\\WP_Http", '\\WP_Http', $contents );
+			$contents = str_replace( "\\$prefix\\WP_Error", '\\WP_Error', $contents );
+
+			return $contents;
+		},
+	],
+
+	// See https://github.com/humbug/php-scoper#whitelist.
+	'whitelist'                  => [],
+
+	// See https://github.com/humbug/php-scoper#constants--classes--functions-from-the-global-namespace.
+	'whitelist-global-constants' => false,
+
+	// See https://github.com/humbug/php-scoper#constants--classes--functions-from-the-global-namespace.
+	'whitelist-global-classes'   => false,
+
+	// See https://github.com/humbug/php-scoper#constants--classes--functions-from-the-global-namespace.
+	'whitelist-global-functions' => false,
+];

--- a/tests/phpunit/tests/AMP/Canonical_Sanitizer.php
+++ b/tests/phpunit/tests/AMP/Canonical_Sanitizer.php
@@ -17,7 +17,7 @@
 
 namespace Google\Web_Stories\Tests\AMP;
 
-use AmpProject\Dom\Document;
+use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
 
 /**
  * @coversDefaultClass \Google\Web_Stories\AMP\Canonical_Sanitizer

--- a/tests/phpunit/tests/AMP/Meta_Sanitizer.php
+++ b/tests/phpunit/tests/AMP/Meta_Sanitizer.php
@@ -18,8 +18,8 @@
 namespace Google\Web_Stories\Tests\AMP;
 
 use AMP_Tag_And_Attribute_Sanitizer;
-use AmpProject\Dom\Document;
 use AMP_Allowed_Tags_Generated;
+use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
 use Google\Web_Stories\Tests\MarkupComparison;
 use Google\Web_Stories\Tests\ScriptHash;
 

--- a/tests/phpunit/tests/AMP/Optimization.php
+++ b/tests/phpunit/tests/AMP/Optimization.php
@@ -17,14 +17,11 @@
 
 namespace Google\Web_Stories\Tests\AMP;
 
-use AMP_DOM_Utils;
-use AmpProject\Dom\Document;
-use AmpProject\Optimizer\Configuration;
-use AmpProject\Optimizer\Transformer\AmpBoilerplate;
-use AmpProject\Optimizer\Transformer\ReorderHead;
-use DOMElement;
+use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Configuration;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\AmpBoilerplate;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\ReorderHead;
 use Google\Web_Stories\Tests\Private_Access;
-use Google\Web_Stories\Traits\Publisher;
 
 /**
  * @coversDefaultClass \Google\Web_Stories\AMP\Optimization

--- a/tests/phpunit/tests/AMP/Sanitization.php
+++ b/tests/phpunit/tests/AMP/Sanitization.php
@@ -17,11 +17,11 @@
 
 namespace Google\Web_Stories\Tests\AMP;
 
-use AMP_DOM_Utils;
-use AmpProject\Dom\Document;
 use DOMElement;
+use Google\Web_Stories_Dependencies\AMP_Style_Sanitizer;
+use Google\Web_Stories_Dependencies\AMP_Tag_And_Attribute_Sanitizer;
+use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
 use Google\Web_Stories\Tests\Private_Access;
-use Google\Web_Stories\Traits\Publisher;
 
 /**
  * @coversDefaultClass \Google\Web_Stories\AMP\Sanitization
@@ -253,9 +253,9 @@ class Sanitization extends \WP_UnitTestCase {
 
 		$ordered_sanitizers = array_keys( $sanitizers );
 		$this->assertEquals( 'Even_After_Validating_Sanitizer', $ordered_sanitizers[ count( $ordered_sanitizers ) - 4 ] );
-		$this->assertEquals( 'AMP_Style_Sanitizer', $ordered_sanitizers[ count( $ordered_sanitizers ) - 3 ] );
+		$this->assertEquals( AMP_Style_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 3 ] );
 		$this->assertEquals( \Google\Web_Stories\AMP\Meta_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 2 ] );
-		$this->assertEquals( 'AMP_Tag_And_Attribute_Sanitizer', $ordered_sanitizers[ count( $ordered_sanitizers ) - 1 ] );
+		$this->assertEquals( AMP_Tag_And_Attribute_Sanitizer::class, $ordered_sanitizers[ count( $ordered_sanitizers ) - 1 ] );
 	}
 
 	/**

--- a/web-stories.php
+++ b/web-stories.php
@@ -60,8 +60,14 @@ if ( ! defined( 'WEBSTORIES_DEV_MODE' ) ) {
 	define( 'WEBSTORIES_DEV_MODE', false );
 }
 
-if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
-	include __DIR__ . '/vendor/autoload.php';
+// Autoloader for dependencies.
+if ( file_exists( __DIR__ . '/third-party/vendor/scoper-autoload.php' ) ) {
+	require __DIR__ . '/third-party/vendor/scoper-autoload.php';
+}
+
+// Autoloader for plugin itself.
+if ( file_exists( __DIR__ . '/includes/vendor/autoload.php' ) ) {
+	require __DIR__ . '/includes/vendor/autoload.php';
 }
 
 // Main plugin initialization happens there so that this file is still parsable in PHP < 5.6.


### PR DESCRIPTION
## Summary

Prefixes dependencies to avoid conflicts with the AMP plugin and other plugins using these dependencies.

## Relevant Technical Choices

* Uses [PHP-Scoper](https://github.com/humbug/php-scoper) to prefix dependencies  
  * Installs it via `civicrm/composer-downloads-plugin` to work around PHP version mismatch issues
  * Updates CI config accordingly
* Separating autoloaders in `third-party` and `includes` makes building the plugin ZIP file much faster
* Removes `composer validate` CI step as it doesn't work with `mcaskill/composer-exclude-files`

## To-do

* [x] Investigate potential `ClassLoader` compatibility issues  
  See https://github.com/humbug/php-scoper/issues/355, https://github.com/composer/composer/issues/3852, https://github.com/dangoodman/composer-for-wordpress, https://gist.github.com/polevaultweb/de44d747b57191a851947d5f5175e922

## User-facing changes

N/A

## Testing Instructions

1. Check out this branch and run `composer install` _or_ check out this branch on the QA site
1. Activate AMP plugin
1. Visit a single story, edit a story, etc.
1. Verify there are no PHP errors or notices

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses one aspect of #4513
