### PR TITLE
Docker: Pin composer at v1

### DIFF
--- a/bin/local-env/install-composer.sh
+++ b/bin/local-env/install-composer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-COMPOSER_VERSION=`curl -Ls -w %{url_effective} -o /dev/null https://github.com/composer/composer/releases/latest | rev | cut -d '/' -f 1 | rev`
+COMPOSER_VERSION='1.10.1'
 
 # Exit if any command fails
 set -e
@@ -30,7 +30,7 @@ fi
 # Check if the current Composer version is up to date.
 if [ "$CI" != "true" ] && ! [[ "$(composer --version)" == "Composer version $COMPOSER_VERSION "* ]]; then
 	echo -en $(status_message "Updating Composer..." )
-	composer self-update
+	composer self-update $COMPOSER_VERSION
 	echo ' done!'
 fi
 

--- a/bin/local-env/install-composer.sh
+++ b/bin/local-env/install-composer.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-COMPOSER_VERSION='1.10.1'
+COMPOSER_VERSION='1.10.17'
 
 # Exit if any command fails
 set -e


### PR DESCRIPTION
## Summary

Until we officially support composer 2 ( https://github.com/google/web-stories-wp/issues/5083 ), lock down composer version to 1.10.1, last stable V1 release. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5250
