### PR TITLE
E2E Tests: Add some more percy snapshots for RTL

### DIFF
--- a/tests/e2e/specs/dashboard/dashboard.js
+++ b/tests/e2e/specs/dashboard/dashboard.js
@@ -20,9 +20,16 @@
 import { percySnapshot } from '@percy/puppeteer';
 
 /**
+ * WordPress dependencies
+ */
+import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
+
+/**
  * Internal dependencies
  */
 import { visitDashboard } from '../../utils';
+
+const percyCSS = `.dashboard-grid-item-date { display: none; }`;
 
 describe('Stories Dashboard', () => {
   it('should be able to open the dashboard', async () => {
@@ -30,8 +37,15 @@ describe('Stories Dashboard', () => {
 
     await expect(page).toMatch('My Stories');
 
-    await percySnapshot(page, 'Stories Dashboard', {
-      percyCSS: `.dashboard-grid-item-date { display: none; }`,
-    });
+    await percySnapshot(page, 'Stories Dashboard', { percyCSS });
+  });
+  it('should be able to open the dashboard on RTL', async () => {
+    await activatePlugin('rtl-tester');
+    await visitDashboard();
+
+    await expect(page).toMatch('My Stories');
+
+    await percySnapshot(page, 'Stories Dashboard on RTL', { percyCSS });
+    await deactivatePlugin('rtl-tester');
   });
 });

--- a/tests/e2e/specs/dashboard/dashboard.js
+++ b/tests/e2e/specs/dashboard/dashboard.js
@@ -20,14 +20,9 @@
 import { percySnapshot } from '@percy/puppeteer';
 
 /**
- * WordPress dependencies
- */
-import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
-
-/**
  * Internal dependencies
  */
-import { visitDashboard } from '../../utils';
+import { activateRTL, deactivateRTL, visitDashboard } from '../../utils';
 
 const percyCSS = `.dashboard-grid-item-date { display: none; }`;
 
@@ -40,12 +35,12 @@ describe('Stories Dashboard', () => {
     await percySnapshot(page, 'Stories Dashboard', { percyCSS });
   });
   it('should be able to open the dashboard on RTL', async () => {
-    await activatePlugin('rtl-tester');
+    await activateRTL();
     await visitDashboard();
 
     await expect(page).toMatch('My Stories');
 
     await percySnapshot(page, 'Stories Dashboard on RTL', { percyCSS });
-    await deactivatePlugin('rtl-tester');
+    await deactivateRTL();
   });
 });

--- a/tests/e2e/specs/dashboard/noJS.js
+++ b/tests/e2e/specs/dashboard/noJS.js
@@ -20,6 +20,11 @@
 import { percySnapshot } from '@percy/puppeteer';
 
 /**
+ * WordPress dependencies
+ */
+import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
+
+/**
  * Internal dependencies
  */
 import { visitDashboard } from '../../utils';
@@ -37,5 +42,21 @@ describe('Stories Dashboard with disabled JavaScript', () => {
     await page.setJavaScriptEnabled(true);
 
     await percySnapshot(page, 'Dashboard no js');
+  });
+
+  it('should display error message on RTL', async () => {
+    await activatePlugin('rtl-tester');
+    // Disable javascript for test.
+    await page.setJavaScriptEnabled(false);
+
+    await visitDashboard();
+
+    await expect(page).toMatchElement('#web-stories-no-js');
+
+    // Re-enable javascript for snapsnots.
+    await page.setJavaScriptEnabled(true);
+
+    await percySnapshot(page, 'Dashboard no js');
+    await deactivatePlugin('rtl-tester');
   });
 });

--- a/tests/e2e/specs/dashboard/noJS.js
+++ b/tests/e2e/specs/dashboard/noJS.js
@@ -20,14 +20,9 @@
 import { percySnapshot } from '@percy/puppeteer';
 
 /**
- * WordPress dependencies
- */
-import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
-
-/**
  * Internal dependencies
  */
