### PR TITLE
Dashboard: add support link to navigation

### DIFF
--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -27,7 +27,7 @@ import { getRelativeDisplayDate } from '../../../../../date';
 import {
   TEMPLATES_GALLERY_VIEWING_LABELS,
   TEMPLATES_GALLERY_STATUS,
-  primaryPaths,
+  PRIMARY_PATHS,
   STORY_STATUS,
   STORY_STATUSES,
   STORY_VIEWING_LABELS,
@@ -71,7 +71,7 @@ describe('Grid view', () => {
 
   it('should navigate to Explore Templates', async () => {
     const exploreTemplatesMenuItem = fixture.screen.queryByRole('link', {
-      name: new RegExp('^' + primaryPaths[2].label + '$'),
+      name: new RegExp('^' + PRIMARY_PATHS[2].label + '$'),
     });
 
     await fixture.events.click(exploreTemplatesMenuItem);

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -30,10 +30,10 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { BEZIER } from '../../../animation';
-import { trackEvent } from '../../../tracking';
+import { trackClick, trackEvent } from '../../../tracking';
 import { useConfig } from '../../app/config';
 import { resolveRoute, useRouteHistory } from '../../app/router';
-import { BUTTON_TYPES, primaryPaths, Z_INDEX } from '../../constants';
+import { BUTTON_TYPES, PRIMARY_PATHS, Z_INDEX } from '../../constants';
 import { DASHBOARD_LEFT_NAV_WIDTH } from '../../constants/pageStructure';
 import { ReactComponent as WebStoriesLogo } from '../../images/webStoriesFullLogo.svg';
 import useFocusOut from '../../utils/useFocusOut';
@@ -120,9 +120,9 @@ export function LeftRail() {
 
   const enabledPaths = useMemo(() => {
     if (enableInProgressViews) {
-      return primaryPaths;
+      return PRIMARY_PATHS;
     }
-    return primaryPaths.filter((path) => !path.inProgress);
+    return PRIMARY_PATHS.filter((path) => !path.inProgress);
   }, [enableInProgressViews]);
 
   const handleSideBarClose = useCallback(() => {
@@ -141,6 +141,10 @@ export function LeftRail() {
 
   const onCreateNewStoryClick = useCallback(async () => {
     await trackEvent('create_new_story', 'dashboard');
+  }, []);
+
+  const onExternalLinkClick = useCallback((evt, path) => {
+    trackClick(evt, path.trackingEvent, 'dashboard', path.value);
   }, []);
 
   return (
@@ -182,6 +186,11 @@ export function LeftRail() {
                         )
                       : path.label
                   }
+                  {...(path.isExternal && {
+                    rel: 'noreferrer',
+                    target: '_blank',
+                    onClick: (evt) => onExternalLinkClick(evt, path),
+                  })}
                 >
                   {path.label}
                 </NavLink>

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -173,7 +173,12 @@ export function LeftRail() {
         <Content>
           <NavList>
             {enabledPaths.map((path) => (
-              <NavListItem key={path.value}>
+              <NavListItem
+                key={path.value}
+                onClick={(evt) =>
+                  path.isExternal ? onExternalLinkClick(evt, path) : () => {}
+                }
+              >
                 <NavLink
                   active={path.value === state.currentPath}
                   href={resolveRoute(path.value)}
@@ -189,7 +194,6 @@ export function LeftRail() {
                   {...(path.isExternal && {
                     rel: 'noreferrer',
                     target: '_blank',
-                    onClick: (evt) => onExternalLinkClick(evt, path),
                   })}
                 >
                   {path.label}

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -30,7 +30,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { BEZIER } from '../../../animation';
-import { trackClick, trackEvent } from '../../../tracking';
+import { trackEvent } from '../../../tracking';
 import { useConfig } from '../../app/config';
 import { resolveRoute, useRouteHistory } from '../../app/router';
 import { BUTTON_TYPES, PRIMARY_PATHS, Z_INDEX } from '../../constants';
@@ -143,8 +143,8 @@ export function LeftRail() {
     await trackEvent('create_new_story', 'dashboard');
   }, []);
 
-  const onExternalLinkClick = useCallback((evt, path) => {
-    trackClick(evt, path.trackingEvent, 'dashboard', path.value);
+  const onExternalLinkClick = useCallback((path) => {
+    trackEvent(path.trackingEvent, 'dashboard');
   }, []);
 
   return (
@@ -173,12 +173,7 @@ export function LeftRail() {
         <Content>
           <NavList>
             {enabledPaths.map((path) => (
-              <NavListItem
-                key={path.value}
-                onClick={(evt) =>
-                  path.isExternal ? onExternalLinkClick(evt, path) : () => {}
-                }
-              >
+              <NavListItem key={path.value}>
                 <NavLink
                   active={path.value === state.currentPath}
                   href={resolveRoute(path.value)}
@@ -194,6 +189,7 @@ export function LeftRail() {
                   {...(path.isExternal && {
                     rel: 'noreferrer',
                     target: '_blank',
+                    onClick: () => onExternalLinkClick(path),
                   })}
                 >
                   {path.label}

--- a/assets/src/dashboard/components/pageStructure/test/pageStructure.js
+++ b/assets/src/dashboard/components/pageStructure/test/pageStructure.js
@@ -27,7 +27,7 @@ import { FlagsProvider } from 'flagged';
 import { renderWithProviders } from '../../../testUtils';
 import { LeftRail } from '../index';
 import NavProvider, { NavContext } from '../../navProvider';
-import { primaryPaths } from '../../../constants';
+import { PRIMARY_PATHS } from '../../../constants';
 
 describe('<LeftRail />', () => {
   it('should be visible by default in a regular viewport.', () => {
@@ -72,7 +72,7 @@ describe('<LeftRail />', () => {
 
     expect(toggleSideBarFn).not.toHaveBeenCalled();
 
-    const firstLink = wrapper.getByText(primaryPaths[0].label);
+    const firstLink = wrapper.getByText(PRIMARY_PATHS[0].label);
     fireEvent.click(firstLink);
 
     expect(toggleSideBarFn).toHaveBeenCalledWith();

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -45,7 +45,7 @@ export const APP_ROUTES = {
   TEMPLATE_DETAIL: 'template-detail',
 
   EDITOR_SETTINGS: '/editor-settings',
-  SUPPORT: '/support',
+  SUPPORT: 'https://wordpress.org/support/plugin/web-stories/',
   STORY_ANIM_TOOL: '/story-anim-tool',
 };
 
@@ -87,7 +87,6 @@ export const primaryPaths = [
   {
     value: APP_ROUTES.SUPPORT,
     label: ROUTE_TITLES[APP_ROUTES.SUPPORT],
-    inProgress: true,
   },
 ];
 

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -69,7 +69,7 @@ export const ROUTE_TITLES = {
   DEFAULT: __('My Stories', 'web-stories'),
 };
 
-export const primaryPaths = [
+export const PRIMARY_PATHS = [
   { value: APP_ROUTES.MY_STORIES, label: ROUTE_TITLES[APP_ROUTES.MY_STORIES] },
   {
     value: APP_ROUTES.SAVED_TEMPLATES,
@@ -87,6 +87,8 @@ export const primaryPaths = [
   {
     value: APP_ROUTES.SUPPORT,
     label: ROUTE_TITLES[APP_ROUTES.SUPPORT],
+    isExternal: true,
+    trackingEvent: 'open_support_page',
   },
 ];
 


### PR DESCRIPTION
## Summary
Adds external support link to side nav in dashboard

## Relevant Technical Choices
- Update link in constants, take `inProgress` off support so it shows up in menu

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- Now you can see and click on 'support' in the dashboard side nav
<img width="331" alt="Screen Shot 2020-09-29 at 9 05 13 AM" src="https://user-images.githubusercontent.com/10720454/94584437-75ed3680-0233-11eb-9a73-bbe9ffeb02bc.png">


## Testing Instructions
- Verify that you see the above 'support' menu item and that clicking it takes you here: https://wordpress.org/support/plugin/web-stories/

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #1519 
