### PR TITLE
Dashboard: Some style tweaks mostly surrounding spacing

### DIFF
--- a/assets/src/dashboard/app/views/exploreTemplates/content/emptyView.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/emptyView.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 /**
  * WordPress dependencies
@@ -28,14 +29,20 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { NoResults } from '../../shared';
-import { DefaultParagraph1 } from '../../../../components';
+import {
+  DefaultParagraph1,
+  StandardViewContentGutter,
+} from '../../../../components';
 
+const Text = styled(DefaultParagraph1)`
+  margin-top: 40px;
+`;
 function EmptyView({ searchKeyword }) {
   if (!searchKeyword) {
     return (
-      <DefaultParagraph1>
-        {__('No templates currently available', 'web-stories')}
-      </DefaultParagraph1>
+      <StandardViewContentGutter>
+        <Text>{__('No templates currently available', 'web-stories')}</Text>
+      </StandardViewContentGutter>
     );
   }
   return <NoResults typeaheadValue={searchKeyword} />;

--- a/assets/src/dashboard/app/views/myStories/content/emptyView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/emptyView/index.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 /**
  * WordPress dependencies
@@ -27,15 +28,22 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { DefaultParagraph1 } from '../../../../../components';
+import {
+  DefaultParagraph1,
+  StandardViewContentGutter,
+} from '../../../../../components';
 import { NoResults } from '../../../shared';
+
+const Text = styled(DefaultParagraph1)`
+  margin-top: 40px;
+`;
 
 function EmptyView({ searchKeyword }) {
   if (!searchKeyword) {
     return (
-      <DefaultParagraph1>
-        {__('Create a story to get started!', 'web-stories')}
-      </DefaultParagraph1>
+      <StandardViewContentGutter>
+        <Text> {__('Create a story to get started!', 'web-stories')}</Text>
+      </StandardViewContentGutter>
     );
   }
   return <NoResults typeaheadValue={searchKeyword} />;

--- a/assets/src/dashboard/app/views/shared/bodyViewOptions.js
+++ b/assets/src/dashboard/app/views/shared/bodyViewOptions.js
@@ -43,6 +43,7 @@ const DisplayFormatContainer = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-top: -10px;
 `;
 
 const StorySortDropdownContainer = styled.div`

--- a/assets/src/dashboard/app/views/shared/noResults.js
+++ b/assets/src/dashboard/app/views/shared/noResults.js
@@ -15,28 +15,38 @@
  */
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-
-/**
  * Internal dependencies
  */
