### PR TITLE
Fix opacity and hue sliders of color picker

### DIFF
--- a/assets/src/edit-story/components/colorPicker/currentColorPicker.js
+++ b/assets/src/edit-story/components/colorPicker/currentColorPicker.js
@@ -92,6 +92,7 @@ const Footer = styled.div`
   font-size: ${CONTROLS_WIDTH}px;
   line-height: 19px;
   position: relative;
+  margin-top: 7px;
   display: grid;
   grid: 'eyedropper hex opacity' ${HEADER_FOOTER_HEIGHT}px / ${EYEDROPPER_ICON_SIZE}px 1fr ${OPACITY_WIDTH}px;
   grid-gap: 10px;


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- Adds margin between the color picker sliders and the footer since otherwise the color picker pointers are partially below the footer area and can't be dragged.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
- Add a text element
- Open color picker for the color
- Drag hue and opacity sliders from the pointer, verify it drags right away.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1901 
