### PR TITLE
Added plain text paste handler

### DIFF
--- a/assets/src/edit-story/components/richText/editor.js
+++ b/assets/src/edit-story/components/richText/editor.js
@@ -37,6 +37,7 @@ function RichTextEditor({ content, onChange }, ref) {
       updateEditorState,
       getHandleKeyCommand,
       getContentFromState,
+      handlePastedText,
       clearState,
     },
   } = useRichText();
@@ -85,6 +86,7 @@ function RichTextEditor({ content, onChange }, ref) {
       onChange={updateEditorState}
       editorState={editorState}
       handleKeyCommand={handleKeyCommand}
+      handlePastedText={handlePastedText}
       customStyleFn={customInlineDisplay}
       stripPastedStyles
     />

--- a/assets/src/edit-story/components/richText/karma/inlineSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/inlineSelection.karma.js
@@ -370,4 +370,48 @@ describe('CUJ: Creator can Add and Write Text: Select an individual word to edit
       expect(getDisplayTextStyles().lineHeight).not.toBe(initialLineHeight);
     });
   });
+
+  describe('when copy-pasting', () => {
+    beforeEach(async () => {
+      // Enter edit-mode
+      await data.fixture.events.keyboard.press('Enter');
+
+      // Select everything and make bold
+      await setSelection(0, 17);
+      const { bold } = data.fixture.editor.inspector.designPanel.textStyle;
+      await data.fixture.events.click(bold.button);
+    });
+
+    it('should paste and match styles on collapsed selection', async () => {
+      // Select nothing and paste
+      await setSelection(12, 12);
+      await data.fixture.events.clipboard.pastePlain(' extra');
+
+      // Exit edit-mode
+      await data.fixture.events.keyboard.press('Escape');
+
+      // Expect text content to have style and content
+      expect(getTextContent()).toBe(
+        '<span style="font-weight: 700">Fill in some extra text</span>'
+      );
+
+      await data.fixture.snapshot('Pasting between text');
+    });
+
+    it('should paste and match styles on non-empty selection', async () => {
+      // Select "some" and paste
+      await setSelection(8, 12);
+      await data.fixture.events.clipboard.pastePlain('extra');
+
+      // Exit edit-mode
+      await data.fixture.events.keyboard.press('Escape');
+
+      // Expect text content to have style and content
+      expect(getTextContent()).toBe(
+        '<span style="font-weight: 700">Fill in extra text</span>'
+      );
+
+      await data.fixture.snapshot('Pasting and replacing text');
+    });
+  });
 });

--- a/assets/src/edit-story/components/richText/provider.js
+++ b/assets/src/edit-story/components/richText/provider.js
@@ -36,6 +36,7 @@ import getStateInfo from './getStateInfo';
 import { useFauxSelection } from './fauxSelection';
 import customImport from './customImport';
 import customExport from './customExport';
+import useHandlePastedText from './useHandlePastedText';
 import useSelectionManipulation from './useSelectionManipulation';
 
 function RichTextProvider({ children }) {
@@ -105,6 +106,8 @@ function RichTextProvider({ children }) {
     [updateEditorState]
   );
 
+  const handlePastedText = useHandlePastedText(setEditorState);
+
   const clearState = useCallback(() => {
     setEditorState(null);
   }, [setEditorState]);
@@ -126,6 +129,7 @@ function RichTextProvider({ children }) {
       setStateFromContent,
       updateEditorState,
       getHandleKeyCommand,
+      handlePastedText,
       clearState,
       selectionActions,
       // These actually don't work on the state at all, just pure functions

--- a/assets/src/edit-story/components/richText/useHandlePastedText.js
+++ b/assets/src/edit-story/components/richText/useHandlePastedText.js
@@ -18,19 +18,23 @@
  * External dependencies
  */
 import { EditorState, Modifier } from 'draft-js';
+import { useCallback } from 'react';
 
 function useHandlePastedText(setEditorState) {
-  return (text, html, editorState) => {
-    // TODO: handle pasted html content
-    // https://github.com/google/web-stories-wp/issues/760
-    const content = editorState.getCurrentContent();
-    const selection = editorState.getSelection();
-    const style = editorState.getCurrentInlineStyle();
-    const newState = Modifier.replaceText(content, selection, text, style);
-    const result = EditorState.push(editorState, newState, 'insert-characters');
-    setEditorState(result);
-    return true;
-  };
+  return useCallback(
+    (text, html, state) => {
+      // TODO: handle pasted html content
+      // https://github.com/google/web-stories-wp/issues/760
+      const content = state.getCurrentContent();
+      const selection = state.getSelection();
+      const style = state.getCurrentInlineStyle();
+      const newState = Modifier.replaceText(content, selection, text, style);
+      const result = EditorState.push(state, newState, 'insert-characters');
+      setEditorState(result);
+      return true;
+    },
+    [setEditorState]
+  );
 }
 
 export default useHandlePastedText;

--- a/assets/src/edit-story/components/richText/useHandlePastedText.js
+++ b/assets/src/edit-story/components/richText/useHandlePastedText.js
@@ -21,6 +21,8 @@ import { EditorState, Modifier } from 'draft-js';
 
 function useHandlePastedText(setEditorState) {
   return (text, html, editorState) => {
+    // TODO: handle pasted html content
+    // https://github.com/google/web-stories-wp/issues/760
     const content = editorState.getCurrentContent();
     const selection = editorState.getSelection();
     const style = editorState.getCurrentInlineStyle();

--- a/assets/src/edit-story/components/richText/useHandlePastedText.js
+++ b/assets/src/edit-story/components/richText/useHandlePastedText.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { EditorState, Modifier } from 'draft-js';
+
+function useHandlePastedText(setEditorState) {
+  return (text, html, editorState) => {
+    const content = editorState.getCurrentContent();
+    const selection = editorState.getSelection();
+    const style = editorState.getCurrentInlineStyle();
+    const newState = Modifier.replaceText(content, selection, text, style);
+    const result = EditorState.push(editorState, newState, 'insert-characters');
+    setEditorState(result);
+    return true;
+  };
+}
+
+export default useHandlePastedText;

--- a/karma/fixture/events.js
+++ b/karma/fixture/events.js
@@ -496,6 +496,32 @@ class Clipboard {
   paste() {
     return this._act(() => karmaPuppeteer.clipboard.paste());
   }
+
+  /**
+   * Paste plain text by sending fake event to current target
+   *
+   * @param {string} plainText Plain-text string to paste
+   */
+  pastePlain(plainText) {
+    const pasteEvent = Object.assign(
+      new Event('paste', { bubbles: true, cancelable: true }),
+      {
+        clipboardData: {
+          types: ['text/plain'],
+          items: {
+            length: 1,
+            0: {
+              kind: 'string',
+              type: 'text/plain',
+              getAsString: () => plainText,
+            },
+          },
+          getData: () => plainText,
+        },
+      }
+    );
+    document.activeElement.dispatchEvent(pasteEvent);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Custom handling of pasted (plain text) content.

Note that this ignores formatted content. That work is still pending in #760.

## Testing Instructions

1. Make a text box
1. Change the text color
1. Double click and place the cursor somewhere inside the text without selecting anything
1. Paste some content and observe text color is preserved and text is correctly inserted
1. Select everything and paste some other content.
1. Observe that formatting is preserved and text is correctly replaced

NB: Note that rich text formatting is ignored in pasted content. The content is pasted to match the style of the text field, not the original formatting from where it was pasted.


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1605
