### PR TITLE
Dashboard: Fix renaming stories

### DIFF
--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -138,10 +138,17 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
   );
 
   const updateStory = useCallback(
-    async (story) => {
+    async ({ id, ...data }) => {
+      const path = queryString.stringifyUrl({
+        url: `${storyApi}/${id}`,
+        query: {
+          _embed: 'author',
+        },
+      });
+
       try {
-        const response = await dataAdapter.post(`${storyApi}/${story.id}`, {
-          data: story,
+        const response = await dataAdapter.post(path, {
+          data,
         });
         dispatch({
           type: STORY_ACTION_TYPES.UPDATE_STORY,

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -108,7 +108,7 @@ function StoriesView({
     async (story, newTitle) => {
       setTitleRenameId(-1);
       await trackEvent('rename_story', 'dashboard');
-      storyActions.updateStory({ ...story, title: { raw: newTitle } });
+      storyActions.updateStory({ id: story.id, title: newTitle });
     },
     [storyActions]
   );


### PR DESCRIPTION
## Summary

Fixes renaming stories, as the title says.

## Relevant Technical Choices

* Ensure `_embed` is used.
* Only send the data that changed, not the whole story object

## To-do

* [ ] Fix tests

## User-facing changes

N/A

## Testing Instructions

1. Rename a story on the dashboard

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5031
