### PR TITLE
Story Editor: Added Editorial Text Sets

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/textSets/raw/editorial.json
+++ b/assets/src/edit-story/components/library/panes/text/textSets/raw/editorial.json
@@ -1,9 +1,100 @@
 {
-  "current": "5f52f0ff-facb-448c-95f1-5153e3c20ad8",
+  "current": "8de5a540-9aa2-4532-b1de-87f071ccdd1a",
   "selection": [],
   "story": {
     "stylePresets": {
-      "colors": [],
+      "colors": [
+        {
+          "color": {
+            "r": 33,
+            "g": 33,
+            "b": 33
+          }
+        },
+        {
+          "color": {
+            "r": 0,
+            "g": 92,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 61,
+            "g": 46,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 200,
+            "g": 122,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 163,
+            "b": 214
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 187,
+            "b": 196
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 187,
+            "b": 196,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 246,
+            "g": 147,
+            "b": 147,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 240,
+            "g": 176,
+            "b": 119,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 220,
+            "g": 211,
+            "b": 67,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 153,
+            "g": 199,
+            "b": 39,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 119,
+            "g": 151,
+            "b": 18,
+            "a": 0.6
+          }
+        }
+      ],
       "textStyles": []
     }
   },
@@ -36,7 +127,7 @@
           "isBackground": true,
           "isDefaultBackground": true,
           "type": "shape",
-          "id": "960d1689-6d73-4d0b-96bc-a0bb5f6bb2ed"
+          "id": "5af75aa3-94b9-42a5-8786-fbcf9649c568"
         },
         {
           "opacity": 100,
@@ -102,14 +193,14 @@
           },
           "type": "text",
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
-          "x": 43,
-          "y": 225,
+          "x": 32,
+          "y": 403,
           "width": 334,
           "height": 183,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
-          "id": "f7167da6-fd69-4abb-b688-60c17f0e2e37"
+          "id": "b16d8411-cf94-4bb8-92ac-e7a800763005"
         },
         {
           "opacity": 100,
@@ -175,14 +266,14 @@
           },
           "type": "text",
           "content": "<span style=\"font-weight: 700\">Good design is innovative</span>",
-          "x": 43,
-          "y": 119,
+          "x": 32,
+          "y": 297,
           "width": 246,
           "height": 86,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
-          "id": "ae467c59-7fac-43c1-b2ad-2b68938879c9"
+          "id": "dff0913d-9a7a-4a40-b3b2-efb2d35a6a1b"
         }
       ],
       "backgroundColor": {
@@ -193,7 +284,7 @@
         }
       },
       "type": "page",
-      "id": "2ac019ba-8ed1-4da0-b823-f4f399b1dae7"
+      "id": "8de5a540-9aa2-4532-b1de-87f071ccdd1a"
     },
     {
       "backgroundOverlay": "none",
@@ -223,7 +314,7 @@
           "isBackground": true,
           "isDefaultBackground": true,
           "type": "shape",
-          "id": "c3e76da9-d593-4be1-9534-e04701760b2d"
+          "id": "e3f68470-4155-4e9b-8121-5f744b23e76d"
         },
         {
           "opacity": 100,
@@ -235,25 +326,44 @@
           "lockAspectRatio": true,
           "backgroundTextMode": "NONE",
           "font": {
-            "family": "Alegreya",
+            "family": "Source Serif Pro",
             "service": "fonts.google.com",
             "fallbacks": ["serif"],
-            "weights": [400, 500, 700, 800, 900],
-            "styles": ["regular", "italic"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
             "variants": [
+              [0, 200],
+              [0, 300],
               [0, 400],
-              [1, 400],
-              [0, 500],
-              [1, 500],
+              [0, 600],
               [0, 700],
-              [1, 700],
-              [0, 800],
-              [1, 800],
               [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700],
               [1, 900]
-            ]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
           },
-          "fontSize": 36,
+          "fontSize": 31,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -261,7 +371,7 @@
               "b": 196
             }
           },
-          "lineHeight": 1.1,
+          "lineHeight": 1.2,
           "textAlign": "center",
           "padding": {
             "locked": true,
@@ -269,16 +379,16 @@
             "vertical": 0
           },
           "type": "text",
