### PR TITLE
Story Editor: Persist Active Page Between Reloads

### DIFF
--- a/assets/src/edit-story/app/story/effects/test/useHashState.js
+++ b/assets/src/edit-story/app/story/effects/test/useHashState.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import useHashState, { hashToParams } from '../useHashState';
+
+const hashKeyVal = (key) =>
+  JSON.parse(decodeURI(hashToParams(window.location.hash).get(key)));
+
+describe('useHashState', () => {
+  afterEach(() => {
+    window.location.hash = '';
+  });
+
+  it('initializes with fallback if no value found under hash key', () => {
+    const fallback = 4;
+    const { result } = renderHook(() => useHashState('test', fallback));
+    expect(result.current[0]).toBe(fallback);
+  });
+
+  it('updates hash key value on every update', () => {
+    const key = 'test';
+    const { result } = renderHook(() => useHashState(key, 5));
+    expect(hashKeyVal(key)).toBe(5);
+
+    act(() => result.current[1](10));
+    expect(hashKeyVal(key)).toBe(10);
+
+    act(() => result.current[1](15));
+    expect(hashKeyVal(key)).toBe(15);
+  });
+
+  it('initializes with hash key value if it exists', () => {
+    const key = 'test';
+    const persisted = 86;
+    window.location.hash = `${key}=${persisted}`;
+    const { result } = renderHook(() => useHashState(key, 0));
+    expect(result.current[0]).toBe(persisted);
+  });
+
+  it('can handle objects', () => {
+    const key = 'test';
+    const fallback = {
+      one: 'thing',
+      two: {
+        three: 4,
+      },
+    };
+    const addFive = (obj) => ({ ...obj, five: true });
+
+    const { result: result1 } = renderHook(() => useHashState(key, fallback));
+    act(() => result1.current[1](addFive));
+
+    const { result: result2 } = renderHook(() => useHashState(key, null));
+    expect(result2.current[0]).toStrictEqual(addFive(fallback));
+  });
+});

--- a/assets/src/edit-story/app/story/effects/useHashState.js
+++ b/assets/src/edit-story/app/story/effects/useHashState.js
@@ -64,7 +64,7 @@ function useHashState(key, fallback) {
     let _value = fallback;
     try {
       if (params.has(key)) {
-        _value = JSON.parse(decodeURI(params.get(key)));
+        _value = JSON.parse(`"${decodeURI(params.get(key))}"`);
       }
     } catch (e) {
       // @TODO Add some error handling

--- a/assets/src/edit-story/app/story/effects/useHashState.js
+++ b/assets/src/edit-story/app/story/effects/useHashState.js
@@ -37,12 +37,6 @@ export function hashToParams(hash) {
   return new URLSearchParams(hash.startsWith('#') ? hash.substr(1) : hash);
 }
 
-function removeDoubleQuotes(string) {
-  return string.startsWith('"') && string.endsWith('"')
-    ? string.slice(1, -1)
-    : string;
-}
-
 /**
  * Functions like a normal `useState()` but reads initial value of of url
  * hash key and uses `fallback` if no value found. Also updates hash key on
@@ -64,7 +58,7 @@ function useHashState(key, fallback) {
     let _value = fallback;
     try {
       if (params.has(key)) {
-        _value = JSON.parse(`"${decodeURI(params.get(key))}"`);
+        _value = JSON.parse(decodeURI(params.get(key)));
       }
     } catch (e) {
       // @TODO Add some error handling
@@ -75,7 +69,7 @@ function useHashState(key, fallback) {
   // update url param when value updates
   useEffect(() => {
     const params = hashToParams(window.location.hash);
-    params.set(key, encodeURI(removeDoubleQuotes(JSON.stringify(value))));
+    params.set(key, encodeURI(JSON.stringify(value)));
     window.location.hash = params.toString();
   }, [key, value]);
 

--- a/assets/src/edit-story/app/story/effects/useHashState.js
+++ b/assets/src/edit-story/app/story/effects/useHashState.js
@@ -31,7 +31,7 @@
 /**
  * External dependencies
  */
-import { useLayoutEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export function hashToParams(hash) {
   return new URLSearchParams(hash.startsWith('#') ? hash.substr(1) : hash);
@@ -67,14 +67,13 @@ function useHashState(key, fallback) {
         _value = JSON.parse(decodeURI(params.get(key)));
       }
     } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error(e);
+      // @TODO Add some error handling
     }
     return _value;
   });
 
   // update url param when value updates
