### PR TITLE
Added update of local duration when story loads

### DIFF
--- a/assets/src/edit-story/components/inspector/document/pageAdvancement.js
+++ b/assets/src/edit-story/components/inspector/document/pageAdvancement.js
@@ -69,6 +69,11 @@ function PageAdvancementPanel() {
 
   const [duration, setDuration] = useState(defaultPageDuration);
 
+  // Update duration if changed in global store
+  useEffect(() => {
+    setDuration(defaultPageDuration);
+  }, [defaultPageDuration]);
+
   const updateAutoAdvance = useCallback(
     (value) => updateStory({ properties: { autoAdvance: value } }),
     [updateStory]


### PR DESCRIPTION
## Summary

The bug was actually reducible to just these steps:

* Create a new story
* Set default page duration to 8
* Save draft
* Reload entire page
* Observe that page duration has been reset to 7, not 8 as previously set

The bug is caused by the default page duration being used on load in the page advancement panel and not overwritten once the true story is loaded.

This fixes that bug by updating the local state for page duration once the story is fully loaded.

## Relevant Technical Choices

- simply updates the local state when the global state updates.

## To-do
- [x] Fix bug
- [x] ~Test~ A test is unfortunately very complex to set up, as the current panel test setup doesn't allow updating the wrapper contexts which would be required for this. So I'll be skipping testing for this one.

## User-facing changes

Above bug fixed.

## Testing Instructions

* Create a new story
* Set default page duration to 8
* Save draft
* Reload entire page
* Observe that page duration is still 8

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5319
