### PR TITLE
E2E Tests: Use `waitForTimeout` instead of `waitFor`

### DIFF
--- a/tests/e2e/utils/previewStory.js
+++ b/tests/e2e/utils/previewStory.js
@@ -42,7 +42,7 @@ async function previewStory(editorPage) {
       throw new Error('There was an error previewing the story');
     }
     /* eslint-disable no-await-in-loop */
-    await editorPage.waitFor(1);
+    await editorPage.waitForTimeout(1);
     openTabs = await browser.pages();
     /* eslint-enable no-await-in-loop */
   }


### PR DESCRIPTION
`waitFor` is deprecated and will be removed in a future release.

See puppeteer/puppeteer/issues/6214

