### PR TITLE
Dashboard: WordPress Admin Menu not highlighting the right page

### DIFF
--- a/assets/src/dashboard/app/router/routerProvider.js
+++ b/assets/src/dashboard/app/router/routerProvider.js
@@ -65,12 +65,18 @@ function RouterProvider({ children, ...props }) {
     const WPSubmenuItems = document.querySelectorAll(
       '#menu-posts-web-story ul.wp-submenu li'
     );
-    WPSubmenuItems?.forEach((el) => el.classList.remove('current'));
-    WPSubmenuItems?.forEach(
-      (el) =>
-        Boolean(el.querySelector(`a[href$="#${currentPath}"]`)) &&
-        el.classList.add('current')
-    );
+    WPSubmenuItems?.forEach((el) => {
+      el.classList.remove('current');
+      el.querySelector('a')?.classList.remove('current');
+      el.querySelector('a')?.removeAttribute('aria-current');
+    });
+    WPSubmenuItems?.forEach((el) => {
+      if (el.querySelector(`a[href$="#${currentPath}"]`)) {
+        el.classList.add('current');
+        el.querySelector('a')?.classList.add('current');
+        el.querySelector('a')?.setAttribute('aria-current', 'page');
+      }
+    });
   }, [currentPath]);
 
   const value = useMemo(

--- a/assets/src/dashboard/app/router/routerProvider.js
+++ b/assets/src/dashboard/app/router/routerProvider.js
@@ -55,6 +55,24 @@ function RouterProvider({ children, ...props }) {
     trackScreenView(currentScreen);
   }, [currentScreen]);
 
