### PR TITLE
Settings: Add Site Kit Specific UI

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 /**
@@ -65,17 +65,17 @@ export const TEXT = {
     'web-stories'
   ),
   SITE_KIT_IN_USE: __(
-    "Since Google Analytics is already enabled through<a>Site Kit by Google</a>, there's no need to do anything else to configure your tracking ID for Web Stories.",
+    'Site Kit by Google has already enabled Google Analytics for your Web Stories, all changes to your analytics tracking should occur there.',
     'web-stories'
   ),
+  SITE_KIT_ADMIN_PLUGIN_LINK: 'https://wordpress.org/plugins/google-site-kit/', // TODO get a direct link to WP admin (it's a modal)
   SITE_KIT_PLUGIN_LINK: 'https://wordpress.org/plugins/google-site-kit/',
-  SITE_KIT_INSTRUCTIONS_LINK:
-    'https://sitekit.withgoogle.com/documentation/install/',
 };
 
 function GoogleAnalyticsSettings({
   googleAnalyticsId,
   handleUpdate,
+  canInstallPlugins,
   siteKitPluginStatus,
 }) {
   const [analyticsId, setAnalyticsId] = useState(googleAnalyticsId);
@@ -116,6 +116,14 @@ function GoogleAnalyticsSettings({
     [handleOnSave]
   );
 
+  const siteKitLink = useMemo(
+    () =>
+      canInstallPlugins
+        ? TEXT.SITE_KIT_ADMIN_PLUGIN_LINK
+        : TEXT.SITE_KIT_PLUGIN_LINK,
+    [canInstallPlugins]
+  );
+
   return (
     <SettingForm onSubmit={(e) => e.preventDefault()}>
       <div>
@@ -126,7 +134,7 @@ function GoogleAnalyticsSettings({
           {!siteKitPluginStatus && (
             <TranslateWithMarkup
               mapping={{
-                a: <InlineLink href={TEXT.SITE_KIT_INSTRUCTIONS_LINK} />,
+                a: <InlineLink href={siteKitLink} />,
               }}
             >
               {TEXT.SITE_KIT_NOT_INSTALLED}
@@ -135,22 +143,14 @@ function GoogleAnalyticsSettings({
           {siteKitPluginStatus === 'inactive' && (
             <TranslateWithMarkup
               mapping={{
-                a: <InlineLink href={TEXT.SITE_KIT_INSTRUCTIONS_LINK} />,
+                a: <InlineLink href={siteKitLink} />,
               }}
             >
               {TEXT.SITE_KIT_INSTALLED}
             </TranslateWithMarkup>
           )}
 
-          {siteKitPluginStatus === 'active' && (
-            <TranslateWithMarkup
-              mapping={{
-                a: <InlineLink href={TEXT.SITE_KIT_INSTRUCTIONS_LINK} />,
-              }}
-            >
-              {TEXT.SITE_KIT_IN_USE}
-            </TranslateWithMarkup>
-          )}
+          {siteKitPluginStatus === 'active' && TEXT.SITE_KIT_IN_USE}
         </HelperText>
       </div>
       <FormContainer>
@@ -190,6 +190,7 @@ GoogleAnalyticsSettings.propTypes = {
   handleUpdate: PropTypes.func,
   googleAnalyticsId: PropTypes.string,
   siteKitPluginStatus: PropTypes.oneOf(['inactive', 'active', false]),
+  canInstallPlugins: PropTypes.bool,
 };
 
 export default GoogleAnalyticsSettings;

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -75,7 +75,7 @@ export const TEXT = {
 function GoogleAnalyticsSettings({
   googleAnalyticsId,
   handleUpdate,
-  siteKitCapabilities,
+  siteKitCapabilities = {},
 }) {
   const [analyticsId, setAnalyticsId] = useState(googleAnalyticsId);
   const [inputError, setInputError] = useState('');

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -121,13 +121,36 @@ function GoogleAnalyticsSettings({
     [handleOnSave]
   );
 
-  const siteKitLink = useMemo(
-    () =>
-      canInstallPlugins
-        ? TEXT.SITE_KIT_ADMIN_PLUGIN_LINK
-        : TEXT.SITE_KIT_PLUGIN_LINK,
-    [canInstallPlugins]
-  );
+  const siteKitDisplayText = useMemo(() => {
+    const siteKitLink = canInstallPlugins
+      ? TEXT.SITE_KIT_ADMIN_PLUGIN_LINK
+      : TEXT.SITE_KIT_PLUGIN_LINK;
+
+    if (siteKitActive) {
+      return TEXT.SITE_KIT_IN_USE;
+    }
+
+    if (siteKitInstalled && !siteKitActive) {
+      return (
+        <TranslateWithMarkup
+          mapping={{
+            a: <InlineLink href={siteKitLink} />,
+          }}
+        >
+          {TEXT.SITE_KIT_INSTALLED}
+        </TranslateWithMarkup>
+      );
+    }
+    return (
+      <TranslateWithMarkup
+        mapping={{
+          a: <InlineLink href={siteKitLink} />,
+        }}
+      >
+        {TEXT.SITE_KIT_NOT_INSTALLED}
+      </TranslateWithMarkup>
+    );
+  }, [canInstallPlugins, siteKitActive, siteKitInstalled]);
 
   return (
     <SettingForm onSubmit={(e) => e.preventDefault()}>
@@ -135,28 +158,7 @@ function GoogleAnalyticsSettings({
         <SettingHeading htmlFor="gaTrackingID">
           {TEXT.SECTION_HEADING}
         </SettingHeading>
-        <HelperText>
-          {!siteKitInstalled && (
-            <TranslateWithMarkup
-              mapping={{
-                a: <InlineLink href={siteKitLink} />,
-              }}
-            >
-              {TEXT.SITE_KIT_NOT_INSTALLED}
-            </TranslateWithMarkup>
-          )}
-          {siteKitInstalled && !siteKitActive && (
-            <TranslateWithMarkup
-              mapping={{
-                a: <InlineLink href={siteKitLink} />,
-              }}
-            >
-              {TEXT.SITE_KIT_INSTALLED}
-            </TranslateWithMarkup>
-          )}
-
-          {siteKitActive && TEXT.SITE_KIT_IN_USE}
-        </HelperText>
+        <HelperText>{siteKitDisplayText}</HelperText>
       </div>
       <FormContainer>
         <InlineForm>

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -41,11 +41,12 @@ import {
   SettingHeading,
   TextInputHelperText,
   VisuallyHiddenLabel,
+  HelperText,
 } from '../components';
 
 export const TEXT = {
   CONTEXT: __(
-    "The story editor will append a default, configurable AMP analytics configuration to your story. If you're interested in going beyond what the default configuration is, read this article on <a>analytics for your Web Stories</a>.",
+    "The story editor will append a default, configurable AMP analytics configuration to your story. If you're interested in going beyond what the default configuration is, read this article on<a>analytics for your Web Stories</a>.",
     'web-stories'
   ),
   CONTEXT_LINK:
@@ -55,9 +56,28 @@ export const TEXT = {
   ARIA_LABEL: __('Enter your Google Analytics Tracking ID', 'web-stories'),
   INPUT_ERROR: __('Invalid ID format', 'web-stories'),
   SUBMIT_BUTTON: __('Save', 'web-stories'),
+  SITE_KIT_NOT_INSTALLED: __(
+    'Install<a>Site Kit by Google</a> to easily enable Google Analytics for Web Stories.',
+    'web-stories'
+  ),
+  SITE_KIT_INSTALLED: __(
+    'Use Site Kit by Google to easily<a>activate Google Analytics</a> for Web Stories.',
+    'web-stories'
+  ),
+  SITE_KIT_IN_USE: __(
+    "Since Google Analytics is already enabled through<a>Site Kit by Google</a>, there's no need to do anything else to configure your tracking ID for Web Stories.",
+    'web-stories'
+  ),
+  SITE_KIT_PLUGIN_LINK: 'https://wordpress.org/plugins/google-site-kit/',
+  SITE_KIT_INSTRUCTIONS_LINK:
+    'https://sitekit.withgoogle.com/documentation/install/',
 };
 
-function GoogleAnalyticsSettings({ googleAnalyticsId, handleUpdate }) {
+function GoogleAnalyticsSettings({
+  googleAnalyticsId,
+  handleUpdate,
+  siteKitPluginStatus,
+}) {
   const [analyticsId, setAnalyticsId] = useState(googleAnalyticsId);
   const [inputError, setInputError] = useState('');
   const canSave = analyticsId !== googleAnalyticsId && !inputError;
@@ -98,9 +118,41 @@ function GoogleAnalyticsSettings({ googleAnalyticsId, handleUpdate }) {
 
   return (
     <SettingForm onSubmit={(e) => e.preventDefault()}>
-      <SettingHeading htmlFor="gaTrackingID">
-        {TEXT.SECTION_HEADING}
-      </SettingHeading>
+      <div>
+        <SettingHeading htmlFor="gaTrackingID">
+          {TEXT.SECTION_HEADING}
+        </SettingHeading>
+        <HelperText>
+          {!siteKitPluginStatus && (
+            <TranslateWithMarkup
+              mapping={{
+                a: <InlineLink href={TEXT.SITE_KIT_INSTRUCTIONS_LINK} />,
+              }}
+            >
+              {TEXT.SITE_KIT_NOT_INSTALLED}
+            </TranslateWithMarkup>
+          )}
+          {siteKitPluginStatus === 'inactive' && (
+            <TranslateWithMarkup
+              mapping={{
+                a: <InlineLink href={TEXT.SITE_KIT_INSTRUCTIONS_LINK} />,
+              }}
+            >
+              {TEXT.SITE_KIT_INSTALLED}
+            </TranslateWithMarkup>
+          )}
+
+          {siteKitPluginStatus === 'active' && (
+            <TranslateWithMarkup
+              mapping={{
+                a: <InlineLink href={TEXT.SITE_KIT_INSTRUCTIONS_LINK} />,
+              }}
+            >
+              {TEXT.SITE_KIT_IN_USE}
+            </TranslateWithMarkup>
+          )}
+        </HelperText>
+      </div>
       <FormContainer>
         <InlineForm>
           <VisuallyHiddenLabel htmlFor="gaTrackingId">
@@ -114,6 +166,7 @@ function GoogleAnalyticsSettings({ googleAnalyticsId, handleUpdate }) {
             onKeyDown={handleOnKeyDown}
             placeholder={TEXT.PLACEHOLDER}
             error={inputError}
+            disabled={Boolean(siteKitPluginStatus)} // if site kit is installed we don't want to change anything here
           />
           <SaveButton isDisabled={disableSaveButton} onClick={handleOnSave}>
             {TEXT.SUBMIT_BUTTON}
@@ -136,6 +189,7 @@ function GoogleAnalyticsSettings({ googleAnalyticsId, handleUpdate }) {
 GoogleAnalyticsSettings.propTypes = {
   handleUpdate: PropTypes.func,
   googleAnalyticsId: PropTypes.string,
+  siteKitPluginStatus: PropTypes.oneOf(['inactive', 'active', false]),
 };
 
 export default GoogleAnalyticsSettings;

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -130,7 +130,7 @@ function GoogleAnalyticsSettings({
       return TEXT.SITE_KIT_IN_USE;
     }
 
-    if (siteKitInstalled && !siteKitActive) {
+    if (siteKitInstalled) {
       return (
         <TranslateWithMarkup
           mapping={{
@@ -173,7 +173,7 @@ function GoogleAnalyticsSettings({
             onKeyDown={handleOnKeyDown}
             placeholder={TEXT.PLACEHOLDER}
             error={inputError}
-            disabled={siteKitInstalled} // if site kit is installed we don't want to change anything here
+            disabled={siteKitInstalled}
           />
           <SaveButton isDisabled={disableSaveButton} onClick={handleOnSave}>
             {TEXT.SUBMIT_BUTTON}

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -75,13 +75,18 @@ export const TEXT = {
 function GoogleAnalyticsSettings({
   googleAnalyticsId,
   handleUpdate,
-  canInstallPlugins,
-  siteKitPluginStatus,
+  siteKitCapabilities,
 }) {
   const [analyticsId, setAnalyticsId] = useState(googleAnalyticsId);
   const [inputError, setInputError] = useState('');
   const canSave = analyticsId !== googleAnalyticsId && !inputError;
   const disableSaveButton = !canSave;
+
+  const {
+    canInstallPlugins,
+    siteKitActive,
+    siteKitInstalled,
+  } = siteKitCapabilities;
 
   useEffect(() => {
     setAnalyticsId(googleAnalyticsId);
@@ -131,7 +136,7 @@ function GoogleAnalyticsSettings({
           {TEXT.SECTION_HEADING}
         </SettingHeading>
         <HelperText>
-          {!siteKitPluginStatus && (
+          {!siteKitInstalled && (
             <TranslateWithMarkup
               mapping={{
                 a: <InlineLink href={siteKitLink} />,
@@ -140,7 +145,7 @@ function GoogleAnalyticsSettings({
               {TEXT.SITE_KIT_NOT_INSTALLED}
             </TranslateWithMarkup>
           )}
-          {siteKitPluginStatus === 'inactive' && (
+          {siteKitInstalled && !siteKitActive && (
             <TranslateWithMarkup
               mapping={{
                 a: <InlineLink href={siteKitLink} />,
@@ -150,7 +155,7 @@ function GoogleAnalyticsSettings({
             </TranslateWithMarkup>
           )}
 
-          {siteKitPluginStatus === 'active' && TEXT.SITE_KIT_IN_USE}
+          {siteKitActive && TEXT.SITE_KIT_IN_USE}
         </HelperText>
       </div>
       <FormContainer>
@@ -166,7 +171,7 @@ function GoogleAnalyticsSettings({
             onKeyDown={handleOnKeyDown}
             placeholder={TEXT.PLACEHOLDER}
             error={inputError}
-            disabled={Boolean(siteKitPluginStatus)} // if site kit is installed we don't want to change anything here
+            disabled={siteKitInstalled} // if site kit is installed we don't want to change anything here
           />
           <SaveButton isDisabled={disableSaveButton} onClick={handleOnSave}>
             {TEXT.SUBMIT_BUTTON}
@@ -189,8 +194,13 @@ function GoogleAnalyticsSettings({
 GoogleAnalyticsSettings.propTypes = {
   handleUpdate: PropTypes.func,
   googleAnalyticsId: PropTypes.string,
-  siteKitPluginStatus: PropTypes.oneOf(['inactive', 'active', false]),
-  canInstallPlugins: PropTypes.bool,
+  siteKitCapabilities: PropTypes.shape({
+    analyticsModuleActive: PropTypes.bool,
+    canActivatePlugins: PropTypes.bool,
+    canInstallPlugins: PropTypes.bool,
+    siteKitActive: PropTypes.bool,
+    siteKitInstalled: PropTypes.bool,
+  }),
 };
 
 export default GoogleAnalyticsSettings;

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -134,7 +134,9 @@ function GoogleAnalyticsSettings({
       return (
         <TranslateWithMarkup
           mapping={{
-            a: <InlineLink href={siteKitLink} />,
+            a: (
+              <InlineLink href={siteKitLink} rel="noreferrer" target="_blank" />
+            ),
           }}
         >
           {TEXT.SITE_KIT_INSTALLED}
@@ -144,7 +146,7 @@ function GoogleAnalyticsSettings({
     return (
       <TranslateWithMarkup
         mapping={{
-          a: <InlineLink href={siteKitLink} />,
+          a: <InlineLink href={siteKitLink} rel="noreferrer" target="_blank" />,
         }}
       >
         {TEXT.SITE_KIT_NOT_INSTALLED}
@@ -183,7 +185,13 @@ function GoogleAnalyticsSettings({
         <TextInputHelperText>
           <TranslateWithMarkup
             mapping={{
-              a: <InlineLink href={TEXT.CONTEXT_LINK} />,
+              a: (
+                <InlineLink
+                  href={TEXT.CONTEXT_LINK}
+                  rel="noreferrer"
+                  target="_blank"
+                />
+              ),
             }}
           >
             {TEXT.CONTEXT}

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { action } from '@storybook/addon-actions';
-import { select, text } from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
@@ -40,6 +40,7 @@ export const _default = () => {
         'active',
         false,
       ])}
+      canInstallPlugins={boolean('canInstallPlugins', true)}
     />
   );
 };

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { action } from '@storybook/addon-actions';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
@@ -35,12 +35,13 @@ export const _default = () => {
     <GoogleAnalyticsSettings
       onUpdateGoogleAnalyticsId={action('update google analytics id submitted')}
       googleAnalyticsId={text('googleAnalyticsId', 'UA-000000-98')}
-      siteKitPluginStatus={select('siteKitPluginStatus', [
-        'inactive',
-        'active',
-        false,
-      ])}
-      canInstallPlugins={boolean('canInstallPlugins', true)}
+      siteKitCapabilities={{
+        analyticsModuleActive: boolean('analyticsModuleActive', false),
+        canActivatePlugins: boolean('canActivatePlugins', true),
+        canInstallPlugins: boolean('canInstallPlugins', true),
+        siteKitActive: boolean('siteKitActive', false),
+        siteKitInstalled: boolean('siteKitInstalled', false),
+      }}
     />
   );
 };

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/stories/index.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { action } from '@storybook/addon-actions';
-import { text } from '@storybook/addon-knobs';
+import { select, text } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
@@ -35,6 +35,11 @@ export const _default = () => {
     <GoogleAnalyticsSettings
       onUpdateGoogleAnalyticsId={action('update google analytics id submitted')}
       googleAnalyticsId={text('googleAnalyticsId', 'UA-000000-98')}
+      siteKitPluginStatus={select('siteKitPluginStatus', [
+        'inactive',
+        'active',
+        false,
+      ])}
     />
   );
 };

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/test/googleAnalytics.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/test/googleAnalytics.js
@@ -49,6 +49,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
 
     const input = getByRole('textbox');
     expect(input).toBeDefined();
+    expect(input).toBeEnabled();
 
     const sectionHeader = getByText(TEXT.SECTION_HEADING);
     expect(sectionHeader).toBeInTheDocument();
@@ -64,6 +65,32 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
 
     const label = getByLabelText(TEXT.ARIA_LABEL);
     expect(label).toBeInTheDocument();
+  });
+
+  it('should not allow the input to be active when siteKitPluginStatus is "inactive"', function () {
+    const { getByRole } = renderWithProviders(
+      <GoogleAnalyticsSettings
+        googleAnalyticsId={googleAnalyticsId}
+        handleUpdate={mockUpdate}
+        siteKitPluginStatus="inactive"
+      />
+    );
+
+    const input = getByRole('textbox');
+    expect(input).toBeDisabled();
+  });
+
+  it('should not allow the input to be active when siteKitPluginStatus is "active"', function () {
+    const { getByRole } = renderWithProviders(
+      <GoogleAnalyticsSettings
+        googleAnalyticsId={googleAnalyticsId}
+        handleUpdate={mockUpdate}
+        siteKitPluginStatus="active"
+      />
+    );
+
+    const input = getByRole('textbox');
+    expect(input).toBeDisabled();
   });
 
   it('should call mockUpdate when enter is keyed on input', function () {

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/test/googleAnalytics.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/test/googleAnalytics.js
@@ -27,6 +27,13 @@ import GoogleAnalyticsSettings, { TEXT } from '../';
 describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
   let googleAnalyticsId;
   let mockUpdate;
+  const defaultSiteKitCapabilities = {
+    analyticsModuleActive: false,
+    canActivatePlugins: true,
+    canInstallPlugins: true,
+    siteKitActive: false,
+    siteKitInstalled: false,
+  };
 
   beforeEach(() => {
     googleAnalyticsId = '';
@@ -44,6 +51,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
       <GoogleAnalyticsSettings
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
+        siteKitCapabilities={{ ...defaultSiteKitCapabilities }}
       />
     );
 
@@ -60,6 +68,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
       <GoogleAnalyticsSettings
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
+        siteKitCapabilities={{ ...defaultSiteKitCapabilities }}
       />
     );
 
@@ -73,9 +82,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
         siteKitCapabilities={{
-          analyticsModuleActive: false,
-          canActivatePlugins: true,
-          canInstallPlugins: true,
+          ...defaultSiteKitCapabilities,
           siteKitActive: true,
           siteKitInstalled: true,
         }}
@@ -92,9 +99,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
         siteKitCapabilities={{
-          analyticsModuleActive: false,
-          canActivatePlugins: true,
-          canInstallPlugins: true,
+          ...defaultSiteKitCapabilities,
           siteKitActive: false,
           siteKitInstalled: true,
         }}
@@ -110,6 +115,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
       <GoogleAnalyticsSettings
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
+        siteKitCapabilities={{ ...defaultSiteKitCapabilities }}
       />
     );
 
@@ -123,6 +129,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
       <GoogleAnalyticsSettings
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
+        siteKitCapabilities={{ ...defaultSiteKitCapabilities }}
       />
     );
 
@@ -136,6 +143,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
       <GoogleAnalyticsSettings
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
+        siteKitCapabilities={{ ...defaultSiteKitCapabilities }}
       />
     );
 
@@ -153,6 +161,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
       <GoogleAnalyticsSettings
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
+        siteKitCapabilities={{ ...defaultSiteKitCapabilities }}
       />
     );
 
@@ -168,6 +177,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
       <GoogleAnalyticsSettings
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
+        siteKitCapabilities={{ ...defaultSiteKitCapabilities }}
       />
     );
 
@@ -182,6 +192,7 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
       <GoogleAnalyticsSettings
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
+        siteKitCapabilities={{ ...defaultSiteKitCapabilities }}
       />
     );
 

--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/test/googleAnalytics.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/test/googleAnalytics.js
@@ -67,12 +67,18 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
     expect(label).toBeInTheDocument();
   });
 
-  it('should not allow the input to be active when siteKitPluginStatus is "inactive"', function () {
+  it('should not allow the input to be active when site kit is active', function () {
     const { getByRole } = renderWithProviders(
       <GoogleAnalyticsSettings
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
-        siteKitPluginStatus="inactive"
+        siteKitCapabilities={{
+          analyticsModuleActive: false,
+          canActivatePlugins: true,
+          canInstallPlugins: true,
+          siteKitActive: true,
+          siteKitInstalled: true,
+        }}
       />
     );
 
@@ -80,12 +86,18 @@ describe('Editor Settings: Google Analytics <GoogleAnalytics />', function () {
     expect(input).toBeDisabled();
   });
 
-  it('should not allow the input to be active when siteKitPluginStatus is "active"', function () {
+  it('should not allow the input to be active when site kit is installed', function () {
     const { getByRole } = renderWithProviders(
       <GoogleAnalyticsSettings
         googleAnalyticsId={googleAnalyticsId}
         handleUpdate={mockUpdate}
-        siteKitPluginStatus="active"
+        siteKitCapabilities={{
+          analyticsModuleActive: false,
+          canActivatePlugins: true,
+          canInstallPlugins: true,
+          siteKitActive: false,
+          siteKitInstalled: true,
+        }}
       />
     );
 

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -87,6 +87,7 @@ function EditorSettings() {
   const {
     capabilities: {
       canUploadFiles,
+      canInstallPlugins,
       canManageSettings,
       siteKitPluginStatus,
     } = {},
@@ -321,6 +322,7 @@ function EditorSettings() {
                 handleUpdate={handleUpdateGoogleAnalyticsId}
                 googleAnalyticsId={googleAnalyticsId}
                 siteKitPluginStatus={siteKitPluginStatus}
+                canInstallPlugins={canInstallPlugins}
               />
             )}
             {canManageSettings && (

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -85,7 +85,11 @@ function EditorSettings() {
   );
 
   const {
-    capabilities: { canUploadFiles, canManageSettings } = {},
+    capabilities: {
+      canUploadFiles,
+      canManageSettings,
+      siteKitPluginStatus,
+    } = {},
     maxUpload,
     maxUploadFormatted,
   } = useConfig();
@@ -316,6 +320,7 @@ function EditorSettings() {
               <GoogleAnalyticsSettings
                 handleUpdate={handleUpdateGoogleAnalyticsId}
                 googleAnalyticsId={googleAnalyticsId}
+                siteKitPluginStatus={siteKitPluginStatus}
               />
             )}
             {canManageSettings && (

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -85,12 +85,8 @@ function EditorSettings() {
   );
 
   const {
-    capabilities: {
-      canUploadFiles,
-      canInstallPlugins,
-      canManageSettings,
-      siteKitPluginStatus,
-    } = {},
+    capabilities: { canUploadFiles, canManageSettings } = {},
+    siteKitCapabilities = {},
     maxUpload,
     maxUploadFormatted,
   } = useConfig();
@@ -321,8 +317,7 @@ function EditorSettings() {
               <GoogleAnalyticsSettings
                 handleUpdate={handleUpdateGoogleAnalyticsId}
                 googleAnalyticsId={googleAnalyticsId}
-                siteKitPluginStatus={siteKitPluginStatus}
-                canInstallPlugins={canInstallPlugins}
+                siteKitCapabilities={siteKitCapabilities}
               />
             )}
             {canManageSettings && (

--- a/assets/src/dashboard/components/input/index.js
+++ b/assets/src/dashboard/components/input/index.js
@@ -31,7 +31,9 @@ export const TextInput = styled.input`
   padding: 1px 8px;
   border-radius: 6px;
   border: ${({ theme, error }) =>
-    error ? theme.DEPRECATED.borders.danger : theme.DEPRECATED.borders.gray100};
+    error
+      ? theme.DEPRECATED_THEME.borders.danger
+      : theme.DEPRECATED_THEME.borders.gray100};
   &:active:enabled {
     border: ${({ theme, error }) =>
       error

--- a/assets/src/dashboard/components/input/index.js
+++ b/assets/src/dashboard/components/input/index.js
@@ -31,10 +31,8 @@ export const TextInput = styled.input`
   padding: 1px 8px;
   border-radius: 6px;
   border: ${({ theme, error }) =>
-    error
-      ? theme.DEPRECATED_THEME.borders.danger
-      : theme.DEPRECATED_THEME.borders.gray100};
-  &:active {
+    error ? theme.DEPRECATED.borders.danger : theme.DEPRECATED.borders.gray100};
+  &:active:enabled {
     border: ${({ theme, error }) =>
       error
         ? theme.DEPRECATED_THEME.borders.danger

--- a/assets/src/dashboard/karma/fixture.js
+++ b/assets/src/dashboard/karma/fixture.js
@@ -45,7 +45,7 @@ const defaultConfig = {
     canActivatePlugins: true,
     canInstallPlugins: true,
     siteKitActive: false,
-    siteKitInstalled: true,
+    siteKitInstalled: false,
   },
   maxUpload: 104857600,
   maxUploadFormatted: '100 MB',

--- a/assets/src/dashboard/karma/fixture.js
+++ b/assets/src/dashboard/karma/fixture.js
@@ -40,6 +40,13 @@ const defaultConfig = {
     canInstallPlugins: true,
     siteKitPluginStatus: false,
   },
+  siteKitCapabilities: {
+    analyticsModuleActive: false,
+    canActivatePlugins: true,
+    canInstallPlugins: true,
+    siteKitActive: false,
+    siteKitInstalled: true,
+  },
   maxUpload: 104857600,
   maxUploadFormatted: '100 MB',
   isRTL: false,

--- a/assets/src/dashboard/karma/fixture.js
+++ b/assets/src/dashboard/karma/fixture.js
@@ -37,6 +37,8 @@ const defaultConfig = {
   capabilities: {
     canManageSettings: true,
     canUploadFiles: true,
+    canInstallPlugins: true,
+    siteKitPluginStatus: false,
   },
   maxUpload: 104857600,
   maxUploadFormatted: '100 MB',

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -100,6 +100,7 @@ class Dashboard {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'admin_notices', [ $this, 'display_link_to_dashboard' ] );
 		add_action( 'load-web-story_page_stories-dashboard', [ $this, 'load_stories_dashboard' ] );
+		add_action( 'determine_site_kit_plugin_status', [ $this, 'determine_site_kit_plugin_status' ] );
 	}
 
 	/**
@@ -233,6 +234,31 @@ class Dashboard {
 	}
 
 	/**
+	 * Find status of site kit plugin in site.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string|false if plugin is present return 'active' or 'inactive', otherwise return false
+	 */
+	public function determine_site_kit_plugin_status() {
+
+		// Get all plugins
+		$all_plugins = get_plugins();
+
+		// check if site kit is an installed plugin
+		if ( array_key_exists( 'google-site-kit/google-site-kit.php', $all_plugins ) ) {
+			$is_site_kit_active = is_plugin_active( 'google-site-kit/google-site-kit.php' );
+			if ( $is_site_kit_active ) {
+				return 'active';
+			}
+			return 'inactive';
+		}
+		
+		// if not installed just return false
+		return false;
+	}
+
+	/**
 	 * Renders the dashboard page.
 	 *
 	 * @since 1.0.0
@@ -342,8 +368,9 @@ class Dashboard {
 				'maxUpload'          => $max_upload_size,
 				'maxUploadFormatted' => size_format( $max_upload_size ),
 				'capabilities'       => [
-					'canManageSettings' => current_user_can( 'manage_options' ),
-					'canUploadFiles'    => current_user_can( 'upload_files' ),
+					'canManageSettings'   => current_user_can( 'manage_options' ),
+					'canUploadFiles'      => current_user_can( 'upload_files' ),
+					'siteKitPluginStatus' => $this->determine_site_kit_plugin_status(),
 				],
 				'siteKitStatus'      => $this->site_kit->get_plugin_status(),
 			],

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -100,7 +100,7 @@ class Dashboard {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
 		add_action( 'admin_notices', [ $this, 'display_link_to_dashboard' ] );
 		add_action( 'load-web-story_page_stories-dashboard', [ $this, 'load_stories_dashboard' ] );
-		add_action( 'determine_site_kit_plugin_status', [ $this, 'determine_site_kit_plugin_status' ] );
+		add_action( 'is_site_kit_plugin_installed', [ $this, 'is_site_kit_plugin_installed' ] );
 	}
 
 	/**
@@ -240,7 +240,7 @@ class Dashboard {
 	 *
 	 * @return boolean 
 	 */
