### PR TITLE
Videos: supply empty string as poster if missing

### DIFF
--- a/assets/src/edit-story/elements/video/output.js
+++ b/assets/src/edit-story/elements/video/output.js
@@ -34,7 +34,10 @@ function VideoOutput({ element, box }) {
 
   const props = {
     autoPlay: 'autoplay',
-    poster: defaultForUndefined(element.poster, resource.poster),
+    poster: defaultForUndefined(
+      defaultForUndefined(element.poster, resource.poster),
+      ''
+    ),
     artwork: defaultForUndefined(element.poster, resource.poster),
     title: defaultForUndefined(element.title, resource.title),
     alt: defaultForUndefined(element.alt, resource.alt),
@@ -55,7 +58,7 @@ function VideoOutput({ element, box }) {
               kind={kind}
               src={src}
               key={key}
-              default={i == 0}
+              default={i === 0}
             />
           ))}
       </amp-video>

--- a/assets/src/edit-story/elements/video/test/output.js
+++ b/assets/src/edit-story/elements/video/test/output.js
@@ -42,7 +42,7 @@ describe('Video output', () => {
         type: 'video',
         mimeType: 'video/mp4',
         id: 123,
-        src: 'https://example.com/image.png',
+        src: 'https://example.com/video.mp4',
         poster: 'https://example.com/poster.png',
         alt: 'alt text',
         height: 1920,
@@ -51,28 +51,6 @@ describe('Video output', () => {
     },
     box: { width: 1080, height: 1920, x: 50, y: 100, rotationAngle: 0 },
   };
-
-  it('should produce valid AMP output', async () => {
-    await expect(<VideoOutput {...baseProps} />).toBeValidAMPStoryElement();
-  });
-
-  it('should produce valid AMP output with track', async () => {
-    const props = {
-      ...baseProps,
-      tracks: [
-        {
-          track: 'https://example.com/track.vtt',
-          trackId: 123,
-          trackName: 'track.vtt',
-          id: 'rersd-fdfd-fdfd-fdfd',
-          srcLang: '',
-          label: '',
-          kind: 'caption',
-        },
-      ],
-    };
-    await expect(<VideoOutput {...props} />).toBeValidAMPStoryElement();
-  });
 
   it('an undefined alt tag in the element should fall back to the resource', async () => {
     const props = {
@@ -93,5 +71,38 @@ describe('Video output', () => {
     await expect(outputStr).not.toStrictEqual(
       expect.stringMatching('alt text')
     );
+  });
+
+  describe('AMP validation', () => {
+    it('should produce valid AMP output', async () => {
+      await expect(<VideoOutput {...baseProps} />).toBeValidAMPStoryElement();
+    });
+
+    it('should produce valid AMP output with missing poster', async () => {
+      const props = {
+        ...baseProps,
+      };
+      delete props.element.resource.poster;
+
+      await expect(<VideoOutput {...props} />).toBeValidAMPStoryElement();
+    });
+
+    it('should produce valid AMP output with track', async () => {
+      const props = {
+        ...baseProps,
+        tracks: [
+          {
+            track: 'https://example.com/track.vtt',
+            trackId: 123,
+            trackName: 'track.vtt',
+            id: 'rersd-fdfd-fdfd-fdfd',
+            srcLang: '',
+            label: '',
+            kind: 'caption',
+          },
+        ],
+      };
+      await expect(<VideoOutput {...props} />).toBeValidAMPStoryElement();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Supply empty string as poster if missing, to ensure AMP validation in that case.

## Relevant Technical Choices

Moved tests around a bit

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

N/A

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5119