-  useLayoutEffect(() => {
+  useEffect(() => {
     const params = hashToParams(window.location.hash);
     params.set(key, encodeURI(removeDoubleQuotes(JSON.stringify(value))));
     window.location.hash = params.toString();

--- a/assets/src/edit-story/app/story/effects/useHashState.js
+++ b/assets/src/edit-story/app/story/effects/useHashState.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useLayoutEffect, useState } from 'react';
+
+export function hashToParams(hash) {
+  return new URLSearchParams(hash.startsWith('#') ? hash.substr(1) : hash);
+}
+
+function removeDoubleQuotes(string) {
+  return string.startsWith('"') && string.endsWith('"')
+    ? string.slice(1, -1)
+    : string;
+}
+
+/**
+ * Functions like a normal `useState()` but reads initial value of of url
+ * hash key and uses `fallback` if no value found. Also updates hash key on
+ * every state update so is persistant between mounts.
+ *
+ * Values held in here must be serializable.
+ *
+ * Can be used as many times as needed, but may exceed url char limit
+ * if over used.
+ *
+ * @param {string} key  identifier for storing hash persisted value.
+ * @param {*} fallback  value state intialized with if none found under key.
+ *
+ * @return {[*, Function]} value & setter tuple like `useState()`
+ */
+function useHashState(key, fallback) {
+  const [value, setValue] = useState(() => {
+    const params = hashToParams(window.location.hash);
+    let _value = fallback;
+    try {
+      if (params.has(key)) {
+        _value = JSON.parse(decodeURI(params.get(key)));
+      }
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(e);
+    }
+    return _value;
+  });
+
+  // update url param when value updates
+  useLayoutEffect(() => {
+    const params = hashToParams(window.location.hash);
+    params.set(key, encodeURI(removeDoubleQuotes(JSON.stringify(value))));
+    window.location.hash = params.toString();
+  }, [key, value]);
+
+  return [value, setValue];
+}
+
+export default useHashState;

--- a/assets/src/edit-story/app/story/storyProvider.js
+++ b/assets/src/edit-story/app/story/storyProvider.js
@@ -160,7 +160,6 @@ function StoryProvider({ storyId, children }) {
     },
     actions: {
       ...api,
-      // setCurrentPage: setCurrentPageAndHash,
       autoSave,
       saveStory,
     },

--- a/assets/src/edit-story/app/story/storyProvider.js
+++ b/assets/src/edit-story/app/story/storyProvider.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -27,17 +27,21 @@ import Context from './context';
 
 import useLoadStory from './effects/useLoadStory';
 import useSaveStory from './actions/useSaveStory';
+import useHashState from './effects/useHashState';
 import useHistoryEntry from './effects/useHistoryEntry';
 import useHistoryReplay from './effects/useHistoryReplay';
 import useStoryReducer from './useStoryReducer';
 import useAutoSave from './actions/useAutoSave';
 
 function StoryProvider({ storyId, children }) {
+  const [hashPageId, setHashPageId] = useHashState('page', null);
   const {
     state: reducerState,
     api,
     internal: { restore },
-  } = useStoryReducer();
+  } = useStoryReducer({
+    current: hashPageId,
+  });
   const {
     pages,
     current,
@@ -46,6 +50,8 @@ function StoryProvider({ storyId, children }) {
     animationState,
     capabilities,
   } = reducerState;
+
+  useEffect(() => setHashPageId(current), [current, setHashPageId]);
 
   // Generate current page info.
   const {
@@ -154,6 +160,7 @@ function StoryProvider({ storyId, children }) {
     },
     actions: {
       ...api,
+      // setCurrentPage: setCurrentPageAndHash,
       autoSave,
       saveStory,
     },

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/restore.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/restore.js
@@ -38,8 +38,9 @@ function restore(state, { pages, current, selection, story }) {
   }
 
   const newStory = typeof story === 'object' ? story : {};
-  const newCurrent = pages.some(({ id }) => id === current)
-    ? current
+  const oldCurrent = current ?? state.current;
+  const newCurrent = pages.some(({ id }) => id === oldCurrent)
+    ? oldCurrent
     : pages[0].id;
   const newSelection = Array.isArray(selection) ? selection : [];
 

--- a/assets/src/edit-story/app/story/useStoryReducer/test/_utils.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/_utils.js
@@ -24,8 +24,8 @@ import { renderHook, act } from '@testing-library/react-hooks';
  */
 import useStoryReducer from '../useStoryReducer';
 
-export function setupReducer() {
-  const { result } = renderHook(() => useStoryReducer());
+export function setupReducer(partial) {
+  const { result } = renderHook(() => useStoryReducer(partial));
 
   // convert each method to be wrapped in act and return the new state
   const wrapWithAct = (methods) =>

--- a/assets/src/edit-story/app/story/useStoryReducer/test/restore.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/restore.js
@@ -149,4 +149,25 @@ describe('restore', () => {
       story: {},
     });
   });
+
+  it('should restore with existing current page (if it exists in restore story) if no current page supplied', () => {
+    // Initialize state with a current story page.
+    const currentPage = { current: '222' };
+    const reducer = setupReducer(currentPage);
+    const { restore } = reducer;
+
+    // Restore state to hold story
+    const storyWithNoCurrentPage = {
+      pages: [{ id: '111' }, { id: '222', elements: [{ id: '333' }] }],
+      selection: ['333'],
+      story: { a: 1 },
+    };
+    const result = restore(storyWithNoCurrentPage);
+
+    expect(result).toStrictEqual({
+      animationState: STORY_ANIMATION_STATE.RESET,
+      ...storyWithNoCurrentPage,
+      ...currentPage,
+    });
+  });
 });

--- a/assets/src/edit-story/app/story/useStoryReducer/test/restore.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/restore.js
@@ -170,4 +170,26 @@ describe('restore', () => {
       ...currentPage,
     });
   });
+
+  it('should restore with first page as current if initialized with faulty current pageId', () => {
+    // Initialize state with a story page that does not exist
+    const currentPage = { current: 'DOES NOT EXIST' };
+    const reducer = setupReducer(currentPage);
+    const { restore } = reducer;
+
+    // Restore state to hold story
+    const storyWithNoCurrentPage = {
+      pages: [{ id: '111' }, { id: '222', elements: [{ id: '333' }] }],
+      selection: ['333'],
+      story: { a: 1 },
+    };
+    const result = restore(storyWithNoCurrentPage);
+
+    // Should set first story as current
+    expect(result).toStrictEqual({
+      animationState: STORY_ANIMATION_STATE.RESET,
+      ...storyWithNoCurrentPage,
+      current: '111',
+    });
+  });
 });