-          "content": "<span style=\"font-weight: 400\">Good design is aesthetic</span>",
+          "content": "<span style=\"font-weight: 600\">Good design is innovative</span>",
           "fontWeight": 700,
-          "x": 40,
-          "y": 291,
+          "x": 42,
+          "y": 296,
           "width": 328,
-          "height": 78,
+          "height": 75,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
-          "id": "3631d6b0-0f6a-4959-9df0-b9f3d7fcab35"
+          "id": "5866ef82-08bf-40fa-87b2-89e2270aeda6"
         },
         {
           "opacity": 100,
@@ -290,25 +400,646 @@
           "lockAspectRatio": true,
           "backgroundTextMode": "NONE",
           "font": {
-            "family": "Roboto",
-            "weights": [100, 300, 400, 500, 700, 900],
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
+          "fontWeight": 400,
+          "x": 40,
+          "y": 403,
+          "width": 333,
+          "height": 180,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "0706b1b6-fc33-4e21-a9a2-64ba4507ff30"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "x": 146,
+          "y": 386,
+          "width": 120,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "id": "6596c712-bc3a-4e5b-8438-74ee1b941b65"
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "7ec0f8c7-5226-4fac-bef5-82755b0d72cc"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "fec7c152-8198-4bc3-aba1-6acffd8e1ca6"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Poppins",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
             "styles": ["italic", "regular"],
             "variants": [
               [0, 100],
-              [1, 100],
+              [0, 200],
               [0, 300],
-              [1, 300],
               [0, 400],
-              [1, 400],
               [0, 500],
-              [1, 500],
+              [0, 600],
               [0, 700],
-              [1, 700],
+              [0, 800],
               [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
               [1, 900]
             ],
-            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1050,
+              "des": -350,
+              "tAsc": 1050,
+              "tDes": -350,
+              "tLGap": 100,
+              "wAsc": 1135,
+              "wDes": 627,
+              "xH": 548,
+              "capH": 698,
+              "yMin": -572,
+              "yMax": 1065,
+              "hAsc": 1050,
+              "hDes": -350,
+              "lGap": 100
+            }
+          },
+          "fontSize": 31,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 600\">GOOD DESIGN IS INNOVATIVE</span>",
+          "fontWeight": 700,
+          "width": 328,
+          "height": 80,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5866ef82-08bf-40fa-87b2-89e2270aeda6",
+          "id": "6fd28db6-2c6b-46c0-ae0b-707af1d36f3f",
+          "x": 33,
+          "y": 317
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
             "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
+          "fontWeight": 400,
+          "width": 333,
+          "height": 181,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "0706b1b6-fc33-4e21-a9a2-64ba4507ff30",
+          "id": "d93c3f60-5073-4e36-9c0f-aeffe4205266",
+          "x": 33,
+          "y": 407
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 32,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "6596c712-bc3a-4e5b-8438-74ee1b941b65",
+          "id": "87936ffe-2e44-44d5-8f4a-93f28a4e5cfc",
+          "x": 33,
+          "y": 297
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "2ce3fbcf-b0ec-4ae9-9e37-e46b94b4856e"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "f4bd63eb-47f0-454c-8734-7d8d4b5461fa"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Playfair Display",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1082,
+              "des": -251,
+              "tAsc": 1082,
+              "tDes": -251,
+              "tLGap": 0,
+              "wAsc": 1159,
+              "wDes": 251,
+              "xH": 514,
+              "capH": 708,
+              "yMin": -241,
+              "yMax": 1159,
+              "hAsc": 1082,
+              "hDes": -251,
+              "lGap": 0
+            }
+          },
+          "fontSize": 27,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; letter-spacing: 0.04em\">GOOD DESIGN IS INNOVATIVE</span>",
+          "fontWeight": 700,
+          "width": 328,
+          "height": 67,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "6fd28db6-2c6b-46c0-ae0b-707af1d36f3f",
+          "id": "ad27512c-2018-404f-9cdd-007a89cb8288",
+          "x": 42,
+          "y": 315
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Lora",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1006,
+              "des": -274,
+              "tAsc": 1006,
+              "tDes": -274,
+              "tLGap": 0,
+              "wAsc": 1206,
+              "wDes": 294,
+              "xH": 500,
+              "capH": 700,
+              "yMin": -271,
+              "yMax": 1114,
+              "hAsc": 1006,
+              "hDes": -274,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
+          "fontWeight": 400,
+          "width": 333,
+          "height": 175,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "d93c3f60-5073-4e36-9c0f-aeffe4205266",
+          "id": "dba6a0b2-7487-4ee4-bd05-6c6aeb6b246e",
+          "x": 39.5,
+          "y": 395
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "64fde279-f5b3-4501-88c1-88e9ae28c698"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "2e117f4a-9267-407b-bd02-08203dbc960c"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Oswald",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 500, 600, 700],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1193,
+              "des": -289,
+              "tAsc": 1193,
+              "tDes": -289,
+              "tLGap": 0,
+              "wAsc": 1325,
+              "wDes": 377,
+              "xH": 578,
+              "capH": 810,
+              "yMin": -287,
+              "yMax": 1297,
+              "hAsc": 1193,
+              "hDes": -289,
+              "lGap": 0
+            }
+          },
+          "fontSize": 27,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 500\">GOOD DESIGN IS INNOVATIVE</span>",
+          "fontWeight": 700,
+          "width": 328,
+          "height": 39,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "6fd28db6-2c6b-46c0-ae0b-707af1d36f3f",
+          "id": "598702ed-bbd1-4744-8e8d-4a1f00ba41b5",
+          "x": 39,
+          "y": 349
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [1, 300],
+              [1, 400],
+              [1, 700]
+            ],
             "metrics": {
               "upm": 2048,
               "asc": 1900,
@@ -336,7 +1067,7 @@
             }
           },
           "lineHeight": 1.5,
