### PR TITLE
Add mbstring polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "ampproject/amp-wp": "^2.0.4",
     "civicrm/composer-downloads-plugin": "^2.1",
     "cweagans/composer-patches": "^1.6",
-    "mcaskill/composer-exclude-files": "^2.0"
+    "mcaskill/composer-exclude-files": "^2.0",
+    "symfony/polyfill-mbstring": "^1.18"
   },
   "provide": {
     "ampproject/common": "dev-develop",
@@ -64,7 +65,10 @@
       "Google\\Web_Stories\\": "includes",
       "AmpProject\\": "vendor/ampproject/amp-wp/lib/common/src",
       "AmpProject\\Optimizer\\": "vendor/ampproject/amp-wp/lib/optimizer/src"
-    }
+    },
+    "files": [
+      "includes/polyfills/mbstring.php"
+    ]
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f4ae95bd05b42e789735da2e57121a6",
+    "content-hash": "6c895b167936648ce453ce6cfe8243b3",
     "packages": [
         {
             "name": "ampproject/amp-wp",
@@ -348,6 +348,83 @@
                 "stylesheet"
             ],
             "time": "2020-08-03T15:45:50+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.18.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "togos/gitignore",

--- a/includes/polyfills/mbstring.php
+++ b/includes/polyfills/mbstring.php
@@ -1,0 +1,219 @@
+<?php
+/*
+ * Adapted from the polyfill-mbstring Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// This is is a copy of symfony/polyfill-mbstring/bootstrap.php.
+// The file is not used directly because after running through PHP-Scoper
+// it won't be in the global scope anymore.
+
+use Google\Web_Stories_Dependencies\Symfony\Polyfill\Mbstring as Google_Web_Stories_Mbstring;
+
+if ( ! function_exists( 'mb_convert_encoding' ) ) {
+	function mb_convert_encoding( $s, $to, $from = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_convert_encoding( $s, $to, $from );
+	}
+}
+if ( ! function_exists( 'mb_decode_mimeheader' ) ) {
+	function mb_decode_mimeheader( $s ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_decode_mimeheader( $s );
+	}
+}
+if ( ! function_exists( 'mb_encode_mimeheader' ) ) {
+	function mb_encode_mimeheader( $s, $charset = null, $transferEnc = null, $lf = null, $indent = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_encode_mimeheader( $s, $charset, $transferEnc, $lf, $indent );
+	}
+}
+if ( ! function_exists( 'mb_decode_numericentity' ) ) {
+	function mb_decode_numericentity( $s, $convmap, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_decode_numericentity( $s, $convmap, $enc );
+	}
+}
+if ( ! function_exists( 'mb_encode_numericentity' ) ) {
+	function mb_encode_numericentity( $s, $convmap, $enc = null, $is_hex = false ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_encode_numericentity( $s, $convmap, $enc, $is_hex );
+	}
+}
+if ( ! function_exists( 'mb_convert_case' ) ) {
+	function mb_convert_case( $s, $mode, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_convert_case( $s, $mode, $enc );
+	}
+}
+if ( ! function_exists( 'mb_internal_encoding' ) ) {
+	function mb_internal_encoding( $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_internal_encoding( $enc );
+	}
+}
+if ( ! function_exists( 'mb_language' ) ) {
+	function mb_language( $lang = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_language( $lang );
+	}
+}
+if ( ! function_exists( 'mb_list_encodings' ) ) {
+	function mb_list_encodings() {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_list_encodings();
+	}
+}
+if ( ! function_exists( 'mb_encoding_aliases' ) ) {
+	function mb_encoding_aliases( $encoding ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_encoding_aliases( $encoding );
+	}
+}
+if ( ! function_exists( 'mb_check_encoding' ) ) {
+	function mb_check_encoding( $var = null, $encoding = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_check_encoding( $var, $encoding );
+	}
+}
+if ( ! function_exists( 'mb_detect_encoding' ) ) {
+	function mb_detect_encoding( $str, $encodingList = null, $strict = false ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_detect_encoding( $str, $encodingList, $strict );
+	}
+}
+if ( ! function_exists( 'mb_detect_order' ) ) {
+	function mb_detect_order( $encodingList = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_detect_order( $encodingList );
+	}
+}
+if ( ! function_exists( 'mb_parse_str' ) ) {
+	function mb_parse_str( $s, &$result = [] ) {
+		parse_str( $s, $result );
+	}
+}
+if ( ! function_exists( 'mb_strlen' ) ) {
+	function mb_strlen( $s, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_strlen( $s, $enc );
+	}
+}
+if ( ! function_exists( 'mb_strpos' ) ) {
+	function mb_strpos( $s, $needle, $offset = 0, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_strpos( $s, $needle, $offset, $enc );
+	}
+}
+if ( ! function_exists( 'mb_strtolower' ) ) {
+	function mb_strtolower( $s, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_strtolower( $s, $enc );
+	}
+}
+if ( ! function_exists( 'mb_strtoupper' ) ) {
+	function mb_strtoupper( $s, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_strtoupper( $s, $enc );
+	}
+}
+if ( ! function_exists( 'mb_substitute_character' ) ) {
+	function mb_substitute_character( $char = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_substitute_character( $char );
+	}
+}
+if ( ! function_exists( 'mb_substr' ) ) {
+	function mb_substr( $s, $start, $length = 2147483647, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_substr( $s, $start, $length, $enc );
+	}
+}
+if ( ! function_exists( 'mb_stripos' ) ) {
+	function mb_stripos( $s, $needle, $offset = 0, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_stripos( $s, $needle, $offset, $enc );
+	}
+}
+if ( ! function_exists( 'mb_stristr' ) ) {
+	function mb_stristr( $s, $needle, $part = false, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_stristr( $s, $needle, $part, $enc );
+	}
+}
+if ( ! function_exists( 'mb_strrchr' ) ) {
+	function mb_strrchr( $s, $needle, $part = false, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_strrchr( $s, $needle, $part, $enc );
+	}
+}
+if ( ! function_exists( 'mb_strrichr' ) ) {
+	function mb_strrichr( $s, $needle, $part = false, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_strrichr( $s, $needle, $part, $enc );
+	}
+}
+if ( ! function_exists( 'mb_strripos' ) ) {
+	function mb_strripos( $s, $needle, $offset = 0, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_strripos( $s, $needle, $offset, $enc );
+	}
+}
+if ( ! function_exists( 'mb_strrpos' ) ) {
+	function mb_strrpos( $s, $needle, $offset = 0, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_strrpos( $s, $needle, $offset, $enc );
+	}
+}
+if ( ! function_exists( 'mb_strstr' ) ) {
+	function mb_strstr( $s, $needle, $part = false, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_strstr( $s, $needle, $part, $enc );
+	}
+}
+if ( ! function_exists( 'mb_get_info' ) ) {
+	function mb_get_info( $type = 'all' ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_get_info( $type );
+	}
+}
+if ( ! function_exists( 'mb_http_output' ) ) {
+	function mb_http_output( $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_http_output( $enc );
+	}
+}
+if ( ! function_exists( 'mb_strwidth' ) ) {
+	function mb_strwidth( $s, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_strwidth( $s, $enc );
+	}
+}
+if ( ! function_exists( 'mb_substr_count' ) ) {
+	function mb_substr_count( $haystack, $needle, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_substr_count( $haystack, $needle, $enc );
+	}
+}
+if ( ! function_exists( 'mb_output_handler' ) ) {
+	function mb_output_handler( $contents, $status ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_output_handler( $contents, $status );
+	}
+}
+if ( ! function_exists( 'mb_http_input' ) ) {
+	function mb_http_input( $type = '' ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_http_input( $type );
+	}
+}
+if ( ! function_exists( 'mb_convert_variables' ) ) {
+	function mb_convert_variables( $toEncoding, $fromEncoding, &$a = null, &$b = null, &$c = null, &$d = null, &$e = null, &$f = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_convert_variables( $toEncoding, $fromEncoding, $a, $b, $c, $d, $e, $f );
+	}
+}
+if ( ! function_exists( 'mb_ord' ) ) {
+	function mb_ord( $s, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_ord( $s, $enc );
+	}
+}
+if ( ! function_exists( 'mb_chr' ) ) {
+	function mb_chr( $code, $enc = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_chr( $code, $enc );
+	}
+}
+if ( ! function_exists( 'mb_scrub' ) ) {
+	function mb_scrub( $s, $enc = null ) {
+		$enc = null === $enc ? mb_internal_encoding() : $enc;
+		return mb_convert_encoding( $s, $enc, $enc );
+	}
+}
+if ( ! function_exists( 'mb_str_split' ) ) {
+	function mb_str_split( $string, $split_length = 1, $encoding = null ) {
+		return Google_Web_Stories_Mbstring\Mbstring::mb_str_split( $string, $split_length, $encoding );
+	}
+}
+if ( extension_loaded( 'mbstring' ) ) {
+	return;
+}
+if ( ! defined( 'MB_CASE_UPPER' ) ) {
+	define( 'MB_CASE_UPPER', 0 );
+}
+if ( ! defined( 'MB_CASE_LOWER' ) ) {
+	define( 'MB_CASE_LOWER', 1 );
+}
+if ( ! defined( 'MB_CASE_TITLE' ) ) {
+	define( 'MB_CASE_TITLE', 2 );
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -80,6 +80,7 @@
 	<exclude-pattern>*/third-party/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>assets/js/*.asset.php</exclude-pattern>
+	<exclude-pattern>includes/polyfills/mbstring.php</exclude-pattern>
 	<exclude-pattern>tests/phpstan/*</exclude-pattern>
 	<exclude-pattern>tests/phpunit/includes/MarkupComparison.php</exclude-pattern>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,6 +20,7 @@ parameters:
     - includes/
   excludes_analyse:
     - includes/vendor/*
+    - includes/polyfills/*
   scanDirectories:
     - third-party/
   scanFiles:

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -142,6 +142,20 @@ return [
 			->in( 'vendor/sabberworm/php-css-parser' )
 			->append( [ 'vendor/sabberworm/php-css-parser/composer.json' ] ),
 
+		// Symfony mbstring polyfill.
+		Finder::create()
+			->files()
+			->ignoreVCS( true )
+			->ignoreDotFiles( true )
+			->name( '*.php' )
+			->in( 'vendor/symfony/polyfill-mbstring/Resources' )
+			->append(
+				[
+					'vendor/symfony/polyfill-mbstring/Mbstring.php',
+					'vendor/symfony/polyfill-mbstring/composer.json',
+				]
+			),
+
 		// Main composer.json file so that we can build a classmap.
 		Finder::create()
 			->append( [ 'composer.json' ] ),


### PR DESCRIPTION
## Summary

Adds a polyfill for mbstring if it's missing on the server.

The polyfill Mbstring code is prefixed in order to avoid conflicts with other plugins using the same  library.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

N/A

## Testing Instructions

N/A

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4898 
