### PR TITLE
Media: Filter REST API responses by media types allowed by plugin

### DIFF
--- a/includes/REST_API/Stories_Media_Controller.php
+++ b/includes/REST_API/Stories_Media_Controller.php
@@ -26,6 +26,7 @@
 
 namespace Google\Web_Stories\REST_API;
 
+use Google\Web_Stories\Traits\Types;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -34,6 +35,7 @@ use WP_REST_Response;
  * Stories_Media_Controller class.
  */
 class Stories_Media_Controller extends \WP_REST_Attachments_Controller {
+	use Types;
 	/**
 	 * Constructor.
 	 *
@@ -84,5 +86,42 @@ class Stories_Media_Controller extends \WP_REST_Attachments_Controller {
 		];
 
 		return $query_params;
+	}
+
+	/**
+	 * Filter request by allowed mime types.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param array           $prepared_args Optional. Array of prepared arguments. Default empty array.
+	 * @param WP_REST_Request $request       Optional. Request to prepare items for.
+	 * @return array Array of query arguments.
+	 */
+	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
+		$query_args = parent::prepare_items_query( $prepared_args, $request );
+
+		if ( empty( $request['mime_type'] ) && empty( $request['media_type'] ) ) {
+			$media_types                  = $this->get_media_types();
+			$media_type_mimes             = array_values( $media_types );
+			$media_type_mimes             = array_filter( $media_type_mimes );
+			$media_type_mimes             = array_merge( ...$media_type_mimes );
+			$query_args['post_mime_type'] = $media_type_mimes;
+		}
+
+		return $query_args;
+	}
+
+
+	/**
+	 * Retrieves the supported media types.
+	 *
+	 * Media types are considered the MIME type category.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return array Array of supported media types.
+	 */
+	protected function get_media_types() {
+		return $this->get_allowed_mime_types();
 	}
 }

--- a/includes/REST_API/Stories_Media_Controller.php
+++ b/includes/REST_API/Stories_Media_Controller.php
@@ -101,10 +101,11 @@ class Stories_Media_Controller extends \WP_REST_Attachments_Controller {
 		$query_args = parent::prepare_items_query( $prepared_args, $request );
 
 		if ( empty( $request['mime_type'] ) && empty( $request['media_type'] ) ) {
-			$media_types                  = $this->get_media_types();
-			$media_type_mimes             = array_values( $media_types );
-			$media_type_mimes             = array_filter( $media_type_mimes );
-			$media_type_mimes             = array_merge( ...$media_type_mimes );
+			$media_types      = $this->get_media_types();
+			$media_type_mimes = array_values( $media_types );
+			$media_type_mimes = array_filter( $media_type_mimes );
+			$media_type_mimes = array_merge( ...$media_type_mimes );
+
 			$query_args['post_mime_type'] = $media_type_mimes;
 		}
 

--- a/includes/REST_API/Stories_Media_Controller.php
+++ b/includes/REST_API/Stories_Media_Controller.php
@@ -97,7 +97,7 @@ class Stories_Media_Controller extends \WP_REST_Attachments_Controller {
 	 * @param WP_REST_Request $request       Optional. Request to prepare items for.
 	 * @return array Array of query arguments.
 	 */
-	protected function prepare_items_query( $prepared_args = array(), $request = null ) {
+	protected function prepare_items_query( $prepared_args = [], $request = null ) {
 		$query_args = parent::prepare_items_query( $prepared_args, $request );
 
 		if ( empty( $request['mime_type'] ) && empty( $request['media_type'] ) ) {


### PR DESCRIPTION
## Summary

Filter REST API responses to only support MIME types. 

## Relevant Technical Choices

If not set, then filter requests by allow mime types in the web stories editor. 

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5118
