### PR TITLE
Story Editor: Added Table Text Sets

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/textSets/loadTextSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/loadTextSets.js
@@ -69,7 +69,14 @@ async function loadTextSet(name) {
 }
 
 export default async function loadTextSets() {
-  const textSets = ['cover', 'step', 'section_header', 'editorial', 'quote'];
+  const textSets = [
+    'cover',
+    'step',
+    'section_header',
+    'editorial',
+    'table',
+    'quote',
+  ];
 
   const results = await Promise.all(
     textSets.map(async (name) => {

--- a/assets/src/edit-story/components/library/panes/text/textSets/raw/table.json
+++ b/assets/src/edit-story/components/library/panes/text/textSets/raw/table.json
@@ -1,5 +1,5 @@
 {
-  "current": "64a7810a-b11c-48ae-b8f9-4820af17bf84",
+  "current": "46255a97-3e9e-444a-acb4-59be70044ac6",
   "selection": [],
   "story": {
     "stylePresets": {
@@ -4553,7 +4553,7 @@
             "vertical": 0
           },
           "type": "text",
-          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
           "fontWeight": 400,
           "width": 100,
           "height": 21,
@@ -4622,10 +4622,10 @@
             "vertical": 0
           },
           "type": "text",
-          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
           "fontWeight": 400,
           "width": 100,
-          "height": 22,
+          "height": 21,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -4691,10 +4691,10 @@
             "vertical": 0
           },
           "type": "text",
-          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
           "fontWeight": 400,
           "width": 100,
-          "height": 22,
+          "height": 21,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -4760,10 +4760,10 @@
             "vertical": 0
           },
           "type": "text",
-          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
           "fontWeight": 400,
           "width": 100,
-          "height": 22,
+          "height": 21,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
@@ -4829,10 +4829,10 @@
             "vertical": 0
           },
           "type": "text",
-          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
           "fontWeight": 400,
           "width": 100,
-          "height": 22,
+          "height": 21,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,

--- a/assets/src/edit-story/components/library/panes/text/textSets/raw/table.json
+++ b/assets/src/edit-story/components/library/panes/text/textSets/raw/table.json
@@ -1,0 +1,7807 @@
+{
+  "current": "64a7810a-b11c-48ae-b8f9-4820af17bf84",
+  "selection": [],
+  "story": {
+    "stylePresets": {
+      "textStyles": [
+        {
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Serif",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700]
+            ]
+          },
+          "fontSize": 37,
+          "lineHeight": 1.2,
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "textAlign": "initial",
+          "color": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "fontWeight": 600,
+          "isItalic": false,
+          "isUnderline": false,
+          "letterSpacing": 0
+        }
+      ],
+      "colors": [
+        {
+          "color": {
+            "r": 33,
+            "g": 33,
+            "b": 33
+          }
+        },
+        {
+          "color": {
+            "r": 0,
+            "g": 92,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 61,
+            "g": 46,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 200,
+            "g": 122,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 163,
+            "b": 214
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 187,
+            "b": 196
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 187,
+            "b": 196,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 246,
+            "g": 147,
+            "b": 147,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 240,
+            "g": 176,
+            "b": 119,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 220,
+            "g": 211,
+            "b": 67,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 153,
+            "g": 199,
+            "b": 39,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 119,
+            "g": 151,
+            "b": 18,
+            "a": 0.6
+          }
+        }
+      ]
+    }
+  },
+  "version": 24,
+  "pages": [
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "27703533-bcd6-4ddf-80c0-0f7573645d8c"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 27,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "initial",
+          "padding": {
+            "vertical": 0,
+            "horizontal": 0,
+            "locked": true
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">Table Title</span>",
+          "fontWeight": 700,
+          "x": 41,
+          "y": 207,
+          "width": 331,
+          "height": 31,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "6cfb2f63-bb73-426f-a8cc-aadb2b5d4ad5"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "x": 41,
+          "y": 254,
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "id": "7e480110-14ff-4ac7-92ee-b23f6a8d1366"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 1",
+          "fontWeight": 400,
+          "x": 41,
+          "y": 263,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "f1c8f5eb-244b-410a-b889-b1941ab8b05d"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 2",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "f1c8f5eb-244b-410a-b889-b1941ab8b05d",
+          "id": "fd1ccbd1-2281-41a1-b2fe-898c19c5210a",
+          "x": 41,
+          "y": 293
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 3",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "f1c8f5eb-244b-410a-b889-b1941ab8b05d",
+          "id": "94e7dbf3-9258-46b5-b9de-c582ac68460b",
+          "x": 41,
+          "y": 323
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 4",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "f1c8f5eb-244b-410a-b889-b1941ab8b05d",
+          "id": "3e205a8e-8fb1-4aa0-8078-51993882297a",
+          "x": 41,
+          "y": 353
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 5",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "f1c8f5eb-244b-410a-b889-b1941ab8b05d",
+          "id": "5fcab657-f470-414f-83eb-45e6975542ba",
+          "x": 41,
+          "y": 383
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "7e480110-14ff-4ac7-92ee-b23f6a8d1366",
+          "id": "4ad591d3-f5a8-4ee8-b514-fd5130944c18",
+          "x": 41,
+          "y": 413
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "x": 272,
+          "y": 263,
+          "width": 100,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "11b6e3dc-5de2-4989-9d5e-5bd7fd8971d3"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "11b6e3dc-5de2-4989-9d5e-5bd7fd8971d3",
+          "id": "b26ebb98-47cc-4431-b70e-9eb65acd50fd",
+          "x": 272,
+          "y": 293
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "11b6e3dc-5de2-4989-9d5e-5bd7fd8971d3",
+          "id": "67020819-fffb-4983-a689-1d8503dcfcf1",
+          "x": 272,
+          "y": 323
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "11b6e3dc-5de2-4989-9d5e-5bd7fd8971d3",
+          "id": "93fba19b-2d49-465e-99d4-b32f436d45e2",
+          "x": 272,
+          "y": 353
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto",
+            "weights": [100, 300, 400, 500, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "fallbacks": ["Helvetica Neue", "Helvetica", "sans-serif"],
+            "service": "fonts.google.com",
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "11b6e3dc-5de2-4989-9d5e-5bd7fd8971d3",
+          "id": "b2725bf6-8f39-4515-96b4-8023af950b05",
+          "x": 272,
+          "y": 383
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "64a7810a-b11c-48ae-b8f9-4820af17bf84"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "fbc49dce-2eea-4214-b8d9-134bd15d4942"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 27,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">Table Title</span>",
+          "fontWeight": 700,
+          "width": 331,
+          "height": 33,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "6cfb2f63-bb73-426f-a8cc-aadb2b5d4ad5",
+          "id": "285e5007-d535-4b3d-acd6-cc745dd1e011",
+          "x": 41,
+          "y": 200
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "4ad591d3-f5a8-4ee8-b514-fd5130944c18",
+          "id": "45996c9d-a162-4fb0-9b1f-afe80221df49",
+          "x": 41,
+          "y": 316
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "7e480110-14ff-4ac7-92ee-b23f6a8d1366",
+          "id": "8fa19274-3cf7-4379-a178-c697ca11aa6c",
+          "x": 41,
+          "y": 278
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 1",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "f1c8f5eb-244b-410a-b889-b1941ab8b05d",
+          "id": "5dcf1716-5ca4-4467-9efd-97180dd6bfa2",
+          "x": 41,
+          "y": 249
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 2",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "fd1ccbd1-2281-41a1-b2fe-898c19c5210a",
+          "id": "16d8ea91-c4ed-4f1d-80d6-26861d3408ed",
+          "x": 41,
+          "y": 287
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 3",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "94e7dbf3-9258-46b5-b9de-c582ac68460b",
+          "id": "1441935b-5b8b-427c-9518-1be5e77b24c7",
+          "x": 42,
+          "y": 325
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 4",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "3e205a8e-8fb1-4aa0-8078-51993882297a",
+          "id": "e847e1bd-6156-407e-917b-4b4946c72bfe",
+          "x": 42,
+          "y": 363
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 5",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5fcab657-f470-414f-83eb-45e6975542ba",
+          "id": "2fbcfe82-26f4-4369-b2bc-49a2bb945c09",
+          "x": 42,
+          "y": 401
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "11b6e3dc-5de2-4989-9d5e-5bd7fd8971d3",
+          "id": "5ab3c137-a155-4895-acb9-4b6861e4fde9",
+          "x": 272,
+          "y": 249
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "b26ebb98-47cc-4431-b70e-9eb65acd50fd",
+          "id": "88f625cb-de28-4b06-b428-d37118075162",
+          "x": 272,
+          "y": 287
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "67020819-fffb-4983-a689-1d8503dcfcf1",
+          "id": "3416ef7b-05ea-47db-b53a-5ff21fb313d3",
+          "x": 273,
+          "y": 325
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "93fba19b-2d49-465e-99d4-b32f436d45e2",
+          "id": "26225f34-2d96-468c-9730-5bc55775d532",
+          "x": 273,
+          "y": 363
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "b2725bf6-8f39-4515-96b4-8023af950b05",
+          "id": "cb1a4cfe-48a2-4633-b7ee-eaac27e20cf3",
+          "x": 273,
+          "y": 401
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "8fa19274-3cf7-4379-a178-c697ca11aa6c",
+          "id": "25c860ab-51db-419f-9b35-09a5cc90d5e5",
+          "x": 41,
+          "y": 354
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "45996c9d-a162-4fb0-9b1f-afe80221df49",
+          "id": "b50a8880-19d1-4ba1-99cc-d22d9bc0073d",
+          "x": 41,
+          "y": 392
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "2f0bbc9f-65d8-4da8-bc87-6be32e970243"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "343a8b28-3932-4e0f-847e-aa69ce34e375"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Poppins",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 800],
+              [1, 800],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1050,
+              "des": -350,
+              "tAsc": 1050,
+              "tDes": -350,
+              "tLGap": 100,
+              "wAsc": 1135,
+              "wDes": 627,
+              "xH": 548,
+              "capH": 698,
+              "yMin": -572,
+              "yMax": 1065,
+              "hAsc": 1050,
+              "hDes": -350,
+              "lGap": 100
+            }
+          },
+          "fontSize": 31,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; letter-spacing: 0.03em\">TABLE TITLE</span>",
+          "fontWeight": 700,
+          "width": 331,
+          "height": 43,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "6cfb2f63-bb73-426f-a8cc-aadb2b5d4ad5",
+          "id": "2b95ebb6-f095-4501-a0b9-540c78efdb76",
+          "x": 41,
+          "y": 207
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 32,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "7e480110-14ff-4ac7-92ee-b23f6a8d1366",
+          "id": "dfb4c355-e101-47d7-b6f6-66fa128106a7",
+          "x": 41,
+          "y": 187
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 1",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "f1c8f5eb-244b-410a-b889-b1941ab8b05d",
+          "id": "1d9c3ea3-c165-4f31-b018-8e01afde53e6",
+          "x": 41,
+          "y": 266
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">Item 2</span>",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 23,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "fd1ccbd1-2281-41a1-b2fe-898c19c5210a",
+          "id": "acc90a9d-ba38-4052-b03c-7f382f6d1acd",
+          "x": 41,
+          "y": 296
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 3",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "94e7dbf3-9258-46b5-b9de-c582ac68460b",
+          "id": "696ecc2a-9806-47b1-911f-1f64d52d7be5",
+          "x": 41,
+          "y": 326
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 4",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "3e205a8e-8fb1-4aa0-8078-51993882297a",
+          "id": "33118e89-5f05-4c87-9292-f715660e55aa",
+          "x": 41,
+          "y": 356
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 5",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5fcab657-f470-414f-83eb-45e6975542ba",
+          "id": "7379c302-0225-484d-acb0-1e48b2b0d82f",
+          "x": 41,
+          "y": 386
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 23,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "11b6e3dc-5de2-4989-9d5e-5bd7fd8971d3",
+          "id": "8eb0169f-2ce6-4bb0-bc52-60ab0d2ecaad",
+          "x": 272,
+          "y": 266
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "$5.00",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "b26ebb98-47cc-4431-b70e-9eb65acd50fd",
+          "id": "d1a33bdd-edde-4bb1-9dce-d61681638581",
+          "x": 272,
+          "y": 296
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 23,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "67020819-fffb-4983-a689-1d8503dcfcf1",
+          "id": "217defea-1605-4b13-a5bc-0a7df4cf37aa",
+          "x": 272,
+          "y": 326
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "$5.00",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "93fba19b-2d49-465e-99d4-b32f436d45e2",
+          "id": "b4bdf110-6cb9-419d-9957-e1fc4531c1bb",
+          "x": 272,
+          "y": 356
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1025,
+              "des": -275,
+              "tAsc": 780,
+              "tDes": -220,
+              "tLGap": 300,
+              "wAsc": 1025,
+              "wDes": 275,
+              "xH": 516,
+              "capH": 698,
+              "yMin": -245,
+              "yMax": 1119,
+              "hAsc": 1025,
+              "hDes": -275,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "$5.00",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "b2725bf6-8f39-4515-96b4-8023af950b05",
+          "id": "882f55cb-6f30-4846-ad14-3a35ac3a910e",
+          "x": 272,
+          "y": 386
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "f90daf3c-f7ef-4b25-b31c-5edbdf61c517"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "2b57bbe2-dbb7-4ac8-91ab-9553a83431c1"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Source Serif Pro",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 918,
+              "des": -335,
+              "tAsc": 918,
+              "tDes": -335,
+              "tLGap": 0,
+              "wAsc": 1036,
+              "wDes": 335,
+              "xH": 475,
+              "capH": 670,
+              "yMin": -335,
+              "yMax": 1002,
+              "hAsc": 918,
+              "hDes": -335,
+              "lGap": 0
+            }
+          },
+          "fontSize": 24,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; letter-spacing: 0.1em\">TABLE TITLE</span>",
+          "fontWeight": 700,
+          "width": 177,
+          "height": 29,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "285e5007-d535-4b3d-acd6-cc745dd1e011",
+          "id": "8d0739f1-537e-4ce4-bc5e-0e6ded648670",
+          "x": 117,
+          "y": 189
+        },
+        {
+          "opacity": 20,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "45996c9d-a162-4fb0-9b1f-afe80221df49",
+          "id": "8dd2e805-d729-412d-a40d-29c55d17a2eb",
+          "x": 41,
+          "y": 314
+        },
+        {
+          "opacity": 20,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "8fa19274-3cf7-4379-a178-c697ca11aa6c",
+          "id": "50f100d5-4481-433e-8e08-abe1e1452ff8",
+          "x": 41,
+          "y": 274
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Lora",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1006,
+              "des": -274,
+              "tAsc": 1006,
+              "tDes": -274,
+              "tLGap": 0,
+              "wAsc": 1206,
+              "wDes": 294,
+              "xH": 500,
+              "capH": 700,
+              "yMin": -271,
+              "yMax": 1114,
+              "hAsc": 1006,
+              "hDes": -274,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 1",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5dcf1716-5ca4-4467-9efd-97180dd6bfa2",
+          "id": "fd063d64-6bde-4214-b75c-0743d6e835b3",
+          "x": 41,
+          "y": 242
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Lora",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1006,
+              "des": -274,
+              "tAsc": 1006,
+              "tDes": -274,
+              "tLGap": 0,
+              "wAsc": 1206,
+              "wDes": 294,
+              "xH": 500,
+              "capH": 700,
+              "yMin": -271,
+              "yMax": 1114,
+              "hAsc": 1006,
+              "hDes": -274,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 2",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "16d8ea91-c4ed-4f1d-80d6-26861d3408ed",
+          "id": "4a682269-3ba8-4f7c-9f37-a42cb0cb74b4",
+          "x": 41,
+          "y": 283
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Lora",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1006,
+              "des": -274,
+              "tAsc": 1006,
+              "tDes": -274,
+              "tLGap": 0,
+              "wAsc": 1206,
+              "wDes": 294,
+              "xH": 500,
+              "capH": 700,
+              "yMin": -271,
+              "yMax": 1114,
+              "hAsc": 1006,
+              "hDes": -274,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 3",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "1441935b-5b8b-427c-9518-1be5e77b24c7",
+          "id": "a494161b-a715-4e6b-a318-439db3299028",
+          "x": 42,
+          "y": 323
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Lora",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1006,
+              "des": -274,
+              "tAsc": 1006,
+              "tDes": -274,
+              "tLGap": 0,
+              "wAsc": 1206,
+              "wDes": 294,
+              "xH": 500,
+              "capH": 700,
+              "yMin": -271,
+              "yMax": 1114,
+              "hAsc": 1006,
+              "hDes": -274,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 4",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "e847e1bd-6156-407e-917b-4b4946c72bfe",
+          "id": "cbb00b75-84e5-4489-9e5f-70bbba2edb26",
+          "x": 42,
+          "y": 363
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Lora",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1006,
+              "des": -274,
+              "tAsc": 1006,
+              "tDes": -274,
+              "tLGap": 0,
+              "wAsc": 1206,
+              "wDes": 294,
+              "xH": 500,
+              "capH": 700,
+              "yMin": -271,
+              "yMax": 1114,
+              "hAsc": 1006,
+              "hDes": -274,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 5",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "2fbcfe82-26f4-4369-b2bc-49a2bb945c09",
+          "id": "836156b8-0f13-4fc1-abb8-560c8006e244",
+          "x": 42,
+          "y": 403
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Playfair Display",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1082,
+              "des": -251,
+              "tAsc": 1082,
+              "tDes": -251,
+              "tLGap": 0,
+              "wAsc": 1159,
+              "wDes": 251,
+              "xH": 514,
+              "capH": 708,
+              "yMin": -241,
+              "yMax": 1159,
+              "hAsc": 1082,
+              "hDes": -251,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 24,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5ab3c137-a155-4895-acb9-4b6861e4fde9",
+          "id": "af54ad2c-0711-4028-931a-f9d872fa61cb",
+          "x": 272,
+          "y": 242
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Playfair Display",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1082,
+              "des": -251,
+              "tAsc": 1082,
+              "tDes": -251,
+              "tLGap": 0,
+              "wAsc": 1159,
+              "wDes": 251,
+              "xH": 514,
+              "capH": 708,
+              "yMin": -241,
+              "yMax": 1159,
+              "hAsc": 1082,
+              "hDes": -251,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 24,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "88f625cb-de28-4b06-b428-d37118075162",
+          "id": "74cc4e82-f838-4581-9351-ae99e0fbc485",
+          "x": 272,
+          "y": 283
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Playfair Display",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1082,
+              "des": -251,
+              "tAsc": 1082,
+              "tDes": -251,
+              "tLGap": 0,
+              "wAsc": 1159,
+              "wDes": 251,
+              "xH": 514,
+              "capH": 708,
+              "yMin": -241,
+              "yMax": 1159,
+              "hAsc": 1082,
+              "hDes": -251,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 24,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "3416ef7b-05ea-47db-b53a-5ff21fb313d3",
+          "id": "919bbfb1-755f-440c-83d2-4c0726ce3af0",
+          "x": 273,
+          "y": 323
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Playfair Display",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1082,
+              "des": -251,
+              "tAsc": 1082,
+              "tDes": -251,
+              "tLGap": 0,
+              "wAsc": 1159,
+              "wDes": 251,
+              "xH": 514,
+              "capH": 708,
+              "yMin": -241,
+              "yMax": 1159,
+              "hAsc": 1082,
+              "hDes": -251,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 24,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "26225f34-2d96-468c-9730-5bc55775d532",
+          "id": "eca735fc-fc7f-478c-aa0c-6438d03ceb49",
+          "x": 273,
+          "y": 363
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Playfair Display",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1082,
+              "des": -251,
+              "tAsc": 1082,
+              "tDes": -251,
+              "tLGap": 0,
+              "wAsc": 1159,
+              "wDes": 251,
+              "xH": 514,
+              "capH": 708,
+              "yMin": -241,
+              "yMax": 1159,
+              "hAsc": 1082,
+              "hDes": -251,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 24,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "cb1a4cfe-48a2-4633-b7ee-eaac27e20cf3",
+          "id": "fe0227e8-1077-4e80-8a74-9c230be11642",
+          "x": 273,
+          "y": 403
+        },
+        {
+          "opacity": 20,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "25c860ab-51db-419f-9b35-09a5cc90d5e5",
+          "id": "758a4943-8039-494b-b97b-da55da993a5f",
+          "x": 41,
+          "y": 354
+        },
+        {
+          "opacity": 20,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "b50a8880-19d1-4ba1-99cc-d22d9bc0073d",
+          "id": "24590da6-c538-4c4f-a09d-afa2e55e6d44",
+          "x": 41,
+          "y": 394
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "x": 69,
+          "y": 203,
+          "width": 32,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "id": "2a9dfe8b-af99-4dbd-90f0-c71bfeaee950"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 32,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "2a9dfe8b-af99-4dbd-90f0-c71bfeaee950",
+          "id": "541d992e-9ad7-4e1f-9568-23af5a7a17a5",
+          "x": 310,
+          "y": 203
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "c867f325-0f47-4d8b-8e3f-6eaa1c59030f"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "2137b448-cc23-4b1e-8ca1-58f83bf79b58"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Oswald",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 500, 600, 700],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1193,
+              "des": -289,
+              "tAsc": 1193,
+              "tDes": -289,
+              "tLGap": 0,
+              "wAsc": 1325,
+              "wDes": 377,
+              "xH": 578,
+              "capH": 810,
+              "yMin": -287,
+              "yMax": 1297,
+              "hAsc": 1193,
+              "hDes": -289,
+              "lGap": 0
+            }
+          },
+          "fontSize": 19,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 500\">TABLE TITLE</span>",
+          "fontWeight": 700,
+          "width": 331,
+          "height": 28,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "285e5007-d535-4b3d-acd6-cc745dd1e011",
+          "id": "f73e0297-1e74-4df6-903c-265df1481a88",
+          "x": 41,
+          "y": 199
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "45996c9d-a162-4fb0-9b1f-afe80221df49",
+          "id": "0cccce3a-7ea2-428c-a04b-c6cb2bf73e26",
+          "x": 41,
+          "y": 318
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "8fa19274-3cf7-4379-a178-c697ca11aa6c",
+          "id": "b6c57d67-11f5-4a05-b6c9-f1861bcd0b74",
+          "x": 41,
+          "y": 279
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 1",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5dcf1716-5ca4-4467-9efd-97180dd6bfa2",
+          "id": "b3d5f68c-da1d-4a6a-808d-812c01c5aa5d",
+          "x": 41,
+          "y": 249
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 2",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "16d8ea91-c4ed-4f1d-80d6-26861d3408ed",
+          "id": "292c632a-edae-4e44-a31e-49119f5b9281",
+          "x": 41,
+          "y": 288
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 3",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "1441935b-5b8b-427c-9518-1be5e77b24c7",
+          "id": "910acfbf-59da-4b59-9a77-6fd20473db7d",
+          "x": 42,
+          "y": 327
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 4",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "e847e1bd-6156-407e-917b-4b4946c72bfe",
+          "id": "16515d79-a2e5-4012-8423-96ee7c495cd4",
+          "x": 42,
+          "y": 366
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 5",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "2fbcfe82-26f4-4369-b2bc-49a2bb945c09",
+          "id": "464f9c6b-943a-4172-9400-3e51376b90fb",
+          "x": 42,
+          "y": 405
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5ab3c137-a155-4895-acb9-4b6861e4fde9",
+          "id": "b878731a-d488-4cbc-b6e7-b930eae92b79",
+          "x": 272,
+          "y": 249
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "88f625cb-de28-4b06-b428-d37118075162",
+          "id": "d00b14c8-bfe8-48e3-bef7-84e5ed7f5851",
+          "x": 272,
+          "y": 288
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "3416ef7b-05ea-47db-b53a-5ff21fb313d3",
+          "id": "64be7770-c026-456d-836e-6fd307111b15",
+          "x": 273,
+          "y": 327
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "26225f34-2d96-468c-9730-5bc55775d532",
+          "id": "ddd2161e-1f4d-41ba-b581-21af64648304",
+          "x": 273,
+          "y": 366
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "cb1a4cfe-48a2-4633-b7ee-eaac27e20cf3",
+          "id": "c084242d-80ff-44f3-ac3e-640ebbc1656b",
+          "x": 273,
+          "y": 405
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "25c860ab-51db-419f-9b35-09a5cc90d5e5",
+          "id": "824dce32-7243-4eb3-9bd8-333e55a332cd",
+          "x": 41,
+          "y": 357
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "b50a8880-19d1-4ba1-99cc-d22d9bc0073d",
+          "id": "793ab90f-35d8-46d1-b5c7-b15de318dc86",
+          "x": 41,
+          "y": 396
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "b6c57d67-11f5-4a05-b6c9-f1861bcd0b74",
+          "id": "197f2dcb-ec81-43b9-a128-6b453afa5f95",
+          "x": 41,
+          "y": 239
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "197f2dcb-ec81-43b9-a128-6b453afa5f95",
+          "id": "6ae291f1-77c1-46c4-9f41-07ac6f48e1df",
+          "x": 41,
+          "y": 435
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "6ae291f1-77c1-46c4-9f41-07ac6f48e1df",
+          "id": "9e69cd18-8235-4d63-8187-d943575079f9",
+          "x": 41,
+          "y": 186
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "46255a97-3e9e-444a-acb4-59be70044ac6"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "b22af226-96b3-4230-8f8d-ce065636a91d"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Merriweather",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [300, 400, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 984,
+              "des": -273,
+              "tAsc": 984,
+              "tDes": -273,
+              "tLGap": 0,
+              "wAsc": 1065,
+              "wDes": 273,
+              "xH": 555,
+              "capH": 743,
+              "yMin": -272,
+              "yMax": 1055,
+              "hAsc": 984,
+              "hDes": -273,
+              "lGap": 0
+            }
+          },
+          "fontSize": 27,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Table Title",
+          "fontWeight": 700,
+          "width": 331,
+          "height": 32,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "285e5007-d535-4b3d-acd6-cc745dd1e011",
+          "id": "ceb8a5d7-83ab-4d3d-8c40-4eb86d263f94",
+          "x": 41,
+          "y": 204
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "45996c9d-a162-4fb0-9b1f-afe80221df49",
+          "id": "86eb0bc9-3ef7-4fc4-904e-236bf8e0a589",
+          "x": 41,
+          "y": 313
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "8fa19274-3cf7-4379-a178-c697ca11aa6c",
+          "id": "1b680c8e-0245-4793-9f06-c2eefd563d05",
+          "x": 41,
+          "y": 278
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Merriweather",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [300, 400, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 984,
+              "des": -273,
+              "tAsc": 984,
+              "tDes": -273,
+              "tLGap": 0,
+              "wAsc": 1065,
+              "wDes": 273,
+              "xH": 555,
+              "capH": 743,
+              "yMin": -272,
+              "yMax": 1055,
+              "hAsc": 984,
+              "hDes": -273,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.6,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 1",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5dcf1716-5ca4-4467-9efd-97180dd6bfa2",
+          "id": "d458932f-0ab1-4083-ad3d-7f130ea3e1c0",
+          "x": 41,
+          "y": 252
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Merriweather",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [300, 400, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 984,
+              "des": -273,
+              "tAsc": 984,
+              "tDes": -273,
+              "tLGap": 0,
+              "wAsc": 1065,
+              "wDes": 273,
+              "xH": 555,
+              "capH": 743,
+              "yMin": -272,
+              "yMax": 1055,
+              "hAsc": 984,
+              "hDes": -273,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.6,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 2",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "16d8ea91-c4ed-4f1d-80d6-26861d3408ed",
+          "id": "00029122-4425-433e-8119-f5ff79cf6f9f",
+          "x": 41,
+          "y": 287
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Merriweather",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [300, 400, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 984,
+              "des": -273,
+              "tAsc": 984,
+              "tDes": -273,
+              "tLGap": 0,
+              "wAsc": 1065,
+              "wDes": 273,
+              "xH": 555,
+              "capH": 743,
+              "yMin": -272,
+              "yMax": 1055,
+              "hAsc": 984,
+              "hDes": -273,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.6,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 3",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "1441935b-5b8b-427c-9518-1be5e77b24c7",
+          "id": "8f8f033e-3b88-4552-a0fb-e47f7c5a242c",
+          "x": 42,
+          "y": 322
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Merriweather",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [300, 400, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 984,
+              "des": -273,
+              "tAsc": 984,
+              "tDes": -273,
+              "tLGap": 0,
+              "wAsc": 1065,
+              "wDes": 273,
+              "xH": 555,
+              "capH": 743,
+              "yMin": -272,
+              "yMax": 1055,
+              "hAsc": 984,
+              "hDes": -273,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.6,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 4",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "e847e1bd-6156-407e-917b-4b4946c72bfe",
+          "id": "00a0da6d-af0f-419b-afb4-8ecf3e2c7133",
+          "x": 42,
+          "y": 357
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Merriweather",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [300, 400, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 984,
+              "des": -273,
+              "tAsc": 984,
+              "tDes": -273,
+              "tLGap": 0,
+              "wAsc": 1065,
+              "wDes": 273,
+              "xH": 555,
+              "capH": 743,
+              "yMin": -272,
+              "yMax": 1055,
+              "hAsc": 984,
+              "hDes": -273,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.6,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Item 5",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 22,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "2fbcfe82-26f4-4369-b2bc-49a2bb945c09",
+          "id": "969d0159-7f68-41b7-98f3-5f944f11e670",
+          "x": 42,
+          "y": 392
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Raleway",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 940,
+              "des": -234,
+              "tAsc": 940,
+              "tDes": -234,
+              "tLGap": 0,
+              "wAsc": 1154,
+              "wDes": 234,
+              "xH": 519,
+              "capH": 710,
+              "yMin": -223,
+              "yMax": 1151,
+              "hAsc": 940,
+              "hDes": -234,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "5ab3c137-a155-4895-acb9-4b6861e4fde9",
+          "id": "9712a3e6-dcd9-4c33-b1b6-e8a696ba9f01",
+          "x": 272,
+          "y": 252
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Raleway",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 940,
+              "des": -234,
+              "tAsc": 940,
+              "tDes": -234,
+              "tLGap": 0,
+              "wAsc": 1154,
+              "wDes": 234,
+              "xH": 519,
+              "capH": 710,
+              "yMin": -223,
+              "yMax": 1151,
+              "hAsc": 940,
+              "hDes": -234,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "88f625cb-de28-4b06-b428-d37118075162",
+          "id": "1c98b558-dbea-46c8-b2cd-2e8a4bebb3eb",
+          "x": 272,
+          "y": 287
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Raleway",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 940,
+              "des": -234,
+              "tAsc": 940,
+              "tDes": -234,
+              "tLGap": 0,
+              "wAsc": 1154,
+              "wDes": 234,
+              "xH": 519,
+              "capH": 710,
+              "yMin": -223,
+              "yMax": 1151,
+              "hAsc": 940,
+              "hDes": -234,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "3416ef7b-05ea-47db-b53a-5ff21fb313d3",
+          "id": "e4befb0b-cfa2-402c-a43d-4ec28e3e37b7",
+          "x": 273,
+          "y": 322
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Raleway",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 940,
+              "des": -234,
+              "tAsc": 940,
+              "tDes": -234,
+              "tLGap": 0,
+              "wAsc": 1154,
+              "wDes": 234,
+              "xH": 519,
+              "capH": 710,
+              "yMin": -223,
+              "yMax": 1151,
+              "hAsc": 940,
+              "hDes": -234,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "26225f34-2d96-468c-9730-5bc55775d532",
+          "id": "7db2ff6c-720f-4ff1-bc70-5ff4c8c648f6",
+          "x": 273,
+          "y": 357
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Raleway",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 940,
+              "des": -234,
+              "tAsc": 940,
+              "tDes": -234,
+              "tLGap": 0,
+              "wAsc": 1154,
+              "wDes": 234,
+              "xH": 519,
+              "capH": 710,
+              "yMin": -223,
+              "yMax": 1151,
+              "hAsc": 940,
+              "hDes": -234,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 400\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 21,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "cb1a4cfe-48a2-4633-b7ee-eaac27e20cf3",
+          "id": "4bc228fa-cb39-4101-9007-84e4705ec1d8",
+          "x": 273,
+          "y": 392
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "25c860ab-51db-419f-9b35-09a5cc90d5e5",
+          "id": "0468061b-09db-4701-9e75-8c87de7152a3",
+          "x": 41,
+          "y": 348
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 331,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "b50a8880-19d1-4ba1-99cc-d22d9bc0073d",
+          "id": "3c424294-d6c5-44e4-9af1-c9233540d504",
+          "x": 41,
+          "y": 383
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "85dbd7cd-ba41-4248-9487-a6b7f5dc4da1"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "60c99225-838c-4d69-9405-007d103c403a"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Titillium Web",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1133,
+              "des": -388,
+              "tAsc": 1133,
+              "tDes": -388,
+              "tLGap": 0,
+              "wAsc": 1133,
+              "wDes": 388,
+              "xH": 500,
+              "capH": 692,
+              "yMin": -285,
+              "yMax": 1082,
+              "hAsc": 1133,
+              "hDes": -388,
+              "lGap": 0
+            }
+          },
+          "fontSize": 27,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">Table Title</span>",
+          "fontWeight": 700,
+          "width": 331,
+          "height": 41,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "ceb8a5d7-83ab-4d3d-8c40-4eb86d263f94",
+          "id": "0bbbbe21-4d2b-4fac-a074-742765b4514d",
+          "x": 39,
+          "y": 184
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "FILL",
+          "font": {
+            "family": "Work Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 930,
+              "des": -243,
+              "tAsc": 930,
+              "tDes": -243,
+              "tLGap": 0,
+              "wAsc": 1105,
+              "wDes": 343,
+              "xH": 500,
+              "capH": 660,
+              "yMin": -337,
+              "yMax": 1100,
+              "hAsc": 930,
+              "hDes": -243,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0.05
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 8,
+            "vertical": 8
+          },
+          "type": "text",
+          "content": "Item 1",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 36,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "d458932f-0ab1-4083-ad3d-7f130ea3e1c0",
+          "id": "e061f22f-29b5-40c8-b961-7f77b4e30ab4",
+          "x": 39,
+          "y": 252
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "FILL",
+          "font": {
+            "family": "Work Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 930,
+              "des": -243,
+              "tAsc": 930,
+              "tDes": -243,
+              "tLGap": 0,
+              "wAsc": 1105,
+              "wDes": 343,
+              "xH": 500,
+              "capH": 660,
+              "yMin": -337,
+              "yMax": 1100,
+              "hAsc": 930,
+              "hDes": -243,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 8,
+            "vertical": 8
+          },
+          "type": "text",
+          "content": "Item 2",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 37,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "00029122-4425-433e-8119-f5ff79cf6f9f",
+          "id": "d3414a40-4c98-4de1-b2b7-af067c1ea863",
+          "x": 39,
+          "y": 287.5
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "FILL",
+          "font": {
+            "family": "Work Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 930,
+              "des": -243,
+              "tAsc": 930,
+              "tDes": -243,
+              "tLGap": 0,
+              "wAsc": 1105,
+              "wDes": 343,
+              "xH": 500,
+              "capH": 660,
+              "yMin": -337,
+              "yMax": 1100,
+              "hAsc": 930,
+              "hDes": -243,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0.05
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 8,
+            "vertical": 8
+          },
+          "type": "text",
+          "content": "Item 3",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 37,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "8f8f033e-3b88-4552-a0fb-e47f7c5a242c",
+          "id": "54efc1f3-9d0d-4b88-a3b0-dd684e8404dc",
+          "x": 39,
+          "y": 323.5
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "FILL",
+          "font": {
+            "family": "Work Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 930,
+              "des": -243,
+              "tAsc": 930,
+              "tDes": -243,
+              "tLGap": 0,
+              "wAsc": 1105,
+              "wDes": 343,
+              "xH": 500,
+              "capH": 660,
+              "yMin": -337,
+              "yMax": 1100,
+              "hAsc": 930,
+              "hDes": -243,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 8,
+            "vertical": 8
+          },
+          "type": "text",
+          "content": "Item 4",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 37,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "00a0da6d-af0f-419b-afb4-8ecf3e2c7133",
+          "id": "4286a076-f3f9-49d5-91da-7565d78e8805",
+          "x": 39,
+          "y": 362
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "FILL",
+          "font": {
+            "family": "Work Sans",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 930,
+              "des": -243,
+              "tAsc": 930,
+              "tDes": -243,
+              "tLGap": 0,
+              "wAsc": 1105,
+              "wDes": 343,
+              "xH": 500,
+              "capH": 660,
+              "yMin": -337,
+              "yMax": 1100,
+              "hAsc": 930,
+              "hDes": -243,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 0.05
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 8,
+            "vertical": 8
+          },
+          "type": "text",
+          "content": "Item 5",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 37,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "969d0159-7f68-41b7-98f3-5f944f11e670",
+          "id": "53f32005-a806-48b1-8156-209d5c15e213",
+          "x": 39,
+          "y": 399
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Titillium Web",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1133,
+              "des": -388,
+              "tAsc": 1133,
+              "tDes": -388,
+              "tLGap": 0,
+              "wAsc": 1133,
+              "wDes": 388,
+              "xH": 500,
+              "capH": 692,
+              "yMin": -285,
+              "yMax": 1082,
+              "hAsc": 1133,
+              "hDes": -388,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 26,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "9712a3e6-dcd9-4c33-b1b6-e8a696ba9f01",
+          "id": "7986ea38-8c10-45b3-95df-d830470642f1",
+          "x": 263,
+          "y": 257
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Titillium Web",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1133,
+              "des": -388,
+              "tAsc": 1133,
+              "tDes": -388,
+              "tLGap": 0,
+              "wAsc": 1133,
+              "wDes": 388,
+              "xH": 500,
+              "capH": 692,
+              "yMin": -285,
+              "yMax": 1082,
+              "hAsc": 1133,
+              "hDes": -388,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 26,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "1c98b558-dbea-46c8-b2cd-2e8a4bebb3eb",
+          "id": "9374f87c-1778-4823-9ad0-83feb6b2c5e5",
+          "x": 263,
+          "y": 293
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Titillium Web",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1133,
+              "des": -388,
+              "tAsc": 1133,
+              "tDes": -388,
+              "tLGap": 0,
+              "wAsc": 1133,
+              "wDes": 388,
+              "xH": 500,
+              "capH": 692,
+              "yMin": -285,
+              "yMax": 1082,
+              "hAsc": 1133,
+              "hDes": -388,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 26,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "e4befb0b-cfa2-402c-a43d-4ec28e3e37b7",
+          "id": "ca632159-bae4-4159-a0dd-6ca16e1a266c",
+          "x": 263,
+          "y": 329
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Titillium Web",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1133,
+              "des": -388,
+              "tAsc": 1133,
+              "tDes": -388,
+              "tLGap": 0,
+              "wAsc": 1133,
+              "wDes": 388,
+              "xH": 500,
+              "capH": 692,
+              "yMin": -285,
+              "yMax": 1082,
+              "hAsc": 1133,
+              "hDes": -388,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 26,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "7db2ff6c-720f-4ff1-bc70-5ff4c8c648f6",
+          "id": "1286e388-91c3-4cf6-8b6f-afbc89d75eb4",
+          "x": 263,
+          "y": 367.5
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Titillium Web",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1133,
+              "des": -388,
+              "tAsc": 1133,
+              "tDes": -388,
+              "tLGap": 0,
+              "wAsc": 1133,
+              "wDes": 388,
+              "xH": 500,
+              "capH": 692,
+              "yMin": -285,
+              "yMax": 1082,
+              "hAsc": 1133,
+              "hDes": -388,
+              "lGap": 0
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">$5.00</span>",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 26,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "4bc228fa-cb39-4101-9007-84e4705ec1d8",
+          "id": "e0430522-1729-4e89-9a26-abe10e8091c8",
+          "x": 263,
+          "y": 404.5
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "6f0273f6-31b1-48a9-b6a7-2ecba9098751"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "288baf91-d4c6-41e9-be40-5afdd06fa84d"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 1,
+          "height": 276,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "9d04a065-85f7-4b9a-985c-f3eb08e768ab",
+          "id": "11d0934e-dbd9-4977-9041-5da02269c7df",
+          "x": 372,
+          "y": 165
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 1,
+          "height": 276,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "11d0934e-dbd9-4977-9041-5da02269c7df",
+          "id": "9b6fe019-ac7d-46a4-b616-c9f129d5797b",
+          "x": 41,
+          "y": 165
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 332,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "38acf74f-94c2-42f4-b796-2b65bd23ae13",
+          "id": "51ea243e-9186-469c-873a-1c3aac942e50",
+          "x": 41,
+          "y": 440
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 332,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "38acf74f-94c2-42f4-b796-2b65bd23ae13",
+          "id": "72f1cb41-bfae-4327-9de7-4d91433277c5",
+          "x": 41,
+          "y": 217
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 332,
+          "height": 1,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "9d04a065-85f7-4b9a-985c-f3eb08e768ab",
+          "id": "38acf74f-94c2-42f4-b796-2b65bd23ae13",
+          "x": 41,
+          "y": 165
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "$5.00",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 46,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "9712a3e6-dcd9-4c33-b1b6-e8a696ba9f01",
+          "id": "14419bd4-8841-471a-aafd-a4666950ea55",
+          "x": 273,
+          "y": 219
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "$5.00",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 46,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "1c98b558-dbea-46c8-b2cd-2e8a4bebb3eb",
+          "id": "8294b7a2-ff36-4135-97da-a44cef0b1dbc",
+          "x": 273,
+          "y": 263
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "$5.00",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 46,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "e4befb0b-cfa2-402c-a43d-4ec28e3e37b7",
+          "id": "ab194138-9aa6-4bf6-a3fd-cd9561937237",
+          "x": 273,
+          "y": 307
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "$5.00",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 46,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "7db2ff6c-720f-4ff1-bc70-5ff4c8c648f6",
+          "id": "aad0c773-a12a-49bf-836c-b3f09f246774",
+          "x": 273,
+          "y": 351
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "right",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "$5.00",
+          "fontWeight": 400,
+          "width": 100,
+          "height": 46,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "4bc228fa-cb39-4101-9007-84e4705ec1d8",
+          "id": "8af1b892-6ced-45d6-a765-4811fc40f26d",
+          "x": 273,
+          "y": 395
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "Item 5",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 46,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "969d0159-7f68-41b7-98f3-5f944f11e670",
+          "id": "9c269db9-b63c-4da9-8933-c2f7447b73c4",
+          "x": 41,
+          "y": 395
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "Item 4",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 46,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "00a0da6d-af0f-419b-afb4-8ecf3e2c7133",
+          "id": "4f686cec-a322-4dd3-be07-9764bf56b121",
+          "x": 41,
+          "y": 351
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "Item 3",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 46,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "8f8f033e-3b88-4552-a0fb-e47f7c5a242c",
+          "id": "1c24a1dd-48af-4cec-a63b-171510492401",
+          "x": 41,
+          "y": 307
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "Item 2",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 46,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "00029122-4425-433e-8119-f5ff79cf6f9f",
+          "id": "13f20b28-4ed4-4b66-bd23-590c110005af",
+          "x": 41,
+          "y": 263
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "Item 1",
+          "fontWeight": 400,
+          "width": 231,
+          "height": 46,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "d458932f-0ab1-4083-ad3d-7f130ea3e1c0",
+          "id": "6c0cd099-a2b9-47f2-9b3c-b812a0c02667",
+          "x": 41,
+          "y": 219
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Karla",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [400, 700],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 917,
+              "des": -252,
+              "tAsc": 917,
+              "tDes": -252,
+              "tLGap": 0,
+              "wAsc": 917,
+              "wDes": 252,
+              "xH": 478,
+              "capH": 629,
+              "yMin": -246,
+              "yMax": 879,
+              "hAsc": 917,
+              "hDes": -252,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 12,
+            "vertical": 12
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">Table Title</span>",
+          "fontWeight": 700,
+          "width": 330,
+          "height": 45,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "ceb8a5d7-83ab-4d3d-8c40-4eb86d263f94",
+          "id": "b3f38031-b2a8-4933-9800-c830946af4f2",
+          "x": 41,
+          "y": 169
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "a2150663-53dc-4475-91b0-80ab58f2b2fb"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds text sets under `Table` category in this design file:
https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Design-System?node-id=837%3A3585

## User-facing changes
NA

## Testing Instructions
Enable the text sets flag in experiments and see the new text sets in the story editor.


---

<!-- Please reference the issue(s) this PR addresses. -->

Partial for #4078 
