### PR TITLE
Readme: add link to license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Visual storytelling for WordPress.
 [![Latest Release)](https://img.shields.io/github/v/release/google/web-stories-wp?include_prereleases)](https://github.com/google/web-stories-wp/releases)
 [![Commit activity](https://img.shields.io/github/commit-activity/m/google/web-stories-wp)](https://github.com/google/web-stories-wp/pulse/monthly)
 [![Code Coverage](https://codecov.io/gh/google/web-stories-wp/branch/main/graph/badge.svg)](https://codecov.io/gh/google/web-stories-wp)
-![License](https://img.shields.io/github/license/google/web-stories-wp)
+[![License](https://img.shields.io/github/license/google/web-stories-wp)](https://github.com/google/web-stories-wp/blob/main/LICENSE)
 
 <details>
 <summary>


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->
- Corrected License Badge Link 
- It now points to License file and not to License Badge Image.

## Changes

- On clicking License badge it should redirect to the following link :  
https://github.com/google/web-stories-wp/blob/main/LICENSE
- Refer #4888 

Fixes #4888 
