### PR TITLE
Dashboard: Fix width bug on settings page

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -43,7 +43,6 @@ export const Main = styled(StandardViewContentGutter)`
   padding-top: 36px;
   margin-top: 20px;
   max-width: 945px;
-  /* width: 100%; */
 `;
 
 export const SettingForm = styled.form`

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -43,7 +43,7 @@ export const Main = styled(StandardViewContentGutter)`
   padding-top: 36px;
   margin-top: 20px;
   max-width: 945px;
-  width: 100%;
+  /* width: 100%; */
 `;
 
 export const SettingForm = styled.form`


### PR DESCRIPTION
## Summary

The width of the settings page was overflowing when at 1280 width

## User-facing changes

- The settings page should be contained/not overflow when the browser width is <=1280px

## Testing Instructions

- Load the settings page and resize your browser to 1280px and verify that the content is displayed correct

### Before
![before](https://user-images.githubusercontent.com/2755722/94050770-b583d080-fda4-11ea-8fef-f846f49f0cfd.png)


### After
![after](https://user-images.githubusercontent.com/2755722/94050690-9b49f280-fda4-11ea-8d21-ad59026ad7fd.png)


---


#4648 