-          "textAlign": "justify",
+          "textAlign": "left",
           "padding": {
             "locked": true,
             "horizontal": 0,
@@ -345,14 +1076,44 @@
           "type": "text",
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
           "fontWeight": 400,
-          "x": 40,
-          "y": 411,
           "width": 333,
-          "height": 181,
+          "height": 153,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
-          "id": "c61010e2-750e-4e6d-8372-bfb5e93f2312"
+          "basedOn": "d93c3f60-5073-4e36-9c0f-aeffe4205266",
+          "id": "b72f7521-ac44-48be-857b-92c41b4c959d",
+          "x": 39,
+          "y": 397
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 332,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "87936ffe-2e44-44d5-8f4a-93f28a4e5cfc",
+          "id": "5708edac-534f-4341-9870-33a7688d0d5a",
+          "x": 40,
+          "y": 332
         }
       ],
       "backgroundColor": {
@@ -363,7 +1124,7 @@
         }
       },
       "type": "page",
-      "id": "5fddb181-523f-417a-bf9f-b564a2aec80d"
+      "id": "0249900f-0801-4cf2-904b-9eb505784148"
     },
     {
       "backgroundOverlay": "none",
@@ -393,7 +1154,7 @@
           "isBackground": true,
           "isDefaultBackground": true,
           "type": "shape",
-          "id": "96a05da5-14c8-4d48-91ca-3a1193c5313c"
+          "id": "733af034-220b-4232-894c-2550379f11a1"
         },
         {
           "opacity": 100,
@@ -405,38 +1166,562 @@
           "lockAspectRatio": true,
           "backgroundTextMode": "NONE",
           "font": {
-            "family": "Alegreya",
+            "family": "Merriweather",
             "service": "fonts.google.com",
             "fallbacks": ["serif"],
-            "weights": [400, 500, 700, 800, 900],
+            "weights": [300, 400, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [0, 900],
+              [1, 300],
+              [1, 400],
+              [1, 700],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 984,
+              "des": -273,
+              "tAsc": 984,
+              "tDes": -273,
+              "tLGap": 0,
+              "wAsc": 1065,
+              "wDes": 273,
+              "xH": 555,
+              "capH": 743,
+              "yMin": -272,
+              "yMax": 1055,
+              "hAsc": 984,
+              "hDes": -273,
+              "lGap": 0
+            }
+          },
+          "fontSize": 27,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">Good design is innovative</span>",
+          "fontWeight": 700,
+          "width": 328,
+          "height": 65,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5866ef82-08bf-40fa-87b2-89e2270aeda6",
+          "id": "2bbf9a2d-cc99-4c08-b6d2-0662761f12bc",
+          "x": 33,
+          "y": 311
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Merriweather",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [300, 400, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [0, 900],
+              [1, 300],
+              [1, 400],
+              [1, 700],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 984,
+              "des": -273,
+              "tAsc": 984,
+              "tDes": -273,
+              "tLGap": 0,
+              "wAsc": 1065,
+              "wDes": 273,
+              "xH": 555,
+              "capH": 743,
+              "yMin": -272,
+              "yMax": 1055,
+              "hAsc": 984,
+              "hDes": -273,
+              "lGap": 0
+            }
+          },
+          "fontSize": 16,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.6,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
+          "fontWeight": 400,
+          "width": 327,
+          "height": 173,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "0706b1b6-fc33-4e21-a9a2-64ba4507ff30",
+          "id": "02a14cfc-5936-462f-a79e-ffca46c2dd7f",
+          "x": 33,
+          "y": 397
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "7193ad78-832b-470b-90fd-c856334ee56a"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "d34c4e1a-4ef0-4f15-8620-f842858e1a3a"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Titillium Web",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1133,
+              "des": -388,
+              "tAsc": 1133,
+              "tDes": -388,
+              "tLGap": 0,
+              "wAsc": 1133,
+              "wDes": 388,
+              "xH": 500,
+              "capH": 692,
+              "yMin": -285,
+              "yMax": 1082,
+              "hAsc": 1133,
+              "hDes": -388,
+              "lGap": 0
+            }
+          },
+          "fontSize": 36,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 900; color: rgba(0,0,0,0.15)\">Good design is innovative</span>",
+          "fontWeight": 700,
+          "width": 328,
+          "height": 94,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "ae3d8b77-a89a-441e-a735-24d256ab1e3d",
+          "id": "c05092f4-7822-416c-98a6-44858a1a9069",
+          "x": 37,
+          "y": 318
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Titillium Web",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1133,
+              "des": -388,
+              "tAsc": 1133,
+              "tDes": -388,
+              "tLGap": 0,
+              "wAsc": 1133,
+              "wDes": 388,
+              "xH": 500,
+              "capH": 692,
+              "yMin": -285,
+              "yMax": 1082,
+              "hAsc": 1133,
+              "hDes": -388,
+              "lGap": 0
+            }
+          },
+          "fontSize": 36,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 900\">Good design is innovative</span>",
+          "fontWeight": 700,
+          "width": 328,
+          "height": 101,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "2bbf9a2d-cc99-4c08-b6d2-0662761f12bc",
+          "id": "ae3d8b77-a89a-441e-a735-24d256ab1e3d",
+          "x": 33,
+          "y": 314
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Work Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
             "styles": ["regular", "italic"],
             "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
               [0, 400],
               [0, 500],