-import { DefaultParagraph1 } from '../../../components';
+import {
+  DefaultParagraph1,
+  StandardViewContentGutter,
+} from '../../../components';
+
+const Text = styled(DefaultParagraph1)`
+  margin-top: 40px;
+`;
 
 const NoResults = ({ typeaheadValue }) => (
-  <DefaultParagraph1>
-    {sprintf(
-      /* translators: %s: search term. */
-      __('Sorry, we couldn\'t find any results matching "%s"', 'web-stories'),
-      typeaheadValue
-    )}
-  </DefaultParagraph1>
+  <StandardViewContentGutter>
+    <Text>
+      {sprintf(
+        /* translators: %s: search term. */
+        __('Sorry, we couldn\'t find any results matching "%s"', 'web-stories'),
+        typeaheadValue
+      )}
+    </Text>
+  </StandardViewContentGutter>
 );
 
 NoResults.propTypes = {

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -40,11 +40,11 @@ const StyledHeader = styled.h2`
   justify-content: flex-start;
   align-items: center;
   line-height: 1;
-  font-size: ${cssLerp('30px', '18px', '--squish-progress')};
+  font-size: ${cssLerp('36px', '30px', '--squish-progress')};
   white-space: nowrap;
 
   @media ${({ theme }) => theme.breakpoint.tablet} {
-    font-size: ${cssLerp('20px', '14px', '--squish-progress')};
+    font-size: ${cssLerp('30px', '24px', '--squish-progress')};
   }
 `;
 

--- a/assets/src/dashboard/components/cardGallery/components.js
+++ b/assets/src/dashboard/components/cardGallery/components.js
@@ -110,7 +110,6 @@ export const ActiveCard = styled.div(
     overflow: hidden;
     height: ${containerHeight}px;
     border: ${theme.borders.gray75};
-    box-shadow: ${theme.storyPreview.shadow};
   `
 );
 ActiveCard.propTypes = {

--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -33,7 +33,7 @@ const DashboardGrid = styled.div(
   display: grid;
   width: 100%;
   grid-column-gap: ${theme.grid.columnGap.desktop}px;
-  grid-row-gap: 20px;
+  grid-row-gap: 80px;
   grid-template-columns:
     repeat(auto-fill, ${columnWidth}px);
   grid-template-rows: minmax(${columnHeight}px, auto);

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -43,7 +43,6 @@ const PreviewPane = styled.div`
   position: relative;
   border-radius: ${({ theme }) => theme.storyPreview.borderRadius}px;
   height: ${({ cardSize }) => `${cardSize.containerHeight}px`};
-  box-shadow: ${({ theme }) => theme.storyPreview.shadow};
   border: ${({ theme }) => theme.borders.gray75};
   width: 100%;
   overflow: hidden;

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -33,13 +33,7 @@ import { BEZIER } from '../../../animation';
 import { trackEvent } from '../../../tracking';
 import { useConfig } from '../../app/config';
 import { resolveRoute, useRouteHistory } from '../../app/router';
-import {
-  BUTTON_TYPES,
-  primaryPaths,
-  secondaryPaths,
-  Z_INDEX,
-  APP_ROUTES,
-} from '../../constants';
+import { BUTTON_TYPES, primaryPaths, Z_INDEX } from '../../constants';
 import { DASHBOARD_LEFT_NAV_WIDTH } from '../../constants/pageStructure';
 import { ReactComponent as WebStoriesLogo } from '../../images/webStoriesFullLogo.svg';
 import useFocusOut from '../../utils/useFocusOut';
@@ -47,11 +41,11 @@ import { useNavContext } from '../navProvider';
 import {
   AppInfo,
   Content,
+  Header,
   NavButton,
   NavLink,
   NavList,
   NavListItem,
-  Rule,
 } from './navigationComponents';
 
 export const AppFrame = styled.div`
@@ -105,7 +99,6 @@ export function LeftRail() {
   const upperContentRef = useRef(null);
 
   const enableInProgressViews = useFeature('enableInProgressViews');
-  const enableSettingsViews = useFeature('enableSettingsView');
 
   const {
     state: { sideBarVisible },
@@ -131,19 +124,6 @@ export function LeftRail() {
     }
     return primaryPaths.filter((path) => !path.inProgress);
   }, [enableInProgressViews]);
-
-  const enabledSecondaryPaths = useMemo(() => {
-    let copyOfSecondaryPaths = enableSettingsViews
-      ? [...secondaryPaths]
-      : secondaryPaths.filter(
-          (path) => !path.value.includes(APP_ROUTES.EDITOR_SETTINGS)
-        );
-
-    if (enableInProgressViews) {
-      return copyOfSecondaryPaths;
-    }
-    return copyOfSecondaryPaths.filter((path) => !path.inProgress);
-  }, [enableInProgressViews, enableSettingsViews]);
 
   const handleSideBarClose = useCallback(() => {
     if (sideBarVisible) {
@@ -173,9 +153,9 @@ export function LeftRail() {
       aria-label={__('Main dashboard navigation', 'web-stories')}
     >
       <div ref={upperContentRef}>
-        <Content>
+        <Header>
           <WebStoriesLogo title={__('Web Stories', 'web-stories')} />
-        </Content>
+        </Header>
         <Content>
           <NavButton
             type={BUTTON_TYPES.CTA}
@@ -200,29 +180,13 @@ export function LeftRail() {
             ))}
           </NavList>
         </Content>
-        <Rule />
-        <Content>
-          <NavList>
-            {enabledSecondaryPaths.map((path) => (
-              <NavListItem key={path.value}>
-                <NavLink
-                  active={path.value === state.currentPath}
-                  href={resolveRoute(path.value)}
-                >
-                  {path.label}
-                </NavLink>
-              </NavListItem>
-            ))}
-          </NavList>
-        </Content>
       </div>
       <Content>
         <AppInfo>
-          {sprintf('\u00A9 %s Google', new Date().getFullYear())}
-          <br />
           {sprintf(
-            /* translators: %s: editor version. */
-            __('Version %s', 'web-stories'),
+            /* translators: %s: Current Year, %v: App Version */
+            __('\u00A9 %s Google Version %v', 'web-stories'),
+            new Date().getFullYear(),
             version
           )}
         </AppInfo>

--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -33,13 +33,32 @@ export const Content = styled.div`
     margin: 20px;
   }
   & > svg {
+    margin: 0;
     max-width: 100%;
+    height: 64px;
   }
+`;
+
+export const Header = styled(Content)`
+  margin-top: 42px;
+  margin-bottom: 72px;
 `;
 
 export const NavButton = styled(Button)`
   margin-bottom: 0;
   margin-top: 0;
+  background-color: ${({ theme }) => theme.colors.foreground.gray12};
+  color: ${({ theme }) => theme.colors.black};
+  border-radius: 4px;
+  border-color: ${({ theme }) => theme.colors.foreground.gray12};
+  height: 36px;
+
+  &:hover,
+  &:focus,
+  &:focus-within {
+    background-color: ${({ theme }) => theme.colors.foreground.gray16};
+    color: ${({ theme }) => theme.colors.black};
+  }
 `;
 
 export const NavList = styled.ul`
@@ -72,14 +91,6 @@ export const NavLink = styled.a`
     }
   `}
 `;
-
-export const Rule = styled.div(
-  ({ theme }) => `
-    height: 1px;
-    margin-left: 20px;
-    background-color: ${theme.colors.gray50};
-  `
-);
 
 export const AppInfo = styled.div`
   ${TypographyPresets.ExtraSmall};

