### PR TITLE
Hiding horizontal scrollbar in media pane

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/common/styles.js
+++ b/assets/src/edit-story/components/library/panes/media/common/styles.js
@@ -36,7 +36,8 @@ export const PaneHeader = styled.div`
 `;
 
 export const MediaGalleryContainer = styled.div`
-  overflow: scroll;
+  overflow-y: scroll;
+  overflow-x: hidden;
   padding: 0 24px;
   margin-top: 1em;
   position: relative;


### PR DESCRIPTION
## Summary

Fixing blank space in bottom of media pane by hiding horizontal scrollbars.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4457 
