### PR TITLE
Design System: Focus style update (Buttons and Pills)

### DIFF
--- a/assets/src/design-system/components/button/index.js
+++ b/assets/src/design-system/components/button/index.js
@@ -27,8 +27,10 @@ import { BUTTON_SIZES, BUTTON_TYPES, BUTTON_VARIANTS } from './constants';
 
 const Base = styled.button(
   ({ size, theme }) => css`
-    position: relative;
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    box-sizing: border-box;
     padding: 0;
     margin: 0;
     background: transparent;
@@ -110,37 +112,20 @@ const ButtonRectangle = styled(Base)`
   min-width: 1px;
   min-height: 1em;
   border-radius: 4px;
-
-  & > div {
-    display: flex;
-    align-items: center;
-    justify-content: space-around;
-    padding: ${({ size }) =>
-      size === BUTTON_SIZES.SMALL ? '8px 16px' : '16px 32px'};
-    height: 100%;
-  }
+  padding: ${({ size }) =>
+    size === BUTTON_SIZES.SMALL ? '8px 16px' : '18px 32px'};
 `;
 
 const ButtonSquare = styled(Base)`
   ${({ type }) => type && buttonColors?.[type]};
   border-radius: 4px;
   ${({ size }) => css`
-    width: ${(size === BUTTON_SIZES.SMALL ? 32 : 56) + 8}px;
-    height: ${(size === BUTTON_SIZES.SMALL ? 32 : 56) + 8}px;
-
-    & > div {
-      display: flex;
-      align-items: center;
-      justify-content: space-around;
-      padding: 10px 10px;
-      height: 100%;
-      width: 100%;
-    }
+    width: ${size === BUTTON_SIZES.SMALL ? 32 : 56}px;
+    height: ${size === BUTTON_SIZES.SMALL ? 32 : 56}px;
 
     svg {
-      width: ${size === BUTTON_SIZES.SMALL ? 16 : 20}px;
-      height: ${size === BUTTON_SIZES.SMALL ? 16 : 20}px;
-      margin: 0 auto;
+      width: ${size === BUTTON_SIZES.SMALL ? 14 : 20}px;
+      height: auto;
     }
   `}
 `;
@@ -151,17 +136,8 @@ const ButtonCircle = styled(ButtonSquare)`
 
 const ButtonIcon = styled(Base)`
   ${({ size }) => css`
-    width: ${(size === BUTTON_SIZES.SMALL ? 16 : 20) + 8}px;
-    height: ${(size === BUTTON_SIZES.SMALL ? 16 : 20) + 8}px;
-
-    & > div {
-      display: flex;
-      align-items: center;
-      justify-content: space-around;
-      height: 100%;
-      width: 100%;
-    }
-
+    width: ${size === BUTTON_SIZES.SMALL ? 14 : 20}px;
+    height: ${size === BUTTON_SIZES.SMALL ? 14 : 20}px;
     svg {
       width: 100%;
       height: auto;
@@ -170,7 +146,6 @@ const ButtonIcon = styled(Base)`
   `}
 `;
 
-// TODO incorporate tooltip as a label on hover per figma
 const ButtonOptions = {
   [BUTTON_VARIANTS.RECTANGLE]: ButtonRectangle,
   [BUTTON_VARIANTS.CIRCLE]: ButtonCircle,
@@ -195,7 +170,7 @@ export const Button = ({
       type={type}
       {...rest}
     >
-      <div>{children}</div>
+      {children}
     </StyledButton>
   );
 };

--- a/assets/src/design-system/components/pill/index.js
+++ b/assets/src/design-system/components/pill/index.js
@@ -26,7 +26,12 @@ import { THEME_CONSTANTS, themeHelpers } from '../../theme';
 
 const StyledPill = styled.button(
   ({ isActive, theme }) => css`
-    min-height: 32px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    padding: 6px 16px;
+    height: 32px;
 
     background-color: ${isActive
       ? theme.colors.interactiveBg.primaryNormal
@@ -51,13 +56,6 @@ const StyledPill = styled.button(
 
     &:focus {
       outline: none;
-    }
-    div {
-      display: flex;
-      align-items: center;
-      justify-content: space-around;
-      padding: 6px 16px;
-      height: 100%;
     }
 
     transition: color 0.6s ease 0s;

--- a/assets/src/design-system/components/pill/index.js
+++ b/assets/src/design-system/components/pill/index.js
@@ -66,7 +66,7 @@ const StyledPill = styled.button(
 export const Pill = ({ children, isActive, onClick, ...rest }) => {
   return (
     <StyledPill isActive={isActive} onClick={onClick} {...rest}>
-      <div>{children}</div>
+      {children}
     </StyledPill>
   );
 };

--- a/assets/src/design-system/theme/helpers/outline.js
+++ b/assets/src/design-system/theme/helpers/outline.js
@@ -19,13 +19,8 @@
 import { css } from 'styled-components';
 
 export const focusableOutlineCSS = (accent) => css`
-  padding: 2px;
-  background-clip: content-box;
   border: solid 2px transparent;
   &:focus {
     border: solid 2px ${accent};
-  }
-  * {
-    box-sizing: border-box;
   }
 `;


### PR DESCRIPTION
## Summary
After trying a few things, landing on `background-clip: content-box;` to achieve the space between focus style and element, and then having that not work great to preserve aspect ratios and radiuses @samitron7 agreed we should drop the space between element and focus style. This PR achieves that so that the rest of the PRs I have open for various system components can have that change reflected to make review easier. 

## Relevant Technical Choices
- removing space between border and elements on focus so that we avoid nesting divs to maintain accurate spacing and can preserve border radius.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None, only exists in storybook

## Testing Instructions

Go to storybook > designSystem and check out the button and pill sections. Focus on a button and see that the blue border is now touching the bg color (if there's color) and that the border radius is preserved. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
