### PR TITLE
Dashboard: A11y improvements for the telemetry banner

### DIFF
--- a/assets/src/dashboard/app/views/shared/karma/telemetryBanner.karma.js
+++ b/assets/src/dashboard/app/views/shared/karma/telemetryBanner.karma.js
@@ -56,7 +56,7 @@ describe('Telemetry Banner', () => {
 
   it('should close the banner when the exit button is closed', async () => {
     const exitButton = await fixture.screen.getByRole('button', {
-      name: /Dismiss Notice/,
+      name: /Dismiss telemetry/,
     });
 
     await fixture.events.click(exitButton);
@@ -102,7 +102,7 @@ describe('Telemetry Banner', () => {
 
   it('should not display the banner after it has been closed with', async () => {
     const exitButton = await fixture.screen.getByRole('button', {
-      name: /Dismiss Notice/,
+      name: /Dismiss telemetry/,
     });
 
     await fixture.events.click(exitButton);

--- a/assets/src/dashboard/app/views/shared/karma/telemetryBanner.karma.js
+++ b/assets/src/dashboard/app/views/shared/karma/telemetryBanner.karma.js
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Internal dependencies
  */
@@ -118,5 +134,36 @@ describe('Telemetry Banner', () => {
     bannerHeader = await fixture.screen.queryByText(/Help improve the editor!/);
 
     expect(bannerHeader).toBeNull();
+  });
+
+  it('should keep focus on the checkbox when checking/unchecking via keyboard', async () => {
+    const checkbox = await fixture.querySelector('#telemetry-banner-opt-in');
+    await fixture.events.focus(checkbox);
+
+    await fixture.events.keyboard.press('Space');
+
+    let optedIn = await fixture.renderHook(() =>
+      useApi(
+        ({ state: { currentUser } }) =>
+          currentUser.data?.meta?.web_stories_tracking_optin ?? false
+      )
+    );
+
+    expect(optedIn).toBeTrue();
+
+    expect(checkbox).toEqual(document.activeElement);
+
+    await fixture.events.keyboard.press('Space');
+
+    optedIn = await fixture.renderHook(() =>
+      useApi(
+        ({ state: { currentUser } }) =>
+          currentUser.data?.meta?.web_stories_tracking_optin ?? false
+      )
+    );
+
+    expect(optedIn).toBeFalse();
+
+    expect(checkbox).toEqual(document.activeElement);
   });
 });

--- a/assets/src/dashboard/app/views/shared/karma/telemetryBanner.karma.js
+++ b/assets/src/dashboard/app/views/shared/karma/telemetryBanner.karma.js
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2020 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /**
  * Internal dependencies
  */

--- a/assets/src/dashboard/app/views/shared/telemetryBanner.js
+++ b/assets/src/dashboard/app/views/shared/telemetryBanner.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { useLayoutEffect, useRef, forwardRef } from 'react';
+import { useLayoutEffect, useRef, forwardRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
@@ -89,7 +89,10 @@ const CloseIcon = styled(CloseSVG)`
 `;
 
 const ToggleButton = styled.button.attrs({
-  ['aria-label']: __('Dismiss Notice', 'web-stories'),
+  ['aria-label']: __(
+    'Dismiss telemetry data sharing opt-in banner',
+    'web-stories'
+  ),
 })`
   display: flex;
   height: 16px;
@@ -122,6 +125,14 @@ export const TelemetryOptInBanner = forwardRef(
     ref
   ) => {
     const { assetsURL } = useConfig();
+    const checkboxRef = useRef();
+    const focusOnCheckbox = useRef(false);
+
+    useEffect(() => {
+      if (focusOnCheckbox.current) {
+        checkboxRef.current.focus();
+      }
+    });
 
     return visible ? (
       <Banner
@@ -142,7 +153,18 @@ export const TelemetryOptInBanner = forwardRef(
           </ToggleButton>
         </Header>
         <Label>
-          <CheckBox checked={checked} disabled={disabled} onChange={onChange} />
+          <CheckBox
+            checked={checked}
+            disabled={disabled}
+            onChange={() => {
+              onChange();
+              focusOnCheckbox.current = true;
+            }}
+            onBlur={() => {
+              focusOnCheckbox.current = false;
+            }}
+            ref={checkboxRef}
+          />
           <LabelText aria-checked={checked}>
             {__(
               'Check the box to help us improve the Web Stories plugin by allowing tracking of product usage stats. All data are treated in accordance with Google Privacy Policy.',
@@ -153,6 +175,10 @@ export const TelemetryOptInBanner = forwardRef(
               href={__('https://policies.google.com/privacy', 'web-stories')}
               rel="noreferrer"
               target="_blank"
+              aria-label={__(
+                'Learn more by visiting https://policies.google.com/privacy',
+                'web-stories'
+              )}
             >
               {__('Learn more', 'web-stories')}
               {'.'}

--- a/assets/src/dashboard/app/views/shared/telemetryBanner.js
+++ b/assets/src/dashboard/app/views/shared/telemetryBanner.js
@@ -176,7 +176,7 @@ export const TelemetryOptInBanner = forwardRef(
               rel="noreferrer"
               target="_blank"
               aria-label={__(
-                'Learn more by visiting https://policies.google.com/privacy',
+                'Learn more by visiting Google Privacy Policy',
                 'web-stories'
               )}
             >

--- a/assets/src/dashboard/app/views/shared/test/telemetryBanner.js
+++ b/assets/src/dashboard/app/views/shared/test/telemetryBanner.js
@@ -110,4 +110,27 @@ describe('TelemetryBanner', () => {
 
     expect(checkbox).not.toBeChecked();
   });
+
+  it('should keep focus on the checkbox when checking/unchecking via', () => {
+    const { getByRole } = renderWithProviders(<TelemetryBannerTestContainer />);
+
+    const checkbox = getByRole('checkbox');
+
+    // Tab to Dismiss button
+    userEvent.tab();
+
+    // Tab to checkbox
+    userEvent.tab();
+
+    expect(checkbox).toHaveFocus();
+
+    expect(checkbox).not.toBeChecked();
+
+    // Check the checkbox via keyboard
+    userEvent.type(checkbox, '{space}');
+
+    expect(checkbox).toHaveFocus();
+
+    expect(checkbox).toBeChecked();
+  });
 });


### PR DESCRIPTION
## Summary

1. The dismiss button should announce what it is dismissing
2. Focus should remain on the checkbox when checked/unchecked
3. The learn more link should announce what it is linking to

## User-facing changes
1. When using keyboard navigation and you check the checkbox, focus should remain on the checkbox.
2. When using a screen reader, the dismiss button should announce what it's dismissing.
3. When using a screen reader, the learn more link should announce what it's linking to.

## Testing Instructions

- Using ChromeVox, validated the screen reader requirements
- Using keyboard navigation, validate that focus remains on the checkbox when interacting with it
- Validate in CI and locally that the new unit and karma tests pass

---

<!-- Please reference the issue(s) this PR addresses. -->

#4627 
