### PR TITLE
Jetpack: Metadata Duplication

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -225,8 +225,8 @@ class Plugin {
 		add_action( 'init', [ $amp, 'init' ] );
 		$this->integrations['amp'] = $amp;
 
-		$jetpack = new Jetpack();
-		add_action( 'init', [ $jetpack, 'init' ] );
+		$jetpack = new Jetpack( $this->discovery );
+		add_action( 'init', [ $jetpack, 'init' ], 9 );
 		$this->integrations['jetpack'] = $jetpack;
 
 		// This runs at init priority -2 because NextGEN inits at -1.

--- a/tests/phpunit/tests/Integrations/Jetpack.php
+++ b/tests/phpunit/tests/Integrations/Jetpack.php
@@ -27,7 +27,8 @@ class Jetpack extends \WP_UnitTestCase {
 	 * @covers ::init
 	 */
 	public function test_init() {
-		$jetpack = new \Google\Web_Stories\Integrations\Jetpack();
+		$discovery = $this->createMock( \Google\Web_Stories\Discovery::class );
+		$jetpack   = new \Google\Web_Stories\Integrations\Jetpack( $discovery );
 		$jetpack->init();
 
 		$this->assertFalse( has_filter( 'wpcom_sitemap_post_types', [ $jetpack, 'add_to_jetpack_sitemap' ] ) );
@@ -44,7 +45,8 @@ class Jetpack extends \WP_UnitTestCase {
 	public function test_init_is_wpcom() {
 		define( 'IS_WPCOM', true );
 
-		$jetpack = new \Google\Web_Stories\Integrations\Jetpack();
+		$discovery = $this->createMock( \Google\Web_Stories\Discovery::class );
+		$jetpack   = new \Google\Web_Stories\Integrations\Jetpack( $discovery );
 		$jetpack->init();
 
 		$this->assertSame( 10, has_filter( 'wpcom_sitemap_post_types', [ $jetpack, 'add_to_jetpack_sitemap' ] ) );
@@ -57,7 +59,8 @@ class Jetpack extends \WP_UnitTestCase {
 	 * @covers ::add_to_jetpack_sitemap
 	 */
 	public function test_add_to_jetpack_sitemap() {
-		$jetpack = new \Google\Web_Stories\Integrations\Jetpack();
+		$discovery = $this->createMock( \Google\Web_Stories\Discovery::class );
+		$jetpack   = new \Google\Web_Stories\Integrations\Jetpack( $discovery );
 		$this->assertEqualSets( [ Story_Post_Type::POST_TYPE_SLUG ], $jetpack->add_to_jetpack_sitemap( [] ) );
 	}
 }

--- a/tests/phpunit/tests/Web_Stories_Compatibility.php
+++ b/tests/phpunit/tests/Web_Stories_Compatibility.php
@@ -134,8 +134,8 @@ class Web_Stories_Compatibility extends \WP_UnitTestCase {
 	 * @return \Web_Stories_Compatibility
 	 */
 	protected function get_compatibility_object() {
-		$compatibility     = \web_stories_get_compat_instance();
-		$extensions        = [
+		$compatibility = \web_stories_get_compat_instance();
+		$extensions    = [
 			'fake_extension' => [
 				'classes'   => [
 					'FAKE_CLASS',


### PR DESCRIPTION
## Summary

If jetpack plugin remove web stories own metadata. 

## Relevant Technical Choices

It felt cleaner to do the removal of web stories meta data, in this plugin and not in jetpack. 

I had to do some clever workaround with filter and actions priorities to get this working. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4913
