### PR TITLE
Fix date and time

### DIFF
--- a/assets/src/date/format.js
+++ b/assets/src/date/format.js
@@ -22,13 +22,15 @@ import { format as _format, toDate } from 'date-fns-tz';
 /**
  * Internal dependencies
  */
-import convertFormatString from './convertFormatString';
+import convertFormatString, {
+  FORMAT_TOKEN_SEPARATOR_REGEX,
+} from './convertFormatString';
 import getOptions from './getOptions';
 
 /**
  * Formats a date by a given format.
  *
- * @param {Date} date Date to format.
+ * @param {Date|string} date Date to format.
  * @param {string} formatString PHP-style date format.
  * @return {string} Formatted date.
  */
@@ -37,7 +39,14 @@ function format(date, formatString) {
     return '';
   }
 
-  return _format(toDate(date), convertFormatString(formatString), getOptions());
+  const parsedDate = toDate(date);
+  const options = getOptions();
+  const convertedFormat = convertFormatString(formatString, parsedDate);
+
+  return _format(parsedDate, convertedFormat, options).replace(
+    FORMAT_TOKEN_SEPARATOR_REGEX,
+    ''
+  );
 }
 
 export default format;

--- a/assets/src/date/getOptions.js
+++ b/assets/src/date/getOptions.js
@@ -28,6 +28,7 @@ import buildLocalizeFn from 'date-fns/locale/_lib/buildLocalizeFn';
  */
 import { getSettings } from './settings';
 import formatDistance from './formatDistance';
