### PR TITLE
PHP 5.3 compatibility

### DIFF
--- a/includes/Compatibility.php
+++ b/includes/Compatibility.php
@@ -104,9 +104,9 @@ class Compatibility {
 		if ( version_compare( PHP_VERSION, $this->get_php_version(), '<' ) ) {
 			/* translators: %s: PHP version number */
 			$message = esc_html( sprintf( __( 'Web Stories requires PHP %s or higher.', 'web-stories' ), $this->get_php_version() ) );
-			$data    = [
+			$data    = array(
 				'title' => $message,
-			];
+			);
 			$this->add_to_error( 'failed_check_php_version', $message, $data );
 
 			return false;
@@ -126,9 +126,9 @@ class Compatibility {
 		if ( version_compare( get_bloginfo( 'version' ), $this->get_wp_version(), '<' ) ) {
 			/* translators: %s: WordPress version number */
 			$message = esc_html( sprintf( __( 'Web Stories requires WordPress %s or higher.', 'web-stories' ), $this->get_wp_version() ) );
-			$data    = [
+			$data    = array(
 				'title' => $message,
-			];
+			);
 			$this->add_to_error( 'failed_check_wp_version', $message, $data );
 
 			return false;
@@ -155,9 +155,9 @@ class Compatibility {
 							__( 'You appear to be running an incomplete version of the plugin. Please run %s to finish installation.', 'web-stories' ),
 							'<code>composer install &amp;&amp; npm install &amp;&amp; npm run build</code>'
 						);
-					$data = [
+					$data = array(
 						'title' => esc_html__( 'Web Stories plugin could not be initialized.', 'web-stories' ),
-					];
+					);
 					$this->add_to_error( 'failed_check_required_files', $message, $data );
 
 					return false;

--- a/includes/Compatibility.php
+++ b/includes/Compatibility.php
@@ -71,7 +71,7 @@ class Compatibility {
 	 *
 	 * @var array
 	 */
-	protected $extensions = [];
+	protected $extensions = array();
 
 	/**
 	 * Array of required files.
@@ -80,7 +80,7 @@ class Compatibility {
 	 *
 	 * @var array
 	 */
-	protected $required_files = [];
+	protected $required_files = array();
 
 	/**
 	 * Compatibility constructor.
@@ -176,7 +176,7 @@ class Compatibility {
 	 * @return bool
 	 */
 	public function check_extensions() {
-		$missing_extensions = [];
+		$missing_extensions = array();
 		foreach ( $this->get_extensions() as $required_extension => $required_constructs ) {
 			if ( ! extension_loaded( $required_extension ) ) {
 				$missing_extensions[] = "<code>$required_extension</code>";
@@ -212,7 +212,7 @@ class Compatibility {
 	 * @return bool
 	 */
 	public function check_classes() {
-		$missing_classes = [];
+		$missing_classes = array();
 		foreach ( $this->get_extensions() as $required_extension => $required_constructs ) {
 			foreach ( $required_constructs as $construct_type => $constructs ) {
 				if ( 'classes' !== $construct_type ) {
@@ -256,7 +256,7 @@ class Compatibility {
 	 * @return bool
 	 */
 	public function check_functions() {
-		$missing_functions = [];
+		$missing_functions = array();
 		foreach ( $this->get_extensions() as $required_extension => $required_constructs ) {
 			foreach ( $required_constructs as $construct_type => $constructs ) {
 				if ( 'functions' !== $construct_type ) {

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -37,14 +37,14 @@ if ( ! class_exists( '\Google\Web_Stories\Compatibility' ) ) {
 global $web_stories_compatibility;
 
 $web_stories_error = new WP_Error();
-$extensions        = [
-	'date'   => [
-		'classes' => [
+$extensions        = array(
+	'date'   => array(
+		'classes' => array(
 			'DateTimeImmutable',
-		],
-	],
-	'dom'    => [
-		'classes' => [
+		),
+	),
+	'dom'    => array(
+		'classes' => array(
 			'DOMAttr',
 			'DOMComment',
 			'DOMDocument',
@@ -53,38 +53,38 @@ $extensions        = [
 			'DOMNodeList',
 			'DOMText',
 			'DOMXPath',
-		],
-	],
-	'json'   => [
-		'functions' => [
+		),
+	),
+	'json'   => array(
+		'functions' => array(
 			'json_decode',
 			'json_encode',
-		],
-	],
-	'libxml' => [
-		'functions' => [
+		),
+	),
+	'libxml' => array(
+		'functions' => array(
 			'libxml_use_internal_errors',
-		],
-	],
-	'spl'    => [
-		'functions' => [
+		),
+	),
+	'spl'    => array(
+		'functions' => array(
 			'spl_autoload_register',
-		],
-	],
-];
+		),
+	),
+);
 
 $web_stories_compatibility = new Compatibility( $web_stories_error );
 $web_stories_compatibility->set_extensions( $extensions );
 $web_stories_compatibility->set_php_version( WEBSTORIES_MINIMUM_PHP_VERSION );
 $web_stories_compatibility->set_wp_version( WEBSTORIES_MINIMUM_WP_VERSION );
 $web_stories_compatibility->set_required_files(
-	[
+	array(
 		WEBSTORIES_PLUGIN_DIR_PATH . '/assets/js/edit-story.js',
 		WEBSTORIES_PLUGIN_DIR_PATH . '/assets/js/stories-dashboard.js',
 		WEBSTORIES_PLUGIN_DIR_PATH . '/assets/js/web-stories-embed-block.js',
 		WEBSTORIES_PLUGIN_DIR_PATH . '/includes/vendor/autoload.php',
 		WEBSTORIES_PLUGIN_DIR_PATH . '/third-party/vendor/scoper-autoload.php',
-	]
+	)
 );
 
 /**
@@ -110,7 +110,7 @@ function _print_missing_build_admin_notice() {
 			<?php
 			foreach ( array_keys( $_error->errors ) as $error_code ) {
 				$message = $_error->get_error_message( $error_code );
-				printf( '<li>%s</li>', wp_kses( $message, [ 'code' => [] ] ) );
+				printf( '<li>%s</li>', wp_kses( $message, array( 'code' => array() ) ) );
 			}
 			?>
 		</ul>
@@ -123,10 +123,10 @@ add_action( 'admin_notices', __NAMESPACE__ . '\_print_missing_build_admin_notice
 if ( ( defined( 'WP_CLI' ) && WP_CLI ) || 'true' === getenv( 'CI' ) || 'cli' === PHP_SAPI ) {
 	// Only check for built php files in a CLI context.
 	$web_stories_compatibility->set_required_files(
-		[
+		array(
 			WEBSTORIES_PLUGIN_DIR_PATH . '/third-party/vendor/scoper-autoload.php',
 			WEBSTORIES_PLUGIN_DIR_PATH . '/includes/vendor/autoload.php',
-		]
+		)
 	);
 	$web_stories_compatibility->run_checks();
 	$_error = $web_stories_compatibility->get_error();

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -151,10 +151,6 @@ if ( ( defined( 'WP_CLI' ) && WP_CLI ) || 'true' === getenv( 'CI' ) || 'cli' ===
 	}
 }
 
-if ( ! $web_stories_compatibility->check_required_files() ) {
-	// However, we still need to stop further execution.
-	return;
-}
 /**
  * Run logic to setup a new site with web stories.
  *
@@ -274,6 +270,22 @@ function deactivate( $network_wide ) {
 
 register_activation_hook( WEBSTORIES_PLUGIN_FILE, __NAMESPACE__ . '\activate' );
 register_deactivation_hook( WEBSTORIES_PLUGIN_FILE, __NAMESPACE__ . '\deactivate' );
+
+
+if ( ! $web_stories_compatibility->check_required_files() ||  ! $web_stories_compatibility->check_php_version() ||  ! $web_stories_compatibility->check_wp_version() ) {
+	// However, we still need to stop further execution.
+	return;
+}
+
+// Autoloader for dependencies.
+if ( file_exists( WEBSTORIES_PLUGIN_DIR_PATH . '/third-party/vendor/scoper-autoload.php' ) ) {
+	require WEBSTORIES_PLUGIN_DIR_PATH . '/third-party/vendor/scoper-autoload.php';
+}
+
+// Autoloader for plugin itself.
+if ( file_exists( WEBSTORIES_PLUGIN_DIR_PATH . '/includes/vendor/autoload.php' ) ) {
+	require WEBSTORIES_PLUGIN_DIR_PATH . '/includes/vendor/autoload.php';
+}
 
 global $web_stories;
 

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -272,7 +272,7 @@ register_activation_hook( WEBSTORIES_PLUGIN_FILE, __NAMESPACE__ . '\activate' );
 register_deactivation_hook( WEBSTORIES_PLUGIN_FILE, __NAMESPACE__ . '\deactivate' );
 
 
-if ( ! $web_stories_compatibility->check_required_files() ||  ! $web_stories_compatibility->check_php_version() ||  ! $web_stories_compatibility->check_wp_version() ) {
+if ( ! $web_stories_compatibility->check_required_files() || ! $web_stories_compatibility->check_php_version() || ! $web_stories_compatibility->check_wp_version() ) {
 	// However, we still need to stop further execution.
 	return;
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -58,6 +58,8 @@
 	<!-- The main plugin file should be parsable by PHP < 5.6. -->
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
 		<exclude-pattern>web-stories.php</exclude-pattern>
+		<exclude-pattern>includes/Compatibility.php</exclude-pattern>
+		<exclude-pattern>includes/namespace.php</exclude-pattern>
 	</rule>
 
 	<!-- Show details about violated sniffs -->

--- a/web-stories.php
+++ b/web-stories.php
@@ -50,7 +50,11 @@ define( 'WEBSTORIES_ASSETS_URL', WEBSTORIES_PLUGIN_DIR_URL . 'assets' );
 define( 'WEBSTORIES_MINIMUM_PHP_VERSION', '5.6' );
 define( 'WEBSTORIES_MINIMUM_WP_VERSION', '5.3' );
 
-$cdn_version = false !== strpos( WEBSTORIES_VERSION, '+' ) ? 'main' : explode( '+', WEBSTORIES_VERSION )[0];
+$cdn_version = 'main';
+if( false !== strpos( WEBSTORIES_VERSION, '+' ) ){
+	$pieces      = explode( '+', WEBSTORIES_VERSION );
+	$cdn_version = array_shift( $pieces );
+}
 
 define( 'WEBSTORIES_CDN_URL', 'https://wp.stories.google/static/' . $cdn_version );
 
@@ -60,15 +64,5 @@ if ( ! defined( 'WEBSTORIES_DEV_MODE' ) ) {
 	define( 'WEBSTORIES_DEV_MODE', false );
 }
 
-// Autoloader for dependencies.
-if ( file_exists( __DIR__ . '/third-party/vendor/scoper-autoload.php' ) ) {
-	require __DIR__ . '/third-party/vendor/scoper-autoload.php';
-}
-
-// Autoloader for plugin itself.
-if ( file_exists( __DIR__ . '/includes/vendor/autoload.php' ) ) {
-	require __DIR__ . '/includes/vendor/autoload.php';
-}
-
 // Main plugin initialization happens there so that this file is still parsable in PHP < 5.6.
-require __DIR__ . '/includes/namespace.php';
+require WEBSTORIES_PLUGIN_DIR_PATH . '/includes/namespace.php';

--- a/web-stories.php
+++ b/web-stories.php
@@ -51,7 +51,7 @@ define( 'WEBSTORIES_MINIMUM_PHP_VERSION', '5.6' );
 define( 'WEBSTORIES_MINIMUM_WP_VERSION', '5.3' );
 
 $cdn_version = 'main';
-if( false !== strpos( WEBSTORIES_VERSION, '+' ) ){
+if ( false !== strpos( WEBSTORIES_VERSION, '+' ) ) {
 	$pieces      = explode( '+', WEBSTORIES_VERSION );
 	$cdn_version = array_shift( $pieces );
 }


### PR DESCRIPTION
## Summary

While testing #4930, I saw that the PHP and WP checks were not working. With a simple amount of work, I got the WordPress and PHP checks working. The WordPress check is working and PHP check only works in 5.3+. PHP 5.3+ requires long php array syntax. 

PHP 5.2 is impossible because of the use of namespaces and use keyword. 


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
