### PR TITLE
Dashboard: fix console warning for htmlFor

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -101,6 +101,9 @@
     "radix": ["error", "as-needed"],
     "require-await": "error",
     "rest-spread-spacing": ["error", "never"],
+    "react/forbid-component-props": ["error", {
+      "forbid": ["for"]
+    }],
     "react/prop-types": "error",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": [

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -103,7 +103,7 @@ function GoogleAnalyticsSettings({ googleAnalyticsId, handleUpdate }) {
       </SettingHeading>
       <FormContainer>
         <InlineForm>
-          <VisuallyHiddenLabel for="gaTrackingId">
+          <VisuallyHiddenLabel htmlFor="gaTrackingId">
             {TEXT.ARIA_LABEL}
           </VisuallyHiddenLabel>
           <GoogleAnalyticsTextInput


### PR DESCRIPTION
## Summary
Used `for` not `htmlFor` in a label, screenreader worked as expected so I didn't catch it. Fixing attribute.

## Relevant Technical Choices

- add eslint `"react/forbid-component-props"` rule to avoid usage of "for" in the future

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None

## Testing Instructions

Verify when you run tests that there's no error warning about using for not htmlFor

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
