### PR TITLE
Embed Block: Do not use amp-story-player in `save` function

### DIFF
--- a/assets/src/story-embed-block/block/deprecated.js
+++ b/assets/src/story-embed-block/block/deprecated.js
@@ -19,11 +19,6 @@
  */
 import PropTypes from 'prop-types';
 
-/**
- * Internal dependencies
- */
-import StoryPlayer from './storyPlayer';
-
 const blockAttributes = {
   url: {
     type: 'string',
@@ -71,13 +66,22 @@ function save({ attributes }) {
 
   return (
     <div className={`wp-block-web-stories-embed align${align}`}>
-      <StoryPlayer
-        url={url}
-        title={title}
-        poster={poster}
-        width={width}
-        height={height}
-      />
+      <amp-story-player
+        style={{
+          width: width ? `${width}px` : undefined,
+          height: height ? `${height}px` : undefined,
+        }}
+        data-testid="amp-story-player"
+      >
+        <a
+          href={url}
+          style={{
+            ['--story-player-poster']: poster ? `url('${poster}')` : undefined,
+          }}
+        >
+          {title}
+        </a>
+      </amp-story-player>
     </div>
   );
 }

--- a/assets/src/story-embed-block/block/deprecated.js
+++ b/assets/src/story-embed-block/block/deprecated.js
@@ -20,6 +20,35 @@
 import PropTypes from 'prop-types';
 
 /**
+ * Internal dependencies
+ */
+import StoryPlayer from './storyPlayer';
+
+const blockAttributes = {
+  url: {
+    type: 'string',
+  },
+  title: {
+    type: 'string',
+  },
+  poster: {
+    type: 'string',
+  },
+  width: {
+    type: 'number',
+    default: 360,
+  },
+  height: {
+    type: 'number',
+    default: 600,
+  },
+  align: {
+    type: 'string',
+    default: 'none',
+  },
+};
+
+/**
  * The block's save function (pure).
  *
  * Represents a cached copy of the block’s content to be shown in case
@@ -42,13 +71,13 @@ function save({ attributes }) {
 
   return (
     <div className={`wp-block-web-stories-embed align${align}`}>
-      <a href={url}>
-        {poster ? (
-          <img alt={title} src={poster} width={width} height={height} />
-        ) : (
-          title
-        )}
-      </a>
+      <StoryPlayer
+        url={url}
+        title={title}
+        poster={poster}
+        width={width}
+        height={height}
+      />
     </div>
   );
 }
@@ -64,4 +93,11 @@ save.propTypes = {
   }).isRequired,
 };
 
-export default save;
+const deprecated = [
+  {
+    attributes: blockAttributes,
+    save,
+  },
+];
+
+export default deprecated;

--- a/assets/src/story-embed-block/block/index.js
+++ b/assets/src/story-embed-block/block/index.js
@@ -24,6 +24,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { ReactComponent as icon } from './icon.svg';
 import metadata from './block.json';
+import deprecated from './deprecated';
 import edit from './edit';
 import save from './save';
 import transforms from './transforms';
@@ -58,6 +59,7 @@ const settings = {
   },
   edit,
   save,
+  deprecated,
   transforms,
 };
 

--- a/assets/src/story-embed-block/block/test/save.js
+++ b/assets/src/story-embed-block/block/test/save.js
@@ -36,16 +36,29 @@ describe('save', () => {
       <div
         class="wp-block-web-stories-embed alignnone"
       >
-        <amp-story-player
-          data-testid="amp-story-player"
+        <a
+          href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp"
         >
-          <a
-            href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp"
-            style="--story-player-poster: url('https://amp.dev/static/samples/img/story_dog2_portrait.jpg');"
-          >
-            Stories in AMP
-          </a>
-        </amp-story-player>
+          <img
+            alt="Stories in AMP"
+            src="https://amp.dev/static/samples/img/story_dog2_portrait.jpg"
+          />
+        </a>
+      </div>
+    `);
+  });
+
+  it('should render nothing if poster is missing', () => {
+    const { container } = render(<Save attributes={{ url, title }} />);
+    expect(container.firstChild).toMatchInlineSnapshot(`
+      <div
+        class="wp-block-web-stories-embed alignnone"
+      >
+        <a
+          href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp"
+        >
+          Stories in AMP
+        </a>
       </div>
     `);
   });

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -28,8 +28,11 @@
 
 namespace Google\Web_Stories;
 
+use Google\Web_Stories\Model\Story;
+use Google\Web_Stories\Story_Renderer\Image;
 use WP_Post;
 use WP_Screen;
+
 
 /**
  * Admin class.
@@ -110,49 +113,28 @@ class Admin {
 			return $content;
 		}
 
-		$block_markup_with_poster = <<<BLOCK
-<!-- wp:web-stories/embed {"url":"%1\$s","title":"%2\$s","poster":"%3\$s"} -->
-<div class="wp-block-web-stories-embed alignnone">
-	<amp-story-player style="width:360px;height:600px" data-testid="amp-story-player"><a
-			href="%1\$s"
-			style="--story-player-poster:url('%3\$s')">%4\$s</a>
-	</amp-story-player>
-</div>
-<!-- /wp:web-stories/embed -->
-BLOCK;
-
-		$block_markup_without_poster = <<<BLOCK
-<!-- wp:web-stories/embed {"url":"%1\$s","title":"%2\$s","poster":""} -->
-<div class="wp-block-web-stories-embed alignnone">
-	<amp-story-player style="width:360px;height:600px" data-testid="amp-story-player"><a
-			href="%1\$s"
-			>%3\$s</a>
-	</amp-story-player>
-</div>
-<!-- /wp:web-stories/embed -->
-BLOCK;
-
-		$url        = (string) get_the_permalink( $post_id );
-		$title      = (string) get_the_title( $post_id );
-		$has_poster = has_post_thumbnail( $post_id );
-
-		if ( $has_poster ) {
-			$poster = (string) wp_get_attachment_image_url( (int) get_post_thumbnail_id( $post_id ), Media::POSTER_PORTRAIT_IMAGE_SIZE );
-
-			return sprintf(
-				$block_markup_with_poster,
-				esc_url( $url ),
-				esc_js( $title ),
-				esc_url( $poster ),
-				esc_html( $title )
-			);
+		$story = new Story();
+		if ( ! $story->load_from_post( $post_id ) ) {
+			return $content;
 		}
 
+		$renderer = new Image( $story );
+		$args     = [
+			'align'  => 'none',
+			'height' => 600,
+			'width'  => 360,
+		];
+
+		$html = $renderer->render( $args );
+
+		$block_markup = '<!-- wp:web-stories/embed {"url":"%1$s","title":"%2$s","poster":"%3$s"} -->%4$s<!-- /wp:web-stories/embed -->';
+
 		return sprintf(
-			$block_markup_without_poster,
-			esc_url( $url ),
-			esc_js( $title ),
-			esc_html( $title )
+			$block_markup,
+			esc_url( $story->get_url() ),
+			esc_js( $story->get_title() ),
+			esc_url( $story->get_poster_portrait() ),
+			$html
 		);
 	}
 

--- a/tests/e2e/specs/editor/__snapshots__/publishingFlow.js.snap
+++ b/tests/e2e/specs/editor/__snapshots__/publishingFlow.js.snap
@@ -2,6 +2,6 @@
 
 exports[`Publishing Flow should guide me towards creating a new post to embed my story 1`] = `
 "<!-- wp:web-stories/embed {\\"url\\":\\"http://localhost:8899/web-stories/publishing-flow-test\\",\\"title\\":\\"Publishing Flow Test\\",\\"poster\\":\\"\\"} -->
-<div class=\\"wp-block-web-stories-embed alignnone\\"><amp-story-player style=\\"width:360px;height:600px\\" data-testid=\\"amp-story-player\\"><a href=\\"http://localhost:8899/web-stories/publishing-flow-test\\">Publishing Flow Test</a></amp-story-player></div>
+<div class=\\"wp-block-web-stories-embed alignnone\\"><a href=\\"http://localhost:8899/web-stories/publishing-flow-test\\">Publishing Flow Test</a></div>
 <!-- /wp:web-stories/embed -->"
 `;


### PR DESCRIPTION
## Summary

Change the fallback contents of a block to a image, so if a user disabled the plugin, the story will work, kind of. 

## Relevant Technical Choices

Have reused the image story render class. 
I have improvement some of the tests for save. 

I haven't added tests for the duplication. I couldn't find a good example of this in gutenberg. Is it even possible to test this?

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4907