### PR TITLE
Change amp-story-page background color to match editor preview

### DIFF
--- a/assets/src/edit-story/output/utils/styles.js
+++ b/assets/src/edit-story/output/utils/styles.js
@@ -20,16 +20,8 @@
 import { FULLBLEED_RATIO, PAGE_RATIO } from '../../constants';
 import theme from '../../theme';
 
-const HEX_CHARS = '1234567890ABCDEF';
-
 function isHexColorString(s) {
-  return (
-    s[0] == '#' &&
-    s
-      .substr(1)
-      .split('')
-      .every((char) => HEX_CHARS.includes(char))
-  );
+  return /^#(?:[a-f0-9]{3}){1,2}$/i.test(s);
 }
 
 function CustomStyles() {
@@ -39,7 +31,7 @@ function CustomStyles() {
   // Match page background color to the workspace background color.
   // Validate since we're using dangerouslySetInnerHTML with imported variable.
   const workspaceColor = theme.colors.bg.workspace;
-  let pageBackgroundColor = isHexColorString(workspaceColor)
+  const pageBackgroundColor = isHexColorString(workspaceColor)
     ? workspaceColor
     : '#1B1D1C';
 

--- a/assets/src/edit-story/output/utils/styles.js
+++ b/assets/src/edit-story/output/utils/styles.js
@@ -22,11 +22,16 @@ import { FULLBLEED_RATIO, PAGE_RATIO } from '../../constants';
 function CustomStyles() {
   const safeToFullRatio = PAGE_RATIO / FULLBLEED_RATIO;
   const fullToSafeRatio = 1 / safeToFullRatio;
+  const pageBackgroundColor = '#1b1d1c'; /* theme.colors.bg.workspace */
   return (
     <style
       amp-custom=""
       dangerouslySetInnerHTML={{
         __html: `
+              amp-story-page {
+                background-color: ${pageBackgroundColor};
+              }
+
               amp-story-grid-layer {
                 overflow: visible;
               }

--- a/assets/src/edit-story/output/utils/styles.js
+++ b/assets/src/edit-story/output/utils/styles.js
@@ -20,11 +20,29 @@
 import { FULLBLEED_RATIO, PAGE_RATIO } from '../../constants';
 import theme from '../../theme';
 
+const HEX_CHARS = '1234567890ABCDEF';
+
+function isHexColorString(s) {
+  return (
+    s[0] == '#' &&
+    s
+      .substr(1)
+      .split('')
+      .every((char) => HEX_CHARS.includes(char))
+  );
+}
+
 function CustomStyles() {
   const safeToFullRatio = PAGE_RATIO / FULLBLEED_RATIO;
   const fullToSafeRatio = 1 / safeToFullRatio;
+
   // Match page background color to the workspace background color.
-  const pageBackgroundColor = theme.colors.bg.workspace;
+  // Validate since we're using dangerouslySetInnerHTML with imported variable.
+  const workspaceColor = theme.colors.bg.workspace;
+  let pageBackgroundColor = isHexColorString(workspaceColor)
+    ? workspaceColor
+    : '#1B1D1C';
+
   return (
     <style
       amp-custom=""

--- a/assets/src/edit-story/output/utils/styles.js
+++ b/assets/src/edit-story/output/utils/styles.js
@@ -18,11 +18,13 @@
  * Internal dependencies
  */
 import { FULLBLEED_RATIO, PAGE_RATIO } from '../../constants';
+import theme from '../../theme';
 
 function CustomStyles() {
   const safeToFullRatio = PAGE_RATIO / FULLBLEED_RATIO;
   const fullToSafeRatio = 1 / safeToFullRatio;
-  const pageBackgroundColor = '#1b1d1c'; /* theme.colors.bg.workspace */
+  // Match page background color to the workspace background color.
+  const pageBackgroundColor = theme.colors.bg.workspace;
   return (
     <style
       amp-custom=""

--- a/assets/src/edit-story/theme.js
+++ b/assets/src/edit-story/theme.js
@@ -83,6 +83,7 @@ export function useTheme(selector) {
 const theme = {
   colors: {
     bg: {
+      // Note: amp-story-page background color matches workspace background color.
       workspace: '#1B1D1C',
       panel: '#282A2A',
       white: '#FFFFFF',


### PR DESCRIPTION
## Summary

Changes the background color of `amp-story-page` (behind the 9:16 authored content) to a dark gray. 

This color matches what users see in the editor preview and is close to what other platforms (IG/Snap) use too.

## Relevant Technical Choices

N/A

## To-do

N/A

## User-facing changes

### Before

<img width="341" alt="Screen Shot 2020-09-28 at 5 12 08 PM" src="https://user-images.githubusercontent.com/20525523/94493188-f1120680-01b9-11eb-9e45-e16979695e4d.png">

### After

<img width="338" alt="Screen Shot 2020-09-28 at 5 35 42 PM" src="https://user-images.githubusercontent.com/20525523/94493196-f5d6ba80-01b9-11eb-927f-d498ce47ab01.png">

## Testing Instructions

- Open a story in Chrome with mobile emulation on iPhone X (or a similarly tall device). 
- Observe the color of the background above/below the actual story content.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3133
