### PR TITLE
Text Style: Reset font weight to regular on font family change

### DIFF
--- a/assets/src/edit-story/components/panels/test/textStyle.js
+++ b/assets/src/edit-story/components/panels/test/textStyle.js
@@ -32,6 +32,7 @@ import DropDown from '../../form/dropDown';
 import FontPicker from '../../fontPicker';
 import ColorInput from '../../form/color/color';
 import createSolid from '../../../utils/createSolid';
+import CanvasContext from '../../canvas/context';
 import { MULTIPLE_VALUE, MULTIPLE_DISPLAY_VALUE } from '../../form';
 import { renderPanel } from './_utils';
 
@@ -44,23 +45,47 @@ const DEFAULT_PADDING = { horizontal: 0, vertical: 0, locked: true };
 
 function Wrapper({ children }) {
   return (
-    <FontContext.Provider
+    <CanvasContext.Provider
       value={{
-        state: {
-          fonts: [
-            {
-              name: 'ABeeZee',
-              value: 'ABeeZee',
-              service: 'foo.bar.baz',
-              weights: [400],
-              styles: ['italic', 'regular'],
-              variants: [
-                [0, 400],
-                [1, 400],
-              ],
-              fallbacks: ['serif'],
-            },
-            {
+        state: {},
+        actions: {
+          clearEditing: jest.fn(),
+        },
+      }}
+    >
+      <FontContext.Provider
+        value={{
+          state: {
+            fonts: [
+              {
+                name: 'ABeeZee',
+                value: 'ABeeZee',
+                service: 'foo.bar.baz',
+                weights: [400],
+                styles: ['italic', 'regular'],
+                variants: [
+                  [0, 400],
+                  [1, 400],
+                ],
+                fallbacks: ['serif'],
+              },
+              {
+                name: 'Neu Font',
+                value: 'Neu Font',
+                service: 'foo.bar.baz',
+                weights: [400],
+                styles: ['italic', 'regular'],
+                variants: [
+                  [0, 400],
+                  [1, 400],
+                ],
+                fallbacks: ['fallback1'],
+              },
+            ],
+          },
+          actions: {
+            maybeEnqueueFontStyle: () => Promise.resolve(),
+            getFontByName: () => ({
               name: 'Neu Font',
               value: 'Neu Font',
               service: 'foo.bar.baz',
@@ -71,33 +96,18 @@ function Wrapper({ children }) {
                 [1, 400],
               ],
               fallbacks: ['fallback1'],
-            },
-          ],
-        },
-        actions: {
-          maybeEnqueueFontStyle: () => Promise.resolve(),
-          getFontByName: () => ({
-            name: 'Neu Font',
-            value: 'Neu Font',
-            service: 'foo.bar.baz',
-            weights: [400],
-            styles: ['italic', 'regular'],
-            variants: [
-              [0, 400],
-              [1, 400],
-            ],
-            fallbacks: ['fallback1'],
-          }),
-          addRecentFont: jest.fn(),
-        },
-      }}
-    >
-      <RichTextContext.Provider
-        value={{ state: {}, actions: { selectionActions: {} } }}
+            }),
+            addRecentFont: jest.fn(),
+          },
+        }}
       >
-        {children}
-      </RichTextContext.Provider>
-    </FontContext.Provider>
+        <RichTextContext.Provider
+          value={{ state: {}, actions: { selectionActions: {} } }}
+        >
+          {children}
+        </RichTextContext.Provider>
+      </FontContext.Provider>
+    </CanvasContext.Provider>
   );
 }
 

--- a/assets/src/edit-story/components/panels/textStyle/font.js
+++ b/assets/src/edit-story/components/panels/textStyle/font.js
@@ -75,9 +75,7 @@ function FontControls({ selectedElements, pushUpdate }) {
     handlers: { handleSelectFontWeight, handleResetFontWeight },
   } = useRichTextFormatting(selectedElements, pushUpdate);
 
