### PR TITLE
Analytics: add events for bookend

### DIFF
--- a/includes/Analytics.php
+++ b/includes/Analytics.php
@@ -232,6 +232,28 @@ class Analytics {
 						'send_to'        => $tracking_id,
 					],
 				],
+				// Fired when the bookend is shown to the user, after the last page of the current story.
+				'storyBookendEnter'   => [
+					'on'      => 'story-bookend-enter',
+					'request' => 'event',
+					'vars'    => [
+						'event_name'     => 'custom',
+						'event_action'   => 'story_bookend_enter',
+						'event_category' => '${title}',
+						'send_to'        => $tracking_id,
+					],
+				],
+				// Fired when the bookend is dismissed by the user.
+				'storyBookendExit'    => [
+					'on'      => 'story-bookend-exit',
+					'request' => 'event',
+					'vars'    => [
+						'event_name'     => 'custom',
+						'event_action'   => 'story_bookend_exit',
+						'event_category' => '${title}',
+						'send_to'        => $tracking_id,
+					],
+				],
 			],
 		];
 


### PR DESCRIPTION
## Summary

After the last page of the current story the story player still shows the bookend. This PR adds the missing analytics events for those.

We didn't include these originally because it's eventually being deprecated. But since it's still there at the moment, I think it makes sense to add that.

## Relevant Technical Choices

Implemented enter & exit triggers as per https://github.com/ampproject/amphtml/blob/master/extensions/amp-story/amp-story-analytics.md

No `story-bookend-click` because we don't add custom items to the bookend.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

N/A

## Testing Instructions

Test GA events being fired using something like https://chrome.google.com/webstore/detail/google-analytics-and-segm/ppknjgihbmfcdmgdenblfomidfomhclp

---

<!-- Please reference the issue(s) this PR addresses. -->

See #4865
