### PR TITLE
Story Editor: Preset Panel Height & Collapse Persistence

### DIFF
--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -45,16 +45,17 @@ function Panel({
   initialHeight = null,
   ariaLabel = null,
   ariaHidden = false,
-  persistenceKey,
+  isPersisted,
 }) {
   const persisted = useMemo(() => {
-    const stored = localStorage.getItem(
-      `${LOCAL_STORAGE_PREFIX}:${persistenceKey}`
-    );
+    if (!isPersisted) {
+      return null;
+    }
+    const stored = localStorage.getItem(`${LOCAL_STORAGE_PREFIX}:${name}`);
     return stored && JSON.parse(stored);
-  }, [persistenceKey]);
+  }, [name, isPersisted]);
   const [isCollapsed, setIsCollapsed] = useState(
-    persisted?.isCollapsed || false
+    Boolean(persisted?.isCollapsed)
   );
   const [expandToHeight, setExpandToHeight] = useState(
     persisted?.expandToHeight || initialHeight
@@ -65,18 +66,18 @@ function Panel({
 
   // If supplied with a persistance key, persist height & collapsed state
   useEffect(() => {
-    if (!persistenceKey) {
+    if (!isPersisted) {
       return;
     }
     localStorage.setItem(
-      `${LOCAL_STORAGE_PREFIX}:${persistenceKey}`,
+      `${LOCAL_STORAGE_PREFIX}:${name}`,
       JSON.stringify({
         height,
         isCollapsed,
         expandToHeight,
       })
     );
-  }, [height, isCollapsed, expandToHeight, persistenceKey]);
+  }, [height, isCollapsed, expandToHeight, isPersisted, name]);
 
   const confirmTitle = useCallback(() => setHasTitle(true), []);
 
@@ -192,7 +193,7 @@ Panel.propTypes = {
   canCollapse: PropTypes.bool,
   ariaLabel: PropTypes.string,
   ariaHidden: PropTypes.bool,
-  persistenceKey: PropTypes.string,
+  isPersisted: PropTypes.bool,
 };
 
 export default Panel;

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -49,8 +49,7 @@ function Panel({
     let parsed = null;
     try {
       const stored = localStorage.getItem(
-        `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`,
-        'null'
+        `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`
       );
       parsed = JSON.parse(stored);
     } catch (e) {

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -25,6 +25,7 @@ import { useState, useCallback, useEffect, useMemo } from 'react';
 /**
  * Internal dependencies
  */
+import { LOCAL_STORAGE_PREFIX } from '../../../constants';
 import panelContext from './context';
 
 export const PANEL_COLLAPSED_THRESHOLD = 10;
@@ -34,8 +35,6 @@ const Wrapper = styled.section`
   flex-direction: column;
   position: relative;
 `;
-
-const LOCAL_STORAGE_PREFIX = 'web_stories_ui_settings';
 
 function Panel({
   name,
@@ -47,7 +46,9 @@ function Panel({
   ariaHidden = false,
 }) {
   const persisted = useMemo(() => {
-    const stored = localStorage.getItem(`${LOCAL_STORAGE_PREFIX}:${name}`);
+    const stored = localStorage.getItem(
+      `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`
+    );
     return stored && JSON.parse(stored);
   }, [name]);
   const [isCollapsed, setIsCollapsed] = useState(
@@ -63,7 +64,7 @@ function Panel({
   // If supplied with a persistance key, persist height & collapsed state
   useEffect(() => {
     localStorage.setItem(
-      `${LOCAL_STORAGE_PREFIX}:${name}`,
+      `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`,
       JSON.stringify({
         height,
         isCollapsed,

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -45,14 +45,14 @@ function Panel({
   initialHeight = null,
   ariaLabel = null,
   ariaHidden = false,
-  persistanceKey,
+  persistenceKey,
 }) {
   const persisted = useMemo(() => {
     const stored = localStorage.getItem(
-      `${LOCAL_STORAGE_PREFIX}:${persistanceKey}`
+      `${LOCAL_STORAGE_PREFIX}:${persistenceKey}`
     );
     return stored && JSON.parse(stored);
-  }, [persistanceKey]);
+  }, [persistenceKey]);
   const [isCollapsed, setIsCollapsed] = useState(
     persisted?.isCollapsed || false
   );
@@ -65,18 +65,18 @@ function Panel({
 
   // If supplied with a persistance key, persist height & collapsed state
   useEffect(() => {
-    if (!persistanceKey) {
+    if (!persistenceKey) {
       return;
     }
     localStorage.setItem(
-      `${LOCAL_STORAGE_PREFIX}:${persistanceKey}`,
+      `${LOCAL_STORAGE_PREFIX}:${persistenceKey}`,
       JSON.stringify({
         height,
         isCollapsed,
         expandToHeight,
       })
     );
-  }, [height, isCollapsed, expandToHeight, persistanceKey]);
+  }, [height, isCollapsed, expandToHeight, persistenceKey]);
 
   const confirmTitle = useCallback(() => setHasTitle(true), []);
 
@@ -192,7 +192,7 @@ Panel.propTypes = {
   canCollapse: PropTypes.bool,
   ariaLabel: PropTypes.string,
   ariaHidden: PropTypes.bool,
-  persistanceKey: PropTypes.string,
+  persistenceKey: PropTypes.string,
 };
 
 export default Panel;

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -45,15 +45,11 @@ function Panel({
   initialHeight = null,
   ariaLabel = null,
   ariaHidden = false,
-  isPersisted,
 }) {
   const persisted = useMemo(() => {
-    if (!isPersisted) {
-      return null;
-    }
     const stored = localStorage.getItem(`${LOCAL_STORAGE_PREFIX}:${name}`);
     return stored && JSON.parse(stored);
-  }, [name, isPersisted]);
+  }, [name]);
   const [isCollapsed, setIsCollapsed] = useState(
     Boolean(persisted?.isCollapsed)
   );
@@ -66,9 +62,6 @@ function Panel({
 
   // If supplied with a persistance key, persist height & collapsed state
   useEffect(() => {
-    if (!isPersisted) {
-      return;
-    }
     localStorage.setItem(
       `${LOCAL_STORAGE_PREFIX}:${name}`,
       JSON.stringify({
@@ -77,7 +70,7 @@ function Panel({
         expandToHeight,
       })
     );
-  }, [height, isCollapsed, expandToHeight, isPersisted, name]);
+  }, [height, isCollapsed, expandToHeight, name]);
 
   const confirmTitle = useCallback(() => setHasTitle(true), []);
 

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -46,15 +46,15 @@ function Panel({
   ariaHidden = false,
 }) {
   const persisted = useMemo(() => {
-    const stored = localStorage.getItem(
-      `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`,
-      'null'
-    );
     let parsed = null;
     try {
+      const stored = localStorage.getItem(
+        `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`,
+        'null'
+      );
       parsed = JSON.parse(stored);
     } catch (e) {
-      // @TODO Handle this error.
+      // @TODO Add some error handling.
     }
     return parsed;
   }, [name]);

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -68,18 +68,6 @@ function Panel({
   const [hasTitle, setHasTitle] = useState(false);
   const [manuallyChanged, setManuallyChanged] = useState(false);
 
-  // If supplied with a persistance key, persist height & collapsed state
-  useEffect(() => {
-    localStorage.setItem(
-      `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`,
-      JSON.stringify({
-        height,
-        isCollapsed,
-        expandToHeight,
-      })
-    );
-  }, [height, isCollapsed, expandToHeight, name]);
-
   const confirmTitle = useCallback(() => setHasTitle(true), []);
 
   const collapse = useCallback(() => {
@@ -87,6 +75,7 @@ function Panel({
       return;
     }
     setIsCollapsed(true);
+    setManuallyChanged(true);
     if (resizeable) {
       setHeight(0);
     }
@@ -123,6 +112,23 @@ function Panel({
     setHeight(initialHeight);
     setExpandToHeight(initialHeight);
   }, [manuallyChanged, initialHeight, resizeable, persisted]);
+
+  // Persist when user collapses
+  useEffect(() => {
+    if (!manuallyChanged) {
+      return;
+    }
+
+    // Persist only when after user interacts
+    localStorage.setItem(
+      `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`,
+      JSON.stringify({
+        height,
+        isCollapsed,
+        expandToHeight,
+      })
+    );
+  }, [name, isCollapsed, height, expandToHeight, manuallyChanged]);
 
   const manuallySetHeight = useCallback(
     (h) => {

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -47,9 +47,16 @@ function Panel({
 }) {
   const persisted = useMemo(() => {
     const stored = localStorage.getItem(
-      `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`
+      `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`,
+      'null'
     );
-    return stored && JSON.parse(stored);
+    let parsed = null;
+    try {
+      parsed = JSON.parse(stored);
+    } catch (e) {
+      // @TODO Handle this error.
+    }
+    return parsed;
   }, [name]);
   const [isCollapsed, setIsCollapsed] = useState(
     Boolean(persisted?.isCollapsed)

--- a/assets/src/edit-story/components/panels/preset/karma/stylePresets.karma.js
+++ b/assets/src/edit-story/components/panels/preset/karma/stylePresets.karma.js
@@ -35,6 +35,7 @@ describe('Panel: Style Presets', () => {
   };
 
   beforeEach(async () => {
+    localStorage.clear();
     fixture = new Fixture();
     await fixture.render();
   });

--- a/assets/src/edit-story/components/panels/preset/karma/stylePresets.karma.js
+++ b/assets/src/edit-story/components/panels/preset/karma/stylePresets.karma.js
@@ -35,9 +35,6 @@ describe('Panel: Style Presets', () => {
   };
 
   beforeEach(async () => {
-    // Make sure panels are starting at initial state on every test
-    localStorage.clear();
-
     fixture = new Fixture();
     await fixture.render();
   });

--- a/assets/src/edit-story/components/panels/preset/karma/stylePresets.karma.js
+++ b/assets/src/edit-story/components/panels/preset/karma/stylePresets.karma.js
@@ -35,6 +35,9 @@ describe('Panel: Style Presets', () => {
   };
 
   beforeEach(async () => {
+    // Make sure panels are starting at initial state on every test
+    localStorage.clear();
+
     fixture = new Fixture();
     await fixture.render();
   });

--- a/assets/src/edit-story/components/panels/preset/presetPanel.js
+++ b/assets/src/edit-story/components/panels/preset/presetPanel.js
@@ -136,7 +136,6 @@ function PresetPanel({
       initialHeight={Math.min(initialHeight, window.innerHeight / 3)}
       resizeable={resizeable}
       canCollapse={canCollapse}
-      isPersisted
     >
       <PresetsHeader
         handleAddPreset={handleAddPreset}

--- a/assets/src/edit-story/components/panels/preset/presetPanel.js
+++ b/assets/src/edit-story/components/panels/preset/presetPanel.js
@@ -132,11 +132,11 @@ function PresetPanel({
 
   return (
     <Panel
-      name="stylepreset"
+      name={`stylepreset-${presetType}`}
       initialHeight={Math.min(initialHeight, window.innerHeight / 3)}
       resizeable={resizeable}
       canCollapse={canCollapse}
-      persistenceKey={title}
+      isPersisted
     >
       <PresetsHeader
         handleAddPreset={handleAddPreset}

--- a/assets/src/edit-story/components/panels/preset/presetPanel.js
+++ b/assets/src/edit-story/components/panels/preset/presetPanel.js
@@ -136,6 +136,7 @@ function PresetPanel({
       initialHeight={Math.min(initialHeight, window.innerHeight / 3)}
       resizeable={resizeable}
       canCollapse={canCollapse}
+      persistanceKey={title}
     >
       <PresetsHeader
         handleAddPreset={handleAddPreset}

--- a/assets/src/edit-story/components/panels/preset/presetPanel.js
+++ b/assets/src/edit-story/components/panels/preset/presetPanel.js
@@ -136,7 +136,7 @@ function PresetPanel({
       initialHeight={Math.min(initialHeight, window.innerHeight / 3)}
       resizeable={resizeable}
       canCollapse={canCollapse}
-      persistanceKey={title}
+      persistenceKey={title}
     >
       <PresetsHeader
         handleAddPreset={handleAddPreset}

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -81,3 +81,7 @@ export const FONT_WEIGHT = {
   NORMAL: 400,
   BOLD: 700,
 };
+
+export const LOCAL_STORAGE_PREFIX = {
+  PANEL: 'web_stories_ui_settings',
+};

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -83,5 +83,5 @@ export const FONT_WEIGHT = {
 };
 
 export const LOCAL_STORAGE_PREFIX = {
-  PANEL: 'web_stories_ui_settings',
+  PANEL: 'web_stories_ui_panel_settings',
 };

--- a/karma/fixture/init.js
+++ b/karma/fixture/init.js
@@ -259,11 +259,6 @@ beforeAll(() => {
   });
 });
 
-// Clean up effects from localStorage.
-withCleanupAll(() => {
-  localStorage.clear();
-});
-
 afterAll(() => {
   if (cleanupsAll) {
     const toCleanup = cleanupsAll.slice(0);

--- a/karma/fixture/init.js
+++ b/karma/fixture/init.js
@@ -259,6 +259,11 @@ beforeAll(() => {
   });
 });
 
+// Clean up effects from localStorage.
+withCleanupAll(() => {
+  localStorage.clear();
+});
+
 afterAll(() => {
   if (cleanupsAll) {
     const toCleanup = cleanupsAll.slice(0);


### PR DESCRIPTION
## Summary
Persists height and collapsed state of all panels in story editor. Panels should remain collapse & height between reloads, element selection & switching stories now.

## Relevant Technical Choices
Persisted all panels height & collapsed state.

## To-do
NA

## User-facing changes
collapse/height state changes to all panels should now maintain between any actions in the editor.

## Testing Instructions
Go to edit a story.
- Click on an item & resize color preset panel. Click off that item so all panels disappear. Click back on the item and see that the color preset panel height is the same.
- Repeat these steps checking if collapse state maintains
- Repeat these steps but reload you page between checks
- See that other than this, design panels still behave as expected with respect to resize/collapse behavior.

---

<!-- Please reference the issue(s) this PR addresses. -->

Partially fixes #825 