-  const { clearEditing } = useCanvas(({ actions: { clearEditing } }) => {
-    return { clearEditing };
-  });
+  const { clearEditing } = useCanvas(({ actions: { clearEditing } }) => ({ clearEditing }));
 
   const {
     fonts,

--- a/assets/src/edit-story/components/panels/textStyle/font.js
+++ b/assets/src/edit-story/components/panels/textStyle/font.js
@@ -75,7 +75,9 @@ function FontControls({ selectedElements, pushUpdate }) {
     handlers: { handleSelectFontWeight, handleResetFontWeight },
   } = useRichTextFormatting(selectedElements, pushUpdate);
 
-  const { clearEditing } = useCanvas(({ actions: { clearEditing } }) => ({ clearEditing }));
+  const { clearEditing } = useCanvas(({ actions: { clearEditing } }) => ({
+    clearEditing,
+  }));
 
   const {
     fonts,

--- a/assets/src/edit-story/components/panels/textStyle/getClosestFontWeight.js
+++ b/assets/src/edit-story/components/panels/textStyle/getClosestFontWeight.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns a number representing closest available font weight to previously selected.
+ *
+ * @param {number} existingWeight previously selected font weight value to get as close to as possible, defaults to 400 (normal).
+ * @param {Array<string>} availableWeights available font weights for newly selected font.
+ * @return {number} Closest font weight available for given font.
+ */
+
+const DEFAULT_FONT_WEIGHT = 400;
+
+function getClosestFontWeight(
+  existingWeight = DEFAULT_FONT_WEIGHT,
+  availableWeights
+) {
+  existingWeight = parseInt(existingWeight);
+  // if the passed in existing weight is "(multiple)" we want to reset the value for the new font family in use
+  if (isNaN(parseInt(existingWeight))) {
+    return DEFAULT_FONT_WEIGHT;
+  }
+
+  if (!availableWeights || availableWeights.length === 0) {
+    return existingWeight;
+  }
+
+  return availableWeights.reduce((a, b) => {
+    a = parseInt(a);
+    b = parseInt(b);
+
+    let aDiff = Math.abs(a - existingWeight);
+    let bDiff = Math.abs(b - existingWeight);
+
+    if (aDiff === bDiff) {
+      return a < b ? a : b;
+    }
+
+    return bDiff < aDiff ? b : a;
+  });
+}
+
+export default getClosestFontWeight;

--- a/assets/src/edit-story/components/panels/textStyle/test/getClosestFontWeight.js
+++ b/assets/src/edit-story/components/panels/textStyle/test/getClosestFontWeight.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import getClosestFontWeight from '../getClosestFontWeight';
+
+describe('getClosestFontWeight', () => {
+  it('should return existing font weight when no availableWeights are present', () => {
+    const result = getClosestFontWeight(300);
+    expect(result).toBe(300);
+  });
+
+  it('should return default 400 font weight when no existingWeight or availableWeights are present', () => {
+    const result = getClosestFontWeight();
+    expect(result).toBe(400);
+  });
+
+  it('should return 600 when availableWeight of 600 is present and existingWeight is 600', () => {
+    const result = getClosestFontWeight(600, [100, 300, 600, 700]);
+    expect(result).toBe(600);
+  });
+
+  it('should return 600 when availableWeight of 600 is present even when weights are not listed in ascending order and existingWeight is 600', () => {
+    const result = getClosestFontWeight(600, [700, 300, 600, 100]);
+    expect(result).toBe(600);
+  });
+
+  it('should return 400 when availableWeights are [100, 300, 400, 600] and existingWeight is 500', () => {
+    const result = getClosestFontWeight(500, [100, 300, 400, 600]);
+    expect(result).toBe(400);
+  });
+
+  it('should return 400 when availableWeights are [600, 300, 400, 100] even when not listed in ascending order and existingWeight is 500', () => {
+    const result = getClosestFontWeight(500, [600, 300, 400, 400]);
+    expect(result).toBe(400);
+  });
+
+  it('should return 800 when availableWeights are [400, 800] and existingWeight is 700', () => {
+    const result = getClosestFontWeight(700, [400, 800]);
+    expect(result).toBe(800);
+  });
+});

--- a/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
+++ b/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
@@ -128,9 +128,8 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
 
     return {
       handleClickBold: (flag) => push(htmlFormatters.toggleBold, flag),
-      handleSelectFontWeight: (weight) => {
-        push(htmlFormatters.setFontWeight, weight);
-      },
+      handleSelectFontWeight: (weight) =>
+        push(htmlFormatters.setFontWeight, weight),
       handleClickItalic: (flag) => push(htmlFormatters.toggleItalic, flag),
       handleClickUnderline: (flag) =>
         push(htmlFormatters.toggleUnderline, flag),

--- a/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
+++ b/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
@@ -107,6 +107,8 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
 
   const handlers = useMemo(() => {
     const htmlFormatters = getHTMLFormatters();
+    const handleResetFontWeight = (weight) =>
+      push(htmlFormatters.setFontWeight, weight);
 
     if (hasCurrentEditor) {
       return {
@@ -116,30 +118,25 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
         handleClickBold: () => selectionActions.toggleBoldInSelection(),
         // All these keep their arguments:
         handleSelectFontWeight: selectionActions.setFontWeightInSelection,
-        handleResetFontWeight: (weight) => {
-          push(htmlFormatters.setFontWeight, weight);
-        },
         handleClickItalic: selectionActions.toggleItalicInSelection,
         handleClickUnderline: selectionActions.toggleUnderlineInSelection,
         handleSetLetterSpacing: selectionActions.setLetterSpacingInSelection,
         handleSetColor: selectionActions.setColorInSelection,
+        handleResetFontWeight,
       };
     }
 
     return {
       handleClickBold: (flag) => push(htmlFormatters.toggleBold, flag),
-      handleSelectFontWeight: (weight) => {
-        push(htmlFormatters.setFontWeight, weight);
-      },
-      handleResetFontWeight: (weight) => {
-        push(htmlFormatters.setFontWeight, weight);
-      },
+      handleSelectFontWeight: (weight) =>
+        push(htmlFormatters.setFontWeight, weight),
       handleClickItalic: (flag) => push(htmlFormatters.toggleItalic, flag),
       handleClickUnderline: (flag) =>
         push(htmlFormatters.toggleUnderline, flag),
       handleSetLetterSpacing: (letterSpacing) =>
         push(htmlFormatters.setLetterSpacing, letterSpacing),
       handleSetColor: (color) => push(htmlFormatters.setColor, color),
+      handleResetFontWeight,
     };
   }, [hasCurrentEditor, selectionActions, push]);
 

--- a/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
+++ b/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
@@ -128,8 +128,9 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
 
     return {
       handleClickBold: (flag) => push(htmlFormatters.toggleBold, flag),
-      handleSelectFontWeight: (weight) =>
-        push(htmlFormatters.setFontWeight, weight),
+      handleSelectFontWeight: (weight) => {
+        push(htmlFormatters.setFontWeight, weight);
+      },
       handleClickItalic: (flag) => push(htmlFormatters.toggleItalic, flag),
       handleClickUnderline: (flag) =>
         push(htmlFormatters.toggleUnderline, flag),

--- a/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
+++ b/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
@@ -106,6 +106,8 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
   );
 
   const handlers = useMemo(() => {
+    const htmlFormatters = getHTMLFormatters();
+
     if (hasCurrentEditor) {
       return {
         // This particular function ignores the flag argument.
@@ -114,6 +116,9 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
         handleClickBold: () => selectionActions.toggleBoldInSelection(),
         // All these keep their arguments:
         handleSelectFontWeight: selectionActions.setFontWeightInSelection,
+        handleResetFontWeight: (weight) => {
+          push(htmlFormatters.setFontWeight, weight);
+        },
         handleClickItalic: selectionActions.toggleItalicInSelection,
         handleClickUnderline: selectionActions.toggleUnderlineInSelection,
         handleSetLetterSpacing: selectionActions.setLetterSpacingInSelection,
@@ -121,12 +126,14 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
       };
     }
 
-    const htmlFormatters = getHTMLFormatters();
-
     return {
       handleClickBold: (flag) => push(htmlFormatters.toggleBold, flag),
-      handleSelectFontWeight: (weight) =>
-        push(htmlFormatters.setFontWeight, weight),
+      handleSelectFontWeight: (weight) => {
+        push(htmlFormatters.setFontWeight, weight);
+      },
+      handleResetFontWeight: (weight) => {
+        push(htmlFormatters.setFontWeight, weight);
+      },
       handleClickItalic: (flag) => push(htmlFormatters.toggleItalic, flag),
       handleClickUnderline: (flag) =>
         push(htmlFormatters.toggleUnderline, flag),

--- a/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
@@ -147,7 +147,7 @@ describe('Styling multiple text fields', () => {
       expect(bold.checked).toBe(false);
       expect(italic.checked).toBe(false);
       expect(underline.checked).toBe(false);
-      expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
+      expect(fontWeight.value).toBe('Regular');
       expect(letterSpacing.value).toBe('');
       expect(letterSpacing.placeholder).toBe(MULTIPLE_DISPLAY_VALUE);
       expect(fontColor.output).toBe(MULTIPLE_DISPLAY_VALUE);

--- a/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
@@ -147,7 +147,7 @@ describe('Styling multiple text fields', () => {
       expect(bold.checked).toBe(false);
       expect(italic.checked).toBe(false);
       expect(underline.checked).toBe(false);
-      expect(fontWeight.value).toBe('Regular');
+      expect(fontWeight.value).toBe('Mixed');
       expect(letterSpacing.value).toBe('');
       expect(letterSpacing.placeholder).toBe(MULTIPLE_DISPLAY_VALUE);
       expect(fontColor.output).toBe(MULTIPLE_DISPLAY_VALUE);

--- a/assets/src/edit-story/karma/textStyle.cuj.karma.js
+++ b/assets/src/edit-story/karma/textStyle.cuj.karma.js
@@ -75,10 +75,10 @@ describe('Element: Text', () => {
     it('should apply the selected font', async () => {
       await fixture.events.keyboard.type('Yrsa');
       // Ensure the debounced callback has taken effect.
-      await wait(TIMEOUT);
+      await fixture.events.sleep(TIMEOUT);
       const option = fixture.screen.getByText('Yrsa');
       await fixture.events.click(option);
-      await wait(TIMEOUT);
+      await fixture.events.sleep(TIMEOUT);
       await openFontPicker();
       const selected = fixture.screen.getAllByRole('option', {
         name: 'Selected Yrsa',
@@ -104,7 +104,7 @@ describe('Element: Text', () => {
       it('should display the correct fonts when searching', async () => {
         await fixture.events.keyboard.type('Ab');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         let options = document
           .getElementById('editor-font-picker-list')
           .querySelectorAll('li[role="option"]');
@@ -114,7 +114,7 @@ describe('Element: Text', () => {
 
         await fixture.events.keyboard.type('el');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         options = document
           .getElementById('editor-font-picker-list')
           .querySelectorAll('li[role="option"]');
@@ -125,7 +125,7 @@ describe('Element: Text', () => {
       it('should not search with less than 2 characters', async () => {
         await fixture.events.keyboard.type('A');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         let options = document
           .getElementById('editor-font-picker-list')
           .querySelectorAll('li[role="option"]');
@@ -135,7 +135,7 @@ describe('Element: Text', () => {
       it('should restore default fonts list when emptying search', async () => {
         await fixture.events.keyboard.type('Ab');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         const options = document
           .getElementById('editor-font-picker-list')
           .querySelectorAll('li[role="option"]');
@@ -143,7 +143,7 @@ describe('Element: Text', () => {
 
         await fixture.events.keyboard.press('Backspace');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         const defaultOptions = document
           .getElementById('editor-font-picker-list')
           .querySelectorAll('li[role="option"]');
@@ -154,7 +154,7 @@ describe('Element: Text', () => {
       it('should show empty list in case of no results', async () => {
         await fixture.events.keyboard.type('No fonts here');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         expect(fixture.screen.getByText('No matches found')).toBeDefined();
       });
     });
@@ -170,10 +170,10 @@ describe('Element: Text', () => {
       it('should add up to 5 recent fonts, displaying the most recent first', async () => {
         await fixture.events.keyboard.type('Space Mono');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         let option = fixture.screen.getByText('Space Mono');
         await fixture.events.click(option);
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         await openFontPicker();
 
         let options = document
@@ -184,10 +184,10 @@ describe('Element: Text', () => {
 
         await fixture.events.keyboard.type('Abel');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         option = fixture.screen.getByText('Abel');
         await fixture.events.click(option);
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         await openFontPicker();
         options = document
           .getElementById('editor-font-picker-list')
@@ -196,10 +196,10 @@ describe('Element: Text', () => {
 
         await fixture.events.keyboard.type('Abhaya Libre');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         option = fixture.screen.getByText('Abhaya Libre');
         await fixture.events.click(option);
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         await openFontPicker();
         options = document
           .getElementById('editor-font-picker-list')
@@ -208,10 +208,10 @@ describe('Element: Text', () => {
 
         await fixture.events.keyboard.type('Source Serif Pro');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         option = fixture.screen.getByText('Source Serif Pro');
         await fixture.events.click(option);
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         await openFontPicker();
         options = document
           .getElementById('editor-font-picker-list')
@@ -220,10 +220,10 @@ describe('Element: Text', () => {
 
         await fixture.events.keyboard.type('Roboto');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         option = fixture.screen.getByText('Roboto');
         await fixture.events.click(option);
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         await openFontPicker();
         options = document
           .getElementById('editor-font-picker-list')
@@ -232,10 +232,10 @@ describe('Element: Text', () => {
 
         await fixture.events.keyboard.type('Yrsa');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         option = fixture.screen.getByText('Yrsa');
         await fixture.events.click(option);
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         await openFontPicker();
 
         options = document
@@ -251,7 +251,7 @@ describe('Element: Text', () => {
       it('should display the selected recent font with a tick', async () => {
         const option = fixture.screen.getByText('Source Serif Pro');
         await fixture.events.click(option);
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         await openFontPicker();
         const selected = fixture.screen.getAllByRole('option', {
           name: 'Selected Source Serif Pro',
@@ -262,15 +262,15 @@ describe('Element: Text', () => {
 
       it('should include recent fonts to search', async () => {
         await fixture.events.keyboard.type('Abe');
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         const option = fixture.screen.getByText('Abel');
         await fixture.events.click(option);
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         await openFontPicker();
 
         await fixture.events.keyboard.type('Abe');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         let options = document
           .getElementById('editor-font-picker-list')
           .querySelectorAll('li[role="option"]');
@@ -290,7 +290,7 @@ describe('Element: Text', () => {
 
         await fixture.events.keyboard.type('Ubuntu');
         // Ensure the debounced callback has taken effect.
-        await wait(TIMEOUT);
+        await fixture.events.sleep(TIMEOUT);
         const selected = fixture.screen.getAllByRole('option', {
           name: 'Selected Ubuntu',
         });
@@ -307,11 +307,32 @@ describe('Element: Text', () => {
         );
       });
     });
+
+    it('should reset font weights when font family is updated', async () => {
+      await fixture.events.keyboard.type('Yrsa');
+      // Ensure the debounced callback has taken effect.
+      await fixture.events.sleep(TIMEOUT);
+      const option = fixture.screen.getByText('Yrsa');
+      await fixture.events.click(option);
+      await fixture.events.sleep(TIMEOUT);
+
+      const { fontWeight } = fixture.editor.inspector.designPanel.textStyle;
+      expect(fontWeight.value).toBe('Regular');
+
+      await fixture.events.click(fontWeight.select);
+      await fixture.events.click(fontWeight.option('Bold'));
+      expect(fontWeight.value).toBe('Bold');
+
+      await openFontPicker();
+
+      await fixture.events.keyboard.type('Roboto');
+      // Ensure the debounced callback has taken effect.
+      await fixture.events.sleep(TIMEOUT);
+      const option2 = fixture.screen.getByText('Roboto');
+      await fixture.events.click(option2);
+      await fixture.events.sleep(TIMEOUT);
+
+      expect(fontWeight.value).toBe('Regular');
+    });
   });
 });
-
-function wait(ms) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}

--- a/assets/src/edit-story/karma/textStyle.cuj.karma.js
+++ b/assets/src/edit-story/karma/textStyle.cuj.karma.js
@@ -93,7 +93,7 @@ describe('Element: Text', () => {
       expect(elements[1].font.family).toBe('Yrsa');
     });
 
-    it('should reset font weights when font family is updated', async () => {
+    it('should reset font weight when font family is updated', async () => {
       await fixture.events.keyboard.type('Yrsa');
       // Ensure the debounced callback has taken effect.
       await fixture.events.sleep(TIMEOUT);
@@ -106,6 +106,7 @@ describe('Element: Text', () => {
 
       await fixture.events.click(fontWeight.select);
       await fixture.events.click(fontWeight.option('Bold'));
+      await fixture.events.sleep(TIMEOUT);
       expect(fontWeight.value).toBe('Bold');
 
       await openFontPicker();
@@ -116,8 +117,10 @@ describe('Element: Text', () => {
       const option2 = fixture.screen.getByText('Roboto');
       await fixture.events.click(option2);
       await fixture.events.sleep(600);
+      const updatedFontWeight =
+        fixture.editor.inspector.designPanel.textStyle.fontWeight;
 
-      expect(fontWeight.value).toBe('Regular');
+      expect(updatedFontWeight.value).toBe('Regular');
     });
 
     it('should display only the fonts from curated list by default', () => {

--- a/assets/src/edit-story/karma/textStyle.cuj.karma.js
+++ b/assets/src/edit-story/karma/textStyle.cuj.karma.js
@@ -330,7 +330,7 @@ describe('Element: Text', () => {
       await fixture.events.sleep(TIMEOUT);
       const option2 = fixture.screen.getByText('Roboto');
       await fixture.events.click(option2);
-      await fixture.events.sleep(TIMEOUT);
+      await fixture.events.sleep(500);
 
       expect(fontWeight.value).toBe('Regular');
     });

--- a/assets/src/edit-story/karma/textStyle.cuj.karma.js
+++ b/assets/src/edit-story/karma/textStyle.cuj.karma.js
@@ -93,6 +93,33 @@ describe('Element: Text', () => {
       expect(elements[1].font.family).toBe('Yrsa');
     });
 
+    it('should reset font weights when font family is updated', async () => {
+      await fixture.events.keyboard.type('Yrsa');
+      // Ensure the debounced callback has taken effect.
+      await fixture.events.sleep(TIMEOUT);
+      const option = fixture.screen.getByText('Yrsa');
+      await fixture.events.click(option);
+      await fixture.events.sleep(TIMEOUT);
+
+      const { fontWeight } = fixture.editor.inspector.designPanel.textStyle;
+      expect(fontWeight.value).toBe('Regular');
+
+      await fixture.events.click(fontWeight.select);
+      await fixture.events.click(fontWeight.option('Bold'));
+      expect(fontWeight.value).toBe('Bold');
+
+      await openFontPicker();
+
+      await fixture.events.keyboard.type('Roboto');
+      // Ensure the debounced callback has taken effect.
+      await fixture.events.sleep(TIMEOUT);
+      const option2 = fixture.screen.getByText('Roboto');
+      await fixture.events.click(option2);
+      await fixture.events.sleep(600);
+
+      expect(fontWeight.value).toBe('Regular');
+    });
+
     it('should display only the fonts from curated list by default', () => {
       const options = document
         .getElementById('editor-font-picker-list')
@@ -306,33 +333,6 @@ describe('Element: Text', () => {
           document.getElementById('editor-font-picker-list')
         );
       });
-    });
-
-    it('should reset font weights when font family is updated', async () => {
-      await fixture.events.keyboard.type('Yrsa');
-      // Ensure the debounced callback has taken effect.
-      await fixture.events.sleep(TIMEOUT);
-      const option = fixture.screen.getByText('Yrsa');
-      await fixture.events.click(option);
-      await fixture.events.sleep(TIMEOUT);
-
-      const { fontWeight } = fixture.editor.inspector.designPanel.textStyle;
-      expect(fontWeight.value).toBe('Regular');
-
-      await fixture.events.click(fontWeight.select);
-      await fixture.events.click(fontWeight.option('Bold'));
-      expect(fontWeight.value).toBe('Bold');
-
-      await openFontPicker();
-
-      await fixture.events.keyboard.type('Roboto');
-      // Ensure the debounced callback has taken effect.
-      await fixture.events.sleep(TIMEOUT);
-      const option2 = fixture.screen.getByText('Roboto');
-      await fixture.events.click(option2);
-      await fixture.events.sleep(500);
-
-      expect(fontWeight.value).toBe('Regular');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Resets the font weight to 400 or as close to 400 as is available in a given font family's weight options when a new font family is selected for a text element 

## Relevant Technical Choices
- After significant back and forth and nailing down functionality, with Morten's direction was able to clear the selection when a new font family is selected in a dropdown, then apply a new font weight (regular or as close to it as possible). 
- The `clearEditing` is key here since the font family could be getting changed from inline the text element or with the whole thing selected. This enables us to make sure the new font weight is applied across the entire text element. 
- Added a new handler to useRichTextElement hook to always look to the entire element to set font weight, regardless of where the selection things it is, it'll get reset with the await for clearing the selection, but this is helpful since there's a lot of updating happening and we don't want it to get out of whack - plus it makes it clearer that there's new functionality happening here.
- I abandoned this other PR (https://github.com/google/web-stories-wp/pull/4734), but copied over the changes to how karma tests were waiting to use the fixture


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- When you change a text element's font family the font weight will reset to 400 or as near to it is available in that font family's available weights. 

## Testing Instructions

- Edit a story or create a new story, get a text element and mess with the font weights, now select a new font family, see that the font weight(s) are reset to 400 - no more inline weights, no "multiple" values when that font family is changed. 

**Bungee reg (only option for this font) to open sans condensed (doesn't have 400 font weight)**
![bungee reg to open sans condensed light](https://user-images.githubusercontent.com/10720454/96056455-785aad80-0e3b-11eb-8dd8-6cd361111e83.gif)

**Roboto with multiple font weights to Bungee (only has 400 font weight)**
![roboto multi to bungee regular](https://user-images.githubusercontent.com/10720454/96056470-83154280-0e3b-11eb-8b64-56fa2ae88cf1.gif)

**Open Sans Condensed with some inline bold to Roboto**
![open sans inline bold to roboto regular](https://user-images.githubusercontent.com/10720454/96056473-83add900-0e3b-11eb-8694-7c3d43648528.gif)


Bug reproduction:
```
Add text element
Assign font family Open Sans Condensed, font weight Light
Now change the font family to Playball
See "multiple" as the font weight.
```

Now:
```
Add text element
Assign font family Open Sans Condensed, font weight Light
Now change the font family to Playball
**See "Regular" as the font weight.**
```


---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #1899 