### PR TITLE
prepublish checklist - missing critical metadata

### DIFF
--- a/assets/src/edit-story/app/prepublish/errors/metadata.js
+++ b/assets/src/edit-story/app/prepublish/errors/metadata.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import isElementBelowLimit from '../../../utils/isElementBelowLimit';
+import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
+
+const FEATURED_MEDIA_RESOURCE_MIN_HEIGHT = 853;
+const FEATURED_MEDIA_RESOURCE_MIN_WIDTH = 640;
+
+const PUBLISHER_LOGO_MIN_HEIGHT = 96;
+const PUBLISHER_LOGO_MIN_WIDTH = 96;
+
+/**
+ *
+ * @typedef {import('../types').Guidance} Guidance
+ * @typedef {import('../../../types').Story} Story
+ */
+
+/**
+ * Check the story for a cover.
+ * If the story does not have a cover, return an error message.
+ * Otherwise, return undefined.
+ *
+ * @param {Story} story The story being checked for critical metadata
+ * @return {Guidance|undefined} Guidance object for consumption
+ */
+export function storyCoverAttached(story) {
+  if (typeof story.featuredMediaUrl !== 'string') {
+    return {
+      type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
+      storyId: story.storyId,
+      message: __('Missing story cover', 'web-stories'),
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Check the story for a title.
+ * If the story does not have a title, return an error message.
+ * Otherwise, return undefined.
+ *
+ * @param {Story} story The story being checked for critical metadata
+ * @return {Guidance|undefined} Guidance object for consumption
+ */
+export function storyTitle(story) {
+  if (typeof story.title !== 'string' || story.title.trim() === '') {
+    return {
+      type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
+      storyId: story.storyId,
+      message: __('Missing story title', 'web-stories'),
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Check that the story's cover resource has sufficient dimensions.
+ * If the resource is too small in either dimension, return an error message.
+ * Otherwise, return undefined.
+ *
+ * @param {Story} story The story being checked for critical metadata
+ * @return {Guidance|undefined} Guidance object for consumption
+ */
+export function storyCoverPortraitSize(story) {
+  if (
+    story.featuredMediaResource.height < FEATURED_MEDIA_RESOURCE_MIN_HEIGHT ||
+    story.featuredMediaResource.width < FEATURED_MEDIA_RESOURCE_MIN_WIDTH
+  ) {
+    return {
+      type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
+      storyId: story.storyId,
+      message: __("Story's portrait cover image is too small", 'web-stories'),
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Check that the story's publisher logo resource has sufficient dimensions.
+ * If the resource is too small in either dimension, return an error message.
+ * Otherwise, return undefined.
+ *
+ * @param {Story} story The story being checked for critical metadata
+ * @return {Guidance|undefined} Guidance object for consumption
+ */
+export function publisherLogoSize(story) {
+  if (
+    story.publisherLogoResource.height < PUBLISHER_LOGO_MIN_HEIGHT ||
+    story.publisherLogoResource.width < PUBLISHER_LOGO_MIN_WIDTH
+  ) {
+    return {
+      type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
+      storyId: story.storyId,
+      message: __("Story's publisher logo image is too small", 'web-stories'),
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Check for link and page attachment conflicts.
+ * If there is an element with a link in the page attachment region, return an error message.
+ * Otherwise, return undefined.
+ *
+ * @param {Story} story The story being checked for critical metadata
+ * @return {Guidance|undefined} Guidance object for consumption
+ */
+export function linkInPageAttachmentRegion(story) {
+  const { pages } = story;
+  const isLinkInPageAttachmentArea = pages.some((page) => {
+    const { elements } = page;
+    const isLinkAttached = Boolean(page?.pageAttachment?.url.length);
+    return (
+      !isLinkAttached &&
+      elements.filter(({ link }) => link?.url?.length).some(isElementBelowLimit)
+    );
+  });
+
+  if (isLinkInPageAttachmentArea) {
+    return {
+      type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
+      storyId: story.storyId,
+      message: __(
+        'Story has a link in the page attachment region',
+        'web-stories'
+      ),
+    };
+  }
+  return undefined;
+}

--- a/assets/src/edit-story/app/prepublish/errors/metadata.js
+++ b/assets/src/edit-story/app/prepublish/errors/metadata.js
@@ -144,21 +144,30 @@ export function publisherLogoSize(story) {
  */
 export function linkInPageAttachmentRegion(story) {
   const { pages } = story;
-  const isLinkInPageAttachmentArea = pages.some((page) => {
-    const { elements } = page;
-    const isLinkAttached = Boolean(page?.pageAttachment?.url.length);
-    return (
-      isLinkAttached &&
-      elements.filter(({ link }) => link?.url?.length).some(isElementBelowLimit)
-    );
-  });
+  const pagesWithLinksInAttachmentArea = pages
+    .filter((page) => {
+      const { elements } = page;
+      const hasPageAttachment = Boolean(page?.pageAttachment?.url.length);
+      return (
+        hasPageAttachment &&
+        elements
+          .filter(({ link }) => Boolean(link?.url?.length))
+          .some(isElementBelowLimit)
+      );
+    })
+    .map((page) => page.id);
+
+  const isLinkInPageAttachmentArea = Boolean(
+    pagesWithLinksInAttachmentArea.length
+  );
 
   if (isLinkInPageAttachmentArea) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
       storyId: story.storyId,
+      pages: pagesWithLinksInAttachmentArea,
       message: __(
-        'Story has a link in the page attachment region',
+        'Page has a link in the page attachment region',
         'web-stories'
       ),
     };

--- a/assets/src/edit-story/app/prepublish/errors/metadata.js
+++ b/assets/src/edit-story/app/prepublish/errors/metadata.js
@@ -100,8 +100,8 @@ export function storyTitle(story) {
  */
 export function storyCoverPortraitSize(story) {
   if (
-    story.featuredMediaResource.height < FEATURED_MEDIA_RESOURCE_MIN_HEIGHT ||
-    story.featuredMediaResource.width < FEATURED_MEDIA_RESOURCE_MIN_WIDTH
+    story.featuredMedia.height < FEATURED_MEDIA_RESOURCE_MIN_HEIGHT ||
+    story.featuredMedia.width < FEATURED_MEDIA_RESOURCE_MIN_WIDTH
   ) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
@@ -122,8 +122,8 @@ export function storyCoverPortraitSize(story) {
  */
 export function publisherLogoSize(story) {
   if (
-    story.publisherLogoResource.height < PUBLISHER_LOGO_MIN_HEIGHT ||
-    story.publisherLogoResource.width < PUBLISHER_LOGO_MIN_WIDTH
+    story.publisherLogo.height < PUBLISHER_LOGO_MIN_HEIGHT ||
+    story.publisherLogo.width < PUBLISHER_LOGO_MIN_WIDTH
   ) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
@@ -148,7 +148,7 @@ export function linkInPageAttachmentRegion(story) {
     const { elements } = page;
     const isLinkAttached = Boolean(page?.pageAttachment?.url.length);
     return (
-      !isLinkAttached &&
+      isLinkAttached &&
       elements.filter(({ link }) => link?.url?.length).some(isElementBelowLimit)
     );
   });

--- a/assets/src/edit-story/app/prepublish/errors/test/metadata.js
+++ b/assets/src/edit-story/app/prepublish/errors/test/metadata.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import * as metadataGuidelines from '../metadata';
+
+describe('Pre-publish checklist - missing critical metadata (errors)', () => {
+  it('should return an error-type guidance message if the story is missing its portrait cover', () => {
+    const testStory = {
+      storyId: 890,
+      title: 'Work work work work work',
+      featuredMediaUrl: undefined,
+    };
+    const testMissingCover = metadataGuidelines.storyCoverAttached(testStory);
+    expect(testMissingCover).not.toBeUndefined();
+    expect(testMissingCover.message).toMatchInlineSnapshot(
+      `"Missing story cover"`
+    );
+    expect(testMissingCover.storyId).toStrictEqual(testStory.storyId);
+  });
+
+  it.todo(
+    "should return an error-type guidance message if the story is missing it's title"
+  );
+  it.todo(
+    "should return an error-type guidance message if the story's publisher logo is too small"
+  );
+  it.todo(
+    'should return an error-type guidance message if there is a link in the page attachment region'
+  );
+
+  // todo the story's cover sizes are not returned by the api
+  it.todo(
+    "should return an error-type guidance message if the story's portrait cover is too small"
+  );
+});

--- a/assets/src/edit-story/app/prepublish/errors/test/metadata.js
+++ b/assets/src/edit-story/app/prepublish/errors/test/metadata.js
@@ -34,18 +34,171 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
     expect(testMissingCover.storyId).toStrictEqual(testStory.storyId);
   });
 
-  it.todo(
-    "should return an error-type guidance message if the story is missing it's title"
-  );
-  it.todo(
-    "should return an error-type guidance message if the story's publisher logo is too small"
-  );
-  it.todo(
-    'should return an error-type guidance message if there is a link in the page attachment region'
-  );
+  it("should return an error-type guidance message if the story is missing it's title", () => {
+    const testEmptyStringStory = {
+      storyId: 890,
+      status: 'draft',
+      title: '',
+    };
+    const testUndefinedTitleStory = {
+      storyId: 890,
+      status: 'draft',
+    };
+    const testUndefined = metadataGuidelines.storyTitle(
+      testUndefinedTitleStory
+    );
+    const testEmptyString = metadataGuidelines.storyTitle(testEmptyStringStory);
+    const testHappy = metadataGuidelines.storyTitle({
+      title: 'The Allegory of the Cave',
+    });
+    expect(testHappy).toBeUndefined();
+    expect(testEmptyString).not.toBeUndefined();
+    expect(testUndefined).not.toBeUndefined();
+    expect(testUndefined.message).toMatchInlineSnapshot(
+      `"Missing story title"`
+    );
+    expect(testEmptyString.message).toMatchInlineSnapshot(
+      `"Missing story title"`
+    );
+    expect(testUndefined.storyId).toStrictEqual(
+      testUndefinedTitleStory.storyId
+    );
+    expect(testEmptyString.storyId).toStrictEqual(testEmptyStringStory.storyId);
+  });
 
-  // todo the story's cover sizes are not returned by the api
-  it.todo(
-    "should return an error-type guidance message if the story's portrait cover is too small"
-  );
+  it('should return an error-type guidance message if there is a link in the page attachment region', () => {
+    const elementInRegion = {
+      x: 35,
+      y: 400,
+      width: 188,
+      height: 141,
+      rotationAngle: 0,
+      link: undefined,
+    };
+    const testPageAttachment = {
+      url: 'http://bomb.com',
+    };
+    const testNoLink = metadataGuidelines.linkInPageAttachmentRegion({
+      pages: [
+        {
+          pageAttachment: testPageAttachment,
+          elements: [elementInRegion],
+        },
+      ],
+    });
+    const testNoAttachment = metadataGuidelines.linkInPageAttachmentRegion({
+      pages: [
+        {
+          pageAttachment: undefined,
+          elements: [{ ...elementInRegion, link: { url: 'bomb.com' } }],
+        },
+      ],
+    });
+    const testLinkInPageAttachmentStory = {
+      storyId: 123,
+      pages: [
+        {
+          pageAttachment: testPageAttachment,
+          elements: [{ ...elementInRegion, link: { url: 'bomb.com ' } }],
+        },
+      ],
+    };
+    const testLinkInPageAttachment = metadataGuidelines.linkInPageAttachmentRegion(
+      testLinkInPageAttachmentStory
+    );
+    expect(testNoLink).toBeUndefined();
+    expect(testNoAttachment).toBeUndefined();
+    expect(testLinkInPageAttachment).not.toBeUndefined();
+    expect(testLinkInPageAttachment.message).toMatchInlineSnapshot(
+      `"Story has a link in the page attachment region"`
+    );
+    expect(testLinkInPageAttachment.storyId).toStrictEqual(
+      testLinkInPageAttachmentStory.storyId
+    );
+  });
+
+  // todo: The story's cover and publisher url are not yet returned by the api. See #5105.
+  it("should return an error-type guidance message if the story's portrait cover is too small", () => {
+    const testHeightStory = {
+      storyId: 123,
+      publisherLogo: {
+        height: 1,
+        width: 96,
+      },
+    };
+    const testWidthStory = {
+      storyId: 345,
+      publisherLogo: {
+        width: 1,
+        height: 96,
+      },
+    };
+    const testStory = {
+      storyId: 456,
+      publisherLogo: { height: 1, width: 1 },
+    };
+    const testHappy = metadataGuidelines.publisherLogoSize({
+      storyId: 345,
+      publisherLogo: {
+        height: 96,
+        width: 96,
+      },
+    });
+    const testHeight = metadataGuidelines.publisherLogoSize(testHeightStory);
+    const testWidth = metadataGuidelines.publisherLogoSize(testWidthStory);
+    const test = metadataGuidelines.publisherLogoSize(testStory);
+    expect(testHappy).toBeUndefined();
+    expect(testHeight).not.toBeUndefined();
+    expect(testHeight.storyId).toStrictEqual(testHeightStory.storyId);
+    expect(testWidth).not.toBeUndefined();
+    expect(testWidth.storyId).toStrictEqual(testWidthStory.storyId);
+    expect(test).not.toBeUndefined();
+    expect(test.message).toMatchInlineSnapshot(
+      `"Story's publisher logo image is too small"`
+    );
+    expect(test.storyId).toStrictEqual(testStory.storyId);
+  });
+
+  it("should return an error-type guidance message if the story's publisher logo is too small", () => {
+    const testHeightStory = {
+      storyId: 123,
+      featuredMedia: {
+        height: 1,
+        width: 640,
+      },
+    };
+    const testWidthStory = {
+      storyId: 345,
+      featuredMedia: {
+        width: 1,
+        height: 853,
+      },
+    };
+    const testStory = {
+      storyId: 456,
+      featuredMedia: { height: 1, width: 1 },
+    };
+    const testHappy = metadataGuidelines.storyCoverPortraitSize({
+      storyId: 345,
+      featuredMedia: {
+        height: 853,
+        width: 640,
+      },
+    });
+    const testHeight = metadataGuidelines.storyCoverPortraitSize(
+      testHeightStory
+    );
+    const testWidth = metadataGuidelines.storyCoverPortraitSize(testWidthStory);
+    const test = metadataGuidelines.storyCoverPortraitSize(testStory);
+    expect(testHappy).toBeUndefined();
+    expect(testHeight).not.toBeUndefined();
+    expect(testHeight.storyId).toStrictEqual(testHeightStory.storyId);
+    expect(testWidth).not.toBeUndefined();
+    expect(testWidth.storyId).toStrictEqual(testWidthStory.storyId);
+    expect(test).not.toBeUndefined();
+    expect(test.message).toMatchInlineSnapshot(
+      `"Story's portrait cover image is too small"`
+    );
+    expect(test.storyId).toStrictEqual(testStory.storyId);
+  });
 });

--- a/assets/src/edit-story/app/prepublish/errors/test/metadata.js
+++ b/assets/src/edit-story/app/prepublish/errors/test/metadata.js
@@ -98,6 +98,7 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
       storyId: 123,
       pages: [
         {
+          id: 890,
           pageAttachment: testPageAttachment,
           elements: [{ ...elementInRegion, link: { url: 'bomb.com ' } }],
         },
@@ -110,7 +111,11 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
     expect(testNoAttachment).toBeUndefined();
     expect(testLinkInPageAttachment).not.toBeUndefined();
     expect(testLinkInPageAttachment.message).toMatchInlineSnapshot(
-      `"Story has a link in the page attachment region"`
+      `"Page has a link in the page attachment region"`
+    );
+    expect(testLinkInPageAttachment.pages).toHaveLength(1);
+    expect(testLinkInPageAttachment.pages[0]).toStrictEqual(
+      testLinkInPageAttachmentStory.pages[0].id
     );
     expect(testLinkInPageAttachment.storyId).toStrictEqual(
       testLinkInPageAttachmentStory.storyId

--- a/assets/src/edit-story/app/story/effects/useLoadStory.js
+++ b/assets/src/edit-story/app/story/effects/useLoadStory.js
@@ -48,8 +48,10 @@ function useLoadStory({ storyId, shouldLoad, restore }) {
           excerpt: { raw: excerpt },
           link,
           story_data: storyDataRaw,
+          // todo: get featured_media_url original dimensions for prepublish checklist
           featured_media: featuredMedia,
           featured_media_url: featuredMediaUrl,
+          // todo: get publisher_logo_url image dimensions for prepublish checklist
           publisher_logo_url: publisherLogoUrl,
           permalink_template: permalinkTemplate,
           style_presets: stylePresets,


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->
- adds tests and logic for the critical story metadata checks for the prepublish checklist.

## Relevant Technical Choices
- I kept the `publisherLogo`/`featuredMedia` tests and logic in, even though it's not supported yet. We might want to eliminate the publisher logo logic for clarity as that will be prevented per #5107. Featured media will be supported after #5105. 

<!-- Please describe your changes. -->

## To-do
- [x] unit tests
- [x] add comment/adjust tests to refer to changes mentioned [here](https://github.com/google/web-stories-wp/issues/5105)

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->
None.
## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->
- Run unit tests.
---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4910 
