### PR TITLE
Dashboard: Minor Template details Perf updates

### DIFF
--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -46,7 +46,6 @@ import Content from './content';
 function TemplateDetails() {
   const [template, setTemplate] = useState(null);
   const [relatedTemplates, setRelatedTemplates] = useState([]);
-  const [orderedTemplates, setOrderedTemplates] = useState([]);
   const enableBookmarks = useFeature('enableBookmarkActions');
 
   const {
@@ -140,6 +139,8 @@ function TemplateDetails() {
     addToast,
   ]);
 
+  const templatedId = template?.id;
+
   useEffect(() => {
     if (!template || !templateId) {
       return;
@@ -152,11 +153,6 @@ function TemplateDetails() {
         centerTargetAction: resolveRelatedTemplateRoute(relatedTemplate),
       }))
     );
-    setOrderedTemplates(
-      templatesOrderById.map(
-        (templateByOrderId) => templates[templateByOrderId]
-      )
-    );
   }, [
     fetchRelatedTemplates,
     template,
@@ -166,26 +162,27 @@ function TemplateDetails() {
   ]);
 
   const activeTemplateIndex = useMemo(() => {
-    if (orderedTemplates.length <= 0) {
+    if (templatesOrderById.length <= 0) {
       return 0;
     }
 
-    return orderedTemplates.findIndex((t) => t.id === template?.id);
-  }, [orderedTemplates, template?.id]);
+    return templatesOrderById.findIndex((id) => id === templatedId);
+  }, [templatesOrderById, templatedId]);
 
   const switchToTemplateByOffset = useCallback(
     (offset) => {
       const index = clamp(activeTemplateIndex + offset, [
         0,
-        orderedTemplates.length - 1,
+        templatesOrderById.length - 1,
       ]);
-      const selectedTemplate = orderedTemplates[index];
+      const selectedTemplateId = templatesOrderById[index];
+      const selectedTemplate = templates[selectedTemplateId];
 
       actions.push(
         `?id=${selectedTemplate.id}&isLocal=${selectedTemplate.isLocal}`
       );
     },
-    [activeTemplateIndex, orderedTemplates, actions]
+    [activeTemplateIndex, templatesOrderById, actions, templates]
   );
 
   const handleBookmarkClickSelected = useCallback(() => {}, []);
