### PR TITLE
Dashboard: Organize error message static text

### DIFF
--- a/assets/src/dashboard/app/api/test/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/test/useSettingsApi.js
@@ -21,6 +21,7 @@ import { act, renderHook } from '@testing-library/react-hooks';
 /**
  * Internal dependencies
  */
+import { ERRORS } from '../../textContent';
 import useSettingsApi from '../useSettingsApi';
 import wpAdapter from '../wpAdapter';
 
@@ -36,7 +37,7 @@ describe('useSettingsApi', () => {
 
     expect(result.current.settings.error.message).toStrictEqual({
       body: 'The response is not a valid JSON response.',
-      title: 'Unable to find settings data',
+      title: ERRORS.LOAD_SETTINGS.TITLE,
     });
   });
 
@@ -51,7 +52,7 @@ describe('useSettingsApi', () => {
 
     expect(result.current.settings.error.message).toStrictEqual({
       body: 'The response is not a valid JSON response.',
-      title: 'Unable to update settings data',
+      title: ERRORS.UPDATE_EDITOR_SETTINGS.TITLE,
     });
   });
 });

--- a/assets/src/dashboard/app/api/useMediaApi.js
+++ b/assets/src/dashboard/app/api/useMediaApi.js
@@ -21,17 +21,13 @@ import { useCallback, useMemo, useReducer } from 'react';
 import queryString from 'query-string';
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import mediaReducer, {
   defaultMediaState,
   ACTION_TYPES as MEDIA_ACTION_TYPES,
 } from '../reducer/media';
+import { ERRORS } from '../textContent';
 
 export default function useMediaApi(dataAdapter, { globalMediaApi }) {
   const [state, dispatch] = useReducer(mediaReducer, defaultMediaState);
@@ -65,7 +61,7 @@ export default function useMediaApi(dataAdapter, { globalMediaApi }) {
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to fetch media', 'web-stories'),
+              title: ERRORS.LOAD_MEDIA.TITLE,
             },
           },
         });
@@ -105,7 +101,7 @@ export default function useMediaApi(dataAdapter, { globalMediaApi }) {
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to add media', 'web-stories'),
+              title: ERRORS.UPLOAD_PUBLISHER_LOGO.TITLE,
             },
           },
         });

--- a/assets/src/dashboard/app/api/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/useSettingsApi.js
@@ -21,17 +21,13 @@ import { useCallback, useMemo, useReducer } from 'react';
 import queryString from 'query-string';
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import settingsReducer, {
   defaultSettingsState,
   ACTION_TYPES as SETTINGS_ACTION_TYPES,
 } from '../reducer/settings';
+import { ERRORS } from '../textContent';
 
 export default function useSettingsApi(
   dataAdapter,
@@ -45,8 +41,8 @@ export default function useSettingsApi(
         type: SETTINGS_ACTION_TYPES.FETCH_SETTINGS_FAILURE,
         payload: {
           message: {
-            body: __('Cannot connect to data source', 'web-stories'),
-            title: __('Unable to find settings data', 'web-stories'),
+            body: ERRORS.LOAD_SETTINGS.DEFAULT_MESSAGE,
+            title: ERRORS.LOAD_SETTINGS.TITLE,
           },
         },
       });
@@ -72,7 +68,7 @@ export default function useSettingsApi(
         payload: {
           message: {
             body: err.message,
-            title: __('Unable to find settings data', 'web-stories'),
+            title: ERRORS.LOAD_SETTINGS.TITLE,
           },
         },
       });
@@ -129,7 +125,7 @@ export default function useSettingsApi(
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to update settings data', 'web-stories'),
+              title: ERRORS.UPDATE_EDITOR_SETTINGS.TITLE,
             },
           },
         });

--- a/assets/src/dashboard/app/api/useStoryApi.js
+++ b/assets/src/dashboard/app/api/useStoryApi.js
@@ -30,6 +30,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import getStoryMarkup from '../../../edit-story/output/utils/getStoryMarkup';
+import base64Encode from '../../../edit-story/utils/base64Encode';
 import {
   STORY_STATUSES,
   STORY_SORT_OPTIONS,
@@ -43,7 +44,7 @@ import storyReducer, {
 } from '../reducer/stories';
 import { getStoryPropsToSave, addQueryArgs } from '../../utils';
 import { reshapeStoryObject, reshapeStoryPreview } from '../serializers';
-import base64Encode from '../../../edit-story/utils/base64Encode';
+import { ERRORS } from '../textContent';
 
 const useStoryApi = (dataAdapter, { editStoryURL, storyApi, encodeMarkup }) => {
   const [state, dispatch] = useReducer(storyReducer, defaultStoriesState);
@@ -68,8 +69,8 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi, encodeMarkup }) => {
           type: STORY_ACTION_TYPES.FETCH_STORIES_FAILURE,
           payload: {
             message: {
-              body: __('Cannot connect to data source', 'web-stories'),
-              title: __('Unable to Load Stories', 'web-stories'),
+              body: ERRORS.LOAD_STORIES.DEFAULT_MESSAGE,
+              title: ERRORS.LOAD_STORIES.TITLE,
             },
           },
         });
