### PR TITLE
Animation Panel: Update UI and connect Direction Picker

### DIFF
--- a/assets/src/animation/constants.js
+++ b/assets/src/animation/constants.js
@@ -117,6 +117,8 @@ export const AXIS = {
 export const FIELD_TYPES = {
   DROPDOWN: 'dropdown',
   HIDDEN: 'hidden',
+  ROTATION_PICKER: 'rotation_picker',
+  DIRECTION_PICKER: 'direction_picker',
   NUMBER: 'number',
   FLOAT: 'float',
   TEXT: 'text',

--- a/assets/src/animation/effects/flyIn/animationProps.js
+++ b/assets/src/animation/effects/flyIn/animationProps.js
@@ -37,7 +37,7 @@ export const FlyInEffectInputPropTypes = {
 export default {
   flyInDir: {
     label: __('Direction', 'web-stories'),
-    type: FIELD_TYPES.DROPDOWN,
+    type: FIELD_TYPES.DIRECTION_PICKER,
     values: [
       DIRECTION.TOP_TO_BOTTOM,
       DIRECTION.BOTTOM_TO_TOP,

--- a/assets/src/animation/effects/pan/animationProps.js
+++ b/assets/src/animation/effects/pan/animationProps.js
@@ -37,7 +37,7 @@ export const PanEffectInputPropTypes = {
 export default {
   panDir: {
     label: __('Direction', 'web-stories'),
-    type: FIELD_TYPES.DROPDOWN,
+    type: FIELD_TYPES.DIRECTION_PICKER,
     values: [
       DIRECTION.TOP_TO_BOTTOM,
       DIRECTION.BOTTOM_TO_TOP,

--- a/assets/src/animation/effects/rotateIn/animationProps.js
+++ b/assets/src/animation/effects/rotateIn/animationProps.js
@@ -39,7 +39,7 @@ export const RotateInEffectInputPropTypes = {
 export default {
   rotateInDir: {
     label: __('Direction', 'web-stories'),
-    type: FIELD_TYPES.DROPDOWN,
+    type: FIELD_TYPES.ROTATION_PICKER,
     values: [DIRECTION.LEFT_TO_RIGHT, DIRECTION.RIGHT_TO_LEFT],
     defaultValue: DIRECTION.LEFT_TO_RIGHT,
   },

--- a/assets/src/animation/effects/rotateIn/animationProps.js
+++ b/assets/src/animation/effects/rotateIn/animationProps.js
@@ -44,12 +44,12 @@ export default {
     defaultValue: DIRECTION.LEFT_TO_RIGHT,
   },
   stopAngle: {
-    label: __('Stop Angle', 'web-stories'),
+    label: __('Angle', 'web-stories'),
     type: FIELD_TYPES.NUMBER,
     defaultValue: 0,
   },
   numberOfRotations: {
-    label: __('# of Rotations', 'web-stories'),
+    label: __('Rotations', 'web-stories'),
     type: FIELD_TYPES.NUMBER,
     defaultValue: 1,
   },

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -55,13 +55,16 @@ const Icon = styled.div`
 
 const RotationIcon = () => (
   <Svg size="19px" viewBox="0 0 19 18">
-    <path d="M1 17.5V17.5C1 10.5964 6.59644 5 13.5 5L17.5 5M17.5 5L13.5 1M17.5 5L13.5 9" />
+    <path
+      strokeLinecap="round"
+      d="M1 17.5V17.5C1 10.5964 6.59644 5 13.5 5L17.5 5M17.5 5L13.5 1M17.5 5L13.5 9"
+    />
   </Svg>
 );
 
 const DirectionIcon = () => (
-  <Svg size="10px" viewBox="0 0 10 11">
-    <path d="M5 11L5 1M5 1L9 5M5 1L1 5" />
+  <Svg size="16px" viewBox="0 0 10 11">
+    <path strokeLinecap="round" d="M5 11L5 1M5 1L9 5M5 1L1 5" />
   </Svg>
 );
 
@@ -85,8 +88,8 @@ const DirectionIndicator = styled(Direction)``;
 
 const Fieldset = styled.fieldset`
   position: relative;
-  height: 63px;
-  width: 63px;
+  height: 80px;
+  width: 80px;
   background-color: ${({ theme }) => theme.colors.bg.workspace};
   border: 1px solid ${({ theme }) => theme.colors.fg.v9};
   border-radius: 4px;

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -51,10 +51,6 @@ import {
   TwirlInAnimation,
   WhooshInLeftAnimation,
   WhooshInRightAnimation,
-  PanRightAnimation,
-  PanBottomAnimation,
-  PanTopAnimation,
-  PanLeftAnimation,
   ZoomInAnimation,
   ZoomOutAnimation,
   BaseAnimationCell,
@@ -116,6 +112,7 @@ const GridItemHalfRow = styled(GridItem)`
 
 export default function EffectChooser({
   onAnimationSelected,
+  onNoEffectSelected,
   onDismiss,
   isBackgroundEffects = false,
 }) {
@@ -130,6 +127,12 @@ export default function EffectChooser({
   return (
     <Container ref={ref}>
       <Grid>
+        <GridItemFullRow
+          onClick={onNoEffectSelected}
+          aria-label={__('No Effect', 'web-stories')}
+        >
+          <span>{__('No Effect', 'web-stories')}</span>
+        </GridItemFullRow>
         {isBackgroundEffects ? (
           <GridItemFullRow
             aria-label={__('Zoom Effect', 'web-stories')}
@@ -337,6 +340,7 @@ export default function EffectChooser({
 
 EffectChooser.propTypes = {
   onAnimationSelected: propTypes.func.isRequired,
+  onNoEffectSelected: propTypes.func.isRequired,
   onDismiss: propTypes.func,
   isBackgroundEffects: propTypes.bool,
 };

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -233,14 +233,11 @@ export default function EffectChooser({
               <PulseAnimation>{__('Pulse', 'web-stories')}</PulseAnimation>
             </GridItemFullRow>
             <GridItemHalfRow
-              aria-label={__(
-                'Rotate In Counter Clockwise Effect',
-                'web-stories'
-              )}
+              aria-label={__('Rotate In Left Effect', 'web-stories')}
               onClick={() =>
                 onAnimationSelected({
                   animation: ANIMATION_EFFECTS.ROTATE_IN.value,
-                  rotateInDir: ROTATION.COUNTER_CLOCKWISE,
+                  rotateInDir: DIRECTION.LEFT_TO_RIGHT,
                 })
               }
             >
@@ -250,11 +247,11 @@ export default function EffectChooser({
               </RotateInLeftAnimation>
             </GridItemHalfRow>
             <GridItemHalfRow
-              aria-label={__('Rotate In Clockwise Effect', 'web-stories')}
+              aria-label={__('Rotate In Right Effect', 'web-stories')}
               onClick={() =>
                 onAnimationSelected({
                   animation: ANIMATION_EFFECTS.ROTATE_IN.value,
-                  rotateInDir: ROTATION.CLOCKWISE,
+                  rotateInDir: DIRECTION.RIGHT_TO_LEFT,
                 })
               }
             >

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -300,56 +300,6 @@ export default function EffectChooser({
               </WhooshInRightAnimation>
               <ContentWrapper>{__('Whoosh In', 'web-stories')}</ContentWrapper>
             </GridItemHalfRow>
-            <GridItem
-              aria-label={__('Pan from Left Effect', 'web-stories')}
-              onClick={() =>
-                onAnimationSelected({
-                  animation: ANIMATION_EFFECTS.PAN.value,
-                  panDir: DIRECTION.LEFT_TO_RIGHT,
-                })
-              }
-            >
-              <ContentWrapper>{__('Pan', 'web-stories')}</ContentWrapper>
-              <PanLeftAnimation>{__('Pan', 'web-stories')}</PanLeftAnimation>
-            </GridItem>
-            <GridItem
-              aria-label={__('Pan from Top Effect', 'web-stories')}
-              onClick={() =>
-                onAnimationSelected({
-                  animation: ANIMATION_EFFECTS.PAN.value,
-                  panDir: DIRECTION.TOP_TO_BOTTOM,
-                })
-              }
-            >
-              <ContentWrapper>{__('Pan', 'web-stories')}</ContentWrapper>
-              <PanTopAnimation>{__('Pan', 'web-stories')}</PanTopAnimation>
-            </GridItem>
-            <GridItem
-              aria-label={__('Pan from Bottom Effect', 'web-stories')}
-              onClick={() =>
-                onAnimationSelected({
-                  animation: ANIMATION_EFFECTS.PAN.value,
-                  panDir: DIRECTION.BOTTOM_TO_TOP,
-                })
-              }
-            >
-              <ContentWrapper>{__('Pan', 'web-stories')}</ContentWrapper>{' '}
-              <PanBottomAnimation>
-                {__('Pan', 'web-stories')}
-              </PanBottomAnimation>
-            </GridItem>
-            <GridItem
-              aria-label={__('Pan from Right Effect', 'web-stories')}
-              onClick={() =>
-                onAnimationSelected({
-                  animation: ANIMATION_EFFECTS.PAN.value,
-                  panDir: DIRECTION.RIGHT_TO_LEFT,
-                })
-              }
-            >
-              <ContentWrapper>{__('Pan', 'web-stories')}</ContentWrapper>
-              <PanRightAnimation>{__('Pan', 'web-stories')}</PanRightAnimation>
-            </GridItem>
             <GridItemHalfRow
               aria-label={__('Zoom In Effect', 'web-stories')}
               onClick={() =>

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -34,7 +34,6 @@ import {
   ANIMATION_EFFECTS,
   BACKGROUND_ANIMATION_EFFECTS,
   DIRECTION,
-  ROTATION,
 } from '../../../../animation';
 import useFocusOut from '../../../utils/useFocusOut';
 import {

--- a/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
@@ -45,6 +45,7 @@ const Container = styled.div`
 
 export default function EffectChooserDropdown({
   onAnimationSelected,
+  onNoEffectSelected,
   isBackgroundEffects = false,
   selectedEffectTitle,
 }) {
@@ -69,6 +70,7 @@ export default function EffectChooserDropdown({
       >
         <Container ref={dropdownRef}>
           <EffectChooser
+            onNoEffectSelected={onNoEffectSelected}
             onAnimationSelected={onAnimationSelected}
             onDismiss={() => setIsOpen(false)}
             isBackgroundEffects={isBackgroundEffects}
@@ -83,4 +85,5 @@ EffectChooserDropdown.propTypes = {
   onAnimationSelected: propTypes.func.isRequired,
   isBackgroundEffects: propTypes.bool,
   selectedEffectTitle: propTypes.string,
+  onNoEffectSelected: propTypes.func.isRequired,
 };

--- a/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
@@ -46,6 +46,7 @@ const Container = styled.div`
 export default function EffectChooserDropdown({
   onAnimationSelected,
   isBackgroundEffects = false,
+  selectedEffectTitle,
 }) {
   const selectRef = useRef();
   const dropdownRef = useRef();
@@ -53,7 +54,9 @@ export default function EffectChooserDropdown({
 
   return (
     <DropDownSelect ref={selectRef} onClick={() => setIsOpen(!isOpen)}>
-      <DropDownTitle>{__('Select Animation', 'web-stories')}</DropDownTitle>
+      <DropDownTitle>
+        {selectedEffectTitle || __('Select Animation', 'web-stories')}
+      </DropDownTitle>
       <DropdownIcon />
       <Popup
         anchor={selectRef}
@@ -75,4 +78,5 @@ export default function EffectChooserDropdown({
 EffectChooserDropdown.propTypes = {
   onAnimationSelected: propTypes.func.isRequired,
   isBackgroundEffects: propTypes.bool,
+  selectedEffectTitle: propTypes.string,
 };

--- a/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
@@ -53,7 +53,11 @@ export default function EffectChooserDropdown({
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <DropDownSelect ref={selectRef} onClick={() => setIsOpen(!isOpen)}>
+    <DropDownSelect
+      aria-label={__('Animation: Effect Chooser', 'web-stories')}
+      ref={selectRef}
+      onClick={() => setIsOpen(!isOpen)}
+    >
       <DropDownTitle>
         {selectedEffectTitle || __('Select Animation', 'web-stories')}
       </DropDownTitle>

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -26,8 +26,8 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { DIRECTION, FIELD_TYPES } from '../../../../animation/constants';
-import { GeneralAnimationPropTypes } from '../../../../animation/outputs/types';
+import { DIRECTION, FIELD_TYPES } from '../../../../animation';
+import { GeneralAnimationPropTypes } from '../../../../animation/outputs';
 import { AnimationFormPropTypes } from '../../../../animation/types';
 import { DropDown, BoxedNumeric } from '../../form';
 import RangeInput from '../../rangeInput';

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -16,7 +16,8 @@
 
 /**
  * External dependencies
- */
+ */ import { useCallback } from 'react';
+
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import { rgba } from 'polished';
@@ -25,11 +26,12 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES } from '../../../../animation/constants';
+import { DIRECTION, FIELD_TYPES } from '../../../../animation/constants';
 import { GeneralAnimationPropTypes } from '../../../../animation/outputs/types';
 import { AnimationFormPropTypes } from '../../../../animation/types';
 import { DropDown, BoxedNumeric } from '../../form';
 import RangeInput from '../../rangeInput';
+import { DirectionRadioInput } from './directionRadioInput';
 
 const RangeContainer = styled.div`
   width: 100%;
@@ -46,6 +48,10 @@ const Label = styled.label`
 
 function EffectInput({ effectProps, effectConfig, field, onChange }) {
   const rangeId = `range-${uuidv4()}`;
+  const directionControlOnChange = useCallback(
+    ({ nativeEvent: { target } }) => onChange(target.value, true),
+    [onChange]
+  );
   switch (effectProps[field].type) {
     case FIELD_TYPES.DROPDOWN:
       return (
@@ -74,6 +80,26 @@ function EffectInput({ effectProps, effectConfig, field, onChange }) {
             style={{ width: '100%' }}
           />
         </RangeContainer>
+      );
+    case FIELD_TYPES.DIRECTION_PICKER:
+      return (
+        <DirectionRadioInput
+          directions={Object.values(DIRECTION)}
+          defaultChecked={
+            effectConfig[field] || effectProps[field].defaultValue
+          }
+          onChange={directionControlOnChange}
+        />
+      );
+    case FIELD_TYPES.ROTATION_PICKER:
+      return (
+        <DirectionRadioInput
+          directions={[DIRECTION.LEFT_TO_RIGHT, DIRECTION.RIGHT_TO_LEFT]}
+          defaultChecked={
+            effectConfig[field] || effectProps[field].defaultValue
+          }
+          onChange={directionControlOnChange}
+        />
       );
     default:
       return (

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -95,21 +95,7 @@ function EffectPanel({
     </Row>
   ));
 
-  return (
-    <Panel key={id} name={type} canCollapse={false}>
-      <PanelTitle
-        canCollapse={false}
-        secondaryAction={
-          <Button onClick={handleRemoveClick}>
-            {__('Delete', 'web-stories')}
-          </Button>
-        }
-      >
-        {getEffectName(type)}
-      </PanelTitle>
-      <PanelContent>{content}</PanelContent>
-    </Panel>
-  );
+  return content;
 }
 
 EffectPanel.propTypes = {

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -85,15 +85,6 @@ function EffectPanel({ animation: { id, type, ...config }, onChange }) {
     [id, type, config, onChange]
   );
 
-  // const handleRemoveClick = useCallback(() => {
-  //   onRemove({
-  //     id,
-  //     type,
-  //     ...config,
-  //     delete: true,
-  //   });
-  // }, [id, type, config, onRemove]);
-
   const containsVisualPicker = useMemo(() => {
     return Object.keys(props).reduce((memo, current) => {
       return (
@@ -127,7 +118,6 @@ function EffectPanel({ animation: { id, type, ...config }, onChange }) {
 EffectPanel.propTypes = {
   animation: PropTypes.shape(AnimationProps),
   onChange: PropTypes.func.isRequired,
-  // onRemove: PropTypes.func.isRequired,
 };
 
 export default EffectPanel;

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -41,7 +41,7 @@ import { Row, Button } from '../../form';
 import { Panel, PanelTitle, PanelContent } from '../panel';
 import EffectInput from './effectInput';
 
-function getEffectName(type) {
+export function getEffectName(type) {
   return (
     [
       ...Object.values(ANIMATION_EFFECTS),
@@ -96,8 +96,9 @@ function EffectPanel({
   ));
 
   return (
-    <Panel key={id} name={type}>
+    <Panel key={id} name={type} canCollapse={false}>
       <PanelTitle
+        canCollapse={false}
         secondaryAction={
           <Button onClick={handleRemoveClick}>
             {__('Delete', 'web-stories')}

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -80,12 +80,14 @@ function AnimationPanel({
       .filter((a) => !a.delete);
   }, [selectedElements, selectedElementAnimations]);
 
-  const handleAddEffect = useCallback(
+  const elAnimationId = updatedAnimations[0]?.id;
+  const handleAddOrUpdateElementEffect = useCallback(
     ({ animation, ...options }) => {
       if (!animation) {
         return;
       }
 
+      const id = elAnimationId || uuidv4();
       const defaults = getAnimationEffectDefaults(animation);
 
       // Background Zoom's `scale from` initial value should match
@@ -102,7 +104,7 @@ function AnimationPanel({
       pushUpdateForObject(
         ANIMATION_PROPERTY,
         {
-          id: uuidv4(),
+          id,
           type: animation,
           ...defaults,
           ...options,
@@ -111,7 +113,7 @@ function AnimationPanel({
         true
       );
     },
-    [pushUpdateForObject, isBackground, backgroundScale]
+    [elAnimationId, isBackground, pushUpdateForObject, backgroundScale]
   );
 
   return selectedElements.length > 1 ? (
@@ -124,7 +126,7 @@ function AnimationPanel({
     <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
       <Row>
         <EffectChooserDropdown
-          onAnimationSelected={handleAddEffect}
+          onAnimationSelected={handleAddOrUpdateElementEffect}
           selectedEffectTitle={getEffectName(updatedAnimations[0]?.type)}
         />
       </Row>

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -67,6 +67,19 @@ function AnimationPanel({
   const isBackground =
     selectedElements.length === 1 && selectedElements[0].isBackground;
   const backgroundScale = isBackground && selectedElements[0].scale;
+  const updatedAnimations = useMemo(() => {
+    // Combining local element updates with the
+    // page level applied updates
+    const updated = selectedElements
+      .map((element) => element.animation)
+      .filter(Boolean);
+    return selectedElementAnimations
+      .map((anim) => ({
+        ...(updated.find((a) => a.id === anim.id) || anim),
+      }))
+      .filter((a) => !a.delete);
+  }, [selectedElements, selectedElementAnimations]);
+
   const handleAddEffect = useCallback(
     ({ animation, ...options }) => {
       if (!animation) {
@@ -100,19 +113,6 @@ function AnimationPanel({
     },
     [pushUpdateForObject, isBackground, backgroundScale]
   );
-
-  const updatedAnimations = useMemo(() => {
-    // Combining local element updates with the
-    // page level applied updates
-    const updated = selectedElements
-      .map((element) => element.animation)
-      .filter(Boolean);
-    return selectedElementAnimations
-      .map((anim) => ({
-        ...(updated.find((a) => a.id === anim.id) || anim),
-      }))
-      .filter((a) => !a.delete);
-  }, [selectedElements, selectedElementAnimations]);
 
   return selectedElements.length > 1 ? (
     <SimplePanel name="animation" title={__('Animation', 'web-stories')}>

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -40,7 +40,7 @@ import StoryPropTypes, { AnimationPropType } from '../../../types';
 import { Row } from '../../form';
 import { SimplePanel } from '../panel';
 import { Note } from '../shared';
-import EffectPanel from './effectPanel';
+import EffectPanel, { getEffectName } from './effectPanel';
 import EffectChooserDropdown from './effectChooserDropdown';
 
 const ANIMATION_PROPERTY = 'animation';
@@ -127,6 +127,7 @@ function AnimationPanel({
           <EffectChooserDropdown
             onAnimationSelected={handleAddEffect}
             isBackgroundEffects={isBackground}
+            selectedEffectTitle={getEffectName(updatedAnimations[0]?.type)}
           />
         </Row>
       </SimplePanel>

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -121,25 +121,21 @@ function AnimationPanel({
       </Row>
     </SimplePanel>
   ) : (
-    <>
-      <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
-        <Row>
-          <EffectChooserDropdown
-            onAnimationSelected={handleAddEffect}
-            isBackgroundEffects={isBackground}
-            selectedEffectTitle={getEffectName(updatedAnimations[0]?.type)}
-          />
-        </Row>
-      </SimplePanel>
-      {updatedAnimations.map((animation) => (
+    <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
+      <Row>
+        <EffectChooserDropdown
+          onAnimationSelected={handleAddEffect}
+          selectedEffectTitle={getEffectName(updatedAnimations[0]?.type)}
+        />
+      </Row>
+      {updatedAnimations[0] && (
         <EffectPanel
-          key={animation.id}
-          animation={animation}
+          animation={updatedAnimations[0]}
           onChange={handlePanelChange}
           onRemove={handleRemoveEffect}
         />
-      ))}
-    </>
+      )}
+    </SimplePanel>
   );
 }
 

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -57,13 +57,6 @@ function AnimationPanel({
     [pushUpdateForObject]
   );
 
-  const handleRemoveEffect = useCallback(
-    (animation) => {
-      pushUpdateForObject(ANIMATION_PROPERTY, animation, null, true);
-    },
-    [pushUpdateForObject]
-  );
-
   const isBackground =
     selectedElements.length === 1 && selectedElements[0].isBackground;
   const backgroundScale = isBackground && selectedElements[0].scale;
@@ -116,6 +109,18 @@ function AnimationPanel({
     [elAnimationId, isBackground, pushUpdateForObject, backgroundScale]
   );
 
+  const handleRemoveEffect = useCallback(() => {
+    pushUpdateForObject(
+      ANIMATION_PROPERTY,
+      {
+        ...updatedAnimations[0],
+        delete: true,
+      },
+      null,
+      true
+    );
+  }, [pushUpdateForObject, updatedAnimations]);
+
   return selectedElements.length > 1 ? (
     <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
       <Row>
@@ -128,13 +133,13 @@ function AnimationPanel({
         <EffectChooserDropdown
           onAnimationSelected={handleAddOrUpdateElementEffect}
           selectedEffectTitle={getEffectName(updatedAnimations[0]?.type)}
+          onNoEffectSelected={handleRemoveEffect}
         />
       </Row>
       {updatedAnimations[0] && (
         <EffectPanel
           animation={updatedAnimations[0]}
           onChange={handlePanelChange}
-          onRemove={handleRemoveEffect}
         />
       )}
     </SimplePanel>

--- a/assets/src/edit-story/components/panels/animation/test/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/test/effectChooser.js
@@ -21,11 +21,7 @@ import { fireEvent } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import {
-  ANIMATION_EFFECTS,
-  DIRECTION,
-  ROTATION,
-} from '../../../../../animation';
+import { ANIMATION_EFFECTS, DIRECTION } from '../../../../../animation';
 import { renderWithTheme } from '../../../../testUtils';
 import EffectChooser from '../effectChooser';
 
@@ -63,11 +59,11 @@ describe('<EffectChooser />', function () {
       <EffectChooser onAnimationSelected={onAnimationSelected} />
     );
 
-    fireEvent.click(getByLabelText('Rotate In Counter Clockwise Effect'));
+    fireEvent.click(getByLabelText('Rotate In Left Effect'));
 
     expect(onAnimationSelected).toHaveBeenCalledWith({
       animation: ANIMATION_EFFECTS.ROTATE_IN.value,
-      rotateInDir: ROTATION.COUNTER_CLOCKWISE,
+      rotateInDir: DIRECTION.LEFT_TO_RIGHT,
     });
   });
 

--- a/assets/src/edit-story/components/panels/karma/animation.karma.js
+++ b/assets/src/edit-story/components/panels/karma/animation.karma.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma/fixture';
+
+describe('Animation Panel', function () {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    fixture.setFlags({ enableAnimation: true });
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  it('should render the animation panel when an element is selected.', async function () {
+    await fixture.events.click(fixture.editor.library.textAdd);
+    const panel = fixture.editor.inspector.designPanel.animation;
+    expect(panel).not.toBeNull();
+  });
+
+  it('can click the animation chooser and select an effect.', async function () {
+    await fixture.events.click(fixture.editor.library.textAdd);
+    const panel = fixture.editor.inspector.designPanel.animation;
+
+    const effectChooser = panel.effectChooser;
+    await fixture.events.click(effectChooser, { clickCount: 1 });
+
+    await fixture.events.click(
+      fixture.screen.getByRole('listitem', { name: /Fade In Effect/ })
+    );
+
+    expect(effectChooser.innerText).toBe('Fade In');
+  });
+
+  it('replaces an existing effect with a new one.', async function () {
+    await fixture.events.click(fixture.editor.library.textAdd);
+    const panel = fixture.editor.inspector.designPanel.animation;
+
+    const effectChooser = panel.effectChooser;
+    await fixture.events.click(effectChooser, { clickCount: 1 });
+
+    await fixture.events.click(
+      fixture.screen.getByRole('listitem', { name: /Fade In Effect/ })
+    );
+
+    expect(effectChooser.innerText).toBe('Fade In');
+
+    await fixture.events.click(effectChooser, { clickCount: 1 });
+
+    await fixture.events.click(
+      fixture.screen.getByRole('listitem', { name: /Drop Effect/ })
+    );
+
+    expect(effectChooser.innerText).toBe('Drop');
+  });
+});

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/animationPanel.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/animationPanel.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { AbstractPanel } from './abstractPanel';
+
+export class Animation extends AbstractPanel {
+  constructor(node, path) {
+    super(node, path);
+  }
+
+  get effectChooser() {
+    return this.getByRole('button', { name: /Animation: Effect Chooser/ });
+  }
+}

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/index.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/index.js
@@ -33,6 +33,7 @@ import { TextStylePreset } from './textStylePreset';
 import { ColorPreset } from './colorPreset';
 import { SizePosition } from './sizePosition';
 import { Border } from './border';
+import { Animation } from './animationPanel';
 
 /**
  * The editor's canvas. Includes: display, frames, editor layers, carousel,
@@ -144,6 +145,14 @@ export class DesignPanel extends Container {
   get videoOptions() {
     // @todo: implement
     return null;
+  }
+
+  get animation() {
+    return this._get(
+      this.getByRole('region', { name: /Animation/ }),
+      'animation',
+      Animation
+    );
   }
 
   get layerPanel() {


### PR DESCRIPTION
## Summary

- Adds in the Direction Picker and dual-column UI for animation effects
- Sets one animation per element
- Removes PAN since it's for background elements only
- Adds "No Effect" option to delete animation for that element

<img width="296" alt="Screen Shot 2020-11-18 at 6 58 16 PM" src="https://user-images.githubusercontent.com/1738349/99611888-16610b00-29da-11eb-8ce0-5243b06def2f.png">
<img width="283" alt="Screen Shot 2020-11-18 at 6 58 05 PM" src="https://user-images.githubusercontent.com/1738349/99611891-16f9a180-29da-11eb-9a97-f4ced909ca16.png">
 

## Relevant Technical Choices

- Continues existing patterns; no major technical choices

## To-do

- None

## User-facing changes

- None, behind flag, updates UI to match new designs and connects direction picker

## Testing Instructions

1. Enable Animation feature flag
2. See the animation panel on the right when an element is selected
3. See the direction picker for Fly In animations
---

<!-- Please reference the issue(s) this PR addresses. -->

#3804 #3443 
