### PR TITLE
Editor: Text sets can now be dragged and dropped onto page

### DIFF
--- a/assets/src/edit-story/app/layout/context.js
+++ b/assets/src/edit-story/app/layout/context.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
-export { default } from './layout';
-export { default as useLayout } from './useLayout';
-export { default as LayoutProvider } from './layoutProvider';
+/**
+ * Internal dependencies
+ */
+import { createContext } from '../../utils/context';
+
+export default createContext({ actions: {}, state: {} });

--- a/assets/src/edit-story/app/layout/layout.js
+++ b/assets/src/edit-story/app/layout/layout.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Library from '../../components/library';
+import Workspace from '../../components/workspace';
+import {
+  CANVAS_MIN_WIDTH,
+  LIBRARY_MIN_WIDTH,
+  LIBRARY_MAX_WIDTH,
+  INSPECTOR_MIN_WIDTH,
+  INSPECTOR_MAX_WIDTH,
+} from '../../constants';
+import LayoutProvider from './layoutProvider';
+
+const Editor = styled.section.attrs({
+  'aria-label': __('Web Stories Editor', 'web-stories'),
+})`
+  font-family: ${({ theme }) => theme.fonts.body1.family};
+  font-size: ${({ theme }) => theme.fonts.body1.size};
+  line-height: ${({ theme }) => theme.fonts.body1.lineHeight};
+  letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing};
+  background-color: ${({ theme }) => theme.colors.bg.workspace};
+
+  position: relative;
+  height: 100%;
+  width: 100%;
+
+  display: grid;
+  grid-template-areas: 'lib canv insp';
+  grid-template-columns:
+    minmax(${LIBRARY_MIN_WIDTH}px, ${LIBRARY_MAX_WIDTH}px)
+    minmax(${CANVAS_MIN_WIDTH}px, 1fr)
+    minmax(${INSPECTOR_MIN_WIDTH}px, ${INSPECTOR_MAX_WIDTH}px);
+`;
+
+const Area = styled.div`
+  grid-area: ${({ area }) => area};
+  position: relative;
+  overflow: hidden;
+  z-index: 2;
+`;
+
+function Layout() {
+  return (
+    <LayoutProvider>
+      <Editor>
+        <Area area="lib">
+          <Library />
+        </Area>
+        <Workspace />
+      </Editor>
+    </LayoutProvider>
+  );
+}
+
+export default Layout;

