### PR TITLE
Fixed numeric sanitization logic so entering in values can be easier

### DIFF
--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -131,6 +131,11 @@ function Numeric({
   const placeholder = isMultiple ? __('multiple', 'web-stories') : '';
 
   const handleChange = useCallback((event) => {
+    // If the user types something in, clear timeout
+    // so onChange doesn't get triggered with possibly
+    // old value.
+    window.clearTimeout(submitOnChangeTimeout.current);
+
     setInputValue(event.target.value);
   }, []);
 

--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -140,21 +140,7 @@ function Numeric({
 
     setInputValue(validValue ?? value);
     onChange(validValue ?? value);
-
-    if (onBlur) {
-      onBlur();
-    }
-    handleBlur();
-  }, [
-    inputValue,
-    canBeNegative,
-    canBeEmpty,
-    float,
-    value,
-    onBlur,
-    onChange,
-    handleBlur,
-  ]);
+  }, [inputValue, canBeNegative, canBeEmpty, float, value, onChange]);
 
   const handleUpDown = useCallback(
     ({ key, altKey }) => {
@@ -258,7 +244,14 @@ function Numeric({
         disabled={disabled}
         {...rest}
         onChange={handleChange}
-        onBlur={validateAndSubmitInput}
+        onBlur={() => {
+          validateAndSubmitInput();
+          if (onBlur) {
+            onBlur();
+          }
+
+          handleBlur();
+        }}
         onFocus={handleFocus}
       />
       {suffix && (

--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -293,7 +293,9 @@ function Numeric({
     let selectContentsTimeout = -1;
 
     if (selectInputContents.current) {
-      inputRef.current.select();
+      if (inputRef.current) {
+        inputRef.current.select();
+      }
 
       // When we want to select the content of the input
       // we hold open the door for a slight moment to allow

--- a/assets/src/edit-story/components/form/test/numeric.js
+++ b/assets/src/edit-story/components/form/test/numeric.js
@@ -28,15 +28,19 @@ import { renderWithTheme } from '../../../testUtils';
 describe('Form/Numeric', () => {
   const arrowUp = (node) => {
     fireEvent.keyDown(node, { key: 'ArrowUp', which: 38 });
+    fireEvent.keyDown(node, { key: 'Enter', which: 13 });
   };
   const altArrowUp = (node) => {
     fireEvent.keyDown(node, { key: 'ArrowUp', which: 38, altKey: true });
+    fireEvent.keyDown(node, { key: 'Enter', which: 13 });
   };
   const arrowDown = (node) => {
     fireEvent.keyDown(node, { key: 'ArrowDown', which: 40 });
+    fireEvent.keyDown(node, { key: 'Enter', which: 13 });
   };
   const altArrowDown = (node) => {
     fireEvent.keyDown(node, { key: 'ArrowDown', which: 40, altKey: true });
+    fireEvent.keyDown(node, { key: 'Enter', which: 13 });
   };
 
   it('should render <Numeric /> form', () => {

--- a/assets/src/edit-story/components/form/test/numeric.js
+++ b/assets/src/edit-story/components/form/test/numeric.js
@@ -26,14 +26,18 @@ import { Numeric } from '../';
 import { renderWithTheme } from '../../../testUtils';
 
 describe('Form/Numeric', () => {
-  const arrowUp = (node) =>
+  const arrowUp = (node) => {
     fireEvent.keyDown(node, { key: 'ArrowUp', which: 38 });
-  const altArrowUp = (node) =>
+  };
+  const altArrowUp = (node) => {
     fireEvent.keyDown(node, { key: 'ArrowUp', which: 38, altKey: true });
-  const arrowDown = (node) =>
+  };
+  const arrowDown = (node) => {
     fireEvent.keyDown(node, { key: 'ArrowDown', which: 40 });
-  const altArrowDown = (node) =>
+  };
+  const altArrowDown = (node) => {
     fireEvent.keyDown(node, { key: 'ArrowDown', which: 40, altKey: true });
+  };
 
   it('should render <Numeric /> form', () => {
     const onChangeMock = jest.fn();

--- a/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
@@ -40,6 +40,11 @@ describe('Text Sets Library Panel', () => {
     });
 
     await fixture.events.mouse.clickOn(textTab, 10, 20);
+    await waitFor(() =>
+      fixture.editor.library.getAllByRole('listitem', {
+        name: /^Insert Text Set$/,
+      })
+    );
   });
 
   afterEach(() => {

--- a/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
@@ -40,11 +40,6 @@ describe('Text Sets Library Panel', () => {
     });
 
     await fixture.events.mouse.clickOn(textTab, 10, 20);
-    await waitFor(() =>
-      fixture.editor.library.getAllByRole('listitem', {
-        name: /^Insert Text Set$/,
-      })
-    );
   });
 
   afterEach(() => {

--- a/assets/src/edit-story/components/panels/test/layerStyle.js
+++ b/assets/src/edit-story/components/panels/test/layerStyle.js
@@ -66,6 +66,7 @@ describe('Panels/LayerStyle', () => {
     ]);
     const input = getByRole('textbox', { name: 'Opacity in percentage' });
     fireEvent.change(input, { target: { value: '23' } });
+    fireEvent.keyDown(input, { key: 'Enter', which: 13 });
     expect(pushUpdate).toHaveBeenCalledWith({ opacity: 23 });
   });
 
@@ -75,6 +76,7 @@ describe('Panels/LayerStyle', () => {
     ]);
     const input = getByRole('textbox', { name: 'Opacity in percentage' });
     fireEvent.change(input, { target: { value: null } });
+    fireEvent.keyDown(input, { key: 'Enter', which: 13 });
     const submits = submit({ opacity: null });
     expect(submits[defaultElement.id]).toStrictEqual({
       opacity: 0,
@@ -87,6 +89,7 @@ describe('Panels/LayerStyle', () => {
     ]);
     const input = getByRole('textbox', { name: 'Opacity in percentage' });
     fireEvent.change(input, { target: { value: 101 } });
+    fireEvent.keyDown(input, { key: 'Enter', which: 13 });
     const submits = submit({ opacity: 101 });
     expect(submits[defaultElement.id]).toStrictEqual({
       opacity: 100,

--- a/assets/src/edit-story/components/panels/test/sizePosition.js
+++ b/assets/src/edit-story/components/panels/test/sizePosition.js
@@ -151,6 +151,7 @@ describe('Panels/SizePosition', () => {
       const { getByRole, pushUpdate } = renderSizePosition([defaultImage]);
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({
         width: 150,
         height: 150 / (100 / 80),
@@ -161,6 +162,7 @@ describe('Panels/SizePosition', () => {
       const { getByRole, pushUpdate } = renderSizePosition([defaultImage]);
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '160' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({
         height: 160,
         width: 160 * (100 / 80),
@@ -174,6 +176,7 @@ describe('Panels/SizePosition', () => {
 
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({ width: 150, height: 80 });
     });
 
@@ -184,22 +187,36 @@ describe('Panels/SizePosition', () => {
 
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '160' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({ height: 160, width: 100 });
     });
 
-    it('should not update width if empty value', () => {
+    it('should not update width if empty value is submitted', () => {
       const { getByRole, pushUpdate } = renderSizePosition([defaultImage]);
-      const input = getByRole('textbox', { name: 'Width' });
-      fireEvent.change(input, { target: { value: '' } });
-      expect(pushUpdate).not.toHaveBeenCalled();
+      const inputWidth = getByRole('textbox', { name: 'Width' });
+      const inputHeight = getByRole('textbox', { name: 'Height' });
+      const originalWidth = parseInt(inputWidth.value);
+      const originalHeight = parseInt(inputHeight.value);
+      fireEvent.change(inputWidth, { target: { value: '' } });
+      fireEvent.keyDown(inputWidth, { key: 'Enter', which: 13 });
+      expect(pushUpdate).toHaveBeenCalledWith({
+        width: originalWidth,
+        height: originalHeight,
+      });
     });
 
-    it('should not update height if empty value', () => {
+    it('should not update height if empty value is submitted', () => {
       const { getByRole, pushUpdate } = renderSizePosition([defaultImage]);
-
-      const input = getByRole('textbox', { name: 'Height' });
-      fireEvent.change(input, { target: { value: '' } });
-      expect(pushUpdate).not.toHaveBeenCalled();
+      const inputWidth = getByRole('textbox', { name: 'Width' });
+      const inputHeight = getByRole('textbox', { name: 'Height' });
+      const originalWidth = parseInt(inputWidth.value);
+      const originalHeight = parseInt(inputHeight.value);
+      fireEvent.change(inputHeight, { target: { value: '' } });
+      fireEvent.keyDown(inputHeight, { key: 'Enter', which: 13 });
+      expect(pushUpdate).toHaveBeenCalledWith({
+        width: originalWidth,
+        height: originalHeight,
+      });
     });
 
     it('should update lock ratio to false for element', () => {
@@ -272,6 +289,7 @@ describe('Panels/SizePosition', () => {
       ]);
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({
         width: 150,
         height: dataPixels(150 / (100 / 80)),
@@ -299,6 +317,7 @@ describe('Panels/SizePosition', () => {
       ]);
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({
         width: 150,
         height: MULTIPLE_VALUE,
@@ -326,6 +345,7 @@ describe('Panels/SizePosition', () => {
       ]);
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '160' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({
         height: 160,
         width: MULTIPLE_VALUE,
@@ -383,6 +403,7 @@ describe('Panels/SizePosition', () => {
       const { getByRole, pushUpdate, submit } = renderSizePosition([image]);
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '2000' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({
         height: 2000,
         width: 2000 * (100 / 80),

--- a/assets/src/edit-story/components/panels/test/textStyle.js
+++ b/assets/src/edit-story/components/panels/test/textStyle.js
@@ -244,6 +244,7 @@ describe('Panels/TextStyle', () => {
         name: 'Edit: Horizontal & Vertical padding',
       });
       fireEvent.change(input, { target: { value: '20' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdateForObject).toHaveBeenCalledWith(
         'padding',
         { horizontal: 20, vertical: 20 },
@@ -271,6 +272,7 @@ describe('Panels/TextStyle', () => {
       ]);
       const input = getByRole('textbox', { name: 'Edit: Horizontal padding' });
       fireEvent.change(input, { target: { value: '11' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdateForObject).toHaveBeenCalledWith(
         'padding',
         { horizontal: 11 },
@@ -296,6 +298,7 @@ describe('Panels/TextStyle', () => {
       ]);
       const input = getByRole('textbox', { name: 'Edit: Vertical padding' });
       fireEvent.change(input, { target: { value: '12' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdateForObject).toHaveBeenCalledWith(
         'padding',
         { vertical: 12 },
@@ -315,13 +318,20 @@ describe('Panels/TextStyle', () => {
       });
     });
 
-    it('should not update if empty padding', () => {
+    it('should not update padding if empty string is submitted', () => {
       const { getByRole, pushUpdateForObject } = renderTextStyle([textElement]);
       const input = getByRole('textbox', {
         name: 'Edit: Horizontal & Vertical padding',
       });
+      const originalPadding = parseInt(input.value);
       fireEvent.change(input, { target: { value: '' } });
-      expect(pushUpdateForObject).not.toHaveBeenCalled();
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
+      expect(pushUpdateForObject).toHaveBeenCalledWith(
+        'padding',
+        { horizontal: originalPadding, vertical: originalPadding },
+        DEFAULT_PADDING,
+        false
+      );
     });
 
     it('should update multi padding with lock and same padding', () => {
@@ -333,6 +343,7 @@ describe('Panels/TextStyle', () => {
         name: 'Edit: Horizontal & Vertical padding',
       });
       fireEvent.change(input, { target: { value: '11' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdateForObject).toHaveBeenCalledWith(
         'padding',
         { horizontal: 11, vertical: 11 },
@@ -350,6 +361,7 @@ describe('Panels/TextStyle', () => {
         name: 'Edit: Horizontal & Vertical padding',
       });
       fireEvent.change(input, { target: { value: '11' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdateForObject).toHaveBeenCalledWith(
         'padding',
         { horizontal: 11, vertical: 11 },
@@ -365,6 +377,7 @@ describe('Panels/TextStyle', () => {
       ]);
       const input = getByRole('textbox', { name: 'Edit: Horizontal padding' });
       fireEvent.change(input, { target: { value: '11' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdateForObject).toHaveBeenCalledWith(
         'padding',
         { horizontal: 11 },
@@ -380,6 +393,7 @@ describe('Panels/TextStyle', () => {
       ]);
       const input = getByRole('textbox', { name: 'Edit: Horizontal padding' });
       fireEvent.change(input, { target: { value: '11' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdateForObject).toHaveBeenCalledWith(
         'padding',
         { horizontal: 11 },
@@ -395,6 +409,7 @@ describe('Panels/TextStyle', () => {
       ]);
       const input = getByRole('textbox', { name: 'Edit: Horizontal padding' });
       fireEvent.change(input, { target: { value: '11' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdateForObject).toHaveBeenCalledWith(
         'padding',
         { horizontal: 11 },
@@ -410,6 +425,7 @@ describe('Panels/TextStyle', () => {
       ]);
       const input = getByRole('textbox', { name: 'Edit: Vertical padding' });
       fireEvent.change(input, { target: { value: '11' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdateForObject).toHaveBeenCalledWith(
         'padding',
         { vertical: 11 },
@@ -509,14 +525,19 @@ describe('Panels/TextStyle', () => {
       const input = getByRole('textbox', { name: 'Font size' });
 
       await fireEvent.change(input, { target: { value: '32' } });
+      await fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({ fontSize: 32 });
     });
 
-    it('should not do anything if empty font size', async () => {
+    it('should not update font size if empty string is submitted', async () => {
       const { getByRole, pushUpdate } = renderTextStyle([textElement]);
       const input = getByRole('textbox', { name: 'Font size' });
+      const originalFontsize = parseInt(input.value);
       await fireEvent.change(input, { target: { value: '' } });
-      expect(pushUpdate).not.toHaveBeenCalled();
+      await fireEvent.keyDown(input, { key: 'Enter', which: 13 });
+      expect(pushUpdate).toHaveBeenCalledWith({
+        fontSize: originalFontsize,
+      });
     });
 
     it('should set the text bold when the key command is pressed', async () => {
@@ -583,6 +604,7 @@ describe('Panels/TextStyle', () => {
       const { getByRole, pushUpdate } = renderTextStyle([textElement]);
       const input = getByRole('textbox', { name: 'Line-height' });
       fireEvent.change(input, { target: { value: '1.5' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({ lineHeight: 1.5 });
     });
 
@@ -590,6 +612,7 @@ describe('Panels/TextStyle', () => {
       const { getByRole, pushUpdate } = renderTextStyle([textElement]);
       const input = getByRole('textbox', { name: 'Line-height' });
       fireEvent.change(input, { target: { value: '' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       expect(pushUpdate).toHaveBeenCalledWith({ lineHeight: '' });
     });
 
@@ -597,6 +620,7 @@ describe('Panels/TextStyle', () => {
       const { getByRole, pushUpdate } = renderTextStyle([textElement]);
       const input = getByRole('textbox', { name: 'Letter-spacing' });
       fireEvent.change(input, { target: { value: '150' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       const updatingFunction = pushUpdate.mock.calls[0][0];
       const resultOfUpdating = updatingFunction({ content: 'Hello world' });
       expect(resultOfUpdating).toStrictEqual(
@@ -611,6 +635,7 @@ describe('Panels/TextStyle', () => {
       const { getByRole, pushUpdate } = renderTextStyle([textElement]);
       const input = getByRole('textbox', { name: 'Letter-spacing' });
       fireEvent.change(input, { target: { value: '' } });
+      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
       const updatingFunction = pushUpdate.mock.calls[0][0];
       const resultOfUpdating = updatingFunction({
         content: '<span style="letter-spacing: 1.5em">Hello world</span>',

--- a/assets/src/edit-story/components/richText/karma/inlineSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/inlineSelection.karma.js
@@ -91,6 +91,7 @@ describe('CUJ: Creator can Add and Write Text: Select an individual word to edit
       // Set letter spacing
       await data.fixture.events.click(letterSpacing, { clickCount: 3 });
       await data.fixture.events.keyboard.type('50');
+      await data.fixture.events.keyboard.press('Enter');
       // Press escape to leave input field (does not leave edit-mode)
       await data.fixture.events.keyboard.press('Escape');
 
@@ -141,6 +142,7 @@ describe('CUJ: Creator can Add and Write Text: Select an individual word to edit
 
       await data.fixture.events.click(letterSpacing, { clickCount: 3 });
       await data.fixture.events.keyboard.type('100');
+      await data.fixture.events.keyboard.press('Enter');
       await data.fixture.events.keyboard.press('Escape');
 
       // Verify all styles again
@@ -367,6 +369,7 @@ describe('CUJ: Creator can Add and Write Text: Select an individual word to edit
       // Change line height to 5
       await data.fixture.events.click(lineHeight, { clickCount: 3 });
       await data.fixture.events.keyboard.type('5');
+      await data.fixture.events.keyboard.press('Enter');
       await data.fixture.events.keyboard.press('Escape');
 
       // Exit edit-mode

--- a/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
@@ -83,6 +83,7 @@ describe('Styling multiple text fields', () => {
       await data.fixture.events.click(fontWeight.option('Black'));
       await data.fixture.events.click(letterSpacing, { clickCount: 3 });
       await data.fixture.events.keyboard.type('50');
+      await data.fixture.events.keyboard.press('Enter');
       await data.fixture.events.keyboard.press('Escape');
       await data.fixture.events.click(fontColor.hex, { clickCount: 3 });
       await data.fixture.events.keyboard.type('FF00FF');
@@ -126,6 +127,7 @@ describe('Styling multiple text fields', () => {
       // Edit formatting for second text field
       await data.fixture.events.click(letterSpacing, { clickCount: 3 });
       await data.fixture.events.keyboard.type('50');
+      await data.fixture.events.keyboard.press('Enter');
       await data.fixture.events.keyboard.press('Escape');
       await data.fixture.events.click(fontColor.hex, { clickCount: 3 });
       await data.fixture.events.keyboard.type('FF00FF');
@@ -160,6 +162,7 @@ describe('Styling multiple text fields', () => {
       await data.fixture.events.sleep(100);
       await data.fixture.events.click(letterSpacing, { clickCount: 3 });
       await data.fixture.events.keyboard.type('100');
+      await data.fixture.events.keyboard.press('Enter');
       await data.fixture.events.keyboard.press('Escape');
 
       // Verify all styles, now expected to be updated

--- a/assets/src/edit-story/components/richText/karma/singleSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/singleSelection.karma.js
@@ -81,6 +81,7 @@ describe('Styling single text field', () => {
       // Set letter spacing
       await data.fixture.events.click(letterSpacing, { clickCount: 3 });
       await data.fixture.events.keyboard.type('50');
+      await data.fixture.events.keyboard.press('Enter');
       // Press escape to leave input field (does not unselect element)
       await data.fixture.events.keyboard.press('Escape');
 
@@ -126,6 +127,7 @@ describe('Styling single text field', () => {
       await setSelection(5, 7);
       await data.fixture.events.click(letterSpacing, { clickCount: 3 });
       await data.fixture.events.keyboard.type('50');
+      await data.fixture.events.keyboard.press('Enter');
       await data.fixture.events.keyboard.press('Escape');
       await data.fixture.events.click(fontColor.hex, { clickCount: 3 });
       await data.fixture.events.keyboard.type('FF00FF');
@@ -161,6 +163,7 @@ describe('Styling single text field', () => {
       await data.fixture.events.sleep(100);
       await data.fixture.events.click(letterSpacing, { clickCount: 3 });
       await data.fixture.events.keyboard.type('100');
+      await data.fixture.events.keyboard.press('Enter');
       await data.fixture.events.keyboard.press('Escape');
 
       // Verify all styles, now expected to be updated


### PR DESCRIPTION
## Summary

This PR removes validation from numeric input until the user manually triggers validation by: triggering `blur`, hitting `enter`, or hitting the `arrow up/down` keys.  If the user hits `esc` while editing a numeric field, the input value will revert to the last saved value.

NOTE: I'm holding off on writing tests, so the interactions can get approved.  Once approved, I'll write jest and karma tests to make sure our numeric interactions get coverage.

## User-facing changes

This PR affects all the numeric fields in the editor (e.g. Size & Position numerics inputs, text Style numeric inputs, etc...).

## Testing Instructions

1.) Open up a new or existing story in the Editor.
2.) Add a new element, or select an existing one to make active.
3.) Use the Style, Size & Position, and any other panel with numeric inputs, and type in anything you want and then trigger one of the saving/revert mechanism described below, confirm they work.  Confirm that you can type in anything in any way and if it ends up being valid... the value will be saved 😎 

- `Enter`: Validates and saves value.  If validation fails, reverts to previously saved value.
- `Esc`: Reverts value to previously saved value and removes focus from input.
- `Blur`: Validates and saves value.  If validation fails, reverts to previously saved value.
- `ArrowUp`/`ArrowDown`: Validates current value.  If validation fails, reverts to previously saved value and then increment/decrements value based on up/down arrows (also respects `alt` key for float numbers).

Fixes #4595
Fixes #4596 

## Screenshots

Type in anything:
![type_in_anything](https://user-images.githubusercontent.com/40646372/93923760-a891af00-fcc8-11ea-902a-c903755f9b16.gif)
