### PR TITLE
Add target=_blank to element links 

### DIFF
--- a/assets/src/edit-story/components/elementLink/output.js
+++ b/assets/src/edit-story/components/elementLink/output.js
@@ -37,6 +37,8 @@ function WithLink({ element, children, ...rest }) {
       href={urlWithProtocol}
       data-tooltip-icon={link.icon}
       data-tooltip-text={link.desc}
+      target="_blank"
+      rel="noreferrer"
       {...rest}
     >
       {children}

--- a/assets/src/edit-story/components/elementLink/test/output.js
+++ b/assets/src/edit-story/components/elementLink/test/output.js
@@ -15,80 +15,69 @@
  */
 
 /**
+ * External dependencies
+ */
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
 import WithLink from '../output';
 
 describe('WithLink', () => {
-  describe('AMP validation', () => {
-    it('should produce valid AMP output', async () => {
-      const props = {
-        element: {
-          id: '123',
+  function withLink() {
+    const props = {
+      element: {
+        id: '123',
+        type: 'image',
+        mimeType: 'image/png',
+        scale: 1,
+        x: 50,
+        y: 100,
+        height: 1920,
+        width: 1080,
+        rotationAngle: 0,
+        resource: {
           type: 'image',
           mimeType: 'image/png',
-          scale: 1,
-          x: 50,
-          y: 100,
+          src: 'https://example.com/image.png',
           height: 1920,
           width: 1080,
-          rotationAngle: 0,
-          resource: {
-            type: 'image',
-            mimeType: 'image/png',
-            src: 'https://example.com/image.png',
-            height: 1920,
-            width: 1080,
-          },
-          link: {
-            url: 'https://example.com/',
-            icon: 'https://example.com/image.png',
-            desc: 'Lorem ipsum dolor',
-            type: 2,
-          },
         },
-      };
+        link: {
+          url: 'https://example.com/',
+          icon: 'https://example.com/image.png',
+          desc: 'Lorem ipsum dolor',
+          type: 2,
+        },
+      },
+    };
+    return (
+      <WithLink {...props}>
+        <amp-img src="https://example.com/image.png" layout="fill" />
+      </WithLink>
+    );
+  }
 
-      await expect(
-        <WithLink {...props}>
-          <amp-img src="https://example.com/image.png" layout="fill" />
-        </WithLink>
-      ).toBeValidAMPStoryElement();
+  describe('a[target]', () => {
+    it('should use target=_blank', async () => {
+      const { container } = render(withLink());
+      const a = container.querySelector('a');
+      await expect(a.target).toBe('_blank');
+      await expect(a.rel).toBe('noreferrer');
+    });
+  });
+
+  describe('AMP validation', () => {
+    it('should produce valid AMP output', async () => {
+      await expect(withLink()).toBeValidAMPStoryElement();
     });
 
     it('should produce valid AMP output for one-tap links', async () => {
-      const props = {
-        element: {
-          id: '123',
-          type: 'image',
-          mimeType: 'image/png',
-          scale: 1,
-          x: 50,
-          y: 100,
-          height: 1920,
-          width: 1080,
-          rotationAngle: 0,
-          resource: {
-            type: 'image',
-            mimeType: 'image/png',
-            src: 'https://example.com/image.png',
-            height: 1920,
-            width: 1080,
-          },
-          link: {
-            url: 'https://example.com/',
-            icon: 'https://example.com/image.png',
-            desc: 'Lorem ipsum dolor',
-            type: 1,
-          },
-        },
-      };
-
-      await expect(
-        <WithLink {...props}>
-          <amp-img src="https://example.com/image.png" layout="fill" />
-        </WithLink>
-      ).toBeValidAMPStoryElement();
+      await expect(withLink()).toBeValidAMPStoryElement();
     });
   });
 });

--- a/assets/src/edit-story/components/elementLink/test/output.js
+++ b/assets/src/edit-story/components/elementLink/test/output.js
@@ -48,7 +48,6 @@ describe('WithLink', () => {
           url: 'https://example.com/',
           icon: 'https://example.com/image.png',
           desc: 'Lorem ipsum dolor',
-          type: 2,
         },
       },
     };
@@ -70,10 +69,6 @@ describe('WithLink', () => {
 
   describe('AMP validation', () => {
     it('should produce valid AMP output', async () => {
-      await expect(withLink()).toBeValidAMPStoryElement();
-    });
-
-    it('should produce valid AMP output for one-tap links', async () => {
       await expect(withLink()).toBeValidAMPStoryElement();
     });
   });

--- a/assets/src/edit-story/components/elementLink/test/output.js
+++ b/assets/src/edit-story/components/elementLink/test/output.js
@@ -17,9 +17,6 @@
 /**
  * External dependencies
  */
-/**
- * External dependencies
- */
 import { render } from '@testing-library/react';
 
 /**


### PR DESCRIPTION
A copy of #4705 but from a branch rather than a fork.

## Summary

Adds attribute `target=_blank` (and `rel=noreferrer`) to element links.

## Relevant Technical Choices

- Only `target=_blank` links are valid in `amp-story`.
- Avoids `target=_top` being added by AMP packager v2 (bug).

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

- Add a link to an image or text element and publish the story.
- Inspect the `<a>` tag and verify that it has attribute `target="_blank"`.

---

<!-- Please reference the issue(s) this PR addresses. -->

Partial for #4689.

Fixes #4719
