### PR TITLE
Dashboard: Left Nav a11y updates

### DIFF
--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -173,6 +173,15 @@ export function LeftRail() {
                 <NavLink
                   active={path.value === state.currentPath}
                   href={resolveRoute(path.value)}
+                  aria-label={
+                    path.value === state.currentPath
+                      ? sprintf(
+                          /* translators: %s: path label.*/
+                          __('%s (active view)', 'web-stories'),
+                          path.label
+                        )
+                      : path.label
+                  }
                 >
                   {path.label}
                 </NavLink>

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -176,7 +176,7 @@ export function LeftRail() {
                   aria-label={
                     path.value === state.currentPath
                       ? sprintf(
-                          /* translators: %s: path label.*/
+                          /* translators: %s: the current page, for example "My Stories". */
                           __('%s (active view)', 'web-stories'),
                           path.label
                         )


### PR DESCRIPTION
## Summary
Updates aria labels for side nav to include "active view" for the view the user is currently on - adds context for SR users

## Relevant Technical Choices
- Updates aria label of list items in side nav to check for current view

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- Using a screen reader (like Chrome Vox), focus on the list items in the dashboard side nav and hear it say "Current view" when announcing the list item that you are currently viewing.

## Testing Instructions

- Verify that the screen reader reads out "current view" when it announces the page you are currently on. For example, if you are on "Explore Templates" the SR should read out "Explore Templates (current view)". 
---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4683 
