### PR TITLE
Load text sets one at a time to prevent blocking Editor from use

### DIFF
--- a/assets/src/edit-story/components/library/libraryPanes.js
+++ b/assets/src/edit-story/components/library/libraryPanes.js
@@ -26,9 +26,12 @@ function LibraryPanes() {
     tabs: state.data.tabs,
   }));
 
-  const { Pane } = tabs.find(({ id }) => id === tab);
-
-  return Pane ? <Pane isActive={true} aria-labelledby={getTabId(tab)} /> : null;
+  return tabs.map(
+    ({ id, Pane }) =>
+      Pane && (
+        <Pane key={id} isActive={id === tab} aria-labelledby={getTabId(id)} />
+      )
+  );
 }
 
 export default LibraryPanes;

--- a/assets/src/edit-story/components/library/libraryPanes.js
+++ b/assets/src/edit-story/components/library/libraryPanes.js
@@ -25,9 +25,10 @@ function LibraryPanes() {
     tab: state.state.tab,
     tabs: state.data.tabs,
   }));
-  return tabs.map(({ id, Pane }) => (
-    <Pane key={id} isActive={id === tab} aria-labelledby={getTabId(id)} />
-  ));
+
+  const { Pane } = tabs.find(({ id }) => id === tab);
+
+  return Pane ? <Pane isActive={true} aria-labelledby={getTabId(tab)} /> : null;
 }
 
 export default LibraryPanes;

--- a/assets/src/edit-story/components/library/libraryProvider.js
+++ b/assets/src/edit-story/components/library/libraryProvider.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useFeatures } from 'flagged';
 
 /**
@@ -32,6 +32,7 @@ import { Media3pPane, Media3pIcon } from './panes/media/media3p';
 import { ShapesPane, ShapesIcon } from './panes/shapes';
 import { TextPane, TextIcon } from './panes/text';
 import { ElementsPane, ElementsIcon } from './panes/elements';
+import { getTextSets } from './panes/text/textSets/utils';
 
 const MEDIA = { icon: MediaIcon, Pane: MediaPane, id: 'media' };
 const MEDIA3P = { icon: Media3pIcon, Pane: Media3pPane, id: 'media3p' };
@@ -43,6 +44,7 @@ const ANIM = { icon: AnimationIcon, Pane: AnimationPane, id: 'animation' };
 function LibraryProvider({ children }) {
   const initialTab = MEDIA.id;
   const [tab, setTab] = useState(initialTab);
+  const [textSets, setTextSets] = useState({});
   const insertElement = useInsertElement();
   const { insertTextSet, insertTextSetByOffset } = useInsertTextSet();
 
@@ -66,6 +68,7 @@ function LibraryProvider({ children }) {
       state: {
         tab,
         initialTab,
+        textSets,
       },
       actions: {
         setTab,
@@ -77,8 +80,20 @@ function LibraryProvider({ children }) {
         tabs: tabs,
       },
     }),
-    [tab, insertElement, insertTextSet, insertTextSetByOffset, initialTab, tabs]
+    [
+      tab,
+      insertElement,
+      insertTextSet,
+      insertTextSetByOffset,
+      initialTab,
+      tabs,
+      textSets,
+    ]
   );
+
+  useEffect(() => {
+    getTextSets().then(setTextSets);
+  }, []);
 
   return <Context.Provider value={state}>{children}</Context.Provider>;
 }

--- a/assets/src/edit-story/components/library/libraryProvider.js
+++ b/assets/src/edit-story/components/library/libraryProvider.js
@@ -55,12 +55,12 @@ function LibraryProvider({ children }) {
     () => [
       MEDIA,
       MEDIA3P,
-      TEXT,
+      ...(tab === TEXT.id ? [TEXT] : [{ icon: TextIcon, id: 'text' }]),
       SHAPES,
       ...(showElementsTab ? [ELEMS] : []),
       ...(showAnimationTab ? [ANIM] : []),
     ],
-    [showAnimationTab, showElementsTab]
+    [showAnimationTab, showElementsTab, tab]
   );
 
   const state = useMemo(

--- a/assets/src/edit-story/components/library/panes/text/textPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textPane.js
@@ -38,7 +38,7 @@ import useInsertPreset from './useInsertPreset';
 import TextSets from './textSets';
 
 const Pane = styled(SharedPane)`
-  overflow-y: auto;
+  overflow-y: scroll;
   max-height: 100%;
 `;
 

--- a/assets/src/edit-story/components/library/panes/text/textSets/getTextSetReducer.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/getTextSetReducer.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const TEXT_SET_ACTIONS = {
+  RESET: 'reset',
+  RENDER_NEXT_TEXT_SET: 'render_next_text_set',
+};
+
+export function getTextSetReducer(textSets, allTextSets, size = 10) {
+  return ({ filteredTextSets, renderedTextSets }, action) => {
+    switch (action.type) {
+      case TEXT_SET_ACTIONS.RESET:
+        return {
+          filteredTextSets: textSets[action.payload] || allTextSets,
+          renderedTextSets: [],
+        };
+      case TEXT_SET_ACTIONS.RENDER_NEXT_TEXT_SET:
+        return {
+          filteredTextSets,
+          renderedTextSets: [
+            ...renderedTextSets,
+            ...filteredTextSets.slice(
+              renderedTextSets.length,
+              renderedTextSets.length + size
+            ),
+          ],
+        };
+      default:
+        return { filteredTextSets, renderedTextSets };
+    }
+  };
+}

--- a/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/karma/textSets.karma.js
@@ -24,6 +24,7 @@ import { waitFor } from '@testing-library/react';
  */
 import { Fixture } from '../../../../../../karma/fixture';
 import { useStory } from '../../../../../../app/story';
