### PR TITLE
Fix pasting for search inputs

### DIFF
--- a/assets/src/edit-story/utils/nativeCopyPasteExpected.js
+++ b/assets/src/edit-story/utils/nativeCopyPasteExpected.js
@@ -29,7 +29,7 @@ function nativeCopyPasteExpected() {
     'true' === contentEditable ||
     'textarea' === tagName.toLowerCase() ||
     ('input' === tagName.toLowerCase() &&
-      ['text', 'number', 'search'].includes(type))
+      ['text', 'number', 'search', 'email', 'tel', 'url'].includes(type))
   ) {
     return true;
   }

--- a/assets/src/edit-story/utils/nativeCopyPasteExpected.js
+++ b/assets/src/edit-story/utils/nativeCopyPasteExpected.js
@@ -29,7 +29,7 @@ function nativeCopyPasteExpected() {
     'true' === contentEditable ||
     'textarea' === tagName.toLowerCase() ||
     ('input' === tagName.toLowerCase() &&
-      ('text' === type || 'number' === type))
+      ['text', 'number', 'search'].includes(type))
   ) {
     return true;
   }

--- a/assets/src/edit-story/utils/test/nativeCopyPasteExpected.js
+++ b/assets/src/edit-story/utils/test/nativeCopyPasteExpected.js
@@ -38,6 +38,12 @@ describe('nativeCopyPasteExpected', () => {
     numberInput.focus();
     expect(nativeCopyPasteExpected()).toBe(true);
 
+    const searchInput = document.createElement('input');
+    searchInput.type = 'search';
+    document.body.appendChild(searchInput);
+    searchInput.focus();
+    expect(nativeCopyPasteExpected()).toBe(true);
+
     const contentEditable = document.createElement('div');
     contentEditable.setAttribute('contenteditable', 'true');
     document.body.appendChild(contentEditable);


### PR DESCRIPTION
## Summary
Adds `search` and some other inputs which allow pasting into to the list of inputs that should handle copying/pasting natively.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
- Copy some text
- Open the font family picker and paste into the search field
- Verify that the text is pasted into the input.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4710 
