### PR TITLE
Story Editor: Added Editorial Funky Text Sets

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/textSets/raw/editorial.json
+++ b/assets/src/edit-story/components/library/panes/text/textSets/raw/editorial.json
@@ -1,5 +1,5 @@
 {
-  "current": "95970834-7a29-4066-9a8f-54f682868d64",
+  "current": "6825bee0-5867-4aee-8230-f3b73a6979c2",
   "selection": [],
   "story": {
     "stylePresets": {
@@ -2507,16 +2507,16 @@
             "vertical": 0
           },
           "type": "text",
-          "content": "<span style=\"font-weight: 700; color: #00c2ff; letter-spacing: 0.02em\">TV SHOW</span>",
+          "content": "<span style=\"font-weight: 700; color: #00c2ff; letter-spacing: 0.04em\">TV SHOW</span>",
           "fontWeight": 400,
-          "width": 176,
+          "width": 180,
           "height": 50,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
           "basedOn": "18e0cf3d-5bbb-48de-bc8c-c2eae97b7a13",
           "id": "31551cfe-d34a-465b-bd2d-1395c0916edc",
-          "x": 118,
+          "x": 116,
           "y": 294
         },
         {
@@ -2714,82 +2714,6 @@
           "lockAspectRatio": false,
           "backgroundTextMode": "NONE",
           "font": {
-            "family": "Nunito",
-            "service": "fonts.google.com",
-            "fallbacks": ["sans-serif"],
-            "weights": [200, 300, 400, 600, 700, 800, 900],
-            "styles": ["italic", "regular"],
-            "variants": [
-              [0, 200],
-              [0, 300],
-              [0, 400],
-              [0, 600],
-              [0, 700],
-              [0, 800],
-              [0, 900],
-              [1, 200],
-              [1, 300],
-              [1, 400],
-              [1, 600],
-              [1, 700],
-              [1, 800],
-              [1, 900]
-            ],
-            "metrics": {
-              "upm": 1000,
-              "asc": 1011,
-              "des": -353,
-              "tAsc": 1011,
-              "tDes": -353,
-              "tLGap": 0,
-              "wAsc": 1092,
-              "wDes": 281,
-              "xH": 487,
-              "capH": 705,
-              "yMin": -275,
-              "yMax": 1081,
-              "hAsc": 1011,
-              "hDes": -353,
-              "lGap": 0
-            }
-          },
-          "fontSize": 18,
-          "backgroundColor": {
-            "color": {
-              "r": 196,
-              "g": 196,
-              "b": 196
-            }
-          },
-          "lineHeight": 1.3,
-          "textAlign": "center",
-          "padding": {
-            "locked": true,
-            "horizontal": 0,
-            "vertical": 0
-          },
-          "type": "text",
-          "content": "<span style=\"font-weight: 700; color: #4dbd58; letter-spacing: 0.02em\">A QUICK RECAP TO OUR</span>",
-          "width": 322,
-          "height": 24,
-          "scale": 100,
-          "focalX": 50,
-          "focalY": 50,
-          "basedOn": "a0baa814-5743-4cf2-9cb7-46196ae8c3c8",
-          "id": "de3317df-e660-4d45-80aa-942e2a30d1b2",
-          "x": 45,
-          "y": 334
-        },
-        {
-          "opacity": 100,
-          "flip": {
-            "vertical": false,
-            "horizontal": false
-          },
-          "rotationAngle": 0,
-          "lockAspectRatio": false,
-          "backgroundTextMode": "NONE",
-          "font": {
             "family": "Playfair Display",
             "service": "fonts.google.com",
             "fallbacks": ["serif"],
@@ -2916,6 +2840,82 @@
           "id": "beeac3d7-6f8e-48bf-920d-2fa25861fb54",
           "x": 45,
           "y": 505
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Nunito",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1011,
+              "des": -353,
+              "tAsc": 1011,
+              "tDes": -353,
+              "tLGap": 0,
+              "wAsc": 1092,
+              "wDes": 281,
+              "xH": 487,
+              "capH": 705,
+              "yMin": -275,
+              "yMax": 1081,
+              "hAsc": 1011,
+              "hDes": -353,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; color: #4dbd58; letter-spacing: 0.02em\">A QUICK RECAP TO OUR</span>",
+          "width": 322,
+          "height": 24,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "a0baa814-5743-4cf2-9cb7-46196ae8c3c8",
+          "id": "de3317df-e660-4d45-80aa-942e2a30d1b2",
+          "x": 45,
+          "y": 334
         }
       ],
       "backgroundColor": {

--- a/assets/src/edit-story/components/library/panes/text/textSets/raw/editorial.json
+++ b/assets/src/edit-story/components/library/panes/text/textSets/raw/editorial.json
@@ -1,5 +1,5 @@
 {
-  "current": "7ec0f8c7-5226-4fac-bef5-82755b0d72cc",
+  "current": "95970834-7a29-4066-9a8f-54f682868d64",
   "selection": [],
   "story": {
     "stylePresets": {
@@ -1826,6 +1826,1775 @@
       },
       "type": "page",
       "id": "ea7b0add-02a4-4746-8c5c-d9422f096533"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "b5cd1ddc-ca45-4f21-808f-404048eaf877"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 288,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "75226e27-dd58-497e-86c1-451cc604df83",
+          "id": "da5457e6-a055-402e-bf12-7ad0b482c2fd",
+          "x": 61.5,
+          "y": 373
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 230,
+              "g": 204,
+              "b": 71
+            }
+          },
+          "type": "shape",
+          "width": 288,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "340f8e9e-6be4-4af0-b15a-d9e16210dbb4",
+          "id": "1a697864-c11c-47c3-8ac8-c2d032530544",
+          "x": 61.5,
+          "y": 382
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 288,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "41cee8be-66ca-4fa7-bbdb-307b6225dc61",
+          "id": "c48a35bf-0386-4138-b065-24831d69b92d",
+          "x": 60,
+          "y": 507
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 230,
+              "g": 204,
+              "b": 71
+            }
+          },
+          "type": "shape",
+          "width": 288,
+          "height": 4,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "4c15a10d-8e6a-4300-9f69-e74f21f989d8",
+          "id": "da49cb47-73d1-4830-993e-f7aa9d51e2ac",
+          "x": 60,
+          "y": 498
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Poppins",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 800],
+              [1, 800],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1050,
+              "des": -350,
+              "tAsc": 1050,
+              "tDes": -350,
+              "tLGap": 100,
+              "wAsc": 1135,
+              "wDes": 627,
+              "xH": 548,
+              "capH": 698,
+              "yMin": -572,
+              "yMax": 1065,
+              "hAsc": 1050,
+              "hDes": -350,
+              "lGap": 100
+            }
+          },
+          "fontSize": 72,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 300\">10</span>",
+          "fontWeight": 400,
+          "width": 66,
+          "height": 99,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "bbf0f087-de38-48be-8328-f701742741f3",
+          "id": "bce65336-1bbb-40d6-bb61-7d19c9bbd777",
+          "x": 61,
+          "y": 393
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Parisienne",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 2048,
+              "asc": 1875,
+              "des": -915,
+              "tAsc": 1875,
+              "tDes": -915,
+              "tLGap": 0,
+              "wAsc": 1875,
+              "wDes": 915,
+              "xH": 723,
+              "capH": 1558,
+              "yMin": -915,
+              "yMax": 1875,
+              "hAsc": 1875,
+              "hDes": -915,
+              "lGap": 0
+            }
+          },
+          "fontSize": 54,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "initial",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #e6cc47\">Christmas</span>",
+          "width": 187,
+          "height": 74,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "0638d9e1-7a53-464f-88ba-eee68fec6402",
+          "id": "a4153098-8497-4247-ba31-a3283e244183",
+          "x": 151,
+          "y": 401
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Poppins",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 800],
+              [1, 800],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1050,
+              "des": -350,
+              "tAsc": 1050,
+              "tDes": -350,
+              "tLGap": 100,
+              "wAsc": 1135,
+              "wDes": 627,
+              "xH": 548,
+              "capH": 698,
+              "yMin": -572,
+              "yMax": 1065,
+              "hAsc": 1050,
+              "hDes": -350,
+              "lGap": 100
+            }
+          },
+          "fontSize": 17,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.4,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"letter-spacing: 0.04em\">RECOMMENDED GIFTS</span>",
+          "fontWeight": 400,
+          "width": 190,
+          "height": 24,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "a0c7a5dc-cf6b-41db-82d6-dfa76b0f2e39",
+          "id": "dc744d4c-1e81-420b-a596-dbc4b489d9b2",
+          "x": 151,
+          "y": 462
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "b8a0da89-3304-4da6-a6f4-8208c39465f1"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "c1ff35cb-5069-4685-a96a-ba26e1ce0573"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 332,
+          "height": 278,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "6273ca64-422d-4c19-a40f-6dd95199d8a5",
+          "id": "1902e4f1-5d9c-4d14-9e6a-718a1a3b6797",
+          "x": 39,
+          "y": 304
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Rock Salt",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 1024,
+              "asc": 1623,
+              "des": -788,
+              "tAsc": 824,
+              "tDes": -240,
+              "tLGap": 63,
+              "wAsc": 1623,
+              "wDes": 788,
+              "xH": 833,
+              "capH": 1154,
+              "yMin": -787,
+              "yMax": 1623,
+              "hAsc": 1623,
+              "hDes": -788,
+              "lGap": 32
+            }
+          },
+          "fontSize": 54,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #fff\">black friday</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 180,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "674454ef-6c76-4036-b518-6e370d6d5fbb",
+          "id": "7704e046-0510-47ac-aabe-c65908a5e879",
+          "x": 40,
+          "y": 328
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Oswald",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 500, 600, 700],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1193,
+              "des": -289,
+              "tAsc": 1193,
+              "tDes": -289,
+              "tLGap": 0,
+              "wAsc": 1325,
+              "wDes": 377,
+              "xH": 578,
+              "capH": 810,
+              "yMin": -287,
+              "yMax": 1297,
+              "hAsc": 1193,
+              "hDes": -289,
+              "lGap": 0
+            }
+          },
+          "fontSize": 43,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.4,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; color: #ff5858; letter-spacing: 0.02em\">SALE</span>",
+          "fontWeight": 400,
+          "width": 160,
+          "height": 64,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "01c1b3ce-5989-4c18-984e-ec32872f5a1c",
+          "id": "b13c515e-8d27-4bfe-bc2b-06ab72d27d34",
+          "x": 121,
+          "y": 508
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "bfddf7b1-ea3a-4283-943f-7aa5340a3758"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "96b3c828-f0ec-439f-af7d-68a4cca261bd"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Poppins",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 800],
+              [1, 800],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1050,
+              "des": -350,
+              "tAsc": 1050,
+              "tDes": -350,
+              "tLGap": 100,
+              "wAsc": 1135,
+              "wDes": 627,
+              "xH": 548,
+              "capH": 698,
+              "yMin": -572,
+              "yMax": 1065,
+              "hAsc": 1050,
+              "hDes": -350,
+              "lGap": 100
+            }
+          },
+          "fontSize": 36,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; color: #00c2ff; letter-spacing: 0.02em\">TV SHOW</span>",
+          "fontWeight": 400,
+          "width": 176,
+          "height": 50,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "18e0cf3d-5bbb-48de-bc8c-c2eae97b7a13",
+          "id": "31551cfe-d34a-465b-bd2d-1395c0916edc",
+          "x": 118,
+          "y": 294
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Monoton",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 2048,
+              "asc": 2366,
+              "des": -822,
+              "tAsc": 2366,
+              "tDes": -822,
+              "tLGap": 0,
+              "wAsc": 2366,
+              "wDes": 822,
+              "xH": 1440,
+              "capH": 1656,
+              "yMin": -822,
+              "yMax": 2366,
+              "hAsc": 2366,
+              "hDes": -822,
+              "lGap": 0
+            }
+          },
+          "fontSize": 72,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #00c2ff; letter-spacing: 0.04em\">POP</span>\n<span style=\"color: #00c2ff; letter-spacing: 0.04em\">QUIZ</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 180,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "d93a1e4f-ed44-4d0d-b469-02c29b4f2ec0",
+          "id": "b27aae73-7930-462a-a725-d5298785fcf1",
+          "x": 40,
+          "y": 352
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Poppins",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 100],
+              [1, 100],
+              [0, 200],
+              [1, 200],
+              [0, 300],
+              [1, 300],
+              [0, 400],
+              [1, 400],
+              [0, 500],
+              [1, 500],
+              [0, 600],
+              [1, 600],
+              [0, 700],
+              [1, 700],
+              [0, 800],
+              [1, 800],
+              [0, 900],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1050,
+              "des": -350,
+              "tAsc": 1050,
+              "tDes": -350,
+              "tLGap": 100,
+              "wAsc": 1135,
+              "wDes": 627,
+              "xH": 548,
+              "capH": 698,
+              "yMin": -572,
+              "yMax": 1065,
+              "hAsc": 1050,
+              "hDes": -350,
+              "lGap": 100
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #00c2ff\">How many of them</span>\n<span style=\"color: #00c2ff\">can you guess correctly?</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 51,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 5.578125,
+          "basedOn": "2153261e-4fa3-429c-9b2c-a2a609160b47",
+          "id": "efaa436a-2d3b-4695-a966-90a6faae1878",
+          "x": 40,
+          "y": 540
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "43ef8035-151e-4a80-81d9-8ed746a2d2be"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "cf00f32a-0bb9-4746-8c80-a24e32fb8166"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Nunito",
+            "service": "fonts.google.com",
+            "fallbacks": ["sans-serif"],
+            "weights": [200, 300, 400, 600, 700, 800, 900],
+            "styles": ["italic", "regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 200],
+              [1, 300],
+              [1, 400],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1011,
+              "des": -353,
+              "tAsc": 1011,
+              "tDes": -353,
+              "tLGap": 0,
+              "wAsc": 1092,
+              "wDes": 281,
+              "xH": 487,
+              "capH": 705,
+              "yMin": -275,
+              "yMax": 1081,
+              "hAsc": 1011,
+              "hDes": -353,
+              "lGap": 0
+            }
+          },
+          "fontSize": 18,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700; color: #4dbd58; letter-spacing: 0.02em\">A QUICK RECAP TO OUR</span>",
+          "width": 322,
+          "height": 24,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "a0baa814-5743-4cf2-9cb7-46196ae8c3c8",
+          "id": "de3317df-e660-4d45-80aa-942e2a30d1b2",
+          "x": 45,
+          "y": 334
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Playfair Display",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [400, 500, 600, 700, 800, 900],
+            "styles": ["regular", "italic"],
+            "variants": [
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900],
+              [1, 400],
+              [1, 500],
+              [1, 600],
+              [1, 700],
+              [1, 800],
+              [1, 900]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1082,
+              "des": -251,
+              "tAsc": 1082,
+              "tDes": -251,
+              "tLGap": 0,
+              "wAsc": 1159,
+              "wDes": 251,
+              "xH": 514,
+              "capH": 708,
+              "yMin": -241,
+              "yMax": 1159,
+              "hAsc": 1082,
+              "hDes": -251,
+              "lGap": 0
+            }
+          },
+          "fontSize": 54,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 900; color: #ffd600\">Week Trip </span><span style=\"font-weight: 900; color: #f69e4c\">to Hawaii</span>",
+          "fontWeight": 400,
+          "width": 322,
+          "height": 131,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "93282c93-f013-496e-96c7-659d83b92bcc",
+          "id": "24d77029-a48d-4e60-8c5e-7c94d7333f86",
+          "x": 45,
+          "y": 366
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Nothing You Could Do",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 1024,
+              "asc": 959,
+              "des": -407,
+              "tAsc": 962,
+              "tDes": -407,
+              "tLGap": 0,
+              "wAsc": 959,
+              "wDes": 407,
+              "xH": 462,
+              "capH": 758,
+              "yMin": -407,
+              "yMax": 959,
+              "hAsc": 959,
+              "hDes": -407,
+              "lGap": 0
+            }
+          },
+          "fontSize": 36,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.3,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #39999f\">Surf all day!</span>",
+          "fontWeight": 400,
+          "width": 322,
+          "height": 47,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "24d7bfb2-b299-4535-af04-4c74ec93b0c5",
+          "id": "beeac3d7-6f8e-48bf-920d-2fa25861fb54",
+          "x": 45,
+          "y": 505
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "6825bee0-5867-4aee-8230-f3b73a6979c2"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "4206e30c-64e1-463a-af93-602e54b57d14"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "BioRhyme",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [200, 300, 400, 700, 800],
+            "styles": ["regular"],
+            "variants": [
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 700],
+              [0, 800]
+            ],
+            "metrics": {
+              "upm": 1000,
+              "asc": 1127,
+              "des": -422,
+              "tAsc": 1127,
+              "tDes": -422,
+              "tLGap": 0,
+              "wAsc": 1127,
+              "wDes": 422,
+              "xH": 471,
+              "capH": 686,
+              "yMin": -369,
+              "yMax": 1117,
+              "hAsc": 1127,
+              "hDes": -422,
+              "lGap": 0
+            }
+          },
+          "fontSize": 43,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 800; letter-spacing: 0.04em\">Build an IoT System</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 114,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "95c8c691-ddf6-4f63-a773-f5bad729070b",
+          "id": "413baa21-b89b-4df8-9756-1ade6e8e268b",
+          "x": 40,
+          "y": 354
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Roboto Slab",
+            "service": "fonts.google.com",
+            "fallbacks": ["serif"],
+            "weights": [100, 200, 300, 400, 500, 600, 700, 800, 900],
+            "styles": ["regular"],
+            "variants": [
+              [0, 100],
+              [0, 200],
+              [0, 300],
+              [0, 400],
+              [0, 500],
+              [0, 600],
+              [0, 700],
+              [0, 800],
+              [0, 900]
+            ],
+            "metrics": {
+              "upm": 2048,
+              "asc": 2146,
+              "des": -555,
+              "tAsc": 2146,
+              "tDes": -555,
+              "tLGap": 0,
+              "wAsc": 2146,
+              "wDes": 618,
+              "xH": 1082,
+              "capH": 1456,
+              "yMin": -555,
+              "yMax": 2146,
+              "hAsc": 2146,
+              "hDes": -555,
+              "lGap": 0
+            }
+          },
+          "fontSize": 22,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.2,
+          "textAlign": "left",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"font-weight: 700\">Make your life easier</span>\n<span style=\"font-weight: 700\">with automations</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 52,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "3ae35c4a-1133-4ab2-8108-45ce52d5f94e",
+          "id": "baddeb36-483e-442f-aab0-d3b8076c4ba9",
+          "x": 40,
+          "y": 480
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "c5df890e-44e6-4ff1-bd3e-62aeb2862c5e"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "2827c4d2-8029-45e2-9e2d-e936fccb2221"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Bungee",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 1000,
+              "asc": 860,
+              "des": -140,
+              "tAsc": 860,
+              "tDes": -140,
+              "tLGap": 200,
+              "wAsc": 1634,
+              "wDes": 914,
+              "xH": 500,
+              "capH": 720,
+              "yMin": -916,
+              "yMax": 1636,
+              "hAsc": 860,
+              "hDes": -140,
+              "lGap": 200
+            }
+          },
+          "fontSize": 31,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "highlights of",
+          "fontWeight": 400,
+          "width": 266,
+          "height": 30,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "27022462-2c4c-4bf7-ae50-656024a8d1e3",
+          "id": "7472564d-c9a0-475f-b23b-cecf0629c7b0",
+          "x": 73,
+          "y": 344
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Bungee Shade",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 1000,
+              "asc": 860,
+              "des": -140,
+              "tAsc": 860,
+              "tDes": -140,
+              "tLGap": 200,
+              "wAsc": 1634,
+              "wDes": 914,
+              "xH": 500,
+              "capH": 720,
+              "yMin": -916,
+              "yMax": 1636,
+              "hAsc": 860,
+              "hDes": -140,
+              "lGap": 200
+            }
+          },
+          "fontSize": 54,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #ff5c00; letter-spacing: 0.04em\">pc game night</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 113,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 8.300000000000011,
+          "basedOn": "d3cce763-731c-42d0-b09e-f692f9a24efa",
+          "id": "e5a66644-3349-4c9b-a076-710f9dd6c404",
+          "x": 40,
+          "y": 382
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "FILL",
+          "font": {
+            "family": "Bungee",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 1000,
+              "asc": 860,
+              "des": -140,
+              "tAsc": 860,
+              "tDes": -140,
+              "tLGap": 200,
+              "wAsc": 1634,
+              "wDes": 914,
+              "xH": 500,
+              "capH": 720,
+              "yMin": -916,
+              "yMax": 1636,
+              "hAsc": 860,
+              "hDes": -140,
+              "lGap": 200
+            }
+          },
+          "fontSize": 16,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 8,
+            "vertical": 8
+          },
+          "type": "text",
+          "content": "<span style=\"color: #fff; letter-spacing: 0.04em\">july 20th, 2020</span>",
+          "fontWeight": 400,
+          "width": 191,
+          "height": 31,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 8.5,
+          "basedOn": "cf24002b-2536-4885-aa57-1cbf59e76ad4",
+          "id": "caf051db-232a-4a3d-8fac-210178b958bd",
+          "x": 111,
+          "y": 511
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "52e8bbd5-0994-4fbc-a129-52e51fdbc831"
+    },
+    {
+      "backgroundOverlay": "none",
+      "elements": [
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 255,
+              "b": 255
+            }
+          },
+          "x": 1,
+          "y": 1,
+          "width": 1,
+          "height": 1,
+          "mask": {
+            "type": "rectangle"
+          },
+          "isBackground": true,
+          "isDefaultBackground": true,
+          "type": "shape",
+          "id": "d367ac7b-3ea3-4405-8cfa-99404da93f26"
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": true,
+          "backgroundColor": {
+            "color": {
+              "r": 0,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "type": "shape",
+          "width": 412,
+          "height": 412,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "mask": {
+            "type": "rectangle"
+          },
+          "basedOn": "3a51ba12-b986-4524-8916-5cf1de243552",
+          "id": "19b1fe3c-dd3e-4272-a2e2-04d6d18e6051",
+          "x": 0,
+          "y": 236
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Bungee",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 1000,
+              "asc": 860,
+              "des": -140,
+              "tAsc": 860,
+              "tDes": -140,
+              "tLGap": 200,
+              "wAsc": 1634,
+              "wDes": 914,
+              "xH": 500,
+              "capH": 720,
+              "yMin": -916,
+              "yMax": 1636,
+              "hAsc": 860,
+              "hDes": -140,
+              "lGap": 200
+            }
+          },
+          "fontSize": 31,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #ffe600\">highlights of</span>",
+          "fontWeight": 400,
+          "width": 266,
+          "height": 31,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "basedOn": "d3f120a7-021e-4e9c-b246-3766bc6016fd",
+          "id": "b36ef221-ee84-431c-95a5-aa291bac6001",
+          "x": 73,
+          "y": 344
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "NONE",
+          "font": {
+            "family": "Bungee",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 1000,
+              "asc": 860,
+              "des": -140,
+              "tAsc": 860,
+              "tDes": -140,
+              "tLGap": 200,
+              "wAsc": 1634,
+              "wDes": 914,
+              "xH": 500,
+              "capH": 720,
+              "yMin": -916,
+              "yMax": 1636,
+              "hAsc": 860,
+              "hDes": -140,
+              "lGap": 200
+            }
+          },
+          "fontSize": 54,
+          "backgroundColor": {
+            "color": {
+              "r": 196,
+              "g": 196,
+              "b": 196
+            }
+          },
+          "lineHeight": 1.1,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 0,
+            "vertical": 0
+          },
+          "type": "text",
+          "content": "<span style=\"color: #fff; letter-spacing: 0.04em\">pc game night</span>",
+          "fontWeight": 400,
+          "width": 332,
+          "height": 113,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 8.300000000000011,
+          "basedOn": "fe0b42f3-54f1-401a-867b-57556c8dc7c9",
+          "id": "2645f9cb-7054-437c-86ed-f979ffaeeeb8",
+          "x": 40,
+          "y": 382
+        },
+        {
+          "opacity": 100,
+          "flip": {
+            "vertical": false,
+            "horizontal": false
+          },
+          "rotationAngle": 0,
+          "lockAspectRatio": false,
+          "backgroundTextMode": "FILL",
+          "font": {
+            "family": "Bungee",
+            "service": "fonts.google.com",
+            "fallbacks": ["cursive"],
+            "weights": [400],
+            "styles": ["regular"],
+            "variants": [[0, 400]],
+            "metrics": {
+              "upm": 1000,
+              "asc": 860,
+              "des": -140,
+              "tAsc": 860,
+              "tDes": -140,
+              "tLGap": 200,
+              "wAsc": 1634,
+              "wDes": 914,
+              "xH": 500,
+              "capH": 720,
+              "yMin": -916,
+              "yMax": 1636,
+              "hAsc": 860,
+              "hDes": -140,
+              "lGap": 200
+            }
+          },
+          "fontSize": 16,
+          "backgroundColor": {
+            "color": {
+              "r": 255,
+              "g": 0,
+              "b": 0
+            }
+          },
+          "lineHeight": 1.5,
+          "textAlign": "center",
+          "padding": {
+            "locked": true,
+            "horizontal": 8,
+            "vertical": 8
+          },
+          "type": "text",
+          "content": "<span style=\"color: #fff; letter-spacing: 0.04em\">july 20th, 2020</span>",
+          "fontWeight": 400,
+          "width": 191,
+          "height": 32,
+          "scale": 100,
+          "focalX": 50,
+          "focalY": 50,
+          "marginOffset": 8.5,
+          "basedOn": "1964a9d5-ccd5-4d70-8080-8e5a1e511d04",
+          "id": "565d5249-cdfb-4ac2-942d-a892ea08cedd",
+          "x": 110.5,
+          "y": 511
+        }
+      ],
+      "backgroundColor": {
+        "color": {
+          "r": 255,
+          "g": 255,
+          "b": 255
+        }
+      },
+      "type": "page",
+      "id": "95970834-7a29-4066-9a8f-54f682868d64"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Sam spread out the funky text sets into other text set groups. This one adds the funky text sets in the editorial text set group.

**Updated Funky Sets with Groupings**
https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories---Post-Stable?node-id=1%3A100429

## User-facing changes
NA

## Testing Instructions
Enable the text sets flag in experiments and see the new text sets in the story editor.


---

<!-- Please reference the issue(s) this PR addresses. -->

Partial for #4078 
