### PR TITLE
Animations: Animation Parts Seen as a Limited Effect to user

### DIFF
--- a/assets/src/animation/constants.js
+++ b/assets/src/animation/constants.js
@@ -74,10 +74,6 @@ export const ANIMATION_EFFECTS = {
   },
 };
 
-/*
- * @TODO See what Sam wants the user facing names of these animation
- *       parts to be here & update `name` field.
- */
 export const ANIMATION_PARTS = {
   BLINK_ON: {
     value: ANIMATION_TYPES.BLINK_ON,

--- a/assets/src/animation/constants.js
+++ b/assets/src/animation/constants.js
@@ -74,6 +74,28 @@ export const ANIMATION_EFFECTS = {
   },
 };
 
+/*
+ * @TODO See what Sam wants the user facing names of these animation
+ *       parts to be here & update `name` field.
+ */
+export const ANIMATION_PARTS = {
+  BLINK_ON: {
+    value: ANIMATION_TYPES.BLINK_ON,
+    name: __('Blink On', 'web-stories'),
+  },
+  BOUNCE: { value: ANIMATION_TYPES.BOUNCE, name: __('Bounce', 'web-stories') },
+  FADE: { value: ANIMATION_TYPES.FADE, name: __('Fade', 'web-stories') },
+  FLIP: { value: ANIMATION_TYPES.FLIP, name: __('Flip', 'web-stories') },
+  FLOAT_ON: {
+    value: ANIMATION_TYPES.FLOAT_ON,
+    name: __('Float On', 'web-stories'),
+  },
+  MOVE: { value: ANIMATION_TYPES.MOVE, name: __('Move', 'web-stories') },
+  PULSE: { value: ANIMATION_TYPES.PULSE, name: __('Pulse', 'web-stories') },
+  SPIN: { value: ANIMATION_TYPES.SPIN, name: __('Spin', 'web-stories') },
+  ZOOM: { value: ANIMATION_TYPES.ZOOM, name: __('Zoom', 'web-stories') },
+};
+
 export const DIRECTION = {
   TOP_TO_BOTTOM: 'topToBottom',
   RIGHT_TO_LEFT: 'rightToLeft',

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -28,7 +28,10 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { ANIMATION_EFFECTS } from '../../../../animation/constants';
+import {
+  ANIMATION_EFFECTS,
+  ANIMATION_PARTS,
+} from '../../../../animation/constants';
 import {
   getAnimationEffectProps,
   AnimationProps,
@@ -39,7 +42,10 @@ import EffectInput from './effectInput';
 
 function getEffectName(type) {
   return (
-    Object.values(ANIMATION_EFFECTS).find((o) => o.value === type)?.name || ''
+    [
+      ...Object.values(ANIMATION_EFFECTS),
+      ...Object.values(ANIMATION_PARTS),
+    ].find((o) => o.value === type)?.name || ''
   );
 }
 


### PR DESCRIPTION
## Summary
Adds support for the user to view name, `delete`, and alter `duration` or `delay` of an animation part. Basically makes it look like an animation effect, but with a limited interface to the user.

## Relevant Technical Choices
Seems like most the work was already done for this except showing the animation part name which I added in.

## To-do
~Clarify exactly what user facing names Sam wants to give the animation parts in the panel~

## User-facing changes
none

## Testing Instructions
Make sure all animation flags are turned on. Create a story out of one of the templates. Click on an object that is animated in the template and see that the animation parts applied to that template now have a name. `Move` is a good one to see that is only an animation part and not an animation effect.

Here's some screen shots of some animation parts working:
<img width="301" alt="Screen Shot 2020-10-15 at 3 33 22 PM" src="https://user-images.githubusercontent.com/35983235/96188353-ce8f2580-0efb-11eb-8f55-5beb65ddf041.png">
<img width="1010" alt="Screen Shot 2020-10-15 at 3 32 06 PM" src="https://user-images.githubusercontent.com/35983235/96188358-cf27bc00-0efb-11eb-83da-81994f563993.png">



---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3805 
