### PR TITLE
Disable amp-to-amp linking for amp-story-player

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -484,7 +484,7 @@ class Story_Post_Type {
 	 * @return bool Whether AMP-to-AMP is excluded.
 	 */
 	public function filter_amp_to_amp_linking_element_excluded( $excluded, $url, $rel, $element ) {
-		if ( $element instanceof DOMElement && $element->parentNode && 'amp-story-player' === $element->parentNode->tagName ) {
+		if ( $element instanceof DOMElement && $element->parentNode instanceof DOMElement && 'amp-story-player' === $element->parentNode->tagName ) {
 			return true;
 		}
 

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -26,6 +26,7 @@
 
 namespace Google\Web_Stories;
 
+use DOMElement;
 use Google\Web_Stories\Model\Story;
 use Google\Web_Stories\REST_API\Stories_Controller;
 use Google\Web_Stories\Story_Renderer\Embed;
@@ -37,7 +38,6 @@ use WP_Post;
 use WP_Role;
 use WP_Post_Type;
 use WP_Screen;
-use WP_Rewrite;
 
 /**
  * Class Story_Post_Type.
@@ -182,6 +182,7 @@ class Story_Post_Type {
 		add_filter( 'option_amp-options', [ $this, 'filter_amp_options' ] );
 		add_filter( 'amp_supportable_post_types', [ $this, 'filter_supportable_post_types' ] );
 		add_filter( 'amp_validation_error_sanitized', [ $this, 'filter_amp_story_element_validation_error_sanitized' ], 10, 2 );
+		add_filter( 'amp_to_amp_linking_element_excluded', [ $this, 'filter_amp_to_amp_linking_element_excluded' ], 10, 4 );
 
 		add_filter( '_wp_post_revision_fields', [ $this, 'filter_revision_fields' ], 10, 2 );
 
@@ -469,6 +470,26 @@ class Story_Post_Type {
 		}
 
 		return $sanitized;
+	}
+
+	/**
+	 * Filters whether AMP-to-AMP is excluded for an element.
+	 *
+	 * The element may be either a link (`a` or `area`) or a `form`.
+	 *
+	 * @param bool       $excluded Excluded. Default value is whether element already has a `noamphtml` link relation or the URL is among `excluded_urls`.
+	 * @param string     $url      URL considered for exclusion.
+	 * @param string[]   $rel      Link relations.
+	 * @param DOMElement $element  The element considered for excluding from AMP-to-AMP linking. May be instance of `a`, `area`, or `form`.
+	 * @return bool Whether AMP-to-AMP is excluded.
+	 */
+	public function filter_amp_to_amp_linking_element_excluded( $excluded, $url, $rel, $element ) {
+		if ( $element instanceof DOMElement && $element->parentNode && 'amp-story-player' === $element->parentNode->tagName ) {
+			return true;
+		}
+
+		return $excluded;
+
 	}
 
 	/**


### PR DESCRIPTION
## Summary

As suggested by @westonruter in https://github.com/google/web-stories-wp/pull/4671#issuecomment-699282505, this disables AMP-to-AMP linking for URLs in the amp-story-player in paired mode.

## Relevant Technical Choices

* Uses the `amp_to_amp_linking_element_excluded` filter

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

1. Enable AMP plugin in Transitional mode
1. Make sure AMP-to-AMP linking is enabled
1. Insert a Web Stories embed block to embed stories from the same site.
1. Verify that the player's `<a>` tag on the frontend does not have `?amp` appended to the URL

---

<!-- Please reference the issue(s) this PR addresses. -->

Related: #3581, #4671
