### PR TITLE
KSES: Prevent more markup being stripped for users without `unfiltered_html` capabilities

### DIFF
--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -84,6 +84,8 @@ class KSES {
 			'left',
 			'transform',
 			'white-space',
+			'clip-path',
+			'-webkit-clip-path',
 		];
 
 		array_push( $attr, ...$additional );
@@ -248,6 +250,9 @@ class KSES {
 
 			'list-style',
 			'list-style-image',
+
+			'clip-path',
+			'-webkit-clip-path',
 		];
 
 		/*

--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -514,7 +514,6 @@ class KSES {
 				'preload'                    => true,
 				'rotate-to-fullscreen'       => true,
 				'src'                        => true,
-				'title'                      => true,
 			],
 			'source'                    => [
 				'type' => true,
@@ -542,7 +541,6 @@ class KSES {
 			],
 			'defs'                      => [],
 			'clippath'                  => [
-				'id'            => true,
 				'transform'     => true,
 				'clippathunits' => true,
 				'path'          => true,

--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -86,6 +86,7 @@ class KSES {
 			'white-space',
 			'clip-path',
 			'-webkit-clip-path',
+			'pointer-events',
 		];
 
 		array_push( $attr, ...$additional );

--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -514,6 +514,11 @@ class KSES {
 				'preload'                    => true,
 				'rotate-to-fullscreen'       => true,
 				'src'                        => true,
+				'title'                      => true,
+			],
+			'source'                    => [
+				'type' => true,
+				'src'  => true,
 			],
 			'img'                       => [
 				'alt'           => true,
@@ -531,21 +536,62 @@ class KSES {
 				'srcset'        => true,
 				'srcwidth'      => true,
 			],
+			'svg'                       => [
+				'width'  => true,
+				'height' => true,
+			],
+			'defs'                      => [],
+			'clippath'                  => [
+				'id'            => true,
+				'transform'     => true,
+				'clippathunits' => true,
+				'path'          => true,
+			],
+			'path'                      => [
+				'd' => true,
+			],
 		];
 
 		$allowed_tags = array_merge( $allowed_tags, $story_components );
 
-		foreach ( $allowed_tags as &$allowed_tag ) {
-			$allowed_tag['animate-in']          = true;
-			$allowed_tag['animate-in-duration'] = true;
-			$allowed_tag['animate-in-delay']    = true;
-			$allowed_tag['animate-in-after']    = true;
-			$allowed_tag['layout']              = true;
-		}
+		$allowed_tags = array_map( [ $this, 'add_global_attributes' ], $allowed_tags );
 
 		return $allowed_tags;
 	}
 
+	/**
+	 * Helper function to add global attributes to a tag in the allowed HTML list.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @see _wp_add_global_attributes
+	 *
+	 * @param array $value An array of attributes.
+	 * @return array The array of attributes with global attributes added.
+	 */
+	protected function add_global_attributes( $value ) {
+		$global_attributes = [
+			'aria-describedby'    => true,
+			'aria-details'        => true,
+			'aria-label'          => true,
+			'aria-labelledby'     => true,
+			'aria-hidden'         => true,
+			'class'               => true,
+			'id'                  => true,
+			'style'               => true,
+			'title'               => true,
+			'role'                => true,
+			'data-*'              => true,
+			'animate-in'          => true,
+			'animate-in-duration' => true,
+			'animate-in-delay'    => true,
+			'animate-in-after'    => true,
+			'animate-in-layout'   => true,
+			'layout'              => true,
+		];
+
+		return array_merge( $value, $global_attributes );
+	}
 
 	/**
 	 * Temporarily renames the style attribute to data-temp-style in full story markup.

--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -304,7 +304,7 @@ class KSES {
 
 			$parts = explode( ':', $css_item, 2 );
 
-			if ( strpos( $css_item, ':' ) === false ) {
+			if ( false === strpos( $css_item, ':' ) ) {
 				$found = true;
 			} else {
 				$css_selector = trim( $parts[0] );
@@ -336,10 +336,10 @@ class KSES {
 					if ( empty( $url ) || wp_kses_bad_protocol( $url, $allowed_protocols ) !== $url ) {
 						$found = false;
 						break;
-					} else {
-						// Remove the whole `url(*)` bit that was matched above from the CSS.
-						$css_test_string = str_replace( $url_match, '', $css_test_string );
 					}
+
+					// Remove the whole `url(*)` bit that was matched above from the CSS.
+					$css_test_string = str_replace( $url_match, '', $css_test_string );
 				}
 			}
 

--- a/tests/phpunit/tests/KSES.php
+++ b/tests/phpunit/tests/KSES.php
@@ -289,4 +289,34 @@ class KSES extends \WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Testing the filter_kses_allowed_html() method.
+	 *
+	 * @dataProvider data_test_filter_kses_allowed_html
+	 * @covers ::filter_kses_allowed_html
+	 *
+	 * @param string $html     HTML string.
+	 * @param string $expected Expected output.
+	 */
+	public function test_filter_kses_allowed_html( $html, $expected ) {
+		$kses = new \Google\Web_Stories\KSES();
+		add_filter( 'wp_kses_allowed_html', [ $kses, 'filter_kses_allowed_html' ] );
+
+		$this->assertSame( $expected, wp_unslash( wp_filter_post_kses( $html ) ) );
+		remove_filter( 'wp_kses_allowed_html', [ $kses, 'filter_kses_allowed_html' ] );
+	}
+
+	public function data_test_filter_kses_allowed_html() {
+		return [
+			'Video Element' => [
+				'<amp-video autoplay="autoplay" poster="https://example.com/poster.png" artwork="https://example.com/poster.png" title="Some Video" alt="Some Video" layout="fill" id="foo"><source type="video/mp4" src="https://example.com/video.mp4"></source></amp-video>',
+				'<amp-video autoplay="autoplay" poster="https://example.com/poster.png" artwork="https://example.com/poster.png" title="Some Video" alt="Some Video" layout="fill" id="foo"><source type="video/mp4" src="https://example.com/video.mp4"></source></amp-video>',
+			],
+			'Masking'       => [
+				'<svg width="0" height="0"><defs><clippath id="mask-foo" transform="scale(1 1)" clippathunits="objectBoundingBox"><path d="M 0.5 0 C 0.777344 0 1 0.222656 1 0.5 C 1 0.777344 0.777344 1 0.5 1 C 0.222656 1 0 0.777344 0 0.5 C 0 0.222656 0.222656 0 0.5 0 Z"></path></clippath></defs></svg></div>',
+				'<svg width="0" height="0"><defs><clippath id="mask-foo" transform="scale(1 1)" clippathunits="objectBoundingBox"><path d="M 0.5 0 C 0.777344 0 1 0.222656 1 0.5 C 1 0.777344 0.777344 1 0.5 1 C 0.222656 1 0 0.777344 0 0.5 C 0 0.222656 0.222656 0 0.5 0 Z"></path></clippath></defs></svg></div>',
+			],
+		];
+	}
 }