+import localStore from '../../../../../../utils/localStore';
 
 describe('Text Sets Library Panel', () => {
   let fixture;
@@ -33,6 +34,12 @@ describe('Text Sets Library Panel', () => {
     fixture.setFlags({ showTextSets: true });
 
     await fixture.render();
+
+    // Filtering text sets to 'cover' so karma
+    // doesn't have to load all text sets to perform tests
+    spyOn(localStore, 'getItemByKey').and.returnValue({
+      selectedCategory: 'cover',
+    });
 
     // Make Text tab active in library panels
     const textTab = fixture.editor.library.getByRole('tab', {
@@ -56,13 +63,19 @@ describe('Text Sets Library Panel', () => {
   }
 
   describe('CUJ: Text Sets (Text and Shape Combinations): Inserting Text Sets', () => {
-    // Disable reason: not implemented yet.
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should display text sets', async () => {});
+    it('should display text sets', async () => {
+      // Should find at least one
+      const textSet = await waitFor(
+        () =>
+          fixture.editor.library.getAllByRole('listitem', {
+            name: /^Insert Text Set$/,
+          })[0]
+      );
 
-    // Disable reason: will be implemented with enabling the feature flag.
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should allow inserting text sets', async () => {
+      expect(textSet).toBeDefined();
+    });
+
+    it('should allow inserting text sets', async () => {
       const textSet = await waitFor(
         () =>
           fixture.editor.library.getAllByRole('listitem', {
@@ -79,9 +92,7 @@ describe('Text Sets Library Panel', () => {
       expect((await getTextElements()).length).toBeGreaterThan(0);
     });
 
-    // Disable reason: timing out in CI, need investigation into async loading of text sets
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should allow user to drag and drop text set onto page', async () => {
+    it('should allow user to drag and drop text set onto page', async () => {
       const textSet = await waitFor(
         () =>
           fixture.editor.library.getAllByRole('listitem', {
@@ -94,7 +105,7 @@ describe('Text Sets Library Panel', () => {
       // The page should start off with no text elements
       expect((await getTextElements()).length).toBe(0);
 
-      await fixture.events.mouse.moveRel(textSet, 25, 25);
+      await fixture.events.mouse.moveRel(textSet, 50, 50);
       await fixture.events.mouse.down();
 
       await fixture.events.mouse.moveRel(page, 50, 100);

--- a/assets/src/edit-story/components/library/panes/text/textSets/test/getTextSetReducer.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/test/getTextSetReducer.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { TEXT_SET_ACTIONS, getTextSetReducer } from '../getTextSetReducer';
+
+const textSets = {
+  caption: [{ id: 'caption1' }, { id: 'caption2' }, { id: 'caption3' }],
+  quote: [{ id: 'quote1' }, { id: 'quote2' }],
+};
+
+const allTextSets = Object.values(textSets).flat();
+
+describe('getTextSetReducer', () => {
+  const reducer = getTextSetReducer(textSets, allTextSets, 1);
+  const initialState = {
+    filteredTextSets: [],
+    renderedTextSets: [],
+  };
+
+  describe('when RESET action is triggered', () => {
+    it('should set renderedTextSets to empty array', () => {
+      const { renderedTextSets } = reducer(
+        {
+          filteredTextSets: [],
+          renderedTextSets: [1, 2, 3, 4],
+        },
+        {
+          type: TEXT_SET_ACTIONS.RESET,
+        }
+      );
+
+      expect(renderedTextSets).toStrictEqual([]);
+    });
+
+    it('should set filteredTextSets based on action.payload', () => {
+      const { filteredTextSets: captionTextSet } = reducer(initialState, {
+        type: TEXT_SET_ACTIONS.RESET,
+        payload: 'caption',
+      });
+
+      expect(captionTextSet).toStrictEqual(textSets.caption);
+
+      const { filteredTextSets } = reducer(initialState, {
+        type: TEXT_SET_ACTIONS.RESET,
+      });
+
+      expect(filteredTextSets).toStrictEqual(allTextSets);
+    });
+  });
+
+  describe('when RENDER_NEXT_TEXT_SET action is triggered', () => {
+    it('should pass through filteredTextSets unchanged', () => {
+      const { filteredTextSets } = reducer(
+        {
+          filteredTextSets: [1, 2, 3, 4],
+          renderedTextSets: [],
+        },
+        {
+          type: TEXT_SET_ACTIONS.RENDER_NEXT_TEXT_SET,
+        }
+      );
+
+      expect(filteredTextSets).toStrictEqual([1, 2, 3, 4]);
+    });
+
+    it('should append text set from filteredTextSets at correct index', () => {
+      const {
+        renderedTextSets: firstTextSet,
+        filteredTextSets: filtered1,
+      } = reducer(
+        {
+          filteredTextSets: allTextSets,
+          renderedTextSets: [],
+        },
+        {
+          type: TEXT_SET_ACTIONS.RENDER_NEXT_TEXT_SET,
+        }
+      );
+
+      expect(firstTextSet[firstTextSet.length - 1]).toStrictEqual(
+        filtered1[firstTextSet.length - 1]
+      );
+
+      const {
+        renderedTextSets: thirdTextSet,
+        filteredTextSets: filtered2,
+      } = reducer(
+        {
+          filteredTextSets: allTextSets,
+          renderedTextSets: [allTextSets[0], allTextSets[1], allTextSets[2]],
+        },
+        {
+          type: TEXT_SET_ACTIONS.RENDER_NEXT_TEXT_SET,
+        }
+      );
+
+      expect(thirdTextSet[thirdTextSet.length - 1]).toStrictEqual(
+        filtered2[thirdTextSet.length - 1]
+      );
+    });
+  });
+
+  describe('when default is triggered', () => {
+    it('should pass through filteredTextSets and renderedTextSets unchanged', () => {
+      const { renderedTextSets, filteredTextSets } = reducer(
+        {
+          filteredTextSets: [1, 2, 3, 4],
+          renderedTextSets: [1, 2, 3],
+        },
+        {
+          type: 'FAKE',
+        }
+      );
+
+      expect(filteredTextSets).toStrictEqual([1, 2, 3, 4]);
+      expect(renderedTextSets).toStrictEqual([1, 2, 3]);
+    });
+  });
+});

--- a/assets/src/edit-story/components/library/panes/text/textSets/test/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/test/textSets.js
@@ -28,6 +28,9 @@ import TextSets from '../textSets';
 
 function setup() {
   const libraryValue = {
+    state: {
+      textSets: [],
+    },
     actions: {
       insertElement: jest.fn(),
     },

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
@@ -31,7 +31,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useLayout } from '../../../../../app/layout';
-import { PAGE_RATIO, TEXT_SET_SIZE } from '../../../../../constants';
+import { TEXT_SET_SIZE } from '../../../../../constants';
 import { KEYBOARD_USER_SELECTOR } from '../../../../../utils/keyboardOnlyOutline';
 import useLibrary from '../../../useLibrary';
 import { dataToEditorX, dataToEditorY } from '../../../../../units';
@@ -118,14 +118,7 @@ function TextSet({ elements }) {
         aria-label={__('Insert Text Set', 'web-stories')}
         onClick={() => insertTextSet(elements)}
       >
-        <TextSetElements
-          isForDisplay
-          elements={elements}
-          pageSize={{
-            width: TEXT_SET_SIZE,
-            height: TEXT_SET_SIZE / PAGE_RATIO,
-          }}
-        />
+        <TextSetElements isForDisplay elements={elements} />
       </TextSetItem>
     </DragWrapper>
   );

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSetElements.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSetElements.js
@@ -39,6 +39,19 @@ function getElementContent(content, isForDisplay) {
   };
 }
 
+function TextSetContainer({ pageSize, children }) {
+  return pageSize ? (
+    <UnitsProvider pageSize={pageSize}>{children}</UnitsProvider>
+  ) : (
+    children
+  );
+}
+
+TextSetContainer.propTypes = {
+  pageSize: StoryPropTypes.size,
+  children: PropTypes.node.isRequired,
+};
+
 function TextSetElements({ elements, isForDisplay, pageSize }) {
   const { textSetHeight, textSetWidth } = elements[0];
 
@@ -46,7 +59,7 @@ function TextSetElements({ elements, isForDisplay, pageSize }) {
   const yOffset = isForDisplay ? (PAGE_WIDTH - textSetHeight) / 2 : 0;
 
   return (
-    <UnitsProvider pageSize={pageSize}>
+    <TextSetContainer pageSize={pageSize}>
       {elements.map(
         ({ id, content, normalizedOffsetX, normalizedOffsetY, ...rest }) => (
           <DisplayElement
@@ -62,13 +75,13 @@ function TextSetElements({ elements, isForDisplay, pageSize }) {
           />
         )
       )}
-    </UnitsProvider>
+    </TextSetContainer>
   );
 }
 
 TextSetElements.propTypes = {
   elements: PropTypes.array.isRequired,
-  pageSize: StoryPropTypes.size.isRequired,
+  pageSize: StoryPropTypes.size,
   isForDisplay: PropTypes.bool,
 };
 

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -66,6 +66,8 @@ const CATEGORIES = {
   quote: __('Quote', 'web-stories'),
 };
 
+const RENDER_TEXT_SET_DELAY = 10;
+
 function TextSets() {
   const { textSets } = useLibrary(({ state: { textSets } }) => ({ textSets }));
 
@@ -75,8 +77,6 @@ function TextSets() {
   const [filteredTextSets, setFilteredTextSets] = useState([]);
   const [renderedTextSets, setRenderedTextSets] = useState([]);
   const ref = useRef();
-  const isLoadingRef = useRef(false);
-  const loadingTimeoutRef = useRef(-1);
 
   const allTextSets = useMemo(() => Object.values(textSets).flat(), [textSets]);
   const categories = useMemo(
@@ -96,35 +96,26 @@ function TextSets() {
   }, []);
 
   useEffect(() => {
-    window.clearTimeout(loadingTimeoutRef.current);
-    isLoadingRef.current = false;
-
     setFilteredTextSets(selectedCat ? textSets[selectedCat] : allTextSets);
     setRenderedTextSets([]);
   }, [selectedCat, textSets, allTextSets]);
 
   useEffect(() => {
-    if (isLoadingRef.current) {
-      return;
+    if (renderedTextSets.length >= filteredTextSets.length) {
+      return () => {};
     }
 
-    if (renderedTextSets.length < filteredTextSets.length) {
-      isLoadingRef.current = true;
+    const loadingTimeoutId = window.setTimeout(() => {
+      setRenderedTextSets((rendered) => [
+        ...rendered,
+        filteredTextSets[rendered.length],
+      ]);
+    }, RENDER_TEXT_SET_DELAY);
 
-      loadingTimeoutRef.current = window.setTimeout(() => {
-        isLoadingRef.current = false;
-        setRenderedTextSets([
-          ...renderedTextSets,
-          filteredTextSets[renderedTextSets.length],
-        ]);
-      }, 10);
-    }
+    return () => {
+      window.clearTimeout(loadingTimeoutId);
+    };
   }, [renderedTextSets, filteredTextSets]);
-
-  useEffect(() => {
-    window.clearTimeout(loadingTimeoutRef.current);
-    isLoadingRef.current = false;
-  }, []);
 
   useRovingTabIndex({ ref });
 

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -30,8 +30,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { Section } from '../../../common';
-import { UnitsProvider } from '../../../../../units';
-import { PAGE_RATIO, TEXT_SET_SIZE } from '../../../../../constants';
 import PillGroup from '../../shared/pillGroup';
 import { PANE_PADDING } from '../../shared';
 import useRovingTabIndex from '../../../../../utils/useRovingTabIndex';
@@ -132,19 +130,12 @@ function TextSets() {
         />
       </CategoryWrapper>
       <TextSetContainer ref={ref} role="list" aria-labelledby={sectionId}>
-        <UnitsProvider
-          pageSize={{
-            width: TEXT_SET_SIZE,
-            height: TEXT_SET_SIZE / PAGE_RATIO,
-          }}
-        >
-          {renderedTextSets.map(
-            (elements) =>
-              elements.length > 0 && (
-                <TextSet key={elements[0].id} elements={elements} />
-              )
-          )}
-        </UnitsProvider>
+        {renderedTextSets.map(
+          (elements) =>
+            elements.length > 0 && (
+              <TextSet key={elements[0].id} elements={elements} />
+            )
+        )}
       </TextSetContainer>
     </Section>
   );

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useRef, useState, useMemo, useEffect } from 'react';
+import { useRef, useState, useMemo, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -33,6 +33,11 @@ import { Section } from '../../../common';
 import PillGroup from '../../shared/pillGroup';
 import { PANE_PADDING } from '../../shared';
 import useRovingTabIndex from '../../../../../utils/useRovingTabIndex';
+import {
+  LOCAL_STORAGE_PREFIX,
+  getItemByKey,
+  setItemByKey,
+} from '../../../../../utils/localStore';
 import useLibrary from '../../../useLibrary';
 import TextSet from './textSet';
 
@@ -64,7 +69,9 @@ const CATEGORIES = {
 function TextSets() {
   const { textSets } = useLibrary(({ state: { textSets } }) => ({ textSets }));
 
-  const [selectedCat, setSelectedCat] = useState(null);
+  const [selectedCat, setSelectedCat] = useState(
+    getItemByKey(`${LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS}`)?.selectedCategory
+  );
   const [filteredTextSets, setFilteredTextSets] = useState([]);
   const [renderedTextSets, setRenderedTextSets] = useState([]);
   const ref = useRef();
@@ -80,6 +87,13 @@ function TextSets() {
       })),
     [textSets]
   );
+
+  const handleSelectedCategory = useCallback((selectedCategory) => {
+    setSelectedCat(selectedCategory);
+    setItemByKey(`${LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS}`, {
+      selectedCategory,
+    });
+  }, []);
 
   useEffect(() => {
     window.clearTimeout(loadingTimeoutRef.current);
@@ -122,8 +136,8 @@ function TextSets() {
         <PillGroup
           items={categories}
           selectedItemId={selectedCat}
-          selectItem={setSelectedCat}
-          deselectItem={() => setSelectedCat(null)}
+          selectItem={handleSelectedCategory}
+          deselectItem={() => handleSelectedCategory(null)}
         />
       </CategoryWrapper>
       <TextSetContainer ref={ref} role="list" aria-labelledby={sectionId}>

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef, useState, useMemo } from 'react';
+import { useRef, useState, useMemo, useEffect } from 'react';
 import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -33,7 +33,7 @@ import { Section } from '../../../common';
 import PillGroup from '../../shared/pillGroup';
 import { PANE_PADDING } from '../../shared';
 import useRovingTabIndex from '../../../../../utils/useRovingTabIndex';
-import { getTextSets } from './utils';
+import useLibrary from '../../../useLibrary';
 import TextSet from './textSet';
 
 const TextSetContainer = styled.div`
@@ -62,7 +62,8 @@ const CATEGORIES = {
 };
 
 function TextSets() {
-  const [textSets, setTextSets] = useState([]);
+  const { textSets } = useLibrary(({ state: { textSets } }) => ({ textSets }));
+
   const [selectedCat, setSelectedCat] = useState(null);
   const [filteredTextSets, setFilteredTextSets] = useState([]);
   const [renderedTextSets, setRenderedTextSets] = useState([]);
@@ -79,10 +80,6 @@ function TextSets() {
       })),
     [textSets]
   );
-
-  useEffect(() => {
-    getTextSets().then(setTextSets);
-  }, []);
 
   useEffect(() => {
     window.clearTimeout(loadingTimeoutRef.current);

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -25,11 +25,7 @@ import { useState, useCallback, useEffect, useMemo } from 'react';
 /**
  * Internal dependencies
  */
-import {
-  LOCAL_STORAGE_PREFIX,
-  getItemByKey,
-  setItemByKey,
-} from '../../../utils/localStore';
+import localStore, { LOCAL_STORAGE_PREFIX } from '../../../utils/localStore';
 import panelContext from './context';
 
 export const PANEL_COLLAPSED_THRESHOLD = 10;
@@ -50,7 +46,7 @@ function Panel({
   ariaHidden = false,
 }) {
   const persisted = useMemo(
-    () => getItemByKey(`${LOCAL_STORAGE_PREFIX.PANEL}:${name}`),
+    () => localStore.getItemByKey(`${LOCAL_STORAGE_PREFIX.PANEL}:${name}`),
     [name]
   );
   const [isCollapsed, setIsCollapsed] = useState(
@@ -115,7 +111,7 @@ function Panel({
     }
 
     // Persist only when after user interacts
-    setItemByKey(`${LOCAL_STORAGE_PREFIX.PANEL}:${name}`, {
+    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.PANEL}:${name}`, {
       height,
       isCollapsed,
       expandToHeight,

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -25,7 +25,11 @@ import { useState, useCallback, useEffect, useMemo } from 'react';
 /**
  * Internal dependencies
  */
-import { LOCAL_STORAGE_PREFIX } from '../../../constants';
+import {
+  LOCAL_STORAGE_PREFIX,
+  getItemByKey,
+  setItemByKey,
+} from '../../../utils/localStore';
 import panelContext from './context';
 
 export const PANEL_COLLAPSED_THRESHOLD = 10;
@@ -45,18 +49,10 @@ function Panel({
   ariaLabel = null,
   ariaHidden = false,
 }) {
-  const persisted = useMemo(() => {
-    let parsed = null;
-    try {
-      const stored = localStorage.getItem(
-        `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`
-      );
-      parsed = JSON.parse(stored);
-    } catch (e) {
-      // @TODO Add some error handling.
-    }
-    return parsed;
-  }, [name]);
+  const persisted = useMemo(
+    () => getItemByKey(`${LOCAL_STORAGE_PREFIX.PANEL}:${name}`),
+    [name]
+  );
   const [isCollapsed, setIsCollapsed] = useState(
     Boolean(persisted?.isCollapsed)
   );
@@ -119,14 +115,11 @@ function Panel({
     }
 
     // Persist only when after user interacts
-    localStorage.setItem(
-      `${LOCAL_STORAGE_PREFIX.PANEL}:${name}`,
-      JSON.stringify({
-        height,
-        isCollapsed,
-        expandToHeight,
-      })
-    );
+    setItemByKey(`${LOCAL_STORAGE_PREFIX.PANEL}:${name}`, {
+      height,
+      isCollapsed,
+      expandToHeight,
+    });
   }, [name, isCollapsed, height, expandToHeight, manuallyChanged]);
 
   const manuallySetHeight = useCallback(

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -83,7 +83,3 @@ export const FONT_WEIGHT = {
   NORMAL: 400,
   BOLD: 700,
 };
-
-export const LOCAL_STORAGE_PREFIX = {
-  PANEL: 'web_stories_ui_panel_settings',
-};

--- a/assets/src/edit-story/utils/localStore.js
+++ b/assets/src/edit-story/utils/localStore.js
@@ -19,7 +19,7 @@ export const LOCAL_STORAGE_PREFIX = {
   TEXT_SET_SETTINGS: 'web_stores_text_set_settings',
 };
 
-export function getItemByKey(key) {
+function getItemByKey(key) {
   let parsed = null;
   try {
     const stored = localStorage.getItem(key);
@@ -30,6 +30,11 @@ export function getItemByKey(key) {
   return parsed;
 }
 
-export function setItemByKey(key, data) {
+function setItemByKey(key, data) {
   localStorage.setItem(key, JSON.stringify(data));
 }
+
+export default {
+  getItemByKey,
+  setItemByKey,
+};

--- a/assets/src/edit-story/utils/localStore.js
+++ b/assets/src/edit-story/utils/localStore.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const LOCAL_STORAGE_PREFIX = {
+  PANEL: 'web_stories_ui_panel_settings',
+  TEXT_SET_SETTINGS: 'web_stores_text_set_settings',
+};
+
+export function getItemByKey(key) {
+  let parsed = null;
+  try {
+    const stored = localStorage.getItem(key);
+    parsed = JSON.parse(stored);
+  } catch (e) {
+    // @TODO Add some error handling.
+  }
+  return parsed;
+}
+
+export function setItemByKey(key, data) {
+  localStorage.setItem(key, JSON.stringify(data));
+}


### PR DESCRIPTION
## Summary

This PR updates the way text sets are loaded so they don't block the Editor from loading and becoming functional.

## Relevant Technical Choices

In order to progressively load the text sets in, I use a `setTimeout` loop to load each one, one-by-one.

## User-facing changes

None.  Hidden behind feature flag.

## Testing Instructions

1.) Open up the Editor with a new or existing story.
2.) Notice that the Editor becomes responsive to user input quickly.
3.) Open up the text tab (click on "T").
4.) See that text sets are loading in one by one.
5.) Notice that you can still use the Editor as the text sets load (including dragging/clicking on a loaded text set to apply to current page)>
6.) Also change filters for text sets and see that you can change filters and see the correct text sets
begin to load too.

---

Fixes #4815 
