### PR TITLE
Improve API usage to prevent WAF false positives

### DIFF
--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -63,16 +63,18 @@ jest.mock('../wpAdapter', () => ({
       _embedded: { author: [{ id: 1, name: 'admin' }] },
     });
   },
-  deleteRequest: (path, { data }) =>
+  deleteRequest: (path) => {
+    const id = path.split('/')[1];
     Promise.resolve({
-      id: data.id,
+      id: id,
       status: 'publish',
-      title: { rendered: data.title, raw: data.title },
+      title: { rendered: 'Carlos', raw: 'Carlos' },
       story_data: { pages: [{ id: 1, elements: [] }] },
       modified_gmt: '1970-01-01T00:00:00.000Z',
       date_gmt: '1970-01-01T00:00:00.000Z',
       link: 'https://www.story-link.com',
-    }),
+    });
+  },
 }));
 
 describe('ApiProvider', () => {

--- a/assets/src/dashboard/app/api/test/wpAdapter.js
+++ b/assets/src/dashboard/app/api/test/wpAdapter.js
@@ -80,14 +80,13 @@ describe('wpAdapter', () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
-      'https://stories.google.com?_locale=user',
+      'https://stories.google.com?_method=DELETE&_locale=user',
       {
+        body: undefined,
         credentials: 'include',
         method: 'POST',
         headers: {
           Accept: 'application/json, */*;q=0.1',
-          'Content-Type': 'application/json',
-          'X-HTTP-Method-Override': 'DELETE',
         },
       }
     );

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -179,9 +179,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi }) => {
   const trashStory = useCallback(
     async (story) => {
       try {
-        await dataAdapter.deleteRequest(`${storyApi}/${story.id}`, {
-          data: story,
-        });
+        await dataAdapter.deleteRequest(`${storyApi}/${story.id}`);
         dispatch({
           type: STORY_ACTION_TYPES.TRASH_STORY,
           payload: { id: story.id, storyStatus: story.status },

--- a/assets/src/dashboard/app/api/wpAdapter.js
+++ b/assets/src/dashboard/app/api/wpAdapter.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import queryString from 'query-string';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -28,11 +33,21 @@ const post = (path, options = {}) =>
     method: 'POST',
   });
 
+// `apiFetch` by default turns `DELETE` requests into `POST` requests
+// with `X-HTTP-Method-Override: DELETE` headers.
+// However, some Web Application Firewall (WAF) solutions prevent this.
+// `?_method=DELETE` is an alternative solution to override the request method.
+// See https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_method-or-x-http-method-override-header
 const deleteRequest = (path, options = {}) =>
   apiFetch({
-    path,
+    path: queryString.stringifyUrl({
+      url: path,
+      query: {
+        _method: 'DELETE',
+      },
+    }),
     ...options,
-    method: 'DELETE',
+    method: 'POST',
   });
 
 export default {

--- a/assets/src/edit-story/app/api/apiProvider.js
+++ b/assets/src/edit-story/app/api/apiProvider.js
@@ -200,10 +200,15 @@ function APIProvider({ children }) {
    */
   const deleteMedia = useCallback(
     (mediaId) => {
+      // `apiFetch` by default turns `DELETE` requests into `POST` requests
+      // with `X-HTTP-Method-Override: DELETE` headers.
+      // However, some Web Application Firewall (WAF) solutions prevent this.
+      // `?_method=DELETE` is an alternative solution to override the request method.
+      // See https://developer.wordpress.org/rest-api/using-the-rest-api/global-parameters/#_method-or-x-http-method-override-header
       return apiFetch({
-        path: `${media}/${mediaId}`,
+        path: addQueryArgs(`${media}/${mediaId}`, { _method: 'DELETE' }),
         data: { force: true },
-        method: 'DELETE',
+        method: 'POST',
       });
     },
     [media]

--- a/codecov.yml
+++ b/codecov.yml
@@ -84,4 +84,6 @@ ignore:
   - includes/namespace.php
   - includes/plugin-compat
   - includes/templates
-  - AMP/Integration/AMP_Story_Sanitizer.php
+  - includes/AMP/Integration/AMP_Story_Sanitizer.php
+  - includes/REST_API/Stories_Settings_Controller.php
+  - includes/REST_API/Stories_Users_Controller.php

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -328,10 +328,10 @@ class Dashboard {
 				'api'                => [
 					'stories'     => sprintf( '/web-stories/v1/%s', $rest_base ),
 					'media'       => '/web-stories/v1/media',
-					'currentUser' => '/wp/v2/users/me',
-					'users'       => '/wp/v2/users',
+					'currentUser' => '/web-stories/v1/users/me',
+					'users'       => '/web-stories/v1/users',
 					'templates'   => '/web-stories/v1/web-story-template',
-					'settings'    => '/wp/v2/settings',
+					'settings'    => '/web-stories/v1/settings',
 				],
 				'maxUpload'          => $max_upload_size,
 				'maxUploadFormatted' => size_format( $max_upload_size ),

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -193,7 +193,8 @@ class Dashboard {
 		// Preload common data.
 		// TODO Preload templates.
 		$preload_paths = [
-			'/wp/v2/settings',
+			'/web-stories/v1/settings',
+			'/web-stories/v1/users/me',
 			'/web-stories/v1/web-story?_embed=author&context=edit&order=desc&orderby=modified&page=1&per_page=24&status=publish%2Cdraft%2Cfuture&_web_stories_envelope=true',
 		];
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -33,6 +33,8 @@ use Google\Web_Stories\REST_API\Stories_Media_Controller;
 use Google\Web_Stories\REST_API\Link_Controller;
 use Google\Web_Stories\REST_API\Stories_Autosaves_Controller;
 use Google\Web_Stories\Block\Embed_Block;
+use Google\Web_Stories\REST_API\Stories_Settings_Controller;
+use Google\Web_Stories\REST_API\Stories_Users_Controller;
 use Google\Web_Stories\Shortcode\Embed_Shortcode;
 use WP_Post;
 
@@ -249,5 +251,11 @@ class Plugin {
 
 		$stories_media = new Stories_Media_Controller( 'attachment' );
 		$stories_media->register_routes();
+
+		$stories_users = new Stories_Users_Controller();
+		$stories_users->register_routes();
+
+		$stories_settings = new Stories_Settings_Controller();
+		$stories_settings->register_routes();
 	}
 }

--- a/includes/REST_API/Stories_Settings_Controller.php
+++ b/includes/REST_API/Stories_Settings_Controller.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Class Stories_Settings_Controller
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\REST_API;
+
+use WP_REST_Settings_Controller;
+
+/**
+ * Stories_Settings_Controller class.
+ */
+class Stories_Settings_Controller extends WP_REST_Settings_Controller {
+	/**
+	 * Constructor.
+	 *
+	 * Override the namespace.
+	 *
+	 * @since 1.2.0
+	 */
+	public function __construct() {
+		parent::__construct();
+		$this->namespace = 'web-stories/v1';
+	}
+}

--- a/includes/REST_API/Stories_Users_Controller.php
+++ b/includes/REST_API/Stories_Users_Controller.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Class Stories_Users_Controller
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\REST_API;
+
+use WP_REST_Users_Controller;
+
+/**
+ * Stories_Users_Controller class.
+ */
+class Stories_Users_Controller extends WP_REST_Users_Controller {
+	/**
+	 * Constructor.
+	 *
+	 * Override the namespace.
+	 *
+	 * @since 1.2.0
+	 */
+	public function __construct() {
+		parent::__construct();
+		$this->namespace = 'web-stories/v1';
+	}
+}

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -721,7 +721,7 @@ class Story_Post_Type {
 					'hasUploadMediaAction'  => $has_upload_media_action,
 				],
 				'api'              => [
-					'users'   => '/wp/v2/users',
+					'users'   => '/web-stories/v1/users',
 					'stories' => sprintf( '/web-stories/v1/%s', $rest_base ),
 					'media'   => '/web-stories/v1/media',
 					'link'    => '/web-stories/v1/link',


### PR DESCRIPTION
## Summary

Improves compatibility with Sucuri WAF setups.

## Relevant Technical Choices

* Do not send request body for DELETE requests
* Use `?_method=DELETE` instead of `POST` with `X-HTTP-Method-Override: DELETE` for deleting stories
* Move all used REST API endpoints under the `web-stories/v1` namespace
* Ignore new REST controllers from coverage
* Preload `/users/me` requests on the dashboard because the dashboard requests it at all times

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None

## Testing Instructions

1. Delete story on dashboard
1. Verify that no request body is sent along with the POST request

Ideally test on a site behind Sucuri firewall.

---

<!-- Please reference the issue(s) this PR addresses. -->

See #5059 