+  // Sync up WP navigation bar with our hash location.
+  useEffect(() => {
+    // Allow default WP behavior for both `page=stories-dashboard` & `page=stories-dashboard#/`
+    if (currentPath.length <= 1) {
+      return;
+    }
+
+    const WPSubmenuItems = document.querySelectorAll(
+      '#menu-posts-web-story ul.wp-submenu li'
+    );
+    WPSubmenuItems?.forEach((el) => el.classList.remove('current'));
+    WPSubmenuItems?.forEach(
+      (el) =>
+        Boolean(el.querySelector(`a[href$="#${currentPath}"]`)) &&
+        el.classList.add('current')
+    );
+  }, [currentPath]);
+
   const value = useMemo(
     () => ({
       state: {

--- a/assets/src/dashboard/app/router/routerProvider.js
+++ b/assets/src/dashboard/app/router/routerProvider.js
@@ -57,9 +57,10 @@ function RouterProvider({ children, ...props }) {
 
   // Sync up WP navigation bar with our hash location.
   useEffect(() => {
-    // Allow default WP behavior for both `page=stories-dashboard` & `page=stories-dashboard#/`
+    let query = `a[href$="#${currentPath}"]`;
+    // `My Stories` link in WP doesn't have a hash in the href
     if (currentPath.length <= 1) {
-      return;
+      query = 'a[href$="page=stories-dashboard"]';
     }
 
     const WPSubmenuItems = document.querySelectorAll(
@@ -71,7 +72,7 @@ function RouterProvider({ children, ...props }) {
       el.querySelector('a')?.removeAttribute('aria-current');
     });
     WPSubmenuItems?.forEach((el) => {
-      if (el.querySelector(`a[href$="#${currentPath}"]`)) {
+      if (el.querySelector(query)) {
         el.classList.add('current');
         el.querySelector('a')?.classList.add('current');
         el.querySelector('a')?.setAttribute('aria-current', 'page');

--- a/assets/src/edit-story/elements/media/imageDisplay.js
+++ b/assets/src/edit-story/elements/media/imageDisplay.js
@@ -73,18 +73,23 @@ function ImageDisplay({ element, box }) {
 
   useEffect(() => {
     let timeout;
+    let mounted = true;
     if (resourceList.get(resource.id)?.type !== 'fullsize') {
       timeout = setTimeout(async () => {
         const preloadedImg = await preloadImage(resource.src, srcSet);
-        resourceList.set(resource.id, {
-          type: 'fullsize',
-        });
-        setSrc(preloadedImg.currentSrc);
-        setSrcType('fullsize');
+        if (mounted) {
+          resourceList.set(resource.id, {
+            type: 'fullsize',
+          });
+          setSrc(preloadedImg.currentSrc);
+          setSrcType('fullsize');
+        }
       });
     }
-
-    return () => clearTimeout(timeout);
+    return () => {
+      mounted = false;
+      clearTimeout(timeout);
+    };
   }, [resource.id, resource.src, srcSet, srcType]);
 
   const showPlaceholder = srcType !== 'fullsize';

--- a/tests/e2e/specs/dashboard/WPSidebarNav.js
+++ b/tests/e2e/specs/dashboard/WPSidebarNav.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { visitDashboard } from '../../utils';
+
+describe('WP Sidebar Nav', () => {
+  it('should sync the WP nav with the dashboard nav', async () => {
+    await visitDashboard();
+
+    // Initial visit to `/` makes `My Stories` link current in WP
+    await page.hover('#menu-posts-web-story');
+    await expect(await page.$('#menu-posts-web-story .current a')).toMatch(
+      'My Stories'
+    );
+    await page.hover('[aria-label="Main dashboard navigation"]');
+
+    // Navigating in the application to a new page syncs the WP current page in Nav
+    await expect(page).toClick('[aria-label="Main dashboard navigation"] a', {
+      text: 'Explore Templates',
+    });
+    await page.hover('#menu-posts-web-story');
+    await expect(await page.$('#menu-posts-web-story .current a')).toMatch(
+      'Explore Templates'
+    );
+    await page.hover('[aria-label="Main dashboard navigation"]');
+
+    // Navigating in the application to a new page syncs the WP current page in Nav
+    await page.hover('#menu-posts-web-story');
+    await expect(page).toClick('#menu-posts-web-story a', {
+      text: 'Settings',
+    });
+    await expect(await page.$('#menu-posts-web-story .current a')).toMatch(
+      'Settings'
+    );
+  });
+});

--- a/tests/e2e/specs/dashboard/WPSidebarNav.js
+++ b/tests/e2e/specs/dashboard/WPSidebarNav.js
@@ -30,7 +30,7 @@ describe('WP Sidebar Nav', () => {
     );
     await page.hover('[aria-label="Main dashboard navigation"]');
 
-    // Navigating in the application to a new page syncs the WP current page in Nav
+    // Navigating through the application to a new page syncs the WP current page in Nav
     await expect(page).toClick('[aria-label="Main dashboard navigation"] a', {
       text: 'Explore Templates',
     });
@@ -40,7 +40,7 @@ describe('WP Sidebar Nav', () => {
     );
     await page.hover('[aria-label="Main dashboard navigation"]');
 
-    // Navigating in the application to a new page syncs the WP current page in Nav
+    // Navigating through WP to a new page syncs the WP current page in Nav
     await page.hover('#menu-posts-web-story');
     await expect(page).toClick('#menu-posts-web-story a', {
       text: 'Settings',

--- a/tests/e2e/specs/dashboard/adminMenu.js
+++ b/tests/e2e/specs/dashboard/adminMenu.js
@@ -19,7 +19,7 @@
  */
 import { visitDashboard } from '../../utils';
 
-describe('WP Sidebar Nav', () => {
+describe('Admin Menu', () => {
   it('should sync the WP nav with the dashboard nav', async () => {
     await visitDashboard();
 

--- a/tests/e2e/specs/dashboard/adminMenu.js
+++ b/tests/e2e/specs/dashboard/adminMenu.js
@@ -48,5 +48,15 @@ describe('Admin Menu', () => {
     await expect(await page.$('#menu-posts-web-story .current a')).toMatch(
       'Settings'
     );
+    await page.hover('[aria-label="Main dashboard navigation"]');
+
+    // Navigating through application back to My Story from another route
+    await expect(page).toClick('[aria-label="Main dashboard navigation"] a', {
+      text: 'My Stories',
+    });
+    await page.hover('#menu-posts-web-story');
+    await expect(await page.$('#menu-posts-web-story .current a')).toMatch(
+      'My Stories'
+    );
   });
 });

--- a/tests/e2e/specs/dashboard/adminMenu.js
+++ b/tests/e2e/specs/dashboard/adminMenu.js
@@ -31,9 +31,14 @@ describe('Admin Menu', () => {
     await page.hover('[aria-label="Main dashboard navigation"]');
 
     // Navigating through the application to a new page syncs the WP current page in Nav
-    await expect(page).toClick('[aria-label="Main dashboard navigation"] a', {
-      text: 'Explore Templates',
-    });
+    await page.waitForTimeout(100);
+    await Promise.all([
+      page.waitForNavigation(),
+      expect(page).toClick('[aria-label="Main dashboard navigation"] a', {
+        text: 'Explore Templates',
+      }),
+    ]);
+    await page.waitForTimeout(100);
     await page.hover('#menu-posts-web-story');
     await expect(await page.$('#menu-posts-web-story .current a')).toMatch(
       'Explore Templates'
@@ -42,18 +47,29 @@ describe('Admin Menu', () => {
 
     // Navigating through WP to a new page syncs the WP current page in Nav
     await page.hover('#menu-posts-web-story');
-    await expect(page).toClick('#menu-posts-web-story a', {
-      text: 'Settings',
-    });
+    await page.waitForTimeout(100);
+    await Promise.all([
+      page.waitForNavigation(),
+      expect(page).toClick('#menu-posts-web-story a', {
+        text: 'Settings',
+      }),
+    ]);
+    await page.waitForTimeout(100);
     await expect(await page.$('#menu-posts-web-story .current a')).toMatch(
       'Settings'
     );
-    await page.hover('[aria-label="Main dashboard navigation"]');
+    // await page.hover('[aria-label="Main dashboard navigation"]');
 
     // Navigating through application back to My Story from another route
-    await expect(page).toClick('[aria-label="Main dashboard navigation"] a', {
-      text: 'My Stories',
-    });
+    await page.waitForTimeout(100);
+    await Promise.all([
+      page.waitForNavigation(),
+      expect(page).toClick('[aria-label="Main dashboard navigation"] a', {
+        text: 'My Stories',
+      }),
+    ]);
+    await page.waitForTimeout(100);
+    await page.hover('#menu-posts-web-story');
     await expect(await page.$('#menu-posts-web-story .current a')).toMatch(
       'My Stories'
     );

--- a/tests/e2e/specs/dashboard/adminMenu.js
+++ b/tests/e2e/specs/dashboard/adminMenu.js
@@ -54,7 +54,6 @@ describe('Admin Menu', () => {
     await expect(page).toClick('[aria-label="Main dashboard navigation"] a', {
       text: 'My Stories',
     });
-    await page.hover('#menu-posts-web-story');
     await expect(await page.$('#menu-posts-web-story .current a')).toMatch(
       'My Stories'
     );


### PR DESCRIPTION
## Summary
Updates the wordpress ui to set active submenu link for hash routes.

## Relevant Technical Choices
Felt like a small effect in the dashboard routing provider.

## To-do
NA

## User-facing changes
Now when you're on `Editor Settings` or `Explore Templates` the WP menu should reflect it as well.
<img width="1436" alt="Screen Shot 2020-10-27 at 2 07 43 PM" src="https://user-images.githubusercontent.com/35983235/97356391-d1740980-185d-11eb-8caf-d035917cf620.png">
<img width="1440" alt="Screen Shot 2020-10-27 at 2 07 33 PM" src="https://user-images.githubusercontent.com/35983235/97356398-d3d66380-185d-11eb-90cd-80b99c844554.png">


## Testing Instructions
Navigate to both `Explore Templates` & `Editor Settings` & see that the WP menu properly highlights the active link. This test is also covered by some e2e tests as well.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4891 