--- a/assets/src/edit-story/app/story/useStoryReducer/useStoryReducer.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/useStoryReducer.js
@@ -54,13 +54,13 @@ const INITIAL_STATE = {
  * - New pages aren't validated for type of elements property when added.
  * - No validation of keys or values in the story object.
  *
- * @param {Object} initial A state partial to initialize with.
+ * @param {Object} partial A state partial to initialize with.
  * @return {Object} An object with keys `state`, `internal` and `api`.
  */
-function useStoryReducer(initial) {
+function useStoryReducer(partial) {
   const [state, dispatch] = useReducer(reducer, {
     ...INITIAL_STATE,
-    ...initial,
+    ...partial,
   });
 
   const { internal, api } = useMemo(() => {

--- a/assets/src/edit-story/app/story/useStoryReducer/useStoryReducer.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/useStoryReducer.js
@@ -54,10 +54,14 @@ const INITIAL_STATE = {
  * - New pages aren't validated for type of elements property when added.
  * - No validation of keys or values in the story object.
  *
+ * @param {Object} initial A state partial to initialize with.
  * @return {Object} An object with keys `state`, `internal` and `api`.
  */
-function useStoryReducer() {
-  const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+function useStoryReducer(initial) {
+  const [state, dispatch] = useReducer(reducer, {
+    ...INITIAL_STATE,
+    ...initial,
+  });
 
   const { internal, api } = useMemo(() => {
     const wrapWithDispatch = (actions) =>

--- a/assets/src/edit-story/karma/fixture/fixture.js
+++ b/assets/src/edit-story/karma/fixture/fixture.js
@@ -118,7 +118,10 @@ export class Fixture {
     this._editor = null;
   }
 
-  restore() {}
+  restore() {
+    window.location.hash = '#';
+    localStorage.clear();
+  }
 
   get container() {
     return this._container;

--- a/assets/src/edit-story/utils/useRefreshPostEditURL.js
+++ b/assets/src/edit-story/utils/useRefreshPostEditURL.js
@@ -39,7 +39,7 @@ function useRefreshPostEditURL(postId) {
     window.history.replaceState(
       { id: postId },
       'Post ' + postId,
-      getPostEditURL
+      getPostEditURL + window.location.hash
     );
   }, [postId]);
   return refreshPostEditURL;


### PR DESCRIPTION
## Summary
Persists active story page in editor between reloads.

## Relevant Technical Choices
Adds a hook that stores key value pairs to hash on updates:
```
const [value, setValue] = useHashState(key, fallback);
``` 

Using this to initialize the current page in story state.

Ready to use in other places if we wanna persist any other editor state through the hash.

## To-do
NA

## User-facing changes
Active page in story should now remain active between reloads.

## Testing Instructions
-> Go to story editor
-> Change active page to something other than the first page
-> Reload browser
-> Check that active page stays active between reloads

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4605 
