### PR TITLE
Force Jetpack to see Web Stories as an AMP request

### DIFF
--- a/includes/Integrations/Jetpack.php
+++ b/includes/Integrations/Jetpack.php
@@ -77,7 +77,7 @@ class Jetpack {
 	 *
 	 * @param boolean $is_amp_request Is the request supposed to return valid AMP content.
 	 *
-	 * @return boolean
+	 * @return bool Whether the current request is an AMP request.
 	 */
 	public function force_amp_request( $is_amp_request ) {
 		if ( ! is_singular( Story_Post_Type::POST_TYPE_SLUG ) ) {

--- a/includes/Integrations/Jetpack.php
+++ b/includes/Integrations/Jetpack.php
@@ -49,6 +49,8 @@ class Jetpack {
 		} else {
 			add_filter( 'jetpack_sitemap_post_types', [ $this, 'add_to_jetpack_sitemap' ] );
 		}
+
+		add_filter( 'jetpack_is_amp_request', [ $this, 'force_amp_request' ] );
 	}
 
 	/**
@@ -66,5 +68,21 @@ class Jetpack {
 		$post_types[] = Story_Post_Type::POST_TYPE_SLUG;
 
 		return $post_types;
+	}
+
+	/**
+	 * Force jetpack to see web stories as AMP.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param boolean $is_amp_request Is the request supposed to return valid AMP content.
+	 *
+	 * @return boolean
+	 */
+	public function force_amp_request( $is_amp_request ) {
+		if ( ! is_singular( Story_Post_Type::POST_TYPE_SLUG ) ) {
+			return $is_amp_request;
+		}
+		return true;
 	}
 }

--- a/tests/phpunit/tests/Integrations/Jetpack.php
+++ b/tests/phpunit/tests/Integrations/Jetpack.php
@@ -32,6 +32,7 @@ class Jetpack extends \WP_UnitTestCase {
 
 		$this->assertFalse( has_filter( 'wpcom_sitemap_post_types', [ $jetpack, 'add_to_jetpack_sitemap' ] ) );
 		$this->assertSame( 10, has_filter( 'jetpack_sitemap_post_types', [ $jetpack, 'add_to_jetpack_sitemap' ] ) );
+		$this->assertSame( 10, has_filter( 'jetpack_is_amp_request', [ $jetpack, 'force_amp_request' ] ) );
 
 		remove_all_filters( 'jetpack_sitemap_post_types' );
 	}

--- a/tests/phpunit/tests/Web_Stories_Compatibility.php
+++ b/tests/phpunit/tests/Web_Stories_Compatibility.php
@@ -134,8 +134,8 @@ class Web_Stories_Compatibility extends \WP_UnitTestCase {
 	 * @return \Web_Stories_Compatibility
 	 */
 	protected function get_compatibility_object() {
-		$compatibility     = \web_stories_get_compat_instance();
-		$extensions        = [
+		$compatibility = \web_stories_get_compat_instance();
+		$extensions    = [
 			'fake_extension' => [
 				'classes'   => [
 					'FAKE_CLASS',


### PR DESCRIPTION
## Summary
The jetpack plugin has a filter called `jetpack_is_amp_request`. Let's force that to be true on a web story. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5016
