### PR TITLE
package(update): replace color-contrast-checker with hues

### DIFF
--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -54,11 +54,11 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
         backgroundColor: {
           color: {
             r: 255,
-            g: 0,
-            b: 153,
+            g: 255,
+            b: 255,
           },
         },
-        content: '<span style="color: #fff">HOT GOSSIP ARTICLE</span>',
+        content: '<span style="color: #000">HOT GOSSIP ARTICLE</span>',
       };
       expect(
         accessibilityChecks.textElementFontLowContrast(element)

--- a/assets/src/edit-story/utils/test/contrastUtils.js
+++ b/assets/src/edit-story/utils/test/contrastUtils.js
@@ -29,11 +29,26 @@ describe('contrastUtils', () => {
       };
       expect(contrastUtils.calculateLuminanceFromRGB(rgb)).toStrictEqual(1);
     });
+    it('calculate from RGBA object', () => {
+      const rgb = {
+        r: 255,
+        g: 255,
+        b: 255,
+        a: 1.0,
+      };
+      expect(contrastUtils.calculateLuminanceFromRGB(rgb)).toStrictEqual(1);
+    });
   });
 
   describe('calculateLuminanceFromStyleColor', () => {
-    it('calculate from element style.color string', () => {
+    it('calculate from element rgb style.color string', () => {
       const color = 'rgb(255, 255, 255)';
+      expect(
+        contrastUtils.calculateLuminanceFromStyleColor(color)
+      ).toStrictEqual(1);
+    });
+    it('calculate from element rgba style.color string', () => {
+      const color = 'rgb(255, 255, 255, 1)';
       expect(
         contrastUtils.calculateLuminanceFromStyleColor(color)
       ).toStrictEqual(1);
@@ -57,19 +72,6 @@ describe('contrastUtils', () => {
         contrastUtils.checkContrastFromLuminances(luminanceA, luminanceB)
           .WCAG_AA
       ).toStrictEqual(false);
-    });
-
-    it('calculate successful contrast check from similar luminances w/ larger font size', () => {
-      const luminanceA = 0.3; // fails with default font size
-      const luminanceB = 1;
-      const fontSize = 50;
-      expect(
-        contrastUtils.checkContrastFromLuminances(
-          luminanceA,
-          luminanceB,
-          fontSize
-        ).WCAG_AA
-      ).toStrictEqual(true);
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,6 +238,11 @@
         }
       }
     },
+    "@ap.cx/hues": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@ap.cx/hues/-/hues-2.2.0.tgz",
+      "integrity": "sha512-/nXBWqW90cTOqDjSzGgPd5aJfzB2YYbF1hUZvBjnikFZAsAzyX4nKF1DwU1l5+tfMpNao9KIpLiTw8wsUQ0cnw=="
+    },
     "@babel/code-frame": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
@@ -11480,11 +11485,6 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-    },
     "amphtml-validator": {
       "version": "1.0.33",
       "resolved": "https://registry.npmjs.org/amphtml-validator/-/amphtml-validator-1.0.33.tgz",
@@ -14061,14 +14061,6 @@
       "requires": {
         "color-convert": "^1.9.1",
         "color-string": "^1.5.2"
-      }
-    },
-    "color-contrast-checker": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/color-contrast-checker/-/color-contrast-checker-1.5.0.tgz",
-      "integrity": "sha512-7vcVIjdieWaxDQk4RTqCgU/iM1JEllxymR7AmoSgoakas5EKqfLhTphwrCEABYGMN9VG+h5a9utUlyGgY1F9WQ==",
-      "requires": {
-        "amdefine": ">=0.2.0"
       }
     },
     "color-convert": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "commander": "bin/commander.js"
   },
   "dependencies": {
+    "@ap.cx/hues": "^2.2.0",
     "@wordpress/api-fetch": "^3.20.0",
     "@wordpress/block-editor": "^5.1.3",
     "@wordpress/blocks": "^6.24.1",
@@ -38,7 +39,6 @@
     "@wordpress/i18n": "^3.15.0",
     "big.js": "^6.0.2",
     "classnames": "^2.2.6",
-    "color-contrast-checker": "^1.5.0",
     "colorthief": "^2.3.2",
     "date-fns": "^2.16.1",
     "date-fns-tz": "^1.0.12",


### PR DESCRIPTION
## Summary
- `color-contrast-checker` package had issues being imported in the React app. Replaced that package with a more recently maintained package. 

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

Importing the `contrastUtils` which relied on `color-contrast-checker` would crash the React app and throw the following error: 
```
Uncaught Error: define cannot be used indirect
    exports amd-define.js:2
    js color-contrast-checker.js:19
    js stories-dashboard.js:125868
```

the offending line in the module is here:

```
if (typeof define !== "function")
    var define = require("amdefine")(module, require);
```

- this package does not rely on `amdefine` so that package will not have to be bundled now. :+1:
- this package unfortunately did not include a font-size check. I wasn't sure how important that was, perhaps we should follow up. I implemented this fix so I could focus on functionality for the prepublish checklist.
- The following fixes were attempted before replacing the package:
    - update the webpack module rules to set `{ parser: { amd: false } }`
    - update the webpack module rules to set `define` to `false`: 
```      
     {
        test: /node_modules\/src\/color-contrast-checker\.js$/,
        use: ['imports-loader?define=>false'],
      },
```
    - but this broke the tests so I also added in the jest setup:
```
global['define'] = () => null;
```
- Without commenting out the line, the above fixes didn't work...
- Creating a babel transform seemed like a lot of effort to get a package which had not seen a publish in two years to work, so we identified a different package so I could focus on the prepublish checklist functionality (which depends on the color contrast checking). I tried to keep the `contrastUtils` api the same.

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- none
<!-- Please describe your changes. -->

## Testing Instructions
- N/A

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

