### PR TITLE
Use pull_request_target event for workflows

### DIFF
--- a/.github/workflows/cleanup-pr-assets.yml
+++ b/.github/workflows/cleanup-pr-assets.yml
@@ -6,7 +6,7 @@
 name: Clean up PR assets for closed PRs
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 jobs:

--- a/.github/workflows/continuous-integration-build.yml
+++ b/.github/workflows/continuous-integration-build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
+  pull_request_target:
 
 jobs:
   build:

--- a/.github/workflows/continuous-integration-bundle-size.yml
+++ b/.github/workflows/continuous-integration-bundle-size.yml
@@ -1,7 +1,7 @@
 name: Bundle size check
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   bundle-size:

--- a/.github/workflows/continuous-integration-e2e.yml
+++ b/.github/workflows/continuous-integration-e2e.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
+  pull_request_target:
 
 jobs:
   e2e:

--- a/.github/workflows/continuous-integration-karma-dashboard.yml
+++ b/.github/workflows/continuous-integration-karma-dashboard.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
+  pull_request_target:
 
 jobs:
   karma:

--- a/.github/workflows/continuous-integration-karma-edit-story.yml
+++ b/.github/workflows/continuous-integration-karma-edit-story.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
+  pull_request_target:
 
 jobs:
   karma:

--- a/.github/workflows/continuous-integration-lint-css.yml
+++ b/.github/workflows/continuous-integration-lint-css.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
+  pull_request_target:
 
 jobs:
   lint-css:

--- a/.github/workflows/continuous-integration-lint-js.yml
+++ b/.github/workflows/continuous-integration-lint-js.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
+  pull_request_target:
 
 jobs:
   lint-js:

--- a/.github/workflows/continuous-integration-lint-md.yml
+++ b/.github/workflows/continuous-integration-lint-md.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
+  pull_request_target:
 
 jobs:
   lint-md:

--- a/.github/workflows/continuous-integration-lint-php.yml
+++ b/.github/workflows/continuous-integration-lint-php.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
+  pull_request_target:
 
 jobs:
   lint-php:

--- a/.github/workflows/continuous-integration-unit-js.yml
+++ b/.github/workflows/continuous-integration-unit-js.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
+  pull_request_target:
 
 jobs:
   unit-js:

--- a/.github/workflows/continuous-integration-unit-php.yml
+++ b/.github/workflows/continuous-integration-unit-php.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release/*
-  pull_request:
+  pull_request_target:
 
 jobs:
   unit-php:


### PR DESCRIPTION
## Summary

This behaves in an almost identical way to the pull_request event with the same set of filters and payload. However, instead of running against the workflow and code from the merge commit, the event runs against the workflow and code from the base of the pull request.

This is needed for PRs from repository forks, and makes it easier for non-members to contribute to the plugin.

See https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/ for details