--- a/tests/phpunit/tests/KSES.php
+++ b/tests/phpunit/tests/KSES.php
@@ -279,6 +279,11 @@ class KSES extends \WP_UnitTestCase {
 				'css'      => '-webkit-clip-path:url(#mask-circle-foo-bar)',
 				'expected' => '-webkit-clip-path:url(#mask-circle-foo-bar)',
 			],
+			// Pointer events.
+			[
+				'css'      => 'pointer-events: initial',
+				'expected' => 'pointer-events: initial',
+			],
 		];
 	}
 }

--- a/tests/phpunit/tests/KSES.php
+++ b/tests/phpunit/tests/KSES.php
@@ -270,6 +270,15 @@ class KSES extends \WP_UnitTestCase {
 				'css'      => 'background-color:rgba(255,255,255,0.6);',
 				'expected' => 'background-color:rgba(255,255,255,0.6)',
 			],
+			// CSS clip paths.
+			[
+				'css'      => 'clip-path:url(#mask-circle-foo-bar)',
+				'expected' => 'clip-path:url(#mask-circle-foo-bar)',
+			],
+			[
+				'css'      => '-webkit-clip-path:url(#mask-circle-foo-bar)',
+				'expected' => '-webkit-clip-path:url(#mask-circle-foo-bar)',
+			],
 		];
 	}
 }