--- a/assets/src/edit-story/app/layout/layoutProvider.js
+++ b/assets/src/edit-story/app/layout/layoutProvider.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { useMemo, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { PAGE_WIDTH, PAGE_RATIO } from '../../constants';
+import Context from './context';
+
+function LayoutProvider({ children }) {
+  const [canvasPageSize, setCanvasPageSize] = useState({
+    width: PAGE_WIDTH,
+    height: PAGE_WIDTH / PAGE_RATIO,
+  });
+
+  const state = useMemo(
+    () => ({
+      state: {
+        canvasPageSize,
+      },
+      actions: {
+        setCanvasPageSize,
+      },
+    }),
+    [canvasPageSize]
+  );
+
+  return <Context.Provider value={state}>{children}</Context.Provider>;
+}
+
+LayoutProvider.propTypes = {
+  children: PropTypes.node,
+};
+
+export default LayoutProvider;

--- a/assets/src/edit-story/app/layout/useLayout.js
+++ b/assets/src/edit-story/app/layout/useLayout.js
@@ -14,6 +14,14 @@
  * limitations under the License.
  */
 
-export { default } from './layout';
-export { default as useLayout } from './useLayout';
-export { default as LayoutProvider } from './layoutProvider';
+/**
+ * Internal dependencies
+ */
+import { identity, useContextSelector } from '../../utils/context';
+import Context from './context';
+
+function useLayout(selector) {
+  return useContextSelector(Context, selector ?? identity);
+}
+
+export default useLayout;

--- a/assets/src/edit-story/components/canvas/canvasElementDropzone.js
+++ b/assets/src/edit-story/components/canvas/canvasElementDropzone.js
@@ -29,6 +29,7 @@ import { useUnits } from '../../units';
 import { isDragType } from '../../utils/dragEvent';
 import useCanvas from './useCanvas';
 import useInsertElement from './useInsertElement';
+import useInsertTextSet from './useInsertTextSet';
 
 const Container = styled.div`
   width: 100%;
@@ -37,6 +38,8 @@ const Container = styled.div`
 
 function CanvasElementDropzone({ children }) {
   const insertElement = useInsertElement();
+  const { insertTextSetByOffset } = useInsertTextSet();
+
   const { activeDropTargetId } = useDropTargets((state) => ({
     activeDropTargetId: state.state.activeDropTargetId,
   }));
@@ -80,11 +83,27 @@ function CanvasElementDropzone({ children }) {
         e.stopPropagation();
         e.preventDefault();
       }
+      // Handles onDrop for text sets.
+      else if (isDragType(e, 'textset') && !activeDropTargetId) {
+        const { grabOffsetX, grabOffsetY, elements } = JSON.parse(
+          e.dataTransfer.getData('textset')
+        );
+        const { x: pageX, y: pageY } = pageContainer.getBoundingClientRect();
+
+        insertTextSetByOffset(elements, {
+          offsetX: editorToDataX(e.clientX - pageX + grabOffsetX),
+          offsetY: editorToDataY(e.clientY - pageY + grabOffsetY),
+        });
+
+        e.stopPropagation();
+        e.preventDefault();
+      }
     },
     [
       activeDropTargetId,
       pageContainer,
       insertElement,
+      insertTextSetByOffset,
       editorToDataX,
       editorToDataY,
     ]

--- a/assets/src/edit-story/components/canvas/canvasElementDropzone.js
+++ b/assets/src/edit-story/components/canvas/canvasElementDropzone.js
@@ -88,12 +88,19 @@ function CanvasElementDropzone({ children }) {
         const { grabOffsetX, grabOffsetY, elements } = JSON.parse(
           e.dataTransfer.getData('textset')
         );
-        const { x: pageX, y: pageY } = pageContainer.getBoundingClientRect();
+        const { x, y, width, height } = pageContainer.getBoundingClientRect();
 
-        insertTextSetByOffset(elements, {
-          offsetX: editorToDataX(e.clientX - pageX + grabOffsetX),
-          offsetY: editorToDataY(e.clientY - pageY + grabOffsetY),
-        });
+        insertTextSetByOffset(
+          elements,
+          {
+            offsetX: editorToDataX(e.clientX - x + grabOffsetX),
+            offsetY: editorToDataY(e.clientY - y + grabOffsetY),
+          },
+          {
+            width: editorToDataX(width),
+            height: editorToDataY(height),
+          }
+        );
 
         e.stopPropagation();
         e.preventDefault();

--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -23,25 +23,27 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /**
  * Internal dependencies
  */
+import { useLayout } from '../../app/layout';
 import { useStory } from '../../app';
-import { PAGE_WIDTH, PAGE_RATIO } from '../../constants';
 import { UnitsProvider } from '../../units';
 import useEditingElement from './useEditingElement';
 import useCanvasCopyPaste from './useCanvasCopyPaste';
+
 import Context from './context';
 
 function CanvasProvider({ children }) {
   const [lastSelectionEvent, setLastSelectionEvent] = useState(null);
   const lastSelectedElementId = useRef(null);
-  const [pageSize, setPageSize] = useState({
-    width: PAGE_WIDTH,
-    height: PAGE_WIDTH / PAGE_RATIO,
-  });
   const [pageContainer, setPageContainer] = useState(null);
   const [fullbleedContainer, setFullbleedContainer] = useState(null);
   const [showSafeZone, setShowSafeZone] = useState(true);
   const [pageAttachmentContainer, setPageAttachmentContainer] = useState(null);
   const [displayLinkGuidelines, setDisplayLinkGuidelines] = useState(false);
+
+  const { pageSize, setPageSize } = useLayout(({ state, actions }) => ({
+    pageSize: state.canvasPageSize,
+    setPageSize: actions.setCanvasPageSize,
+  }));
 
   const {
     nodesById,

--- a/assets/src/edit-story/components/canvas/index.js
+++ b/assets/src/edit-story/components/canvas/index.js
@@ -17,3 +17,4 @@
 export { default } from './canvas';
 export { default as useCanvas } from './useCanvas';
 export { default as useInsertElement } from './useInsertElement';
+export { default as useInsertTextSet } from './useInsertTextSet';

--- a/assets/src/edit-story/components/canvas/test/_utils.js
+++ b/assets/src/edit-story/components/canvas/test/_utils.js
@@ -26,6 +26,7 @@ import PropTypes from 'prop-types';
 import FrameElement from '../frameElement';
 import DisplayElement from '../displayElement';
 import CanvasProvider from '../canvasProvider';
+import { LayoutProvider } from '../../../app/layout';
 import ConfigProvider from '../../../app/config/configProvider';
 import StoryContext from '../../../app/story/context';
 import { TransformProvider, useTransform } from '../../transform';
@@ -73,13 +74,15 @@ export function TestFrameElement({
     <ThemeProvider theme={theme}>
       <ConfigProvider config={configContext}>
         <StoryContext.Provider value={storyContext}>
-          <CanvasProvider>
-            <TransformProvider>
-              <WithRefs refs={refs}>
-                <FrameElement element={element} />
-              </WithRefs>
-            </TransformProvider>
-          </CanvasProvider>
+          <LayoutProvider>
+            <CanvasProvider>
+              <TransformProvider>
+                <WithRefs refs={refs}>
+                  <FrameElement element={element} />
+                </WithRefs>
+              </TransformProvider>
+            </CanvasProvider>
+          </LayoutProvider>
         </StoryContext.Provider>
       </ConfigProvider>
     </ThemeProvider>
@@ -131,13 +134,15 @@ export function TestDisplayElement({
     <ThemeProvider theme={theme}>
       <ConfigProvider config={configContext}>
         <StoryContext.Provider value={storyContext}>
-          <CanvasProvider>
-            <TransformProvider>
-              <WithRefs refs={refs}>
-                <DisplayElement element={element} page={null} />
-              </WithRefs>
-            </TransformProvider>
-          </CanvasProvider>
+          <LayoutProvider>
+            <CanvasProvider>
+              <TransformProvider>
+                <WithRefs refs={refs}>
+                  <DisplayElement element={element} page={null} />
+                </WithRefs>
+              </TransformProvider>
+            </CanvasProvider>
+          </LayoutProvider>
         </StoryContext.Provider>
       </ConfigProvider>
     </ThemeProvider>

--- a/assets/src/edit-story/components/canvas/test/getElementProperties.js
+++ b/assets/src/edit-story/components/canvas/test/getElementProperties.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { PAGE_WIDTH, PAGE_HEIGHT } from '../../../constants';
+import { getElementProperties } from '../useInsertElement';
+
+const BASIC_SHAPE = {
+  id: '8e06a649-ad1f-455d-a76b-ad012aff08ad',
+  opacity: 100,
+  flip: {
+    vertical: false,
+    horizontal: false,
+  },
+  rotationAngle: 0,
+  lockAspectRatio: true,
+  backgroundColor: {
+    color: {
+      r: 196,
+      g: 196,
+      b: 196,
+    },
+  },
+  type: 'shape',
+  x: 94,
+  y: 77,
+  width: 137,
+  height: 137,
+  scale: 100,
+  focalX: 50,
+  focalY: 50,
+  mask: {
+    type: 'triangle',
+  },
+};
+
+describe('getElementProperties', () => {
+  it('should modify x,y to be within page boundary by default', () => {
+    const outOfBoundsX = PAGE_WIDTH + BASIC_SHAPE.width;
+    const outOfBoundsY = PAGE_HEIGHT + BASIC_SHAPE.height;
+
+    const result = getElementProperties(BASIC_SHAPE.type, {
+      ...BASIC_SHAPE,
+      x: outOfBoundsX,
+      y: outOfBoundsY,
+    });
+
+    expect(result.x).toBe(PAGE_WIDTH - BASIC_SHAPE.width);
+    expect(result.y).toBe(PAGE_HEIGHT - BASIC_SHAPE.height);
+  });
+
+  it('should keey x,y unmodified if already within page boundary', () => {
+    const inboundsX = 50;
+    const inboundsY = 25;
+
+    const result = getElementProperties(BASIC_SHAPE.type, {
+      ...BASIC_SHAPE,
+      x: inboundsX,
+      y: inboundsY,
+    });
+
+    expect(result.x).toBe(inboundsX);
+    expect(result.y).toBe(inboundsY);
+  });
+
+  it('should keep x,y unmodified when ignorePageBoundary is true', () => {
+    const outOfBoundsX = PAGE_WIDTH + BASIC_SHAPE.width;
+    const outOfBoundsY = PAGE_HEIGHT + BASIC_SHAPE.height;
+
+    const results = getElementProperties(BASIC_SHAPE.type, {
+      ...BASIC_SHAPE,
+      x: outOfBoundsX,
+      y: outOfBoundsY,
+      ignorePageBoundary: true,
+    });
+
+    expect(results.x).toBe(outOfBoundsX);
+    expect(results.y).toBe(outOfBoundsY);
+  });
+});

--- a/assets/src/edit-story/components/canvas/test/getElementProperties.js
+++ b/assets/src/edit-story/components/canvas/test/getElementProperties.js
@@ -77,19 +77,4 @@ describe('getElementProperties', () => {
     expect(result.x).toBe(inboundsX);
     expect(result.y).toBe(inboundsY);
   });
-
-  it('should keep x,y unmodified when ignorePageBoundary is true', () => {
-    const outOfBoundsX = PAGE_WIDTH + BASIC_SHAPE.width;
-    const outOfBoundsY = PAGE_HEIGHT + BASIC_SHAPE.height;
-
-    const results = getElementProperties(BASIC_SHAPE.type, {
-      ...BASIC_SHAPE,
-      x: outOfBoundsX,
-      y: outOfBoundsY,
-      ignorePageBoundary: true,
-    });
-
-    expect(results.x).toBe(outOfBoundsX);
-    expect(results.y).toBe(outOfBoundsY);
-  });
 });

--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -121,6 +121,7 @@ function useInsertElement() {
  * @param {number} props.width The element's width.
  * @param {number} props.height The element's height.
  * @param {?Object} props.mask The element's mask.
+ * @param {boolean} props.ignorePageBoundary If true, an element's position will not be adjusted based on page dimensions
  * @return {Object} The element properties.
  */
 function getElementProperties(
@@ -136,6 +137,7 @@ function getElementProperties(
     scale = 100,
     focalX = 50,
     focalY = 50,
+    ignorePageBoundary = false,
     ...rest
   }
 ) {
@@ -166,8 +168,8 @@ function getElementProperties(
   if (!isNum(y)) {
     y = 0;
   }
-  x = dataPixels(Math.min(x, PAGE_WIDTH - width));
-  y = dataPixels(Math.min(y, PAGE_HEIGHT - height));
+  x = dataPixels(ignorePageBoundary ? x : Math.min(x, PAGE_WIDTH - width));
+  y = dataPixels(ignorePageBoundary ? y : Math.min(y, PAGE_HEIGHT - height));
 
   return {
     ...attrs,

--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -121,7 +121,6 @@ function useInsertElement() {
  * @param {number} props.width The element's width.
  * @param {number} props.height The element's height.
  * @param {?Object} props.mask The element's mask.
- * @param {boolean} props.ignorePageBoundary If true, an element's position will not be adjusted based on page dimensions
  * @return {Object} The element properties.
  */
 function getElementProperties(
@@ -137,7 +136,6 @@ function getElementProperties(
     scale = 100,
     focalX = 50,
     focalY = 50,
-    ignorePageBoundary = false,
     ...rest
   }
 ) {
@@ -168,8 +166,8 @@ function getElementProperties(
   if (!isNum(y)) {
     y = 0;
   }
-  x = dataPixels(ignorePageBoundary ? x : Math.min(x, PAGE_WIDTH - width));
-  y = dataPixels(ignorePageBoundary ? y : Math.min(y, PAGE_HEIGHT - height));
+  x = dataPixels(Math.min(x, PAGE_WIDTH - width));
+  y = dataPixels(Math.min(y, PAGE_HEIGHT - height));
 
   return {
     ...attrs,

--- a/assets/src/edit-story/components/canvas/useInsertTextSet.js
+++ b/assets/src/edit-story/components/canvas/useInsertTextSet.js
@@ -49,9 +49,7 @@ function useInsertTextSet() {
           'textSetWidth',
           'textSetHeight',
         ]);
-        addedElements.push(
-          insertElement(element.type, { ...toInsert, ignorePageBoundary: true })
-        );
+        addedElements.push(insertElement(element.type, toInsert));
       });
       // Select all added elements.
       setSelectedElementsById({
@@ -62,14 +60,42 @@ function useInsertTextSet() {
   );
 
   const insertTextSetByOffset = useCallback(
-    (elements, { offsetX, offsetY }) => {
+    (elements, { offsetX, offsetY }, boundary) => {
+      if (!elements.length) {
+        return;
+      }
+
+      let adjustedOffsetX = offsetX;
+      let adjustedOffsetY = offsetY;
+
+      if (boundary) {
+        const { width, height } = boundary;
+        const { textSetWidth, textSetHeight } = elements[0];
+
+        if (offsetX < 0) {
+          adjustedOffsetX = 0;
+        } else if (offsetX > width) {
+          adjustedOffsetX = width - textSetWidth;
+        } else if (offsetX + textSetWidth > width) {
+          adjustedOffsetX -= offsetX + textSetWidth - width;
+        }
+
+        if (offsetY < 0) {
+          adjustedOffsetY = 0;
+        } else if (offsetY > height) {
+          adjustedOffsetY = height - textSetHeight;
+        } else if (offsetY + textSetHeight > height) {
+          adjustedOffsetY -= offsetY + textSetHeight - height;
+        }
+      }
+
       const positionedTextSet = elements.reduce(
         (acc, element) => [
           ...acc,
           {
             ...element,
-            x: element.normalizedOffsetX + offsetX,
-            y: element.normalizedOffsetY + offsetY,
+            x: element.normalizedOffsetX + adjustedOffsetX,
+            y: element.normalizedOffsetY + adjustedOffsetY,
           },
         ],
         []

--- a/assets/src/edit-story/components/canvas/useInsertTextSet.js
+++ b/assets/src/edit-story/components/canvas/useInsertTextSet.js
@@ -89,17 +89,11 @@ function useInsertTextSet() {
         }
       }
 
-      const positionedTextSet = elements.reduce(
-        (acc, element) => [
-          ...acc,
-          {
-            ...element,
-            x: element.normalizedOffsetX + adjustedOffsetX,
-            y: element.normalizedOffsetY + adjustedOffsetY,
-          },
-        ],
-        []
-      );
+      const positionedTextSet = elements.map((element) => ({
+        ...element,
+        x: element.normalizedOffsetX + adjustedOffsetX,
+        y: element.normalizedOffsetY + adjustedOffsetY,
+      }));
 
       insertTextSet(positionedTextSet);
     },

--- a/assets/src/edit-story/components/library/libraryProvider.js
+++ b/assets/src/edit-story/components/library/libraryProvider.js
@@ -24,7 +24,7 @@ import { useFeatures } from 'flagged';
 /**
  * Internal dependencies
  */
-import { useInsertElement } from '../canvas';
+import { useInsertElement, useInsertTextSet } from '../canvas';
 import Context from './context';
 import { AnimationPane, AnimationIcon } from './panes/animation';
 import { MediaPane, MediaIcon } from './panes/media/local';
@@ -44,6 +44,7 @@ function LibraryProvider({ children }) {
   const initialTab = MEDIA.id;
   const [tab, setTab] = useState(initialTab);
   const insertElement = useInsertElement();
+  const { insertTextSet, insertTextSetByOffset } = useInsertTextSet();
 
   const { showAnimationTab, showElementsTab } = useFeatures();
 
@@ -69,12 +70,14 @@ function LibraryProvider({ children }) {
       actions: {
         setTab,
         insertElement,
+        insertTextSet,
+        insertTextSetByOffset,
       },
       data: {
         tabs: tabs,
       },
     }),
-    [tab, insertElement, initialTab, tabs]
+    [tab, insertElement, insertTextSet, insertTextSetByOffset, initialTab, tabs]
   );
 
   return <Context.Provider value={state}>{children}</Context.Provider>;

--- a/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
@@ -18,23 +18,75 @@
  * Internal dependencies
  */
 import { Fixture } from '../../../../../../karma/fixture';
+import { useStory } from '../../../../../../app/story';
 
-describe('CUJ: Text Sets (Text and Shape Combinations): Inserting Text Sets', () => {
+describe('Text Sets Library Panel', () => {
   let fixture;
+
   beforeEach(async () => {
     fixture = new Fixture();
+    fixture.setFlags({ showTextSets: true });
+
     await fixture.render();
+
+    // Make Text tab active in library panels
+    const textTab = fixture.editor.library.getByRole('tab', {
+      name: /^Text library$/,
+    });
+
+    await fixture.events.mouse.clickOn(textTab, 10, 20);
   });
 
   afterEach(() => {
     fixture.restore();
   });
 
-  // Disable reason: not implemented yet.
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should display text sets', async () => {});
+  async function getTextElements() {
+    const {
+      state: {
+        currentPage: { elements },
+      },
+    } = await fixture.renderHook(() => useStory());
+    return elements.filter((e) => e.type === 'text');
+  }
 
-  // Disable reason: not implemented yet.
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should allow inserting text sets', () => {});
+  describe('CUJ: Text Sets (Text and Shape Combinations): Inserting Text Sets', () => {
+    // Disable reason: not implemented yet.
+    // eslint-disable-next-line jasmine/no-disabled-tests
+    xit('should display text sets', async () => {});
+
+    it('should allow inserting text sets', async () => {
+      const textSet = fixture.editor.library.getAllByRole('listitem', {
+        name: /^Insert Text Set$/,
+      })[0];
+
+      // The page should start off with no text elements
+      expect((await getTextElements()).length).toBe(0);
+
+      await fixture.events.mouse.clickOn(textSet, 25, 25);
+
+      // After text set has been added, there should some text elements
+      expect((await getTextElements()).length).toBeGreaterThan(0);
+    });
+
+    it('should allow user to drag and drop text set onto page', async () => {
+      const textSet = fixture.editor.library.getAllByRole('listitem', {
+        name: /^Insert Text Set$/,
+      })[0];
+
+      const page = fixture.editor.canvas.fullbleed.container;
+
+      // The page should start off with no text elements
+      expect((await getTextElements()).length).toBe(0);
+
+      await fixture.events.mouse.moveRel(textSet, 25, 25);
+      await fixture.events.mouse.down();
+
+      await fixture.events.mouse.moveRel(page, 50, 100);
+      await fixture.events.mouse.up();
+
+      // After text set has been added, there should some text elements
+      expect((await getTextElements()).length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
@@ -83,9 +83,11 @@ describe('Text Sets Library Panel', () => {
       await fixture.events.mouse.down();
 
       await fixture.events.mouse.moveRel(page, 50, 100);
+      await fixture.snapshot('Text set dragged');
       await fixture.events.mouse.up();
 
       // After text set has been added, there should some text elements
+      await fixture.snapshot('Text set added');
       expect((await getTextElements()).length).toBeGreaterThan(0);
     });
   });

--- a/assets/src/edit-story/components/library/panes/text/textSets/loadTextSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/loadTextSets.js
@@ -55,8 +55,8 @@ async function loadTextSet(name) {
         ...e,
         // Offset elements so the text set's
         // default position is (0,0)
-        previewOffsetX: e.x - minMax.minX,
-        previewOffsetY: e.y - minMax.minY,
+        normalizedOffsetX: e.x - minMax.minX,
+        normalizedOffsetY: e.y - minMax.minY,
         // The overall text set width & height
         // is the delta between the max/mins
         textSetWidth: minMax.maxX - minMax.minX,

--- a/assets/src/edit-story/components/library/panes/text/textSets/test/textSet.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/test/textSet.js
@@ -175,12 +175,12 @@ const SETS = [
   },
 ];
 
-const insertElement = jest.fn();
+const insertTextSet = jest.fn();
 
 function setup(elements) {
   const libraryValue = {
     actions: {
-      insertElement,
+      insertTextSet,
     },
   };
   const transformValue = {
@@ -234,7 +234,7 @@ function setup(elements) {
 
 describe('TextSets', () => {
   beforeEach(() => {
-    insertElement.mockReset();
+    insertTextSet.mockReset();
   });
 
   it('should render', () => {
@@ -254,23 +254,17 @@ describe('TextSets', () => {
   });
 
   it('should allow inserting a text set', async () => {
-    insertElement.mockImplementation((type, element) => {
-      return {
-        type,
-        id: '123',
-        ...element,
-      };
-    });
+    insertTextSet.mockImplementation((elements) => elements);
     const { queryAllByRole } = setup(SETS);
     const sets = queryAllByRole('listitem');
     expect(sets).toHaveLength(1);
     await fireEvent.click(sets[0]);
 
-    expect(insertElement).toHaveBeenCalledTimes(2);
+    expect(insertTextSet).toHaveBeenCalledTimes(1);
 
-    const element1 = insertElement.mock.calls[0][1];
+    const element1 = insertTextSet.mock.calls[0][0][0];
     expect(element1.content).toContain('Good design is aesthetic');
-    const element2 = insertElement.mock.calls[1][1];
+    const element2 = insertTextSet.mock.calls[0][0][1];
     expect(element2.content).toContain(
       'The possibilities for innovation are not'
     );

--- a/assets/src/edit-story/components/library/panes/text/textSets/test/textSet.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/test/textSet.js
@@ -260,8 +260,8 @@ describe('TextSets', () => {
     insertTextSet.mockImplementation((elements) => elements);
     const { queryAllByRole } = setup(SETS);
     const sets = queryAllByRole('listitem');
-    expect(sets).toHaveLength(1);
-    await fireEvent.click(sets[0]);
+    expect(sets).toHaveLength(2);
+    await fireEvent.click(sets[1]);
 
     expect(insertTextSet).toHaveBeenCalledTimes(1);
 

--- a/assets/src/edit-story/components/library/panes/text/textSets/test/textSet.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/test/textSet.js
@@ -33,6 +33,7 @@ import { renderWithTheme } from '../../../../../../testUtils';
 import { PAGE_RATIO, TEXT_SET_SIZE } from '../../../../../../constants';
 import { UnitsProvider } from '../../../../../../units';
 import StoryContext from '../../../../../../app/story/context';
+import { LayoutProvider } from '../../../../../../app/layout';
 
 const SETS = [
   {
@@ -212,17 +213,19 @@ function setup(elements) {
         <APIContext.Provider value={apiValue}>
           <StoryContext.Provider value={storyValue}>
             <FontContext.Provider value={fontsValue}>
-              <LibraryContext.Provider value={libraryValue}>
-                <UnitsProvider
-                  pageSize={{
-                    width: TEXT_SET_SIZE,
-                    height: TEXT_SET_SIZE / PAGE_RATIO,
-                  }}
-                  getBox={getBox}
-                >
-                  <TextSet elements={elements} index={0} />
-                </UnitsProvider>
-              </LibraryContext.Provider>
+              <LayoutProvider>
+                <LibraryContext.Provider value={libraryValue}>
+                  <UnitsProvider
+                    pageSize={{
+                      width: TEXT_SET_SIZE,
+                      height: TEXT_SET_SIZE / PAGE_RATIO,
+                    }}
+                    getBox={getBox}
+                  >
+                    <TextSet elements={elements} index={0} />
+                  </UnitsProvider>
+                </LibraryContext.Provider>
+              </LayoutProvider>
             </FontContext.Provider>
           </StoryContext.Provider>
         </APIContext.Provider>

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
@@ -31,15 +31,10 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useLayout } from '../../../../../app/layout';
-import DisplayElement from '../../../../canvas/displayElement';
-import { UnitsProvider } from '../../../../../units';
-import {
-  PAGE_WIDTH,
-  PAGE_RATIO,
-  TEXT_SET_SIZE,
-} from '../../../../../constants';
+import { PAGE_RATIO, TEXT_SET_SIZE } from '../../../../../constants';
 import useLibrary from '../../../useLibrary';
 import { dataToEditorX, dataToEditorY } from '../../../../../units/dimensions';
+import TextSetElements from './textSetElements';
 
 const TextSetItem = styled.button`
   border: 0;
@@ -51,6 +46,10 @@ const TextSetItem = styled.button`
   border-radius: 4px;
   cursor: pointer;
 `;
+
+const DragWrapper = styled.div.attrs({
+  role: 'listitem',
+})``;
 
 const DragContainer = styled.div`
   position: absolute;
@@ -98,36 +97,15 @@ function TextSet({ elements }) {
   const dragHeight = dataToEditorY(textSetHeight, pageHeight);
 
   return (
-    <>
+    <DragWrapper>
       <DragContainer ref={elementRef} width={dragWidth} height={dragHeight}>
-        <UnitsProvider
+        <TextSetElements
+          elements={elements}
           pageSize={{
             width: pageWidth,
             height: pageHeight,
           }}
-        >
-          {elements.map(
-            ({
-              id,
-              content,
-              normalizedOffsetX,
-              normalizedOffsetY,
-              ...rest
-            }) => (
-              <DisplayElement
-                previewMode
-                key={id}
-                element={{
-                  id,
-                  content,
-                  ...rest,
-                  x: normalizedOffsetX,
-                  y: normalizedOffsetY,
-                }}
-              />
-            )
-          )}
-        </UnitsProvider>
+        />
       </DragContainer>
       <TextSetItem
         role="listitem"
@@ -136,39 +114,16 @@ function TextSet({ elements }) {
         aria-label={__('Insert Text Set', 'web-stories')}
         onClick={() => insertTextSet(elements)}
       >
-        <UnitsProvider
+        <TextSetElements
+          isForDisplay
+          elements={elements}
           pageSize={{
             width: TEXT_SET_SIZE,
             height: TEXT_SET_SIZE / PAGE_RATIO,
           }}
-        >
-          {elements.map(
-            ({
-              id,
-              content,
-              normalizedOffsetX,
-              normalizedOffsetY,
-              ...rest
-            }) => (
-              <DisplayElement
-                previewMode
-                key={id}
-                element={{
-                  id,
-                  content: `<span style="color: #fff">${content}<span>`,
-                  ...rest,
-                  x: normalizedOffsetX + (PAGE_WIDTH - textSetWidth) / 2,
-                  y:
-                    normalizedOffsetY +
-                    (PAGE_WIDTH - textSetHeight) /
-                      2 /* Use PAGE_WIDTH here since the area is square */,
-                }}
-              />
-            )
-          )}
-        </UnitsProvider>
+        />
       </TextSetItem>
-    </>
+    </DragWrapper>
   );
 }
 

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSetElements.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSetElements.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import StoryPropTypes from '../../../../../types';
+import DisplayElement from '../../../../canvas/displayElement';
+import { UnitsProvider } from '../../../../../units';
+import { PAGE_WIDTH } from '../../../../../constants';
+
+function getElementContent(content, isForDisplay) {
+  if (!content) {
+    return {};
+  }
+
+  return {
+    content: isForDisplay
+      ? `<span style="color: #fff">${content}<span>`
+      : content,
+  };
+}
+
+function TextSetElements({ elements, isForDisplay, pageSize }) {
+  const { textSetHeight, textSetWidth } = elements[0];
+
+  const xOffset = isForDisplay ? (PAGE_WIDTH - textSetWidth) / 2 : 0;
+  const yOffset = isForDisplay ? (PAGE_WIDTH - textSetHeight) / 2 : 0;
+
+  return (
+    <UnitsProvider pageSize={pageSize}>
+      {elements.map(
+        ({ id, content, normalizedOffsetX, normalizedOffsetY, ...rest }) => (
+          <DisplayElement
+            previewMode
+            key={id}
+            element={{
+              id,
+              ...getElementContent(content, isForDisplay),
+              ...rest,
+              x: normalizedOffsetX + xOffset,
+              y: normalizedOffsetY + yOffset,
+            }}
+          />
+        )
+      )}
+    </UnitsProvider>
+  );
+}
+
+TextSetElements.propTypes = {
+  elements: PropTypes.array.isRequired,
+  pageSize: StoryPropTypes.size.isRequired,
+  isForDisplay: PropTypes.bool,
+};
+
+export default TextSetElements;

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -59,10 +59,9 @@ function TextSets() {
             height: TEXT_SET_SIZE / PAGE_RATIO,
           }}
         >
-          {textSets.map((elements, index) =>
-            elements.length > 0 ? (
-              <TextSet key={index} elements={elements} />
-            ) : null
+          {textSets.map(
+            (elements, index) =>
+              elements.length > 0 && <TextSet key={index} elements={elements} />
           )}
         </UnitsProvider>
       </TextSetContainer>

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -59,9 +59,11 @@ function TextSets() {
             height: TEXT_SET_SIZE / PAGE_RATIO,
           }}
         >
-          {textSets.map((elements, index) => (
-            <TextSet key={index} elements={elements} />
-          ))}
+          {textSets.map((elements, index) =>
+            elements.length > 0 ? (
+              <TextSet key={index} elements={elements} />
+            ) : null
+          )}
         </UnitsProvider>
       </TextSetContainer>
     </Section>

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -67,5 +67,5 @@ export default {
     '!**/test/**',
     '!**/stories/**',
   ],
-  reporters: [['jest-silent-reporter', { useDots: true, showWarnings: true }]],
+  // reporters: [['jest-silent-reporter', { useDots: true, showWarnings: true }]],
 };

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -67,5 +67,5 @@ export default {
     '!**/test/**',
     '!**/stories/**',
   ],
-  // reporters: [['jest-silent-reporter', { useDots: true, showWarnings: true }]],
+  reporters: [['jest-silent-reporter', { useDots: true, showWarnings: true }]],
 };


### PR DESCRIPTION
## Summary

This PR adds drag-n-drop functionality to our text sets.

## Relevant Technical Choices

In order to be able to size the text set drag icon to its actual rendered size on the page (within the Editor), I had to create a context provider that wrapped both the `Library` and the `Canvas`.  I called it `Layout` and it stores the current `canvasPageSize` and provides an action to `setCanvasPageSize`.  I then updated the `Canvas` provider so it no longer holds `pageSize` locally, it routes its `pageSize` logic to the `Layout` provider.   This way elements in the `Library` and `Canvas` can both size themselves to the current canvas page size.  

And finally, using the `Layout` provider from within the `Library`, I was able to size the drag icon for the selected text set so it matches the exact size of its rendered self.

## User-facing changes

None.  Hidden behind flag.

## Testing Instructions

1.) Make sure "Enable text sets" is checked on the Experiments page.
2.) Open up a new/exisiting story in the editor.
3.) Click on the "T" in the libary panel to open up the Text tab.
4.) Use your mouse to drag and drop a text set onto the screen.  Note that the size and position of the dragged text set should match the dropped and rendered text set (however, if you drop the text set outside the boundaries of the page, it'll be adjusted to within the page on drop).

Fixes #4079 

## Screenshot

Drag and drop text set to page.  Notice the rendered text set's top-left corner aligns with the drag icon's top-left corner:
![better_drag_n_drop](https://user-images.githubusercontent.com/40646372/94202396-6efca780-fe72-11ea-88ec-3338843084b9.gif)

Drag and drop the text set outside the page, and we'll adjust it to fit onto the page nicely:
![boudary_protection](https://user-images.githubusercontent.com/40646372/94202404-72902e80-fe72-11ea-8686-0596c9136e1e.gif)
