### PR TITLE
Workspace: Grow/shrink text box element when padding increases or decreases.

### DIFF
--- a/assets/src/edit-story/components/panels/test/textStyle.js
+++ b/assets/src/edit-story/components/panels/test/textStyle.js
@@ -237,21 +237,36 @@ describe('Panels/TextStyle', () => {
     });
 
     it('should update horizontal padding with lock', () => {
-      const { getByRole, pushUpdateForObject } = renderTextStyle([textElement]);
+      const { getByRole, pushUpdateForObject, pushUpdate } = renderTextStyle([
+        textElement,
+      ]);
       const input = getByRole('textbox', {
         name: 'Edit: Horizontal & Vertical padding',
       });
-      fireEvent.change(input, { target: { value: '11' } });
+      fireEvent.change(input, { target: { value: '20' } });
       expect(pushUpdateForObject).toHaveBeenCalledWith(
         'padding',
-        { horizontal: 11, vertical: 11 },
+        { horizontal: 20, vertical: 20 },
         DEFAULT_PADDING,
         false
       );
+      const updaterFunction = pushUpdate.mock.calls[0][0];
+      const updatedContent = updaterFunction({
+        x: 40,
+        y: 40,
+        width: 100,
+        height: 100,
+      });
+      expect(updatedContent).toStrictEqual({
+        x: 20,
+        y: 20,
+        width: 140,
+        height: 140,
+      });
     });
 
     it('should update horizontal padding without lock', () => {
-      const { getByRole, pushUpdateForObject } = renderTextStyle([
+      const { getByRole, pushUpdateForObject, pushUpdate } = renderTextStyle([
         unlockPaddingTextElement,
       ]);
       const input = getByRole('textbox', { name: 'Edit: Horizontal padding' });
@@ -262,10 +277,21 @@ describe('Panels/TextStyle', () => {
         DEFAULT_PADDING,
         false
       );
+      const updaterFunction = pushUpdate.mock.calls[0][0];
+      const updatedContent = updaterFunction({
+        x: 50,
+        y: 50,
+        width: 100,
+        height: 100,
+      });
+      expect(updatedContent).toStrictEqual({
+        x: 39,
+        width: 122,
+      });
     });
 
     it('should update vertical padding without lock', () => {
-      const { getByRole, pushUpdateForObject } = renderTextStyle([
+      const { getByRole, pushUpdateForObject, pushUpdate } = renderTextStyle([
         unlockPaddingTextElement,
       ]);
       const input = getByRole('textbox', { name: 'Edit: Vertical padding' });
@@ -276,6 +302,17 @@ describe('Panels/TextStyle', () => {
         DEFAULT_PADDING,
         false
       );
+      const updaterFunction = pushUpdate.mock.calls[0][0];
+      const updatedContent = updaterFunction({
+        x: 50,
+        y: 50,
+        width: 100,
+        height: 100,
+      });
+      expect(updatedContent).toStrictEqual({
+        y: 38,
+        height: 124,
+      });
     });
 
     it('should not update if empty padding', () => {

--- a/assets/src/edit-story/components/panels/textStyle/padding.js
+++ b/assets/src/edit-story/components/panels/textStyle/padding.js
@@ -54,7 +54,11 @@ const Space = styled.div`
   flex: 0 0 10px;
 `;
 
-function PaddingControls({ selectedElements, pushUpdateForObject }) {
+function PaddingControls({
+  selectedElements,
+  pushUpdateForObject,
+  pushUpdate,
+}) {
   const padding = useCommonObjectValue(
     selectedElements,
     'padding',
@@ -67,9 +71,26 @@ function PaddingControls({ selectedElements, pushUpdateForObject }) {
 
   const handleChange = useCallback(
     (newPadding, submit = false) => {
+      pushUpdate(({ x, y, width, height }) => {
+        const updates = {};
+
+        if ('horizontal' in newPadding) {
+          updates.x = x - (newPadding.horizontal - padding.horizontal || 0);
+          updates.width =
+            width + (newPadding.horizontal - padding.horizontal || 0) * 2;
+        }
+
+        if ('vertical' in newPadding) {
+          updates.y = y - (newPadding.vertical - padding.vertical || 0);
+          updates.height =
+            height + (newPadding.vertical - padding.vertical || 0) * 2;
+        }
+
+        return updates;
+      });
       pushUpdateForObject('padding', newPadding, DEFAULT_PADDING, submit);
     },
-    [pushUpdateForObject]
+    [pushUpdate, pushUpdateForObject, padding]
   );
 
   usePresubmitHandler(
@@ -157,6 +178,7 @@ function PaddingControls({ selectedElements, pushUpdateForObject }) {
 PaddingControls.propTypes = {
   selectedElements: PropTypes.array.isRequired,
   pushUpdateForObject: PropTypes.func.isRequired,
+  pushUpdate: PropTypes.func.isRequired,
 };
 
 export default PaddingControls;


### PR DESCRIPTION
## Summary

Increases the metrics on a text box when padding is increased. The idea is that text should stay in the same position while the frame and origin grow (or shrink) around it.

**From 0 to 20**
![image-1](https://user-images.githubusercontent.com/1738349/94698860-56bbdb00-02ff-11eb-9009-50d310a7500c.png)
![image](https://user-images.githubusercontent.com/1738349/94698865-57547180-02ff-11eb-8aae-bac14b39e1cf.png)

![image-2](https://user-images.githubusercontent.com/1738349/94698919-63403380-02ff-11eb-8710-dace9e470c60.png)

**Supports locked or unlocked (both horizontal + vertical, or just one)**

![image-3](https://user-images.githubusercontent.com/1738349/94698999-78b55d80-02ff-11eb-99ff-5d7f8bf6bd10.png)

![image](https://user-images.githubusercontent.com/1738349/94699029-810d9880-02ff-11eb-9cfd-2d4404c2488e.png)

**Rotation too!**
![image](https://user-images.githubusercontent.com/1738349/94699049-879c1000-02ff-11eb-8fe6-f8c36fed6017.png)


## Relevant Technical Choices

- Math! When we increase the padding we subtract the new padding minus the current padding and assign that to either the x or y.
- For width and height we also do a delta between current vs new then add a 2x because it's both on top and bottom, or right and left.

## User-facing changes

- The text box now grows or shrinks depending on how much padding is added or subtracted. The text should stay in place.

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

1. Open the editor
2. Select a text box
3. Add padding either for both directions or just one, or separate values for each
4. See that the framing increases accordingly and the text stays in place.

<!-- Please reference the issue(s) this PR addresses. -->

#2089 