### PR TITLE
Dashboard: Add missing H1 tag

### DIFF
--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -36,6 +36,11 @@ export const Content = styled.div`
 
 export const Header = styled.h1`
   margin: 42px 0px 72px;
+
+  & > svg {
+    margin: 0 28px;
+    height: 64px;
+  }
 `;
 
 export const NavButton = styled(Button)`

--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -32,16 +32,10 @@ export const Content = styled.div`
   > * {
     margin: 20px 28px;
   }
-  & > svg {
-    margin: 0 28px;
-    height: 64px;
-  }
 `;
 
-export const Header = styled(Content)`
-  margin-top: 42px;
-  margin-bottom: 72px;
-  align-items: flex-start;
+export const Header = styled.h1`
+  margin: 42px 28px 72px;
 `;
 
 export const NavButton = styled(Button)`

--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -35,7 +35,7 @@ export const Content = styled.div`
 `;
 
 export const Header = styled.h1`
-  margin: 42px 28px 72px;
+  margin: 42px 0px 72px;
 `;
 
 export const NavButton = styled(Button)`


### PR DESCRIPTION
## Summary

This adds an H1 tag for A11y to our Title/Header component

## Relevant Technical Choices

- Converted the wrapper of the svg from a div to h1

## User-facing changes

None

## Testing Instructions

- Verify no visual regressions and that screen readers work correctly

---

#4626 