--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -30,11 +30,10 @@ export const Content = styled.div`
   flex-direction: column;
   margin: 20px 0;
   > * {
-    margin: 20px;
+    margin: 20px 28px;
   }
   & > svg {
-    margin: 0;
-    max-width: 100%;
+    margin: 0 28px;
     height: 64px;
   }
 `;
@@ -42,6 +41,7 @@ export const Content = styled.div`
 export const Header = styled(Content)`
   margin-top: 42px;
   margin-bottom: 72px;
+  align-items: flex-start;
 `;
 
 export const NavButton = styled(Button)`
@@ -76,7 +76,7 @@ export const NavLink = styled.a`
   ${TypographyPresets.Medium};
   ${({ theme, active }) => `
     display: block;
-    padding: 4px 20px;
+    padding: 4px 28px;
     margin: 4px 0;
     font-weight: ${theme.typography.weight[active ? 'bold' : 'normal']};
     text-decoration: none;

--- a/assets/src/dashboard/components/typography/index.js
+++ b/assets/src/dashboard/components/typography/index.js
@@ -91,7 +91,6 @@ export const Paragraph1 = styled.p(Medium);
 
 export const DefaultParagraph1 = styled(Paragraph1)`
   color: ${({ theme }) => theme.colors.gray200};
-  margin: 40px 20px;
 `;
 
 export const Paragraph2 = styled.p(Small);

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -80,9 +80,6 @@ export const primaryPaths = [
     value: APP_ROUTES.TEMPLATES_GALLERY,
     label: ROUTE_TITLES[APP_ROUTES.TEMPLATES_GALLERY],
   },
