### PR TITLE
Karma: Add custom matcher for aXe accessibility violations

### DIFF
--- a/assets/src/edit-story/components/canvas/karma/cloneSelection.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/cloneSelection.karma.js
@@ -27,7 +27,6 @@ describe('Clone element integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
-    jasmine.addMatchers(customMatchers);
 
     bg = await getElementByIndex(1);
     const bgRect = (
@@ -212,49 +211,3 @@ describe('Clone element integration', () => {
     );
   }
 });
-
-const customMatchers = {
-  toBeEmpty: () => ({
-    compare: function (actual) {
-      const innerHTML = actual?.innerHTML ?? '';
-      const pass = innerHTML === '';
-      return {
-        pass,
-        message: pass
-          ? `Expected element to not be empty`
-          : `Expected element to be empty`,
-      };
-    },
-  }),
-  toHaveStyle: (util, customEqualityTesters) => ({
-    compare: function (element, property, expected) {
-      const actual = getComputedStyle(element)[property];
-      const pass = util.equals(actual, expected, customEqualityTesters);
-      return {
-        pass,
-        message: pass
-          ? `Expected element to not have style "${property}: ${expected}"`
-          : `Expected element to have style "${property}: ${expected}" but found "${actual}"`,
-      };
-    },
-  }),
-  toHaveProperty: (util, customEqualityTesters) => ({
-    compare: function (element, property, expected) {
-      const actual = element?.[property] ?? '';
-      const pass =
-        typeof expected === 'string'
-          ? util.equals(actual, expected, customEqualityTesters)
-          : expected.test(actual);
-      return {
-        pass,
-        message: pass
-          ? `Expected element to not have src "${expected}"`
-          : `Expected element to have src "${expected}" but found "${actual}"`,
-      };
-    },
-  }),
-};
-
-function getComputedStyle(element) {
-  return element ? window.getComputedStyle(element) : {};
-}

--- a/assets/src/edit-story/components/dropTargets/karma/background.karma.js
+++ b/assets/src/edit-story/components/dropTargets/karma/background.karma.js
@@ -26,7 +26,6 @@ describe('Background Drop-Target integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
-    jasmine.addMatchers(customMatchers);
   });
 
   afterEach(() => {
@@ -474,45 +473,6 @@ async function dragToDropTarget(fixture, from, toId) {
     move(toRect.x + 3, toRect.y + 103, { steps: 5 }),
   ]);
 }
-
-const customMatchers = {
-  toBeEmpty: () => ({
-    compare: function (actual) {
-      const innerHTML = actual?.innerHTML ?? '';
-      const pass = innerHTML === '';
-      return {
-        pass,
-        message: pass
-          ? `Expected element to not be empty`
-          : `Expected element to be empty`,
-      };
-    },
-  }),
-  toHaveStyle: (util, customEqualityTesters) => ({
-    compare: function (element, property, expected) {
-      const actual = getComputedStyle(element)[property];
-      const pass = util.equals(actual, expected, customEqualityTesters);
-      return {
-        pass,
-        message: pass
-          ? `Expected element to not have background color "${expected}"`
-          : `Expected element to have background color "${expected}" but found "${actual}"`,
-      };
-    },
-  }),
-  toHaveProperty: (util, customEqualityTesters) => ({
-    compare: function (element, property, expected) {
-      const actual = element?.[property] ?? '';
-      const pass = util.equals(actual, expected, customEqualityTesters);
-      return {
-        pass,
-        message: pass
-          ? `Expected element to not have src "${expected}"`
-          : `Expected element to have src "${expected}" but found "${actual}"`,
-      };
-    },
-  }),
-};
 
 function getButtonByText(fixture, buttonText) {
   return Array.from(fixture.querySelectorAll('button')).find(

--- a/karma-dashboard.config.cjs
+++ b/karma-dashboard.config.cjs
@@ -118,7 +118,7 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
+    autoWatch: true,
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher

--- a/karma-dashboard.config.cjs
+++ b/karma-dashboard.config.cjs
@@ -34,6 +34,7 @@ module.exports = function (config) {
       'build/karma-dashboard-failed-tests.txt',
       'utf-8'
     )
+      .replace(/\s+$/g, '')
       .replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
       .replace(/-/g, '\\x2d')
       .split('\n')
@@ -69,6 +70,7 @@ module.exports = function (config) {
         served: true,
         nocache: false,
       },
+      'node_modules/axe-core/axe.js',
     ],
 
     // list of files / patterns to exclude
@@ -116,7 +118,7 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
+    autoWatch: false,
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher

--- a/karma-edit-story.config.cjs
+++ b/karma-edit-story.config.cjs
@@ -119,7 +119,7 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
+    autoWatch: true,
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher

--- a/karma-edit-story.config.cjs
+++ b/karma-edit-story.config.cjs
@@ -34,6 +34,7 @@ module.exports = function (config) {
       'build/karma-edit-story-failed-tests.txt',
       'utf-8'
     )
+      .replace(/\s+$/g, '')
       .replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
       .replace(/-/g, '\\x2d')
       .split('\n')
@@ -69,6 +70,7 @@ module.exports = function (config) {
         served: true,
         nocache: false,
       },
+      'node_modules/axe-core/axe.js',
     ],
 
     // list of files / patterns to exclude
