### PR TITLE
Redirect for child pages with stories slug

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -789,7 +789,6 @@ class Story_Post_Type {
 		if ( ! $wp_rewrite instanceof \WP_Rewrite || ! $wp_rewrite->using_permalinks() ) {
 			return $bypass;
 		}
- 
 		// 'pagename' is for most permalink types, name is for when the %postname% is used as a top-level field.
 		if ( isset( $query->query['pagename'] ) && 'stories' === $query->query['pagename'] && ( 'stories' === $query->get( 'pagename' ) || 'stories' === $query->get( 'name' ) ) ) {
 			$redirect_url = get_post_type_archive_link( self::POST_TYPE_SLUG );

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -789,9 +789,9 @@ class Story_Post_Type {
 		if ( ! $wp_rewrite instanceof \WP_Rewrite || ! $wp_rewrite->using_permalinks() ) {
 			return $bypass;
 		}
-
+ 
 		// 'pagename' is for most permalink types, name is for when the %postname% is used as a top-level field.
-		if ( 'stories' === $query->get( 'pagename' ) || 'stories' === $query->get( 'name' ) ) {
+		if ( isset( $query->query['pagename'] ) && 'stories' === $query->query['pagename'] && ( 'stories' === $query->get( 'pagename' ) || 'stories' === $query->get( 'name' ) ) ) {
 			$redirect_url = get_post_type_archive_link( self::POST_TYPE_SLUG );
 			if (
 				$query->get( 'page' ) &&

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -358,7 +358,8 @@ class Story_Post_Type extends \WP_UnitTestCase {
 
 		$story_post_type = new \Google\Web_Stories\Story_Post_Type( $this->createMock( \Google\Web_Stories\Experiments::class ) );
 
-		$query = new \WP_Query();
+		$query                    = new \WP_Query();
+		$query->query['pagename'] = 'stories';
 		$query->set( 'name', 'stories' );
 		$query->set( 'page', self::$story_id );
 
@@ -379,7 +380,27 @@ class Story_Post_Type extends \WP_UnitTestCase {
 
 		$story_post_type = new \Google\Web_Stories\Story_Post_Type( $this->createMock( \Google\Web_Stories\Experiments::class ) );
 
-		$query = new \WP_Query();
+		$query                    = new \WP_Query();
+		$query->query['pagename'] = 'stories';
+		$query->set( 'pagename', 'stories' );
+
+		add_filter( 'post_type_archive_link', '__return_false' );
+		$result = $story_post_type->redirect_post_type_archive_urls( false, $query );
+		remove_filter( 'post_type_archive_link', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @covers ::redirect_post_type_archive_urls
+	 */
+	public function test_redirect_post_type_archive_urls_pagename_child_set() {
+		$this->set_permalink_structure( '/%postname%/' );
+
+		$story_post_type = new \Google\Web_Stories\Story_Post_Type( $this->createMock( \Google\Web_Stories\Experiments::class ) );
+
+		$query                    = new \WP_Query();
+		$query->query['pagename'] = 'client/stories';
 		$query->set( 'pagename', 'stories' );
 
 		add_filter( 'post_type_archive_link', '__return_false' );
@@ -398,7 +419,8 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		$story_post_type = new \Google\Web_Stories\Story_Post_Type( $this->createMock( \Google\Web_Stories\Experiments::class ) );
 		$story_post_type->init();
 
-		$query = new \WP_Query();
+		$query                    = new \WP_Query();
+		$query->query['pagename'] = 'stories';
 		$query->set( 'pagename', 'stories' );
 		$query->set( 'feed', 'feed' );
 


### PR DESCRIPTION
## Summary

Check to see it is just stories in only part of the slug 

## Relevant Technical Choices

`query` property is different from `query_vars`.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5128