-];
-
-export const secondaryPaths = [
   {
     value: APP_ROUTES.EDITOR_SETTINGS,
     label: ROUTE_TITLES[APP_ROUTES.EDITOR_SETTINGS],

--- a/assets/src/dashboard/constants/pageStructure.js
+++ b/assets/src/dashboard/constants/pageStructure.js
@@ -26,6 +26,6 @@ export {
 
 export const WPBODY_ID = 'wpbody';
 
-export const DASHBOARD_LEFT_NAV_WIDTH = 190;
+export const DASHBOARD_LEFT_NAV_WIDTH = 288;
 export const DASHBOARD_TOP_MARGIN = 45;
 export const DEFAULT_DASHBOARD_TOP_SPACE = 10;

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -238,8 +238,8 @@ const theme = {
   },
   grid: {
     columnGap: {
-      desktop: 10,
-      tablet: 10,
+      desktop: 20,
+      tablet: 20,
       largeDisplayPhone: 10,
       smallDisplayPhone: 10,
       min: 10,

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -230,8 +230,8 @@ const theme = {
     min: 10,
   },
   standardViewContentGutter: {
-    desktop: 20,
-    tablet: 20,
+    desktop: 52,
+    tablet: 52,
     largeDisplayPhone: 10,
     smallDisplayPhone: 10,
     min: 10,

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -146,7 +146,6 @@ const theme = {
     shadow: '0px 2px 8px rgba(0, 0, 0, 0.17)',
   },
   storyPreview: {
-    shadow: '1px 1px 5px hsla(0, 0%, 0%, 0.15)',
     borderRadius: 4,
   },
   tooltip: {

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -135,7 +135,7 @@ const theme = {
     borderRadius: 100,
   },
   formatContainer: {
-    height: 44,
+    height: 76,
   },
   expandedTypeahead: {
     borderRadius: 8,

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -246,11 +246,11 @@ const theme = {
     },
   },
   previewWidth: {
-    desktop: 221,
-    tablet: 189,
-    largeDisplayPhone: 162,
-    smallDisplayPhone: 185,
-    min: 139,
+    desktop: 232,
+    tablet: 200,
+    largeDisplayPhone: 173,
+    smallDisplayPhone: 200,
+    min: 152,
     thumbnail: 33,
   },
   breakpoint: {

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -74,6 +74,12 @@ const colors = {
   // todo
   placeholder: '#d9dbdd',
   storyPreviewBackground: '#202125',
+
+  foreground: {
+    gray24: '#A1A09B',
+    gray16: '#D1D1CC',
+    gray12: '#E8E8E8', // bonus shade added for side nav create story button
+  },
 };
 
 const borders = {


### PR DESCRIPTION
## Summary
Sam and I were chatting today and she asked if we could make these changes to hold over until the new designs are ready to get implemented. Changes are listed below on user facing changes. 

**Updated My Stories** 
![Screen Shot 2020-09-18 at 3 08 06 PM](https://user-images.githubusercontent.com/10720454/93650339-184f2380-f9c3-11ea-81af-a13ffca229d5.png)
**Old My Stories** 
![Screen Shot 2020-09-18 at 3 08 44 PM](https://user-images.githubusercontent.com/10720454/93650342-18e7ba00-f9c3-11ea-8a7d-6183e8212f73.png)

**Updated Explore Templates** 
![Screen Shot 2020-09-18 at 3 08 28 PM](https://user-images.githubusercontent.com/10720454/93650341-184f2380-f9c3-11ea-90e5-f016aeafde03.png)
**Old Explore Templates** 
![Screen Shot 2020-09-18 at 3 08 55 PM](https://user-images.githubusercontent.com/10720454/93650328-138a6f80-f9c3-11ea-9860-4f74de808aca.png)


## Relevant Technical Choices
- Opted for some duplication of code instead of a new shared component for the empty grid text messages (search or when there's nothing there to show by default). Thought this was easier to read for now, we can clean up this as 1 shared bodyTextMessage component or something like that on it's own - wanted to keep code separate for PR sake. 
- Condenses left nav paths to 1 object, Sam requested that the nav items all be together (instead of the secondary pushed to the bottom), so it really didn't make sense anymore for those to be separated anymore.`primaryPaths` could probably be renamed in a follow up pr to clean up. 
- Removed the check for the settings flag in the side nav since settings is flipped totally on at this point.
- Added a few of the new theme colors to the dashboard, kept the same structure as the design library adds are (last I saw) to eventually map/share a theme. 

## To-do

- Follow up PR to consolidate grid message text components 
- Rest of dashboard design will follow at a later date. 

## User-facing changes

- Main header font size is updated from 30px (start of squish) 18px (end of squish) to 36px (start of squish) 30px (end of squish, in line with figma)
- Removes box shadow from card grids (my stories, templates, template detail active card) 
- Updates grid row gap from 20px to 80px and grid column gap from 10px to 20px
- Aligns side nav content in 1 straight left align ( 28px from edge of dashboard space) 
- Copyright and app version on same line in side nav 
- white space adjusted in side nav to give logo breathing room
- "create story" button in side nav colors and border radius changed (gray and 4px instead of 8px) so that it doesn't compete with logo 
-  Side nav is now 288px wide instead of 190px 
-  Content gutters increased from 20px to 52px 
-  Increases story preview size for grid items, uses desktop width in figma of 232px to adjust for desktop, tablet, etc. 

## Testing Instructions

- Verify the above visual changes. I used this as reference: https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories---Stable-Release?node-id=2%3A91986 however measurements adjusted should be divisible by 4, some of these in here are not divisible by 4px, so diverted from it as necessary. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4549 