-import { visitDashboard } from '../../utils';
+import { activateRTL, deactivateRTL, visitDashboard } from '../../utils';
 
 describe('Stories Dashboard with disabled JavaScript', () => {
   it('should display error message', async () => {
@@ -45,7 +40,7 @@ describe('Stories Dashboard with disabled JavaScript', () => {
   });
 
   it('should display error message on RTL', async () => {
-    await activatePlugin('rtl-tester');
+    await activateRTL();
     // Disable javascript for test.
     await page.setJavaScriptEnabled(false);
 
@@ -57,6 +52,6 @@ describe('Stories Dashboard with disabled JavaScript', () => {
     await page.setJavaScriptEnabled(true);
 
     await percySnapshot(page, 'Dashboard no js on RTL');
-    await deactivatePlugin('rtl-tester');
+    await deactivateRTL();
   });
 });

--- a/tests/e2e/specs/dashboard/noJS.js
+++ b/tests/e2e/specs/dashboard/noJS.js
@@ -56,7 +56,7 @@ describe('Stories Dashboard with disabled JavaScript', () => {
     // Re-enable javascript for snapsnots.
     await page.setJavaScriptEnabled(true);
 
-    await percySnapshot(page, 'Dashboard no js');
+    await percySnapshot(page, 'Dashboard no js on RTL');
     await deactivatePlugin('rtl-tester');
   });
 });

--- a/tests/e2e/specs/editor/editor.js
+++ b/tests/e2e/specs/editor/editor.js
@@ -20,14 +20,9 @@
 import { percySnapshot } from '@percy/puppeteer';
 
 /**
- * WordPress dependencies
- */
-import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
-
-/**
  * Internal dependencies
  */
-import { createNewStory } from '../../utils';
+import { createNewStory, deactivateRTL, activateRTL } from '../../utils';
 
 describe('Story Editor', () => {
   it('should be able to create a blank story', async () => {
@@ -38,12 +33,12 @@ describe('Story Editor', () => {
     await percySnapshot(page, 'Empty Editor');
   });
   it('should be able to create a blank story on RTL', async () => {
-    await activatePlugin('rtl-tester');
+    await activateRTL();
     await createNewStory();
 
     await expect(page).toMatchElement('input[placeholder="Add title"]');
 
     await percySnapshot(page, 'Empty Editor on RTL');
-    await deactivatePlugin('rtl-tester');
+    await deactivateRTL();
   });
 });

--- a/tests/e2e/specs/editor/editor.js
+++ b/tests/e2e/specs/editor/editor.js
@@ -43,7 +43,7 @@ describe('Story Editor', () => {
 
     await expect(page).toMatchElement('input[placeholder="Add title"]');
 
-    await percySnapshot(page, 'Empty Editor');
+    await percySnapshot(page, 'Empty Editor on RTL');
     await deactivatePlugin('rtl-tester');
   });
 });

--- a/tests/e2e/specs/editor/editor.js
+++ b/tests/e2e/specs/editor/editor.js
@@ -20,6 +20,11 @@
 import { percySnapshot } from '@percy/puppeteer';
 
 /**
+ * WordPress dependencies
+ */
+import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
+
+/**
  * Internal dependencies
  */
 import { createNewStory } from '../../utils';
@@ -31,5 +36,14 @@ describe('Story Editor', () => {
     await expect(page).toMatchElement('input[placeholder="Add title"]');
 
     await percySnapshot(page, 'Empty Editor');
+  });
+  it('should be able to create a blank story on RTL', async () => {
+    await activatePlugin('rtl-tester');
+    await createNewStory();
+
+    await expect(page).toMatchElement('input[placeholder="Add title"]');
+
+    await percySnapshot(page, 'Empty Editor');
+    await deactivatePlugin('rtl-tester');
   });
 });

--- a/tests/e2e/specs/editor/noJS.js
+++ b/tests/e2e/specs/editor/noJS.js
@@ -20,6 +20,11 @@
 import { percySnapshot } from '@percy/puppeteer';
 
 /**
+ * WordPress dependencies
+ */
+import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
+
+/**
  * Internal dependencies
  */
 import { createNewStory } from '../../utils';
