### PR TITLE
Use dialog to warn users about lack of upload permissions

### DIFF
--- a/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { useFeature } from 'flagged';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
 
 /**
@@ -56,6 +56,7 @@ import { DropDown } from '../../../../form';
 import { Placement } from '../../../../popup';
 import { PANE_PADDING } from '../../shared';
 import { useSnackbar } from '../../../../../app';
+import MissingUploadPermissionDialog from './missingUploadPermissionDialog';
 import paneId from './paneId';
 
 export const ROOT_MARGIN = 300;
@@ -131,6 +132,8 @@ function MediaPane(props) {
     insertElement: state.actions.insertElement,
   }));
 
+  const [isPermissionDialogOpen, setIsPermissionDialogOpen] = useState(false);
+
   const onClose = resetWithFetch;
 
   /**
@@ -170,6 +173,7 @@ function MediaPane(props) {
     onSelect,
     onClose,
     type: allowedMimeTypes,
+    onPermissionError: () => setIsPermissionDialogOpen(true),
   });
 
   /**
@@ -271,6 +275,11 @@ function MediaPane(props) {
             searchTerm={searchTerm}
           />
         )}
+
+        <MissingUploadPermissionDialog
+          open={isPermissionDialogOpen}
+          onClose={() => setIsPermissionDialogOpen(false)}
+        />
       </PaneInner>
     </StyledPane>
   );

--- a/assets/src/edit-story/components/library/panes/media/local/missingUploadPermissionDialog.js
+++ b/assets/src/edit-story/components/library/panes/media/local/missingUploadPermissionDialog.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Plain } from '../../../../button';
+import Dialog from '../../../../dialog';
+
+function MissingUploadPermissionDialog({ open, onClose }) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={__('Access Restrictions', 'web-stories')}
+      actions={<Plain onClick={onClose}>{__('Got it', 'web-stories')}</Plain>}
+      maxWidth={285}
+    >
+      {__(
+        `You don't have access to upload images or publish a story. Please check with your administrator to request upload and publish access.`,
+        'web-stories'
+      )}
+    </Dialog>
+  );
+}
+
+MissingUploadPermissionDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default MissingUploadPermissionDialog;

--- a/assets/src/edit-story/components/library/panes/media/local/stories/missingUploadPermissionDialog.js
+++ b/assets/src/edit-story/components/library/panes/media/local/stories/missingUploadPermissionDialog.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+
+/**
+ * Internal dependencies
+ */
+import MissingUploadPermissionDialog from '../missingUploadPermissionDialog';
+import ApiContext from '../../../../../../app/api/context';
+import MediaContext from '../../../../../../app/media/context';
+import SnackbarContext from '../../../../../../app/snackbar/context';
+
+export default {
+  title: 'Stories Editor/Components/Dialog/Missing Upload Permission',
+  component: MissingUploadPermissionDialog,
+};
+
+export const _default = () => {
+  const apiValue = {
+    actions: {
+      deleteMedia: action('close dialog'),
+    },
+  };
+  const mediaValue = {
+    local: {
+      actions: { deleteMediaElement: action('close dialog') },
+    },
+  };
+  const snackbarValue = { showSnackbar: action('show snackbar') };
+
+  return (
+    <SnackbarContext.Provider value={snackbarValue}>
+      <MediaContext.Provider value={mediaValue}>
+        <ApiContext.Provider value={apiValue}>
+          <MissingUploadPermissionDialog
+            open={true}
+            onClose={action('closed')}
+          />
+        </ApiContext.Provider>
+      </MediaContext.Provider>
+    </SnackbarContext.Provider>
+  );
+};

--- a/assets/src/edit-story/components/mediaPicker/useMediaPicker.js
+++ b/assets/src/edit-story/components/mediaPicker/useMediaPicker.js
@@ -29,7 +29,6 @@ import { __ } from '@wordpress/i18n';
  */
 import useLocalMedia from '../../app/media/local/useLocalMedia';
 import { useConfig } from '../../app/config';
-import { useSnackbar } from '../../app/snackbar';
 import { useAPI } from '../../app/api';
 import { trackEvent } from '../../../tracking';
 
@@ -38,6 +37,7 @@ export default function useMediaPicker({
   buttonInsertText = __('Insert into page', 'web-stories'),
   onSelect = () => {},
   onClose = () => {},
+  onPermissionError = () => {},
   type = '',
   multiple = false,
 }) {
@@ -50,7 +50,6 @@ export default function useMediaPicker({
   const {
     capabilities: { hasUploadMediaAction },
   } = useConfig();
-  const { showSnackbar } = useSnackbar();
   useEffect(() => {
     try {
       // Work around that forces default tab as upload tab.
@@ -77,11 +76,7 @@ export default function useMediaPicker({
 
     // If a user does not have the rights to upload to the media library, do not show the media picker.
     if (!hasUploadMediaAction) {
-      const message = __(
-        'Sorry, you are unable to upload files.',
-        'web-stories'
-      );
-      showSnackbar({ message });
+      onPermissionError();
       evt.preventDefault();
       return false;
     }


### PR DESCRIPTION
## Summary

Add a popup dialog to notify the user to check access permission when they are restricted to upload.

## Relevant Technical Choices

Add a RestrictAccessDialog component
Add a state [isPermissionDialogOpen] and pass MissingUploadPermissionDialog component under mediaPane component.
Add a onPermissionError props function on useMediaPicker, for controlling the dialog show.

## To-do

N/A

## User-facing changes

Will get a popup warning dialog instead of Snackbar when they click on the upload button and do not have access.

## Testing Instructions

The Snackbar should no longer shows up.
The dialog should popup with the accurate instruction test when not permitted user click on the 'Upload' button.
The dialog should close when the user click on 'GOT IT'

---

Fixes #2481 
