### PR TITLE
Dashboard: Scroll to top a11y updates

### DIFF
--- a/assets/src/dashboard/components/layout/provider.js
+++ b/assets/src/dashboard/components/layout/provider.js
@@ -119,6 +119,8 @@ const Provider = ({ children }) => {
       top: 0,
       behavior: 'smooth',
     });
+    // bring focus back to area getting scrolled instead of it jumping to wordpress menus
+    scrollFrameEl.children[0]?.focus();
   }, []);
 
   const value = useMemo(

--- a/assets/src/dashboard/components/layout/scrollable.js
+++ b/assets/src/dashboard/components/layout/scrollable.js
@@ -61,7 +61,11 @@ const Scrollable = ({ children }) => {
 
   return (
     <ScrollContent ref={scrollFrameRef}>
-      <Inner scrollbarWidth={scrollbarWidth} paddingTop={squishContentHeight}>
+      <Inner
+        tabIndex={0}
+        scrollbarWidth={scrollbarWidth}
+        paddingTop={squishContentHeight}
+      >
         {children}
       </Inner>
     </ScrollContent>


### PR DESCRIPTION

## Summary
Keeps focus on scrollable content when scroll to top is selected, prevents focus jump.

## Relevant Technical Choices
Make scrollable area focusable with tabindex 0 so that on `scrollToTop` we can refocus the scrollable area and prevent focus jumping to WordPress menus

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
When scroll to top button clicked or entered, should focus shift to top of scrollable content. 


## Testing Instructions
- Click scroll to top, see that page looks as expected (no changes)
- Now use the keyboard (navigate through the grid) and press 'enter' on scroll to top. Now press tab and see that focus remains in scrollable area (the grid container)

![focus to grid container](https://user-images.githubusercontent.com/10720454/94312219-57d0bf00-ff31-11ea-91f5-d2a81f5fe8dc.gif)

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4683 
