### PR TITLE
Update PHPStan config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
   "extra": {
     "downloads": {
       "phpstan": {
-        "url": "https://github.com/phpstan/phpstan/releases/latest/download/phpstan.phar",
+        "url": "https://github.com/phpstan/phpstan/releases/download/0.12.52/phpstan.phar",
         "path": "vendor/bin/phpstan",
         "type": "phar"
       },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd6b75f736cd8a60e1ade184f26bcd71",
+    "content-hash": "75ddee839b193c1e9d287eaa63da5b8f",
     "packages": [
         {
             "name": "ampproject/amp-wp",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -32,6 +32,8 @@ parameters:
     - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
     - tests/phpstan/stubs/wordpress-defines.php
     - tests/phpstan/bootstrap.php
+    - third-party/vendor/ampproject/amp-wp/includes/sanitizers/class-amp-base-sanitizer.php
+    - third-party/vendor/ampproject/amp-wp/includes/sanitizers/class-amp-meta-sanitizer.php
   dynamicConstantNames:
     - WP_DEBUG
     - WP_DEBUG_LOG
@@ -59,14 +61,3 @@ parameters:
     # wp_die() is called with [ 'exit' => false ]
     - message: '#^Unreachable statement - code above always terminates.$#'
       path: includes/Story_Renderer/HTML.php
-
-    # AMP PHP Library files
-    # TODO: Actually fix this.
-    -
-      message: '#AMP_Base_Sanitizer not found#'
-      paths:
-        - includes/AMP
-        - includes/Story_Renderer/HTML.php
-    -
-      message: '#AMP_Meta_Sanitizer not found#'
-      path: includes/AMP


### PR DESCRIPTION
As of recently, the "class not found" errors we've been ignoring in PHPStan cannot be ignored anymore.

This PR aims to fix the root cause by not ignoriing these errors but instead ensure PHPStan is aware of these classes.

These should have been discovered through the `scanDirectories` option which simply scans & analyzes files (https://phpstan.org/user-guide/discovering-symbols#third-party-code-outside-of-composer-dependencies), but apparently that doesn’t work

With the `bootstrapFiles` option these files will actually be executed by the PHP runtime (not ideal), but it seems to do the trick.
