### PR TITLE
Fix ability to rename dashboard stories

### DIFF
--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -162,8 +162,11 @@ describe('ApiProvider', () => {
           },
         ],
         status: 'publish',
-        title: 'New Title',
+        title: { raw: 'New Title' },
         link: 'https://www.story-link.com',
+        originalStoryData: {
+          author: 1,
+        },
       });
     });
 

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -140,8 +140,18 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
   const updateStory = useCallback(
     async (story) => {
       try {
-        const response = await dataAdapter.post(`${storyApi}/${story.id}`, {
-          data: story,
+        const path = queryString.stringifyUrl({
+          url: `${storyApi}/${story.id}`,
+          query: {
+            _embed: 'author',
+          },
+        });
+
+        const response = await dataAdapter.post(path, {
+          data: {
+            ...story,
+            author: story.originalStoryData.author,
+          },
         });
         dispatch({
           type: STORY_ACTION_TYPES.UPDATE_STORY,

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -147,11 +147,14 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
           },
         });
 
+        const data = {
+          id: story.id,
+          author: story.originalStoryData.author,
+          title: story.title?.raw || story.title,
+        };
+
         const response = await dataAdapter.post(path, {
-          data: {
-            ...story,
-            author: story.originalStoryData.author,
-          },
+          data,
         });
         dispatch({
           type: STORY_ACTION_TYPES.UPDATE_STORY,


### PR DESCRIPTION
## Summary
fixing ability to rename a story. 

## Relevant Technical Choices

Needed two things - 
1. the author is an ID not a string (we only use the string in the dashboard after embedding the author info and serializing so pulling from original story data that is attached to a story and never messed with in the dashboard so it will always be there. 
2. Query needed to know that author info is embedded coming back otherwise the response is wrong (just like this PR earlier today: https://github.com/google/web-stories-wp/pull/5019) 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Renaming a story should work again

## Testing Instructions

Rename a story

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5031 