@@ -37,5 +42,21 @@ describe('Story Editor with disabled JavaScript', () => {
     await page.setJavaScriptEnabled(true);
 
     await percySnapshot(page, 'Editor no js');
+  });
+
+  it('should display error message on RTL', async () => {
+    await activatePlugin('rtl-tester');
+    // Disable javascript for test.
+    await page.setJavaScriptEnabled(false);
+
+    await createNewStory();
+
+    await expect(page).toMatchElement('#web-stories-no-js');
+
+    // Re-enable javascript for snapsnots.
+    await page.setJavaScriptEnabled(true);
+
+    await percySnapshot(page, 'Editor no js');
+    await deactivatePlugin('rtl-tester');
   });
 });

--- a/tests/e2e/specs/editor/noJS.js
+++ b/tests/e2e/specs/editor/noJS.js
@@ -20,14 +20,9 @@
 import { percySnapshot } from '@percy/puppeteer';
 
 /**
- * WordPress dependencies
- */
-import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
-
-/**
  * Internal dependencies
  */
-import { createNewStory } from '../../utils';
+import { activateRTL, createNewStory, deactivateRTL } from '../../utils';
 
 describe('Story Editor with disabled JavaScript', () => {
   it('should display error message', async () => {
@@ -45,7 +40,7 @@ describe('Story Editor with disabled JavaScript', () => {
   });
 
   it('should display error message on RTL', async () => {
-    await activatePlugin('rtl-tester');
+    await activateRTL();
     // Disable javascript for test.
     await page.setJavaScriptEnabled(false);
 
@@ -57,6 +52,6 @@ describe('Story Editor with disabled JavaScript', () => {
     await page.setJavaScriptEnabled(true);
 
     await percySnapshot(page, 'Editor no js on RTL');
-    await deactivatePlugin('rtl-tester');
+    await deactivateRTL();
   });
 });

--- a/tests/e2e/specs/editor/noJS.js
+++ b/tests/e2e/specs/editor/noJS.js
@@ -56,7 +56,7 @@ describe('Story Editor with disabled JavaScript', () => {
     // Re-enable javascript for snapsnots.
     await page.setJavaScriptEnabled(true);
 
-    await percySnapshot(page, 'Editor no js');
+    await percySnapshot(page, 'Editor no js on RTL');
     await deactivatePlugin('rtl-tester');
   });
 });

--- a/tests/e2e/specs/wordpress/pluginActivation.js
+++ b/tests/e2e/specs/wordpress/pluginActivation.js
@@ -48,7 +48,7 @@ describe('Plugin Activation', () => {
     await expect(page).toMatch("You're all set!");
     await expect(page).toMatch('Tell some stories.');
 
-    await percySnapshot(page, 'Plugin Activation', { percyCSS });
+    await percySnapshot(page, 'Plugin Activation on RTL', { percyCSS });
     await deactivatePlugin('rtl-tester');
   });
 

--- a/tests/e2e/specs/wordpress/pluginActivation.js
+++ b/tests/e2e/specs/wordpress/pluginActivation.js
@@ -45,6 +45,8 @@ describe('Plugin Activation', () => {
 
   it('should display a custom message after plugin activation on RTL', async () => {
     await activatePlugin('rtl-tester');
+    await deactivatePlugin('web-stories');
+    await activatePlugin('web-stories');
     await expect(page).toMatch("You're all set!");
     await expect(page).toMatch('Tell some stories.');
 

--- a/tests/e2e/specs/wordpress/pluginActivation.js
+++ b/tests/e2e/specs/wordpress/pluginActivation.js
@@ -28,6 +28,11 @@ import {
   visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
+/**
+ * Internal dependencies
+ */
+import { activateRTL, deactivateRTL } from '../../utils';
+
 const percyCSS = `.plugin-version-author-uri, .amp-plugin-notice, .update-message, .subsubsub { display: none; }`;
 
 describe('Plugin Activation', () => {
@@ -44,14 +49,14 @@ describe('Plugin Activation', () => {
   });
 
   it('should display a custom message after plugin activation on RTL', async () => {
-    await activatePlugin('rtl-tester');
+    await activateRTL();
     await deactivatePlugin('web-stories');
     await activatePlugin('web-stories');
     await expect(page).toMatch("You're all set!");
     await expect(page).toMatch('Tell some stories.');
 
     await percySnapshot(page, 'Plugin Activation on RTL', { percyCSS });
-    await deactivatePlugin('rtl-tester');
+    await deactivateRTL();
   });
 
   it('should dismiss plugin activation message', async () => {

--- a/tests/e2e/specs/wordpress/pluginActivation.js
+++ b/tests/e2e/specs/wordpress/pluginActivation.js
@@ -28,6 +28,8 @@ import {
   visitAdminPage,
 } from '@wordpress/e2e-test-utils';
 
+const percyCSS = `.plugin-version-author-uri, .amp-plugin-notice, .update-message, .subsubsub { display: none; }`;
+
 describe('Plugin Activation', () => {
   beforeEach(async () => {
     await deactivatePlugin('web-stories');
@@ -38,9 +40,16 @@ describe('Plugin Activation', () => {
     await expect(page).toMatch("You're all set!");
     await expect(page).toMatch('Tell some stories.');
 
-    await percySnapshot(page, 'Plugin Activation', {
-      percyCSS: `.plugin-version-author-uri, .amp-plugin-notice, .update-message, .subsubsub { display: none; }`,
-    });
+    await percySnapshot(page, 'Plugin Activation', { percyCSS });
+  });
+
+  it('should display a custom message after plugin activation on RTL', async () => {
+    await activatePlugin('rtl-tester');
+    await expect(page).toMatch("You're all set!");
+    await expect(page).toMatch('Tell some stories.');
+
+    await percySnapshot(page, 'Plugin Activation', { percyCSS });
+    await deactivatePlugin('rtl-tester');
   });
 
   it('should dismiss plugin activation message', async () => {

--- a/tests/e2e/utils/activateRTL.js
+++ b/tests/e2e/utils/activateRTL.js
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-export { default as createNewStory } from './createNewStory';
-export { default as previewStory } from './previewStory';
-export { default as visitDashboard } from './visitDashboard';
-export { default as addRequestInterception } from './addRequestInterception';
-export { default as withExperimentalFeatures } from './experimentalFeatures';
-export { default as withDisabledToolbarOnFrontend } from './toolbarProfileOption';
-export { default as deactivateRTL } from './deactivateRTL';
-export { default as activateRTL } from './activateRTL';
-export { default as publishPost } from './publishPost';
+/**
+ * WordPress dependencies
+ */
+import { visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Creates a new story.
+ */
+async function activateRTL() {
+  await visitAdminPage('plugins.php', 'd=rtl');
+}
+
+export default activateRTL;

--- a/tests/e2e/utils/deactivateRTL.js
+++ b/tests/e2e/utils/deactivateRTL.js
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-export { default as createNewStory } from './createNewStory';
-export { default as previewStory } from './previewStory';
-export { default as visitDashboard } from './visitDashboard';
-export { default as addRequestInterception } from './addRequestInterception';
-export { default as withExperimentalFeatures } from './experimentalFeatures';
-export { default as withDisabledToolbarOnFrontend } from './toolbarProfileOption';
-export { default as deactivateRTL } from './deactivateRTL';
-export { default as activateRTL } from './activateRTL';
-export { default as publishPost } from './publishPost';
+/**
+ * WordPress dependencies
+ */
+import { visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Creates a new story.
+ */
+async function deactivateRTL() {
+  await visitAdminPage('plugins.php', 'd=ltr');
+}
+
+export default deactivateRTL;


### PR DESCRIPTION
## Summary

Add some screenshot for different views in editor, dashboard and plugin activation. 

## Relevant Technical Choices

The screenshots are limited to not slow down e2e tests. 
Tests following views. 
- NO JS, dashboard.
- NO JS, editor.
- Empty editor. 
- Activation message.
 
## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5021
