### PR TITLE
Prevent issues with centered embed blocks on certain themes

### DIFF
--- a/includes/assets/embed.css
+++ b/includes/assets/embed.css
@@ -19,6 +19,10 @@
   width: 100%;
 }
 
+.web-stories-embed.aligncenter {
+  text-align: initial;
+}
+
 .web-stories-embed .wp-block-embed__wrapper {
   position: relative;
 }


### PR DESCRIPTION
## Summary

Certain themes use `text-align: center;` for `aligncenter`, which causes issues with the embed block.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Before:

<img width="893" alt="Screenshot 2020-10-30 at 14 56 57" src="https://user-images.githubusercontent.com/841956/97713480-2f079080-1ac0-11eb-96ef-510aa50a8fc3.png">

After:

<img width="889" alt="Screenshot 2020-10-30 at 14 56 49" src="https://user-images.githubusercontent.com/841956/97713496-362e9e80-1ac0-11eb-861d-1cd3cb200629.png">

## Testing Instructions

1. Install OceanWP theme
1. Insert embed block and center it
1. See that it displays fine.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5053
