### PR TITLE
Fix disabling background reordering for layer panel

### DIFF
--- a/assets/src/edit-story/components/panels/layer/layerList.js
+++ b/assets/src/edit-story/components/panels/layer/layerList.js
@@ -95,7 +95,7 @@ function LayerPanel({ layers }) {
           <ReorderableItem
             position={layer.position}
             onStartReordering={handleStartReordering(layer.id)}
-            disabled={layer.type === 'background'}
+            disabled={layer.isBackground}
           >
             <Layer layer={layer} />
           </ReorderableItem>


### PR DESCRIPTION
## Summary
Disables reodering for background element in the layer panel, it was previously using incorrect value.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
1. Add a few elements
2. Try to reorder the background element in the layer section in the design panel.
3. Verify that no blue lines appear when trying to drag it.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #2339 
