### PR TITLE
prepublish media guidelines (guidance)

### DIFF
--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const PRE_PUBLISH_MESSAGE_TYPES = {
+  GUIDANCE: 'guidance',
+  ERROR: 'error',
+  WARNING: 'warning',
+};

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function mediaElementSizeOnPage(/*element*/) {}
+
+export function mediaElementResolution(/*element*/) {}
+
+export function videoElementLength(/*element*/) {}
+
+export function videoElementFps(/*element*/) {}

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -17,7 +17,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -28,15 +28,13 @@ import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
 
 const SAFE_ZONE_AREA = PAGE_HEIGHT * PAGE_WIDTH;
 
-const MAX_VIDEO_LENGTH_SECONDS = 60;
 const MAX_VIDEO_WIDTH = 3840;
 const MAX_VIDEO_HEIGHT = 2160;
 const MIN_VIDEO_HEIGHT = 480;
 const MIN_VIDEO_WIDTH = 852;
 
-// todo: get video frames per second
-// MIN_VIDEO_FPS = 24;
-// export function videoElementFps(element) {}
+const MAX_VIDEO_LENGTH_SECONDS = 60;
+const MAX_VIDEO_LENGTH_MINUTES = Math.floor(MAX_VIDEO_LENGTH_SECONDS / 60);
 
 /**
  * @typedef {import('../../../types').Page} Page
@@ -210,9 +208,15 @@ export function videoElementLength(element) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       elementId: element.id,
-      message: __(
-        'Video is longer than 1 minute (suggest breaking video up into multiple segments)',
-        'web-stories'
+      message: sprintf(
+        /* translators: %d: number of minutes; */
+        _n(
+          'Video is longer than %d minute (suggest breaking video up into multiple segments)',
+          'Video is longer than %d minutes (suggest breaking video up into multiple segments)',
+          MAX_VIDEO_LENGTH_MINUTES,
+          'web-stories'
+        ),
+        MAX_VIDEO_LENGTH_MINUTES
       ),
     };
   }

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -68,15 +68,16 @@ export function videoElementSizeOnPage(page) {
 }
 
 export function mediaElementResolution(element) {
-  if (element.type === 'video') {
-    return videoElementResolution(element);
+  switch (element.type) {
+    case 'image':
+      return imageElementResolution(element);
+    case 'video':
+      return videoElementResolution(element);
+    case 'gif':
+      return gifElementResolution(element);
+    default:
+      throw new Error('Invalid media type');
   }
-
-  if (element.type === 'image' || element.type === 'gif') {
-    return imageElementResolution(element);
-  }
-
-  return undefined;
 }
 
 function videoElementResolution(element) {
@@ -119,6 +120,23 @@ function imageElementResolution(element) {
       type: 'guidance',
       elementId: element.id,
       message: __('Image has low resolution', 'web-stories'),
+    };
+  }
+  return undefined;
+}
+
+function gifElementResolution(element) {
+  // gif/output uses the MP4 video provided by the 3P Media API for displaying gifs
+  const heightResTooLow =
+    element.resource.output.sizes.mp4.full.height < 2 * element.height;
+  const widthResTooLow =
+    element.resource.output.sizes.mp4.full.width < 2 * element.width;
+
+  if (heightResTooLow || widthResTooLow) {
+    return {
+      type: 'guidance',
+      elementId: element.id,
+      message: __('GIF has low resolution', 'web-stories'),
     };
   }
   return undefined;

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -37,10 +37,32 @@ const MIN_VIDEO_WIDTH = 852;
 // export function videoElementFps(element) {}
 
 export function mediaElementSizeOnPage(element) {
-  // triggered if only one video is on the page and it takes less than 50% of the safe zone area
-  // encourage users to consider a more immersive media sizing and cropping.
-  const elementArea = element.height * element.width;
-  const isTooSmallOnPage = SAFE_ZONE_AREA / 2 > elementArea;
+  // get the intersecting area of the element's rectangle and the safe zone's rectangle
+  const safeZone = {
+      left: 0,
+      right: PAGE_WIDTH,
+      bottom: PAGE_HEIGHT,
+      top: 0,
+    },
+    elemRect = {
+      left: element.x,
+      right: element.x + element.width,
+      bottom: element.y + element.height,
+      top: element.y,
+    };
+  const xOverlap = Math.max(
+    0,
+    Math.min(safeZone.right, elemRect.right) -
+      Math.max(safeZone.left, elemRect.left)
+  );
+  const yOverlap = Math.max(
+    0,
+    Math.min(safeZone.bottom, elemRect.bottom) -
+      Math.max(safeZone.top, elemRect.top)
+  );
+  const elementArea = xOverlap * yOverlap;
+
+  const isTooSmallOnPage = elementArea < SAFE_ZONE_AREA / 2;
 
   if (isTooSmallOnPage) {
     return {
@@ -62,7 +84,10 @@ export function videoElementSizeOnPage(page) {
   );
   if (videoElementsOnPage.length === 1) {
     const [videoElement] = videoElementsOnPage;
-    return mediaElementSizeOnPage(videoElement);
+    return {
+      pageId: page.id,
+      ...mediaElementSizeOnPage(videoElement),
+    };
   }
   return undefined;
 }

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { PAGE_HEIGHT, PAGE_WIDTH } from '../../../constants';
@@ -33,12 +38,6 @@ const MIN_VIDEO_WIDTH = 852;
 // MIN_VIDEO_FPS = 24;
 // export function videoElementFps(element) {}
 
-const getChecklistMessage = (elementId, message) => ({
-  type: 'guidance',
-  elementId,
-  message,
-});
-
 export function mediaElementSizeOnPage(element) {
   // triggered if only one video is on the page and it takes less than 50% of the safe zone area
   // encourage users to consider a more immersive media sizing and cropping.
@@ -46,8 +45,14 @@ export function mediaElementSizeOnPage(element) {
   const isTooSmallOnPage = SAFE_ZONE_AREA / 2 > elementArea;
 
   if (isTooSmallOnPage) {
-    const media = element.type === 'video' ? 'Video' : 'Image';
-    return getChecklistMessage(element.id, `${media} is too small on the page`);
+    return {
+      type: 'guidance',
+      elementId: element.id,
+      message:
+        element.type === 'video'
+          ? __(`Video is too small on the page`, 'web-stories')
+          : __(`Image is too small on the page`, 'web-stories'),
+    };
   }
 
   return undefined;
@@ -85,14 +90,22 @@ function videoElementResolution(element) {
     element.resource.full.width >= MAX_VIDEO_WIDTH;
 
   if (videoResolutionHigh) {
-    return getChecklistMessage(
-      element.id,
-      "Video's resolution is too high to display on most mobile devices (>4k)"
-    );
+    return {
+      type: 'guidance',
+      elementId: element.id,
+      message: __(
+        "Video's resolution is too high to display on most mobile devices (>4k)",
+        'web-stories'
+      ),
+    };
   }
 
   if (videoResolutionLow) {
-    return getChecklistMessage(element.id, 'Video has low resolution');
+    return {
+      type: 'guidance',
+      elementId: element.id,
+      message: __('Video has low resolution', 'web-stories'),
+    };
   }
 
   return undefined;
@@ -103,17 +116,25 @@ function imageElementResolution(element) {
   const elementDims = element.height * element.width;
   const minDensity = resourceDims / MIN_PIXEL_DENSITY;
   if (elementDims > minDensity) {
-    return getChecklistMessage(element.id, 'Image has low resolution');
+    return {
+      type: 'guidance',
+      elementId: element.id,
+      message: __('Image has low resolution', 'web-stories'),
+    };
   }
   return undefined;
 }
 
 export function videoElementLength(element) {
   if (element.resource.length > MAX_VIDEO_LENGTH_SECONDS) {
-    return getChecklistMessage(
-      element.id,
-      'Video is longer than 1 minute (suggest breaking video up into multiple segments)'
-    );
+    return {
+      type: 'guidance',
+      elementId: element.id,
+      message: __(
+        'Video is longer than 1 minute (suggest breaking video up into multiple segments)',
+        'web-stories'
+      ),
+    };
   }
   return undefined;
 }

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -14,10 +14,106 @@
  * limitations under the License.
  */
 
-export function mediaElementSizeOnPage(/*element*/) {}
+/**
+ * Internal dependencies
+ */
+import { PAGE_HEIGHT, PAGE_WIDTH } from '../../../constants';
 
-export function mediaElementResolution(/*element*/) {}
+const SAFE_ZONE_AREA = PAGE_HEIGHT * PAGE_WIDTH;
 
-export function videoElementLength(/*element*/) {}
+const MIN_PIXEL_DENSITY = 2;
 
-export function videoElementFps(/*element*/) {}
+const MAX_VIDEO_LENGTH_SECONDS = 60;
+const MAX_VIDEO_WIDTH = 3840;
+const MAX_VIDEO_HEIGHT = 2160;
+const MIN_VIDEO_HEIGHT = 480;
+const MIN_VIDEO_WIDTH = 852;
+
+// todo: get video frames per second
+// MIN_VIDEO_FPS = 24;
+// export function videoElementFps(element) {}
+
+const getChecklistMessage = (elementId, message) => ({
+  type: 'guidance',
+  elementId,
+  message,
+});
+
+export function mediaElementSizeOnPage(element) {
+  // triggered if only one video is on the page and it takes less than 50% of the safe zone area
+  // encourage users to consider a more immersive media sizing and cropping.
+  const elementArea = element.height * element.width;
+  const isTooSmallOnPage = SAFE_ZONE_AREA / 2 > elementArea;
+
+  if (isTooSmallOnPage) {
+    const media = element.type === 'video' ? 'Video' : 'Image';
+    return getChecklistMessage(element.id, `${media} is too small on the page`);
+  }
+
+  return undefined;
+}
+
+export function videoElementSizeOnPage(page) {
+  const videoElementsOnPage = page.elements.filter(
+    ({ type }) => type === 'video'
+  );
+  if (videoElementsOnPage.length === 1) {
+    const [videoElement] = videoElementsOnPage;
+    return mediaElementSizeOnPage(videoElement);
+  }
+  return undefined;
+}
+
+export function mediaElementResolution(element) {
+  if (element.type === 'video') {
+    return videoElementResolution(element);
+  }
+
+  if (element.type === 'image' || element.type === 'gif') {
+    return imageElementResolution(element);
+  }
+
+  return undefined;
+}
+
+function videoElementResolution(element) {
+  const videoResolutionLow =
+    element.resource.full.height <= MIN_VIDEO_HEIGHT &&
+    element.resource.full.width <= MIN_VIDEO_WIDTH;
+  const videoResolutionHigh =
+    element.resource.full.height >= MAX_VIDEO_HEIGHT &&
+    element.resource.full.width >= MAX_VIDEO_WIDTH;
+
+  if (videoResolutionHigh) {
+    return getChecklistMessage(
+      element.id,
+      "Video's resolution is too high to display on most mobile devices (>4k)"
+    );
+  }
+
+  if (videoResolutionLow) {
+    return getChecklistMessage(element.id, 'Video has low resolution');
+  }
+
+  return undefined;
+}
+
+function imageElementResolution(element) {
+  const resourceDims = element.resource.height * element.resource.width;
+  const elementDims = element.height * element.width;
+  const minDensity = resourceDims / MIN_PIXEL_DENSITY;
+  if (elementDims > minDensity) {
+    return getChecklistMessage(element.id, 'Image has low resolution');
+  }
+  return undefined;
+}
+
+export function videoElementLength(element) {
+  if (element.resource.length > MAX_VIDEO_LENGTH_SECONDS) {
+    return getChecklistMessage(
+      element.id,
+      'Video is longer than 1 minute (suggest breaking video up into multiple segments)'
+    );
+  }
+  return undefined;
+}

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -23,6 +23,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { PAGE_HEIGHT, PAGE_WIDTH } from '../../../constants';
+import getBoundRect from '../../../utils/getBoundRect';
 
 const SAFE_ZONE_AREA = PAGE_HEIGHT * PAGE_WIDTH;
 
@@ -38,6 +39,8 @@ const MIN_VIDEO_WIDTH = 852;
 
 export function mediaElementSizeOnPage(element) {
   // get the intersecting area of the element's rectangle and the safe zone's rectangle
+  // use the bounding rectangle for rotated elements
+  const { startX, startY, endX, endY } = getBoundRect([element]);
   const safeZone = {
       left: 0,
       right: PAGE_WIDTH,
@@ -45,10 +48,10 @@ export function mediaElementSizeOnPage(element) {
       top: 0,
     },
     elemRect = {
-      left: element.x,
-      right: element.x + element.width,
-      bottom: element.y + element.height,
-      top: element.y,
+      left: startX,
+      right: endX,
+      bottom: endY,
+      top: startY,
     };
   const xOverlap = Math.max(
     0,

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -26,8 +26,6 @@ import { PAGE_HEIGHT, PAGE_WIDTH } from '../../../constants';
 
 const SAFE_ZONE_AREA = PAGE_HEIGHT * PAGE_WIDTH;
 
-const MIN_PIXEL_DENSITY = 2;
-
 const MAX_VIDEO_LENGTH_SECONDS = 60;
 const MAX_VIDEO_WIDTH = 3840;
 const MAX_VIDEO_HEIGHT = 2160;
@@ -112,10 +110,11 @@ function videoElementResolution(element) {
 }
 
 function imageElementResolution(element) {
-  const resourceDims = element.resource.height * element.resource.width;
-  const elementDims = element.height * element.width;
-  const minDensity = resourceDims / MIN_PIXEL_DENSITY;
-  if (elementDims > minDensity) {
+  const heightResTooLow =
+    element.resource.sizes.full.height < 2 * element.height;
+  const widthResTooLow = element.resource.sizes.full.width < 2 * element.width;
+
+  if (heightResTooLow || widthResTooLow) {
     return {
       type: 'guidance',
       elementId: element.id,

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -59,9 +59,11 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
       id: 789,
       type: 'video',
       resource: {
-        full: {
-          height: 480,
-          width: 852,
+        sizes: {
+          full: {
+            height: 480,
+            width: 852,
+          },
         },
       },
     };
@@ -134,9 +136,11 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
       id: 101,
       type: 'video',
       resource: {
-        full: {
-          height: 2160,
-          width: 3840,
+        sizes: {
+          full: {
+            height: 2160,
+            width: 3840,
+          },
         },
       },
     };
@@ -156,9 +160,11 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
       type: 'video',
       resource: {
         length: 75,
-        full: {
-          height: 2160,
-          width: 3840,
+        sizes: {
+          full: {
+            height: 2160,
+            width: 3840,
+          },
         },
       },
     };

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -70,6 +70,60 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
     expect(result.elementId).toStrictEqual(tooLowResolutionVideoElement.id);
   });
 
+  it("should return a message if an image element's resolution is too low (<2x pixel density)", () => {
+    const tooLowResolutionImageElement = {
+      id: 910,
+      type: 'image',
+      height: 1000,
+      width: 1000,
+      resource: {
+        sizes: {
+          full: {
+            height: 1000,
+            width: 1000,
+          },
+        },
+      },
+    };
+
+    const result = mediaGuidance.mediaElementResolution(
+      tooLowResolutionImageElement
+    );
+    expect(result).not.toBeUndefined();
+    expect(result.message).toMatchInlineSnapshot(`"Image has low resolution"`);
+    expect(result.type).toStrictEqual('guidance');
+    expect(result.elementId).toStrictEqual(tooLowResolutionImageElement.id);
+  });
+
+  it("should return a message if a gif element's resolution is too low (<2x pixel density)", () => {
+    const tooLowResolutionImageElement = {
+      id: 911,
+      type: 'gif',
+      height: 1000,
+      width: 1000,
+      resource: {
+        output: {
+          sizes: {
+            mp4: {
+              full: {
+                height: 1000,
+                width: 1000,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = mediaGuidance.mediaElementResolution(
+      tooLowResolutionImageElement
+    );
+    expect(result).not.toBeUndefined();
+    expect(result.message).toMatchInlineSnapshot(`"GIF has low resolution"`);
+    expect(result.type).toStrictEqual('guidance');
+    expect(result.elementId).toStrictEqual(tooLowResolutionImageElement.id);
+  });
+
   it('should return a message if any video resolution is too high to display on most mobile devices (>4k)', () => {
     const tooHighVideoResolution = {
       id: 101,
@@ -113,6 +167,5 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
     expect(result.elementId).toStrictEqual(tooLongVideo.id);
   });
 
-  it.todo('should return a message if an image element has low resolution');
   it.todo('should return a message if the video element is less than 24fps');
 });

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -17,24 +17,102 @@
 /**
  * Internal dependencies
  */
-// import * as mediaGuidance from '../media';
+import * as mediaGuidance from '../media';
 
 describe('Pre-publish checklist - media guidelines (guidance)', () => {
-  // triggered if only one video is on the page and it takes less than 50% of the safe zone area
-  // encourage users to consider a more immersive media sizing and cropping.
-  it.todo(
-    'should return a message if a video or image element is too small on the page'
-  );
-  // actual image asset on screen, at the current zoom, offers <2x pixel density
-  // guideline is to strive for >828 x 1792
+  it('should return a message if an image element takes up <50% of the safe zone area', () => {
+    const tooSmallImageElement = {
+      id: 123,
+      type: 'image',
+      height: 50,
+      width: 50,
+    };
+    const result = mediaGuidance.mediaElementSizeOnPage(tooSmallImageElement);
+    expect(result).not.toBeUndefined();
+    expect(result.type).toStrictEqual('guidance');
+    expect(result.elementId).toStrictEqual(tooSmallImageElement.id);
+  });
+
+  it('should return a message if a video element takes up <50% of the safe zone area', () => {
+    const tooSmallVideoElement = {
+      id: 456,
+      type: 'video',
+      height: 100,
+      width: 400,
+    };
+    const result = mediaGuidance.mediaElementSizeOnPage(tooSmallVideoElement);
+    expect(result).not.toBeUndefined();
+    expect(result.message).toMatchInlineSnapshot(
+      `"Video is too small on the page"`
+    );
+    expect(result.type).toStrictEqual('guidance');
+    expect(result.elementId).toStrictEqual(tooSmallVideoElement.id);
+  });
+
+  it('should return a message if a video element is less than 480p', () => {
+    const tooLowResolutionVideoElement = {
+      id: 789,
+      type: 'video',
+      resource: {
+        full: {
+          height: 480,
+          width: 852,
+        },
+      },
+    };
+
+    const result = mediaGuidance.mediaElementResolution(
+      tooLowResolutionVideoElement
+    );
+    expect(result).not.toBeUndefined();
+    expect(result.message).toMatchInlineSnapshot(`"Video has low resolution"`);
+    expect(result.type).toStrictEqual('guidance');
+    expect(result.elementId).toStrictEqual(tooLowResolutionVideoElement.id);
+  });
+
+  it('should return a message if any video resolution is too high to display on most mobile devices (>4k)', () => {
+    const tooHighVideoResolution = {
+      id: 101,
+      type: 'video',
+      resource: {
+        full: {
+          height: 2160,
+          width: 3840,
+        },
+      },
+    };
+
+    const result = mediaGuidance.mediaElementResolution(tooHighVideoResolution);
+    expect(result).not.toBeUndefined();
+    expect(result.message).toMatchInlineSnapshot(
+      `"Video's resolution is too high to display on most mobile devices (>4k)"`
+    );
+    expect(result.type).toStrictEqual('guidance');
+    expect(result.elementId).toStrictEqual(tooHighVideoResolution.id);
+  });
+
+  it('should return a message if the video element is longer than 1 minute', () => {
+    const tooLongVideo = {
+      id: 202,
+      type: 'video',
+      resource: {
+        length: 75,
+        full: {
+          height: 2160,
+          width: 3840,
+        },
+      },
+    };
+
+    const result = mediaGuidance.videoElementLength(tooLongVideo);
+    expect(result).not.toBeUndefined();
+    expect(result.message).toMatchInlineSnapshot(
+      `"Video is longer than 1 minute (suggest breaking video up into multiple segments)"`
+    );
+    expect(result.type).toStrictEqual('guidance');
+    expect(result.elementId).toStrictEqual(tooLongVideo.id);
+  });
+
   it.todo('should return a message if an image element has low resolution');
-  // suggest breaking video up into multiple segments
-  it.todo(
-    'should return a message if the video element is longer than 1 minute'
-  );
   it.todo('should return a message if the video element is less than 24fps');
-  it.todo('should return a message if any videos are less than 480p');
-  it.todo(
-    'should return a message if any video resolution is too high to display on most mobile devices (>4k)'
-  );
 });

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { PAGE_HEIGHT, PAGE_WIDTH } from '../../../../constants';
 import * as mediaGuidance from '../media';
 
 describe('Pre-publish checklist - media guidelines (guidance)', () => {
@@ -26,6 +27,8 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
       type: 'image',
       height: 50,
       width: 50,
+      x: 0,
+      y: 0,
     };
     const result = mediaGuidance.mediaElementSizeOnPage(tooSmallImageElement);
     expect(result).not.toBeUndefined();
@@ -37,8 +40,10 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
     const tooSmallVideoElement = {
       id: 456,
       type: 'video',
-      height: 100,
-      width: 400,
+      height: PAGE_HEIGHT,
+      width: PAGE_WIDTH,
+      x: 0,
+      y: -(PAGE_HEIGHT / 2) - 1,
     };
     const result = mediaGuidance.mediaElementSizeOnPage(tooSmallVideoElement);
     expect(result).not.toBeUndefined();

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+// import * as mediaGuidance from '../media';
+
+describe('Pre-publish checklist - media guidelines (guidance)', () => {
+  // triggered if only one video is on the page and it takes less than 50% of the safe zone area
+  // encourage users to consider a more immersive media sizing and cropping.
+  it.todo(
+    'should return a message if a video or image element is too small on the page'
+  );
+  // actual image asset on screen, at the current zoom, offers <2x pixel density
+  // guideline is to strive for >828 x 1792
+  it.todo('should return a message if an image element has low resolution');
+  // suggest breaking video up into multiple segments
+  it.todo(
+    'should return a message if the video element is longer than 1 minute'
+  );
+  it.todo('should return a message if the video element is less than 24fps');
+  it.todo('should return a message if any videos are less than 480p');
+  it.todo(
+    'should return a message if any video resolution is too high to display on most mobile devices (>4k)'
+  );
+});

--- a/assets/src/edit-story/app/prepublish/types.js
+++ b/assets/src/edit-story/app/prepublish/types.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Guidance return object
+ *
+ * @typedef {Guidance} Guidance
+ * @property {string} type The type/severity of the message [error, warning, guidance]
+ * @property {string} [pageId] The ID of the page being checked
+ * @property {string} [elementId] The ID of the element being checked
+ * @property {string} [storyId] The ID of the story element being checked
+ *
+ */

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -318,7 +318,35 @@ export default StoryPropTypes;
  * Page object.
  *
  * @typedef {Page} Page
- * @property {Array} elements Array of all elements.
+ * @property {Element[]} elements Array of all elements.
+ */
+
+/**
+ * Element object
+ *
+ * @typedef {Element} Element A story element
+ * @property {string} id  A unique uuid for the element
+ * @property {string} type The type of the element, e.g. video, gif, image
+ * @property {number} x The x position of the element, its top left corner
+ * @property {number} y The y position of the element, its top left corner
+ * @property {number} width The width of the element
+ * @property {number} height The height of the element
+ * @property {Object} flip If the element has been flipped vertical/horizontal
+ * @property {number} rotationAngle The element's rotation angle
+ * @property {Object} mask The type of mask applied to the element
+ * @property {Object} link The url, icon and description of a link applied to element
+ * @property {number} opacity The opacity of the element
+ * @property {boolean} lockAspectRatio Whether the element's aspect ratio is locked
+ * @property {Resource} resource The element's resource object
+ */
+
+/**
+ * Resource object
+ *
+ * @typedef {Resource} Resource Resource data for elements
+ * @property {{ full: { height: number, width: number }, output: Object }} sizes The data for the full-size element
+ * @property {boolean} local Whether the media was uploaded by the user
+ * @property {string} src The source string for the resource
  */
 
 /**


### PR DESCRIPTION
## Summary

- adds logic to check media elements against web story guidelines
- [ticket](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/4915)

## Relevant Technical Choices

- I created a simple return object for these checkers that looks like this right now:
```
{
  type: "guidance",
  message: /* translated message */
  elementId: /* id of element */
  pageId: /* id of page (if applicable) */
}
```
I figure we'll need a reference to the element to easily point the user to the problem and we can use the `type` to distinguish guidance from warnings and errors.


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
- [x] add some typedefs to these functions and document the function signatures
- [x] return and test for `pageId` on page-related functions

## User-facing changes
None.

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->
N/A
---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4915 
