### PR TITLE
Workspace: Font variant bug

### DIFF
--- a/assets/src/edit-story/components/richText/getFontVariants.js
+++ b/assets/src/edit-story/components/richText/getFontVariants.js
@@ -48,31 +48,22 @@ function getVariants(editorState) {
     return [getFontStylesForCharacter(editorState.getCurrentInlineStyle())];
   }
 
-  const styles = [];
-  const hasStyle = (style) =>
-    styles.some((val) => val[0] === style[0] && val[1] === style[1]);
-  styleSets.forEach((styleSet) => {
-    const styleArray = getFontStylesForCharacter(styleSet);
-
-    if (!hasStyle(styleArray)) {
-      styles.push(styleArray);
-    }
+  const styles = styleSets.map((styleSet) => {
+    const [style = ''] = getFontStylesForCharacter(styleSet);
+    return style;
   });
-
-  return [...styles];
+  return [...new Set(styles)];
 }
 
 export default function getFontVariants(html) {
   const htmlState = getSelectAllStateFromHTML(html);
-  const variants = getVariants(htmlState)
-    .filter((variant) => variant.length)
-    .map((variant) => {
-      const weight = variant.find((val) => val.startsWith(WEIGHT));
-      return [
-        Number(variant.includes(ITALIC)),
-        weight ? styleToNumeric(WEIGHT, weight) : 400,
-      ];
-    });
+  const variants = getVariants(htmlState).map((variant) => {
+    return [
+      variant.startsWith(ITALIC) ? 1 : 0,
+      variant.startsWith(WEIGHT) ? styleToNumeric(WEIGHT, variant) : 400,
+    ];
+  });
+
   // Return default variant or the found variants.
   return variants.length > 0 ? variants : [[0, 400]];
 }

--- a/assets/src/edit-story/components/richText/getFontVariants.js
+++ b/assets/src/edit-story/components/richText/getFontVariants.js
@@ -45,24 +45,23 @@ function getFontStylesForCharacter(styles) {
 function getVariants(editorState) {
   const styleSets = getAllStyleSetsInSelection(editorState);
   if (styleSets.length === 0) {
-    return [getFontStylesForCharacter(editorState.getCurrentInlineStyle())];
+    return [...getFontStylesForCharacter(editorState.getCurrentInlineStyle())];
   }
-
   const styles = styleSets.map((styleSet) => {
     const [style = ''] = getFontStylesForCharacter(styleSet);
+
     return style;
   });
+
   return [...new Set(styles)];
 }
 
 export default function getFontVariants(html) {
   const htmlState = getSelectAllStateFromHTML(html);
-  const variants = getVariants(htmlState).map((variant) => {
-    return [
-      variant.startsWith(ITALIC) ? 1 : 0,
-      variant.startsWith(WEIGHT) ? styleToNumeric(WEIGHT, variant) : 400,
-    ];
-  });
+  const variants = getVariants(htmlState).map((variant) => [
+    variant.startsWith(ITALIC) ? 1 : 0,
+    variant.startsWith(WEIGHT) ? styleToNumeric(WEIGHT, variant) : 400,
+  ]);
 
   // Return default variant or the found variants.
   return variants.length > 0 ? variants : [[0, 400]];

--- a/assets/src/edit-story/components/richText/getFontVariants.js
+++ b/assets/src/edit-story/components/richText/getFontVariants.js
@@ -45,7 +45,7 @@ function getFontStylesForCharacter(styles) {
 function getVariants(editorState) {
   const styleSets = getAllStyleSetsInSelection(editorState);
   if (styleSets.length === 0) {
-    return [...getFontStylesForCharacter(editorState.getCurrentInlineStyle())];
+    return getFontStylesForCharacter(editorState.getCurrentInlineStyle());
   }
   const styles = styleSets.map((styleSet) => {
     const [style = ''] = getFontStylesForCharacter(styleSet);

--- a/assets/src/edit-story/components/richText/test/getFontVariants.js
+++ b/assets/src/edit-story/components/richText/test/getFontVariants.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import getFontVariants from '../getFontVariants';
+
+describe('getfontVariants', () => {
+  it('should produce correct variants', () => {
+    const htmlContent =
+      '<span style="font-weight: 700">F</span>ill in some text';
+    const expected = [
+      [0, 700],
+      [0, 400],
+    ];
+    const actual = getFontVariants(htmlContent);
+
+    expect(actual).toStrictEqual(expected);
+  });
+});

--- a/assets/src/edit-story/output/utils/getFontDeclarations.js
+++ b/assets/src/edit-story/output/utils/getFontDeclarations.js
@@ -106,6 +106,7 @@ const getFontDeclarations = (pages) => {
         break;
     }
   }
+
   return fontDeclarations;
 };
 

--- a/assets/src/edit-story/utils/test/getGoogleFontURL.js
+++ b/assets/src/edit-story/utils/test/getGoogleFontURL.js
@@ -36,6 +36,15 @@ describe('getGoogleFontURL', () => {
         [0, 400],
       ],
     };
+
+    const roboto_400_700 = {
+      family: 'Roboto',
+      variants: [
+        [0, 400],
+        [0, 700],
+      ],
+    };
+
     const lato_300i_900i = {
       family: 'Lato',
       variants: [
@@ -70,6 +79,9 @@ describe('getGoogleFontURL', () => {
     );
     expect(getGoogleFontURL([roboto_400_400i])).toStrictEqual(
       'https://fonts.googleapis.com/css2?display=swap&family=Roboto%3Aital%400%3B1'
+    );
+    expect(getGoogleFontURL([roboto_400_700])).toStrictEqual(
+      'https://fonts.googleapis.com/css2?display=swap&family=Roboto%3Awght%40400%3B700'
     );
     expect(getGoogleFontURL([roboto_100_400])).toStrictEqual(
       'https://fonts.googleapis.com/css2?display=swap&family=Roboto%3Awght%40100%3B400'


### PR DESCRIPTION
## Summary

This PR resolves the bug where not all variants were loading in preview when text contained more than one.

## Relevant Technical Choices

- Refactored `getVariants` and `getFontVariants` to ensure `[0,400]` is added if there is plain text.

## User-facing changes

- All font variants should load, render, and be visible in preview mode.

## Testing Instructions

1. Import the following base64 story data to a new story:
```
ewogICJjdXJyZW50IjogImE2YzM2YzMwLWY0NzktNDk5Zi1iMWZjLWU4MGVjZTRlM2RhZCIsCiAgInNlbGVjdGlvbiI6IFsKICAgICI0N2NmNjVlMy04MGY4LTRkY2UtYjE5MS1jOGRlMGQ5NTAxZTMiCiAgXSwKICAic3RvcnkiOiB7CiAgICAic3R5bGVQcmVzZXRzIjogewogICAgICAiY29sb3JzIjogWwogICAgICAgIHsKICAgICAgICAgICJjb2xvciI6IHsKICAgICAgICAgICAgInIiOiAyNTUsCiAgICAgICAgICAgICJnIjogMjU1LAogICAgICAgICAgICAiYiI6IDI1NQogICAgICAgICAgfQogICAgICAgIH0sCiAgICAgICAgewogICAgICAgICAgImNvbG9yIjogewogICAgICAgICAgICAiciI6IDAsCiAgICAgICAgICAgICJnIjogMCwKICAgICAgICAgICAgImIiOiAwCiAgICAgICAgICB9CiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAiY29sb3IiOiB7CiAgICAgICAgICAgICJyIjogMTM1LAogICAgICAgICAgICAiZyI6IDk3LAogICAgICAgICAgICAiYiI6IDE4MAogICAgICAgICAgfQogICAgICAgIH0KICAgICAgXSwKICAgICAgInRleHRTdHlsZXMiOiBbXQogICAgfQogIH0sCiAgInBhZ2VzIjogWwogICAgewogICAgICAiZWxlbWVudHMiOiBbCiAgICAgICAgewogICAgICAgICAgIm9wYWNpdHkiOiAxMDAsCiAgICAgICAgICAiZmxpcCI6IHsKICAgICAgICAgICAgInZlcnRpY2FsIjogZmFsc2UsCiAgICAgICAgICAgICJob3Jpem9udGFsIjogZmFsc2UKICAgICAgICAgIH0sCiAgICAgICAgICAicm90YXRpb25BbmdsZSI6IDAsCiAgICAgICAgICAibG9ja0FzcGVjdFJhdGlvIjogdHJ1ZSwKICAgICAgICAgICJiYWNrZ3JvdW5kQ29sb3IiOiB7CiAgICAgICAgICAgICJjb2xvciI6IHsKICAgICAgICAgICAgICAiciI6IDI1NSwKICAgICAgICAgICAgICAiZyI6IDI1NSwKICAgICAgICAgICAgICAiYiI6IDI1NQogICAgICAgICAgICB9CiAgICAgICAgICB9LAogICAgICAgICAgIngiOiAxLAogICAgICAgICAgInkiOiAxLAogICAgICAgICAgIndpZHRoIjogMSwKICAgICAgICAgICJoZWlnaHQiOiAxLAogICAgICAgICAgIm1hc2siOiB7CiAgICAgICAgICAgICJ0eXBlIjogInJlY3RhbmdsZSIKICAgICAgICAgIH0sCiAgICAgICAgICAiaXNCYWNrZ3JvdW5kIjogdHJ1ZSwKICAgICAgICAgICJpc0RlZmF1bHRCYWNrZ3JvdW5kIjogdHJ1ZSwKICAgICAgICAgICJ0eXBlIjogInNoYXBlIiwKICAgICAgICAgICJpZCI6ICI4Y2ZlYzFjYy04NzEwLTQ4M2MtOTdiZi00NDU3MjYzNWMyMjMiCiAgICAgICAgfSwKICAgICAgICB7CiAgICAgICAgICAib3BhY2l0eSI6IDEwMCwKICAgICAgICAgICJmbGlwIjogewogICAgICAgICAgICAidmVydGljYWwiOiBmYWxzZSwKICAgICAgICAgICAgImhvcml6b250YWwiOiBmYWxzZQogICAgICAgICAgfSwKICAgICAgICAgICJyb3RhdGlvbkFuZ2xlIjogMCwKICAgICAgICAgICJsb2NrQXNwZWN0UmF0aW8iOiB0cnVlLAogICAgICAgICAgImJhY2tncm91bmRUZXh0TW9kZSI6ICJOT05FIiwKICAgICAgICAgICJmb250IjogewogICAgICAgICAgICAiZmFtaWx5IjogIlJvYm90byIsCiAgICAgICAgICAgICJ3ZWlnaHRzIjogWwogICAgICAgICAgICAgIDEwMCwKICAgICAgICAgICAgICAzMDAsCiAgICAgICAgICAgICAgNDAwLAogICAgICAgICAgICAgIDUwMCwKICAgICAgICAgICAgICA3MDAsCiAgICAgICAgICAgICAgOTAwCiAgICAgICAgICAgIF0sCiAgICAgICAgICAgICJzdHlsZXMiOiBbCiAgICAgICAgICAgICAgIml0YWxpYyIsCiAgICAgICAgICAgICAgInJlZ3VsYXIiCiAgICAgICAgICAgIF0sCiAgICAgICAgICAgICJ2YXJpYW50cyI6IFsKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAwLAogICAgICAgICAgICAgICAgMTAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAxLAogICAgICAgICAgICAgICAgMTAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAwLAogICAgICAgICAgICAgICAgMzAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAxLAogICAgICAgICAgICAgICAgMzAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAwLAogICAgICAgICAgICAgICAgNDAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAxLAogICAgICAgICAgICAgICAgNDAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAwLAogICAgICAgICAgICAgICAgNTAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAxLAogICAgICAgICAgICAgICAgNTAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAwLAogICAgICAgICAgICAgICAgNzAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAxLAogICAgICAgICAgICAgICAgNzAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAwLAogICAgICAgICAgICAgICAgOTAwCiAgICAgICAgICAgICAgXSwKICAgICAgICAgICAgICBbCiAgICAgICAgICAgICAgICAxLAogICAgICAgICAgICAgICAgOTAwCiAgICAgICAgICAgICAgXQogICAgICAgICAgICBdLAogICAgICAgICAgICAiZmFsbGJhY2tzIjogWwogICAgICAgICAgICAgICJIZWx2ZXRpY2EgTmV1ZSIsCiAgICAgICAgICAgICAgIkhlbHZldGljYSIsCiAgICAgICAgICAgICAgInNhbnMtc2VyaWYiCiAgICAgICAgICAgIF0sCiAgICAgICAgICAgICJzZXJ2aWNlIjogImZvbnRzLmdvb2dsZS5jb20iCiAgICAgICAgICB9LAogICAgICAgICAgImZvbnRTaXplIjogMTYsCiAgICAgICAgICAiYmFja2dyb3VuZENvbG9yIjogewogICAgICAgICAgICAiY29sb3IiOiB7CiAgICAgICAgICAgICAgInIiOiAxOTYsCiAgICAgICAgICAgICAgImciOiAxOTYsCiAgICAgICAgICAgICAgImIiOiAxOTYKICAgICAgICAgICAgfQogICAgICAgICAgfSwKICAgICAgICAgICJsaW5lSGVpZ2h0IjogMS41LAogICAgICAgICAgInRleHRBbGlnbiI6ICJjZW50ZXIiLAogICAgICAgICAgInBhZGRpbmciOiB7CiAgICAgICAgICAgICJsb2NrZWQiOiB0cnVlLAogICAgICAgICAgICAiaG9yaXpvbnRhbCI6IDAsCiAgICAgICAgICAgICJ2ZXJ0aWNhbCI6IDAKICAgICAgICAgIH0sCiAgICAgICAgICAidHlwZSI6ICJ0ZXh0IiwKICAgICAgICAgICJjb250ZW50IjogIjxzcGFuIHN0eWxlPVwiZm9udC13ZWlnaHQ6IDcwMFwiPkY8L3NwYW4+aWxsIGluIHNvbWUgdGV4dCIsCiAgICAgICAgICAieCI6IDAsCiAgICAgICAgICAieSI6IC0yOCwKICAgICAgICAgICJ3aWR0aCI6IDE2MCwKICAgICAgICAgICJoZWlnaHQiOiAyNCwKICAgICAgICAgICJzY2FsZSI6IDEwMCwKICAgICAgICAgICJmb2NhbFgiOiA1MCwKICAgICAgICAgICJmb2NhbFkiOiA1MCwKICAgICAgICAgICJpZCI6ICI0N2NmNjVlMy04MGY4LTRkY2UtYjE5MS1jOGRlMGQ5NTAxZTMiCiAgICAgICAgfQogICAgICBdLAogICAgICAiYmFja2dyb3VuZENvbG9yIjogewogICAgICAgICJjb2xvciI6IHsKICAgICAgICAgICJyIjogMjU1LAogICAgICAgICAgImciOiAyNTUsCiAgICAgICAgICAiYiI6IDI1NQogICAgICAgIH0KICAgICAgfSwKICAgICAgInR5cGUiOiAicGFnZSIsCiAgICAgICJpZCI6ICJhNmMzNmMzMC1mNDc5LTQ5OWYtYjFmYy1lODBlY2U0ZTNkYWQiCiAgICB9CiAgXQp9
```
2. Click preview
3. Verify that not all of the font is bold

---

#3259 
