### PR TITLE
Dashboard: Fix failing settings page karma test

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/karma/editorSettings.karma.js
+++ b/assets/src/dashboard/app/views/editorSettings/karma/editorSettings.karma.js
@@ -47,10 +47,11 @@ describe('Settings View', () => {
     );
 
     expect(publisherLogosContainer).toBeTruthy();
+    await fixture.events.click(publisherLogosContainer);
 
     while (
       !publisherLogosContainer.contains(document.activeElement) &&
-      limit < 8
+      limit < 10
     ) {
       // eslint-disable-next-line no-await-in-loop
       await fixture.events.keyboard.press('tab');


### PR DESCRIPTION
## Summary

The publisher logo keyboard test was failing because we were not allowing for enough tabs through the page to get to the element after adding in the support menu item (count was off). Adding a click to the container of the logos to then use keyboard off of and increasing tab-able count as a back up if click should not take in time.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

All dashboard karma tests should now pass 

(you shouldn't get this)
<img width="670" alt="Screen Shot 2020-10-06 at 8 57 39 AM" src="https://user-images.githubusercontent.com/10720454/95226630-0686c200-07b2-11eb-84b1-73bae8c5324c.png">

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
