### PR TITLE
Fix base64 encoding when using chars from different range

### DIFF
--- a/assets/src/edit-story/app/api/base64Encode.js
+++ b/assets/src/edit-story/app/api/base64Encode.js
@@ -30,7 +30,10 @@ function toBinary(string) {
   }
 
   // Not using String.fromCharCode(...new Uint8Array(...)) to avoid RangeError due to too many arguments.
-  return new TextDecoder('utf-8').decode(new Uint8Array(codeUnits.buffer));
+  return new Uint8Array(codeUnits.buffer).reduce(
+    (data, byte) => data + String.fromCharCode(byte),
+    ''
+  );
 }
 
 /**

--- a/assets/src/edit-story/app/api/test/base64Encode.js
+++ b/assets/src/edit-story/app/api/test/base64Encode.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { TextDecoder, TextEncoder } from 'util';
-
-/**
  * Internal dependencies
  */
 import base64Encode from '../base64Encode';
@@ -33,37 +28,18 @@ function fromBinary(binary) {
   return String.fromCharCode(...new Uint16Array(bytes.buffer));
 }
 
-// These are not yet available in jsdom environment.
-// See https://github.com/facebook/jest/issues/9983.
-// See https://github.com/jsdom/jsdom/issues/2524.
-global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder;
-
 describe('base64Encode', () => {
-  beforeAll(() => {
-    // eslint-disable-next-line jest/prefer-spy-on
-    global.btoa = jest.fn().mockImplementation(() => '*encoded*');
-  });
-  afterAll(() => {
-    global.btoa.mockClear();
-  });
-
   it('prefixes encoded content', () => {
     expect(base64Encode('Hello World')).toStartWith('__WEB_STORIES_ENCODED__');
   });
 
   it('converts Unicode characters', () => {
-    // eslint-disable-next-line jest/prefer-spy-on
-    global.btoa = jest
-      .fn()
-      .mockImplementation(() => 'SABlAGwAbABvACAAPNgN3w==');
-
-    const actual = base64Encode('Hello 🌍');
+    const actual = base64Encode('Hello 🌍 - これはサンプルです。');
     expect(actual).toStrictEqual(
-      '__WEB_STORIES_ENCODED__SABlAGwAbABvACAAPNgN3w=='
-    ); // Hello 🌍
+      '__WEB_STORIES_ENCODED__SABlAGwAbABvACAAPNgN3yAALQAgAFMwjDBvMLUw8zDXMOswZzBZMAIw'
+    ); // Hello 🌍 - これはサンプルです。
     expect(
       fromBinary(atob(actual.replace('__WEB_STORIES_ENCODED__', '')))
-    ).toStrictEqual('Hello 🌍');
+    ).toStrictEqual('Hello 🌍 - これはサンプルです。');
   });
 });


### PR DESCRIPTION
## Summary

Quick follow-up to #4859 / #4805 that fixes issues with `TextDecoder`, which did not work as expected.

## Relevant Technical Choices

* Using `String.fromCharCode` again as originally envisioned, but now with a twist to avoid passing too many arguments.

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

1. Ensure `WEBSTORIES_DEV_MODE` is `false`
1. Write a new story with title `Hello 🌍 - これはサンプルです。`
1. Verfiy that saving/publishing works as expected

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