+import getTimeZoneString from './getTimeZoneString';
 
 /**
  * Returns date-fns option.
@@ -44,8 +45,6 @@ function getOptions() {
   const settings = getSettings();
   const {
     locale: localeCode,
-    timezone,
-    gmtOffset,
     weekStartsOn,
     months,
     monthsShort,
@@ -141,7 +140,7 @@ function getOptions() {
    */
   const locale = {
     ...originalLocale,
-    code: localeCode,
+    code: localeCode || originalLocale.code,
     formatDistance: formatDistance,
     localize: localize,
     options: {
@@ -151,7 +150,7 @@ function getOptions() {
 
   return {
     weekStartsOn,
-    timeZone: timezone || gmtOffset,
+    timeZone: getTimeZoneString(),
     locale,
   };
 }

--- a/assets/src/date/getTimeZoneString.js
+++ b/assets/src/date/getTimeZoneString.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getSettings } from './settings';
+
+/**
+ * Transforms a given integer into a valid UTC Offset in hours.
+ *
+ * @param {number} offset A UTC offset as an integer
+ * @return {string} UTC offset in hours.
+ */
+function integerToUTCOffset(offset) {
+  const offsetInHours = offset > 23 ? offset / 60 : offset;
+  const sign = offset < 0 ? '-' : '+';
+  const absoluteOffset = Math.abs(offsetInHours);
+
+  return offsetInHours < 10
+    ? `${sign}0${absoluteOffset}`
+    : `${sign}${absoluteOffset}`;
+}
+
+/**
+ * Returns a properly formatted timezone from a timezone string or offset.
+ *
+ * @return {string} Timezone string.
+ */
+function getTimeZoneString() {
+  const settings = getSettings();
+  const { timezone, gmtOffset } = settings;
+
+  if (timezone) {
+    return timezone;
+  }
+
+  if (!Number.isNaN(Number(gmtOffset))) {
+    return integerToUTCOffset(gmtOffset);
+  }
+
+  return '+00:00';
+}
+
+export default getTimeZoneString;

--- a/assets/src/date/settings.js
+++ b/assets/src/date/settings.js
@@ -17,7 +17,7 @@
 export const DEFAULT_DATE_SETTINGS = {
   dateFormat: 'Y-m-d',
   timeFormat: 'g:i a',
-  gmtOffset: null,
+  gmtOffset: 0,
   timezone: '',
   weekStartsOn: 0,
 };

--- a/assets/src/date/test/convertFormatString.js
+++ b/assets/src/date/test/convertFormatString.js
@@ -17,7 +17,9 @@
 /**
  * Internal dependencies
  */
-import convertFormatString from '../convertFormatString';
+import convertFormatString, {
+  FORMAT_TOKEN_SEPARATOR_REGEX,
+} from '../convertFormatString';
 import format from '../format';
 
 describe('date/convertFormatString', () => {
@@ -25,11 +27,15 @@ describe('date/convertFormatString', () => {
     ['d-m-Y H:i', 'dd-MM-yyyy HH:mm'],
     ['F j, Y', 'MMMM d, yyyy'],
     ['F M l D', 'MMMM MMM EEEE EEE'],
+    ['G \\h h \\m\\i\\n', "H 'h' hh 'm''i''n'"],
   ])(
     'converts PHP date format string to its date-fns equivalent',
     (formatString, expectedOutput) => {
-      expect(convertFormatString(formatString)).toStrictEqual(expectedOutput);
-      expect(() => () => format(new Date(), formatString)).not.toThrow();
+      const convertedWithoutSeparator = convertFormatString(
+        formatString
+      ).replace(FORMAT_TOKEN_SEPARATOR_REGEX, '');
+      expect(convertedWithoutSeparator).toStrictEqual(expectedOutput);
+      expect(() => format(new Date(), formatString)).not.toThrow();
     }
   );
 });

--- a/assets/src/date/test/format.js
+++ b/assets/src/date/test/format.js
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import MockDate from 'mockdate';
+
+/**
+ * Internal dependencies
+ */
+import format from '../format';
+import { resetSettings, updateSettings } from '../settings';
+
+describe('date/format', () => {
+  beforeEach(() => {
+    MockDate.set('2020-07-15T22:47:26+00:00');
+  });
+
+  afterEach(() => {
+    MockDate.reset();
+    resetSettings();
+  });
+
+  it('should support "S" to obtain ordinal suffix of day of the month', () => {
+    const formattedDate = format('2019-06-18T11:00:00.000', 'S');
+
+    // th for 18th
+    expect(formattedDate).toBe('th');
+  });
+
+  it('should support "z" to obtain zero-indexed day of the year', () => {
+    const formattedDate = format('2019-01-01', 'z');
+
+    expect(formattedDate).toBe('0');
+  });
+
+  it('should support "t" to obtain the days in a given month', () => {
+    const formattedDate = format('2019-02', 't');
+
+    expect(formattedDate).toBe('28');
+  });
+
+  it('should support "L" to obtain whether or not the year is a leap year', () => {
+    const formattedDate = format('2020', 'L');
+
+    expect(formattedDate).toBe('1');
+  });
+
+  // TODO: Fix implementation/tests.
+  //eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should support "B" to obtain the time in Swatch Internet Time (.beats)', () => {
+    const formattedDate = format('2020-10-09T11:00:00.000', 'B');
+
+    expect(formattedDate).toBe('500');
+  });
+
+  it('should support "T" to obtain the timezone abbreviation for the given date', () => {
+    updateSettings({
+      gmtOffset: -4,
+      timezone: 'America/New_York',
+    });
+
+    const formattedDate = format('2020-01-01T11:00:00.000', 'T');
+
+    expect(formattedDate).toBe('EST');
+  });
+
+  it('should support "e" to obtain timezone identifier', () => {
+    updateSettings({
+      gmtOffset: -4,
+      timezone: 'America/New_York',
+    });
+
+    const formattedDate = format('2020-10-09T11:00:00.000', 'e');
+
+    expect(formattedDate).toBe('Eastern Daylight Time');
+  });
+
+  it('should support "w" to obtain day of the week starting from 0', () => {
+    const formattedDate = format('2020-01-01T12:00:00.000', 'w'); // Wednesday Jan 1st, 2020
+
+    expect(formattedDate).toBe('2');
+  });
+
+  // TODO: Fix implementation/tests.
+  //eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should support "U" to get epoc for given date', () => {
+    const formattedDate = format('2020-10-09T02:00:00.000', 'U');
+
+    expect(formattedDate).toBe('1602201600');
+  });
+
+  it('should support "c" to obtain the full date', () => {
+    const formattedDate = format('2020-10-09T11:00:00.000', 'c');
+
+    expect(formattedDate).toBe('2020-10-09T11:00:00+00:00');
+  });
+
+  it('should support "r" to obtain RFC2822 formatted date', () => {
+    const formattedDate = format('2020-10-09T11:00:00.000', 'r');
+
+    expect(formattedDate).toBe('Fri, 09 Oct 2020 11:00:00 +0000');
+  });
+
+  it('should support "M" to obtain short textual representation of a month, three letters', () => {
+    const formattedDate = format('2020-10-09T11:00:00.000', 'MM');
+
+    expect(formattedDate).toBe('OctOct');
+  });
+
+  // Disable reason: Not implemented yet.
+  //eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should support "I" to obtain whether or not the timezone is observing DST', () => {
+    const formattedFall = format('2020-10-09T11:00:00.000', 'I');
+
+    expect(formattedFall).toBe('1');
+
+    const formattedWinter = format('2020-01-09T11:00:00.000', 'I');
+
+    expect(formattedWinter).toBe('0');
+  });
+
+  it('should support "Z" to obtain timezone offset in seconds', () => {
+    const formattedDate = format('2020-10-09T11:00:00.000', 'Z');
+
+    expect(formattedDate).toBe('0');
+  });
+
+  it('should support "G \\h i \\m\\i\\n" date format', () => {
+    const formattedDate = format(
+      '2019-06-18T11:22:00.000',
+      'G \\h i \\m\\i\\n'
+    );
+
+    // th for 18th
+    expect(formattedDate).toBe('11 h 22 min');
+  });
+});

