### PR TITLE
Dashboard: Settings view a11y updates

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -178,7 +178,7 @@ function PublisherLogoSettings({
             tabIndex={0}
             ref={gridRef}
             role="list"
-            ariaLabel={__('Viewing existing publisher logos', 'web-stories')}
+            aria-label={__('Viewing existing publisher logos', 'web-stories')}
           >
             {publisherLogos.map((publisherLogo, idx) => {
               if (!publisherLogo) {
@@ -207,12 +207,9 @@ function PublisherLogoSettings({
                       setActivePublisherLogoId(publisherLogo.id);
                     }}
                     aria-label={sprintf(
-                      /* translators: %s: logo number.*/
-                      __(
-                        'Publisher Logo %s (currently selected)',
-                        'web-stories'
-                      ),
-                      idx + 1
+                      /* translators: %s: logo title.*/
+                      __('Publisher Logo %s', 'web-stories'),
+                      publisherLogo.title
                     )}
                   >
                     <Logo src={publisherLogo.src} alt={publisherLogo.title} />

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/index.js
@@ -79,7 +79,7 @@ function PublisherLogoSettings({
   const gridRef = useRef();
   const itemRefs = useRef({});
 
-  const [activePublisherLogo, setActivePublisherLogoId] = useState(null);
+  const [activePublisherLogoId, setActivePublisherLogoId] = useState(null);
   const [indexRemoved, setIndexRemoved] = useState(null);
 
   const [contextMenuId, setContextMenuId] = useState(null);
@@ -126,23 +126,22 @@ function PublisherLogoSettings({
       return setIndexRemoved(null);
     }
     return undefined;
-  }, [
-    activePublisherLogo,
-    indexRemoved,
-    publisherLogosById,
-    setActivePublisherLogoId,
-  ]);
+  }, [indexRemoved, publisherLogosById, setActivePublisherLogoId]);
 
   useGridViewKeys({
     containerRef,
     gridRef,
     itemRefs,
     isRTL,
-    currentItemId: activePublisherLogo,
+    currentItemId: activePublisherLogoId,
     items: publisherLogos,
   });
 
   const showLogoContextMenu = !hasOnlyOneLogo;
+
+  const onMenuItemToggle = useCallback((newMenuId) => {
+    setActivePublisherLogoId(newMenuId);
+  }, []);
 
   const onMenuItemSelected = useCallback(
     (sender, logo, index) => {
@@ -164,7 +163,14 @@ function PublisherLogoSettings({
     [handleUpdateDefaultLogo, handleRemoveLogoClick]
   );
 
-  useFocusOut(containerRef, () => setActivePublisherLogoId(null), []);
+  useFocusOut(
+    containerRef,
+    () => {
+      setActivePublisherLogoId(null);
+      setContextMenuId(null);
+    },
+    []
+  );
 
   return (
     <SettingForm>
@@ -185,7 +191,7 @@ function PublisherLogoSettings({
                 return null;
               }
 
-              const isActive = activePublisherLogo === publisherLogo.id;
+              const isActive = activePublisherLogoId === publisherLogo.id;
 
               return (
                 <GridItemContainer
@@ -222,10 +228,11 @@ function PublisherLogoSettings({
                   {showLogoContextMenu && (
                     <PopoverLogoContextMenu
                       isActive={isActive}
-                      activePublisherLogo={activePublisherLogo}
+                      activePublisherLogo={activePublisherLogoId}
                       idx={idx}
                       publisherLogo={publisherLogo}
                       onMenuItemSelected={onMenuItemSelected}
+                      onMenuItemToggle={onMenuItemToggle}
                       contextMenuId={{
                         set: setContextMenuId,
                         value: contextMenuId,

--- a/assets/src/dashboard/app/views/editorSettings/publisherLogo/popoverLogoContextMenu.js
+++ b/assets/src/dashboard/app/views/editorSettings/publisherLogo/popoverLogoContextMenu.js
@@ -41,6 +41,7 @@ function PopoverLogoContextMenu({
   publisherLogo,
   contextMenuId,
   onMenuItemSelected,
+  onMenuItemToggle,
 }) {
   const popoverMenuContainerRef = useRef(null);
 
@@ -53,10 +54,10 @@ function PopoverLogoContextMenu({
   );
 
   const handleFocusOut = useCallback(() => {
-    if (contextMenuId === activePublisherLogo) {
+    if (contextMenuId.value === activePublisherLogo) {
       onMoreButtonSelected(-1);
     }
-  }, [activePublisherLogo, contextMenuId, onMoreButtonSelected]);
+  }, [activePublisherLogo, contextMenuId.value, onMoreButtonSelected]);
 
   useFocusOut(popoverMenuContainerRef, handleFocusOut, [contextMenuId]);
 
@@ -74,7 +75,11 @@ function PopoverLogoContextMenu({
         )}
         onClick={(e) => {
           e.preventDefault();
+          onMenuItemToggle(isPopoverMenuOpen ? null : publisherLogo.id);
           onMoreButtonSelected(isPopoverMenuOpen ? -1 : publisherLogo.id);
+        }}
+        onFocus={() => {
+          onMenuItemToggle(isPopoverMenuOpen ? null : publisherLogo.id);
         }}
       >
         <EditPencilIcon aria-hidden="true" />
@@ -117,6 +122,7 @@ PopoverLogoContextMenu.propTypes = {
     set: PropTypes.func,
   }).isRequired,
   onMenuItemSelected: PropTypes.func.isRequired,
+  onMenuItemToggle: PropTypes.func.isRequired,
 };
 
 export default PopoverLogoContextMenu;

--- a/assets/src/dashboard/app/views/editorSettings/telemetry/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/telemetry/index.js
@@ -97,6 +97,10 @@ export default function TelemetrySettings({
                     )}
                     rel="noreferrer"
                     target="_blank"
+                    aria-label={__(
+                      'Learn more by visiting Google Privacy Policy',
+                      'web-stories'
+                    )}
                   />
                 ),
               }}

--- a/assets/src/dashboard/app/views/editorSettings/telemetry/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/telemetry/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import * as React from 'react';
+import { useEffect, useRef } from 'react';
 import propTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -52,7 +52,17 @@ export default function TelemetrySettings({
   onCheckboxSelected,
   disabled,
 }) {
+  const checkboxRef = useRef();
+  const focusOnCheckbox = useRef(false);
+
   const checked = Boolean(selected);
+
+  useEffect(() => {
+    if (focusOnCheckbox.current) {
+      checkboxRef.current.focus();
+    }
+  });
+
   return (
     <SettingForm>
       <div>
@@ -63,9 +73,16 @@ export default function TelemetrySettings({
       <div>
         <Label>
           <CheckBox
+            ref={checkboxRef}
             data-testid="telemetry-settings-checkbox"
             disabled={disabled}
-            onChange={onCheckboxSelected}
+            onChange={() => {
+              onCheckboxSelected();
+              focusOnCheckbox.current = true;
+            }}
+            onBlur={() => {
+              focusOnCheckbox.current = false;
+            }}
             checked={checked}
           />
           <FormLabel aria-checked={checked}>

--- a/assets/src/dashboard/components/popoverMenu/menu.js
+++ b/assets/src/dashboard/components/popoverMenu/menu.js
@@ -22,6 +22,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
 /**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { KEYS, STORY_CONTEXT_MENU_ACTIONS } from '../../constants';
@@ -182,6 +187,16 @@ const Menu = ({ isOpen, currentValueIndex = 0, items, onSelect, ...rest }) => {
           onClick={() => !itemIsDisabled && onSelect && onSelect(item)}
           onMouseEnter={() => setHoveredIndex(index)}
           isDisabled={itemIsDisabled}
+          aria-label={
+            // allow users to know what is in menu while still telling them items are disabled
+            itemIsDisabled
+              ? sprintf(
+                  /* translators: %s: item label.*/
+                  __('%s (currently unavailable)', 'web-stories'),
+                  item.label
+                )
+              : item.label
+          }
           className={
             (item.separator === 'top' && 'separatorTop') ||
             (item.separator === 'bottom' && 'separatorBottom')


### PR DESCRIPTION
## Summary

1. Publisher Logo Group on the Settings view reads out all stories as "Currently Selected" when group is focused.
2. Publisher Logo Group on the Settings view; Default logo's 'make default' option is disabled but does not announce as unavailable.
3. Telemetry Checkbox on the Settings View; On check exits page and enters it again, focus on this checkbox is weird.


## Relevant Technical Choices

- Copy @dmmulroy 's  changes from banner to prevent focus out since how the telemetry data updates causes a repaint and we lose focus of the input. PR #4654 for reference.
- Separate hovered and focused index on popoverMenu and give keyboard focus styles - follows updates done in typeahead which shares a lot of core functionality - PR #4680 
-  `ariaLabel` was a typo, needed `aria-label` to properly read out w/ screen reader on uploaded logo group. Updating logo `aria-label` to be the title of the uploaded image, removing (currently selected) since that is redundant.
- Set `aria-label` on popover menu so that when items are unavailable they can still be interacted with but sr will notify users that they are unavailable
- While testing updates to popover on editor logos I noticed it wasn't closing the menu sometimes if I opened it with the keyboard and then commandeered control with my mouse - looked into it and saw that there was some mismatches occurring - likely from the quick implementation, anyway, took this chance to fix that - that's why you'll see some updates in the context menu. The functionality here's different from the story context menu (this button is visibly on top of another button necessary for the keyboard arrow functionality), so tweaked the implementation it a bit. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Navigate to dashboard -> editor settings:
- when focused on uploaded logo group, sr will read out 'Viewing existing publisher logos'
- When focused on individual logos in uploaded logo group, sr will read out 'Publisher logo [title of image uploaded]'
- When focused on telemetry checkbox and sr is reading notice, when it gets to the link it will read out 'Learn more by visiting google privacy policy'
- when a popover menu is expanded on an uploaded logo and the 'set as default' option is disabled (if the logo is already the default), sr will announce '[label] (currently unavailable)'
- when using a keyboard to check or uncheck telemetry checkbox, focus will return to checkbox after interaction

## Testing Instructions
- Verify the above screen reader changes to publisher logo upload group 
- I updated the popover menus to have separate hovered index and focused index, just like I did yesterday with the search component so that we can have keyboard specific focus borders. 
  - Verify that the blue keyboard outline shows up when you use a keyboard to navigate context menus (uploaded logo menu as well as the story context menus) 
  - Verify that hover and click works as expected with those menus 
  - Confirm that you cannot hit 'enter' OR click on a disabled item (only one is the default publisher logo can't get set as default again)

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4683 
