### PR TITLE
Added waitFor call to let text sets load before executing karma tests

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
+
+/**
  * Internal dependencies
  */
 import { Fixture } from '../../../../../../karma/fixture';
@@ -56,9 +61,12 @@ describe('Text Sets Library Panel', () => {
     xit('should display text sets', async () => {});
 
     it('should allow inserting text sets', async () => {
-      const textSet = fixture.editor.library.getAllByRole('listitem', {
-        name: /^Insert Text Set$/,
-      })[0];
+      const textSet = await waitFor(
+        () =>
+          fixture.editor.library.getAllByRole('listitem', {
+            name: /^Insert Text Set$/,
+          })[0]
+      );
 
       // The page should start off with no text elements
       expect((await getTextElements()).length).toBe(0);
@@ -70,9 +78,12 @@ describe('Text Sets Library Panel', () => {
     });
 
     it('should allow user to drag and drop text set onto page', async () => {
-      const textSet = fixture.editor.library.getAllByRole('listitem', {
-        name: /^Insert Text Set$/,
-      })[0];
+      const textSet = await waitFor(
+        () =>
+          fixture.editor.library.getAllByRole('listitem', {
+            name: /^Insert Text Set$/,
+          })[0]
+      );
 
       const page = fixture.editor.canvas.fullbleed.container;
 


### PR DESCRIPTION
## Summary

I noticed that our textSets karma tests are failing at high rates and realized it's because karma isn't giving enough time for the text set components to load before executing the tests.  So I added in a simple `waitFor` command in the `beforeEach` that waits for the text sets to load so the tests shouldn't be so flakey.

## User-facing changes

None.  Just test updates.

## Testing Instructions

1.) Run karma tests in `textSets.karma.js`, make sure they run and pass.
