### PR TITLE
Design System Storybook: Banner

### DIFF
--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { forwardRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { Close } from '../../icons';
+import { THEME_CONSTANTS } from '../../';
+import { Button, Headline } from '../';
+import { BUTTON_TYPES } from '../button';
+
+const Container = styled.div`
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  border: 1px solid red;
+`;
+
+const CloseButton = styled(Button)`
+  align-self: flex-end;
+  color: black;
+  margin: 0;
+  min-width: 1px;
+  width: 32px;
+  height: 32px;
+
+  & > svg {
+    width: 13px;
+    height: 13px;
+  }
+`;
+
+export const Banner = forwardRef(
+  (
+    { backgroundUrl, closeButtonLabel, children, title, onClose, ...props },
+    ref
+  ) => {
+    return (
+      <Container ref={ref} {...props}>
+        <CloseButton
+          type={BUTTON_TYPES.PLAIN}
+          variant={BUTTON_TYPES.ICON}
+          aria-label={closeButtonLabel}
+        >
+          <Close aria-hidden={true} />
+        </CloseButton>
+        <Headline>{title}</Headline>
+        {children}
+      </Container>
+    );
+  }
+);
+
+Banner.displayName = 'Banner';
+
+Banner.propTypes = {
+  backgroundUrl: PropTypes.string,
+  closeButtonLabel: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  title: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { forwardRef } from 'react';
 
 /**
@@ -26,50 +26,101 @@ import { forwardRef } from 'react';
  */
 import { Close } from '../../icons';
 import { THEME_CONSTANTS } from '../../';
-import { Button, Headline } from '../';
+import { Button, Text } from '../';
 import { BUTTON_TYPES } from '../button';
 
-const Container = styled.div`
-  box-sizing: border-box;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+const Title = styled(Text)`
+  grid-area: title;
+  font-weight: 600;
+`;
 
-  border: 1px solid red;
+const Content = styled.div`
+  grid-area: content;
+  padding-top: 4px;
+  margin-bottom: 4px;
 `;
 
 const CloseButton = styled(Button)`
-  align-self: flex-end;
-  color: black;
-  margin: 0;
+  grid-area: closeButton;
+  justify-self: end;
   min-width: 1px;
   width: 32px;
   height: 32px;
+  margin: 2px 0 0;
+  padding: 9.5px;
 
   & > svg {
-    width: 13px;
-    height: 13px;
+    width: 100%;
+    height: 100%;
+    display: block;
   }
+`;
+
+// TODO update this once new theme colors are merged
+const Container = styled.div`
+  box-sizing: border-box;
+  display: grid;
+  width: 100%;
+  max-height: 60px;
+  grid-template-columns: 96px 408px auto;
+  grid-column-gap: 33px;
+  grid-template-areas: 'title content closeButton';
+  padding: 6px 8px;
+  background-color: ${({ theme }) => theme.colors.gray[10]};
+  background-image: url('${({ backgroundUrl }) => backgroundUrl}');
+
+  ${({ isDashboard }) =>
+    isDashboard &&
+    css`
+      max-height: 164px;
+      grid-template-columns: 1fr 32px;
+      grid-template-rows: 3;
+      grid-column-gap: 0;
+      grid-template-areas: '. closeButton' 'title title' 'content content';
+      text-align: center;
+
+      ${Title} {
+        margin-top: -16px;
+        font-weight: normal;
+      }
+      ${Content} {
+        margin: 12px 0;
+      }
+    `}
 `;
 
 export const Banner = forwardRef(
   (
-    { backgroundUrl, closeButtonLabel, children, title, onClose, ...props },
+    {
+      backgroundUrl,
+      children,
+      closeButtonLabel,
+      isDashboard,
+      title,
+      onClose,
+      ...props
+    },
     ref
   ) => {
     return (
-      <Container ref={ref} {...props}>
+      <Container
+        ref={ref}
+        backgroundUrl={backgroundUrl}
+        isDashboard={isDashboard}
+        {...props}
+      >
+        <Title size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.LARGE}>
+          {title}
+        </Title>
         <CloseButton
           type={BUTTON_TYPES.PLAIN}
           variant={BUTTON_TYPES.ICON}
           aria-label={closeButtonLabel}
+          onClick={onClose}
         >
           <Close aria-hidden={true} />
         </CloseButton>
-        <Headline>{title}</Headline>
-        {children}
+        <Content>{children}</Content>
       </Container>
     );
   }
@@ -78,9 +129,10 @@ export const Banner = forwardRef(
 Banner.displayName = 'Banner';
 
 Banner.propTypes = {
-  backgroundUrl: PropTypes.string,
-  closeButtonLabel: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
+  closeButtonLabel: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   onClose: PropTypes.func.isRequired,
+  backgroundUrl: PropTypes.string,
+  isDashboard: PropTypes.bool,
 };

--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -17,21 +17,22 @@
 /**
  * External dependencies
  */
+import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { forwardRef } from 'react';
 
 /**
  * Internal dependencies
  */
 import { Close } from '../../icons';
-import { THEME_CONSTANTS } from '../../';
-import { Button, Text } from '../';
-import { BUTTON_TYPES } from '../button';
+import { THEME_CONSTANTS } from '../../theme';
+import { Button, BUTTON_TYPES } from '../button';
+import { Text } from '../typography';
 
 const Title = styled(Text)`
   grid-area: title;
   font-weight: 600;
+  padding-left: 8px;
 `;
 
 const Content = styled.div`
@@ -50,9 +51,9 @@ const CloseButton = styled(Button)`
   padding: 9.5px;
 
   & > svg {
+    display: block;
     width: 100%;
     height: 100%;
-    display: block;
   }
 `;
 
@@ -62,8 +63,8 @@ const Container = styled.div`
   display: grid;
   width: 100%;
   max-height: 60px;
-  grid-template-columns: 96px 408px auto;
-  grid-column-gap: 33px;
+  grid-template-columns: 104px 408px auto;
+  grid-column-gap: 32px;
   grid-template-areas: 'title content closeButton';
   padding: 6px 8px;
   background-color: ${({ theme }) => theme.colors.gray[10]};
@@ -81,10 +82,11 @@ const Container = styled.div`
 
       ${Title} {
         margin-top: -16px;
+        padding-left: 0;
         font-weight: normal;
       }
       ${Content} {
-        margin: 12px 0;
+        margin: 8px 0 18px;
       }
     `}
 `;
@@ -98,7 +100,7 @@ export const Banner = forwardRef(
       isDashboard,
       title,
       onClose,
-      ...props
+      ...rest
     },
     ref
   ) => {
@@ -107,7 +109,7 @@ export const Banner = forwardRef(
         ref={ref}
         backgroundUrl={backgroundUrl}
         isDashboard={isDashboard}
-        {...props}
+        {...rest}
       >
         <Title size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.LARGE}>
           {title}

--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -26,7 +26,7 @@ import styled, { css } from 'styled-components';
  */
 import { Close } from '../../icons';
 import { THEME_CONSTANTS } from '../../theme';
-import { Button, BUTTON_TYPES } from '../button';
+import { Button, BUTTON_SIZES, BUTTON_TYPES, BUTTON_VARIANTS } from '../button';
 import { Text } from '../typography';
 
 const Title = styled(Text)`
@@ -44,17 +44,7 @@ const Content = styled.div`
 const CloseButton = styled(Button)`
   grid-area: closeButton;
   justify-self: end;
-  min-width: 1px;
-  width: 32px;
-  height: 32px;
   margin: 2px 0 0;
-  padding: 9.5px;
-
-  & > svg {
-    display: block;
-    width: 100%;
-    height: 100%;
-  }
 `;
 
 // TODO update this once new theme colors are merged
@@ -116,7 +106,8 @@ export const Banner = forwardRef(
         </Title>
         <CloseButton
           type={BUTTON_TYPES.PLAIN}
-          variant={BUTTON_TYPES.ICON}
+          variant={BUTTON_VARIANTS.ICON}
+          size={BUTTON_SIZES.SMALL}
           aria-label={closeButtonLabel}
           onClick={onClose}
         >

--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -71,7 +71,6 @@ const Container = styled.div`
       text-align: center;
 
       ${Title} {
-        margin-top: -16px;
         padding-left: 0;
         font-weight: normal;
       }

--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -72,6 +72,7 @@ const Container = styled.div`
 
       ${Title} {
         padding-left: 0;
+        margin-top: -10px;
         font-weight: normal;
       }
       ${Content} {

--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -37,14 +37,14 @@ const Title = styled(Text)`
 
 const Content = styled.div`
   grid-area: content;
-  padding-top: 4px;
   margin-bottom: 4px;
+  max-width: 480px;
 `;
 
 const CloseButton = styled(Button)`
   grid-area: closeButton;
   justify-self: end;
-  margin: 2px 0 0;
+  align-self: flex-start;
 `;
 
 // TODO update this once new theme colors are merged
@@ -56,6 +56,7 @@ const Container = styled.div`
   grid-template-columns: 104px 408px auto;
   grid-column-gap: 32px;
   grid-template-areas: 'title content closeButton';
+  align-items: baseline;
   padding: 6px 8px;
   background-color: ${({ theme }) => theme.colors.gray[10]};
   background-image: url('${({ backgroundUrl }) => backgroundUrl}');
@@ -76,7 +77,7 @@ const Container = styled.div`
         font-weight: normal;
       }
       ${Content} {
-        margin: 8px 0 18px;
+        margin: 8px auto 18px;
       }
     `}
 `;
@@ -105,8 +106,8 @@ export const Banner = forwardRef(
           {title}
         </Title>
         <CloseButton
-          type={BUTTON_TYPES.PLAIN}
-          variant={BUTTON_VARIANTS.ICON}
+          type={BUTTON_TYPES.TERTIARY}
+          variant={BUTTON_VARIANTS.SQUARE}
           size={BUTTON_SIZES.SMALL}
           aria-label={closeButtonLabel}
           onClick={onClose}

--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -59,7 +59,7 @@ const Container = styled.div`
   padding: 6px 8px;
   background-color: ${({ theme }) => theme.colors.gray[5]};
   background-image: url('${({ backgroundUrl }) => backgroundUrl}');
-  border-radius: 8px;
+  border-radius: ${({ theme }) => theme.borders.radius.medium};
 
   ${({ isDashboard }) =>
     isDashboard &&
@@ -102,7 +102,7 @@ export const Banner = forwardRef(
         isDashboard={isDashboard}
         {...rest}
       >
-        <Title size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.LARGE}>
+        <Title size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.LARGE}>
           {title}
         </Title>
         <CloseButton

--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -47,7 +47,6 @@ const CloseButton = styled(Button)`
   align-self: flex-start;
 `;
 
-// TODO update this once new theme colors are merged
 const Container = styled.div`
   box-sizing: border-box;
   display: grid;

--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -58,8 +58,9 @@ const Container = styled.div`
   grid-template-areas: 'title content closeButton';
   align-items: baseline;
   padding: 6px 8px;
-  background-color: ${({ theme }) => theme.colors.gray[10]};
+  background-color: ${({ theme }) => theme.colors.gray[5]};
   background-image: url('${({ backgroundUrl }) => backgroundUrl}');
+  border-radius: 8px;
 
   ${({ isDashboard }) =>
     isDashboard &&

--- a/assets/src/design-system/components/banner/stories/index.js
+++ b/assets/src/design-system/components/banner/stories/index.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import { THEME_CONSTANTS } from '../../../';
+import { Text } from '../../';
+import { Banner } from '..';
+
+export default {
+  title: 'DesignSystem/Components/Banner',
+  component: Banner,
+};
+
+export const _default = () => {
+  return (
+    <Banner
+      closeButtonLabel={'Dismiss storybook banner'}
+      title={'my storybook banner'}
+      onClose={action('close banner clicked')}
+    >
+      <Text>{'I am a banner child'}</Text>
+    </Banner>
+  );
+};

--- a/assets/src/design-system/components/banner/stories/index.js
+++ b/assets/src/design-system/components/banner/stories/index.js
@@ -17,9 +17,8 @@
 /**
  * External dependencies
  */
-import { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-import { text } from '@storybook/addon-knobs';
+import { boolean, text } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
@@ -27,6 +26,8 @@ import { text } from '@storybook/addon-knobs';
 import { THEME_CONSTANTS } from '../../../';
 import { Text } from '../../';
 import { Banner } from '..';
+
+const demoBgUrl = 'https://picsum.photos/1500/160';
 
 export default {
   title: 'DesignSystem/Components/Banner',
@@ -37,10 +38,54 @@ export const _default = () => {
   return (
     <Banner
       closeButtonLabel={'Dismiss storybook banner'}
-      title={'my storybook banner'}
+      title={'my banner'}
       onClose={action('close banner clicked')}
+      isDashboard={boolean('isDashboard', false)}
+      backgroundUrl={demoBgUrl}
     >
-      <Text>{'I am a banner child'}</Text>
+      <Text>{text('children', 'I am a banner child')}</Text>
+    </Banner>
+  );
+};
+
+export const EditorBanner = () => {
+  return (
+    <Banner
+      closeButtonLabel={'Dismiss storybook banner'}
+      title={'Animations are here!'}
+      onClose={(e) => action('close banner clicked')(e)}
+      backgroundUrl={demoBgUrl}
+    >
+      <Text size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.X_SMALL}>
+        {
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+        }
+      </Text>
+    </Banner>
+  );
+};
+
+export const DashboardBanner = () => {
+  return (
+    <Banner
+      closeButtonLabel={'Dismiss storybook banner'}
+      title={'Help improve the editor!'}
+      onClose={(e) => action('close banner clicked')(e)}
+      isDashboard
+      backgroundUrl={demoBgUrl}
+    >
+      <Text size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.X_SMALL}>
+        {
+          'Check the box to help us improve the Web Stories plugin by allowing tracking of product usage stats. All data are treated in accordance with '
+        }
+        <Text
+          size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.X_SMALL}
+          href="#"
+          as="a"
+        >
+          {'Google Privacy Policy'}
+        </Text>
+      </Text>
     </Banner>
   );
 };

--- a/assets/src/design-system/components/banner/stories/index.js
+++ b/assets/src/design-system/components/banner/stories/index.js
@@ -27,7 +27,7 @@ import { THEME_CONSTANTS } from '../../../';
 import { Text } from '../../';
 import { Banner } from '..';
 
-const demoBgUrl = 'https://picsum.photos/1500/160';
+const demoBgUrl = 'https://picsum.photos/id/240/1500/160';
 
 export default {
   title: 'DesignSystem/Components/Banner',
@@ -38,7 +38,7 @@ export const _default = () => {
   return (
     <Banner
       closeButtonLabel={'Dismiss storybook banner'}
-      title={'my banner'}
+      title={text('title', 'my banner')}
       onClose={action('close banner clicked')}
       isDashboard={boolean('isDashboard', false)}
       backgroundUrl={demoBgUrl}
@@ -85,6 +85,23 @@ export const DashboardBanner = () => {
         >
           {'Google Privacy Policy'}
         </Text>
+      </Text>
+    </Banner>
+  );
+};
+
+export const BannerNoBackgroundImage = () => {
+  return (
+    <Banner
+      closeButtonLabel={'Dismiss storybook banner'}
+      title={text('title', 'New Feature!')}
+      onClose={(e) => action('close banner clicked')(e)}
+      isDashboard={boolean('isDashboard', true)}
+    >
+      <Text size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.X_SMALL}>
+        {
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+        }
       </Text>
     </Banner>
   );

--- a/assets/src/design-system/components/banner/stories/index.js
+++ b/assets/src/design-system/components/banner/stories/index.js
@@ -43,7 +43,9 @@ export const _default = () => {
       isDashboard={boolean('isDashboard', false)}
       backgroundUrl={demoBgUrl}
     >
-      <Text>{text('children', 'I am a banner child')}</Text>
+      <Text size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.X_SMALL}>
+        {text('children', 'I am a banner child')}
+      </Text>
     </Banner>
   );
 };

--- a/assets/src/design-system/components/banner/stories/index.js
+++ b/assets/src/design-system/components/banner/stories/index.js
@@ -43,7 +43,7 @@ export const _default = () => {
       isDashboard={boolean('isDashboard', false)}
       backgroundUrl={demoBgUrl}
     >
-      <Text size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.X_SMALL}>
+      <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
         {text('children', 'I am a banner child')}
       </Text>
     </Banner>
@@ -58,7 +58,7 @@ export const EditorBanner = () => {
       onClose={(e) => action('close banner clicked')(e)}
       backgroundUrl={demoBgUrl}
     >
-      <Text size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.X_SMALL}>
+      <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
         {
           'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }
@@ -76,12 +76,12 @@ export const DashboardBanner = () => {
       isDashboard
       backgroundUrl={demoBgUrl}
     >
-      <Text size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.X_SMALL}>
+      <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
         {
           'Check the box to help us improve the Web Stories plugin by allowing tracking of product usage stats. All data are treated in accordance with '
         }
         <Text
-          size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.X_SMALL}
+          size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
           href="#"
           as="a"
         >
@@ -100,7 +100,7 @@ export const BannerNoBackgroundImage = () => {
       onClose={(e) => action('close banner clicked')(e)}
       isDashboard={boolean('isDashboard', true)}
     >
-      <Text size={THEME_CONSTANTS.TYPOGRAPHY_PRESET_SIZES.X_SMALL}>
+      <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
         {
           'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
         }

--- a/assets/src/design-system/components/button/index.js
+++ b/assets/src/design-system/components/button/index.js
@@ -111,14 +111,16 @@ const ButtonRectangle = styled(Base)`
   ${({ type }) => type && buttonColors?.[type]};
   min-width: 1px;
   min-height: 1em;
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+
   padding: ${({ size }) =>
     size === BUTTON_SIZES.SMALL ? '8px 16px' : '18px 32px'};
 `;
 
 const ButtonSquare = styled(Base)`
   ${({ type }) => type && buttonColors?.[type]};
-  border-radius: 4px;
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+
   ${({ size }) => css`
     width: ${size === BUTTON_SIZES.SMALL ? 32 : 56}px;
     height: ${size === BUTTON_SIZES.SMALL ? 32 : 56}px;
@@ -131,7 +133,7 @@ const ButtonSquare = styled(Base)`
 `;
 
 const ButtonCircle = styled(ButtonSquare)`
-  border-radius: 50%;
+  border-radius: ${({ theme }) => theme.borders.radius.round};
 `;
 
 const ButtonIcon = styled(Base)`

--- a/assets/src/design-system/components/dialog/index.js
+++ b/assets/src/design-system/components/dialog/index.js
@@ -61,16 +61,9 @@ const DialogActions = styled.div`
   }
 `;
 
-export function Dialog({
-  children,
-  title,
-  actions,
-  isOpen,
-  onClose,
-  ...props
-}) {
+export function Dialog({ children, title, actions, isOpen, onClose, ...rest }) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} {...props}>
+    <Modal isOpen={isOpen} onClose={onClose} {...rest}>
       <DialogBox>
         {Boolean(title) && (
           <Headline

--- a/assets/src/design-system/components/dialog/index.js
+++ b/assets/src/design-system/components/dialog/index.js
@@ -37,7 +37,7 @@ const DialogBox = styled.div`
   background-color: ${({ theme }) => theme.colors.bg.primary};
   overflow-y: auto;
   padding: 12px 16px;
-  border-radius: 8px;
+  border-radius: ${({ theme }) => theme.borders.radius.medium};
   border: ${({ theme }) => `1px solid ${theme.colors.divider.primary}`};
 `;
 

--- a/assets/src/design-system/components/modal/index.js
+++ b/assets/src/design-system/components/modal/index.js
@@ -82,7 +82,7 @@ export function Modal({
   modalStyles = {},
   onClose,
   overlayStyles,
-  ...props
+  ...rest
 }) {
   const themeContext = useContext(ThemeContext);
 
@@ -100,7 +100,7 @@ export function Modal({
         overlay: { ...customStyles.overlay(themeContext), ...overlayStyles },
         content: { ...customStyles.content, ...contentStyles },
       }}
-      {...props}
+      {...rest}
     >
       {children}
     </ReactModal>

--- a/assets/src/design-system/components/pill/index.js
+++ b/assets/src/design-system/components/pill/index.js
@@ -37,7 +37,7 @@ const StyledPill = styled.button(
       ? theme.colors.interactiveBg.primaryNormal
       : theme.colors.opacity.footprint};
     border: none;
-    border-radius: 50px;
+    border-radius: ${theme.borders.radius.x_large};
     ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)};
 
     color: ${isActive ? theme.colors.bg.primary : theme.colors.fg.secondary};

--- a/assets/src/design-system/components/snackbar/snackbarMessage.js
+++ b/assets/src/design-system/components/snackbar/snackbarMessage.js
@@ -56,7 +56,7 @@ const MessageContainer = styled.div`
   color: ${({ theme }) => theme.colors.inverted.fg.primary};
   border: ${({ theme }) =>
     `1px solid ${rgba(theme.colors.standard.white, 0.24)}`};
-  border-radius: ${({ theme }) => theme.borders.radius};
+  border-radius: ${({ theme }) => theme.borders.radius.small};
 
   animation: 0.5s ${slideIn} ease-out;
 `;

--- a/assets/src/design-system/components/typography/text/index.js
+++ b/assets/src/design-system/components/typography/text/index.js
@@ -38,6 +38,10 @@ export const Text = styled.p`
         &:hover {
           color: ${theme.colors.fg.linkHover};
         }
+        &:focus {
+          outline: none;
+        }
+        ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)}
       `;
     return css`
       ${themeHelpers.expandPresetStyles({

--- a/assets/src/design-system/theme/borders.js
+++ b/assets/src/design-system/theme/borders.js
@@ -15,5 +15,10 @@
  */
 
 export const borders = {
-  radius: '8px',
+  radius: {
+    small: '4px',
+    medium: '8px',
+    x_large: '50px',
+    round: '50%',
+  },
 };


### PR DESCRIPTION
## Summary
Two variations of a banner [ built from figma](https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories-Post-Stable?node-id=2013%3A252969) - one for editor, one for dashboard

## Relevant Technical Choices

Includes only the presentational aspect of the banner and forwards the banner ref to manipulate the functionality however is necessary. 
Used css grid to maintain dimensions and minimize checks for where to put elements since banners look different in each version. 

## To-do

## User-facing changes

None, storybook only

## Testing Instructions

See banner in storybook (designsystem/components/banner). 
- default is set with all the knobs so you can see things change 
- the editor and dashboard varieties should follow the designs in figma. Background urls will come from components, these don't match the specs. 

![editor banner](https://user-images.githubusercontent.com/10720454/99155637-eb438800-2676-11eb-86bb-d8d7f921ef3a.gif)

![dashboard banner](https://user-images.githubusercontent.com/10720454/99155640-eda5e200-2676-11eb-96db-02e7e16c7947.gif)




---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5214 
