### PR TITLE
Dashboard: Trigger load more stories when using keyboard to navigate grid

### DIFF
--- a/assets/src/dashboard/app/views/exploreTemplates/content/index.js
+++ b/assets/src/dashboard/app/views/exploreTemplates/content/index.js
@@ -78,6 +78,14 @@ function Content({
                       'No more templates',
                       'web-stories'
                     )}
+                    allDataLoadedAriaMessage={__(
+                      'All templates are loaded',
+                      'web-stories'
+                    )}
+                    loadingAriaMessage={__(
+                      'Loading more templates',
+                      'web-stories'
+                    )}
                     onLoadMore={page.requestNextPage}
                   />
                 </>

--- a/assets/src/dashboard/app/views/savedTemplates/content/index.js
+++ b/assets/src/dashboard/app/views/savedTemplates/content/index.js
@@ -135,8 +135,12 @@ function Content({
                     returnFocusId={initialFocusId}
                   />
                   <InfiniteScroller
-                    allDataLoadedMessage={__(
-                      'No more templates',
+                    allDataLoadedAriaMessage={__(
+                      'All templates are loaded',
+                      'web-stories'
+                    )}
+                    loadingAriaMessage={__(
+                      'Loading more templates',
                       'web-stories'
                     )}
                     isLoading={isLoading}

--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -37,7 +37,7 @@ const DashboardGrid = styled.div(
   grid-template-columns:
     repeat(auto-fill, ${columnWidth}px);
   grid-template-rows: minmax(${columnHeight}px, auto);
-  scroll-margin-top: 50vh;
+  scroll-margin-top: 30vh;
   margin-top: 2px; // this is for keyboard focus 
 
   ${theme.breakpoint.tablet} {

--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -54,7 +54,7 @@ const DashboardGrid = styled.div(
   }
   
   ${KEYBOARD_USER_SELECTOR} &:focus {
-    outline: 2px solid ${rgba(theme.colors.bluePrimary, 0.85)};
+    outline: 2px solid ${rgba(theme.colors.bluePrimary, 0.85)} !important; 
   }
 `
 );

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -67,7 +67,7 @@ const EditControls = styled.div`
 
   ${KEYBOARD_USER_SELECTOR} &:focus {
     outline: ${({ theme }) =>
-      `2px solid ${rgba(theme.colors.bluePrimary, 0.85)}`};
+      `2px solid ${rgba(theme.colors.bluePrimary, 0.85)} !important`};
   }
 
   @media ${({ theme }) => theme.breakpoint.smallDisplayPhone} {

--- a/assets/src/dashboard/components/detailViewNavBar/index.js
+++ b/assets/src/dashboard/components/detailViewNavBar/index.js
@@ -24,11 +24,12 @@ import { __ } from '@wordpress/i18n';
  */
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import { rgba } from 'polished';
 
 /**
  * Internal dependencies
  */
-import { BUTTON_TYPES } from '../../constants';
+import { BUTTON_TYPES, KEYBOARD_USER_SELECTOR } from '../../constants';
 import { BookmarkChip, Button } from '../../components';
 import { parentRoute } from '../../app/router/route';
 import { TypographyPresets } from '../typography';
@@ -73,6 +74,10 @@ const CloseLink = styled.a`
     text-decoration: none;
     font-weight: ${theme.typography.weight.bold};
     color: ${theme.colors.gray700};
+
+    ${KEYBOARD_USER_SELECTOR} &:focus {
+      outline: 2px solid ${rgba(theme.colors.bluePrimary, 0.85)} !important;
+    }
   `}
 `;
 const CapitalizedButton = styled(Button)`

--- a/assets/src/dashboard/components/infiniteScroller/index.js
+++ b/assets/src/dashboard/components/infiniteScroller/index.js
@@ -107,7 +107,7 @@ const InfiniteScroller = ({
     if (loadState === STATE.loading_internal) {
       onLoadMoreRef.current();
     }
-  }, [loadState, loadingAriaMessage]);
+  }, [loadState]);
 
   useEffect(() => {
     if (isLoading) {

--- a/assets/src/dashboard/components/infiniteScroller/index.js
+++ b/assets/src/dashboard/components/infiniteScroller/index.js
@@ -34,7 +34,8 @@ import { TypographyPresets } from '../typography';
 const ScrollMessage = styled.div`
   ${TypographyPresets.Small};
   width: 100%;
-  margin: 40px auto;
+  padding: 140px 0 40px;
+  margin: -100px auto 0;
   text-align: center;
   color: ${({ theme }) => theme.colors.gray500};
 `;
@@ -150,7 +151,7 @@ const InfiniteScroller = ({
       },
       {
         rootMargin: '0px',
-        threshold: 1,
+        threshold: 0,
       }
     );
 
@@ -163,7 +164,9 @@ const InfiniteScroller = ({
 
   return (
     <ScrollMessage data-testid="load-more-on-scroll" ref={loadingRef}>
-      {loadingAlert && <AriaOnlyAlert>{loadingAlert}</AriaOnlyAlert>}
+      {loadingAlert && (
+        <AriaOnlyAlert role="status">{loadingAlert}</AriaOnlyAlert>
+      )}
       {!canLoadMore ? allDataLoadedMessage : loadingMessage}
     </ScrollMessage>
   );

--- a/assets/src/dashboard/components/infiniteScroller/index.js
+++ b/assets/src/dashboard/components/infiniteScroller/index.js
@@ -21,7 +21,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useEffect, useRef, useReducer, useState } from 'react';
+import { useEffect, useRef, useReducer, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -93,21 +93,18 @@ const InfiniteScroller = ({
   onLoadMoreRef.current = onLoadMore;
 
   const [loadState, dispatch] = useReducer(loadReducer, STATE.loadable);
-  const [loadingAlert, setLoadingAlert] = useState(null);
 
-  useEffect(() => {
-    if (!loadingAlert) {
-      return () => {};
+  const loadingAlert = useMemo(() => {
+    if (loadState === STATE.loading_internal) {
+      return loadingAriaMessage;
+    } else if (!canLoadMore) {
+      return allDataLoadedAriaMessage;
     }
-
-    const dismissLoadingAlert = setTimeout(() => setLoadingAlert(null), 1000);
-
-    return () => clearTimeout(dismissLoadingAlert);
-  }, [loadingAlert]);
+    return null;
+  }, [allDataLoadedAriaMessage, loadingAriaMessage, loadState, canLoadMore]);
 
   useEffect(() => {
     if (loadState === STATE.loading_internal) {
-      setLoadingAlert(loadingAriaMessage);
       onLoadMoreRef.current();
     }
   }, [loadState, loadingAriaMessage]);
@@ -129,12 +126,6 @@ const InfiniteScroller = ({
       dispatch(ACTION.ON_CAN_LOAD_MORE);
     }
   }, [canLoadMore]);
-
-  useEffect(() => {
-    if (!canLoadMore) {
-      setLoadingAlert(allDataLoadedAriaMessage);
-    }
-  }, [allDataLoadedAriaMessage, canLoadMore]);
 
   useEffect(() => {
     if (!loadingRef.current) {

--- a/assets/src/dashboard/components/scrollToTop/index.js
+++ b/assets/src/dashboard/components/scrollToTop/index.js
@@ -19,6 +19,7 @@
  */
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import { rgba } from 'polished';
 
 /**
  * WordPress dependencies
@@ -31,6 +32,7 @@ import { __ } from '@wordpress/i18n';
 import { ChevronLeft } from '../../icons';
 import cssLerp from '../../utils/cssLerp';
 import { useLayoutContext, SQUISH_CSS_VAR } from '../layout';
+import { KEYBOARD_USER_SELECTOR } from '../../constants';
 
 const ScrollButton = styled.button`
   position: absolute;
@@ -52,6 +54,11 @@ const ScrollButton = styled.button`
   color: ${({ theme }) => theme.colors.gray900};
   background-color: ${({ theme }) => theme.colors.white};
   opacity: ${cssLerp(0, 1, SQUISH_CSS_VAR)};
+
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    outline: ${({ theme }) =>
+      `2px solid ${rgba(theme.colors.bluePrimary, 0.85)} !important`};
+  }
 `;
 
 const DropUpArrowIcon = styled(ChevronLeft)`

--- a/assets/src/dashboard/components/storyMenu/index.js
+++ b/assets/src/dashboard/components/storyMenu/index.js
@@ -20,6 +20,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useCallback, useRef } from 'react';
+import { rgba } from 'polished';
 
 /**
  * Internal dependencies
@@ -29,10 +30,11 @@ import { MoreVertical as MoreVerticalSvg } from '../../icons';
 import useFocusOut from '../../utils/useFocusOut';
 import { PopoverMenuCard } from '../popoverMenu';
 import { DROPDOWN_ITEM_PROP_TYPE } from '../types';
+import { KEYBOARD_USER_SELECTOR } from '../../constants';
 
 export const MoreVerticalButton = styled.button`
   display: flex;
-  border: none;
+  border: ${({ theme }) => theme.borders.transparent};
   background: transparent;
   padding: 0 8px;
   opacity: ${({ menuOpen, isVisible }) => (menuOpen || isVisible ? 1 : 0)};
@@ -43,6 +45,11 @@ export const MoreVerticalButton = styled.button`
   & > svg {
     width: 4px;
     max-height: 100%;
+  }
+
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    border-color: ${({ theme }) => rgba(theme.colors.bluePrimary, 0.85)};
+    border-width: 2px;
   }
 `;
 

--- a/assets/src/dashboard/components/typeahead/components.js
+++ b/assets/src/dashboard/components/typeahead/components.js
@@ -19,11 +19,13 @@
  */
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import { rgba } from 'polished';
 
 /**
  * Internal dependencies
  */
 import { TypographyPresets } from '../typography';
+import { KEYBOARD_USER_SELECTOR } from '../../constants';
 
 export const SearchContainer = styled.div`
   width: 100%;
@@ -85,6 +87,11 @@ export const StyledInput = styled.input`
     cursor: default;
   }
 
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    outline: ${({ theme }) =>
+      `2px solid ${rgba(theme.colors.bluePrimary, 0.85)} !important`};
+  }
+
   @media ${({ theme }) => theme.breakpoint.largeDisplayPhone} {
     width: ${({ isExpanded }) => (isExpanded ? '100%' : '0')};
   }
@@ -120,5 +127,10 @@ export const ClearInputButton = styled.button`
 
   & > svg {
     height: 100%;
+  }
+
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    outline: ${({ theme }) =>
+      `2px solid ${rgba(theme.colors.bluePrimary, 0.85)} !important`};
   }
 `;

--- a/assets/src/dashboard/components/viewStyleBar/index.js
+++ b/assets/src/dashboard/components/viewStyleBar/index.js
@@ -19,13 +19,19 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { rgba } from 'polished';
 
 /**
  * Internal dependencies
  */
 
 import { Grid as GridSVG, List as ListSVG } from '../../icons';
-import { ICON_METRICS, VIEW_STYLE, VIEW_STYLE_LABELS } from '../../constants';
+import {
+  ICON_METRICS,
+  KEYBOARD_USER_SELECTOR,
+  VIEW_STYLE,
+  VIEW_STYLE_LABELS,
+} from '../../constants';
 import Tooltip from '../tooltip';
 
 const Container = styled.div`
@@ -45,6 +51,10 @@ const ToggleButton = styled.button`
   }
   &:active svg {
     color: ${({ theme }) => theme.colors.gray800};
+  }
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    outline: ${({ theme }) =>
+      `2px solid ${rgba(theme.colors.bluePrimary, 0.85)} !important`};
   }
 `;
 


### PR DESCRIPTION
## Summary
Fixes bug where when using keyboard and you navigate to the last loaded story more stories are sometimes not loaded. 

## Relevant Technical Choices
- Got a little clever with the infinite scroll loading component to trigger an intersection as soon as 1 px is seen of the loading component (instead of the whole thing) and adjusted the top margin to be `-100px` so that it would overlap the grid slightly to make sure we start loading content early. Compensating the negative margin top with padding. Couldn't use `rootMargin` in the IO because the root element here is the loading component. 
- Adding and then removing a span with a role of `status` when loading occurs or all possible elements have been loaded so that SR will politely announce. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- Should be able to continue loading stories while using the grid with a keyboard 
- `loading more stories` and `all stories are loaded` should be announced by a screen reader when those events occur

## Testing Instructions
- Key through the story grid (arrows once you get to the grid container), when you get to the last loaded story you should get more stories loaded (if available). If you turn on your screen reader and do the above, loading will announce and so will 'all stories are loaded' when you reach the true end of the grid items. 
- Verify scrolling works as expected still with cursor. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4723 
