### PR TITLE
Fix AMP plugin sanitizer setup

### DIFF
--- a/includes/AMP/Integration/AMP_Story_Sanitizer.php
+++ b/includes/AMP/Integration/AMP_Story_Sanitizer.php
@@ -51,7 +51,6 @@ class AMP_Story_Sanitizer extends \AMP_Base_Sanitizer {
 	public function sanitize() {
 		$this->transform_html_start_tag( $this->dom );
 		$this->transform_a_tags( $this->dom );
-		$this->insert_analytics_configuration( $this->dom );
 		$this->add_publisher_logo( $this->dom, $this->args['publisher_logo'], $this->args['publisher_logo_placeholder'] );
 		$this->add_poster_images( $this->dom, $this->args['poster_images'] );
 	}

--- a/includes/AMP/Story_Sanitizer.php
+++ b/includes/AMP/Story_Sanitizer.php
@@ -49,7 +49,6 @@ class Story_Sanitizer extends AMP_Base_Sanitizer {
 	public function sanitize() {
 		$this->transform_html_start_tag( $this->dom );
 		$this->transform_a_tags( $this->dom );
-		$this->insert_analytics_configuration( $this->dom );
 		$this->add_publisher_logo( $this->dom, $this->args['publisher_logo'], $this->args['publisher_logo_placeholder'] );
 		$this->add_poster_images( $this->dom, $this->args['poster_images'] );
 	}

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -84,57 +84,6 @@ trait Sanitization_Utils {
 	}
 
 	/**
-	 * Replaces the amp-story end tag to include amp-analytics tag if set up.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param Document|AMP_Document $document Document instance.
-	 * @return void
-	 */
-	private function insert_analytics_configuration( &$document ) {
-		/**
-		 * The <amp-story> element.
-		 *
-		 * @var DOMElement $story_element The <amp-story> element.
-		 */
-		$story_element = $document->body->getElementsByTagName( 'amp-story' )->item( 0 );
-
-		if ( ! $story_element instanceof DOMElement ) {
-			return;
-		}
-
-		ob_start();
-
-		/**
-		 * Fires before the closing <amp-story> tag.
-		 *
-		 * Can be used to print <amp-analytics> configuration.
-		 *
-		 * @since 1.1.0
-		 */
-		do_action( 'web_stories_print_analytics' );
-
-		$output = (string) ob_get_clean();
-
-		if ( empty( $output ) ) {
-			return;
-		}
-
-		$fragment          = $document->createDocumentFragment();
-		$fragment_document = Document::fromHtmlFragment( $output );
-
-		if ( $fragment_document ) {
-			while ( $fragment_document->body->firstChild ) {
-				$node = $fragment_document->body->removeChild( $fragment_document->body->firstChild );
-				$node = $document->importNode( $node, true );
-				$fragment->appendChild( $node );
-			}
-		}
-
-		$story_element->appendChild( $fragment );
-	}
-
-	/**
 	 * Replaces the placeholder of publisher logo in the content.
 	 *
 	 * @since 1.1.0

--- a/includes/Story_Renderer/HTML.php
+++ b/includes/Story_Renderer/HTML.php
@@ -26,6 +26,7 @@
 
 namespace Google\Web_Stories\Story_Renderer;
 
+use AmpProject\Dom\Document as AMP_Document;
 use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
 use Google\Web_Stories\Traits\Publisher;
 use Google\Web_Stories\Model\Story;
@@ -76,6 +77,7 @@ class HTML {
 		$markup = $this->story->get_markup();
 		$markup = $this->replace_html_head( $markup );
 		$markup = $this->replace_url_scheme( $markup );
+		$markup = $this->print_analytics( $markup );
 
 		// If the AMP plugin is installed and available in a version >= than ours,
 		// all sanitization and optimization should be delegated to the AMP plugin.
@@ -232,6 +234,32 @@ class HTML {
 
 		return $content;
 
+	}
+
+	/**
+	 * Force home urls to http / https based on context.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param string $content String to replace.
+	 *
+	 * @return string
+	 */
+	protected function print_analytics( $content ) {
+		ob_start();
+
+		/**
+		 * Fires before the closing <amp-story> tag.
+		 *
+		 * Can be used to print <amp-analytics> configuration.
+		 *
+		 * @since 1.1.0
+		 */
+		do_action( 'web_stories_print_analytics' );
+
+		$output = (string) ob_get_clean();
+
+		return str_replace( '</amp-story>', $output . '</amp-story>', $content );
 	}
 
 	/**

--- a/tests/phpunit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/tests/AMP/Story_Sanitizer.php
@@ -153,48 +153,4 @@ class Story_Sanitizer extends \WP_UnitTestCase {
 		$this->assertContains( 'rel="noreferrer"', $actual );
 		$this->assertContains( 'target="_blank"', $actual );
 	}
-
-	/**
-	 * @covers ::insert_analytics_configuration
-	 * @covers ::get_element_by_tag_name
-	 */
-	public function test_insert_analytics_configuration() {
-		$source = '<html><head></head><body><amp-story standalone="" publisher="Web Stories" title="Example Story" publisher-logo-src="https://example.com/image.png" poster-portrait-src="https://example.com/image.png"><amp-story-page id="example"><amp-story-grid-layer template="fill"></amp-story-grid-layer></amp-story-page></amp-story></body></html>';
-
-		add_action(
-			'web_stories_print_analytics',
-			static function() {
-				echo '<amp-analytics type="gtag" data-credentials="include"><script type="application/json">{}</script></amp-analytics>';
-			}
-		);
-
-		$args = [
-			'publisher_logo'             => '',
-			'publisher_logo_placeholder' => '',
-			'poster_images'              => [],
-		];
-
-		$actual = $this->sanitize_and_get( $source, $args );
-
-		remove_all_actions( 'web_stories_print_analytics' );
-
-		$this->assertContains( '<amp-analytics type="gtag" data-credentials="include"', $actual );
-	}
-
-	/**
-	 * @covers ::insert_analytics_configuration
-	 */
-	public function test_insert_analytics_configuration_no_output() {
-		$source = '<html><head></head><body><amp-story standalone="" publisher="Web Stories" title="Example Story" publisher-logo-src="https://example.com/image.png" poster-portrait-src="https://example.com/image.png"><amp-story-page id="example"><amp-story-grid-layer template="fill"></amp-story-grid-layer></amp-story-page></amp-story></body></html>';
-
-		$args = [
-			'publisher_logo'             => '',
-			'publisher_logo_placeholder' => '',
-			'poster_images'              => [],
-		];
-
-		$actual = $this->sanitize_and_get( $source, $args );
-
-		$this->assertNotContains( 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js', $actual );
-	}
 }

--- a/tests/phpunit/tests/Story_Renderer/HTML.php
+++ b/tests/phpunit/tests/Story_Renderer/HTML.php
@@ -267,6 +267,46 @@ class HTML extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::print_analytics
+	 */
+	public function test_print_analytics() {
+		$source   = '<html><head></head><body><amp-story standalone="" publisher="Web Stories" title="Example Story" publisher-logo-src="https://example.com/image.png" poster-portrait-src="https://example.com/image.png"><amp-story-page id="example"><amp-story-grid-layer template="fill"></amp-story-grid-layer></amp-story-page></amp-story></body></html>';
+		$expected = '<html><head></head><body><amp-story standalone="" publisher="Web Stories" title="Example Story" publisher-logo-src="https://example.com/image.png" poster-portrait-src="https://example.com/image.png"><amp-story-page id="example"><amp-story-grid-layer template="fill"></amp-story-grid-layer></amp-story-page><amp-analytics type="gtag" data-credentials="include"><script type="application/json">{}</script></amp-analytics></amp-story></body></html>';
+
+		add_action(
+			'web_stories_print_analytics',
+			static function() {
+				echo '<amp-analytics type="gtag" data-credentials="include"><script type="application/json">{}</script></amp-analytics>';
+			}
+		);
+
+		$story    = new Story();
+		$renderer = new \Google\Web_Stories\Story_Renderer\HTML( $story );
+
+		$actual = $this->call_private_method( $renderer, 'print_analytics', [ $source ] );
+
+		remove_all_actions( 'web_stories_print_analytics' );
+
+		$this->assertContains( '<amp-analytics type="gtag" data-credentials="include"', $actual );
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::print_analytics
+	 */
+	public function test_print_analytics_no_output() {
+		$source = '<html><head></head><body><amp-story standalone="" publisher="Web Stories" title="Example Story" publisher-logo-src="https://example.com/image.png" poster-portrait-src="https://example.com/image.png"><amp-story-page id="example"><amp-story-grid-layer template="fill"></amp-story-grid-layer></amp-story-page></amp-story></body></html>';
+
+		$story    = new Story();
+		$renderer = new \Google\Web_Stories\Story_Renderer\HTML( $story );
+
+		$actual = $this->call_private_method( $renderer, 'print_analytics', [ $source ] );
+
+		$this->assertNotContains( '<amp-analytics type="gtag" data-credentials="include"', $actual );
+		$this->assertSame( $source, $actual );
+	}
+
+	/**
 	 * Helper to setup renderer.
 	 *
 	 * @param WP_Post $post Post Object.


### PR DESCRIPTION
## Summary

Fixes incorrect AMP sanitizer setup that prevented the sanitizer from actually running when the AMP plugin is present, which resulted in things like analytics tags not being printed.

## Relevant Technical Choices

* Registers AMP sanitizer early enough so that it gets added in time
* Does NOT do output buffering in `Sanitization_Utils` as it doesn't work in an output buffering callback

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

N/A

## Testing Instructions

1. Insert GA tracking ID in editor settings
1. Activate AMP plugin
1. View a story on the frontend
1. Verify that `<amp-analytics>` tag is there in the source code
1. Deactivate AMP plugin
1. Verify that `<amp-analytics>` tag is still there in the source code

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5113
