### PR TITLE
Admin menu: avoid unnecessary redirects

### DIFF
--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -126,7 +126,7 @@ class Dashboard {
 			__( 'Explore Templates', 'web-stories' ),
 			__( 'Explore Templates', 'web-stories' ),
 			'edit_web-stories',
-			'stories-dashboard-explore',
+			'stories-dashboard#/templates-gallery',
 			'__return_null',
 			1
 		);
@@ -136,7 +136,7 @@ class Dashboard {
 			__( 'Settings', 'web-stories' ),
 			__( 'Settings', 'web-stories' ),
 			'edit_web-stories',
-			'stories-dashboard-settings',
+			'stories-dashboard#/editor-settings',
 			'__return_null',
 			20
 		);
@@ -166,33 +166,6 @@ class Dashboard {
 					[
 						'post_type' => Story_Post_Type::POST_TYPE_SLUG,
 						'page'      => 'stories-dashboard',
-					],
-					admin_url( 'edit.php' )
-				)
-			);
-			exit;
-		}
-
-
-		if ( 'edit.php' === $pagenow && 'stories-dashboard-settings' === $page ) {
-			wp_safe_redirect(
-				add_query_arg(
-					[
-						'post_type' => Story_Post_Type::POST_TYPE_SLUG,
-						'page'      => 'stories-dashboard#/editor-settings',
-					],
-					admin_url( 'edit.php' )
-				)
-			);
-			exit;
-		}
-
-		if ( 'edit.php' === $pagenow && 'stories-dashboard-explore' === $page ) {
-			wp_safe_redirect(
-				add_query_arg(
-					[
-						'post_type' => Story_Post_Type::POST_TYPE_SLUG,
-						'page'      => 'stories-dashboard#/templates-gallery',
 					],
 					admin_url( 'edit.php' )
 				)


### PR DESCRIPTION
## Summary

See https://github.com/google/web-stories-wp/issues/4891#issuecomment-716892605

Turns out we can avoid these redirects, making the whole experience much faster as it doesn't cause page reloads.

## Relevant Technical Choices

* Avoids redirects for dashboard sub pages in the admin menu

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

N/A

## Testing Instructions

1. Ensure the admin menu items still work as expected

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
