### PR TITLE
Put eyedropper behind feature flag

### DIFF
--- a/assets/src/edit-story/components/colorPicker/currentColorPicker.js
+++ b/assets/src/edit-story/components/colorPicker/currentColorPicker.js
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { CustomPicker } from 'react-color';
 import { Saturation, Hue, Alpha } from 'react-color/lib/components/common';
+import { useFeatures } from 'flagged';
 
 /**
  * WordPress dependencies
@@ -41,6 +42,7 @@ const HEADER_FOOTER_HEIGHT = 42;
 const BODY_HEIGHT = 140;
 const CONTROLS_WIDTH = 12;
 const CONTROLS_BORDER_RADIUS = 6;
+const OPACITY_WIDTH = 32;
 
 const Container = styled.div`
   font-family: ${({ theme }) => theme.fonts.body1.family};
@@ -86,22 +88,32 @@ const AlphaWrapper = styled.div`
 `;
 
 const Footer = styled.div`
-  padding: ${CONTAINER_PADDING}px 0px;
   height: ${HEADER_FOOTER_HEIGHT}px;
   font-size: ${CONTROLS_WIDTH}px;
   line-height: 19px;
   position: relative;
+  display: grid;
+  grid: 'eyedropper hex opacity' ${HEADER_FOOTER_HEIGHT}px / ${EYEDROPPER_ICON_SIZE}px 1fr ${OPACITY_WIDTH}px;
+  grid-gap: 10px;
+`;
+
+const HexValue = styled.div`
+  grid-area: hex;
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: center;
 `;
 
 const EyedropperButton = styled(Eyedropper)`
   line-height: ${EYEDROPPER_ICON_SIZE}px;
+  grid-area: eyedropper;
 `;
 
-const OpacityPlaceholder = styled.div`
-  width: 32px;
+const Opacity = styled.div`
+  grid-area: opacity;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 function CurrentColorPicker({ rgb, hsl, hsv, hex, onChange, showOpacity }) {
@@ -122,6 +134,8 @@ function CurrentColorPicker({ rgb, hsl, hsv, hex, onChange, showOpacity }) {
       onChange({ ...rgb, a: isNaN(value) ? 1 : parseInt(value) / 100 }),
     [rgb, onChange]
   );
+
+  const { eyeDropper } = useFeatures();
 
   return (
     <Container>
@@ -164,30 +178,33 @@ function CurrentColorPicker({ rgb, hsl, hsv, hex, onChange, showOpacity }) {
         )}
       </Body>
       <Footer>
-        {/* TODO: implement (see https://github.com/google/web-stories-wp/issues/262) */}
-        <EyedropperButton
-          width={EYEDROPPER_ICON_SIZE}
-          height={EYEDROPPER_ICON_SIZE}
-          aria-label={__('Select color', 'web-stories')}
-          isDisabled
-        />
-        <EditablePreview
-          label={__('Edit hex value', 'web-stories')}
-          value={hexValue}
-          onChange={handleHexInputChange}
-          width={56}
-          format={handleFormatHex}
-        />
-        {showOpacity ? (
-          <EditablePreview
-            label={__('Edit opacity', 'web-stories')}
-            value={alphaPercentage}
-            width={32}
-            format={handleFormatPercentage}
-            onChange={handleOpacityInputChange}
+        {eyeDropper && (
+          <EyedropperButton
+            width={EYEDROPPER_ICON_SIZE}
+            height={EYEDROPPER_ICON_SIZE}
+            aria-label={__('Select color', 'web-stories')}
+            isDisabled
           />
-        ) : (
-          <OpacityPlaceholder />
+        )}
+        <HexValue>
+          <EditablePreview
+            label={__('Edit hex value', 'web-stories')}
+            value={hexValue}
+            onChange={handleHexInputChange}
+            width={56}
+            format={handleFormatHex}
+          />
+        </HexValue>
+        {showOpacity && (
+          <Opacity>
+            <EditablePreview
+              label={__('Edit opacity', 'web-stories')}
+              value={alphaPercentage}
+              width={OPACITY_WIDTH}
+              format={handleFormatPercentage}
+              onChange={handleOpacityInputChange}
+            />
+          </Opacity>
         )}
       </Footer>
     </Container>

--- a/assets/src/edit-story/components/colorPicker/stories/index.js
+++ b/assets/src/edit-story/components/colorPicker/stories/index.js
@@ -17,7 +17,8 @@
 /**
  * External dependencies
  */
-import { object } from '@storybook/addon-knobs';
+import { object, boolean } from '@storybook/addon-knobs';
+import { FlagsProvider } from 'flagged';
 
 /**
  * Internal dependencies
@@ -48,5 +49,18 @@ export const _default = () => {
     ],
   });
 
-  return <ColorPicker color={initialColor} onChange={() => {}} />;
+  const eyeDropper = boolean('Enable Eyedropper', false);
+  const hasGradient = boolean('Has Gradients', false);
+  const hasOpacity = boolean('Has Opacity', true);
+
+  return (
+    <FlagsProvider features={{ eyeDropper }}>
+      <ColorPicker
+        color={initialColor}
+        onChange={() => {}}
+        hasGradient={hasGradient}
+        hasOpacity={hasOpacity}
+      />
+    </FlagsProvider>
+  );
 };

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -361,6 +361,17 @@ class Experiments {
 				'description' => __( 'Encode story markup in the REST API to prevent conflicts with Web Application Firewalls (WAFs).', 'web-stories' ),
 				'group'       => 'general',
 			],
+			/**
+			 * Author: @swissspidy
+			 * Issue: #4081
+			 * Creation date: 2020-10-28
+			 */
+			[
+				'name'        => 'eyeDropper',
+				'label'       => __( 'Eyedropper', 'web-stories' ),
+				'description' => __( 'Enable eyedropper in color picker.', 'web-stories' ),
+				'group'       => 'editor',
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

Supersedes #4266

Puts the eyedropper functionality behind a feature flag because it's not functional yet.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<img width="257" alt="Screenshot 2020-10-27 at 20 55 59" src="https://user-images.githubusercontent.com/841956/97356978-5a5c6680-1899-11eb-8cd5-0f9790e6175d.png">
<img width="251" alt="Screenshot 2020-10-27 at 20 56 05" src="https://user-images.githubusercontent.com/841956/97356983-5c262a00-1899-11eb-8c96-31e1b9b44ddc.png">
<img width="251" alt="Screenshot 2020-10-27 at 20 56 13" src="https://user-images.githubusercontent.com/841956/97356988-5e888400-1899-11eb-9197-ec2fbaad4be9.png">
<img width="254" alt="Screenshot 2020-10-27 at 20 56 22" src="https://user-images.githubusercontent.com/841956/97356989-5e888400-1899-11eb-83cd-469ddcfdef16.png">


## Testing Instructions

1. Open color picker
1. Verify that eyedropper icon is not visible

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4081
