### PR TITLE
WordPress 5.6 Compatibility

### DIFF
--- a/.github/workflows/continuous-integration-unit-php.yml
+++ b/.github/workflows/continuous-integration-unit-php.yml
@@ -24,10 +24,13 @@ jobs:
     continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       matrix:
-        php: [ '7.4', '7.0', '5.6' ]
+        php: [ '7.0', '5.6' ]
         wp: [ 'latest' ]
         coverage: [ false ]
         include:
+          - php: '7.4'
+            wp: 'latest'
+            coverage: true
 
           - php: '5.6'
             wp: '5.3'
@@ -40,9 +43,11 @@ jobs:
             wp: 'trunk'
             experimental: true
 
-          - php: '8.0'
-            wp: 'trunk'
-            experimental: true
+# Disabled as long as WordPress trunk does not properly support PHP 8
+#          - php: '8.0'
+#            wp: 'trunk'
+#            coverage: false
+#            experimental: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/continuous-integration-unit-php.yml
+++ b/.github/workflows/continuous-integration-unit-php.yml
@@ -24,22 +24,28 @@ jobs:
     continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       matrix:
-        php: ['7.0', '5.6']
-        wp: ['5.3', 'latest']
-        coverage: [false]
+        php: [ '7.4', '7.0' ]
+        wp: [ 'latest' ]
+        coverage: [ false ]
         include:
           - php: '7.4'
             wp: 'latest'
             coverage: true
+
+          - php: '5.6'
+            wp: '5.3'
+
+          - php: '7.4'
+            wp: '5.6'
+            experimental: true
+
           - php: '7.4'
             wp: 'trunk'
-            coverage: false
             experimental: true
-    # Disabled as long as WordPress trunk does not properly support PHP 8
-    #          - php: '8.0'
-    #            wp: 'trunk'
-    #            coverage: false
-    #            experimental: true
+
+          - php: '8.0'
+            wp: 'trunk'
+            experimental: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/continuous-integration-unit-php.yml
+++ b/.github/workflows/continuous-integration-unit-php.yml
@@ -36,6 +36,7 @@ jobs:
             wp: '5.3'
 
           - php: '7.4'
+# TODO Change to 5.6 after stable release of WP.
             wp: '5.6-RC1'
             experimental: true
 

--- a/.github/workflows/continuous-integration-unit-php.yml
+++ b/.github/workflows/continuous-integration-unit-php.yml
@@ -24,19 +24,16 @@ jobs:
     continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       matrix:
-        php: [ '7.4', '7.0' ]
+        php: [ '7.4', '7.0', '5.6' ]
         wp: [ 'latest' ]
         coverage: [ false ]
         include:
-          - php: '7.4'
-            wp: 'latest'
-            coverage: true
 
           - php: '5.6'
             wp: '5.3'
 
           - php: '7.4'
-            wp: '5.6'
+            wp: '5.6-RC1'
             experimental: true
 
           - php: '7.4'

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      google
 Requires at least: 5.3
-Tested up to:      5.5
+Tested up to:      5.6
 Requires PHP:      5.6
 Stable tag:        1.1.1
 License:           Apache License 2.0


### PR DESCRIPTION
## Summary

Change tested to 5.6. 

## Relevant Technical Choices

Tweak testing matrix. 

I have set the version 5.6-RC1 for now. We can change this later when finally released. 

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4788