+              [0, 600],
               [0, 700],
               [0, 800],
               [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
               [1, 400],
               [1, 500],
+              [1, 600],
               [1, 700],
               [1, 800],
               [1, 900]
             ],
             "metrics": {
               "upm": 1000,
-              "asc": 1016,
-              "des": -345,
-              "tAsc": 1016,
-              "tDes": -345,
+              "asc": 930,
+              "des": -243,
+              "tAsc": 930,
+              "tDes": -243,
               "tLGap": 0,
-              "wAsc": 1123,
-              "wDes": 345,
-              "xH": 452,
-              "capH": 636,
-              "yMin": -293,
-              "yMax": 962,
-              "hAsc": 1016,
-              "hDes": -345,
+              "wAsc": 1105,
+              "wDes": 343,
+              "xH": 500,
+              "capH": 660,
+              "yMin": -337,
+              "yMax": 1100,
+              "hAsc": 930,
+              "hDes": -243,
+              "lGap": 0
+            }
+          },
+          "fontSize": 16,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
+          "fontWeight": 400,
+          "width": 327,
+          "height": 160,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "02a14cfc-5936-462f-a79e-ffca46c2dd7f",
+          "id": "1cbbe1a0-99b7-4fac-9eb5-18dbfc50272d",
+          "x": 33,
+          "y": 414
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "f6204eaa-9008-45ca-9559-17a6e43efc33"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "1391f8a5-7162-4ac7-bdb0-7ad1832b93d6"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Nunito",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1011,
+              "des": -353,
+              "tAsc": 1011,
+              "tDes": -353,
+              "tLGap": 0,
+              "wAsc": 1092,
+              "wDes": 281,
+              "xH": 487,
+              "capH": 705,
+              "yMin": -275,
+              "yMax": 1081,
+              "hAsc": 1011,
+              "hDes": -353,
+              "lGap": 0
+            }
+          },
+          "fontSize": 31,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 300\">Good design is innovative</span>",
+          "fontWeight": 700,
+          "width": 328,
+          "height": 75,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "ae3d8b77-a89a-441e-a735-24d256ab1e3d",
+          "id": "ee1c31cf-c782-4cd7-9bd9-7ebc08f01fed",
+          "x": 33,
+          "y": 305
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 700],
+              [1, 400],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
               "lGap": 0
             }
           },