@@ -224,7 +221,7 @@ function TemplateDetails() {
           <Content
             activeTemplateIndex={activeTemplateIndex}
             isRTL={isRTL}
-            orderedTemplatesLength={orderedTemplates?.length}
+            orderedTemplatesLength={templatesOrderById.length}
             pageSize={pageSize}
             switchToTemplateByOffset={switchToTemplateByOffset}
             template={template}

--- a/assets/src/dashboard/components/cardGallery/components.js
+++ b/assets/src/dashboard/components/cardGallery/components.js
@@ -25,7 +25,7 @@ import PropTypes from 'prop-types';
  */
 import { KEYBOARD_USER_SELECTOR } from '../../constants';
 
-export const GalleryContainer = styled.div`
+export const GalleryContainer = styled.div.attrs({ id: 'dillon' })`
   ${({ maxWidth }) => `
     display: flex;
     justify-content: space-around;

--- a/assets/src/dashboard/components/cardGallery/components.js
+++ b/assets/src/dashboard/components/cardGallery/components.js
@@ -25,7 +25,7 @@ import PropTypes from 'prop-types';
  */
 import { KEYBOARD_USER_SELECTOR } from '../../constants';
 
-export const GalleryContainer = styled.div.attrs({ id: 'dillon' })`
+export const GalleryContainer = styled.div`
   ${({ maxWidth }) => `
     display: flex;
     justify-content: space-around;

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -139,7 +139,10 @@ function CardGallery({ story, isRTL, galleryLabel }) {
       const onLoadId = ++_id;
 
       if (img) {
+        const prevOnLoad =
+          typeof img.onload === 'function' ? img.onload : () => {};
         img.onload = () => {
+          prevOnLoad();
           if (onLoadId === _id) {
             setRenderPages(true);
           }

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -51,9 +51,7 @@ function CardGallery({ story, isRTL, galleryLabel }) {
   const [dimensionMultiplier, setDimensionMultiplier] = useState(null);
   const [activePageIndex, setActivePageIndex] = useState(0);
   const [activePageId, setActivePageId] = useState();
-  const [renderPages, setRenderPages] = useState(false);
   const containerRef = useRef();
-  const activeCardRef = useRef();
   const gridRef = useRef();
   const pageRefs = useRef({});
   const { pages = [] } = story;
@@ -119,7 +117,6 @@ function CardGallery({ story, isRTL, galleryLabel }) {
     // Reset state when the story changes
     setActivePageIndex(0);
     setActivePageId(pages[0].id);
-    setRenderPages(false);
   }, [pages]);
 
   useGridViewKeys({
@@ -132,7 +129,7 @@ function CardGallery({ story, isRTL, galleryLabel }) {
   });
 
   const GalleryItems = useMemo(() => {
-    if (!metrics.miniCardSize || !renderPages) {
+    if (!metrics.miniCardSize) {
       return null;
     }
 
@@ -198,24 +195,11 @@ function CardGallery({ story, isRTL, galleryLabel }) {
     isInteractive,
     metrics,
     pages,
-    renderPages,
   ]);
-
-  useEffect(() => {
-    if (activeCardRef.current && !renderPages) {
-      const img = activeCardRef.current.querySelector('img');
-
-      if (img) {
-        img.onload = () => {
-          setRenderPages(true);
-        };
-      }
-    }
-  });
 
   return (
     <GalleryContainer ref={containerRef} maxWidth={MAX_WIDTH}>
-      {renderPages && GalleryItems}
+      {GalleryItems}
       {metrics.activeCardSize && pages[activePageIndex] && (
         <UnitsProvider
           pageSize={{
@@ -230,7 +214,6 @@ function CardGallery({ story, isRTL, galleryLabel }) {
               __('Active Page Preview - Page %s', 'web-stories'),
               activePageIndex + 1
             )}
-            ref={activeCardRef}
           >
             <PreviewPage
               page={pages[activePageIndex]}

--- a/assets/src/dashboard/components/cardGallery/index.js
+++ b/assets/src/dashboard/components/cardGallery/index.js
@@ -47,14 +47,10 @@ const MINI_CARD_WIDTH = 75;
 const CARD_GAP = 15;
 const CARD_WRAPPER_BUFFER = 12;
 
-let _id = 0;
-
 function CardGallery({ story, isRTL, galleryLabel }) {
   const [dimensionMultiplier, setDimensionMultiplier] = useState(null);
   const [activePageIndex, setActivePageIndex] = useState(0);
   const [activePageId, setActivePageId] = useState();
-  const [renderPages, setRenderPages] = useState(false);
-  const activeCardRef = useRef();
   const containerRef = useRef();
   const gridRef = useRef();
   const pageRefs = useRef({});
@@ -121,7 +117,6 @@ function CardGallery({ story, isRTL, galleryLabel }) {
     // Reset state when the story changes
     setActivePageIndex(0);
     setActivePageId(pages[0].id);
-    setRenderPages(false);
   }, [pages]);
 
   useGridViewKeys({
@@ -133,82 +128,78 @@ function CardGallery({ story, isRTL, galleryLabel }) {
     items: pages,
   });
 
-  useEffect(() => {
-    if (!renderPages && activeCardRef.current) {
-      const img = activeCardRef.current.querySelector('img');
-      const onLoadId = ++_id;
-
-      if (img) {
-        const prevOnLoad =
-          typeof img.onload === 'function' ? img.onload : () => {};
-        img.onload = () => {
-          prevOnLoad();
-          if (onLoadId === _id) {
-            setRenderPages(true);
-          }
-        };
-      }
+  const GalleryItems = useMemo(() => {
+    if (!metrics.miniCardSize) {
+      return null;
     }
-  });
 
-  const { miniCardSize, gap, miniWrapperSize } = metrics;
+    const { miniCardSize, gap, miniWrapperSize } = metrics;
+    return (
+      <UnitsProvider
+        pageSize={{
+          width: miniCardSize.width,
+          height: miniCardSize.height,
+        }}
+      >
+        <MiniCardsContainer
+          rowHeight={miniWrapperSize.height}
+          gap={gap}
+          ref={gridRef}
+          aria-label={galleryLabel}
+          data-testid="mini-cards-container"
+        >
+          {pages.map((page, index) => {
+            const isCurrentPage = activePageId === page.id;
+            const isActive = isCurrentPage && isInteractive;
+            return (
+              <ItemContainer
+                key={`page-${index}`}
+                ref={(el) => {
+                  pageRefs.current[page.id] = el;
+                }}
+                width={miniWrapperSize.width}
+              >
+                <MiniCardButton
+                  isSelected={isCurrentPage}
+                  tabIndex={isActive ? 0 : -1}
+                  {...miniWrapperSize}
+                  onClick={() => handleMiniCardClick(index, page.id)}
+                  aria-label={
+                    isCurrentPage
+                      ? sprintf(
+                          /* translators: %s: page number. */
+                          __('Page %s (current page)', 'web-stories'),
+                          index + 1
+                        )
+                      : sprintf(
+                          /* translators: %s: page number. */
+                          __('Page %s', 'web-stories'),
+                          index + 1
+                        )
+                  }
+                >
+                  <MiniCard {...miniCardSize}>
+                    <PreviewPage page={page} pageSize={miniCardSize} />
+                  </MiniCard>
+                </MiniCardButton>
+              </ItemContainer>
+            );
+          })}
+        </MiniCardsContainer>
+      </UnitsProvider>
+    );
+  }, [
+    activePageId,
+    galleryLabel,
+    handleMiniCardClick,
+    isInteractive,
+    metrics,
+    pages,
+  ]);
 
   return (
     <GalleryContainer ref={containerRef} maxWidth={MAX_WIDTH}>
-      {renderPages && miniCardSize && (
-        <UnitsProvider
-          pageSize={{
-            width: miniCardSize.width,
-            height: miniCardSize.height,
-          }}
-        >
-          <MiniCardsContainer
-            rowHeight={miniWrapperSize.height}
-            gap={gap}
-            ref={gridRef}
-            aria-label={galleryLabel}
-            data-testid="mini-cards-container"
-          >
-            {pages.map((page, index) => {
-              const isCurrentPage = activePageId === page.id;
-              const isActive = isCurrentPage && isInteractive;
-              return (
-                <ItemContainer
-                  key={`page-${index}`}
-                  ref={(el) => {
-                    pageRefs.current[page.id] = el;
-                  }}
-                  width={miniWrapperSize.width}
-                >
-                  <MiniCardButton
-                    isSelected={isCurrentPage}
-                    tabIndex={isActive ? 0 : -1}
-                    {...miniWrapperSize}
-                    onClick={() => handleMiniCardClick(index, page.id)}
-                    aria-label={
-                      isCurrentPage
-                        ? sprintf(
-                            /* translators: %s: page number. */
-                            __('Page %s (current page)', 'web-stories'),
-                            index + 1
-                          )
-                        : sprintf(
-                            /* translators: %s: page number. */
-                            __('Page %s', 'web-stories'),
-                            index + 1
-                          )
-                    }
-                  >
-                    <MiniCard {...miniCardSize}>
-                      <PreviewPage page={page} pageSize={miniCardSize} />
-                    </MiniCard>
-                  </MiniCardButton>
-                </ItemContainer>
-              );
-            })}
-          </MiniCardsContainer>
-        </UnitsProvider>
-      )}
+      {GalleryItems}
       {metrics.activeCardSize && pages[activePageIndex] && (
         <UnitsProvider
           pageSize={{
@@ -223,7 +214,6 @@ function CardGallery({ story, isRTL, galleryLabel }) {
               __('Active Page Preview - Page %s', 'web-stories'),
               activePageIndex + 1
             )}
-            ref={activeCardRef}
           >
             <PreviewPage
               page={pages[activePageIndex]}


### PR DESCRIPTION
## Summary

I spent sometime trying to improve the performance of changing templates in the Template Details view.  Without `Suspense` or UX to not render the Mini Pages of the template until the user wants to view them it's going to be hard 

## Relevant Technical Choices

- Removed some unnecessary state/ setState calls.


## User-facing changes

None

## Testing Instructions

- Make sure the tests pass/ Template Details page has no regressions

