### PR TITLE
Story Editor: Added Funky-Cooking Instructions Text Sets

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/textSets/loadTextSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/loadTextSets.js
@@ -76,6 +76,7 @@ export default async function loadTextSets() {
     'editorial',
     'table',
     'quote',
+    'funkyCookingInstructions',
   ];
 
   const results = await Promise.all(

--- a/assets/src/edit-story/components/library/panes/text/textSets/raw/funkyCookingInstructions.json
+++ b/assets/src/edit-story/components/library/panes/text/textSets/raw/funkyCookingInstructions.json
@@ -1,0 +1,1065 @@
+{
+  "current": "ad8debff-c9b6-41a3-ad48-6f5778da6009",
+  "selection": [],
+  "story": {
+    "stylePresets": {
+      "textStyles": [
+        {
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "IBM Plex Serif",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [1, 100],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700]
+            ]
+          },
+          "fontSize": 37,
+          "lineHeight": 1.2,
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "textAlign": "initial",
+          "color": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "fontWeight": 600,
+          "isItalic": false,
+          "isUnderline": false,
+          "letterSpacing": 0
+        }
+      ],
+      "colors": [
+        {
+          "color": {
+            "r": 33,
+            "g": 33,
+            "b": 33
+          }
+        },
+        {
+          "color": {
+            "r": 0,
+            "g": 92,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 61,
+            "g": 46,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 200,
+            "g": 122,
+            "b": 255
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 163,
+            "b": 214
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 187,
+            "b": 196
+          }
+        },
+        {
+          "color": {
+            "r": 255,
+            "g": 187,
+            "b": 196,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 246,
+            "g": 147,
+            "b": 147,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 240,
+            "g": 176,
+            "b": 119,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 220,
+            "g": 211,
+            "b": 67,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 153,
+            "g": 199,
+            "b": 39,
+            "a": 0.6
+          }
+        },
+        {
+          "color": {
+            "r": 119,
+            "g": 151,
+            "b": 18,
+            "a": 0.6
+          }
+        }
+      ]
+    }
+  },
+  "version": 24,
+  "pages": [
+    {
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "0262a402-0151-4a4f-88e0-14d3ef6f2768"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Oswald",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 500, 600, 700],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1193,
+              "des": -289,
+              "tAsc": 1193,
+              "tDes": -289,
+              "tLGap": 0,
+              "wAsc": 1325,
+              "wDes": 377,
+              "xH": 578,
+              "capH": 810,
+              "yMin": -287,
+              "yMax": 1297,
+              "hAsc": 1193,
+              "hDes": -289,
+              "lGap": 0
+            }
+          },
+          "fontSize": 26,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"letter-spacing: 0.08em\">QUICK RECIPE</span>",
+          "fontWeight": 400,
+          "x": 40,
+          "y": 334,
+          "width": 332,
+          "height": 38,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "cffed56c-4c0f-4b3b-b999-038ebea4af81",
+          "marginOffset": -7.614000000000004
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Cookie",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 1000,
+              "asc": 789,
+              "des": -320,
+              "tAsc": 789,
+              "tDes": -320,
+              "tLGap": 0,
+              "wAsc": 789,
+              "wDes": 320,
+              "xH": 115,
+              "capH": 312,
+              "yMin": -320,
+              "yMax": 789,
+              "hAsc": 789,
+              "hDes": -320,
+              "lGap": 0
+            }
+          },
+          "fontSize": 72,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Apple Pie",
+          "fontWeight": 400,
+          "x": 40,
+          "y": 384,
+          "width": 332,
+          "height": 78,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "d8f38c57-354f-4319-a999-3c37158a7a30"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "Easy to follow, this guide will get you to bake a delicious crusty apple pie right off the bat.",
+          "fontWeight": 400,
+          "x": 81,
+          "y": 478,
+          "width": 250,
+          "height": 75,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "7ff432f0-12e1-42ae-9ef0-b0222e4f12f8"
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "ce1e35a3-1162-4dee-abd1-150f6dfb87f7"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "beb0ee05-1e21-460a-9239-fea9501ab16a"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Oswald",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 500, 600, 700],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1193,
+              "des": -289,
+              "tAsc": 1193,
+              "tDes": -289,
+              "tLGap": 0,
+              "wAsc": 1325,
+              "wDes": 377,
+              "xH": 578,
+              "capH": 810,
+              "yMin": -287,
+              "yMax": 1297,
+              "hAsc": 1193,
+              "hDes": -289,
+              "lGap": 0
+            }
+          },
+          "fontSize": 26,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #c88c55; letter-spacing: 0.08em\">QUICK RECIPE</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 38,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": -7.614000000000004,
+          "basedOn": "cffed56c-4c0f-4b3b-b999-038ebea4af81",
+          "id": "11c63eff-fda4-4b2b-ba0a-f1b7a9f63157",
+          "x": 40,
+          "y": 334
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Cookie",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 1000,
+              "asc": 789,
+              "des": -320,
+              "tAsc": 789,
+              "tDes": -320,
+              "tLGap": 0,
+              "wAsc": 789,
+              "wDes": 320,
+              "xH": 115,
+              "capH": 312,
+              "yMin": -320,
+              "yMax": 789,
+              "hAsc": 789,
+              "hDes": -320,
+              "lGap": 0
+            }
+          },
+          "fontSize": 72,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #c88c55\">Apple Pie</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 80,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "d8f38c57-354f-4319-a999-3c37158a7a30",
+          "id": "47cbd1b5-151d-4df2-b5b2-71cf5e2faf08",
+          "x": 40,
+          "y": 384
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Condensed",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [300, 400, 700],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 700],
+              [1, 700]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1900,
+              "des": -500,
+              "tAsc": 1536,
+              "tDes": -512,
+              "tLGap": 102,
+              "wAsc": 1946,
+              "wDes": 512,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2163,
+              "hAsc": 1900,
+              "hDes": -500,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #666\">Easy to follow, this guide will get you to bake a delicious crusty apple pie right off the bat.</span>",
+          "fontWeight": 400,
+          "width": 250,
+          "height": 74,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "7ff432f0-12e1-42ae-9ef0-b0222e4f12f8",
+          "id": "c22a1f8b-d483-47fb-bf8c-6d9949e28407",
+          "x": 81,
+          "y": 478
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "052edfcc-c7fd-4300-b6c8-e89433665856"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "1fb368fe-f855-48da-b558-265b07594bb5"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "BioRhyme",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 700, 800],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [0, 800]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1127,
+              "des": -422,
+              "tAsc": 1127,
+              "tDes": -422,
+              "tLGap": 0,
+              "wAsc": 1127,
+              "wDes": 422,
+              "xH": 471,
+              "capH": 686,
+              "yMin": -369,
+              "yMax": 1117,
+              "hAsc": 1127,
+              "hDes": -422,
+              "lGap": 0
+            }
+          },
+          "fontSize": 43,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 800; letter-spacing: 0.04em\">Build an IoT System</span>",
+          "fontWeight": 400,
+          "x": 40,
+          "y": 354,
+          "width": 332,
+          "height": 114,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "269395eb-3128-483f-9122-9547c992bda7"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Slab",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 2146,
+              "des": -555,
+              "tAsc": 2146,
+              "tDes": -555,
+              "tLGap": 0,
+              "wAsc": 2146,
+              "wDes": 618,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2146,
+              "hAsc": 2146,
+              "hDes": -555,
+              "lGap": 0
+            }
+          },
+          "fontSize": 22,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">Make your life easier</span>\n<span style=\"font-weight: 700\">with automations</span>",
+          "fontWeight": 400,
+          "x": 40,
+          "y": 480,
+          "width": 332,
+          "height": 52,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "id": "48bebd34-c553-4e01-b379-aa0e47f9fb66"
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "df0d4270-479e-4f11-99d3-a207c479fa38"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "2814c537-ed48-4778-af1f-430084d5c2c9"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "BioRhyme",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 700, 800],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [0, 800]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1127,
+              "des": -422,
+              "tAsc": 1127,
+              "tDes": -422,
+              "tLGap": 0,
+              "wAsc": 1127,
+              "wDes": 422,
+              "xH": 471,
+              "capH": 686,
+              "yMin": -369,
+              "yMax": 1117,
+              "hAsc": 1127,
+              "hDes": -422,
+              "lGap": 0
+            }
+          },
+          "fontSize": 43,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 800; color: #409622; letter-spacing: 0.04em\">Build an IoT System</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 114,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "3bcd1ec7-dcd9-4fee-975d-24c8db4b111f",
+          "id": "80b35276-f868-4582-8dc6-23928b44ab1f",
+          "x": 38,
+          "y": 358
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "BioRhyme",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 700, 800],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [0, 800]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1127,
+              "des": -422,
+              "tAsc": 1127,
+              "tDes": -422,
+              "tLGap": 0,
+              "wAsc": 1127,
+              "wDes": 422,
+              "xH": 471,
+              "capH": 686,
+              "yMin": -369,
+              "yMax": 1117,
+              "hAsc": 1127,
+              "hDes": -422,
+              "lGap": 0
+            }
+          },
+          "fontSize": 43,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 800; color: #ffd66b; letter-spacing: 0.04em\">Build an IoT System</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 114,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "269395eb-3128-483f-9122-9547c992bda7",
+          "id": "3bcd1ec7-dcd9-4fee-975d-24c8db4b111f",
+          "x": 40,
+          "y": 354
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Slab",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 2146,
+              "des": -555,
+              "tAsc": 2146,
+              "tDes": -555,
+              "tLGap": 0,
+              "wAsc": 2146,
+              "wDes": 618,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2146,
+              "hAsc": 2146,
+              "hDes": -555,
+              "lGap": 0
+            }
+          },
+          "fontSize": 22,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; color: #409622\">Make your life easier</span>\n<span style=\"font-weight: 700; color: #409622\">with automations</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 55,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "48bebd34-c553-4e01-b379-aa0e47f9fb66",
+          "id": "2c27c0ba-45e7-44e9-8560-9bf759348571",
+          "x": 40,
+          "y": 480
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "ad8debff-c9b6-41a3-ad48-6f5778da6009"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds text sets under `Funky-Cooking Instructions` category in this design file:
https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Design-System?node-id=837%3A3585

## User-facing changes
NA

## TODO
- Find where this is supposed to be placed vertically
- Figure out alternative for text outline/drop shadow on last text set here

## Testing Instructions
Enable the text sets flag in experiments and see the new text sets in the story editor.


---

<!-- Please reference the issue(s) this PR addresses. -->

Partial for #4078 
