### PR TITLE
Text: Ensure content is updated on blur to keep content when font changes.

### DIFF
--- a/assets/src/edit-story/components/richText/editor.js
+++ b/assets/src/edit-story/components/richText/editor.js
@@ -28,7 +28,7 @@ import useUnmount from '../../utils/useUnmount';
 import useRichText from './useRichText';
 import customInlineDisplay from './customInlineDisplay';
 
-function RichTextEditor({ content, onChange }, ref) {
+function RichTextEditor({ content, onChange, onBlur }, ref) {
   const editorRef = useRef(null);
   const {
     state: { editorState },
@@ -88,6 +88,7 @@ function RichTextEditor({ content, onChange }, ref) {
       handleKeyCommand={handleKeyCommand}
       handlePastedText={handlePastedText}
       customStyleFn={customInlineDisplay}
+      onBlur={onBlur}
       stripPastedStyles
     />
   );
@@ -98,6 +99,7 @@ const RichTextEditorWithRef = forwardRef(RichTextEditor);
 RichTextEditor.propTypes = {
   content: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func,
 };
 
 export default RichTextEditorWithRef;

--- a/assets/src/edit-story/elements/text/edit.js
+++ b/assets/src/edit-story/elements/text/edit.js
@@ -360,6 +360,7 @@ function TextEdit({
           ref={editorRef}
           content={content}
           onChange={handleUpdate}
+          onBlur={updateContent}
         />
       </EditTextBox>
     </Wrapper>


### PR DESCRIPTION
## Summary

Ensures the state of the text is updated on blur. Otherwise when the font is updated it has no idea what the current transient text content is.

## Relevant Technical Choices

—

## To-do

None

## User-facing changes

Prevents text from reverting on font change.

## Testing Instructions

1. Edit a story
2. Select a text box and edit the text
3. Change the font and see that the text content does not change

---

<!-- Please reference the issue(s) this PR addresses. -->

#5035 
