### PR TITLE
Add accessibility and distribution pre-publish warnings

### DIFF
--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import {
+  calculateLuminanceFromRGB,
+  calculateLuminanceFromStyleColor,
+  checkContrastFromLuminances,
+} from '../../../utils/contrastUtils';
+import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
+
+const MAX_PAGE_LINKS = 3;
+const LINK_TAPPABLE_REGION_MIN_WIDTH = 48;
+const LINK_TAPPABLE_REGION_MIN_HEIGHT = 48;
+
+/**
+ * @typedef {import('../../../types').Page} Page
+ * @typedef {import('../../../types').Element} Element
+ * @typedef {import('../types').Guidance} Guidance
+ */
+
+let spansFromContentBuffer;
+function getSpansFromContent(content) {
+  // memoize buffer
+  if (!spansFromContentBuffer) {
+    spansFromContentBuffer = document.createElement('div');
+  }
+
+  spansFromContentBuffer.innerHTML = content;
+
+  // return Array instead of HtmlCollection
+  return Array.prototype.slice.call(
+    spansFromContentBuffer.getElementsByTagName('span')
+  );
+}
+
+/**
+ * Check text element for low contrast between font and background color
+ *
+ * @param {Element} element The text element being checked for warnings
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
+export function textElementFontLowContrast(element) {
+  if (element.backgroundTextMode === 'NONE' || !element.backgroundColor) {
+    return undefined;
+  }
+
+  // get background luminance from text fill
+  // @todo: look for background image/color
+  const backgroundLuminance = calculateLuminanceFromRGB(
+    element.backgroundColor.color
+  );
+
+  // check all spans for contrast ratios that don't pass verification
+  const spans = getSpansFromContent(element.content);
+  let lowContrast = spans.some((span) => {
+    if (!span.style?.color) {
+      return false;
+    }
+
+    const textLuminance = calculateLuminanceFromStyleColor(span.style.color);
+
+    const contrastCheck = checkContrastFromLuminances(
+      textLuminance,
+      backgroundLuminance,
+      element.fontSize
+    );
+    return !contrastCheck.WCAG_AA;
+  });
+
+  if (lowContrast) {
+    return {
+      message: __(
+        'Low contrast between font and background color',
+        'web-stories'
+      ),
+      elementId: element.id,
+      type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Check text element for font size too small (<12)
+ *
+ * @param {Element} element The text element being checked for warnings
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
+export function textElementFontSizeTooSmall(element) {
+  if (element.fontSize && element.fontSize < 12) {
+    return {
+      message: __('Font size too small', 'web-stories'),
+      elementId: element.id,
+      type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Check image element for very low image resolution: actual image asset on screen, at the current zoom,
+ * offers <1x pixel density (guideline is to strive for >828 x 1792)
+ *
+ * @param  {Object} element Element object
+ * @return {Object} Prepublish check response
+ */
+export function imageElementLowResolution(element) {
+  const scaleMultiplier = element.scale / 100;
+  if (
+    element.width * scaleMultiplier > element.resource.width ||
+    element.height * scaleMultiplier > element.resource.height
+  ) {
+    return {
+      message: __('Very low image resolution', 'web-stories'),
+      elementId: element.id,
+      type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Check video element for doesn’t include title
+ *
+ * @param {Element} element The video element being checked for warnings
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
+export function videoElementMissingTitle(element) {
+  if (!element.title?.length && !element.resource?.title?.length) {
+    return {
+      message: __('Video is missing title', 'web-stories'),
+      elementId: element.id,
+      type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Check video element for doesn’t include assistive text
+ *
+ * @param {Element} element The video element being checked for warnings
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
+export function videoElementMissingAlt(element) {
+  if (!element.alt?.length && !element.resource?.alt?.length) {
+    return {
+      message: __('Video is missing assistive text', 'web-stories'),
+      elementId: element.id,
+      type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Check video element for doesn’t include captions
+ *
+ * @param {Element} element The video element being checked for warnings
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
+export function videoElementMissingCaptions(element) {
+  if (!element.tracks?.length) {
+    return {
+      message: __('Video is missing captions', 'web-stories'),
+      elementId: element.id,
+      type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Check page for too many links (more than 3)
+ *
+ * @param {Page} page The page being checked for warnings
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
+export function pageTooManyLinks(page) {
+  let linkCount = 0;
+  page.elements.forEach((element) => {
+    if (element.link?.url?.length) {
+      linkCount += 1;
+    }
+  });
+
+  if (linkCount > MAX_PAGE_LINKS) {
+    return {
+      message: __('Too many links on page', 'web-stories'),
+      pageId: page.id,
+      type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Check element with link for tappable region too small
+ *
+ * @param {Element} element The element being checked for warnings
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
+export function elementLinkTappableRegionTooSmall(element) {
+  if (!element.link?.url?.length) {
+    return undefined;
+  }
+
+  if (
+    element.width < LINK_TAPPABLE_REGION_MIN_WIDTH ||
+    element.height < LINK_TAPPABLE_REGION_MIN_HEIGHT
+  ) {
+    return {
+      message: __('Link tappable region is too small', 'web-stories'),
+      elementId: element.id,
+      type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Check image element for missing alt text
+ *
+ * @param {Element} element The image element being checked for warnings
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
+export function imageElementMissingAlt(element) {
+  if (!element.alt?.length && !element.resource?.alt?.length) {
+    return {
+      message: __('Image is missing alt text', 'web-stories'),
+      elementId: element.id,
+      type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
+    };
+  }
+
+  return undefined;
+}

--- a/assets/src/edit-story/app/prepublish/warning/distribution.js
+++ b/assets/src/edit-story/app/prepublish/warning/distribution.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
+
+/**
+ * @typedef {import('../../../types').Story} Story
+ * @typedef {import('../types').Guidance} Guidance
+ */
+
+/**
+ * Check story for missing excerpt
+ *
+ * @param {Story} story The story being checked for warnings
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
+export function storyMissingExcerpt(story) {
+  if (!story.excerpt?.length) {
+    return {
+      message: __('Missing story excerpt', 'web-stories'),
+      storyId: story.id,
+      type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
+    };
+  }
+
+  return undefined;
+}

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -1,0 +1,547 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import * as accessibilityChecks from '../accessibility';
+
+describe('Pre-publish checklist - accessibility issues (warnings)', () => {
+  describe('textElementFontLowContrast', () => {
+    it('should return a warning if text element is low contrast', () => {
+      const element = {
+        id: 'elementid',
+        type: 'text',
+        fontSize: 19,
+        backgroundTextMode: 'FILL',
+        backgroundColor: {
+          color: {
+            r: 200,
+            g: 200,
+            b: 200,
+          },
+        },
+        content: '<span style="color: #fff">HOT GOSSIP ARTICLE</span>',
+      };
+      expect(
+        accessibilityChecks.textElementFontLowContrast(element)
+      ).toStrictEqual({
+        message: 'Low contrast between font and background color',
+        elementId: element.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return undefined if text element is high enough contrast', () => {
+      const element = {
+        id: 'elementid',
+        type: 'text',
+        fontSize: 19,
+        backgroundTextMode: 'FILL',
+        backgroundColor: {
+          color: {
+            r: 255,
+            g: 0,
+            b: 153,
+          },
+        },
+        content: '<span style="color: #fff">HOT GOSSIP ARTICLE</span>',
+      };
+      expect(
+        accessibilityChecks.textElementFontLowContrast(element)
+      ).toBeUndefined();
+    });
+
+    it('should return undefined if content has no spans', () => {
+      const element = {
+        id: 'elementid',
+        type: 'text',
+        fontSize: 19,
+        backgroundTextMode: 'FILL',
+        backgroundColor: {
+          color: {
+            r: 255,
+            g: 0,
+            b: 153,
+          },
+        },
+        content: 'HOT GOSSIP ARTICLE',
+      };
+      expect(
+        accessibilityChecks.textElementFontLowContrast(element)
+      ).toBeUndefined();
+    });
+
+    it('should return undefined if element has no background fill', () => {
+      const element = {
+        id: 'elementid',
+        type: 'text',
+        fontSize: 19,
+        backgroundTextMode: 'NONE',
+        content: '<span style="color: #fff">HOT GOSSIP ARTICLE</span>',
+      };
+      expect(
+        accessibilityChecks.textElementFontLowContrast(element)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('textElementFontSizeTooSmall', () => {
+    it('should return a warning if text element font size is too small', () => {
+      const element = {
+        id: 'elementid',
+        type: 'text',
+        fontSize: 11,
+      };
+      expect(
+        accessibilityChecks.textElementFontSizeTooSmall(element)
+      ).toStrictEqual({
+        message: 'Font size too small',
+        elementId: element.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return undefined if text element font size is large enough', () => {
+      const element = {
+        id: 'elementid',
+        type: 'text',
+        fontSize: 12,
+      };
+      expect(
+        accessibilityChecks.textElementFontSizeTooSmall(element)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('imageElementLowResolution', () => {
+    it('should return a warning if image element is low pixel density', () => {
+      const element = {
+        id: 'elementid',
+        type: 'image',
+        width: 100,
+        height: 100,
+        scale: 100,
+        resource: {
+          type: 'image',
+          width: 99,
+          height: 99,
+        },
+      };
+      expect(
+        accessibilityChecks.imageElementLowResolution(element)
+      ).toStrictEqual({
+        message: 'Very low image resolution',
+        elementId: element.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return a warning if image element is low pixel density adjusted with scale', () => {
+      const element = {
+        id: 'elementid',
+        type: 'image',
+        width: 100,
+        height: 100,
+        scale: 130,
+        resource: {
+          type: 'image',
+          width: 100,
+          height: 100,
+        },
+      };
+      expect(
+        accessibilityChecks.imageElementLowResolution(element)
+      ).toStrictEqual({
+        message: 'Very low image resolution',
+        elementId: element.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return undefined if image element has high enough pixel density', () => {
+      const element = {
+        id: 'elementid',
+        type: 'image',
+        width: 100,
+        height: 100,
+        scale: 100,
+        resource: {
+          type: 'image',
+          width: 100,
+          height: 100,
+        },
+      };
+      expect(
+        accessibilityChecks.imageElementLowResolution(element)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('videoElementMissingTitle', () => {
+    it('should return a warning if video element missing title', () => {
+      const element = {
+        id: 'elementid',
+        type: 'video',
+        resource: {},
+      };
+      expect(
+        accessibilityChecks.videoElementMissingTitle(element)
+      ).toStrictEqual({
+        message: 'Video is missing title',
+        elementId: element.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return a warning if video element has empty title', () => {
+      const element = {
+        id: 'elementid',
+        type: 'video',
+        title: '',
+        resource: {
+          title: '',
+        },
+      };
+      expect(
+        accessibilityChecks.videoElementMissingTitle(element)
+      ).toStrictEqual({
+        message: 'Video is missing title',
+        elementId: element.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return undefined if video element has title', () => {
+      const element = {
+        id: 'elementid',
+        type: 'video',
+        title: 'Video title',
+        resource: {},
+      };
+      expect(
+        accessibilityChecks.videoElementMissingTitle(element)
+      ).toBeUndefined();
+    });
+
+    it('should return undefined if video resource has title', () => {
+      const element = {
+        id: 'elementid',
+        type: 'video',
+        resource: {
+          title: 'Video title',
+        },
+      };
+      expect(
+        accessibilityChecks.videoElementMissingTitle(element)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('videoElementMissingAlt', () => {
+    it('should return a warning if video element missing alt', () => {
+      const element = {
+        id: 'elementid',
+        type: 'video',
+        resource: {},
+      };
+      expect(accessibilityChecks.videoElementMissingAlt(element)).toStrictEqual(
+        {
+          message: 'Video is missing assistive text',
+          elementId: element.id,
+          type: 'warning',
+        }
+      );
+    });
+
+    it('should return a warning if video element has empty alt', () => {
+      const element = {
+        id: 'elementid',
+        type: 'video',
+        alt: '',
+        resource: {
+          alt: '',
+        },
+      };
+      expect(accessibilityChecks.videoElementMissingAlt(element)).toStrictEqual(
+        {
+          message: 'Video is missing assistive text',
+          elementId: element.id,
+          type: 'warning',
+        }
+      );
+    });
+
+    it('should return undefined if video element has alt', () => {
+      const element = {
+        id: 'elementid',
+        type: 'video',
+        alt: 'Video is about things',
+        resource: {},
+      };
+      expect(
+        accessibilityChecks.videoElementMissingAlt(element)
+      ).toBeUndefined();
+    });
+
+    it('should return undefined if video resource has alt', () => {
+      const element = {
+        id: 'elementid',
+        type: 'image',
+        resource: {
+          alt: 'Image is about things',
+        },
+      };
+      expect(
+        accessibilityChecks.videoElementMissingAlt(element)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('videoElementMissingCaptions', () => {
+    it('should return a warning if video element missing captions', () => {
+      const element = {
+        id: 'elementid',
+        type: 'video',
+      };
+      expect(
+        accessibilityChecks.videoElementMissingCaptions(element)
+      ).toStrictEqual({
+        message: 'Video is missing captions',
+        elementId: element.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return a warning if video element has empty captions', () => {
+      const element = {
+        id: 'elementid',
+        type: 'video',
+        tracks: [],
+      };
+      expect(
+        accessibilityChecks.videoElementMissingCaptions(element)
+      ).toStrictEqual({
+        message: 'Video is missing captions',
+        elementId: element.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return undefined if video element has captions', () => {
+      const element = {
+        id: 'elementid',
+        type: 'text',
+        tracks: [{ id: 'trackid' }],
+      };
+      expect(
+        accessibilityChecks.videoElementMissingCaptions(element)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('pageTooManyLinks', () => {
+    it('should return a warning if page has too many links', () => {
+      const page = {
+        id: 'pageid',
+        elements: [
+          { type: 'text' },
+          { type: 'video' },
+          {
+            type: 'text',
+            link: {
+              url: 'https://google.com',
+            },
+          },
+          {
+            type: 'image',
+            link: {
+              url: 'https://google.com',
+            },
+          },
+          {
+            type: 'text',
+            link: {
+              url: '',
+            },
+          },
+          {
+            type: 'text',
+            link: {
+              url: 'https://google.com',
+            },
+          },
+          {
+            type: 'text',
+            link: {
+              url: 'https://google.com',
+            },
+          },
+        ],
+      };
+      expect(accessibilityChecks.pageTooManyLinks(page)).toStrictEqual({
+        message: 'Too many links on page',
+        pageId: page.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return undefined if page has a reasonable number of links', () => {
+      const page = {
+        elements: [
+          { type: 'text' },
+          { type: 'video' },
+          {
+            type: 'text',
+            link: {
+              url: 'https://google.com',
+            },
+          },
+          {
+            type: 'image',
+            link: {
+              url: 'https://google.com',
+            },
+          },
+          {
+            type: 'text',
+            link: {
+              url: '',
+            },
+          },
+          {
+            type: 'text',
+            link: {
+              url: 'https://google.com',
+            },
+          },
+        ],
+      };
+      expect(accessibilityChecks.pageTooManyLinks(page)).toBeUndefined();
+    });
+  });
+
+  describe('elementLinkTappableRegionTooSmall', () => {
+    it('should return a warning if element tappable region is too small', () => {
+      const element = {
+        id: 'elementid',
+        type: 'text',
+        link: {
+          url: 'https://google.com',
+        },
+        content: 'G',
+        width: 40,
+        height: 40,
+      };
+      expect(
+        accessibilityChecks.elementLinkTappableRegionTooSmall(element)
+      ).toStrictEqual({
+        message: 'Link tappable region is too small',
+        elementId: element.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return undefined if element has large enough tappable region', () => {
+      const element = {
+        id: 'elementid',
+        type: 'text',
+        link: {
+          url: 'https://google.com',
+        },
+        content: 'G',
+        width: 48,
+        height: 48,
+      };
+      expect(
+        accessibilityChecks.elementLinkTappableRegionTooSmall(element)
+      ).toBeUndefined();
+    });
+
+    it('should return undefined if not an element with link', () => {
+      const element = {
+        id: 'elementid',
+        type: 'text',
+        content: 'G',
+        width: 40,
+        height: 40,
+      };
+      expect(
+        accessibilityChecks.elementLinkTappableRegionTooSmall(element)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('imageElementMissingAlt', () => {
+    it('should return a warning if image element missing alt', () => {
+      const element = {
+        id: 'elementid',
+        type: 'image',
+        resource: {},
+      };
+      expect(accessibilityChecks.imageElementMissingAlt(element)).toStrictEqual(
+        {
+          message: 'Image is missing alt text',
+          elementId: element.id,
+          type: 'warning',
+        }
+      );
+    });
+
+    it('should return a warning if image element has empty alt', () => {
+      const element = {
+        id: 'elementid',
+        type: 'image',
+        alt: '',
+        resource: {
+          alt: '',
+        },
+      };
+      expect(accessibilityChecks.imageElementMissingAlt(element)).toStrictEqual(
+        {
+          message: 'Image is missing alt text',
+          elementId: element.id,
+          type: 'warning',
+        }
+      );
+    });
+
+    it('should return undefined if image element has alt', () => {
+      const element = {
+        id: 'elementid',
+        type: 'image',
+        alt: 'Image is about things',
+        resource: {},
+      };
+      expect(
+        accessibilityChecks.imageElementMissingAlt(element)
+      ).toBeUndefined();
+    });
+
+    it('should return undefined if image resource has alt', () => {
+      const element = {
+        id: 'elementid',
+        type: 'image',
+        resource: {
+          alt: 'Image is about things',
+        },
+      };
+      expect(
+        accessibilityChecks.imageElementMissingAlt(element)
+      ).toBeUndefined();
+    });
+  });
+});

--- a/assets/src/edit-story/app/prepublish/warning/test/distribution.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/distribution.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import * as distributionChecks from '../distribution';
+
+describe('Pre-publish checklist - distribution issues (warnings)', () => {
+  describe('storyMissingExcerpt', () => {
+    it('should return a warning if story is missing excerpt', () => {
+      const story = {
+        id: 'storyid',
+      };
+      expect(distributionChecks.storyMissingExcerpt(story)).toStrictEqual({
+        message: 'Missing story excerpt',
+        storyId: story.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return a warning if story has empty excerpt', () => {
+      const story = {
+        id: 'storyid',
+        excerpt: '',
+      };
+      expect(distributionChecks.storyMissingExcerpt(story)).toStrictEqual({
+        message: 'Missing story excerpt',
+        storyId: story.id,
+        type: 'warning',
+      });
+    });
+
+    it('should return undefined if story has excerpt', () => {
+      const story = {
+        id: 'storyid',
+        excerpt: 'This is an excerpt',
+      };
+      expect(distributionChecks.storyMissingExcerpt(story)).toBeUndefined();
+    });
+  });
+});

--- a/assets/src/edit-story/utils/contrastUtils.js
+++ b/assets/src/edit-story/utils/contrastUtils.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import ColorContrastChecker from 'color-contrast-checker';
+
+// Parse style.color from "rgb(000, 000, 000)" into {r, g, b} format
+function parseRGBFromStyleColor(styleColor) {
+  const [r, g, b] = styleColor.match(/\d+/g).map((number) => parseInt(number));
+  return { r, g, b };
+}
+
+/**
+ * Calculate luminance from RGB Object
+ *
+ * @param  {Object} rgb RGB Object. Example: { r, g, b }
+ * @return {number} Luminance
+ */
+export function calculateLuminanceFromRGB(rgb) {
+  const ccc = new ColorContrastChecker();
+  const lrgb = ccc.calculateLRGB(rgb);
+  return ccc.calculateLuminance(lrgb);
+}
+
+/**
+ * Calculate luminance from RGB Object
+ *
+ * @param  {string} styleColor Color from html element style.color. Example: "rgb(000, 000, 000)"
+ * @return {number} Luminance
+ */
+export function calculateLuminanceFromStyleColor(styleColor) {
+  const rgb = parseRGBFromStyleColor(styleColor);
+  return calculateLuminanceFromRGB(rgb);
+}
+
+/**
+ * Check contrast ratios from luminances for WCAG guidelines
+ *
+ * @param  {number} luminanceA Luminance A
+ * @param  {number} luminanceB Luminance B
+ * @param  {number} fontSize Optional fontSize for checking contrast ratio
+ * @return {Object} WCAG contrast ratio checks
+ */
+export function checkContrastFromLuminances(luminanceA, luminanceB, fontSize) {
+  const ccc = new ColorContrastChecker();
+  if (fontSize) {
+    ccc.fontSize = fontSize;
+  }
+  const contrastRatio = ccc.getContrastRatio(luminanceA, luminanceB);
+  return ccc.verifyContrastRatio(contrastRatio);
+}

--- a/assets/src/edit-story/utils/test/contrastUtils.js
+++ b/assets/src/edit-story/utils/test/contrastUtils.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import * as contrastUtils from '../contrastUtils';
+
+describe('contrastUtils', () => {
+  describe('calculateLuminanceFromRGB', () => {
+    it('calculate from RGB object', () => {
+      const rgb = {
+        r: 255,
+        g: 255,
+        b: 255,
+      };
+      expect(contrastUtils.calculateLuminanceFromRGB(rgb)).toStrictEqual(1);
+    });
+  });
+
+  describe('calculateLuminanceFromStyleColor', () => {
+    it('calculate from element style.color string', () => {
+      const color = 'rgb(255, 255, 255)';
+      expect(
+        contrastUtils.calculateLuminanceFromStyleColor(color)
+      ).toStrictEqual(1);
+    });
+  });
+
+  describe('checkContrastFromLuminances', () => {
+    it('calculate successful contrast check from differing luminances', () => {
+      const luminanceA = 0;
+      const luminanceB = 1;
+      expect(
+        contrastUtils.checkContrastFromLuminances(luminanceA, luminanceB)
+          .WCAG_AA
+      ).toStrictEqual(true);
+    });
+
+    it('calculate failed contrast check from similar luminances', () => {
+      const luminanceA = 0.3;
+      const luminanceB = 1;
+      expect(
+        contrastUtils.checkContrastFromLuminances(luminanceA, luminanceB)
+          .WCAG_AA
+      ).toStrictEqual(false);
+    });
+
+    it('calculate successful contrast check from similar luminances w/ larger font size', () => {
+      const luminanceA = 0.3; // fails with default font size
+      const luminanceB = 1;
+      const fontSize = 50;
+      expect(
+        contrastUtils.checkContrastFromLuminances(
+          luminanceA,
+          luminanceB,
+          fontSize
+        ).WCAG_AA
+      ).toStrictEqual(true);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12988,6 +12988,11 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
     "amphtml-validator": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/amphtml-validator/-/amphtml-validator-1.0.33.tgz",
@@ -15622,6 +15627,14 @@
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
+      }
+    },
+    "color-contrast-checker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/color-contrast-checker/-/color-contrast-checker-1.5.0.tgz",
+      "integrity": "sha512-7vcVIjdieWaxDQk4RTqCgU/iM1JEllxymR7AmoSgoakas5EKqfLhTphwrCEABYGMN9VG+h5a9utUlyGgY1F9WQ==",
+      "requires": {
+        "amdefine": ">=0.2.0"
       }
     },
     "color-convert": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@wordpress/i18n": "^3.15.0",
     "big.js": "^6.0.2",
     "classnames": "^2.2.6",
+    "color-contrast-checker": "^1.5.0",
     "colorthief": "^2.3.2",
     "date-fns": "^2.16.1",
     "date-fns-tz": "^1.0.12",


### PR DESCRIPTION
## Summary

* Adds accessibility and distribution warnings
* Adds contrast util that uses [color-contrast-checker](https://github.com/bbc/color-contrast-checker) package to help with calculating luminances and checking against WCAG guidelines

[ticket](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/4911)

Replaces #5074 (borked PR)

## Relevant Technical Choices

* Checking test contrast against background could either be (1) against the text fill or (2) against the background image/color of elements behind it. This implementation only addresses the first scenario.
* Contrast test uses WCAG AA check (vs AAA)
* Element tappable area check chosen to be 48x48 which is what lighthouse uses

## To-do

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4911 
