### PR TITLE
Change "Multiple" to "Mixed"

### DIFF
--- a/assets/src/edit-story/components/form/color/colorPreview.js
+++ b/assets/src/edit-story/components/form/color/colorPreview.js
@@ -33,7 +33,7 @@ import { __, _x } from '@wordpress/i18n';
 import { KEYBOARD_USER_SELECTOR } from '../../../utils/keyboardOnlyOutline';
 import useUnmount from '../../../utils/useUnmount';
 import { PatternPropType } from '../../../types';
-import MULTIPLE_VALUE from '../multipleValue';
+import MULTIPLE_VALUE, { MULTIPLE_DISPLAY_VALUE } from '../multipleValue';
 import Popup from '../../popup';
 import ColorPicker from '../../colorPicker';
 import useInspector from '../../inspector/useInspector';
@@ -241,7 +241,7 @@ function ColorPreview({
           </VisualPreviewInsideButton>
           <TextualPreview>
             {isMultiple
-              ? __('Multiple', 'web-stories')
+              ? MULTIPLE_DISPLAY_VALUE
               : previewText ||
                 _x('None', 'No color or gradient selected', 'web-stories')}
           </TextualPreview>

--- a/assets/src/edit-story/components/form/color/test/colorPreview.js
+++ b/assets/src/edit-story/components/form/color/test/colorPreview.js
@@ -110,7 +110,7 @@ describe('<ColorPreview />', () => {
       <ColorPreview onChange={() => {}} value={MULTIPLE_VALUE} label="Color" />
     );
 
-    expect(button).toHaveTextContent('Multiple');
+    expect(button).toHaveTextContent('Mixed');
   });
 
   it('should render none if applicable', () => {

--- a/assets/src/edit-story/components/form/color/test/colorPreview.js
+++ b/assets/src/edit-story/components/form/color/test/colorPreview.js
@@ -26,7 +26,7 @@ import createSolid from '../../../../utils/createSolid';
 import ColorPreview from '../colorPreview';
 import getPreviewStyleMock from '../getPreviewStyle';
 import getPreviewTextMock from '../getPreviewText';
-import MULTIPLE_VALUE from '../../multipleValue';
+import MULTIPLE_VALUE, { MULTIPLE_DISPLAY_VALUE } from '../../multipleValue';
 import { renderWithTheme } from '../../../../testUtils';
 
 jest.mock('../getPreviewStyle', () => jest.fn());
@@ -110,7 +110,7 @@ describe('<ColorPreview />', () => {
       <ColorPreview onChange={() => {}} value={MULTIPLE_VALUE} label="Color" />
     );
 
-    expect(button).toHaveTextContent('Mixed');
+    expect(button).toHaveTextContent(MULTIPLE_DISPLAY_VALUE);
   });
 
   it('should render none if applicable', () => {

--- a/assets/src/edit-story/components/form/index.js
+++ b/assets/src/edit-story/components/form/index.js
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-export { default as MULTIPLE_VALUE } from './multipleValue';
+export {
+  default as MULTIPLE_VALUE,
+  MULTIPLE_DISPLAY_VALUE,
+} from './multipleValue';
 export { default as Button } from './button';
 export { default as Color } from './color';
 export { default as Input } from './input';

--- a/assets/src/edit-story/components/form/multipleValue.js
+++ b/assets/src/edit-story/components/form/multipleValue.js
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 const MULTIPLE_VALUE = '((MULTIPLE))';
+export const MULTIPLE_DISPLAY_VALUE = __('Mixed', 'web-stories');
 
 export default MULTIPLE_VALUE;

--- a/assets/src/edit-story/components/form/numeric.js
+++ b/assets/src/edit-story/components/form/numeric.js
@@ -24,18 +24,13 @@ import { useCallback, useRef, useState, useEffect } from 'react';
 import Big from 'big.js';
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { defaultUnit } from '../../../animation/utils/defaultUnit';
 import useFocusAndSelect from '../../utils/useFocusAndSelect';
 import { useKeyDownEffect } from '../keyboard';
 import Input from './input';
-import MULTIPLE_VALUE from './multipleValue';
+import MULTIPLE_VALUE, { MULTIPLE_DISPLAY_VALUE } from './multipleValue';
 
 const DECIMAL_POINT = (1.1).toLocaleString().substring(1, 2);
 
@@ -98,7 +93,7 @@ function Numeric({
   ...rest
 }) {
   const isMultiple = value === MULTIPLE_VALUE;
-  const placeholder = isMultiple ? __('multiple', 'web-stories') : '';
+  const placeholder = isMultiple ? MULTIPLE_DISPLAY_VALUE : '';
   const [dot, setDot] = useState(false);
   const [inputValue, setInputValue] = useState(value);
   const ref = useRef();

--- a/assets/src/edit-story/components/form/text.js
+++ b/assets/src/edit-story/components/form/text.js
@@ -32,7 +32,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { CloseAlt as Close } from '../../icons';
 import { useKeyDownEffect } from '../keyboard';
-import MULTIPLE_VALUE from './multipleValue';
+import MULTIPLE_VALUE, { MULTIPLE_DISPLAY_VALUE } from './multipleValue';
 import { Input } from '.';
 
 const INPUT_PADDING = 6;
@@ -125,7 +125,7 @@ function TextInput({
   const inputRef = useRef();
   const isMultiple = value === MULTIPLE_VALUE;
   value = isMultiple ? '' : value;
-  placeholder = isMultiple ? __('multiple', 'web-stories') : placeholder;
+  placeholder = isMultiple ? MULTIPLE_DISPLAY_VALUE : placeholder;
 
   const onClear = useCallback(() => {
     onChange('');

--- a/assets/src/edit-story/components/panels/test/imageAccessibility.js
+++ b/assets/src/edit-story/components/panels/test/imageAccessibility.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import ImageAccessibility from '../imageAccessibility';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form';
+import { renderPanel } from './_utils';
+
+jest.mock('../../mediaPicker', () => ({
+  useMediaPicker: ({ onSelect }) => {
+    const image = { url: 'media1' };
+    return () => onSelect(image);
+  },
+}));
+
+describe('Panels/ImageAccessibility', () => {
+  const defaultElement = {
+    type: 'image',
+    resource: { title: '', alt: '', src: '1' },
+  };
+  function renderImageAccessibility(...args) {
+    return renderPanel(ImageAccessibility, ...args);
+  }
+
+  it('should render <ImageAccessibility /> panel', () => {
+    const { getByRole } = renderImageAccessibility([defaultElement]);
+    const input = getByRole('textbox', { name: /Edit: Assistive text/i });
+    expect(input).toBeDefined();
+  });
+
+  it('should display Mixed placeholder in case of mixed multi-selection', () => {
+    const { getByRole } = renderImageAccessibility([
+      defaultElement,
+      {
+        type: 'image',
+        resource: { title: '', alt: 'Hello!', src: '2' },
+      },
+    ]);
+    const input = getByRole('textbox', { name: /Edit: Assistive text/i });
+    expect(input.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+    expect(input).toHaveValue('');
+  });
+});

--- a/assets/src/edit-story/components/panels/test/layerStyle.js
+++ b/assets/src/edit-story/components/panels/test/layerStyle.js
@@ -95,4 +95,14 @@ describe('Panels/LayerStyle', () => {
       opacity: 100,
     });
   });
+
+  it('should display mixed in case of multi-selection with different values', () => {
+    const { getByRole } = renderLayerStyle([
+      { ...defaultElement, opacity: 50 },
+      { id: 2, opacity: 80 },
+    ]);
+    const input = getByRole('textbox', { name: 'Opacity in percentage' });
+    expect(input.placeholder).toStrictEqual('Mixed');
+    expect(input.value).toStrictEqual('');
+  });
 });

--- a/assets/src/edit-story/components/panels/test/layerStyle.js
+++ b/assets/src/edit-story/components/panels/test/layerStyle.js
@@ -23,6 +23,7 @@ import { fireEvent } from '@testing-library/react';
  * Internal dependencies
  */
 import LayerStyle from '../layerStyle';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form/multipleValue';
 import { renderPanel } from './_utils';
 
 describe('Panels/LayerStyle', () => {
@@ -102,7 +103,7 @@ describe('Panels/LayerStyle', () => {
       { id: 2, opacity: 80 },
     ]);
     const input = getByRole('textbox', { name: 'Opacity in percentage' });
-    expect(input.placeholder).toStrictEqual('Mixed');
+    expect(input.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
     expect(input.value).toStrictEqual('');
   });
 });

--- a/assets/src/edit-story/components/panels/test/layerStyle.js
+++ b/assets/src/edit-story/components/panels/test/layerStyle.js
@@ -23,7 +23,7 @@ import { fireEvent } from '@testing-library/react';
  * Internal dependencies
  */
 import LayerStyle from '../layerStyle';
-import { MULTIPLE_DISPLAY_VALUE } from '../../form/multipleValue';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form';
 import { renderPanel } from './_utils';
 
 describe('Panels/LayerStyle', () => {

--- a/assets/src/edit-story/components/panels/test/linkPanel.js
+++ b/assets/src/edit-story/components/panels/test/linkPanel.js
@@ -25,7 +25,7 @@ import { screen } from '@testing-library/react';
 import ConfigContext from '../../../app/config/context';
 import LinkPanel from '../link';
 import StoryContext from '../../../app/story/context';
-import { MULTIPLE_DISPLAY_VALUE } from '../../form/multipleValue';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form';
 import { renderPanel } from './_utils';
 
 jest.mock('../../../elements');

--- a/assets/src/edit-story/components/panels/test/linkPanel.js
+++ b/assets/src/edit-story/components/panels/test/linkPanel.js
@@ -54,21 +54,20 @@ function renderLinkPanel(selectedElements) {
 }
 
 describe('Panels/Link', () => {
+  const DEFAULT_ELEMENT = {
+    id: '1',
+    isBackground: false,
+    x: 10,
+    y: 10,
+    width: 100,
+    height: 80,
+    rotationAngle: 0,
+    link: {
+      url: '',
+    },
+  };
   it('should not display metadata fields if URL is missing', () => {
-    const defaultElement = {
-      id: '1',
-      isBackground: false,
-      x: 10,
-      y: 10,
-      width: 100,
-      height: 80,
-      rotationAngle: 0,
-      link: {
-        url: '',
-      },
-    };
-
-    renderLinkPanel([defaultElement]);
+    renderLinkPanel([DEFAULT_ELEMENT]);
     expect(
       screen.getByRole('textbox', {
         name: 'Edit: Element link',
@@ -87,38 +86,26 @@ describe('Panels/Link', () => {
   });
 
   it('should display an error message for invalid URLs', () => {
-    const defaultElement = {
-      id: '1',
-      isBackground: false,
-      x: 10,
-      y: 10,
-      width: 100,
-      height: 80,
-      rotationAngle: 0,
-      link: {
-        url: 'http://',
+    renderLinkPanel([
+      {
+        ...DEFAULT_ELEMENT,
+        link: {
+          url: 'http://',
+        },
       },
-    };
-
-    renderLinkPanel([defaultElement]);
+    ]);
     expect(screen.getByText('Invalid web address.')).toBeInTheDocument();
   });
 
   it('should not display metadata fields if URL is invalid', () => {
-    const defaultElement = {
-      id: '1',
-      isBackground: false,
-      x: 10,
-      y: 10,
-      width: 100,
-      height: 80,
-      rotationAngle: 0,
-      link: {
-        url: 'http://',
+    renderLinkPanel([
+      {
+        ...DEFAULT_ELEMENT,
+        link: {
+          url: 'http://',
+        },
       },
-    };
-
-    renderLinkPanel([defaultElement]);
+    ]);
     expect(
       screen.queryByRole('textbox', {
         name: 'Edit: Link description',
@@ -129,5 +116,33 @@ describe('Panels/Link', () => {
         name: 'Edit link icon',
       })
     ).toBeNull();
+  });
+
+  it('should display Mixed placeholder in case of mixed values multi-selection', () => {
+    renderLinkPanel([
+      {
+        ...DEFAULT_ELEMENT,
+        link: {
+          url: 'http://example.com',
+          desc: 'Example',
+        },
+      },
+      {
+        ...DEFAULT_ELEMENT,
+        id: 2,
+      },
+    ]);
+
+    const linkInput = screen.getByRole('textbox', {
+      name: 'Edit: Element link',
+    });
+    expect(linkInput.placeholder).toStrictEqual('Mixed');
+    expect(linkInput.value).toStrictEqual('');
+
+    const descInput = screen.queryByRole('textbox', {
+      name: 'Edit: Link description',
+    });
+    expect(descInput.placeholder).toStrictEqual('Mixed');
+    expect(descInput.value).toStrictEqual('');
   });
 });

--- a/assets/src/edit-story/components/panels/test/linkPanel.js
+++ b/assets/src/edit-story/components/panels/test/linkPanel.js
@@ -25,6 +25,7 @@ import { screen } from '@testing-library/react';
 import ConfigContext from '../../../app/config/context';
 import LinkPanel from '../link';
 import StoryContext from '../../../app/story/context';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form/multipleValue';
 import { renderPanel } from './_utils';
 
 jest.mock('../../../elements');
@@ -136,13 +137,13 @@ describe('Panels/Link', () => {
     const linkInput = screen.getByRole('textbox', {
       name: 'Edit: Element link',
     });
-    expect(linkInput.placeholder).toStrictEqual('Mixed');
+    expect(linkInput.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
     expect(linkInput.value).toStrictEqual('');
 
     const descInput = screen.queryByRole('textbox', {
       name: 'Edit: Link description',
     });
-    expect(descInput.placeholder).toStrictEqual('Mixed');
+    expect(descInput.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
     expect(descInput.value).toStrictEqual('');
   });
 });

--- a/assets/src/edit-story/components/panels/test/sizePosition.js
+++ b/assets/src/edit-story/components/panels/test/sizePosition.js
@@ -24,9 +24,9 @@ import { fireEvent } from '@testing-library/react';
  */
 import SizePosition from '../sizePosition';
 import { getDefinitionForType } from '../../../elements';
-import { MULTIPLE_VALUE } from '../../form';
+import { MULTIPLE_VALUE, MULTIPLE_DISPLAY_VALUE } from '../../form';
 import { dataPixels } from '../../../units';
-import { MULTIPLE_DISPLAY_VALUE } from '../../form/multipleValue';
+
 import { renderPanel } from './_utils';
 
 jest.mock('../../../elements');

--- a/assets/src/edit-story/components/panels/test/sizePosition.js
+++ b/assets/src/edit-story/components/panels/test/sizePosition.js
@@ -26,6 +26,7 @@ import SizePosition from '../sizePosition';
 import { getDefinitionForType } from '../../../elements';
 import { MULTIPLE_VALUE } from '../../form';
 import { dataPixels } from '../../../units';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form/multipleValue';
 import { renderPanel } from './_utils';
 
 jest.mock('../../../elements');
@@ -416,6 +417,30 @@ describe('Panels/SizePosition', () => {
           width: 1000,
         })
       );
+    });
+
+    it('should display Mixed as placeholder in case of mixed values multi-selectio', () => {
+      const { getByRole } = renderSizePosition([
+        defaultText,
+        {
+          ...defaultImage,
+          width: 200,
+          height: 200,
+          rotationAngle: 20,
+        },
+      ]);
+
+      const height = getByRole('textbox', { name: 'Height' });
+      expect(height.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+      expect(height.value).toStrictEqual('');
+
+      const width = getByRole('textbox', { name: 'Width' });
+      expect(width.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+      expect(width.value).toStrictEqual('');
+
+      const rotationAngle = getByRole('textbox', { name: 'Rotation' });
+      expect(rotationAngle.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+      expect(rotationAngle.value).toStrictEqual('');
     });
   });
 });

--- a/assets/src/edit-story/components/panels/test/textStyle.js
+++ b/assets/src/edit-story/components/panels/test/textStyle.js
@@ -32,7 +32,7 @@ import DropDown from '../../form/dropDown';
 import FontPicker from '../../fontPicker';
 import ColorInput from '../../form/color/color';
 import createSolid from '../../../utils/createSolid';
-import { MULTIPLE_VALUE } from '../../form';
+import { MULTIPLE_VALUE, MULTIPLE_DISPLAY_VALUE } from '../../form';
 import { renderPanel } from './_utils';
 
 jest.mock('../../../utils/textMeasurements');
@@ -707,6 +707,73 @@ describe('Panels/TextStyle', () => {
       };
       renderTextStyle([textWithColor1, textWithColor2]);
       expect(controls['text.color'].value).toStrictEqual(MULTIPLE_VALUE);
+    });
+  });
+
+  describe('Mixed value multi-selection', () => {
+    it('should display Mixed value in case of mixed value multi-selection', () => {
+      const textElement1 = {
+        ...textElement,
+        font: {
+          family: 'Neu Font',
+          service: 'foo.bar.baz',
+          styles: ['italic', 'regular'],
+          weights: [400],
+          variants: [
+            [0, 400],
+            [1, 400],
+          ],
+          fallbacks: ['fallback1'],
+        },
+      };
+      const textElement2 = {
+        ...textElement,
+        font: {
+          name: 'ABeeZee',
+          value: 'ABeeZee',
+          service: 'foo.bar.baz',
+          weights: [400, 700],
+          styles: ['italic', 'regular'],
+          variants: [
+            [0, 400],
+            [1, 400],
+            [0, 700],
+          ],
+          fallbacks: ['serif'],
+        },
+        fontSize: 36,
+        padding: {
+          vertical: 1,
+          horizontal: 1,
+        },
+        lineHeight: 2.2,
+        content:
+          '<span style="font-weight: 700; letter-spacing: 0.2em">Hello world</span>',
+      };
+
+      const { getByRole } = renderTextStyle([textElement1, textElement2]);
+
+      const letterSpacing = getByRole('textbox', { name: 'Letter-spacing' });
+      expect(letterSpacing.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+
+      const lineHeight = getByRole('textbox', { name: 'Line-height' });
+      expect(lineHeight.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+
+      const fontSize = getByRole('textbox', { name: 'Font size' });
+      expect(fontSize.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+
+      const paddingH = getByRole('textbox', {
+        name: 'Edit: Horizontal padding',
+      });
+      expect(paddingH.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+
+      const paddingV = getByRole('textbox', { name: 'Edit: Vertical padding' });
+      expect(paddingV.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+
+      expect(controls.font.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+      expect(controls['font.weight'].placeholder).toStrictEqual(
+        MULTIPLE_DISPLAY_VALUE
+      );
     });
   });
 });

--- a/assets/src/edit-story/components/panels/test/videoAccessibility.js
+++ b/assets/src/edit-story/components/panels/test/videoAccessibility.js
@@ -23,6 +23,7 @@ import { fireEvent } from '@testing-library/react';
  * Internal dependencies
  */
 import VideoAccessibility, { MIN_MAX } from '../videoAccessibility';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form';
 import { renderPanel } from './_utils';
 
 jest.mock('../../mediaPicker', () => ({
@@ -34,6 +35,7 @@ jest.mock('../../mediaPicker', () => ({
 
 describe('Panels/VideoAccessibility', () => {
   const defaultElement = {
+    type: 'video',
     resource: { posterId: 0, title: '', poster: '', alt: '' },
   };
   function renderVideoAccessibility(...args) {
@@ -93,5 +95,26 @@ describe('Panels/VideoAccessibility', () => {
     expect(submits[defaultElement.id].resource.title).toHaveLength(
       MIN_MAX.TITLE.MAX
     );
+  });
+
+  it('should display Mixed as placeholder in case of mixed value multi-selection', () => {
+    const { getByRole } = renderVideoAccessibility([
+      defaultElement,
+      {
+        resource: {
+          posterId: 0,
+          title: 'Hello, video!',
+          poster: '',
+          alt: 'Hello!',
+        },
+      },
+    ]);
+    const title = getByRole('textbox', { name: 'Edit: Video title' });
+    expect(title.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+    expect(title).toHaveValue('');
+
+    const alt = getByRole('textbox', { name: 'Edit: Assistive text' });
+    expect(alt.placeholder).toStrictEqual(MULTIPLE_DISPLAY_VALUE);
+    expect(alt).toHaveValue('');
   });
 });

--- a/assets/src/edit-story/components/panels/textStyle/font.js
+++ b/assets/src/edit-story/components/panels/textStyle/font.js
@@ -29,7 +29,14 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Numeric, Row, DropDown, usePresubmitHandler } from '../../form';
+import {
+  Numeric,
+  Row,
+  DropDown,
+  usePresubmitHandler,
+  MULTIPLE_VALUE,
+  MULTIPLE_DISPLAY_VALUE,
+} from '../../form';
 import FontPicker from '../../fontPicker';
 import { useFont } from '../../../app/font';
 import { getCommonValue } from '../utils';
@@ -159,7 +166,8 @@ function FontControls({ selectedElements, pushUpdate }) {
             data-testid="font"
             aria-label={__('Font family', 'web-stories')}
             options={fonts}
-            value={fontFamily}
+            value={MULTIPLE_VALUE === fontFamily ? '' : fontFamily}
+            placeholder={MULTIPLE_DISPLAY_VALUE}
             onChange={handleFontPickerChange}
           />
         </Row>
@@ -170,9 +178,9 @@ function FontControls({ selectedElements, pushUpdate }) {
             <DropDown
               data-testid="font.weight"
               aria-label={__('Font weight', 'web-stories')}
-              placeholder={__('(multiple)', 'web-stories')}
+              placeholder={MULTIPLE_DISPLAY_VALUE}
               options={fontWeights}
-              value={fontWeight}
+              value={MULTIPLE_VALUE === fontWeight ? '' : fontWeight}
               onChange={handleFontWeightPickerChange}
             />
             <Space />

--- a/assets/src/edit-story/components/richText/karma/inlineSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/inlineSelection.karma.js
@@ -23,6 +23,7 @@ import { waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form';
 import { initHelpers } from './_utils';
 
 describe('CUJ: Creator can Add and Write Text: Select an individual word to edit', () => {
@@ -119,10 +120,10 @@ describe('CUJ: Creator can Add and Write Text: Select an individual word to edit
       expect(underline.checked).toBe(false);
 
       // Expect font weight, letter spacing and font color to be "multiple"
-      expect(fontWeight.value).toBe('(multiple)');
+      expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
       expect(letterSpacing.value).toBe('');
-      expect(letterSpacing.placeholder).toBe('Mixed');
-      expect(fontColor.output).toBe('Mixed');
+      expect(letterSpacing.placeholder).toBe(MULTIPLE_DISPLAY_VALUE);
+      expect(fontColor.output).toBe(MULTIPLE_DISPLAY_VALUE);
 
       // Now toggle all toggles, and set new color and letter spacing
       await data.fixture.events.click(italic.button);
@@ -258,7 +259,7 @@ describe('CUJ: Creator can Add and Write Text: Select an individual word to edit
 
         // Check that bold toggle is on but font weight is "multiple"
         expect(bold.checked).toBe(true);
-        expect(fontWeight.value).toBe('(multiple)');
+        expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
 
         // Toggle it by pressing the bold button
         await data.fixture.events.click(bold.button);
@@ -287,7 +288,7 @@ describe('CUJ: Creator can Add and Write Text: Select an individual word to edit
 
         // Check that bold toggle is off but font weight is "multiple"
         expect(bold.checked).toBe(false);
-        expect(fontWeight.value).toBe('(multiple)');
+        expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
 
         // Toggle it by pressing the bold button
         await data.fixture.events.click(bold.button);
@@ -322,7 +323,7 @@ describe('CUJ: Creator can Add and Write Text: Select an individual word to edit
 
         // Check that bold toggle is off but font weight is "multiple"
         expect(bold.checked).toBe(false);
-        expect(fontWeight.value).toBe('(multiple)');
+        expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
 
         // Toggle it by pressing the bold button
         await data.fixture.events.click(bold.button);

--- a/assets/src/edit-story/components/richText/karma/inlineSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/inlineSelection.karma.js
@@ -120,8 +120,8 @@ describe('CUJ: Creator can Add and Write Text: Select an individual word to edit
       // Expect font weight, letter spacing and font color to be "multiple"
       expect(fontWeight.value).toBe('(multiple)');
       expect(letterSpacing.value).toBe('');
-      expect(letterSpacing.placeholder).toBe('multiple');
-      expect(fontColor.output).toBe('Multiple');
+      expect(letterSpacing.placeholder).toBe('Mixed');
+      expect(fontColor.output).toBe('Mixed');
 
       // Now toggle all toggles, and set new color and letter spacing
       await data.fixture.events.click(italic.button);

--- a/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
@@ -144,8 +144,8 @@ describe('Styling multiple text fields', () => {
       expect(underline.checked).toBe(false);
       expect(fontWeight.value).toBe('(multiple)');
       expect(letterSpacing.value).toBe('');
-      expect(letterSpacing.placeholder).toBe('multiple');
-      expect(fontColor.output).toBe('Multiple');
+      expect(letterSpacing.placeholder).toBe('Mixed');
+      expect(fontColor.output).toBe('Mixed');
 
       // Toggle all styles
       await data.fixture.events.click(italic.button);

--- a/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
@@ -23,6 +23,7 @@ import { waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form';
 import { initHelpers } from './_utils';
 
 describe('Styling multiple text fields', () => {
@@ -144,10 +145,10 @@ describe('Styling multiple text fields', () => {
       expect(bold.checked).toBe(false);
       expect(italic.checked).toBe(false);
       expect(underline.checked).toBe(false);
-      expect(fontWeight.value).toBe('(multiple)');
+      expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
       expect(letterSpacing.value).toBe('');
-      expect(letterSpacing.placeholder).toBe('Mixed');
-      expect(fontColor.output).toBe('Mixed');
+      expect(letterSpacing.placeholder).toBe(MULTIPLE_DISPLAY_VALUE);
+      expect(fontColor.output).toBe(MULTIPLE_DISPLAY_VALUE);
 
       // Toggle all styles
       await data.fixture.events.click(italic.button);
@@ -211,7 +212,7 @@ describe('Styling multiple text fields', () => {
 
       // Check that bold toggle is on but font weight is "multiple"
       expect(bold.checked).toBe(true);
-      expect(fontWeight.value).toBe('(multiple)');
+      expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
 
       // Toggle it by pressing the bold button
       await data.fixture.events.click(bold.button);
@@ -248,7 +249,7 @@ describe('Styling multiple text fields', () => {
 
       // Check that bold toggle is off but font weight is "multiple"
       expect(bold.checked).toBe(false);
-      expect(fontWeight.value).toBe('(multiple)');
+      expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
 
       // Toggle it by pressing the bold button
       await data.fixture.events.click(bold.button);

--- a/assets/src/edit-story/components/richText/karma/singleSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/singleSelection.karma.js
@@ -145,8 +145,8 @@ describe('Styling single text field', () => {
       expect(underline.checked).toBe(false);
       expect(fontWeight.value).toBe('(multiple)');
       expect(letterSpacing.value).toBe('');
-      expect(letterSpacing.placeholder).toBe('multiple');
-      expect(fontColor.output).toBe('Multiple');
+      expect(letterSpacing.placeholder).toBe('Mixed');
+      expect(fontColor.output).toBe('Mixed');
 
       // Toggle all styles
       await data.fixture.events.click(italic.button);

--- a/assets/src/edit-story/components/richText/karma/singleSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/singleSelection.karma.js
@@ -23,6 +23,7 @@ import { waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form';
 import { initHelpers } from './_utils';
 
 describe('Styling single text field', () => {
@@ -145,10 +146,10 @@ describe('Styling single text field', () => {
       expect(bold.checked).toBe(false);
       expect(italic.checked).toBe(false);
       expect(underline.checked).toBe(false);
-      expect(fontWeight.value).toBe('(multiple)');
+      expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
       expect(letterSpacing.value).toBe('');
-      expect(letterSpacing.placeholder).toBe('Mixed');
-      expect(fontColor.output).toBe('Mixed');
+      expect(letterSpacing.placeholder).toBe(MULTIPLE_DISPLAY_VALUE);
+      expect(fontColor.output).toBe(MULTIPLE_DISPLAY_VALUE);
 
       // Toggle all styles
       await data.fixture.events.click(italic.button);
@@ -244,9 +245,9 @@ describe('Styling single text field', () => {
       await richTextHasFocus();
       await data.fixture.events.keyboard.press('Escape');
 
-      // Check that bold toggle is on but font weight is "multiple"
+      // Check that bold toggle is on but font weight is "mixed"
       expect(bold.checked).toBe(true);
-      expect(fontWeight.value).toBe('(multiple)');
+      expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
 
       // Toggle it by pressing the bold button
       await data.fixture.events.click(bold.button);
@@ -275,9 +276,9 @@ describe('Styling single text field', () => {
       await richTextHasFocus();
       await data.fixture.events.keyboard.press('Escape');
 
-      // Check that bold toggle is on but font weight is "multiple"
+      // Check that bold toggle is on but font weight is "mixed"
       expect(bold.checked).toBe(false);
-      expect(fontWeight.value).toBe('(multiple)');
+      expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
 
       // Toggle it by pressing the bold button
       await data.fixture.events.click(bold.button);
@@ -316,9 +317,9 @@ describe('Styling single text field', () => {
       await richTextHasFocus();
       await data.fixture.events.keyboard.press('Escape');
 
-      // Check that bold toggle is off but font weight is "multiple"
+      // Check that bold toggle is off but font weight is "mixed"
       expect(bold.checked).toBe(false);
-      expect(fontWeight.value).toBe('(multiple)');
+      expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
 
       // Toggle it by pressing the bold button
       await data.fixture.events.click(bold.button);


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

- [x] Tests

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
1. Add two elements of the same type (try with Text, Shape, Image, Video)
2. Set all the input values so that they would be different for the two elements.
3. Select the two elements.
4. Verify that "Mixed" is used in the inputs whenever the two values differ as opposed to "Multiple"

Note: There is a bug for Text elements where one element doesn't have a background and the other has -- in this case "Mixed" it not shown and the background of the element with the background is shown instead. Please ignore that when testing.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2088 
