### PR TITLE
prepublish(task): organize text and translations into central location

### DIFF
--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -237,10 +237,11 @@ export const MESSAGES = {
   TEXT: {
     TOO_MUCH_PAGE_TEXT: {
       MAIN_TEXT: __('Too much text on page', 'web-stories'),
+      // eslint-disable eslint/no-useless-escape
       HELPER_TEXT: sprintf(
         /* translators: 1: maximum number of story characters. 2: maximum percentage of characters, depending on number of pages. */
         __(
-          'Keep text to max %1$d characters per page. Consider using a page attachment, breaking up the text into multiple screens, or keeping the total number of pages with a lot of text to less than %2$d% of the pages in the story.',
+          'Keep text to max %1$d characters per page. Consider using a page attachment, breaking up the text into multiple screens, or keeping the total number of pages with a lot of text to less than %2$d%% percent of the pages in the story.',
           'web-stories'
         ),
         MAX_STORY_CHARACTERS,

--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -18,11 +18,15 @@
  * WordPress dependencies
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { TranslateWithMarkup } from '../../../i18n';
 
 export const MIN_STORY_PAGES = 4;
 export const MAX_STORY_PAGES = 30;
-export const MIN_STORY_TITLE_LENGTH = 10;
-export const MAX_STORY_TITLE_LENGTH = 40;
+export const MAX_STORY_TITLE_LENGTH_WORDS = 10;
+export const MAX_STORY_TITLE_LENGTH_CHARS = 40;
 const COVER_DIMENSION_WIDTH_PX = 640;
 const COVER_DIMENSION_HEIGHT_PX = 853;
 const ASPECT_RATIO_LEFT = 3;
@@ -49,69 +53,63 @@ export const PRE_PUBLISH_MESSAGE_TYPES = {
 export const MESSAGES = {
   CRITICAL_METADATA: {
     MISSING_TITLE: {
-      MAIN_TEXT: __('Missing title', 'web-stories'),
+      MAIN_TEXT: __('Missing story title', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum story title length. 2: maximum story title length. */
+        /* translators: 1: minimum story title length in words. 2: maximum story title length in characters. */
         __(
           'Keep the title clear and clean, ideally under %1$d words in less than %2$d characters.',
           'web-stories'
         ),
-        MIN_STORY_TITLE_LENGTH,
-        MAX_STORY_TITLE_LENGTH
+        MAX_STORY_TITLE_LENGTH_WORDS,
+        MAX_STORY_TITLE_LENGTH_CHARS
       ),
     },
     MISSING_COVER: {
       MAIN_TEXT: __('Missing story cover image', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum cover dimension width. 2: minimum cover dimension height. 3: cover dimensions aspect ratio left. 4: cover dimension aspect ratio right. */
+        /* translators: 1: minimum cover dimension width x minimum cover dimension height. 2: cover dimensions aspect ratio.  */
         __(
-          'Used as the cover for the Story and is representative of the story. Should not have the Story title pre-embedded on it or any other burned in text. Should be at least %1$dpx by %2$dpx and maintain a %3$d:%4$d aspect ratio.',
+          'Used as the cover for the Story and is representative of the story. Should not have the Story title pre-embedded on it or any other burned in text. Should be at least %1$s and maintain a %2$s aspect ratio.',
           'web-stories'
         ),
-        COVER_DIMENSION_WIDTH_PX,
-        COVER_DIMENSION_HEIGHT_PX,
-        ASPECT_RATIO_LEFT,
-        ASPECT_RATIO_RIGHT
+        `${COVER_DIMENSION_WIDTH_PX}x${COVER_DIMENSION_HEIGHT_PX}px`,
+        `${ASPECT_RATIO_LEFT}:${ASPECT_RATIO_RIGHT}`
       ),
     },
     COVER_TOO_SMALL: {
       MAIN_TEXT: __('Story cover image too small', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum cover dimension width. 2: minimum cover dimension height. 3: cover dimensions aspect ratio left. 4: cover dimension aspect ratio right. */
+        /* translators: 1: minimum cover dimension width X minimum cover dimension height. 2: cover dimensions aspect ratio. */
         __(
-          'Should be at least %1$dpx by %2$dpx and maintain a %3$d:%4$d aspect ratio.',
+          'Should be at least %1$s and maintain a %2$s aspect ratio.',
           'web-stories'
         ),
-        COVER_DIMENSION_WIDTH_PX,
-        COVER_DIMENSION_HEIGHT_PX,
-        ASPECT_RATIO_LEFT,
-        ASPECT_RATIO_RIGHT
+        `${COVER_DIMENSION_WIDTH_PX}x${COVER_DIMENSION_HEIGHT_PX}px`,
+        `${ASPECT_RATIO_LEFT}:${ASPECT_RATIO_RIGHT}`
       ),
     },
     COVER_WRONG_ASPECT_RATIO: {
       MAIN_TEXT: __('Story cover image wrong aspect ratio ', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum cover dimension width. 2: minimum cover dimension height. 3: cover dimensions aspect ratio left. 4: cover dimension aspect ratio right. */
+        /* translators: 1: minimum cover dimension width X minimum cover dimension height. 2: cover dimensions aspect ratio. */
         __(
-          'Should be at least %1$dpx by %2$dpx and maintain a %3$d:%4$d aspect ratio.',
+          'Should be at least %1$s and maintain a %2$s aspect ratio.',
           'web-stories'
         ),
-        COVER_DIMENSION_WIDTH_PX,
-        COVER_DIMENSION_HEIGHT_PX,
-        ASPECT_RATIO_LEFT,
-        ASPECT_RATIO_RIGHT
+        `${COVER_DIMENSION_WIDTH_PX}x${COVER_DIMENSION_HEIGHT_PX}px`,
+        `${ASPECT_RATIO_LEFT}:${ASPECT_RATIO_RIGHT}`
       ),
     },
     LOGO_TOO_SMALL: {
       MAIN_TEXT: __('Publisher logo is too small', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum publisher logo dimension 2: publisher logo dimension ratio */
+        /* translators: 1: minimum publisher logo dimensions. 2: publisher logo dimension ratio. */
         __(
-          'Should be at least %1$dpx by %1$dpx and maintain a %2$d:%2$d aspect ratio.',
+          'Should be at least %1$s and maintain a %2$s aspect ratio.',
           'web-stories'
         ),
-        PUBLISHER_LOGO_DIMENSION,
-        PUBLISHER_LOGO_RATIO
+        `${PUBLISHER_LOGO_DIMENSION}x${PUBLISHER_LOGO_DIMENSION}px`,
+        `${PUBLISHER_LOGO_RATIO}x${PUBLISHER_LOGO_RATIO}px`
       ),
     },
     LINK_ATTACHMENT_CONFLICT: {
@@ -122,8 +120,11 @@ export const MESSAGES = {
       ),
     },
     MISSING_VIDEO_POSTER: {
-      MAIN_TEXT: __('Video missing poster', 'web-stories'),
-      HELPER_TEXT: __('', 'web-stories'),
+      MAIN_TEXT: __('Video missing poster image', 'web-stories'),
+      HELPER_TEXT: __(
+        'Add a poster image for every video. Posters are displayed while a video loads for a better user experience.',
+        'web-stories'
+      ),
     },
   },
   ACCESSIBILITY: {
@@ -140,21 +141,20 @@ export const MESSAGES = {
     FONT_TOO_SMALL: {
       MAIN_TEXT: __('Font size too small', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum font size */
-        __('Text should be size %1$d or higher.', 'web-stories'),
+        /* translators: 1: minimum font size. */
+        __('Text should be size %d or higher.', 'web-stories'),
         MIN_FONT_SIZE
       ),
     },
     LOW_IMAGE_RESOLUTION: {
       MAIN_TEXT: __('Low image resolution', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum image size width 2: minimum image size height */
+        /* translators: 1: minimum image size width x minimum image size height. */
         __(
-          'Use %1$dpx by %2$dpx for full screen images. Use similar pixel density for cropped images.',
+          'Use %s for full screen images. Use similar pixel density for cropped images.',
           'web-stories'
         ),
-        IMAGE_SIZE_WIDTH,
-        IMAGE_SIZE_HEIGHT
+        `${IMAGE_SIZE_WIDTH}x${IMAGE_SIZE_HEIGHT}px`
       ),
     },
     MISSING_CAPTIONS: {
@@ -165,9 +165,9 @@ export const MESSAGES = {
       ),
     },
     MISSING_VIDEO_TITLE: {
-      MAIN_TEXT: __('Video missing title', 'web-stories'),
+      MAIN_TEXT: __('Video missing description', 'web-stories'),
       HELPER_TEXT: __(
-        'For burned-in text in your video, add the precise text displayed inside of the video.',
+        'Add a video description. Descriptions help with indexability and accessibility (for videos without captions). Include any burned-in text inside of the video.',
         'web-stories'
       ),
     },
@@ -187,16 +187,24 @@ export const MESSAGES = {
     },
     MISSING_IMAGE_ALT_TEXT: {
       MAIN_TEXT: __('Image missing alt text', 'web-stories'),
-      HELPER_TEXT: __(
-        'Add meaningful “alt” text to images to optimize accessibility and indexability.',
-        'web-stories'
+      HELPER_TEXT: sprintf(
+        /* translators: %s: alt. */
+        __(
+          'Add meaningful “%s” text to images to optimize accessibility and indexability.',
+          'web-stories'
+        ),
+        'alt'
       ),
     },
     MISSING_VIDEO_ALT_TEXT: {
-      MAIN_TEXT: __('Video is missing assistive text', 'web-stories'),
-      HELPER_TEXT: __(
-        'Add meaningful “alt” text to images to optimize accessibility and indexability.',
-        'web-stories'
+      MAIN_TEXT: __('Video missing assistive text', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: %s: alt. */
+        __(
+          'Add meaningful “%s” text to videos to optimize accessibility and indexability.',
+          'web-stories'
+        ),
+        'alt'
       ),
     },
   },
@@ -228,8 +236,8 @@ export const MESSAGES = {
     STORY_TITLE_TOO_LONG: {
       MAIN_TEXT: __('Story title too long', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum number of story characters */
-        __('Story title should have %1$d characters or fewer.', 'web-stories'),
+        /* translators: 1: minimum number of story characters. */
+        __('Story title should have %d characters or fewer.', 'web-stories'),
         MAX_STORY_CHARACTERS
       ),
     },
@@ -251,9 +259,9 @@ export const MESSAGES = {
     TOO_LITTLE_TEXT: {
       MAIN_TEXT: __('Too little text', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum number of story characters */
+        /* translators: %d: minimum number of story characters. */
         __(
-          'The entire story should have a minimum of %1$d characters of text in total.',
+          'The entire story should have a minimum of %d characters of text in total.',
           'web-stories'
         ),
         MIN_STORY_CHARACTERS
@@ -263,31 +271,44 @@ export const MESSAGES = {
   MEDIA: {
     VIDEO_IMAGE_TOO_SMALL_ON_PAGE: {
       MAIN_TEXT: __('Video or image too small on the page', 'web-stories'),
-      HELPER_TEXT: __(
-        // todo add [more info](https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/#visual-treat)
-        'Use full screen videos and images where possible to keep to an immersive feeling.',
-        'web-stories'
+      HELPER_TEXT: (
+        <TranslateWithMarkup
+          mapping={{
+            a: (
+              //eslint-disable-next-line jsx-a11y/anchor-has-content
+              <a
+                href="https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/#visual-treat"
+                rel="noreferrer"
+                target="_blank"
+              />
+            ),
+          }}
+        >
+          {__(
+            'Use full screen videos and images where possible to keep to an immersive feeling. <a>(more info)</a>',
+            'web-stories'
+          )}
+        </TranslateWithMarkup>
       ),
     },
     LOW_IMAGE_RESOLUTION: {
       MAIN_TEXT: __('Low image resolution', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum image size width 2: minimum image size height */
+        /* translators: 1: minimum image size width x minimum image size height. */
         __(
-          'Use %1$d x %2$dpx for full screen images, keep to similar pixel density for cropped images.',
+          'Use %s for full screen images. Use similar pixel density for cropped images.',
           'web-stories'
         ),
-        IMAGE_SIZE_WIDTH,
-        IMAGE_SIZE_HEIGHT
+        `${IMAGE_SIZE_WIDTH}x${IMAGE_SIZE_HEIGHT}px`
       ),
     },
     VIDEO_TOO_LONG: {
       MAIN_TEXT: __('Video too long', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: maximum video length in minutes */
+        /* translators: %d: maximum video length in minutes. */
         _n(
-          'Break longer videos into segments of %1$d minute or less.',
-          'Break longer videos into segments of %1$d minutes or less.',
+          'Break longer videos into segments of %d minute or less.',
+          'Break longer videos into segments of %d minutes or less.',
           MAX_VIDEO_LENGTH_MINUTES,
           'web-stories'
         ),
@@ -297,9 +318,9 @@ export const MESSAGES = {
     VIDEO_FRAME_RATE_TOO_LOW: {
       MAIN_TEXT: __('Video frame rate low', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum number of frames per second for video */
+        /* translators: %d: minimum number of frames per second for video. */
         __(
-          'Video should have a minimum of %1$d frames per second.',
+          'Video should have a minimum of %d frames per second.',
           'web-stories'
         ),
         MIN_VIDEO_FPS
@@ -308,9 +329,9 @@ export const MESSAGES = {
     VIDEO_RESOLUTION_TOO_LOW: {
       MAIN_TEXT: __('Video resolution low', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum video resolution */
-        __('Videos should have a minimum resolution of %1$dp.', 'web-stories'),
-        MIN_VIDEO_RESOLUTION
+        /* translators: 1: minimum video resolution. */
+        __('Videos should have a minimum resolution of %s.', 'web-stories'),
+        `${MIN_VIDEO_RESOLUTION}p`
       ),
     },
     VIDEO_RESOLUTION_TOO_HIGH: {

--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -14,8 +14,310 @@
  * limitations under the License.
  */
 
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf, _n } from '@wordpress/i18n';
+
+export const MIN_STORY_PAGES = 4;
+export const MAX_STORY_PAGES = 30;
+export const MIN_STORY_TITLE_LENGTH = 10;
+export const MAX_STORY_TITLE_LENGTH = 40;
+const COVER_DIMENSION_WIDTH_PX = 640;
+const COVER_DIMENSION_HEIGHT_PX = 853;
+const ASPECT_RATIO_LEFT = 3;
+const ASPECT_RATIO_RIGHT = 4;
+const PUBLISHER_LOGO_DIMENSION = 96;
+const PUBLISHER_LOGO_RATIO = 1;
+const MIN_FONT_SIZE = 12;
+const IMAGE_SIZE_WIDTH = 828;
+const IMAGE_SIZE_HEIGHT = 1792;
+const MIN_STORY_CHARACTERS = 100;
+const MAX_STORY_CHARACTERS = 200;
+const MAX_CHARACTER_PERCENTAGE = 10;
+const MIN_VIDEO_RESOLUTION = 480;
+const MIN_VIDEO_FPS = 24;
+const MAX_VIDEO_LENGTH_SECONDS = 60;
+const MAX_VIDEO_LENGTH_MINUTES = Math.floor(MAX_VIDEO_LENGTH_SECONDS / 60);
+
 export const PRE_PUBLISH_MESSAGE_TYPES = {
   GUIDANCE: 'guidance',
   ERROR: 'error',
   WARNING: 'warning',
+};
+
+export const MESSAGES = {
+  CRITICAL_METADATA: {
+    MISSING_TITLE: {
+      MAIN_TEXT: __('Missing title', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum story title length. 2: maximum story title length. */
+        __(
+          'Keep the title clear and clean, ideally under %1$d words in less than %2$d characters.',
+          'web-stories'
+        ),
+        MIN_STORY_TITLE_LENGTH,
+        MAX_STORY_TITLE_LENGTH
+      ),
+    },
+    MISSING_COVER: {
+      MAIN_TEXT: __('Missing story cover image', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum cover dimension width. 2: minimum cover dimension height. 3: cover dimensions aspect ratio left. 4: cover dimension aspect ratio right. */
+        __(
+          'Used as the cover for the Story and is representative of the story. Should not have the Story title pre-embedded on it or any other burned in text. Should be at least %1$dpx by %2$dpx and maintain a %3$d:%4$d aspect ratio.',
+          'web-stories'
+        ),
+        COVER_DIMENSION_WIDTH_PX,
+        COVER_DIMENSION_HEIGHT_PX,
+        ASPECT_RATIO_LEFT,
+        ASPECT_RATIO_RIGHT
+      ),
+    },
+    COVER_TOO_SMALL: {
+      MAIN_TEXT: __('Story cover image too small', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum cover dimension width. 2: minimum cover dimension height. 3: cover dimensions aspect ratio left. 4: cover dimension aspect ratio right. */
+        __(
+          'Should be at least %1$dpx by %2$dpx and maintain a %3$d:%4$d aspect ratio.',
+          'web-stories'
+        ),
+        COVER_DIMENSION_WIDTH_PX,
+        COVER_DIMENSION_HEIGHT_PX,
+        ASPECT_RATIO_LEFT,
+        ASPECT_RATIO_RIGHT
+      ),
+    },
+    COVER_WRONG_ASPECT_RATIO: {
+      MAIN_TEXT: __('Story cover image wrong aspect ratio ', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum cover dimension width. 2: minimum cover dimension height. 3: cover dimensions aspect ratio left. 4: cover dimension aspect ratio right. */
+        __(
+          'Should be at least %1$dpx by %2$dpx and maintain a %3$d:%4$d aspect ratio.',
+          'web-stories'
+        ),
+        COVER_DIMENSION_WIDTH_PX,
+        COVER_DIMENSION_HEIGHT_PX,
+        ASPECT_RATIO_LEFT,
+        ASPECT_RATIO_RIGHT
+      ),
+    },
+    LOGO_TOO_SMALL: {
+      MAIN_TEXT: __('Publisher logo is too small', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum publisher logo dimension 2: publisher logo dimension ratio */
+        __(
+          'Should be at least %1$dpx by %1$dpx and maintain a %2$d:%2$d aspect ratio.',
+          'web-stories'
+        ),
+        PUBLISHER_LOGO_DIMENSION,
+        PUBLISHER_LOGO_RATIO
+      ),
+    },
+    LINK_ATTACHMENT_CONFLICT: {
+      MAIN_TEXT: __('Link conflict with page attachment', 'web-stories'),
+      HELPER_TEXT: __(
+        'Links in the bottom of a page with a Page Attachment are disabled. ',
+        'web-stories'
+      ),
+    },
+    MISSING_VIDEO_POSTER: {
+      MAIN_TEXT: __('Video missing poster', 'web-stories'),
+      HELPER_TEXT: __('', 'web-stories'),
+    },
+  },
+  ACCESSIBILITY: {
+    LOW_CONTRAST: {
+      MAIN_TEXT: __(
+        'Low contrast between font and background color',
+        'web-stories'
+      ),
+      HELPER_TEXT: __(
+        'A high contrast makes the words easy to see.',
+        'web-stories'
+      ),
+    },
+    FONT_TOO_SMALL: {
+      MAIN_TEXT: __('Font size too small', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum font size */
+        __('Text should be size %1$d or higher.', 'web-stories'),
+        MIN_FONT_SIZE
+      ),
+    },
+    LOW_IMAGE_RESOLUTION: {
+      MAIN_TEXT: __('Low image resolution', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum image size width 2: minimum image size height */
+        __(
+          'Use %1$dpx by %2$dpx for full screen images. Use similar pixel density for cropped images. ',
+          'web-stories'
+        ),
+        IMAGE_SIZE_WIDTH,
+        IMAGE_SIZE_HEIGHT
+      ),
+    },
+    MISSING_CAPTIONS: {
+      MAIN_TEXT: __('Video missing captions', 'web-stories'),
+      HELPER_TEXT: __(
+        'Add captions to your video. Captions help keep your audience engaged, even when they can’t listen to the audio.',
+        'web-stories'
+      ),
+    },
+    MISSING_VIDEO_TITLE: {
+      MAIN_TEXT: __('Video missing title', 'web-stories'),
+      HELPER_TEXT: __(
+        'For burned-in text in your video, add the precise text displayed inside of the video.',
+        'web-stories'
+      ),
+    },
+    TOO_MANY_LINKS: {
+      MAIN_TEXT: __('Too many links on a page', 'web-stories'),
+      HELPER_TEXT: __(
+        'Avoid having more than one link per page. ',
+        'web-stories'
+      ),
+    },
+    LINK_REGION_TOO_SMALL: {
+      MAIN_TEXT: __('Link tappable region too small', 'web-stories'),
+      HELPER_TEXT: __(
+        "Make the linked element large enough so it's easy for a user to tap it.",
+        'web-stories'
+      ),
+    },
+    MISSING_IMAGE_ALT_TEXT: {
+      MAIN_TEXT: __('Image missing alt text', 'web-stories'),
+      HELPER_TEXT: __(
+        'Add meaningful “alt” text to images to optimize accessibility and indexability.',
+        'web-stories'
+      ),
+    },
+    MISSING_VIDEO_ALT_TEXT: {
+      MAIN_TEXT: __('Video is missing assistive text', 'web-stories'),
+      HELPER_TEXT: __(
+        'Add meaningful “alt” text to images to optimize accessibility and indexability.',
+        'web-stories'
+      ),
+    },
+  },
+  DISTRIBUTION: {
+    MISSING_DESCRIPTION: {
+      MAIN_TEXT: __('Missing story description', 'web-stories'),
+      HELPER_TEXT: __('Add a description for your story.', 'web-stories'),
+    },
+  },
+  GENERAL_GUIDELINES: {
+    STORY_TOO_SHORT: {
+      MAIN_TEXT: __('Story too short', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum number of pages. 2: maximum number of pages. */
+        __('Use between %1$d and %2$d pages in your story', 'web-stories'),
+        MIN_STORY_PAGES,
+        MAX_STORY_PAGES
+      ),
+    },
+    STORY_TOO_LONG: {
+      MAIN_TEXT: __('Story too long', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum number of pages. 2: maximum number of pages. */
+        __('Use between %1$d and %2$d pages in your story', 'web-stories'),
+        MIN_STORY_PAGES,
+        MAX_STORY_PAGES
+      ),
+    },
+    STORY_TITLE_TOO_LONG: {
+      MAIN_TEXT: __('Story title too long', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum number of story characters */
+        __('Story title should have %1$d characters or fewer.', 'web-stories'),
+        MAX_STORY_CHARACTERS
+      ),
+    },
+  },
+  TEXT: {
+    TOO_MUCH_PAGE_TEXT: {
+      MAIN_TEXT: __('Too much text on page', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: maximum number of story characters. 2: maximum percentage of characters, depending on number of pages. */
+        __(
+          'Keep text to max %1$d characters per page. Consider using a page attachment, breaking up the text into multiple screens, or keeping the total number of pages with a lot of text to less than %2$d% of the pages in the story.',
+          'web-stories'
+        ),
+        MAX_STORY_CHARACTERS,
+        MAX_CHARACTER_PERCENTAGE
+      ),
+    },
+    TOO_LITTLE_TEXT: {
+      MAIN_TEXT: __('Too little text', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum number of story characters */
+        __(
+          'The entire story should have a minimum of %1$d characters of text in total.',
+          'web-stories'
+        ),
+        MIN_STORY_CHARACTERS
+      ),
+    },
+  },
+  MEDIA: {
+    VIDEO_IMAGE_TOO_SMALL_ON_PAGE: {
+      MAIN_TEXT: __('Video or image too small on the page', 'web-stories'),
+      HELPER_TEXT: __(
+        // todo add [more info](https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/#visual-treat)
+        'Use full screen videos and images where possible to keep to an immersive feeling.',
+        'web-stories'
+      ),
+    },
+    LOW_IMAGE_RESOLUTION: {
+      MAIN_TEXT: __('Low image resolution', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum image size width 2: minimum image size height */
+        __(
+          'Use %1$d x %2$dpx for full screen images, keep to similar pixel density for cropped images. ',
+          'web-stories'
+        ),
+        IMAGE_SIZE_WIDTH,
+        IMAGE_SIZE_HEIGHT
+      ),
+    },
+    VIDEO_TOO_LONG: {
+      MAIN_TEXT: __('Video too long', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: maximum video length in minutes */
+        _n(
+          'Break longer videos into segments of %1$d minute or less.',
+          'Break longer videos into segments of %1$d minutes or less.',
+          MAX_VIDEO_LENGTH_MINUTES,
+          'web-stories'
+        ),
+        MAX_VIDEO_LENGTH_MINUTES
+      ),
+    },
+    VIDEO_FRAME_RATE_TOO_LOW: {
+      MAIN_TEXT: __('Video frame rate low', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum number of frames per second for video */
+        __(
+          'Video should have a minimum of %1$d frames per second.',
+          'web-stories'
+        ),
+        MIN_VIDEO_FPS
+      ),
+    },
+    VIDEO_RESOLUTION_TOO_LOW: {
+      MAIN_TEXT: __('Video resolution low', 'web-stories'),
+      HELPER_TEXT: sprintf(
+        /* translators: 1: minimum video resolution */
+        __('Videos should have a minimum resolution of %1$dp.', 'web-stories'),
+        MIN_VIDEO_RESOLUTION
+      ),
+    },
+    VIDEO_RESOLUTION_TOO_HIGH: {
+      MAIN_TEXT: __('Video resolution too high', 'web-stories'),
+      HELPER_TEXT: __(
+        "Many mobile devices don't support video resolutions larger than 4K. Reduce the video resolution.",
+        'web-stories'
+      ),
+    },
+  },
 };

--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -69,7 +69,7 @@ export const MESSAGES = {
       HELPER_TEXT: sprintf(
         /* translators: 1: minimum cover dimension width x minimum cover dimension height. 2: cover dimensions aspect ratio.  */
         __(
-          'Used as the cover for the Story and is representative of the story. Should not have the Story title pre-embedded on it or any other burned in text. Should be at least %1$s and maintain a %2$s aspect ratio.',
+          'Used as the cover for the Story and is representative of the story. Should not have the Story title pre-embedded on it or any other burned-in text. Should be at least %1$s in size and maintain a %2$s aspect ratio.',
           'web-stories'
         ),
         `${COVER_DIMENSION_WIDTH_PX}x${COVER_DIMENSION_HEIGHT_PX}px`,
@@ -89,7 +89,7 @@ export const MESSAGES = {
       ),
     },
     COVER_WRONG_ASPECT_RATIO: {
-      MAIN_TEXT: __('Story cover image wrong aspect ratio ', 'web-stories'),
+      MAIN_TEXT: __('Story cover image wrong aspect ratio', 'web-stories'),
       HELPER_TEXT: sprintf(
         /* translators: 1: minimum cover dimension width X minimum cover dimension height. 2: cover dimensions aspect ratio. */
         __(
@@ -142,7 +142,7 @@ export const MESSAGES = {
       MAIN_TEXT: __('Font size too small', 'web-stories'),
       HELPER_TEXT: sprintf(
         /* translators: 1: minimum font size. */
-        __('Text should be size %d or higher.', 'web-stories'),
+        __('Text should have size %d or larger.', 'web-stories'),
         MIN_FONT_SIZE
       ),
     },
@@ -197,7 +197,7 @@ export const MESSAGES = {
       ),
     },
     MISSING_VIDEO_ALT_TEXT: {
-      MAIN_TEXT: __('Video missing assistive text', 'web-stories'),
+      MAIN_TEXT: __('Video missing alt text', 'web-stories'),
       HELPER_TEXT: sprintf(
         /* translators: %s: alt. */
         __(
@@ -249,7 +249,7 @@ export const MESSAGES = {
       HELPER_TEXT: sprintf(
         /* translators: 1: maximum number of story characters. 2: maximum percentage of characters, depending on number of pages. */
         __(
-          'Keep text to max %1$d characters per page. Consider using a page attachment, breaking up the text into multiple screens, or keeping the total number of pages with a lot of text to less than %2$d%% percent of the pages in the story.',
+          'Keep text to max %1$d characters per page. Consider using a page attachment, breaking up the text into multiple screens, or keeping the total number of pages with a lot of text to less than %2$d%% of the pages in the story.',
           'web-stories'
         ),
         MAX_STORY_CHARACTERS,
@@ -296,7 +296,7 @@ export const MESSAGES = {
       HELPER_TEXT: sprintf(
         /* translators: 1: minimum image size width x minimum image size height. */
         __(
-          'Use %s for full screen images. Use similar pixel density for cropped images.',
+          'Use %s for full screen images, keep to similar pixel density for cropped images.',
           'web-stories'
         ),
         `${IMAGE_SIZE_WIDTH}x${IMAGE_SIZE_HEIGHT}px`

--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -117,7 +117,7 @@ export const MESSAGES = {
     LINK_ATTACHMENT_CONFLICT: {
       MAIN_TEXT: __('Link conflict with page attachment', 'web-stories'),
       HELPER_TEXT: __(
-        'Links in the bottom of a page with a Page Attachment are disabled. ',
+        'Links in the bottom of a page with a Page Attachment are disabled.',
         'web-stories'
       ),
     },
@@ -150,7 +150,7 @@ export const MESSAGES = {
       HELPER_TEXT: sprintf(
         /* translators: 1: minimum image size width 2: minimum image size height */
         __(
-          'Use %1$dpx by %2$dpx for full screen images. Use similar pixel density for cropped images. ',
+          'Use %1$dpx by %2$dpx for full screen images. Use similar pixel density for cropped images.',
           'web-stories'
         ),
         IMAGE_SIZE_WIDTH,
@@ -174,7 +174,7 @@ export const MESSAGES = {
     TOO_MANY_LINKS: {
       MAIN_TEXT: __('Too many links on a page', 'web-stories'),
       HELPER_TEXT: __(
-        'Avoid having more than one link per page. ',
+        'Avoid having more than one link per page.',
         'web-stories'
       ),
     },
@@ -211,7 +211,7 @@ export const MESSAGES = {
       MAIN_TEXT: __('Story too short', 'web-stories'),
       HELPER_TEXT: sprintf(
         /* translators: 1: minimum number of pages. 2: maximum number of pages. */
-        __('Use between %1$d and %2$d pages in your story', 'web-stories'),
+        __('Use between %1$d and %2$d pages in your story.', 'web-stories'),
         MIN_STORY_PAGES,
         MAX_STORY_PAGES
       ),
@@ -220,7 +220,7 @@ export const MESSAGES = {
       MAIN_TEXT: __('Story too long', 'web-stories'),
       HELPER_TEXT: sprintf(
         /* translators: 1: minimum number of pages. 2: maximum number of pages. */
-        __('Use between %1$d and %2$d pages in your story', 'web-stories'),
+        __('Use between %1$d and %2$d pages in your story.', 'web-stories'),
         MIN_STORY_PAGES,
         MAX_STORY_PAGES
       ),
@@ -274,7 +274,7 @@ export const MESSAGES = {
       HELPER_TEXT: sprintf(
         /* translators: 1: minimum image size width 2: minimum image size height */
         __(
-          'Use %1$d x %2$dpx for full screen images, keep to similar pixel density for cropped images. ',
+          'Use %1$d x %2$dpx for full screen images, keep to similar pixel density for cropped images.',
           'web-stories'
         ),
         IMAGE_SIZE_WIDTH,

--- a/assets/src/edit-story/app/prepublish/errors/metadata.js
+++ b/assets/src/edit-story/app/prepublish/errors/metadata.js
@@ -30,15 +30,10 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import isElementBelowLimit from '../../../utils/isElementBelowLimit';
-import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
+import { PRE_PUBLISH_MESSAGE_TYPES, MESSAGES } from '../constants';
 
 const FEATURED_MEDIA_RESOURCE_MIN_HEIGHT = 853;
 const FEATURED_MEDIA_RESOURCE_MIN_WIDTH = 640;
@@ -65,7 +60,8 @@ export function storyCoverAttached(story) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
       storyId: story.storyId,
-      message: __('Missing story cover', 'web-stories'),
+      message: MESSAGES.CRITICAL_METADATA.MISSING_COVER.MAIN_TEXT,
+      help: MESSAGES.CRITICAL_METADATA.MISSING_COVER.HELPER_TEXT,
     };
   }
   return undefined;
@@ -84,7 +80,8 @@ export function storyTitle(story) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
       storyId: story.storyId,
-      message: __('Missing story title', 'web-stories'),
+      message: MESSAGES.CRITICAL_METADATA.MISSING_TITLE.MAIN_TEXT,
+      help: MESSAGES.CRITICAL_METADATA.MISSING_TITLE.HELPER_TEXT,
     };
   }
   return undefined;
@@ -106,7 +103,8 @@ export function storyCoverPortraitSize(story) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
       storyId: story.storyId,
-      message: __("Story's portrait cover image is too small", 'web-stories'),
+      message: MESSAGES.CRITICAL_METADATA.COVER_TOO_SMALL.MAIN_TEXT,
+      help: MESSAGES.CRITICAL_METADATA.COVER_TOO_SMALL.HELPER_TEXT,
     };
   }
   return undefined;
@@ -128,7 +126,8 @@ export function publisherLogoSize(story) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
       storyId: story.storyId,
-      message: __("Story's publisher logo image is too small", 'web-stories'),
+      message: MESSAGES.CRITICAL_METADATA.LOGO_TOO_SMALL.MAIN_TEXT,
+      help: MESSAGES.CRITICAL_METADATA.LOGO_TOO_SMALL.HELPER_TEXT,
     };
   }
   return undefined;
@@ -166,10 +165,8 @@ export function linkInPageAttachmentRegion(story) {
       type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
       storyId: story.storyId,
       pages: pagesWithLinksInAttachmentArea,
-      message: __(
-        'Page has a link in the page attachment region',
-        'web-stories'
-      ),
+      message: MESSAGES.CRITICAL_METADATA.LINK_ATTACHMENT_CONFLICT.MAIN_TEXT,
+      help: MESSAGES.CRITICAL_METADATA.LINK_ATTACHMENT_CONFLICT.HELPER_TEXT,
     };
   }
   return undefined;

--- a/assets/src/edit-story/app/prepublish/errors/test/metadata.js
+++ b/assets/src/edit-story/app/prepublish/errors/test/metadata.js
@@ -54,8 +54,12 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
     expect(testHappy).toBeUndefined();
     expect(testEmptyString).not.toBeUndefined();
     expect(testUndefined).not.toBeUndefined();
-    expect(testUndefined.message).toMatchInlineSnapshot(`"Missing title"`);
-    expect(testEmptyString.message).toMatchInlineSnapshot(`"Missing title"`);
+    expect(testUndefined.message).toMatchInlineSnapshot(
+      `"Missing story title"`
+    );
+    expect(testEmptyString.message).toMatchInlineSnapshot(
+      `"Missing story title"`
+    );
     expect(testUndefined.storyId).toStrictEqual(
       testUndefinedTitleStory.storyId
     );

--- a/assets/src/edit-story/app/prepublish/errors/test/metadata.js
+++ b/assets/src/edit-story/app/prepublish/errors/test/metadata.js
@@ -29,7 +29,7 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
     const testMissingCover = metadataGuidelines.storyCoverAttached(testStory);
     expect(testMissingCover).not.toBeUndefined();
     expect(testMissingCover.message).toMatchInlineSnapshot(
-      `"Missing story cover"`
+      `"Missing story cover image"`
     );
     expect(testMissingCover.storyId).toStrictEqual(testStory.storyId);
   });
@@ -54,12 +54,8 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
     expect(testHappy).toBeUndefined();
     expect(testEmptyString).not.toBeUndefined();
     expect(testUndefined).not.toBeUndefined();
-    expect(testUndefined.message).toMatchInlineSnapshot(
-      `"Missing story title"`
-    );
-    expect(testEmptyString.message).toMatchInlineSnapshot(
-      `"Missing story title"`
-    );
+    expect(testUndefined.message).toMatchInlineSnapshot(`"Missing title"`);
+    expect(testEmptyString.message).toMatchInlineSnapshot(`"Missing title"`);
     expect(testUndefined.storyId).toStrictEqual(
       testUndefinedTitleStory.storyId
     );
@@ -111,7 +107,7 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
     expect(testNoAttachment).toBeUndefined();
     expect(testLinkInPageAttachment).not.toBeUndefined();
     expect(testLinkInPageAttachment.message).toMatchInlineSnapshot(
-      `"Page has a link in the page attachment region"`
+      `"Link conflict with page attachment"`
     );
     expect(testLinkInPageAttachment.pages).toHaveLength(1);
     expect(testLinkInPageAttachment.pages[0]).toStrictEqual(
@@ -158,9 +154,7 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
     expect(testWidth).not.toBeUndefined();
     expect(testWidth.storyId).toStrictEqual(testWidthStory.storyId);
     expect(test).not.toBeUndefined();
-    expect(test.message).toMatchInlineSnapshot(
-      `"Story's publisher logo image is too small"`
-    );
+    expect(test.message).toMatchInlineSnapshot(`"Publisher logo is too small"`);
     expect(test.storyId).toStrictEqual(testStory.storyId);
   });
 
@@ -201,9 +195,7 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
     expect(testWidth).not.toBeUndefined();
     expect(testWidth.storyId).toStrictEqual(testWidthStory.storyId);
     expect(test).not.toBeUndefined();
-    expect(test.message).toMatchInlineSnapshot(
-      `"Story's portrait cover image is too small"`
-    );
+    expect(test.message).toMatchInlineSnapshot(`"Story cover image too small"`);
     expect(test.storyId).toStrictEqual(testStory.storyId);
   });
 });

--- a/assets/src/edit-story/app/prepublish/guidance/general.js
+++ b/assets/src/edit-story/app/prepublish/guidance/general.js
@@ -22,7 +22,7 @@ import {
   MESSAGES,
   MIN_STORY_PAGES,
   MAX_STORY_PAGES,
-  MAX_STORY_TITLE_LENGTH,
+  MAX_STORY_TITLE_LENGTH_CHARS,
 } from '../constants';
 
 /**
@@ -69,7 +69,7 @@ export function storyPagesCount(story) {
  * @return {Guidance|undefined} The guidance object for consumption
  */
 export function storyTitleLength(story) {
-  if (story.title.length > MAX_STORY_TITLE_LENGTH) {
+  if (story.title.length > MAX_STORY_TITLE_LENGTH_CHARS) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       storyId: story.storyId,

--- a/assets/src/edit-story/app/prepublish/guidance/general.js
+++ b/assets/src/edit-story/app/prepublish/guidance/general.js
@@ -15,24 +15,20 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __, sprintf } from '@wordpress/i18n';
-/**
  * Internal dependencies
  */
-import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
+import {
+  PRE_PUBLISH_MESSAGE_TYPES,
+  MESSAGES,
+  MIN_STORY_PAGES,
+  MAX_STORY_PAGES,
+  MAX_STORY_TITLE_LENGTH,
+} from '../constants';
 
 /**
  * @typedef {import('../types').Guidance} Guidance
  * @typedef {import('../../../types').Story} Story
  */
-
-const MIN_STORY_PAGES = 4;
-const MAX_STORY_PAGES = 30;
-const MIN_STORY_PAGES_RECOMMENDED = 10;
-const MAX_STORY_PAGES_RECOMMENDED = 20;
-const MAX_STORY_TITLE_LENGTH = 40;
 
 /**
  * Check the number of pages in a Story.
@@ -47,28 +43,18 @@ export function storyPagesCount(story) {
   const hasTooManyPages = story.pages.length > MAX_STORY_PAGES;
   if (hasTooFewPages || hasTooManyPages) {
     const message = hasTooFewPages
-      ? sprintf(
-          /* translators: 1: minimum number of pages. 2: recommended number of pages. */
-          __(
-            'Story has fewer than %1$d pages (ideally, stories should have a minimum of %2$d pages)',
-            'web-stories'
-          ),
-          MIN_STORY_PAGES,
-          MIN_STORY_PAGES_RECOMMENDED
-        )
-      : sprintf(
-          /* translators: 1: maximum number of pages. 2: recommended number of pages. */
-          __(
-            "Story has more than %1$d pages (ideally, stories shouldn't have more than %2$d pages)",
-            'web-stories'
-          ),
-          MAX_STORY_PAGES,
-          MAX_STORY_PAGES_RECOMMENDED
-        );
+      ? {
+          message: MESSAGES.GENERAL_GUIDELINES.STORY_TOO_SHORT.MAIN_TEXT,
+          help: MESSAGES.GENERAL_GUIDELINES.STORY_TOO_SHORT.HELPER_TEXT,
+        }
+      : {
+          message: MESSAGES.GENERAL_GUIDELINES.STORY_TOO_LONG.MAIN_TEXT,
+          help: MESSAGES.GENERAL_GUIDELINES.STORY_TOO_LONG.HELPER_TEXT,
+        };
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       storyId: story.storyId,
-      message,
+      ...message,
     };
   }
   return undefined;
@@ -87,11 +73,8 @@ export function storyTitleLength(story) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       storyId: story.storyId,
-      message: sprintf(
-        /* translators: %d: maximum story title length. */
-        __('Story title is longer than %d characters', 'web-stories'),
-        MAX_STORY_TITLE_LENGTH
-      ),
+      message: MESSAGES.GENERAL_GUIDELINES.STORY_TITLE_TOO_LONG.MAIN_TEXT,
+      help: MESSAGES.GENERAL_GUIDELINES.STORY_TITLE_TOO_LONG.HELPER_TEXT,
     };
   }
   return undefined;

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -15,16 +15,11 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __, sprintf, _n } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { PAGE_HEIGHT, PAGE_WIDTH } from '../../../constants';
 import getBoundRect from '../../../utils/getBoundRect';
-import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
+import { MESSAGES, PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
 
 const SAFE_ZONE_AREA = PAGE_HEIGHT * PAGE_WIDTH;
 
@@ -34,7 +29,6 @@ const MIN_VIDEO_HEIGHT = 480;
 const MIN_VIDEO_WIDTH = 852;
 
 const MAX_VIDEO_LENGTH_SECONDS = 60;
-const MAX_VIDEO_LENGTH_MINUTES = Math.floor(MAX_VIDEO_LENGTH_SECONDS / 60);
 
 /**
  * @typedef {import('../../../types').Page} Page
@@ -84,10 +78,8 @@ export function mediaElementSizeOnPage(element) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       elementId: element.id,
-      message:
-        element.type === 'video'
-          ? __(`Video is too small on the page`, 'web-stories')
-          : __(`Image is too small on the page`, 'web-stories'),
+      message: MESSAGES.MEDIA.VIDEO_IMAGE_TOO_SMALL_ON_PAGE.MAIN_TEXT,
+      help: MESSAGES.MEDIA.VIDEO_IMAGE_TOO_SMALL_ON_PAGE.HELPER_TEXT,
     };
   }
 
@@ -146,10 +138,8 @@ function videoElementResolution(element) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       elementId: element.id,
-      message: __(
-        "Video's resolution is too high to display on most mobile devices (>4k)",
-        'web-stories'
-      ),
+      message: MESSAGES.MEDIA.VIDEO_RESOLUTION_TOO_HIGH.MAIN_TEXT,
+      help: MESSAGES.MEDIA.VIDEO_RESOLUTION_TOO_HIGH.HELPER_TEXT,
     };
   }
 
@@ -157,7 +147,8 @@ function videoElementResolution(element) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       elementId: element.id,
-      message: __('Video has low resolution', 'web-stories'),
+      message: MESSAGES.MEDIA.VIDEO_RESOLUTION_TOO_LOW.MAIN_TEXT,
+      help: MESSAGES.MEDIA.VIDEO_RESOLUTION_TOO_LOW.HELPER_TEXT,
     };
   }
 
@@ -173,7 +164,8 @@ function imageElementResolution(element) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       elementId: element.id,
-      message: __('Image has low resolution', 'web-stories'),
+      message: MESSAGES.MEDIA.LOW_IMAGE_RESOLUTION.MAIN_TEXT,
+      help: MESSAGES.MEDIA.LOW_IMAGE_RESOLUTION.HELPER_TEXT,
     };
   }
   return undefined;
@@ -190,7 +182,8 @@ function gifElementResolution(element) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       elementId: element.id,
-      message: __('GIF has low resolution', 'web-stories'),
+      message: MESSAGES.MEDIA.LOW_IMAGE_RESOLUTION.MAIN_TEXT,
+      help: MESSAGES.MEDIA.LOW_IMAGE_RESOLUTION.HELPER_TEXT,
     };
   }
   return undefined;
@@ -208,16 +201,8 @@ export function videoElementLength(element) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       elementId: element.id,
-      message: sprintf(
-        /* translators: %d: number of minutes; */
-        _n(
-          'Video is longer than %d minute (suggest breaking video up into multiple segments)',
-          'Video is longer than %d minutes (suggest breaking video up into multiple segments)',
-          MAX_VIDEO_LENGTH_MINUTES,
-          'web-stories'
-        ),
-        MAX_VIDEO_LENGTH_MINUTES
-      ),
+      message: MESSAGES.MEDIA.VIDEO_TOO_LONG.MAIN_TEXT,
+      help: MESSAGES.MEDIA.VIDEO_TOO_LONG.HELPER_TEXT,
     };
   }
   return undefined;

--- a/assets/src/edit-story/app/prepublish/guidance/test/general.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/general.js
@@ -38,15 +38,11 @@ describe('Pre-publish checklist - general guidelines (guidance)', () => {
     });
 
     expect(storyTooShort).not.toBeUndefined();
-    expect(storyTooShort.message).toMatchInlineSnapshot(
-      `"Story has fewer than 4 pages (ideally, stories should have a minimum of 10 pages)"`
-    );
+    expect(storyTooShort.message).toMatchInlineSnapshot(`"Story too short"`);
     expect(storyTooShort.storyId).toStrictEqual(123);
 
     expect(storyTooLong).not.toBeUndefined();
-    expect(storyTooLong.message).toMatchInlineSnapshot(
-      `"Story has more than 30 pages (ideally, stories shouldn't have more than 20 pages)"`
-    );
+    expect(storyTooLong.message).toMatchInlineSnapshot(`"Story too long"`);
     expect(storyTooLong.storyId).toStrictEqual(456);
 
     expect(testUndefined).toBeUndefined();
@@ -65,9 +61,7 @@ describe('Pre-publish checklist - general guidelines (guidance)', () => {
     const test = generalGuidelines.storyTitleLength(testStory);
     expect(test).not.toBeUndefined();
     expect(test.type).toStrictEqual(PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE);
-    expect(test.message).toMatchInlineSnapshot(
-      `"Story title is longer than 40 characters"`
-    );
+    expect(test.message).toMatchInlineSnapshot(`"Story title too long"`);
     expect(test.storyId).toStrictEqual(testStory.storyId);
     expect(testUndefined).toBeUndefined();
   });

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -48,7 +48,7 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
     const result = mediaGuidance.mediaElementSizeOnPage(tooSmallVideoElement);
     expect(result).not.toBeUndefined();
     expect(result.message).toMatchInlineSnapshot(
-      `"Video is too small on the page"`
+      `"Video or image too small on the page"`
     );
     expect(result.type).toStrictEqual('guidance');
     expect(result.elementId).toStrictEqual(tooSmallVideoElement.id);
@@ -72,7 +72,7 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
       tooLowResolutionVideoElement
     );
     expect(result).not.toBeUndefined();
-    expect(result.message).toMatchInlineSnapshot(`"Video has low resolution"`);
+    expect(result.message).toMatchInlineSnapshot(`"Video resolution low"`);
     expect(result.type).toStrictEqual('guidance');
     expect(result.elementId).toStrictEqual(tooLowResolutionVideoElement.id);
   });
@@ -97,7 +97,7 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
       tooLowResolutionImageElement
     );
     expect(result).not.toBeUndefined();
-    expect(result.message).toMatchInlineSnapshot(`"Image has low resolution"`);
+    expect(result.message).toMatchInlineSnapshot(`"Low image resolution"`);
     expect(result.type).toStrictEqual('guidance');
     expect(result.elementId).toStrictEqual(tooLowResolutionImageElement.id);
   });
@@ -126,7 +126,7 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
       tooLowResolutionImageElement
     );
     expect(result).not.toBeUndefined();
-    expect(result.message).toMatchInlineSnapshot(`"GIF has low resolution"`);
+    expect(result.message).toMatchInlineSnapshot(`"Low image resolution"`);
     expect(result.type).toStrictEqual('guidance');
     expect(result.elementId).toStrictEqual(tooLowResolutionImageElement.id);
   });
@@ -147,9 +147,7 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
 
     const result = mediaGuidance.mediaElementResolution(tooHighVideoResolution);
     expect(result).not.toBeUndefined();
-    expect(result.message).toMatchInlineSnapshot(
-      `"Video's resolution is too high to display on most mobile devices (>4k)"`
-    );
+    expect(result.message).toMatchInlineSnapshot(`"Video resolution too high"`);
     expect(result.type).toStrictEqual('guidance');
     expect(result.elementId).toStrictEqual(tooHighVideoResolution.id);
   });
@@ -171,9 +169,7 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
 
     const result = mediaGuidance.videoElementLength(tooLongVideo);
     expect(result).not.toBeUndefined();
-    expect(result.message).toMatchInlineSnapshot(
-      `"Video is longer than 1 minute (suggest breaking video up into multiple segments)"`
-    );
+    expect(result.message).toMatchInlineSnapshot(`"Video too long"`);
     expect(result.type).toStrictEqual('guidance');
     expect(result.elementId).toStrictEqual(tooLongVideo.id);
   });

--- a/assets/src/edit-story/app/prepublish/guidance/test/text.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/text.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { MESSAGES } from '../../constants';
 import { pageTooMuchText, storyTooLittleText } from '../text';
 
 describe('Pre-publish checklist - text guidelines (guidance)', () => {
@@ -40,9 +41,10 @@ describe('Pre-publish checklist - text guidelines (guidance)', () => {
         ],
       };
       expect(pageTooMuchText(page)).toStrictEqual({
-        message: 'Too much text on page',
         pageId: page.id,
         type: 'guidance',
+        message: MESSAGES.TEXT.TOO_MUCH_PAGE_TEXT.MAIN_TEXT,
+        help: MESSAGES.TEXT.TOO_MUCH_PAGE_TEXT.HELPER_TEXT,
       });
     });
 
@@ -98,9 +100,10 @@ describe('Pre-publish checklist - text guidelines (guidance)', () => {
         ],
       };
       expect(storyTooLittleText(story)).toStrictEqual({
-        message: 'Too little text in story',
         storyId: story.id,
         type: 'guidance',
+        message: MESSAGES.TEXT.TOO_LITTLE_TEXT.MAIN_TEXT,
+        help: MESSAGES.TEXT.TOO_LITTLE_TEXT.HELPER_TEXT,
       });
     });
 

--- a/assets/src/edit-story/app/prepublish/guidance/text.js
+++ b/assets/src/edit-story/app/prepublish/guidance/text.js
@@ -15,15 +15,10 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import stripHTML from '../../../utils/stripHTML';
-import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
+import { PRE_PUBLISH_MESSAGE_TYPES, MESSAGES } from '../constants';
 
 const MAX_PAGE_CHARACTER_COUNT = 200;
 const MIN_STORY_CHARACTER_COUNT = 100;
@@ -55,9 +50,10 @@ export function pageTooMuchText(page) {
 
   if (characterCount > MAX_PAGE_CHARACTER_COUNT) {
     return {
-      message: __('Too much text on page', 'web-stories'),
       pageId: page.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
+      message: MESSAGES.TEXT.TOO_MUCH_PAGE_TEXT.MAIN_TEXT,
+      help: MESSAGES.TEXT.TOO_MUCH_PAGE_TEXT.HELPER_TEXT,
     };
   }
 
@@ -78,9 +74,10 @@ export function storyTooLittleText(story) {
 
   if (characterCount < MIN_STORY_CHARACTER_COUNT) {
     return {
-      message: __('Too little text in story', 'web-stories'),
       storyId: story.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
+      message: MESSAGES.TEXT.TOO_LITTLE_TEXT.MAIN_TEXT,
+      help: MESSAGES.TEXT.TOO_LITTLE_TEXT.HELPER_TEXT,
     };
   }
 

--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import {
@@ -27,7 +22,7 @@ import {
   calculateLuminanceFromStyleColor,
   checkContrastFromLuminances,
 } from '../../../utils/contrastUtils';
-import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
+import { MESSAGES, PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
 
 const MAX_PAGE_LINKS = 3;
 const LINK_TAPPABLE_REGION_MIN_WIDTH = 48;
@@ -90,10 +85,8 @@ export function textElementFontLowContrast(element) {
 
   if (lowContrast) {
     return {
-      message: __(
-        'Low contrast between font and background color',
-        'web-stories'
-      ),
+      message: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.MAIN_TEXT,
+      help: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.HELPER_TEXT,
       elementId: element.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };
@@ -111,7 +104,8 @@ export function textElementFontLowContrast(element) {
 export function textElementFontSizeTooSmall(element) {
   if (element.fontSize && element.fontSize < 12) {
     return {
-      message: __('Font size too small', 'web-stories'),
+      message: MESSAGES.ACCESSIBILITY.FONT_TOO_SMALL.MAIN_TEXT,
+      help: MESSAGES.ACCESSIBILITY.FONT_TOO_SMALL.HELPER_TEXT,
       elementId: element.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };
@@ -134,7 +128,8 @@ export function imageElementLowResolution(element) {
     element.height * scaleMultiplier > element.resource.height
   ) {
     return {
-      message: __('Very low image resolution', 'web-stories'),
+      message: MESSAGES.ACCESSIBILITY.LOW_IMAGE_RESOLUTION.MAIN_TEXT,
+      help: MESSAGES.ACCESSIBILITY.LOW_IMAGE_RESOLUTION.HELPER_TEXT,
       elementId: element.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };
@@ -152,7 +147,8 @@ export function imageElementLowResolution(element) {
 export function videoElementMissingTitle(element) {
   if (!element.title?.length && !element.resource?.title?.length) {
     return {
-      message: __('Video is missing title', 'web-stories'),
+      message: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_TITLE.MAIN_TEXT,
+      help: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_TITLE.HELPER_TEXT,
       elementId: element.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };
@@ -170,7 +166,8 @@ export function videoElementMissingTitle(element) {
 export function videoElementMissingAlt(element) {
   if (!element.alt?.length && !element.resource?.alt?.length) {
     return {
-      message: __('Video is missing assistive text', 'web-stories'),
+      message: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_ALT_TEXT.MAIN_TEXT,
+      help: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_ALT_TEXT.HELPER_TEXT,
       elementId: element.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };
@@ -188,7 +185,8 @@ export function videoElementMissingAlt(element) {
 export function videoElementMissingCaptions(element) {
   if (!element.tracks?.length) {
     return {
-      message: __('Video is missing captions', 'web-stories'),
+      message: MESSAGES.ACCESSIBILITY.MISSING_CAPTIONS.MAIN_TEXT,
+      help: MESSAGES.ACCESSIBILITY.MISSING_CAPTIONS.HELPER_TEXT,
       elementId: element.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };
@@ -213,7 +211,8 @@ export function pageTooManyLinks(page) {
 
   if (linkCount > MAX_PAGE_LINKS) {
     return {
-      message: __('Too many links on page', 'web-stories'),
+      message: MESSAGES.ACCESSIBILITY.TOO_MANY_LINKS.MAIN_TEXT,
+      help: MESSAGES.ACCESSIBILITY.TOO_MANY_LINKS.HELPER_TEXT,
       pageId: page.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };
@@ -238,7 +237,8 @@ export function elementLinkTappableRegionTooSmall(element) {
     element.height < LINK_TAPPABLE_REGION_MIN_HEIGHT
   ) {
     return {
-      message: __('Link tappable region is too small', 'web-stories'),
+      message: MESSAGES.ACCESSIBILITY.LINK_REGION_TOO_SMALL.MAIN_TEXT,
+      help: MESSAGES.ACCESSIBILITY.LINK_REGION_TOO_SMALL.HELPER_TEXT,
       elementId: element.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };
@@ -256,7 +256,8 @@ export function elementLinkTappableRegionTooSmall(element) {
 export function imageElementMissingAlt(element) {
   if (!element.alt?.length && !element.resource?.alt?.length) {
     return {
-      message: __('Image is missing alt text', 'web-stories'),
+      message: MESSAGES.ACCESSIBILITY.MISSING_IMAGE_ALT_TEXT.MAIN_TEXT,
+      help: MESSAGES.ACCESSIBILITY.MISSING_IMAGE_ALT_TEXT.HELPER_TEXT,
       elementId: element.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };

--- a/assets/src/edit-story/app/prepublish/warning/distribution.js
+++ b/assets/src/edit-story/app/prepublish/warning/distribution.js
@@ -15,14 +15,9 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
-import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
+import { PRE_PUBLISH_MESSAGE_TYPES, MESSAGES } from '../constants';
 
 /**
  * @typedef {import('../../../types').Story} Story
@@ -38,7 +33,8 @@ import { PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
 export function storyMissingExcerpt(story) {
   if (!story.excerpt?.length) {
     return {
-      message: __('Missing story excerpt', 'web-stories'),
+      message: MESSAGES.DISTRIBUTION.MISSING_DESCRIPTION.MAIN_TEXT,
+      help: MESSAGES.DISTRIBUTION.MISSING_DESCRIPTION.HELPER_TEXT,
       storyId: story.id,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { MESSAGES } from '../../constants';
 import * as accessibilityChecks from '../accessibility';
 
 describe('Pre-publish checklist - accessibility issues (warnings)', () => {
@@ -39,7 +40,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       expect(
         accessibilityChecks.textElementFontLowContrast(element)
       ).toStrictEqual({
-        message: 'Low contrast between font and background color',
+        message: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.MAIN_TEXT,
+        help: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.HELPER_TEXT,
         elementId: element.id,
         type: 'warning',
       });
@@ -109,7 +111,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       expect(
         accessibilityChecks.textElementFontSizeTooSmall(element)
       ).toStrictEqual({
-        message: 'Font size too small',
+        message: MESSAGES.ACCESSIBILITY.FONT_TOO_SMALL.MAIN_TEXT,
+        help: MESSAGES.ACCESSIBILITY.FONT_TOO_SMALL.HELPER_TEXT,
         elementId: element.id,
         type: 'warning',
       });
@@ -144,7 +147,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       expect(
         accessibilityChecks.imageElementLowResolution(element)
       ).toStrictEqual({
-        message: 'Very low image resolution',
+        message: MESSAGES.ACCESSIBILITY.LOW_IMAGE_RESOLUTION.MAIN_TEXT,
+        help: MESSAGES.ACCESSIBILITY.LOW_IMAGE_RESOLUTION.HELPER_TEXT,
         elementId: element.id,
         type: 'warning',
       });
@@ -166,7 +170,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       expect(
         accessibilityChecks.imageElementLowResolution(element)
       ).toStrictEqual({
-        message: 'Very low image resolution',
+        message: MESSAGES.ACCESSIBILITY.LOW_IMAGE_RESOLUTION.MAIN_TEXT,
+        help: MESSAGES.ACCESSIBILITY.LOW_IMAGE_RESOLUTION.HELPER_TEXT,
         elementId: element.id,
         type: 'warning',
       });
@@ -201,7 +206,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       expect(
         accessibilityChecks.videoElementMissingTitle(element)
       ).toStrictEqual({
-        message: 'Video is missing title',
+        message: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_TITLE.MAIN_TEXT,
+        help: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_TITLE.HELPER_TEXT,
         elementId: element.id,
         type: 'warning',
       });
@@ -219,7 +225,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       expect(
         accessibilityChecks.videoElementMissingTitle(element)
       ).toStrictEqual({
-        message: 'Video is missing title',
+        message: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_TITLE.MAIN_TEXT,
+        help: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_TITLE.HELPER_TEXT,
         elementId: element.id,
         type: 'warning',
       });
@@ -260,7 +267,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       };
       expect(accessibilityChecks.videoElementMissingAlt(element)).toStrictEqual(
         {
-          message: 'Video is missing assistive text',
+          message: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_ALT_TEXT.MAIN_TEXT,
+          help: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_ALT_TEXT.HELPER_TEXT,
           elementId: element.id,
           type: 'warning',
         }
@@ -278,7 +286,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       };
       expect(accessibilityChecks.videoElementMissingAlt(element)).toStrictEqual(
         {
-          message: 'Video is missing assistive text',
+          message: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_ALT_TEXT.MAIN_TEXT,
+          help: MESSAGES.ACCESSIBILITY.MISSING_VIDEO_ALT_TEXT.HELPER_TEXT,
           elementId: element.id,
           type: 'warning',
         }
@@ -320,7 +329,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       expect(
         accessibilityChecks.videoElementMissingCaptions(element)
       ).toStrictEqual({
-        message: 'Video is missing captions',
+        message: MESSAGES.ACCESSIBILITY.MISSING_CAPTIONS.MAIN_TEXT,
+        help: MESSAGES.ACCESSIBILITY.MISSING_CAPTIONS.HELPER_TEXT,
         elementId: element.id,
         type: 'warning',
       });
@@ -335,7 +345,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       expect(
         accessibilityChecks.videoElementMissingCaptions(element)
       ).toStrictEqual({
-        message: 'Video is missing captions',
+        message: MESSAGES.ACCESSIBILITY.MISSING_CAPTIONS.MAIN_TEXT,
+        help: MESSAGES.ACCESSIBILITY.MISSING_CAPTIONS.HELPER_TEXT,
         elementId: element.id,
         type: 'warning',
       });
@@ -393,7 +404,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
         ],
       };
       expect(accessibilityChecks.pageTooManyLinks(page)).toStrictEqual({
-        message: 'Too many links on page',
+        message: MESSAGES.ACCESSIBILITY.TOO_MANY_LINKS.MAIN_TEXT,
+        help: MESSAGES.ACCESSIBILITY.TOO_MANY_LINKS.HELPER_TEXT,
         pageId: page.id,
         type: 'warning',
       });
@@ -449,7 +461,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       expect(
         accessibilityChecks.elementLinkTappableRegionTooSmall(element)
       ).toStrictEqual({
-        message: 'Link tappable region is too small',
+        message: MESSAGES.ACCESSIBILITY.LINK_REGION_TOO_SMALL.MAIN_TEXT,
+        help: MESSAGES.ACCESSIBILITY.LINK_REGION_TOO_SMALL.HELPER_TEXT,
         elementId: element.id,
         type: 'warning',
       });
@@ -494,7 +507,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       };
       expect(accessibilityChecks.imageElementMissingAlt(element)).toStrictEqual(
         {
-          message: 'Image is missing alt text',
+          message: MESSAGES.ACCESSIBILITY.MISSING_IMAGE_ALT_TEXT.MAIN_TEXT,
+          help: MESSAGES.ACCESSIBILITY.MISSING_IMAGE_ALT_TEXT.HELPER_TEXT,
           elementId: element.id,
           type: 'warning',
         }
@@ -512,7 +526,8 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       };
       expect(accessibilityChecks.imageElementMissingAlt(element)).toStrictEqual(
         {
-          message: 'Image is missing alt text',
+          message: MESSAGES.ACCESSIBILITY.MISSING_IMAGE_ALT_TEXT.MAIN_TEXT,
+          help: MESSAGES.ACCESSIBILITY.MISSING_IMAGE_ALT_TEXT.HELPER_TEXT,
           elementId: element.id,
           type: 'warning',
         }

--- a/assets/src/edit-story/app/prepublish/warning/test/distribution.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/distribution.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { MESSAGES } from '../../constants';
 import * as distributionChecks from '../distribution';
 
 describe('Pre-publish checklist - distribution issues (warnings)', () => {
@@ -26,7 +27,8 @@ describe('Pre-publish checklist - distribution issues (warnings)', () => {
         id: 'storyid',
       };
       expect(distributionChecks.storyMissingExcerpt(story)).toStrictEqual({
-        message: 'Missing story excerpt',
+        message: MESSAGES.DISTRIBUTION.MISSING_DESCRIPTION.MAIN_TEXT,
+        help: MESSAGES.DISTRIBUTION.MISSING_DESCRIPTION.HELPER_TEXT,
         storyId: story.id,
         type: 'warning',
       });
@@ -38,7 +40,8 @@ describe('Pre-publish checklist - distribution issues (warnings)', () => {
         excerpt: '',
       };
       expect(distributionChecks.storyMissingExcerpt(story)).toStrictEqual({
-        message: 'Missing story excerpt',
+        message: MESSAGES.DISTRIBUTION.MISSING_DESCRIPTION.MAIN_TEXT,
+        help: MESSAGES.DISTRIBUTION.MISSING_DESCRIPTION.HELPER_TEXT,
         storyId: story.id,
         type: 'warning',
       });


### PR DESCRIPTION
## Summary

- Organize the translatable text for the pre-publish checklist error messages in a centralized file

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- Instead of including this just in the MVP #78 (PR out [here](https://github.com/google/web-stories-wp/pull/5244)), I decided to split this task out and rebase the other PR on this one, so this could be more easily reviewed.

- Text and helper text came from [this spreadsheet](https://docs.google.com/spreadsheets/d/1PjaRp4bueQ3Cv14A7I696m0vjGCIX_kN9tIGh-V-Bkc/edit?pli=1#gid=0)

<!-- Please describe your changes. -->

## To-do

- [x] Not sure how to include this "more info" link, which goes with video/image too small message: [more info](https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/#visual-treat ... what wp translator tools am I missing?

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- none
<!-- Please describe your changes. -->

## Testing Instructions
- N/A, unit tests should pass 👍 
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