@@ -117,7 +119,7 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
+    autoWatch: false,
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher

--- a/karma/fixture/init.js
+++ b/karma/fixture/init.js
@@ -233,6 +233,44 @@ beforeAll(() => {
     }),
   });
 
+  jasmine.addAsyncMatchers({
+    toHaveNoViolations: () => ({
+      compare: async function (element, options) {
+        const result = await window.axe.run(element, options);
+        const pass = result.violations.length === 0;
+
+        const formattedViolations = result.violations.map((violation) => {
+          const { id, impact, description, help, helpUrl } = violation;
+
+          const message = [];
+
+          message.push(`[ ${id}] ${description}`);
+          message.push(helpUrl ? `${help} (${helpUrl}` : help);
+          message.push(`Impact: ${impact}`);
+          message.push('\n');
+
+          for (const { html, failureSummary } of violation.nodes) {
+            message.push(`HTML: ${html}`);
+            message.push(failureSummary);
+            message.push('\n');
+          }
+
+          return message.join('\n');
+        });
+
+        const message = !pass
+          ? `Expected element to pass aXe accessibility tests. Violations found:
+            ${formattedViolations.join('\n')}`
+          : 'Expected element to contain aXe accessibility test violations. No violations found.';
+
+        return {
+          pass,
+          message: () => message,
+        };
+      },
+    }),
+  });
+
   // Virtual cursor.
   withCleanupAll(() => {
     const el = document.createElement('div');

--- a/package-lock.json
+++ b/package-lock.json
@@ -7019,6 +7019,12 @@
             "ts-dedent": "^1.1.1"
           }
         },
+        "axe-core": {
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+          "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+          "dev": true
+        },
         "resolve-from": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -12691,9 +12697,9 @@
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
     "axe-core": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.4.tgz",
-      "integrity": "sha512-JRuxixN5bPHre+815qnyqBQzNpRTqGxLWflvjr4REpGZ5o0WXm+ik2IS4PZ01EnacWmVRB4jCPWFiYENMiiasA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.0.2.tgz",
+      "integrity": "sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==",
       "dev": true
     },
     "axe-puppeteer": {
@@ -12703,6 +12709,14 @@
       "dev": true,
       "requires": {
         "axe-core": "^3.5.3"
+      },
+      "dependencies": {
+        "axe-core": {
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+          "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+          "dev": true
+        }
       }
     },
     "axios": {
@@ -17760,6 +17774,12 @@
             "@babel/runtime": "^7.10.2",
             "@babel/runtime-corejs3": "^7.10.2"
           }
+        },
+        "axe-core": {
+          "version": "3.5.5",
+          "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
+          "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+          "dev": true
         },
         "emoji-regex": {
           "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@wordpress/jest-console": "^3.8.0",
     "@wordpress/jest-puppeteer-axe": "^1.9.0",
     "amphtml-validator": "^1.0.33",
+    "axe-core": "^4.0.2",
     "babel-jest": "^26.3.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-inline-json-import": "^0.3.2",


### PR DESCRIPTION
## Summary

Usage: `await expectAsync(node).toHaveNoViolations();`

An optional [`options`](https://www.deque.com/axe/core-documentation/api-documentation/#options-parameter) object can be passed to `toHaveNoViolations()` to configure aXe.

**Example**

I added `await expectAsync(layerPanel.node).toHaveNoViolations();` to `assets/src/edit-story/components/panels/layer/karma/layer.karma.js` and got the following result:

```
     Expected element to pass aXe accessibility tests. Violations found:
            [ color-contrast] Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
Elements must have sufficient color contrast (https://dequeuniversity.com/rules/axe/4.0/color-contrast?application=axeAPI
Impact: serious


HTML: <div class="layer__BackgroundDescription-sc-18ebmzf-4 gSyHal">Background (locked)</div>
Fix any of the following:
  Element has insufficient color contrast of 4.22 (foreground color: #9b9c9c, background color: #373939, font size: 9.8pt (13px), font weight: normal). Expected contrast ratio of 4.5:1

```

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

* [ ] Set up some default options for aXe
* [ ] Documentation
* [ ] Use in tests

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Add `await expectAsync(node).toHaveNoViolations();` assertion to a test
1. Run tests
1. Verify results

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4019