--- a/includes/Locale.php
+++ b/includes/Locale.php
@@ -42,10 +42,26 @@ class Locale {
 	public function get_locale_settings() {
 		global $wp_locale;
 
+		/* translators: Date format, see https://www.php.net/date */
+		$default_date_format = __( 'd/m/Y', 'web-stories' );
+
+		/* translators: Date format, see https://www.php.net/date */
+		$default_time_format = __( 'g:i a', 'web-stories' );
+
+		$date_format = get_option( 'date_format' );
+		if ( empty( trim( $date_format ) ) ) {
+			$date_format = $default_date_format;
+		}
+
+		$time_format = get_option( 'time_format' );
+		if ( empty( trim( $time_format ) ) ) {
+			$time_format = $default_time_format;
+		}
+
 		return [
 			'locale'           => str_replace( '_', '-', get_user_locale() ),
-			'dateFormat'       => get_option( 'date_format' ),
-			'timeFormat'       => get_option( 'time_format' ),
+			'dateFormat'       => $date_format,
+			'timeFormat'       => $time_format,
 			'gmtOffset'        => get_option( 'gmt_offset' ),
 			'timezone'         => get_option( 'timezone_string' ),
 			'months'           => array_values( $wp_locale->month ),

--- a/includes/Locale.php
+++ b/includes/Locale.php
@@ -48,12 +48,12 @@ class Locale {
 		/* translators: Date format, see https://www.php.net/date */
 		$default_time_format = __( 'g:i a', 'web-stories' );
 
-		$date_format = get_option( 'date_format' );
+		$date_format = get_option( 'date_format', $default_date_format );
 		if ( empty( trim( $date_format ) ) ) {
 			$date_format = $default_date_format;
 		}
 
-		$time_format = get_option( 'time_format' );
+		$time_format = get_option( 'time_format', $default_time_format );
 		if ( empty( trim( $time_format ) ) ) {
 			$time_format = $default_time_format;
 		}


### PR DESCRIPTION
## Summary

Fixes some of the recurring date/time issues users have been reporting

## Relevant Technical Choices

* Fixes issue with incorrect character escaping in `convertFormatString`
* Adds fallback date and time formats if none is provided by WordPress
* Adds a ton of tests
* Fixes some existing tests

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

1. Under Settings -> General, try various different date formats and time formats (including leaving the box empty)
1. Go to editor / dashboard
1. Verify that time and date is showing correctly everywhere
1. Verify that document sidebar is not crashing

(Note: the publish time picker in the document sidebar uses its own custom date format and cannot be customized this way).

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5089
