### PR TITLE
Dashboard: My Stories - A11y Improvements

### DIFF
--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -256,10 +256,29 @@ function StoriesView({
                   setFocusedStory({ id: activeStory.id });
                   setActiveDialog('');
                 }}
+                aria-label={sprintf(
+                  /* translators: %s is story title */
+                  __(
+                    'No, I do not want to delete the story titled: %s',
+                    'web-stories'
+                  ),
+                  activeStory.title
+                )}
               >
                 {__('Cancel', 'web-stories')}
               </Button>
-              <Button type={BUTTON_TYPES.DEFAULT} onClick={handleOnDeleteStory}>
+              <Button
+                type={BUTTON_TYPES.DEFAULT}
+                onClick={handleOnDeleteStory}
+                aria-label={sprintf(
+                  /* translators: %s is story title */
+                  __(
+                    'Yes, I want to delete the story titled: %s',
+                    'web-stories'
+                  ),
+                  activeStory.title
+                )}
+              >
                 {__('Delete', 'web-stories')}
               </Button>
             </>

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -154,7 +154,7 @@ function StoriesView({
               body:
                 story.title.length > 0
                   ? sprintf(
-                      /* translators: %s is the story title. */
+                      /* translators: %s: story title. */
                       __(
                         '%s has been copied to your clipboard.',
                         'web-stories'
@@ -257,7 +257,7 @@ function StoriesView({
                   setActiveDialog('');
                 }}
                 aria-label={sprintf(
-                  /* translators: %s is story title */
+                  /* translators: %s: story title */
                   __('Cancel deleting story "%s"', 'web-stories'),
                   activeStory.title
                 )}
@@ -268,7 +268,7 @@ function StoriesView({
                 type={BUTTON_TYPES.DEFAULT}
                 onClick={handleOnDeleteStory}
                 aria-label={sprintf(
-                  /* translators: %s is story title */
+                  /* translators: %s: story title */
                   __('Confirm deleting story "%s"', 'web-stories'),
                   activeStory.title
                 )}

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -258,10 +258,7 @@ function StoriesView({
                 }}
                 aria-label={sprintf(
                   /* translators: %s is story title */
-                  __(
-                    'No, I do not want to delete the story titled: %s',
-                    'web-stories'
-                  ),
+                  __('Cancel deleting story "%s"', 'web-stories'),
                   activeStory.title
                 )}
               >
@@ -272,10 +269,7 @@ function StoriesView({
                 onClick={handleOnDeleteStory}
                 aria-label={sprintf(
                   /* translators: %s is story title */
-                  __(
-                    'Yes, I want to delete the story titled: %s',
-                    'web-stories'
-                  ),
+                  __('Confirm deleting story "%s"', 'web-stories'),
                   activeStory.title
                 )}
               >

--- a/assets/src/dashboard/app/views/myStories/header/index.js
+++ b/assets/src/dashboard/app/views/myStories/header/index.js
@@ -24,7 +24,7 @@ import { useDebouncedCallback } from 'use-debounce';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -108,6 +108,11 @@ function Header({
               key: storyStatus.value,
               isActive: filter.value === storyStatus.value,
               disabled: totalStoriesByStatus?.[storyStatus.status] <= 0,
+              ['aria-label']: sprintf(
+                /* translators: %s is story status */
+                __('Filter stories by %s', 'web-stories'),
+                storyStatus.label
+              ),
               text: `${storyStatus.label} ${
                 totalStoriesByStatus?.[storyStatus.status]
                   ? `(${totalStoriesByStatus?.[storyStatus.status]})`

--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -165,7 +165,7 @@ describe('Grid view', () => {
     await fixture.events.click(deleteStory);
 
     const confirmDeleteButton = fixture.screen.getByRole('button', {
-      name: /^Delete$/,
+      name: /^Confirm deleting story/,
     });
 
     await fixture.events.click(confirmDeleteButton);
@@ -195,7 +195,7 @@ describe('Grid view', () => {
     await fixture.events.click(deleteStory);
 
     const cancel = fixture.screen.getByRole('button', {
-      name: /^Cancel$/,
+      name: /^Cancel deleting story/,
     });
 
     await fixture.events.click(cancel);
@@ -215,7 +215,7 @@ describe('Grid view', () => {
       expect(numDrafts).toBeGreaterThan(0);
 
       const draftsTabButton = fixture.screen.getByRole('button', {
-        name: new RegExp('^' + STORY_STATUSES[1].label),
+        name: new RegExp('^Filter stories by ' + STORY_STATUSES[1].label),
       });
 
       await fixture.events.click(draftsTabButton);
@@ -240,7 +240,7 @@ describe('Grid view', () => {
       expect(numPublished).toBeGreaterThan(0);
 
       const publishedTabButton = fixture.screen.getByRole('button', {
-        name: new RegExp('^' + STORY_STATUSES[2].label),
+        name: new RegExp('^Filter stories by ' + STORY_STATUSES[2].label),
       });
 
       expect(publishedTabButton).toBeTruthy();
@@ -652,7 +652,7 @@ describe('List view', () => {
       await fixture.events.click(deleteButton);
 
       const confirmDeleteButton = fixture.screen.getByRole('button', {
-        name: /^Delete$/,
+        name: /^Confirm deleting/,
       });
 
       await fixture.events.click(confirmDeleteButton);
@@ -697,7 +697,7 @@ describe('List view', () => {
       await fixture.events.click(deleteButton);
 
       const cancel = fixture.screen.getByRole('button', {
-        name: /^Cancel$/,
+        name: /^Cancel deleting story/,
       });
 
       await fixture.events.click(cancel);

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -287,7 +287,7 @@ export default function StoryListView({
             <TableDateHeaderCell>
               <SelectableTitle
                 aria-label={__(
-                  'Date last modified, select to sort table by date story was last modified on',
+                  'Date last modified, select to sort table by date story was last modified',
                   'web-stories'
                 )}
                 onClick={() =>

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -287,7 +287,7 @@ export default function StoryListView({
             <TableDateHeaderCell>
               <SelectableTitle
                 aria-label={__(
-                  'Date last modified, select to sort table by date story was last modified',
+                  'Modification date, select to sort table by date story was last modified',
                   'web-stories'
                 )}
                 onClick={() =>

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -205,20 +205,29 @@ export default function StoryListView({
 
   return (
     <ListView data-testid="story-list-view">
-      <Table>
+      <Table aria-label={__('List view of created stories', 'web-stories')}>
         <StickyTableHeader top={stickyTopPosition}>
           <TableRow>
             <TablePreviewHeaderCell
               onClick={() => onSortTitleSelected(STORY_SORT_OPTIONS.NAME)}
               onKeyDown={(e) => onKeyDownSort(e, STORY_SORT_OPTIONS.NAME)}
             >
-              <SelectableTitle>{__('Title', 'web-stories')}</SelectableTitle>
+              <SelectableTitle
+                aria-label={__(
+                  'Title, select to sort table by story title',
+                  'web-stories'
+                )}
+              >
+                {__('Title', 'web-stories')}
+              </SelectableTitle>
             </TablePreviewHeaderCell>
             <TableTitleHeaderCell
               onClick={() => onSortTitleSelected(STORY_SORT_OPTIONS.NAME)}
               onKeyDown={(e) => onKeyDownSort(e, STORY_SORT_OPTIONS.NAME)}
             >
-              <SelectableTitle>{__('Title', 'web-stories')}</SelectableTitle>
+              <SelectableTitle aria-hidden="true">
+                {__('Title', 'web-stories')}
+              </SelectableTitle>
               <ArrowIcon active={storySort === STORY_SORT_OPTIONS.NAME}>
                 {sortDirection === SORT_DIRECTION.DESC ? (
                   <ArrowAlphaDescendingSvg />
@@ -229,6 +238,10 @@ export default function StoryListView({
             </TableTitleHeaderCell>
             <TableAuthorHeaderCell>
               <SelectableTitle
+                aria-label={__(
+                  'Author, select to sort table by story author',
+                  'web-stories'
+                )}
                 onClick={() =>
                   onSortTitleSelected(STORY_SORT_OPTIONS.CREATED_BY)
                 }
@@ -250,6 +263,10 @@ export default function StoryListView({
             </TableAuthorHeaderCell>
             <TableDateHeaderCell>
               <SelectableTitle
+                aria-label={__(
+                  'Date created, select to sort table by date story was created',
+                  'web-stories'
+                )}
                 onClick={() =>
                   onSortTitleSelected(STORY_SORT_OPTIONS.DATE_CREATED)
                 }
@@ -260,6 +277,7 @@ export default function StoryListView({
                 {__('Date Created', 'web-stories')}
               </SelectableTitle>
               <ArrowIconWithTitle
+                aria-hidden={true}
                 active={storySort === STORY_SORT_OPTIONS.DATE_CREATED}
                 asc={sortDirection === SORT_DIRECTION.ASC}
               >
@@ -268,6 +286,10 @@ export default function StoryListView({
             </TableDateHeaderCell>
             <TableDateHeaderCell>
               <SelectableTitle
+                aria-label={__(
+                  'Date last modified, select to sort table by date story was last modified on',
+                  'web-stories'
+                )}
                 onClick={() =>
                   onSortTitleSelected(STORY_SORT_OPTIONS.LAST_MODIFIED)
                 }
@@ -278,6 +300,7 @@ export default function StoryListView({
                 {__('Last Modified', 'web-stories')}
               </SelectableTitle>
               <ArrowIconWithTitle
+                aria-hidden={true}
                 active={storySort === STORY_SORT_OPTIONS.LAST_MODIFIED}
                 asc={sortDirection === SORT_DIRECTION.ASC}
               >

--- a/assets/src/dashboard/app/views/shared/storyListView.js
+++ b/assets/src/dashboard/app/views/shared/storyListView.js
@@ -264,7 +264,7 @@ export default function StoryListView({
             <TableDateHeaderCell>
               <SelectableTitle
                 aria-label={__(
-                  'Date created, select to sort table by date story was created',
+                  'Creation date, select to sort table by date story was created',
                   'web-stories'
                 )}
                 onClick={() =>

--- a/assets/src/dashboard/types.js
+++ b/assets/src/dashboard/types.js
@@ -39,7 +39,7 @@ export const StoryPropType = PropTypes.shape({
   status: DashboardStatusesPropType,
   title: PropTypes.string.isRequired,
   pages: PropTypes.arrayOf(StoryPropTypes.page),
-  modified: PropTypes.object,
+  modified: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   author: PropTypes.string,
 });
 


### PR DESCRIPTION
## Summary
Giving buttons on My Stories aria-labels where context isn't clear to a screen reader. 

## Relevant Technical Choices
- `aria-labels` 🔁  👍 

## To-do
- N/A

## User-facing changes
- The filter buttons for my stories, when using a screen reader should now announce "Filter stories by [status]" instead of just status
![Screen Shot 2020-09-22 at 3 30 21 PM](https://user-images.githubusercontent.com/10720454/93944272-34b3ce80-fce9-11ea-9962-7b5a74761dec.png)

- The story delete dialog buttons should now announce "No, I do not want to delete the story titled: [story title]" for "Cancel" and "Yes, I want to delete the story titled: [story title]" for "Delete"
![Screen Shot 2020-09-22 at 3 30 11 PM](https://user-images.githubusercontent.com/10720454/93944277-38dfec00-fce9-11ea-9592-d77c4977b681.png)

- The table headings on the list view of stories should now announce: "[Column Name], select to sort table by [column name]' - which is maybe a little overbearing but I thought it was a better ease into the functionality that keeps context of the table first. 
![Screen Shot 2020-09-22 at 3 30 37 PM](https://user-images.githubusercontent.com/10720454/93944289-3da4a000-fce9-11ea-9435-2b1911e4dbf9.png)


## Testing Instructions

- See that the above user facing changes are valid by using a screen reader and focusing on these elements

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4628 
