### PR TITLE
Permalinks: Handle redirects for `/stories/1234/`

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -732,6 +732,7 @@ class Story_Post_Type {
 	 * Handles redirects to the post type archive.
 	 *
 	 * Redirects requests to `/stories` (old) to `/web-stories` (new).
+	 * Redirects requests to `/stories/1234` (old) to `/web-stories/1234` (new).
 	 *
 	 * @since 1.0.0
 	 *
@@ -753,18 +754,19 @@ class Story_Post_Type {
 
 		// 'pagename' is for most permalink types, name is for when the %postname% is used as a top-level field.
 		if ( 'stories' === $query->get( 'pagename' ) || 'stories' === $query->get( 'name' ) ) {
-			if ( $query->get( 'feed' ) ) {
-				$feed                  = ( $query->get( 'feed' ) === 'feed ' ) ? $query->get( 'feed' ) : '';
-				$post_type_archive_url = get_post_type_archive_feed_link( self::POST_TYPE_SLUG, $feed );
-			} else {
-				$post_type_archive_url = get_post_type_archive_link( self::POST_TYPE_SLUG );
+			$redirect_url = get_post_type_archive_link( self::POST_TYPE_SLUG );
+			if ( $query->get( 'page' ) && self::POST_TYPE_SLUG === get_post_type( absint( $query->get( 'page' ) ) ) ) {
+				$redirect_url = get_permalink( absint( $query->get( 'page' ) ) );
+			} elseif ( $query->get( 'feed' ) ) {
+				$feed         = ( $query->get( 'feed' ) === 'feed ' ) ? $query->get( 'feed' ) : '';
+				$redirect_url = get_post_type_archive_feed_link( self::POST_TYPE_SLUG, $feed );
 			}
 
-			if ( ! $post_type_archive_url ) {
+			if ( ! $redirect_url ) {
 				return $bypass;
 			}
 
-			wp_safe_redirect( $post_type_archive_url, 301 );
+			wp_safe_redirect( $redirect_url, 301 );
 			exit;
 		}
 

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -755,10 +755,14 @@ class Story_Post_Type {
 		// 'pagename' is for most permalink types, name is for when the %postname% is used as a top-level field.
 		if ( 'stories' === $query->get( 'pagename' ) || 'stories' === $query->get( 'name' ) ) {
 			$redirect_url = get_post_type_archive_link( self::POST_TYPE_SLUG );
-			if ( $query->get( 'page' ) && self::POST_TYPE_SLUG === get_post_type( absint( $query->get( 'page' ) ) ) ) {
+			if (
+				$query->get( 'page' ) &&
+				is_numeric( $query->get( 'page' ) ) &&
+				self::POST_TYPE_SLUG === get_post_type( absint( $query->get( 'page' ) ) )
+			) {
 				$redirect_url = get_permalink( absint( $query->get( 'page' ) ) );
 			} elseif ( $query->get( 'feed' ) ) {
-				$feed         = ( $query->get( 'feed' ) === 'feed ' ) ? $query->get( 'feed' ) : '';
+				$feed         = ( 'feed ' === $query->get( 'feed' ) ) ? $query->get( 'feed' ) : '';
 				$redirect_url = get_post_type_archive_feed_link( self::POST_TYPE_SLUG, $feed );
 			}
 

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -44,6 +44,9 @@ class Story_Post_Type extends \WP_UnitTestCase {
 	 */
 	protected static $story_id;
 
+	/**
+	 * @param \WP_UnitTest_Factory $factory
+	 */
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$admin_id      = $factory->user->create(
 			[ 'role' => 'administrator' ]
@@ -328,7 +331,7 @@ class Story_Post_Type extends \WP_UnitTestCase {
 	 * @covers ::redirect_post_type_archive_urls
 	 */
 	public function test_redirect_post_type_archive_urls_permalinks() {
-		$this->set_permalink_structure( '/%post_name%/' );
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$story_post_type = new \Google\Web_Stories\Story_Post_Type( $this->createMock( \Google\Web_Stories\Experiments::class ) );
 		$query           = new \WP_Query();
@@ -339,23 +342,47 @@ class Story_Post_Type extends \WP_UnitTestCase {
 	/**
 	 * @covers ::redirect_post_type_archive_urls
 	 */
-	public function test_redirect_post_type_archive_urls_page_set() {
-		$this->set_permalink_structure( '/%post_name%/' );
+	public function test_redirect_post_type_archive_urls_page() {
+		$this->set_permalink_structure( '/%postname%/' );
 
-		add_filter( 'post_type_archive_link', '__return_false' );
 		$story_post_type = new \Google\Web_Stories\Story_Post_Type( $this->createMock( \Google\Web_Stories\Experiments::class ) );
-		$query           = new \WP_Query();
-		$query->set( 'pagename', 'stories' );
+
+		$query = new \WP_Query();
+		$query->set( 'name', 'stories' );
+		$query->set( 'page', self::$story_id );
+
+		add_filter( 'post_type_link', '__return_false' );
+		add_filter( 'post_type_archive_link', '__return_false' );
 		$result = $story_post_type->redirect_post_type_archive_urls( false, $query );
-		$this->assertFalse( $result );
+		remove_filter( 'post_type_link', '__return_false' );
 		remove_filter( 'post_type_archive_link', '__return_false' );
+
+		$this->assertFalse( $result );
 	}
 
 	/**
 	 * @covers ::redirect_post_type_archive_urls
 	 */
-	public function test_redirect_post_type_archive_urls_page_feed() {
-		$this->set_permalink_structure( '/%post_name%/' );
+	public function test_redirect_post_type_archive_urls_pagename_set() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$story_post_type = new \Google\Web_Stories\Story_Post_Type( $this->createMock( \Google\Web_Stories\Experiments::class ) );
+
+		$query = new \WP_Query();
+		$query->set( 'pagename', 'stories' );
+
+		add_filter( 'post_type_archive_link', '__return_false' );
+		$result = $story_post_type->redirect_post_type_archive_urls( false, $query );
+		remove_filter( 'post_type_archive_link', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @covers ::redirect_post_type_archive_urls
+	 */
+	public function test_redirect_post_type_archive_urls_pagename_feed() {
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$story_post_type = new \Google\Web_Stories\Story_Post_Type( $this->createMock( \Google\Web_Stories\Experiments::class ) );
 		$story_post_type->init();
@@ -367,6 +394,7 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		add_filter( 'post_type_archive_feed_link', '__return_false' );
 		$result = $story_post_type->redirect_post_type_archive_urls( false, $query );
 		remove_filter( 'post_type_archive_feed_link', '__return_false' );
+
 		$this->assertFalse( $result );
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #4515 / #4501 

If a published story does not have a slug, its URL will be `https://example.com/web-stories/1234`, where 1234 is the post ID.

This change ensures `https://example.com/stories/1234` properly redirects to that one.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