--- a/tests/phpunit/tests/KSES.php
+++ b/tests/phpunit/tests/KSES.php
@@ -295,6 +295,7 @@ class KSES extends \WP_UnitTestCase {
 	 *
 	 * @dataProvider data_test_filter_kses_allowed_html
 	 * @covers ::filter_kses_allowed_html
+	 * @covers ::add_global_attributes
 	 *
 	 * @param string $html     HTML string.
 	 * @param string $expected Expected output.
@@ -309,13 +310,33 @@ class KSES extends \WP_UnitTestCase {
 
 	public function data_test_filter_kses_allowed_html() {
 		return [
-			'Video Element' => [
+			'Video Element'     => [
 				'<amp-video autoplay="autoplay" poster="https://example.com/poster.png" artwork="https://example.com/poster.png" title="Some Video" alt="Some Video" layout="fill" id="foo"><source type="video/mp4" src="https://example.com/video.mp4"></source></amp-video>',
 				'<amp-video autoplay="autoplay" poster="https://example.com/poster.png" artwork="https://example.com/poster.png" title="Some Video" alt="Some Video" layout="fill" id="foo"><source type="video/mp4" src="https://example.com/video.mp4"></source></amp-video>',
 			],
-			'Masking'       => [
+			'Masking'           => [
 				'<svg width="0" height="0"><defs><clippath id="mask-foo" transform="scale(1 1)" clippathunits="objectBoundingBox"><path d="M 0.5 0 C 0.777344 0 1 0.222656 1 0.5 C 1 0.777344 0.777344 1 0.5 1 C 0.222656 1 0 0.777344 0 0.5 C 0 0.222656 0.222656 0 0.5 0 Z"></path></clippath></defs></svg></div>',
 				'<svg width="0" height="0"><defs><clippath id="mask-foo" transform="scale(1 1)" clippathunits="objectBoundingBox"><path d="M 0.5 0 C 0.777344 0 1 0.222656 1 0.5 C 1 0.777344 0.777344 1 0.5 1 C 0.222656 1 0 0.777344 0 0.5 C 0 0.222656 0.222656 0 0.5 0 Z"></path></clippath></defs></svg></div>',
+			],
+			'ARIA Roles'        => [
+				'<div aria-describedby="foo"></div><div aria-details="bar"></div><div aria-label="Hello World"></div><div aria-labelledby="foo bar baz"></div><div aria-hidden="true"></div>',
+				'<div aria-describedby="foo"></div><div aria-details="bar"></div><div aria-label="Hello World"></div><div aria-labelledby="foo bar baz"></div><div aria-hidden="true"></div>',
+			],
+			'Global Attributes' => [
+				'<div class="foo" id="bar" style="color: pink" role="main" title="Test"></div>',
+				'<div class="foo" id="bar" style="color: pink" role="main" title="Test"></div>',
+			],
+			'Data Attributes'   => [
+				'<a href="https://example.com" data-vars-tooltip-click-id="link1" data-vars-tooltip-href="example.com"></a>',
+				'<a href="https://example.com" data-vars-tooltip-click-id="link1" data-vars-tooltip-href="example.com"></a>',
+			],
+			'AMP Layout'        => [
+				'<amp-img layout="fill" src="https://example.com/image.png" />',
+				'<amp-img layout="fill" src="https://example.com/image.png" />',
+			],
+			'AMP Animations'    => [
+				'<p id="foo" animate-in="fly-in-left" animate-in-delay="0.3s" animate-in-duration="0.5s" animate-in-layout="nodisplay">Hello World</p><p id="bar" animate-in="fade-in" animate-in-after="foo">Hello World</p>',
+				'<p id="foo" animate-in="fly-in-left" animate-in-delay="0.3s" animate-in-duration="0.5s" animate-in-layout="nodisplay">Hello World</p><p id="bar" animate-in="fade-in" animate-in-after="foo">Hello World</p>',
 			],
 		];
 	}

--- a/tests/phpunit/tests/KSES.php
+++ b/tests/phpunit/tests/KSES.php
@@ -17,13 +17,15 @@
 
 namespace Google\Web_Stories\Tests;
 
-use WP_REST_Request;
-
+/**
+ * @coversDefaultClass \Google\Web_Stories\KSES
+ */
 class KSES extends \WP_UnitTestCase {
 	/**
 	 * Testing the safecss_filter_attr() function.
 	 *
 	 * @dataProvider data_test_safecss_filter_attr
+	 * @covers ::safecss_filter_attr
 	 *
 	 * @param string $css      A string of CSS rules.
 	 * @param string $expected Expected string of CSS rules.
@@ -38,6 +40,7 @@ class KSES extends \WP_UnitTestCase {
 	 *
 	 * @dataProvider data_test_safecss_filter_attr
 	 * @dataProvider data_test_safecss_filter_attr_extended
+	 * @covers ::safecss_filter_attr
 	 *
 	 * @param string $css      A string of CSS rules.
 	 * @param string $expected Expected string of CSS rules.


### PR DESCRIPTION
## Summary

The default HTML and sanitization in WordPress is very strict.

Our plugin extends it a little bit, but it hasn't kept up with some of our newest developments like masking.

This caused video sources and SVGs to be (partially) stripped.

## Relevant Technical Choices

* Extends HTML element & CSS attribute filters

## To-do

* E2E Tests with Percy snapshots could be a nice addition.

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Publish a story as an author or another user without `unfiltered_html` capabilities
1. Verify that no markup is being stripped and the frontend  output looks and works as expected.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
