### PR TITLE
Workspace: Enable Tenor GIF integration in editor

### DIFF
--- a/assets/src/edit-story/app/media/media3p/providerConfiguration.js
+++ b/assets/src/edit-story/app/media/media3p/providerConfiguration.js
@@ -94,7 +94,6 @@ export const PROVIDERS = {
   },
   [ProviderType.TENOR]: {
     displayName: __('GIFs', 'web-stories'),
-    featureName: 'showGifTab',
     contentTypeFilter: ContentType.GIF,
     supportsCategories: true,
     requiresAuthorAttribution: false,

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -360,18 +360,6 @@ class Experiments {
 				'description' => __( 'Enable incremental search in the Upload and Third-party media tabs.', 'web-stories' ),
 				'group'       => 'editor',
 			],
-			/**
-			 * Description: Flag for showing the Gif Media3p subtab.
-			 * Author: @diegovar
-			 * Issue: #3349
-			 * Creation date: 2020-08-28
-			 */
-			[
-				'name'        => 'showGifTab',
-				'label'       => __( 'GIFs', 'web-stories' ),
-				'description' => __( 'Enable the GIF tab in the Third-party media tab.', 'web-stories' ),
-				'group'       => 'editor',
-			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

[#4599 - Release Third Party GIF Integration](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/4599). The majority of the work for releasing the 3P gifs feature is in the base branch for this PR, or [here](https://github.com/google/web-stories-wp/pull/4885)

## Relevant Technical Choices

- Removed the `featureName` from the 3P provider
- Removed "GIFs" from Experiments, show the GIF tab to release it

## To-do

- Rendering Tenor gifs as videos in preview/publish should be merged to main before GIFs are released (linked in summary above). That branch does not need QA

## User-facing changes

- GIFs tab now shown under images in the editor:

<img width="354" alt="Screen Shot 2020-10-15 at 12 31 01 PM" src="https://user-images.githubusercontent.com/41136059/96177182-4cdece00-0ee2-11eb-8a1c-5e564007d112.png">

## Testing Instructions

- Launch WordPress admin and go to Stories/Experiments
- Verify the Show GIFs Tab label and checkbox are not available
- Launch editor
- Go to the Images section in the media gallery
- Confirm that `GIFs` appears after `Video` and `Images`
- Trending Tenor GIFs appear in the media gallery after clicking on GIFs

---

#4599 