@@ -123,7 +124,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi, encodeMarkup }) => {
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to Load Stories', 'web-stories'),
+              title: ERRORS.LOAD_STORIES.TITLE,
             },
             code: err.code,
           },
@@ -168,7 +169,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi, encodeMarkup }) => {
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to Update Story', 'web-stories'),
+              title: ERRORS.UPDATE_STORY.TITLE,
             },
             code: err.code,
           },
@@ -192,7 +193,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi, encodeMarkup }) => {
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to Delete Story', 'web-stories'),
+              title: ERRORS.DELETE_STORY.TITLE,
             },
             code: err.code,
           },
@@ -270,7 +271,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi, encodeMarkup }) => {
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to Render Preview', 'web-stories'),
+              title: ERRORS.RENDER_PREVIEW.TITLE,
             },
             code: err.code,
           },
@@ -329,7 +330,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi, encodeMarkup }) => {
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to Create Story From Template', 'web-stories'),
+              title: ERRORS.CREATE_STORY_FROM_TEMPLATE.TITLE,
             },
             code: err.code,
           },
@@ -394,7 +395,7 @@ const useStoryApi = (dataAdapter, { editStoryURL, storyApi, encodeMarkup }) => {
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to Duplicate Story', 'web-stories'),
+              title: ERRORS.DUPLICATE_STORY.TITLE,
             },
             code: err.code,
           },

--- a/assets/src/dashboard/app/api/useTemplateApi.js
+++ b/assets/src/dashboard/app/api/useTemplateApi.js
@@ -21,21 +21,17 @@ import { useCallback, useMemo, useReducer } from 'react';
 import queryString from 'query-string';
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { toUTCDate } from '../../../date';
+import base64Encode from '../../../edit-story/utils/base64Encode';
 import getAllTemplates from '../../templates';
 import { APP_ROUTES } from '../../constants';
 import templateReducer, {
   defaultTemplatesState,
   ACTION_TYPES as TEMPLATE_ACTION_TYPES,
 } from '../reducer/templates';