@@ -457,70 +1742,16 @@
           },
           "type": "text",
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
-          "width": 305,
-          "height": 189,
+          "fontWeight": 400,
+          "width": 336,
+          "height": 179,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
-          "basedOn": "e52be0d8-bcab-4b87-af5b-b12f0f4dc55e",
-          "id": "faa53471-3148-4e24-acb0-37ac4b001c61",
-          "x": 43,
-          "y": 225
-        },
-        {
-          "opacity": 100,
-          "flip": {
-            "vertical": false,
-            "horizontal": false
-          },
-          "rotationAngle": 0,
-          "lockAspectRatio": true,
-          "backgroundTextMode": "NONE",
-          "font": {
-            "family": "Alegreya",
-            "service": "fonts.google.com",
-            "fallbacks": ["serif"],
-            "weights": [400, 500, 700, 800, 900],
-            "styles": ["regular", "italic"],
-            "variants": [
-              [0, 400],
-              [0, 500],
-              [0, 700],
-              [0, 800],
-              [0, 900],
-              [1, 400],
-              [1, 500],
-              [1, 700],
-              [1, 800],
-              [1, 900]
-            ]
-          },
-          "fontSize": 36,
-          "backgroundColor": {
-            "color": {
-              "r": 196,
-              "g": 196,
-              "b": 196
-            }
-          },
-          "lineHeight": 1.2,
-          "textAlign": "initial",
-          "padding": {
-            "locked": true,
-            "horizontal": 0,
-            "vertical": 0
-          },
-          "type": "text",
-          "content": "<span style=\"font-weight: 600\">Good design is innovative</span>",
-          "width": 246,
-          "height": 86,
-          "scale": 100,
-          "focalX": 50,
-          "focalY": 50,
-          "basedOn": "7f81d372-6b04-4174-884d-cb51b613ebb7",
-          "id": "8bef3e06-b1bf-467d-9e20-5b2c1bf7042e",
-          "x": 43,
-          "y": 119
+          "basedOn": "1cbbe1a0-99b7-4fac-9eb5-18dbfc50272d",
+          "id": "f2d01d29-e755-4634-b346-e0a2682f159d",
+          "x": 33,
+          "y": 395
         }
       ],
       "backgroundColor": {
@@ -531,7 +1762,7 @@
         }
       },
       "type": "page",
-      "id": "5f52f0ff-facb-448c-95f1-5153e3c20ad8"
+      "id": "ea7b0add-02a4-4746-8c5c-d9422f096533"
     }
   ]
 }

--- a/assets/src/edit-story/components/library/panes/text/textSets/raw/editorial.json
+++ b/assets/src/edit-story/components/library/panes/text/textSets/raw/editorial.json
@@ -1,8 +1,62 @@
 {
-  "current": "8de5a540-9aa2-4532-b1de-87f071ccdd1a",
+  "current": "7ec0f8c7-5226-4fac-bef5-82755b0d72cc",
   "selection": [],
   "story": {
     "stylePresets": {
+      "textStyles": [
+        {
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Serif",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700]
+            ]
+          },
+          "fontSize": 37,
+          "lineHeight": 1.2,
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "textAlign": "initial",
+          "color": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "fontWeight": 600,
+          "isItalic": false,
+          "isUnderline": false,
+          "letterSpacing": 0
+        }
+      ],
       "colors": [
         {
           "color": {
@@ -94,8 +148,7 @@
             "a": 0.6
           }
         }
-      ],
-      "textStyles": []
+      ]
     }
   },
   "version": 24,
