### PR TITLE
Dashboard: Template Details a11y updates

### DIFF
--- a/assets/src/dashboard/app/views/exploreTemplates/karma/exploreTemplates.karma.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/karma/exploreTemplates.karma.js
@@ -158,7 +158,9 @@ describe('Grid view', () => {
 
       await fixture.events.click(view);
 
-      const closeBtn = fixture.screen.getByRole('link', { name: /^Close$/ });
+      const closeBtn = fixture.screen.getByRole('link', {
+        name: /^Go to Explore Templates$/,
+      });
 
       expect(closeBtn).toBeTruthy();
     });

--- a/assets/src/dashboard/app/views/templateDetails/header/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/header/index.js
@@ -21,19 +21,24 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { DetailViewNavBar, Layout } from '../../../../components';
+import { APP_ROUTES, ROUTE_TITLES } from '../../../../constants';
 
 function Header({ onBookmarkClick, onHandleCtaClick }) {
   return (
     <Layout.Fixed>
       <DetailViewNavBar
         ctaText={__('Use template', 'web-stories')}
-        closeViewAriaLabel={__('Go to explore templates', 'web-stories')}
+        closeViewAriaLabel={sprintf(
+          /* translators: %s: page title of link */
+          __('Go to %s', 'web-stories'),
+          ROUTE_TITLES[APP_ROUTES.TEMPLATES_GALLERY]
+        )}
         handleBookmarkClick={onBookmarkClick}
         handleCta={onHandleCtaClick}
       />

--- a/assets/src/dashboard/app/views/templateDetails/header/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/header/index.js
@@ -33,6 +33,7 @@ function Header({ onBookmarkClick, onHandleCtaClick }) {
     <Layout.Fixed>
       <DetailViewNavBar
         ctaText={__('Use template', 'web-stories')}
+        closeViewAriaLabel={__('Go to explore templates', 'web-stories')}
         handleBookmarkClick={onBookmarkClick}
         handleCta={onHandleCtaClick}
       />

--- a/assets/src/dashboard/app/views/templateDetails/karma/templateDetails.karma.js
+++ b/assets/src/dashboard/app/views/templateDetails/karma/templateDetails.karma.js
@@ -108,8 +108,10 @@ describe('CUJ: Creator can browse templates in grid view: See pre-built template
   }
 
   describe('Action: See pre-built template details page', () => {
-    it('should navigate to "Explore Templates" when "Close" is clicked', async () => {
-      const closeLink = fixture.screen.getByRole('link', { name: /^Close$/ });
+    it('should navigate to "Explore Templates" when "Go to Explore Templates" is clicked', async () => {
+      const closeLink = fixture.screen.getByRole('link', {
+        name: /^Go to Explore Templates$/,
+      });
 
       await fixture.events.click(closeLink);
 

--- a/assets/src/dashboard/components/detailViewNavBar/index.js
+++ b/assets/src/dashboard/components/detailViewNavBar/index.js
@@ -79,11 +79,18 @@ const CapitalizedButton = styled(Button)`
   text-transform: uppercase;
 `;
 
-export function DetailViewNavBar({ handleCta, handleBookmarkClick, ctaText }) {
+export function DetailViewNavBar({
+  closeViewAriaLabel = __('Close', 'web-stories'),
+  handleCta,
+  handleBookmarkClick,
+  ctaText,
+}) {
   return (
     <Nav>
       <Container>
-        <CloseLink href={parentRoute()}>{__('Close', 'web-stories')}</CloseLink>
+        <CloseLink aria-label={closeViewAriaLabel} href={parentRoute()}>
+          {__('Close', 'web-stories')}
+        </CloseLink>
       </Container>
       <Container>
         {handleBookmarkClick && (
@@ -100,6 +107,7 @@ export function DetailViewNavBar({ handleCta, handleBookmarkClick, ctaText }) {
 }
 
 DetailViewNavBar.propTypes = {
+  closeViewAriaLabel: PropTypes.string,
   ctaText: PropTypes.string,
   handleBookmarkClick: PropTypes.func,
   handleCta: PropTypes.func.isRequired,


### PR DESCRIPTION
## Summary
The close button in the template details view should give more context. Since it is not a dialog it should tell the user where they are navigating to when they close it.

## Relevant Technical Choices
- an aria label

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- Using a screen reader, when you are focused on the "button" (it's a link) that says "Close" on the template detail view it will speak "Go to explore templates" 

## Testing Instructions

- Use a screen reader to verify the above

---

<!-- Please reference the issue(s) this PR addresses. -->

addresses #4683 