-	public function determine_site_kit_plugin_status() {
+	public function is_site_kit_plugin_installed() {
 
 		// Get all plugins
 		$all_plugins = get_plugins();
@@ -338,16 +338,16 @@ class Dashboard {
 		$settings = [
 			'id'         => 'web-stories-dashboard',
 			'config'     => [
-				'isRTL'              => is_rtl(),
-				'locale'             => ( new Locale() )->get_locale_settings(),
-				'newStoryURL'        => $new_story_url,
-				'editStoryURL'       => $edit_story_url,
-				'wpListURL'          => $classic_wp_list_url,
-				'assetsURL'          => trailingslashit( WEBSTORIES_ASSETS_URL ),
-				'cdnURL'             => trailingslashit( WEBSTORIES_CDN_URL ),
-				'version'            => WEBSTORIES_VERSION,
-				'encodeMarkup'       => $this->decoder->supports_decoding(),
-				'api'                => [
+				'isRTL'               => is_rtl(),
+				'locale'              => ( new Locale() )->get_locale_settings(),
+				'newStoryURL'         => $new_story_url,
+				'editStoryURL'        => $edit_story_url,
+				'wpListURL'           => $classic_wp_list_url,
+				'assetsURL'           => trailingslashit( WEBSTORIES_ASSETS_URL ),
+				'cdnURL'              => trailingslashit( WEBSTORIES_CDN_URL ),
+				'version'             => WEBSTORIES_VERSION,
+				'encodeMarkup'        => $this->decoder->supports_decoding(),
+				'api'                 => [
 					'stories'     => sprintf( '/web-stories/v1/%s', $rest_base ),
 					'media'       => '/web-stories/v1/media',
 					'currentUser' => '/web-stories/v1/users/me',
@@ -363,7 +363,7 @@ class Dashboard {
 					
 				],
 				'siteKitCapabilities' => [
-					'siteKitInstalled'      => $this->determine_site_kit_plugin_status(),
+					'siteKitInstalled'      => $this->is_site_kit_plugin_installed(),
 					'siteKitActive'         => defined( 'GOOGLESITEKIT_VERSION' ),
 					'analyticsModuleActive' => false, // TODO: copy the logic from Analytics.php we need to share somehow.
 					'canInstallPlugins'     => current_user_can( 'install_plugins' ),

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -238,24 +238,14 @@ class Dashboard {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @return string|false if plugin is present return 'active' or 'inactive', otherwise return false
+	 * @return boolean 
 	 */
 	public function determine_site_kit_plugin_status() {
 
 		// Get all plugins
 		$all_plugins = get_plugins();
 
-		// check if site kit is an installed plugin
-		if ( array_key_exists( 'google-site-kit/google-site-kit.php', $all_plugins ) ) {
-			$is_site_kit_active = is_plugin_active( 'google-site-kit/google-site-kit.php' );
-			if ( $is_site_kit_active ) {
-				return 'active';
-			}
-			return 'inactive';
-		}
-		
-		// if not installed just return false
-		return false;
+		return array_key_exists( 'google-site-kit/google-site-kit.php', $all_plugins );
 	}
 
 	/**
@@ -365,13 +355,19 @@ class Dashboard {
 					'templates'   => '/web-stories/v1/web-story-template',
 					'settings'    => '/web-stories/v1/settings',
 				],
-				'maxUpload'          => $max_upload_size,
-				'maxUploadFormatted' => size_format( $max_upload_size ),
-				'capabilities'       => [
-					'canManageSettings'   => current_user_can( 'manage_options' ),
-					'canInstallPlugins'   => current_user_can( 'install_plugins' ),
-					'canUploadFiles'      => current_user_can( 'upload_files' ),
-					'siteKitPluginStatus' => $this->determine_site_kit_plugin_status(),
+				'maxUpload'           => $max_upload_size,
+				'maxUploadFormatted'  => size_format( $max_upload_size ),
+				'capabilities'        => [
+					'canManageSettings' => current_user_can( 'manage_options' ),
+					'canUploadFiles'    => current_user_can( 'upload_files' ),
+					
+				],
+				'siteKitCapabilities' => [
+					'siteKitInstalled'      => $this->determine_site_kit_plugin_status(),
+					'siteKitActive'         => defined( 'GOOGLESITEKIT_VERSION' ),
+					'analyticsModuleActive' => false, // TODO: copy the logic from Analytics.php we need to share somehow.
+					'canInstallPlugins'     => current_user_can( 'install_plugins' ),
+					'canActivatePlugins'    => current_user_can( 'activate_plugin', 'google-site-kit/google-site-kit.php' ),
 				],
 				'siteKitStatus'      => $this->site_kit->get_plugin_status(),
 			],

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -369,6 +369,7 @@ class Dashboard {
 				'maxUploadFormatted' => size_format( $max_upload_size ),
 				'capabilities'       => [
 					'canManageSettings'   => current_user_can( 'manage_options' ),
+					'canInstallPlugins'   => current_user_can( 'install_plugins' ),
 					'canUploadFiles'      => current_user_can( 'upload_files' ),
 					'siteKitPluginStatus' => $this->determine_site_kit_plugin_status(),
 				],

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -241,8 +241,6 @@ class Dashboard {
 	 * @return boolean 
 	 */
 	public function is_site_kit_plugin_installed() {
-
-		// Get all plugins
 		$all_plugins = get_plugins();
 
 		return array_key_exists( 'google-site-kit/google-site-kit.php', $all_plugins );


### PR DESCRIPTION
## Summary
Provides user helpful information about using Site Kit for google analytics specific to if they are already using it or not. 

## Relevant Technical Choices

- ~Wrote a PHP function to find out if the site kit plugin is installed - WordPress has `is_plugin_active` built in but that doesn't tell me if the plugin is installed and inactive so I'm grabbing all of the installed plugins regardless of activation, seeing if site kit exists and returning either 'active' or 'inactive' if the plugin is found and returning false otherwise. Figured this was a decent starting point and @swissspidy or @spacedmonkey can specify if anything needs to change - tried to avoid adding to their plate.~ 
- Pascal assisted in adding a new set of config for siteKit to access in dashboard and tell what the status is
- Otherwise this is straightforward, conditionally render text on /settings in dashboard and limit usage of ga tracking id input if site kit is installed

## To-do
- Verify that existing tracking ID set up in site kit is readable in settings input
- Verify that text is accurate with @o-fernandez 
- ~figure out how to link directly to the site kit plugin within admin but not as a direct installation link (it's a modal)~ (will be done later)

## User-facing changes

- Shows user 1 of three messages depending on if site kit is installed and conditionally disables tracking id input. 
1) `Install Site Kit by Google to easily enable Google Analytics for Web Stories.` (input enabled)
2) `Use Site Kit by Google to easily activate Google Analytics for Web Stories.` (input disabled)
3) `Site Kit by Google has already enabled Google Analytics for your Web Stories, all changes to your analytics tracking should occur there.` (input disabled)

## Testing Instructions

- In storybook: see the above text update conditionally rendering by using the `siteKitPluginStatus` knob to go through available responses 
- In the dashboard locally: install site kit and enable it and see messages change 

Of note - I did this locally and would love to test out if the tracking id will show up in the input if site kit is active and tracking set up but haven't followed the docs to set up a local instance of site kit. 

Installed and active:
![Screen Shot 2020-10-29 at 12 07 19 PM](https://user-images.githubusercontent.com/10720454/97620953-7833e380-19df-11eb-9d69-e4b5e4ab1e90.png)

Installed and inactive
![Screen Shot 2020-10-29 at 12 05 55 PM](https://user-images.githubusercontent.com/10720454/97620744-34d97500-19df-11eb-94b5-1815a177670f.png)

Not installed
![Screen Shot 2020-10-29 at 12 05 19 PM](https://user-images.githubusercontent.com/10720454/97620752-35720b80-19df-11eb-9e57-5f868974461a.png)

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #3809 