@@ -136,7 +189,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Roboto",
@@ -193,14 +246,15 @@
           },
           "type": "text",
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
-          "x": 32,
-          "y": 403,
-          "width": 334,
+          "x": 40,
+          "y": 402,
+          "width": 332,
           "height": 183,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
-          "id": "b16d8411-cf94-4bb8-92ac-e7a800763005"
+          "id": "b16d8411-cf94-4bb8-92ac-e7a800763005",
+          "marginOffset": 5.90625
         },
         {
           "opacity": 100,
@@ -209,7 +263,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Roboto",
@@ -249,7 +303,7 @@
               "lGap": 0
             }
           },
-          "fontSize": 36,
+          "fontSize": 37,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -266,14 +320,15 @@
           },
           "type": "text",
           "content": "<span style=\"font-weight: 700\">Good design is innovative</span>",
-          "x": 32,
-          "y": 297,
-          "width": 246,
+          "x": 40,
+          "y": 300,
+          "width": 332,
           "height": 86,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
-          "id": "dff0913d-9a7a-4a40-b3b2-efb2d35a6a1b"
+          "id": "dff0913d-9a7a-4a40-b3b2-efb2d35a6a1b",
+          "marginOffset": 1.0406249999999986
         }
       ],
       "backgroundColor": {
@@ -323,7 +378,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Source Serif Pro",
@@ -381,10 +436,10 @@
           "type": "text",
           "content": "<span style=\"font-weight: 600\">Good design is innovative</span>",
           "fontWeight": 700,
-          "x": 42,
-          "y": 296,
-          "width": 328,
-          "height": 75,
+          "x": 40,
+          "y": 299,
+          "width": 332,
+          "height": 76,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -456,9 +511,9 @@
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
           "fontWeight": 400,
           "x": 40,
-          "y": 403,
-          "width": 333,
-          "height": 180,
+          "y": 408,
+          "width": 332,
+          "height": 179,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -481,7 +536,7 @@
           },
           "type": "shape",
           "x": 146,
-          "y": 386,
+          "y": 391,
           "width": 120,
           "height": 1,
           "scale": 100,
@@ -540,7 +595,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Poppins",
@@ -604,15 +659,16 @@
           "type": "text",
           "content": "<span style=\"font-weight: 600\">GOOD DESIGN IS INNOVATIVE</span>",
           "fontWeight": 700,
-          "width": 328,
+          "width": 332,
           "height": 80,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "5866ef82-08bf-40fa-87b2-89e2270aeda6",
           "id": "6fd28db6-2c6b-46c0-ae0b-707af1d36f3f",
-          "x": 33,
-          "y": 317
+          "x": 40,
+          "y": 313,
+          "marginOffset": -6.399999999999999
         },
         {
           "opacity": 100,
@@ -621,7 +677,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "IBM Plex Sans",
@@ -663,7 +719,7 @@
               "lGap": 0
             }
           },
-          "fontSize": 18,
+          "fontSize": 17,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -681,15 +737,16 @@
           "type": "text",
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
           "fontWeight": 400,
-          "width": 333,
+          "width": 332,
           "height": 181,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "0706b1b6-fc33-4e21-a9a2-64ba4507ff30",
           "id": "d93c3f60-5073-4e36-9c0f-aeffe4205266",
-          "x": 33,
-          "y": 407
+          "x": 40,
+          "y": 409,
+          "marginOffset": 3.3999999999999986
         },
         {
           "opacity": 100,
@@ -717,8 +774,8 @@
           },
           "basedOn": "6596c712-bc3a-4e5b-8438-74ee1b941b65",
           "id": "87936ffe-2e44-44d5-8f4a-93f28a4e5cfc",
