### PR TITLE
Surface third party media usage notice 

### DIFF
--- a/assets/src/edit-story/components/library/karma/libraryTabs.karma.js
+++ b/assets/src/edit-story/components/library/karma/libraryTabs.karma.js
@@ -23,6 +23,7 @@ import { waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
+import localStore, { LOCAL_STORAGE_PREFIX } from '../../../utils/localStore';
 
 describe('LibraryTabs integration', () => {
   let fixture;
@@ -42,6 +43,7 @@ describe('LibraryTabs integration', () => {
 
   describe('keyboad navigation', () => {
     beforeEach(async () => {
+      localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_3P}`, true);
       const textTab = fixture.container.querySelector('#library-tab-media');
       await fixture.events.focus(textTab);
     });

--- a/assets/src/edit-story/components/library/karma/libraryTabs.karma.js
+++ b/assets/src/edit-story/components/library/karma/libraryTabs.karma.js
@@ -43,7 +43,7 @@ describe('LibraryTabs integration', () => {
 
   describe('keyboad navigation', () => {
     beforeEach(async () => {
-      localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_3P}`, true);
+      localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
       const textTab = fixture.container.querySelector('#library-tab-media');
       await fixture.events.focus(textTab);
     });

--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -199,7 +199,7 @@ describe('Media3pPane fetching', () => {
   let media3pPane;
 
   beforeEach(async () => {
-    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_3P}`, true);
+    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
 
     fixture = new Fixture();
 

--- a/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -25,6 +25,9 @@ import { waitFor } from '@testing-library/react';
 import apiFetcher from '../../../../../../app/media/media3p/api/apiFetcher';
 import { Fixture, MEDIA_PER_PAGE } from '../../../../../../karma/fixture';
 import { ROOT_MARGIN } from '../../local/mediaPane';
+import localStore, {
+  LOCAL_STORAGE_PREFIX,
+} from '../../../../../../utils/localStore';
 
 const RESOURCE_BUILDERS = {
   unsplash: (name) => ({
@@ -196,6 +199,8 @@ describe('Media3pPane fetching', () => {
   let media3pPane;
 
   beforeEach(async () => {
+    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_3P}`, true);
+
     fixture = new Fixture();
 
     jasmine.clock().install();

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
@@ -87,6 +87,13 @@ const ProviderMediaCategoriesWrapper = styled.div`
   }
 `;
 
+const Paragraph = styled.p`
+  font-family: ${({ theme }) => theme.fonts.body1.family};
+  font-size: ${({ theme }) => theme.fonts.body1.size};
+  line-height: ${({ theme }) => theme.fonts.body1.lineHeight};
+  letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing};
+`;
+
 /**
  * Pane that contains the media 3P integrations.
  *
@@ -233,27 +240,29 @@ function Media3pPane(props) {
   return (
     <>
       <Dialog open={dialogOpen} onClose={acknowledgeTerms} ariaHideApp={false}>
-        <TranslateWithMarkup
-          mapping={{
-            a: (
-              //eslint-disable-next-line jsx-a11y/anchor-has-content
-              <a
-                href="https://wp.stories.google/docs#Using-media-from-third-party-providers"
-                rel="noreferrer"
-                target="_blank"
-                aria-label={__(
-                  'Learn more by visiting Web Stories for WordPress',
-                  'web-stories'
-                )}
-              />
-            ),
-          }}
-        >
-          {__(
-            'Your use of stock content is subject to third party terms. <a>Learn more.</a>',
-            'web-stories'
-          )}
-        </TranslateWithMarkup>
+        <Paragraph>
+          <TranslateWithMarkup
+            mapping={{
+              a: (
+                //eslint-disable-next-line jsx-a11y/anchor-has-content
+                <a
+                  href="https://wp.stories.google/docs#Using-media-from-third-party-providers"
+                  rel="noreferrer"
+                  target="_blank"
+                  aria-label={__(
+                    'Learn more by visiting Web Stories for WordPress',
+                    'web-stories'
+                  )}
+                />
+              ),
+            }}
+          >
+            {__(
+              'Your use of stock content is subject to third party terms. <a>Learn more.</a>',
+              'web-stories'
+            )}
+          </TranslateWithMarkup>
+        </Paragraph>
       </Dialog>
       <StyledPane id={paneId} {...props}>
         <PaneInner>

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
@@ -147,14 +147,14 @@ function Media3pPane(props) {
     isActive && !hasAcknowledgedTerms3p
   );
 
-  useEffect(() => {
-    setDialogOpen(isActive && !hasAcknowledgedTerms3p);
-  }, [isActive, hasAcknowledgedTerms3p]);
-
   const acknowledgeTerms = () => {
     setDialogOpen(false);
     localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_3P}`, true);
   };
+
+  useEffect(() => {
+    setDialogOpen(isActive && !hasAcknowledgedTerms3p);
+  }, [isActive, hasAcknowledgedTerms3p]);
 
   useEffect(() => {
     if (isActive && !selectedProvider) {
@@ -232,7 +232,7 @@ function Media3pPane(props) {
   // TODO(#2368): handle pagination / infinite scrolling
   return (
     <>
-      <Dialog onClose={acknowledgeTerms} open={dialogOpen}>
+      <Dialog open={dialogOpen} onClose={acknowledgeTerms} ariaHideApp={false}>
         <TranslateWithMarkup
           mapping={{
             a: (
@@ -242,7 +242,7 @@ function Media3pPane(props) {
                 rel="noreferrer"
                 target="_blank"
                 aria-label={__(
-                  'Learn more by visiting Web Stories for Wordpress',
+                  'Learn more by visiting Web Stories for WordPress',
                   'web-stories'
                 )}
               />

--- a/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/media3pPane.js
@@ -19,7 +19,7 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useFeature, useFeatures } from 'flagged';
 
 /**
@@ -44,11 +44,8 @@ import Flags from '../../../../../flags';
 import { PROVIDERS } from '../../../../../app/media/media3p/providerConfiguration';
 import resourceList from '../../../../../utils/resourceList';
 import { PillGroup } from '../../shared';
-import localStore, {
-  LOCAL_STORAGE_PREFIX,
-} from '../../../../../utils/localStore';
-import Dialog from '../../../../dialog';
-import { TranslateWithMarkup } from '../../../../../../i18n';
+import TermsDialog from './termsDialog';
+
 import paneId from './paneId';
 import ProviderTab from './providerTab';
 
@@ -85,13 +82,6 @@ const ProviderMediaCategoriesWrapper = styled.div`
     position: relative;
     visibility: visible;
   }
-`;
-
-const Paragraph = styled.p`
-  font-family: ${({ theme }) => theme.fonts.body1.family};
-  font-size: ${({ theme }) => theme.fonts.body1.size};
-  line-height: ${({ theme }) => theme.fonts.body1.lineHeight};
-  letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing};
 `;
 
 /**
@@ -145,23 +135,6 @@ function Media3pPane(props) {
       media3p,
     })
   );
-
-  const hasAcknowledgedTerms3p = localStore.getItemByKey(
-    `${LOCAL_STORAGE_PREFIX.TERMS_3P}`
-  );
-
-  const [dialogOpen, setDialogOpen] = useState(
-    isActive && !hasAcknowledgedTerms3p
-  );
-
-  const acknowledgeTerms = () => {
-    setDialogOpen(false);
-    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_3P}`, true);
-  };
-
-  useEffect(() => {
-    setDialogOpen(isActive && !hasAcknowledgedTerms3p);
-  }, [isActive, hasAcknowledgedTerms3p]);
 
   useEffect(() => {
     if (isActive && !selectedProvider) {
@@ -239,31 +212,7 @@ function Media3pPane(props) {
   // TODO(#2368): handle pagination / infinite scrolling
   return (
     <>
-      <Dialog open={dialogOpen} onClose={acknowledgeTerms} ariaHideApp={false}>
-        <Paragraph>
-          <TranslateWithMarkup
-            mapping={{
-              a: (
-                //eslint-disable-next-line jsx-a11y/anchor-has-content
-                <a
-                  href="https://wp.stories.google/docs#Using-media-from-third-party-providers"
-                  rel="noreferrer"
-                  target="_blank"
-                  aria-label={__(
-                    'Learn more by visiting Web Stories for WordPress',
-                    'web-stories'
-                  )}
-                />
-              ),
-            }}
-          >
-            {__(
-              'Your use of stock content is subject to third party terms. <a>Learn more.</a>',
-              'web-stories'
-            )}
-          </TranslateWithMarkup>
-        </Paragraph>
-      </Dialog>
+      {isActive && <TermsDialog />}
       <StyledPane id={paneId} {...props}>
         <PaneInner>
           <PaneHeader>

--- a/assets/src/edit-story/components/library/panes/media/media3p/stories/termsDialog.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/stories/termsDialog.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import TermsDialog from '../termsDialog';
+
+export default {
+  title: 'Stories Editor/Components/Dialog/Media Use Terms Notice',
+  component: TermsDialog,
+};
+
+export const _default = () => {
+  return <TermsDialog />;
+};

--- a/assets/src/edit-story/components/library/panes/media/media3p/termsDialog.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/termsDialog.js
@@ -43,14 +43,14 @@ const Paragraph = styled.p`
 
 function TermsDialog() {
   const hasAcknowledgedTerms3p = localStore.getItemByKey(
-    `${LOCAL_STORAGE_PREFIX.TERMS_3P}`
+    `${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`
   );
 
   const [dialogOpen, setDialogOpen] = useState(!hasAcknowledgedTerms3p);
 
   const acknowledgeTerms = () => {
     setDialogOpen(false);
-    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_3P}`, true);
+    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
   };
 
   useEffect(() => {

--- a/assets/src/edit-story/components/library/panes/media/media3p/termsDialog.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/termsDialog.js
@@ -31,6 +31,7 @@ import localStore, {
   LOCAL_STORAGE_PREFIX,
 } from '../../../../../utils/localStore';
 import Dialog from '../../../../dialog';
+import { Plain } from '../../../../button';
 import { TranslateWithMarkup } from '../../../../../../i18n';
 
 const Paragraph = styled.p`
@@ -61,14 +62,21 @@ function TermsDialog() {
   }
 
   return (
-    <Dialog open={dialogOpen} onClose={acknowledgeTerms} ariaHideApp={false}>
+    <Dialog
+      open={dialogOpen}
+      onClose={acknowledgeTerms}
+      ariaHideApp={false}
+      actions={
+        <Plain onClick={acknowledgeTerms}>{__('Dismiss', 'web-stories')}</Plain>
+      }
+    >
       <Paragraph>
         <TranslateWithMarkup
           mapping={{
             a: (
               //eslint-disable-next-line jsx-a11y/anchor-has-content
               <a
-                href="https://wp.stories.google/docs#Using-media-from-third-party-providers"
+                href="https://wp.stories.google/docs#Terms"
                 rel="noreferrer"
                 target="_blank"
                 aria-label={__(

--- a/assets/src/edit-story/components/library/panes/media/media3p/termsDialog.js
+++ b/assets/src/edit-story/components/library/panes/media/media3p/termsDialog.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from 'react';
+import styled from 'styled-components';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import localStore, {
+  LOCAL_STORAGE_PREFIX,
+} from '../../../../../utils/localStore';
+import Dialog from '../../../../dialog';
+import { TranslateWithMarkup } from '../../../../../../i18n';
+
+const Paragraph = styled.p`
+  font-family: ${({ theme }) => theme.fonts.body1.family};
+  font-size: ${({ theme }) => theme.fonts.body1.size};
+  line-height: ${({ theme }) => theme.fonts.body1.lineHeight};
+  letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing};
+`;
+
+function TermsDialog() {
+  const hasAcknowledgedTerms3p = localStore.getItemByKey(
+    `${LOCAL_STORAGE_PREFIX.TERMS_3P}`
+  );
+
+  const [dialogOpen, setDialogOpen] = useState(!hasAcknowledgedTerms3p);
+
+  const acknowledgeTerms = () => {
+    setDialogOpen(false);
+    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_3P}`, true);
+  };
+
+  useEffect(() => {
+    setDialogOpen(!hasAcknowledgedTerms3p);
+  }, [hasAcknowledgedTerms3p]);
+
+  if (hasAcknowledgedTerms3p) {
+    return null;
+  }
+
+  return (
+    <Dialog open={dialogOpen} onClose={acknowledgeTerms} ariaHideApp={false}>
+      <Paragraph>
+        <TranslateWithMarkup
+          mapping={{
+            a: (
+              //eslint-disable-next-line jsx-a11y/anchor-has-content
+              <a
+                href="https://wp.stories.google/docs#Using-media-from-third-party-providers"
+                rel="noreferrer"
+                target="_blank"
+                aria-label={__(
+                  'Learn more by visiting Web Stories for WordPress',
+                  'web-stories'
+                )}
+              />
+            ),
+          }}
+        >
+          {__(
+            'Your use of stock content is subject to third party terms. <a>Learn more.</a>',
+            'web-stories'
+          )}
+        </TranslateWithMarkup>
+      </Paragraph>
+    </Dialog>
+  );
+}
+
+export default TermsDialog;

--- a/assets/src/edit-story/components/library/test/__snapshots__/termsDialog.js.snap
+++ b/assets/src/edit-story/components/library/test/__snapshots__/termsDialog.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TermsDialog should render 1`] = `
+<a
+  aria-label="Learn more by visiting Web Stories for WordPress"
+  href="https://wp.stories.google/docs#Terms"
+  rel="noreferrer"
+  target="_blank"
+>
+  Learn more.
+</a>
+`;

--- a/assets/src/edit-story/components/library/test/termsDialog.js
+++ b/assets/src/edit-story/components/library/test/termsDialog.js
@@ -55,21 +55,21 @@ describe('TermsDialog', () => {
     const link = queryByText(/^Learn more/);
     expect(link).toMatchSnapshot();
     expect(localStore.getItemByKey).toHaveBeenCalledWith(
-      LOCAL_STORAGE_PREFIX.TERMS_3P
+      LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P
     );
   });
   it('should store the acknowledgement in the localStore when the window is dismissed', async () => {
     const { queryByText } = renderWithTheme(<TermsDialog />);
     const dismiss = queryByText(/^Dismiss/);
     expect(localStore.getItemByKey).toHaveBeenCalledWith(
-      LOCAL_STORAGE_PREFIX.TERMS_3P
+      LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P
     );
     act(() => {
       fireEvent.click(dismiss);
     });
     await waitFor(() =>
       expect(localStore.setItemByKey).toHaveBeenCalledWith(
-        LOCAL_STORAGE_PREFIX.TERMS_3P,
+        LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P,
         true
       )
     );

--- a/assets/src/edit-story/components/library/test/termsDialog.js
+++ b/assets/src/edit-story/components/library/test/termsDialog.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { waitFor, fireEvent, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import TermsDialog from '../panes/media/media3p/termsDialog';
+import { renderWithTheme } from '../../../testUtils';
+
+jest.mock('../../../utils/localStore', () => {
+  const actual = jest.requireActual('../../../utils/localStore');
+  return {
+    ...actual,
+    setItemByKey: jest.fn(),
+    getItemByKey: jest.fn(() => false),
+  };
+});
+import localStore, { LOCAL_STORAGE_PREFIX } from '../../../utils/localStore';
+
+describe('TermsDialog', () => {
+  it('should render', () => {
+    const { queryByText } = renderWithTheme(<TermsDialog />);
+    const link = queryByText(/^Learn more/);
+    expect(link).toMatchSnapshot();
+    expect(localStore.getItemByKey).toHaveBeenCalledWith(
+      LOCAL_STORAGE_PREFIX.TERMS_3P
+    );
+  });
+  it('should store the acknowledgement in the localStore when the window is dismissed', async () => {
+    const { queryByText } = renderWithTheme(<TermsDialog />);
+    const dismiss = queryByText(/^Dismiss/);
+    expect(localStore.getItemByKey).toHaveBeenCalledWith(
+      LOCAL_STORAGE_PREFIX.TERMS_3P
+    );
+    act(() => {
+      fireEvent.click(dismiss);
+    });
+    await waitFor(() =>
+      expect(localStore.setItemByKey).toHaveBeenCalledWith(
+        LOCAL_STORAGE_PREFIX.TERMS_3P,
+        true
+      )
+    );
+  });
+});

--- a/assets/src/edit-story/utils/localStore.js
+++ b/assets/src/edit-story/utils/localStore.js
@@ -17,7 +17,7 @@
 export const LOCAL_STORAGE_PREFIX = {
   PANEL: 'web_stories_ui_panel_settings',
   TEXT_SET_SETTINGS: 'web_stores_text_set_settings',
-  TERMS_MEDIA3P: 'web_stories_third_party_terms_agreement',
+  TERMS_MEDIA3P: 'web_stories_media3p_terms_agreement',
 };
 
 function getItemByKey(key) {

--- a/assets/src/edit-story/utils/localStore.js
+++ b/assets/src/edit-story/utils/localStore.js
@@ -17,7 +17,7 @@
 export const LOCAL_STORAGE_PREFIX = {
   PANEL: 'web_stories_ui_panel_settings',
   TEXT_SET_SETTINGS: 'web_stores_text_set_settings',
-  TERMS_3P: 'web_stories_third_party_terms_agreement',
+  TERMS_MEDIA3P: 'web_stories_third_party_terms_agreement',
 };
 
 function getItemByKey(key) {

--- a/assets/src/edit-story/utils/localStore.js
+++ b/assets/src/edit-story/utils/localStore.js
@@ -17,6 +17,7 @@
 export const LOCAL_STORAGE_PREFIX = {
   PANEL: 'web_stories_ui_panel_settings',
   TEXT_SET_SETTINGS: 'web_stores_text_set_settings',
+  TERMS_3P: 'web_stories_third_party_terms_agreement',
 };
 
 function getItemByKey(key) {


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

- Add a dialog which has a link to the [docs on using media from third party providers](https://wp.stories.google/docs#Using-media-from-third-party-providers)
- Dialog is dismissable (only shows up once)

## Relevant Technical Choices

<!-- Please describe your changes. -->
-  I stored the user's acknowledgement in the `localStore` and added a storage key for the acknowledgement so it does not show up every time the user goes to the 3rd party media tab
- I reused the edit-story dialog component to create a new component which checks for the acknowledgement in local storage and displays a modal
- I added the new TermsDialog component to the `media3pPane`, it only renders it when the tab is active.

## To-do

Right now it looks like this and appears as soon as you go to the 3p media tab (link location is shown in the corner):
![Screen Shot 2020-10-23 at 11 36 24 AM](https://user-images.githubusercontent.com/41136059/97041206-04e42a80-1524-11eb-88d9-bd42984ae1a3.png)

It's kind of jarring but very simple. The way you acknowledge/dismiss is to click outside the modal. I'm wondering how to organize the actions for this dialog. Should there be buttons to close the modal? Or just one button that links to "Learn More"? Should clicking `Learn More` close the dialog automatically?

- [x] unit test for new component
- [x] fix integration
- [x] update link
- [x] add a close button
- [x] ~~ux? see above~~

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->
- A user will see a new modal when they switch to the third party media tab and have not dismissed this dialog before (or have cleared their local storage since the first time they saw the dialog)

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

- open an incognito browser window
- log in as admin and go to the wordpress story editor
- create a new story
- go to the third party media tab
- a modal should appear with text that links the user to the docs page for using third party media
- clicking outside the modal closes the modal
- clicking away from the 3p media tab and back does not trigger the modal again

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4989 