-import base64Encode from '../../../edit-story/utils/base64Encode';
+import { ERRORS } from '../textContent';
 
 export function reshapeTemplateObject(isLocal) {
   return ({
@@ -138,8 +134,8 @@ const useTemplateApi = (dataAdapter, config) => {
           type: TEMPLATE_ACTION_TYPES.FETCH_MY_TEMPLATES_FAILURE,
           payload: {
             message: {
-              body: __('Cannot connect to data source', 'web-stories'),
-              title: __('Unable to Load Templates', 'web-stories'),
+              body: ERRORS.LOAD_TEMPLATES.DEFAULT_MESSAGE,
+              title: ERRORS.LOAD_TEMPLATES.TITLE,
             },
           },
         });
@@ -188,7 +184,7 @@ const useTemplateApi = (dataAdapter, config) => {
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to Load Templates', 'web-stories'),
+              title: ERRORS.LOAD_TEMPLATES.TITLE,
             },
             code: err.code,
           },
@@ -287,7 +283,7 @@ const useTemplateApi = (dataAdapter, config) => {
           payload: {
             message: {
               body: err.message,
-              title: __('Unable to Create Template from Story', 'web-stories'),
+              title: ERRORS.CREATE_TEMPLATE_FROM_STORY.TITLE,
             },
             code: err.code,
           },

--- a/assets/src/dashboard/app/reducer/test/media.js
+++ b/assets/src/dashboard/app/reducer/test/media.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { ERRORS } from '../../textContent';
 import mediaReducer, { ACTION_TYPES } from '../media';
 
 describe('mediaReducer', () => {
@@ -55,7 +56,7 @@ describe('mediaReducer', () => {
       payload: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to fetch media',
+          title: ERRORS.LOAD_MEDIA.TITLE,
         },
         code: 'my_error_code',
       },
@@ -65,7 +66,7 @@ describe('mediaReducer', () => {
       error: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to fetch media',
+          title: ERRORS.LOAD_MEDIA.TITLE,
         },
         id: MOCK_ERROR_ID,
         code: 'my_error_code',
@@ -82,7 +83,7 @@ describe('mediaReducer', () => {
       payload: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to add media',
+          title: ERRORS.UPLOAD_PUBLISHER_LOGO.TITLE,
         },
         code: 'my_error_code',
       },
@@ -92,7 +93,7 @@ describe('mediaReducer', () => {
       error: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to add media',
+          title: ERRORS.UPLOAD_PUBLISHER_LOGO.TITLE,
         },
         id: MOCK_ERROR_ID,
         code: 'my_error_code',

--- a/assets/src/dashboard/app/reducer/test/settings.js
+++ b/assets/src/dashboard/app/reducer/test/settings.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { ERRORS } from '../../textContent';
 import settingsReducer, { ACTION_TYPES } from '../settings';
 
 describe('settingsReducer', () => {
@@ -56,7 +57,7 @@ describe('settingsReducer', () => {
       payload: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to find settings data',
+          title: ERRORS.LOAD_SETTINGS.TITLE,
         },
         code: 'my_error_code',
       },
@@ -66,7 +67,7 @@ describe('settingsReducer', () => {
       error: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to find settings data',
+          title: ERRORS.LOAD_SETTINGS.TITLE,
         },
         id: MOCK_ERROR_ID,
         code: 'my_error_code',
@@ -80,7 +81,7 @@ describe('settingsReducer', () => {
       payload: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to update settings data',
+          title: ERRORS.UPDATE_EDITOR_SETTINGS.TITLE,
         },
         code: 'my_error_code',
       },
@@ -90,7 +91,7 @@ describe('settingsReducer', () => {
       error: {
         message: {
           body: 'The response is not a valid JSON response.',
-          title: 'Unable to update settings data',
+          title: ERRORS.UPDATE_EDITOR_SETTINGS.TITLE,
         },
         id: MOCK_ERROR_ID,
         code: 'my_error_code',

--- a/assets/src/dashboard/app/reducer/test/stories.js
+++ b/assets/src/dashboard/app/reducer/test/stories.js
@@ -19,6 +19,7 @@
  */
 import storyReducer, { ACTION_TYPES } from '../stories';
 import { STORY_STATUS } from '../../../constants';
+import { ERRORS } from '../../textContent';
 
 describe('storyReducer', () => {
   const initialState = {
@@ -90,7 +91,7 @@ describe('storyReducer', () => {
         payload: {
           message: {
             body: 'my trash story failure message',
-            title: 'Unable to Delete Story',
+            title: ERRORS.DELETE_STORY.TITLE,
           },
           code: 'my_error_code',
         },
@@ -102,7 +103,7 @@ describe('storyReducer', () => {
       error: {
         message: {
           body: 'my trash story failure message',
-          title: 'Unable to Delete Story',
+          title: ERRORS.DELETE_STORY.TITLE,
         },
         id: MOCK_ERROR_ID,
         code: 'my_error_code',
@@ -161,7 +162,7 @@ describe('storyReducer', () => {
         type: ACTION_TYPES.DUPLICATE_STORY_FAILURE,
         payload: {
           message: {
-            title: 'Unable to Duplciate Story',
+            title: ERRORS.DUPLICATE_STORY.TITLE,
             body: 'my duplicate story failure message',
           },
           code: 'my_error_code',
@@ -173,7 +174,7 @@ describe('storyReducer', () => {
       ...initialState,
       error: {
         message: {
-          title: 'Unable to Duplciate Story',
+          title: ERRORS.DUPLICATE_STORY.TITLE,
           body: 'my duplicate story failure message',
         },
         id: MOCK_ERROR_ID,
@@ -379,7 +380,7 @@ describe('storyReducer', () => {
         type: ACTION_TYPES.FETCH_STORIES_FAILURE,
         payload: {
           message: {
-            title: 'Unable to Load Stories',
+            title: ERRORS.LOAD_STORIES.TITLE,
             body: 'my error message',
           },
           code: 'my_error_code',
@@ -391,7 +392,7 @@ describe('storyReducer', () => {
       ...initialState,
       error: {
         message: {
-          title: 'Unable to Load Stories',
+          title: ERRORS.LOAD_STORIES.TITLE,
           body: 'my error message',
         },
         id: MOCK_ERROR_ID,
@@ -407,7 +408,7 @@ describe('storyReducer', () => {
         type: ACTION_TYPES.CREATE_STORY_FROM_TEMPLATE_FAILURE,
         payload: {
           message: {
-            title: 'Unable to Create Story From Template',
+            title: ERRORS.CREATE_STORY_FROM_TEMPLATE.TITLE,
             body: 'my error message',
           },
           code: 'my_error_code',
@@ -419,7 +420,7 @@ describe('storyReducer', () => {
       ...initialState,
       error: {
         message: {
-          title: 'Unable to Create Story From Template',
+          title: ERRORS.CREATE_STORY_FROM_TEMPLATE.TITLE,
           body: 'my error message',
         },
         id: MOCK_ERROR_ID,
@@ -463,7 +464,7 @@ describe('storyReducer', () => {
         type: ACTION_TYPES.UPDATE_STORY_FAILURE,
         payload: {
           message: {
-            title: 'Unable to Update Story',
+            title: ERRORS.UPDATE_STORY.TITLE,
             body: 'my error message',
           },
           code: 'my_error_code',
@@ -475,7 +476,7 @@ describe('storyReducer', () => {
       ...initialState,
       error: {
         message: {
-          title: 'Unable to Update Story',
+          title: ERRORS.UPDATE_STORY.TITLE,
           body: 'my error message',
         },
         id: MOCK_ERROR_ID,
@@ -522,7 +523,7 @@ describe('storyReducer', () => {
         type: ACTION_TYPES.CREATE_STORY_PREVIEW_FAILURE,
         payload: {
           message: {
-            title: 'Unable to Create Story Preview From Template',
+            title: ERRORS.RENDER_PREVIEW.TITLE,
             body: 'my error message',
           },
           code: 'my_error_code',
@@ -534,7 +535,7 @@ describe('storyReducer', () => {
       ...initialState,
       error: {
         message: {
-          title: 'Unable to Create Story Preview From Template',
+          title: ERRORS.RENDER_PREVIEW.TITLE,
           body: 'my error message',
         },
         id: MOCK_ERROR_ID,

--- a/assets/src/dashboard/app/reducer/test/templates.js
+++ b/assets/src/dashboard/app/reducer/test/templates.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { ERRORS } from '../../textContent';
 import templateReducer, {
   ACTION_TYPES,
   defaultTemplatesState as initialState,
@@ -196,7 +197,7 @@ describe('templateReducer', () => {
         type: ACTION_TYPES.FETCH_TEMPLATES_FAILURE,
         payload: {
           message: {
-            title: 'Unable to Load Templates',
+            title: ERRORS.LOAD_TEMPLATES.TITLE,
             body: 'test error message',
           },
           code: 'test-error-code',
@@ -208,7 +209,7 @@ describe('templateReducer', () => {
       ...initialState,
       error: {
         message: {
-          title: 'Unable to Load Templates',
+          title: ERRORS.LOAD_TEMPLATES.TITLE,
           body: 'test error message',
         },
         id: MOCK_ERROR_ID,
@@ -224,7 +225,7 @@ describe('templateReducer', () => {
         type: ACTION_TYPES.CREATE_TEMPLATE_FROM_STORY_FAILURE,
         payload: {
           message: {
-            title: 'Unable to Create Template from Story',
+            title: ERRORS.CREATE_TEMPLATE_FROM_STORY.TITLE,
             body: 'test error message',
           },
           code: 'test-error-code',
@@ -236,7 +237,7 @@ describe('templateReducer', () => {
       ...initialState,
       error: {
         message: {
-          title: 'Unable to Create Template from Story',
+          title: ERRORS.CREATE_TEMPLATE_FROM_STORY.TITLE,
           body: 'test error message',
         },
         id: MOCK_ERROR_ID,

--- a/assets/src/dashboard/app/textContent/index.js
+++ b/assets/src/dashboard/app/textContent/index.js
@@ -60,6 +60,6 @@ export const ERRORS = {
     TITLE: __('Unable to Render Preview', 'web-stories'),
   },
   LOAD_TEMPLATE: {
-    DEFAULT_MESSAGE: 'Could not load the template',
+    DEFAULT_MESSAGE: __('Could not load the template', 'web-stories'),
   },
 };

--- a/assets/src/dashboard/app/textContent/index.js
+++ b/assets/src/dashboard/app/textContent/index.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const ERRORS = {
+  LOAD_STORIES: {
+    TITLE: __('Unable to Load Stories', 'web-stories'),
+    DEFAULT_MESSAGE: __('Cannot connect to data source', 'web-stories'),
+  },
+  UPDATE_STORY: {
+    TITLE: __('Unable to Update Story', 'web-stories'),
+  },
+  DELETE_STORY: {
+    TITLE: __('Unable to Delete Story', 'web-stories'),
+  },
+  CREATE_STORY_FROM_TEMPLATE: {
+    TITLE: __('Unable to Create Story From Template', 'web-stories'),
+  },
+  DUPLICATE_STORY: {
+    TITLE: __('Unable to Duplicate Story', 'web-stories'),
+  },
+  LOAD_TEMPLATES: {
+    TITLE: __('Unable to Load Templates', 'web-stories'),
+    DEFAULT_MESSAGE: __('Cannot connect to data source', 'web-stories'),
+  },
+  CREATE_TEMPLATE_FROM_STORY: {
+    TITLE: __('Unable to Create Template from Story', 'web-stories'),
+  },
+  UPLOAD_PUBLISHER_LOGO: {
+    TITLE: __('Unable to Add Media', 'web-stories'),
+  },
+  LOAD_MEDIA: {
+    TITLE: __('Unable to Load Media', 'web-stories'),
+  },
+  LOAD_SETTINGS: {
+    TITLE: __('Unable to Load Settings', 'web-stories'),
+    DEFAULT_MESSAGE: __('Cannot connect to data source', 'web-stories'),
+  },
+  UPDATE_EDITOR_SETTINGS: {
+    TITLE: __('Unable to Update Settings Data', 'web-stories'),
+  },
+  RENDER_PREVIEW: {
+    TITLE: __('Unable to Render Preview', 'web-stories'),
+  },
+  LOAD_TEMPLATE: {
+    DEFAULT_MESSAGE: 'Could not load the template',
+  },
+};

--- a/assets/src/dashboard/app/views/previewStory/index.js
+++ b/assets/src/dashboard/app/views/previewStory/index.js
@@ -42,6 +42,7 @@ import { WPBODY_ID } from '../../../constants';
 import { StoryPropType } from '../../../types';
 import { useResizeEffect } from '../../../utils';
 import useApi from '../../api/useApi';
+import { ERRORS } from '../../textContent';
 
 const AMP_LOCAL_STORAGE = 'amp-story-state';
 const PREVIEW_CONTAINER_ID = 'previewContainer';
@@ -142,7 +143,7 @@ const PreviewStory = ({ story, handleClose }) => {
       localStorage.removeItem(AMP_LOCAL_STORAGE);
     }
     if (!story || !story.pages.length) {
-      setPreviewError(__('Unable to Render Preview', 'web-stories'));
+      setPreviewError(ERRORS.RENDER_PREVIEW.TITLE);
     } else {
       createStoryPreview(story);
     }

--- a/assets/src/dashboard/app/views/templateDetails/index.js
+++ b/assets/src/dashboard/app/views/templateDetails/index.js
@@ -21,26 +21,21 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useFeature } from 'flagged';
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { clamp } from '../../../../animation';
 import { trackEvent } from '../../../../tracking';
 import { TransformProvider } from '../../../../edit-story/components/transform';
 import { Layout, useToastContext } from '../../../components';
+import { ALERT_SEVERITY } from '../../../constants';
 import { useTemplateView, usePagePreviewSize } from '../../../utils/';
+import useApi from '../../api/useApi';
 import { useConfig } from '../../config';
 import FontProvider from '../../font/fontProvider';
 import { resolveRelatedTemplateRoute } from '../../router';
 import useRouteHistory from '../../router/useRouteHistory';
+import { ERRORS } from '../../textContent';
 import { PreviewStoryView } from '..';
-
-import useApi from '../../api/useApi';
-import { ALERT_SEVERITY } from '../../../constants';
 import Header from './header';
 import Content from './content';
 
@@ -124,7 +119,7 @@ function TemplateDetails() {
       .then(setTemplate)
       .catch(() => {
         addToast({
-          message: { body: __('Could not load the template.', 'web-stories') },
+          message: { body: ERRORS.LOAD_TEMPLATES.DEFAULT_MESSAGE },
           severity: ALERT_SEVERITY.ERROR,
           id: Date.now(),
         });


### PR DESCRIPTION
## Summary

Moving error messaging static text to 1 file and importing messages accordingly - this is just something Sam and I talked about briefly. This is a small first step as I prep to swap out the old message system in the dashboard that was make shift more or less for the new snackbar in the design system. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

Eventually, having a single source of truth that handles all our static messaging across both editor and dashboard. 

## User-facing changes

No changes, just some code clean up

## Testing Instructions

Regression testing around CRUD of dashboard. I blocked some APIs to test error messages out. They should match this list: https://docs.google.com/spreadsheets/d/1eG77iwDbKSdOIQCOl2ROSMvSegMq4qm1gophOubcu5w/edit#gid=0 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4967 and #5330 