-          "x": 33,
-          "y": 297
+          "x": 40,
+          "y": 293
         }
       ],
       "backgroundColor": {
@@ -768,7 +825,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Playfair Display",
@@ -826,15 +883,15 @@
           "type": "text",
           "content": "<span style=\"font-weight: 700; letter-spacing: 0.04em\">GOOD DESIGN IS INNOVATIVE</span>",
           "fontWeight": 700,
-          "width": 328,
+          "width": 332,
           "height": 67,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "6fd28db6-2c6b-46c0-ae0b-707af1d36f3f",
           "id": "ad27512c-2018-404f-9cdd-007a89cb8288",
-          "x": 42,
-          "y": 315
+          "x": 33,
+          "y": 313
         },
         {
           "opacity": 100,
@@ -843,7 +900,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Lora",
@@ -897,15 +954,16 @@
           "type": "text",
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
           "fontWeight": 400,
-          "width": 333,
+          "width": 332,
           "height": 175,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "d93c3f60-5073-4e36-9c0f-aeffe4205266",
           "id": "dba6a0b2-7487-4ee4-bd05-6c6aeb6b246e",
-          "x": 39.5,
-          "y": 395
+          "x": 33,
+          "y": 396,
+          "marginOffset": 3.7399999999999984
         }
       ],
       "backgroundColor": {
@@ -955,7 +1013,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Oswald",
@@ -989,7 +1047,7 @@
               "lGap": 0
             }
           },
-          "fontSize": 27,
+          "fontSize": 26,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1007,15 +1065,16 @@
           "type": "text",
           "content": "<span style=\"font-weight: 500\">GOOD DESIGN IS INNOVATIVE</span>",
           "fontWeight": 700,
-          "width": 328,
+          "width": 332,
           "height": 39,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "6fd28db6-2c6b-46c0-ae0b-707af1d36f3f",
           "id": "598702ed-bbd1-4744-8e8d-4a1f00ba41b5",
-          "x": 39,
-          "y": 349
+          "x": 40,
+          "y": 347,
+          "marginOffset": -7.614000000000004
         },
         {
           "opacity": 100,
@@ -1024,7 +1083,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Roboto Condensed",
@@ -1076,15 +1135,15 @@
           "type": "text",
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
           "fontWeight": 400,
-          "width": 333,
+          "width": 332,
           "height": 153,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "d93c3f60-5073-4e36-9c0f-aeffe4205266",
           "id": "b72f7521-ac44-48be-857b-92c41b4c959d",
-          "x": 39,
-          "y": 397
+          "x": 40,
+          "y": 402
         },
         {
           "opacity": 100,
@@ -1113,7 +1172,7 @@
           "basedOn": "87936ffe-2e44-44d5-8f4a-93f28a4e5cfc",
           "id": "5708edac-534f-4341-9870-33a7688d0d5a",
           "x": 40,
-          "y": 332
+          "y": 330
         }
       ],
       "backgroundColor": {
@@ -1163,7 +1222,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Merriweather",
@@ -1217,15 +1276,15 @@
           "type": "text",
           "content": "<span style=\"font-weight: 400\">Good design is innovative</span>",
           "fontWeight": 700,
-          "width": 328,
-          "height": 65,
+          "width": 332,
+          "height": 60,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "5866ef82-08bf-40fa-87b2-89e2270aeda6",
           "id": "2bbf9a2d-cc99-4c08-b6d2-0662761f12bc",
-          "x": 33,
-          "y": 311
+          "x": 40,
+          "y": 318
         },
         {
           "opacity": 100,
@@ -1234,7 +1293,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Merriweather",
@@ -1288,15 +1347,16 @@
           "type": "text",
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
           "fontWeight": 400,
-          "width": 327,
-          "height": 173,
+          "width": 332,
+          "height": 170,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "0706b1b6-fc33-4e21-a9a2-64ba4507ff30",
           "id": "02a14cfc-5936-462f-a79e-ffca46c2dd7f",
-          "x": 33,
-          "y": 397
+          "x": 40,
+          "y": 394,
+          "marginOffset": 5.831000000000003
         }
       ],
       "backgroundColor": {
@@ -1346,7 +1406,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Titillium Web",
@@ -1403,15 +1463,15 @@
           "type": "text",
           "content": "<span style=\"font-weight: 900; color: rgba(0,0,0,0.15)\">Good design is innovative</span>",
           "fontWeight": 700,
-          "width": 328,
+          "width": 332,
           "height": 94,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "ae3d8b77-a89a-441e-a735-24d256ab1e3d",
           "id": "c05092f4-7822-416c-98a6-44858a1a9069",
-          "x": 37,
-          "y": 318
+          "x": 44,
+          "y": 312
         },
         {
           "opacity": 100,
@@ -1420,7 +1480,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Titillium Web",
@@ -1430,16 +1490,16 @@
             "styles": ["italic", "regular"],
             "variants": [
               [0, 200],
-              [0, 300],
-              [0, 400],
-              [0, 600],
-              [0, 700],
-              [0, 900],
               [1, 200],
+              [0, 300],
               [1, 300],
+              [0, 400],
               [1, 400],
+              [0, 600],
               [1, 600],
-              [1, 700]
+              [0, 700],
+              [1, 700],
+              [0, 900]
             ],
             "metrics": {
               "upm": 1000,
@@ -1477,15 +1537,15 @@
           "type": "text",
           "content": "<span style=\"font-weight: 900\">Good design is innovative</span>",
           "fontWeight": 700,
-          "width": 328,
-          "height": 101,
+          "width": 332,
+          "height": 93,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "2bbf9a2d-cc99-4c08-b6d2-0662761f12bc",
           "id": "ae3d8b77-a89a-441e-a735-24d256ab1e3d",
-          "x": 33,
-          "y": 314
+          "x": 40,
+          "y": 308
         },
         {
           "opacity": 100,
@@ -1494,7 +1554,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Work Sans",
@@ -1558,15 +1618,16 @@
           "type": "text",
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
           "fontWeight": 400,
-          "width": 327,
+          "width": 332,
           "height": 160,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "02a14cfc-5936-462f-a79e-ffca46c2dd7f",
           "id": "1cbbe1a0-99b7-4fac-9eb5-18dbfc50272d",
-          "x": 33,
-          "y": 414
+          "x": 40,
+          "y": 417,
+          "marginOffset": 5.5589999999999975
         }
       ],
       "backgroundColor": {
@@ -1616,7 +1677,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Nunito",
@@ -1658,7 +1719,7 @@
               "lGap": 0
             }
           },
