### PR TITLE
Added embed query for getting author data on duplication.

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -338,7 +338,14 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
           title,
         } = story.originalStoryData;
 
-        const response = await dataAdapter.post(storyApi, {
+        const path = queryString.stringifyUrl({
+          url: storyApi,
+          query: {
+            _embed: 'author',
+          },
+        });
+
+        const response = await dataAdapter.post(path, {
           data: {
             content,
             story_data,


### PR DESCRIPTION
## Summary

- Adds the `_embed` key to the query to ensure the author data comes back.
- Makes duplication work without a front-end error

## Relevant Technical Choices

- None

## To-do

- Create e2e tests for Dashboard actions

## User-facing changes

- Duplication should work again with no errors

## Testing Instructions

1. Visit the dashboard
2. Duplicate a story with the dropdown
3. See that the story shows up


#5020