### PR TITLE
Design System Storybook (new theme colors)

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -18,6 +18,7 @@ module.exports = {
   stories: [
     './stories/**/*.js',
     '../assets/src/dashboard/**/stories/*.@(js|mdx)',
+    '../assets/src/design-system/**/stories/*.@(js|mdx)',
     '../assets/src/edit-story/**/stories/*.@(js|mdx)',
     '../assets/src/animation/**/stories/*.@(js|mdx)',
     '../assets/src/activation-notice/**/stories/*.@(js|mdx)',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -40,6 +40,11 @@ import DashboardKeyboardOnlyOutline from '../assets/src/dashboard/utils/keyboard
 import { ConfigProvider } from '../assets/src/dashboard/app/config';
 import ApiProvider from '../assets/src/dashboard/app/api/apiProvider';
 
+import {
+  theme as designSystemTheme,
+  lightMode,
+} from '../assets/src/design-system/theme';
+
 // @todo: Find better way to mock these.
 const wp = {};
 window.wp = window.wp || wp;
@@ -81,9 +86,10 @@ addParameters({
 addDecorator(withKnobs);
 
 addDecorator((story, { id }) => {
-  const useDashboardTheme = id.startsWith('dashboard');
+  const isDesignSystemStorybook = id.startsWith('designsystem');
+  const isDashboardStorybook = id.startsWith('dashboard');
 
-  if (useDashboardTheme) {
+  if (isDashboardStorybook) {
     return (
       <FlagsProvider features={{ enableAnimation: true }}>
         <ThemeProvider theme={dashboardTheme}>
@@ -100,6 +106,12 @@ addDecorator((story, { id }) => {
         </ThemeProvider>
       </FlagsProvider>
     );
+  }
+
+  if (isDesignSystemStorybook) {
+    // override darkMode colors
+    const dsTheme = { ...designSystemTheme, colors: { ...lightMode } };
+    return <ThemeProvider theme={dsTheme}>{story()}</ThemeProvider>;
   }
 
   return (

--- a/assets/src/design-system/index.js
+++ b/assets/src/design-system/index.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { theme, lightMode } from './theme';
+export * from './theme';

--- a/assets/src/design-system/index.js
+++ b/assets/src/design-system/index.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { theme, lightMode } from './theme';

--- a/assets/src/design-system/stories/index.js
+++ b/assets/src/design-system/stories/index.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 /**
@@ -32,83 +33,50 @@ const Row = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  & > h2 {
+    width: 100%;
+  }
 `;
 
 const Container = styled.div`
-  width: 200px;
-  height: 200px;
+  width: 100px;
+  height: 150px;
   display: flex;
+  margin-right: 20px;
   flex-direction: column;
   align-items: center;
 `;
 
 const ColorBlock = styled.span`
-  width: 60%;
-  height: 60%;
+  width: 75px;
+  height: 75px;
   border-radius: 50%;
   border: 1px solid gray;
   background-color: ${({ color }) => color};
 `;
 
 export const _default = () => {
-  const { brandColors, standard, accent, status } = dark;
-  const getColorSet = (color, idx) => (
-    <Container key={idx}>
-      <ColorBlock color={color} />
-      <p>{color}</p>
-    </Container>
-  );
-
-  const StandardColors = Object.values(standard).map(getColorSet);
-
-  const AccentColors = Object.values(accent).map(getColorSet);
-
-  const StatusColors = Object.values(status).map(getColorSet);
-
-  const fgLightColors = Object.values(light.fg).map(getColorSet);
-
-  const bgLightColors = Object.values(light.bg).map(getColorSet);
-
-  const fgDarkColors = Object.values(dark.fg).map(getColorSet);
-
-  const bgDarkColors = Object.values(dark.bg).map(getColorSet);
-
-  const brandColorsGray = Object.values(brandColors.gray).map(getColorSet);
-
-  const brandColorsViolet = Object.values(brandColors.violet).map(getColorSet);
-
-  const brandColorsBlue = Object.values(brandColors.blue).map(getColorSet);
-
-  const brandColorsRed = Object.values(brandColors.red).map(getColorSet);
-
-  const brandColorsGreen = Object.values(brandColors.green).map(getColorSet);
+  const [isDarkTheme, setIsDarkTheme] = useState(true);
+  const activeTheme = useMemo(() => (isDarkTheme ? dark : light), [
+    isDarkTheme,
+  ]);
 
   return (
-    <>
-      <h2>{'Standard Colors'}</h2>
-      <Row>{StandardColors}</Row>
-      <h2>{'Accent Colors'}</h2>
-      <Row>{AccentColors}</Row>
-      <h2>{'Status Colors'}</h2>
-      <Row>{StatusColors}</Row>
-      <h2>{'Dark Mode (default) - Foreground'}</h2>
-      <Row>{fgDarkColors}</Row>
-      <h2>{'Dark Mode (default) - Background'}</h2>
-      <Row>{bgDarkColors}</Row>
-      <h2>{'Light Mode (dashboard) - Foreground'}</h2>
-      <Row>{fgLightColors}</Row>
-      <h2>{'Light Mode (dashboard) - Background'}</h2>
-      <Row>{bgLightColors}</Row>
-      <h2>{'Brand Colors - Gray'}</h2>
-      <Row>{brandColorsGray}</Row>
-      <h2>{'Brand Colors - Violet'}</h2>
-      <Row>{brandColorsViolet}</Row>
-      <h2>{'Brand Colors - Blue'}</h2>
-      <Row>{brandColorsBlue}</Row>
-      <h2>{'Brand Colors - Red'}</h2>
-      <Row>{brandColorsRed}</Row>
-      <h2>{'Brand Colors - Green'}</h2>
-      <Row>{brandColorsGreen}</Row>
-    </>
+    <div>
+      <button onClick={() => setIsDarkTheme(!isDarkTheme)}>{`Toggle to ${
+        isDarkTheme ? 'light' : 'dark'
+      } theme`}</button>
+      {Object.keys(activeTheme).map((themeSection) => (
+        <Row key={themeSection}>
+          <h2>{themeSection}</h2>
+          {Object.keys(activeTheme[themeSection]).map((sectionValue) => (
+            <Container key={`${themeSection}_${sectionValue}`}>
+              <ColorBlock color={activeTheme[themeSection][sectionValue]} />
+              <p>{`${themeSection}.${sectionValue} (${activeTheme[themeSection][sectionValue]})`}</p>
+            </Container>
+          ))}
+        </Row>
+      ))}
+    </div>
   );
 };

--- a/assets/src/design-system/stories/index.js
+++ b/assets/src/design-system/stories/index.js
@@ -51,7 +51,7 @@ const ColorBlock = styled.span`
 `;
 
 export const _default = () => {
-  const { standard, accent, status } = dark;
+  const { brandColors, standard, accent, status } = dark;
   const getColorSet = (color, idx) => (
     <Container key={idx}>
       <ColorBlock color={color} />
@@ -73,6 +73,16 @@ export const _default = () => {
 
   const bgDarkColors = Object.values(dark.bg).map(getColorSet);
 
+  const brandColorsGray = Object.values(brandColors.gray).map(getColorSet);
+
+  const brandColorsViolet = Object.values(brandColors.violet).map(getColorSet);
+
+  const brandColorsBlue = Object.values(brandColors.blue).map(getColorSet);
+
+  const brandColorsRed = Object.values(brandColors.red).map(getColorSet);
+
+  const brandColorsGreen = Object.values(brandColors.green).map(getColorSet);
+
   return (
     <>
       <h2>{'Standard Colors'}</h2>
@@ -89,6 +99,16 @@ export const _default = () => {
       <Row>{fgLightColors}</Row>
       <h2>{'Light Mode (dashboard) - Background'}</h2>
       <Row>{bgLightColors}</Row>
+      <h2>{'Brand Colors - Gray'}</h2>
+      <Row>{brandColorsGray}</Row>
+      <h2>{'Brand Colors - Violet'}</h2>
+      <Row>{brandColorsViolet}</Row>
+      <h2>{'Brand Colors - Blue'}</h2>
+      <Row>{brandColorsBlue}</Row>
+      <h2>{'Brand Colors - Red'}</h2>
+      <Row>{brandColorsRed}</Row>
+      <h2>{'Brand Colors - Green'}</h2>
+      <Row>{brandColorsGreen}</Row>
     </>
   );
 };

--- a/assets/src/design-system/stories/index.js
+++ b/assets/src/design-system/stories/index.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { dark, light } from '../theme/colors';
+
+export default {
+  title: 'DesignSystem/Colors',
+};
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+`;
+
+const Container = styled.div`
+  width: 200px;
+  height: 200px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const ColorBlock = styled.span`
+  width: 60%;
+  height: 60%;
+  border-radius: 50%;
+  border: 1px solid gray;
+  background-color: ${({ color }) => color};
+`;
+
+export const _default = () => {
+  const { standard, accent, status } = dark;
+  const getColorSet = (color, idx) => (
+    <Container key={idx}>
+      <ColorBlock color={color} />
+      <p>{color}</p>
+    </Container>
+  );
+
+  const StandardColors = Object.values(standard).map(getColorSet);
+
+  const AccentColors = Object.values(accent).map(getColorSet);
+
+  const StatusColors = Object.values(status).map(getColorSet);
+
+  const fgLightColors = Object.values(light.fg).map(getColorSet);
+
+  const bgLightColors = Object.values(light.bg).map(getColorSet);
+
+  const fgDarkColors = Object.values(dark.fg).map(getColorSet);
+
+  const bgDarkColors = Object.values(dark.bg).map(getColorSet);
+
+  return (
+    <>
+      <h2>{'Standard Colors'}</h2>
+      <Row>{StandardColors}</Row>
+      <h2>{'Accent Colors'}</h2>
+      <Row>{AccentColors}</Row>
+      <h2>{'Status Colors'}</h2>
+      <Row>{StatusColors}</Row>
+      <h2>{'Dark Mode (default) - Foreground'}</h2>
+      <Row>{fgDarkColors}</Row>
+      <h2>{'Dark Mode (default) - Background'}</h2>
+      <Row>{bgDarkColors}</Row>
+      <h2>{'Light Mode (dashboard) - Foreground'}</h2>
+      <Row>{fgLightColors}</Row>
+      <h2>{'Light Mode (dashboard) - Background'}</h2>
+      <Row>{bgLightColors}</Row>
+    </>
+  );
+};

--- a/assets/src/design-system/theme/colors.js
+++ b/assets/src/design-system/theme/colors.js
@@ -18,7 +18,7 @@
 // colors related to light or dark mode are nested in colors.light or colors.dark
 // it's important that the object structure be the same so that eventually we can flip from dark to light theme, vic versa
 
-const brandColors = {
+const brand = {
   gray: {
     60: '#2F3131',
     50: '#414442',
@@ -53,8 +53,8 @@ const brandColors = {
   },
 };
 const accent = {
-  primary: brandColors.violet[30],
-  secondary: brandColors.blue[30],
+  primary: brand.violet[30],
+  secondary: brand.blue[30],
 };
 const status = {
   negative: '#D93025',
@@ -69,7 +69,7 @@ export const dark = {
   standard,
   accent,
   status,
-  brandColors,
+  ...brand,
   fg: {
     primary: '#EDEFEC',
     secondary: '#A1A09B',
@@ -90,7 +90,7 @@ export const light = {
   standard,
   accent,
   status,
-  brandColors,
+  ...brand,
   fg: {
     primary: '#181D1C',
     secondary: '#5E615C',

--- a/assets/src/design-system/theme/colors.js
+++ b/assets/src/design-system/theme/colors.js
@@ -18,9 +18,43 @@
 // colors related to light or dark mode are nested in colors.light or colors.dark
 // it's important that the object structure be the same so that eventually we can flip from dark to light theme, vic versa
 
+const brandColors = {
+  gray: {
+    60: '#2F3131',
+    50: '#414442',
+    40: '#5E615C',
+    30: '#767570',
+    20: '#A1A09B',
+    10: '#EDEFEC',
+  },
+  violet: {
+    60: '#6343CB',
+    40: '#9A72EC',
+    30: '#CBACFF',
+    10: '#DFCDFE',
+  },
+  blue: {
+    60: '#3E4796',
+    40: '#5A72D0',
+    30: '#79B3FF',
+    10: '#C2DDFF',
+  },
+  red: {
+    60: '#A92217',
+    40: '#D84F35',
+    30: '#F28B82',
+    10: '#F6C6C6',
+  },
+  green: {
+    60: '#325E37',
+    40: '#518F58',
+    30: '#81C995',
+    10: '#CEE6D2',
+  },
+};
 const accent = {
-  primary: '#CBACFF',
-  secondary: '#79B3FF',
+  primary: brandColors.violet[30],
+  secondary: brandColors.blue[30],
 };
 const status = {
   negative: '#D93025',
@@ -35,6 +69,7 @@ export const dark = {
   standard,
   accent,
   status,
+  brandColors,
   fg: {
     primary: '#EDEFEC',
     secondary: '#A1A09B',
@@ -55,6 +90,7 @@ export const light = {
   standard,
   accent,
   status,
+  brandColors,
   fg: {
     primary: '#181D1C',
     secondary: '#5E615C',

--- a/assets/src/design-system/theme/colors.js
+++ b/assets/src/design-system/theme/colors.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// colors that are not subject to light or dark mode are stored in colors.
+// colors related to light or dark mode are nested in colors.light or colors.dark
+// it's important that the object structure be the same so that eventually we can flip from dark to light theme, vic versa
+
+const accent = {
+  primary: '#CBACFF',
+  secondary: '#79B3FF',
+};
+const status = {
+  negative: '#D93025',
+  positive: '#188038',
+};
+const standard = {
+  black: '#000',
+  white: '#FFF',
+};
+
+export const dark = {
+  standard,
+  accent,
+  status,
+  fg: {
+    primary: '#EDEFEC',
+    secondary: '#A1A09B',
+    tertiary: '#767570',
+    gray24: '#5E615C',
+    gray16: '#414442',
+    gray8: '#2F3131',
+  },
+  bg: {
+    primary: standard.black,
+    workspace: '#1B1D1C',
+    panel: '#282A2A',
+    divider: standard.white,
+  },
+};
+
+export const light = {
+  standard,
+  accent,
+  status,
+  fg: {
+    primary: '#181D1C',
+    secondary: '#5E615C',
+    tertiary: '#767570',
+    gray24: '#A1A09B',
+    gray16: '#D1D1CC',
+    gray8: '#EFEFEF',
+  },
+  bg: {
+    primary: standard.white,
+    workspace: '#FCFCFC',
+    panel: '#F7F8F7',
+    divider: '#1B1D1C',
+  },
+};

--- a/assets/src/design-system/theme/index.js
+++ b/assets/src/design-system/theme/index.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { dark as darkMode, light as lightMode } from './colors';
+
+export const theme = {
+  colors: { ...darkMode },
+};
+
+export { lightMode };


### PR DESCRIPTION
## Summary
Establishes a new subdirectory within /assets for the new design system, beginning with theme colors (light and dark mode) 
Colors for reference: https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Design-System?node-id=1286%3A457091

## Relevant Technical Choices

- By developing the new design system in a neutral location we should be able to reference components in both dashboard and the editor. After discussing with Sam, I will be starting in on this process with the Dashboard - which is significantly less complex - think this will be a good place to stress test a bit before affecting the editor. 
- Separated light and dark themes so it can eventually be user set. For the sake of my own use case with the dashboard, I'm overriding the default dark mode with light.
- Began scaffolding out some structure

## To-do

- Typography next, then icons 

## User-facing changes

- None, just a new storybook subdirectory. 

## Testing Instructions

- Verify you now see a design systems directory in storybook and that the theme colors render there. 

![Screen Shot 2020-10-13 at 5 02 29 PM](https://user-images.githubusercontent.com/10720454/95928310-e6d53800-0d75-11eb-902d-550e6bf1a1a7.png)

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
