### PR TITLE
Admin Menu should not be collapsed on dashboard

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -74,8 +74,8 @@ class Admin {
 			return $class;
 		}
 
-		// Default WordPress posts list table screen.
-		if ( 'edit' === $screen->base ) {
+		// Default WordPress posts list table screen and dashboard.
+		if ( 'post' !== $screen->base ) {
 			return $class;
 		}
 


### PR DESCRIPTION
## Summary
Admin Menu should not be collapsed on dashboard.

## Relevant Technical Choices

Use post as base. Experiments also now shows the full menu. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Admin menu should be collapsed on editor
1. Admin menu should **not** be collapsed on dashboard screens
1. Admin menu should **not** be collapsed on experiments page
1. Admin menu should **not** be collapsed on "All Stories" page

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5058
