### PR TITLE
Skip AMP sanitization for missing video posters, accepting AMP invalidation

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -526,7 +526,7 @@ class Story_Post_Type {
 			return false;
 		}
 
-		// Skip sanitization for missing vide posters.
+		// Skip sanitization for missing video posters.
 		if ( isset( $error['node_name'] ) && 'amp-video' === $error['node_name'] ) {
 			return false;
 		}

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -196,8 +196,8 @@ class Story_Post_Type {
 		add_filter( 'amp_supportable_post_types', [ $this, 'filter_supportable_post_types' ] );
 		add_filter( 'amp_to_amp_linking_element_excluded', [ $this, 'filter_amp_to_amp_linking_element_excluded' ], 10, 4 );
 		add_filter( 'amp_content_sanitizers', [ $this, 'add_amp_content_sanitizers' ] );
-		add_filter( 'amp_validation_error_sanitized', [ $this, 'filter_amp_story_element_validation_error_sanitized' ], 10, 2 );
-		add_filter( 'web_stories_amp_validation_error_sanitized', [ $this, 'filter_amp_story_element_validation_error_sanitized' ], 10, 2 );
+		add_filter( 'amp_validation_error_sanitized', [ $this, 'filter_amp_validation_error_sanitized' ], 10, 2 );
+		add_filter( 'web_stories_amp_validation_error_sanitized', [ $this, 'filter_amp_validation_error_sanitized' ], 10, 2 );
 
 		add_filter( '_wp_post_revision_fields', [ $this, 'filter_revision_fields' ], 10, 2 );
 
@@ -495,7 +495,7 @@ class Story_Post_Type {
 	}
 
 	/**
-	 * Filter amp_validation_error_sanitized to prevent invalid markup removal for the amp-story element.
+	 * Filter amp_validation_error_sanitized to prevent invalid markup removal for Web Stories.
 	 *
 	 * Since the amp-story element requires the poster-portrait-src attribute to be valid, when this attribute is absent
 	 * the AMP plugin will try to remove the amp-story element altogether. This is not the preferred resolution! So
@@ -504,14 +504,17 @@ class Story_Post_Type {
 	 * element so that the page will not be advertised as AMP. This prevents GSC from complaining about a validation
 	 * issue which we already know about.
 	 *
-	 * @since 1.0.0
+	 * The same is done for <amp-video> elements, for example when they have missing poster images.
+	 *
+	 * @since 1.1.1
 	 * @link https://github.com/ampproject/amp-wp/blob/c6aed8f/includes/validation/class-amp-validation-manager.php#L1777-L1809
 	 *
 	 * @param null|bool $sanitized Whether sanitized. Null means sanitization is not overridden.
 	 * @param array     $error Validation error being sanitized.
 	 * @return null|bool Whether sanitized.
 	 */
-	public function filter_amp_story_element_validation_error_sanitized( $sanitized, $error ) {
+	public function filter_amp_validation_error_sanitized( $sanitized, $error ) {
+		// Skip sanitization for missing publisher logos and poster portrait images.
 		if (
 			( isset( $error['node_type'], $error['node_name'], $error['parent_name'] ) ) &&
 			(
@@ -520,6 +523,11 @@ class Story_Post_Type {
 				( XML_ATTRIBUTE_NODE === $error['node_type'] && 'publisher-logo-src' === $error['node_name'] && 'amp-story' === $error['parent_name'] )
 			)
 		) {
+			return false;
+		}
+
+		// Skip sanitization for missing vide posters.
+		if ( isset( $error['node_name'] ) && 'amp-video' === $error['node_name'] ) {
 			return false;
 		}
 

--- a/tests/phpunit/tests/AMP/Sanitization.php
+++ b/tests/phpunit/tests/AMP/Sanitization.php
@@ -363,4 +363,37 @@ class Sanitization extends \WP_UnitTestCase {
 			$sanitizers['AMP_Dev_Mode_Sanitizer']['element_xpaths']
 		);
 	}
+
+	/**
+	 * @covers \Google\Web_Stories\Story_Post_Type::filter_amp_validation_error_sanitized
+	 */
+	public function test_sanitize_amp_video_with_missing_poster() {
+		ob_start();
+		?>
+		<html>
+		<head>
+		<script async="" src="https://cdn.ampproject.org/v0.js"></script>
+		<script async="" src="https://cdn.ampproject.org/v0/amp-story-1.0.js" custom-element="amp-story"></script>
+		</head>
+		<body>
+		<amp-story standalone="" publisher="Web Stories" title="Example Story" publisher-logo-src="https://example.com/image.png" poster-portrait-src="https://example.com/image.png">
+			<amp-story-page id="foo">
+				<amp-story-grid-layer template="fill">
+					<amp-video autoplay="autoplay" title="Some Video" alt="Some Video" layout="fill" id="foo"><source type="video/mp4" src="https://example.com/video.mp4"/></amp-video>
+				</amp-story-grid-layer>
+			</amp-story-page>
+		</amp-story>
+		</body>
+		</html>
+		<?php
+		$original_html = ob_get_clean();
+
+		$sanitization = new \Google\Web_Stories\AMP\Sanitization();
+
+		$document = Document::fromHtml( $original_html );
+		$sanitization->sanitize_document( $document );
+
+		$video_element = $document->body->getElementsByTagName( 'amp-video' )->item( 0 );
+		$this->assertInstanceOf( DOMElement::class, $video_element );
+	}
 }

--- a/tests/phpunit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/tests/AMP/Story_Sanitizer.php
@@ -102,7 +102,7 @@ class Story_Sanitizer extends \WP_UnitTestCase {
 	/**
 	 * @dataProvider get_poster_image_data
 	 * @covers ::sanitize
-	 * @covers Sanitization_Utils::sanitize_poster_portrait
+	 * @covers Sanitization_Utils::add_poster_images
 	 *
 	 * @param string   $source   Source.
 	 * @param string   $expected Expected.

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -98,7 +98,7 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		$this->assertSame( PHP_INT_MAX, has_filter( 'template_include', [ $story_post_type, 'filter_template_include' ] ) );
 		$this->assertSame( 10, has_filter( 'option_amp-options', [ $story_post_type, 'filter_amp_options' ] ) );
 		$this->assertSame( 10, has_filter( 'amp_supportable_post_types', [ $story_post_type, 'filter_supportable_post_types' ] ) );
-		$this->assertSame( 10, has_filter( 'amp_validation_error_sanitized', [ $story_post_type, 'filter_amp_story_element_validation_error_sanitized' ] ) );
+		$this->assertSame( 10, has_filter( 'amp_validation_error_sanitized', [ $story_post_type, 'filter_amp_validation_error_sanitized' ] ) );
 		$this->assertSame( 10, has_filter( 'amp_to_amp_linking_element_excluded', [ $story_post_type, 'filter_amp_to_amp_linking_element_excluded' ] ) );
 		$this->assertSame( 10, has_filter( '_wp_post_revision_fields', [ $story_post_type, 'filter_revision_fields' ] ) );
 		$this->assertSame( 10, has_filter( 'jetpack_sitemap_post_types', [ $story_post_type, 'add_to_jetpack_sitemap' ] ) );


### PR DESCRIPTION
## Summary

Better to have an invalid AMP document rather than the video being stripped from the page

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

* [x] Unit tests

## User-facing changes

Videos without posters should not be removed

## Testing Instructions

1. Upload new video via "Upload" button or by dragging
1. Preview story right away
1. Notice that there is a video visible
1. Check source code and noticed that the `<amp-video>` element does not have a `poster` attribute

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5218
