### PR TITLE
Always override existing poster attribute on render

### DIFF
--- a/includes/Story_Renderer/HTML.php
+++ b/includes/Story_Renderer/HTML.php
@@ -460,12 +460,10 @@ class HTML {
 	 * @return string[] Images.
 	 */
 	protected function get_poster_images() {
-		$images = [
+		return [
 			'poster-portrait-src'  => $this->story->get_poster_portrait(),
 			'poster-square-src'    => $this->story->get_poster_square(),
 			'poster-landscape-src' => $this->story->get_poster_landscape(),
 		];
-
-		return array_filter( $images );
 	}
 }

--- a/tests/phpunit/tests/Story_Renderer/HTML.php
+++ b/tests/phpunit/tests/Story_Renderer/HTML.php
@@ -17,10 +17,16 @@
 
 namespace Google\Web_Stories\Tests\Story_Renderer;
 
+use Google\Web_Stories\Model\Story;
+use Google\Web_Stories\Settings;
+use Google\Web_Stories\Story_Post_Type;
+use WP_Post;
+use WP_UnitTestCase;
+
 /**
  * @coversDefaultClass \Google\Web_Stories\Story_Renderer\HTML
  */
-class HTML extends \WP_UnitTestCase {
+class HTML extends WP_UnitTestCase {
 	public function setUp() {
 		// When running the tests, we don't have unfiltered_html capabilities.
 		// This change avoids HTML in post_content being stripped in our test posts because of KSES.
@@ -39,7 +45,7 @@ class HTML extends \WP_UnitTestCase {
 	public function test_render() {
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => '<!DOCTYPE html><html><head></head><body><amp-story></amp-story></body></html>',
 			]
 		);
@@ -56,7 +62,7 @@ class HTML extends \WP_UnitTestCase {
 	public function test_transform_html_start_tag() {
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => '<html><head></head><body><amp-story poster-portrait-src="https://example.com/poster.png"></amp-story></body></html>',
 			]
 		);
@@ -72,7 +78,7 @@ class HTML extends \WP_UnitTestCase {
 	public function test_transform_a_tags() {
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => '<html><head></head><body><amp-story><a href="https://www.google.com">Google</a></amp-story></body></html>',
 			]
 		);
@@ -93,7 +99,7 @@ class HTML extends \WP_UnitTestCase {
 
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => "<html><head>FOO{$start_tag}BAR{$end_tag}BAZ</head><body><amp-story></amp-story></body></html>",
 			]
 		);
@@ -120,16 +126,16 @@ class HTML extends \WP_UnitTestCase {
 	 */
 	public function test_add_publisher_logo() {
 		$attachment_id = self::factory()->attachment->create_upload_object( __DIR__ . '/../../data/attachment.jpg', 0 );
-		add_option( \Google\Web_Stories\Settings::SETTING_NAME_ACTIVE_PUBLISHER_LOGO, $attachment_id );
+		add_option( Settings::SETTING_NAME_ACTIVE_PUBLISHER_LOGO, $attachment_id );
 
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
 			]
 		);
 
-		$story = new \Google\Web_Stories\Model\Story();
+		$story = new Story();
 		$story->load_from_post( $post );
 		$renderer    = new \Google\Web_Stories\Story_Renderer\HTML( $story );
 		$placeholder = $renderer->get_publisher_logo_placeholder();
@@ -143,7 +149,7 @@ class HTML extends \WP_UnitTestCase {
 
 		$rendered = $renderer->render();
 
-		delete_option( \Google\Web_Stories\Settings::SETTING_NAME_ACTIVE_PUBLISHER_LOGO );
+		delete_option( Settings::SETTING_NAME_ACTIVE_PUBLISHER_LOGO );
 
 		$this->assertContains( 'attachment', $rendered );
 		$this->assertNotContains( $placeholder, $rendered );
@@ -158,7 +164,7 @@ class HTML extends \WP_UnitTestCase {
 
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
 			]
 		);
@@ -179,7 +185,7 @@ class HTML extends \WP_UnitTestCase {
 	public function test_add_poster_images_no_fallback_image_added() {
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
 			]
 		);
@@ -197,7 +203,7 @@ class HTML extends \WP_UnitTestCase {
 	public function test_add_poster_images_no_poster_no_amp() {
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
 			]
 		);
@@ -214,7 +220,7 @@ class HTML extends \WP_UnitTestCase {
 	public function test_insert_analytics_configuration() {
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
 			]
 		);
@@ -240,7 +246,7 @@ class HTML extends \WP_UnitTestCase {
 	public function test_insert_analytics_configuration_no_output() {
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
 			]
 		);
@@ -257,7 +263,7 @@ class HTML extends \WP_UnitTestCase {
 	public function test_removes_and_reinserts_noscript_amp_boilerplate() {
 		$post = self::factory()->post->create_and_get(
 			[
-				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
 				'post_content' => '<html><head><noscript><style amp-boilerplate="">body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript></head><body><amp-story></amp-story></body></html>',
 			]
 		);
@@ -270,12 +276,12 @@ class HTML extends \WP_UnitTestCase {
 	/**
 	 * Helper to setup rendered.
 	 *
-	 * @param \WP_Post $post Post Object.
+	 * @param WP_Post $post Post Object.
 	 *
 	 * @return string
 	 */
 	protected function setup_renderer( $post ) {
-		$story = new \Google\Web_Stories\Model\Story();
+		$story = new Story();
 		$story->load_from_post( $post );
 		$renderer = new \Google\Web_Stories\Story_Renderer\HTML( $story );
 		return $renderer->render();

--- a/tests/phpunit/tests/Story_Renderer/HTML.php
+++ b/tests/phpunit/tests/Story_Renderer/HTML.php
@@ -63,13 +63,13 @@ class HTML extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get(
 			[
 				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
-				'post_content' => '<html><head></head><body><amp-story poster-portrait-src="https://example.com/poster.png"></amp-story></body></html>',
+				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
 			]
 		);
 
 		$actual = $this->setup_renderer( $post );
 
-		$this->assertContains( '<html amp="" lang="en-US">', $actual );
+		$this->assertContains( 'lang="en-US">', $actual );
 	}
 
 	/**
@@ -182,6 +182,28 @@ class HTML extends WP_UnitTestCase {
 	 * @covers ::add_poster_images
 	 * @covers ::get_poster_images
 	 */
+	public function test_add_poster_images_overrides_existing_poster() {
+		$attachment_id = self::factory()->attachment->create_upload_object( __DIR__ . '/../../data/attachment.jpg', 0 );
+
+		$post = self::factory()->post->create_and_get(
+			[
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
+				'post_content' => '<html><head></head><body><amp-story poster-portrait-src="https://example.com/poster.jpg"></amp-story></body></html>',
+			]
+		);
+
+		set_post_thumbnail( $post->ID, $attachment_id );
+
+		$rendered = $this->setup_renderer( $post );
+
+		$this->assertNotContains( 'https://example.com/poster.jpg', $rendered );
+		$this->assertContains( 'poster-portrait-src=', $rendered );
+	}
+
+	/**
+	 * @covers ::add_poster_images
+	 * @covers ::get_poster_images
+	 */
 	public function test_add_poster_images_no_fallback_image_added() {
 		$post = self::factory()->post->create_and_get(
 			[
@@ -192,9 +214,9 @@ class HTML extends WP_UnitTestCase {
 
 		$rendered = $this->setup_renderer( $post );
 
-		$this->assertNotContains( 'poster-portrait-src=', $rendered );
-		$this->assertNotContains( 'poster-square-src=', $rendered );
-		$this->assertNotContains( 'poster-landscape-src=', $rendered );
+		$this->assertContains( 'poster-portrait-src=""', $rendered );
+		$this->assertContains( 'poster-square-src=""', $rendered );
+		$this->assertContains( 'poster-landscape-src=""', $rendered );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Always override existing poster attribute with the featured image URL to ensure no incorrect poster images are used.

## Relevant Technical Choices

Removes the `array_filter` call that caused this.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4760
