### PR TITLE
Karma: retry failed tests in the same step

### DIFF
--- a/.github/workflows/continuous-integration-karma-dashboard.yml
+++ b/.github/workflows/continuous-integration-karma-dashboard.yml
@@ -43,15 +43,9 @@ jobs:
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Run integration tests
-        run: npm run test:karma:dashboard -- --headless --viewport=1600:1000 --coverage
+        run: npm run test:karma:dashboard -- --headless --viewport=1600:1000 --coverage || npm run test:karma:dashboard:retry-failed -- --headless --viewport=1600:1000
         env:
           DISABLE_ERROR_BOUNDARIES: true
-
-      - name: Retry failed tests
-        run: npm run test:karma:dashboard:retry-failed -- --headless --viewport=1600:1000
-        env:
-          DISABLE_ERROR_BOUNDARIES: true
-        if: failure()
 
       - name: Upload code coverage report
         uses: codecov/codecov-action@v1

--- a/.github/workflows/continuous-integration-karma-dashboard.yml
+++ b/.github/workflows/continuous-integration-karma-dashboard.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Run integration tests
-        run: npm run test:karma:dashboard -- --headless --viewport=1600:1000 --coverage || npm run test:karma:dashboard:retry-failed -- --headless --viewport=1600:1000
+        run: npm run test:karma:dashboard -- --headless --viewport=1600:1000 --coverage || npm run test:karma:dashboard:retry-failed -- --headless --viewport=1600:1000 --coverage
         env:
           DISABLE_ERROR_BOUNDARIES: true
 

--- a/.github/workflows/continuous-integration-karma-edit-story.yml
+++ b/.github/workflows/continuous-integration-karma-edit-story.yml
@@ -43,7 +43,7 @@ jobs:
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Run integration tests
-        run: npm run test:karma:edit-story -- --headless --snapshots --viewport=1600:1000 --coverage || npm run test:karma:edit-story:retry-failed -- --headless --snapshots --viewport=1600:1000
+        run: npm run test:karma:edit-story -- --headless --snapshots --viewport=1600:1000 --coverage || npm run test:karma:edit-story:retry-failed -- --headless --snapshots --viewport=1600:1000 --coverage
         env:
           DISABLE_ERROR_BOUNDARIES: true
 

--- a/.github/workflows/continuous-integration-karma-edit-story.yml
+++ b/.github/workflows/continuous-integration-karma-edit-story.yml
@@ -43,15 +43,9 @@ jobs:
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Run integration tests
-        run: npm run test:karma:edit-story -- --headless --snapshots --viewport=1600:1000 --coverage
+        run: npm run test:karma:edit-story -- --headless --snapshots --viewport=1600:1000 --coverage || npm run test:karma:edit-story:retry-failed -- --headless --snapshots --viewport=1600:1000
         env:
           DISABLE_ERROR_BOUNDARIES: true
-
-      - name: Retry failed teststests
-        run: npm run test:karma:edit-story:retry-failed -- --headless --snapshots --viewport=1600:1000
-        env:
-          DISABLE_ERROR_BOUNDARIES: true
-        if: failure()
 
       - name: Add files for snapshotting
         run: cp -r __static__ .test_artifacts/karma_snapshots/


### PR DESCRIPTION
This is a follow-up  to #4676 to avoid this:

<img width="834" alt="Screenshot 2020-09-25 at 15 46 46" src="https://user-images.githubusercontent.com/841956/94274820-755c5380-ff46-11ea-9795-5266bfb30d74.png">

The retrying was successful, but because it's in a separate job GitHub will still mark it as a failure, and not upload any coverage reports or the like.