-          "fontSize": 31,
+          "fontSize": 30,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1676,15 +1737,16 @@
           "type": "text",
           "content": "<span style=\"font-weight: 300\">Good design is innovative</span>",
           "fontWeight": 700,
-          "width": 328,
+          "width": 332,
           "height": 75,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "ae3d8b77-a89a-441e-a735-24d256ab1e3d",
           "id": "ee1c31cf-c782-4cd7-9bd9-7ebc08f01fed",
-          "x": 33,
-          "y": 305
+          "x": 40,
+          "y": 308,
+          "marginOffset": -7.920000000000002
         },
         {
           "opacity": 100,
@@ -1693,7 +1755,7 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": true,
+          "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
             "family": "Karla",
@@ -1725,7 +1787,7 @@
               "lGap": 0
             }
           },
-          "fontSize": 18,
+          "fontSize": 17,
           "backgroundColor": {
             "color": {
               "r": 196,
@@ -1743,15 +1805,16 @@
           "type": "text",
           "content": "The possibilities for innovation are not, by any means, exhausted. Technological development is always offering new opportunities for innovative design. But innovative design always develops in tandem with innovative technology, and can never be an end in itself.",
           "fontWeight": 400,
-          "width": 336,
+          "width": 332,
           "height": 179,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "1cbbe1a0-99b7-4fac-9eb5-18dbfc50272d",
           "id": "f2d01d29-e755-4634-b346-e0a2682f159d",
-          "x": 33,
-          "y": 395
+          "x": 40,
+          "y": 399,
+          "marginOffset": 5.626999999999999
         }
       ],
       "backgroundColor": {


### PR DESCRIPTION
## Summary
Adds text sets under `Editorial` category in this design file:
https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Design-System?node-id=837%3A3585

## User-facing changes
NA

## Testing Instructions
Enable the text sets flag in experiments and see the new text sets in the story editor.


---

<!-- Please reference the issue(s) this PR addresses. -->

Partial for #4078 
