### PR TITLE
Dashboard: Restore GA Tracking Input's Label

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -214,7 +214,7 @@ export const ErrorText = styled.p`
 export const InlineForm = styled.div`
   display: flex;
 `;
-
+export const VisuallyHiddenLabel = styled.label(visuallyHiddenStyles);
 export const GoogleAnalyticsTextInput = styled(TextInput)`
   flex: 3;
   width: auto;

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -30,15 +30,16 @@ import { __ } from '@wordpress/i18n';
  */
 import { validateGoogleAnalyticsIdFormat } from '../../../../utils';
 import {
+  ErrorText,
   FormContainer,
+  GoogleAnalyticsTextInput,
   InlineLink,
+  InlineForm,
+  SaveButton,
   SettingForm,
   SettingHeading,
   TextInputHelperText,
-  SaveButton,
-  ErrorText,
-  InlineForm,
-  GoogleAnalyticsTextInput,
+  VisuallyHiddenLabel,
 } from '../components';
 
 export const TEXT = {
@@ -50,9 +51,10 @@ export const TEXT = {
     'https://blog.amp.dev/2019/08/28/analytics-for-your-amp-stories/',
   CONTEXT_ARTICLE: __('Analytics for your Web Stories', 'web-stories'),
   SECTION_HEADING: __('Google Analytics Tracking ID', 'web-stories'),
-  PLACEHOLDER: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
-  ARIA_LABEL: __('Enter your Google Analtyics Tracking ID', 'web-stories'),
+  PLACEHOLDER: __('Enter your Google Analytics Tracking ID', 'web-stories'),
+  ARIA_LABEL: __('Enter your Google Analytics Tracking ID', 'web-stories'),
   INPUT_ERROR: __('Invalid ID format', 'web-stories'),
+  SUBMIT_BUTTON: __('Save', 'web-stories'),
 };
 
 function GoogleAnalyticsSettings({ googleAnalyticsId, handleUpdate }) {
@@ -101,6 +103,9 @@ function GoogleAnalyticsSettings({ googleAnalyticsId, handleUpdate }) {
       </SettingHeading>
       <FormContainer>
         <InlineForm>
+          <VisuallyHiddenLabel for="gaTrackingId">
+            {TEXT.ARIA_LABEL}
+          </VisuallyHiddenLabel>
           <GoogleAnalyticsTextInput
             label={TEXT.ARIA_LABEL}
             id="gaTrackingId"
@@ -111,7 +116,7 @@ function GoogleAnalyticsSettings({ googleAnalyticsId, handleUpdate }) {
             error={inputError}
           />
           <SaveButton isDisabled={disableSaveButton} onClick={handleOnSave}>
-            {__('Save', 'web-stories')}
+            {TEXT.SUBMIT_BUTTON}
           </SaveButton>
         </InlineForm>
         {inputError && <ErrorText>{inputError}</ErrorText>}

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/test/googleAnalytics.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/test/googleAnalytics.js
@@ -54,6 +54,18 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
     expect(sectionHeader).toBeInTheDocument();
   });
 
+  it('should render a visually hidden label for google analytics input', function () {
+    const { getByLabelText } = renderWithProviders(
+      <GoogleAnalyticsSettings
+        googleAnalyticsId={googleAnalyticsId}
+        handleUpdate={mockUpdate}
+      />
+    );
+
+    const label = getByLabelText(TEXT.ARIA_LABEL);
+    expect(label).toBeInTheDocument();
+  });
+
   it('should call mockUpdate when enter is keyed on input', function () {
     let { getByRole, rerender } = renderWithProviders(
       <GoogleAnalyticsSettings


### PR DESCRIPTION

## Summary
Restores label to google analytics input on editor settings view. 

## Relevant Technical Choices
This was a regression that happened when we restructured the way the input submit works, added a test so it doesn't happen again.

## To-do
- Nothing

## User-facing changes
- Now when you use a screen reader the google analytics input will read a hidden label, saying "Enter your Google Analytics Tracking ID"

## Testing Instructions
- Run unit tests, added 1 test to verify the label's there. 
- Inspect DOM, see that a label is present for the `gaTrackingId` input 
- Run a screen reader (Chrome Vox is a good one, voice over will work too on system prefs on macs) and see that `Enter your Google Analytics Tracking ID` is read when you are focused on the ga tracking input

<img width="769" alt="Screen Shot 2020-09-22 at 1 16 52 PM" src="https://user-images.githubusercontent.com/10720454/93933029-e5b06e00-fcd5-11ea-8cae-23332f5020c2.png">


---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4620 
