### PR TITLE
Text Style: Reset font weight to regular on font family change

### DIFF
--- a/assets/src/edit-story/components/panels/karma/textStyle.karma.js
+++ b/assets/src/edit-story/components/panels/karma/textStyle.karma.js
@@ -160,6 +160,36 @@ describe('Text Style Panel', () => {
         expect(elements[1].font.family).toBe('Yrsa');
       });
 
+      it('should reset font weight when font family is updated', async () => {
+        await fixture.events.keyboard.type('Yrsa');
+        // Ensure the debounced callback has taken effect.
+        await fixture.events.sleep(TIMEOUT);
+        const option = fixture.screen.getByText('Yrsa');
+        await fixture.events.click(option);
+        await fixture.events.sleep(TIMEOUT);
+
+        const { fontWeight } = fixture.editor.inspector.designPanel.textStyle;
+        expect(fontWeight.value).toBe('Regular');
+
+        await fixture.events.click(fontWeight.select);
+        await fixture.events.click(fontWeight.option('Bold'));
+        await fixture.events.sleep(TIMEOUT);
+        expect(fontWeight.value).toBe('Bold');
+
+        await openFontPicker();
+
+        await fixture.events.keyboard.type('Roboto');
+        // Ensure the debounced callback has taken effect.
+        await fixture.events.sleep(TIMEOUT);
+        const option2 = fixture.screen.getByText('Roboto');
+        await fixture.events.click(option2);
+        await fixture.events.sleep(600);
+        const updatedFontWeight =
+          fixture.editor.inspector.designPanel.textStyle.fontWeight;
+
+        expect(updatedFontWeight.value).toBe('Regular');
+      });
+
       it('should display only the fonts from curated list by default', () => {
         const options = getOptions();
         expect(options.length).toBe(DEFAULT_VISIBLE_FONTS);

--- a/assets/src/edit-story/components/panels/test/textStyle.js
+++ b/assets/src/edit-story/components/panels/test/textStyle.js
@@ -32,6 +32,7 @@ import DropDown from '../../form/dropDown';
 import AdvancedDropDown from '../../form/advancedDropDown';
 import ColorInput from '../../form/color/color';
 import createSolid from '../../../utils/createSolid';
+import CanvasContext from '../../canvas/context';
 import { MULTIPLE_VALUE, MULTIPLE_DISPLAY_VALUE } from '../../form';
 import { renderPanel } from './_utils';
 
@@ -44,23 +45,47 @@ const DEFAULT_PADDING = { horizontal: 0, vertical: 0, locked: true };
 
 function Wrapper({ children }) {
   return (
-    <FontContext.Provider
+    <CanvasContext.Provider
       value={{
-        state: {
-          fonts: [
-            {
-              name: 'ABeeZee',
-              value: 'ABeeZee',
-              service: 'foo.bar.baz',
-              weights: [400],
-              styles: ['italic', 'regular'],
-              variants: [
-                [0, 400],
-                [1, 400],
-              ],
-              fallbacks: ['serif'],
-            },
-            {
+        state: {},
+        actions: {
+          clearEditing: jest.fn(),
+        },
+      }}
+    >
+      <FontContext.Provider
+        value={{
+          state: {
+            fonts: [
+              {
+                name: 'ABeeZee',
+                value: 'ABeeZee',
+                service: 'foo.bar.baz',
+                weights: [400],
+                styles: ['italic', 'regular'],
+                variants: [
+                  [0, 400],
+                  [1, 400],
+                ],
+                fallbacks: ['serif'],
+              },
+              {
+                name: 'Neu Font',
+                value: 'Neu Font',
+                service: 'foo.bar.baz',
+                weights: [400],
+                styles: ['italic', 'regular'],
+                variants: [
+                  [0, 400],
+                  [1, 400],
+                ],
+                fallbacks: ['fallback1'],
+              },
+            ],
+          },
+          actions: {
+            maybeEnqueueFontStyle: () => Promise.resolve(),
+            getFontByName: () => ({
               name: 'Neu Font',
               value: 'Neu Font',
               service: 'foo.bar.baz',
@@ -71,33 +96,18 @@ function Wrapper({ children }) {
                 [1, 400],
               ],
               fallbacks: ['fallback1'],
-            },
-          ],
-        },
-        actions: {
-          maybeEnqueueFontStyle: () => Promise.resolve(),
-          getFontByName: () => ({
-            name: 'Neu Font',
-            value: 'Neu Font',
-            service: 'foo.bar.baz',
-            weights: [400],
-            styles: ['italic', 'regular'],
-            variants: [
-              [0, 400],
-              [1, 400],
-            ],
-            fallbacks: ['fallback1'],
-          }),
-          addRecentFont: jest.fn(),
-        },
-      }}
-    >
-      <RichTextContext.Provider
-        value={{ state: {}, actions: { selectionActions: {} } }}
+            }),
+            addRecentFont: jest.fn(),
+          },
+        }}
       >
-        {children}
-      </RichTextContext.Provider>
-    </FontContext.Provider>
+        <RichTextContext.Provider
+          value={{ state: {}, actions: { selectionActions: {} } }}
+        >
+          {children}
+        </RichTextContext.Provider>
+      </FontContext.Provider>
+    </CanvasContext.Provider>
   );
 }
 

--- a/assets/src/edit-story/components/panels/textStyle/font.js
+++ b/assets/src/edit-story/components/panels/textStyle/font.js
@@ -67,7 +67,6 @@ function FontControls({ selectedElements, pushUpdate }) {
     ({ font }) => font?.family
   );
   const fontSize = getCommonValue(selectedElements, 'fontSize');
-
   const {
     textInfo: { fontWeight, isItalic },
     handlers: { handleSelectFontWeight },
@@ -83,6 +82,7 @@ function FontControls({ selectedElements, pushUpdate }) {
       fonts,
     })
   );
+
   const fontWeights = useMemo(() => getFontWeights(getFontByName(fontFamily)), [
     getFontByName,
     fontFamily,

--- a/assets/src/edit-story/components/panels/textStyle/fontPicker.js
+++ b/assets/src/edit-story/components/panels/textStyle/fontPicker.js
@@ -38,7 +38,6 @@ import stripHTML from '../../../utils/stripHTML';
 import { useFont } from '../../../app/font';
 import { getCommonValue } from '../utils';
 import { Option, Selected } from '../../form/advancedDropDown/list/styled';
-import { useCanvas } from '../../canvas';
 import useRichTextFormatting from './useRichTextFormatting';
 import getClosestFontWeight from './getClosestFontWeight';
 
@@ -75,19 +74,6 @@ function FontPicker({ selectedElements, pushUpdate }) {
     })
   );
 
-  const { clearEditing } = useCanvas(({ actions: { clearEditing } }) => ({
-    clearEditing,
-  }));
-
-  const resetFontWeight = useCallback(
-    async ({ weights }) => {
-      const newFontWeight = getClosestFontWeight(400, weights);
-      await clearEditing();
-      handleResetFontWeight(newFontWeight);
-    },
-    [clearEditing, handleResetFontWeight]
-  );
-
   const handleFontPickerChange = useCallback(
     async ({ id }) => {
       const fontObj = fonts.find((item) => item.value === id);
@@ -102,6 +88,7 @@ function FontPicker({ selectedElements, pushUpdate }) {
           'metrics',
         ]),
       };
+
       await maybeEnqueueFontStyle(
         selectedElements.map(({ content }) => {
           return {
@@ -114,7 +101,9 @@ function FontPicker({ selectedElements, pushUpdate }) {
       );
       addRecentFont(fontObj);
       pushUpdate({ font: newFont }, true);
-      resetFontWeight(newFont);
+
+      const newFontWeight = getClosestFontWeight(400, fontObj.weights);
+      await handleResetFontWeight(newFontWeight);
     },
     [
       addRecentFont,
@@ -124,7 +113,7 @@ function FontPicker({ selectedElements, pushUpdate }) {
       maybeEnqueueFontStyle,
       pushUpdate,
       selectedElements,
-      resetFontWeight,
+      handleResetFontWeight,
     ]
   );
 

--- a/assets/src/edit-story/components/panels/textStyle/fontPicker.js
+++ b/assets/src/edit-story/components/panels/textStyle/fontPicker.js
@@ -38,7 +38,9 @@ import stripHTML from '../../../utils/stripHTML';
 import { useFont } from '../../../app/font';
 import { getCommonValue } from '../utils';
 import { Option, Selected } from '../../form/advancedDropDown/list/styled';
+import { useCanvas } from '../../canvas';
 import useRichTextFormatting from './useRichTextFormatting';
+import getClosestFontWeight from './getClosestFontWeight';
 
 function FontPicker({ selectedElements, pushUpdate }) {
   const fontFamily = getCommonValue(
@@ -48,6 +50,7 @@ function FontPicker({ selectedElements, pushUpdate }) {
 
   const {
     textInfo: { fontWeight, isItalic },
+    handlers: { handleResetFontWeight },
   } = useRichTextFormatting(selectedElements, pushUpdate);
   const fontStyle = isItalic ? 'italic' : 'normal';
 
@@ -70,6 +73,19 @@ function FontPicker({ selectedElements, pushUpdate }) {
       curatedFonts,
       fonts,
     })
+  );
+
+  const { clearEditing } = useCanvas(({ actions: { clearEditing } }) => ({
+    clearEditing,
+  }));
+
+  const resetFontWeight = useCallback(
+    async ({ weights }) => {
+      const newFontWeight = getClosestFontWeight(400, weights);
+      await clearEditing();
+      handleResetFontWeight(newFontWeight);
+    },
+    [clearEditing, handleResetFontWeight]
   );
 
   const handleFontPickerChange = useCallback(
@@ -98,6 +114,7 @@ function FontPicker({ selectedElements, pushUpdate }) {
       );
       addRecentFont(fontObj);
       pushUpdate({ font: newFont }, true);
+      resetFontWeight(newFont);
     },
     [
       addRecentFont,
@@ -107,6 +124,7 @@ function FontPicker({ selectedElements, pushUpdate }) {
       maybeEnqueueFontStyle,
       pushUpdate,
       selectedElements,
+      resetFontWeight,
     ]
   );
 

--- a/assets/src/edit-story/components/panels/textStyle/getClosestFontWeight.js
+++ b/assets/src/edit-story/components/panels/textStyle/getClosestFontWeight.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns a number representing closest available font weight to previously selected.
+ *
+ * @param {number} existingWeight previously selected font weight value to get as close to as possible, defaults to 400 (normal).
+ * @param {Array<string>} availableWeights available font weights for newly selected font.
+ * @return {number} Closest font weight available for given font.
+ */
+
+const DEFAULT_FONT_WEIGHT = 400;
+
+function getClosestFontWeight(
+  existingWeight = DEFAULT_FONT_WEIGHT,
+  availableWeights
+) {
+  existingWeight = parseInt(existingWeight);
+  // if the passed in existing weight is "(multiple)" we want to reset the value for the new font family in use
+  if (isNaN(parseInt(existingWeight))) {
+    return DEFAULT_FONT_WEIGHT;
+  }
+
+  if (!availableWeights || availableWeights.length === 0) {
+    return existingWeight;
+  }
+
+  return availableWeights.reduce((a, b) => {
+    a = parseInt(a);
+    b = parseInt(b);
+
+    let aDiff = Math.abs(a - existingWeight);
+    let bDiff = Math.abs(b - existingWeight);
+
+    if (aDiff === bDiff) {
+      return a < b ? a : b;
+    }
+
+    return bDiff < aDiff ? b : a;
+  });
+}
+
+export default getClosestFontWeight;

--- a/assets/src/edit-story/components/panels/textStyle/test/getClosestFontWeight.js
+++ b/assets/src/edit-story/components/panels/textStyle/test/getClosestFontWeight.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import getClosestFontWeight from '../getClosestFontWeight';
+
+describe('getClosestFontWeight', () => {
+  it('should return existing font weight when no availableWeights are present', () => {
+    const result = getClosestFontWeight(300);
+    expect(result).toBe(300);
+  });
+
+  it('should return default 400 font weight when no existingWeight or availableWeights are present', () => {
+    const result = getClosestFontWeight();
+    expect(result).toBe(400);
+  });
+
+  it('should return 600 when availableWeight of 600 is present and existingWeight is 600', () => {
+    const result = getClosestFontWeight(600, [100, 300, 600, 700]);
+    expect(result).toBe(600);
+  });
+
+  it('should return 600 when availableWeight of 600 is present even when weights are not listed in ascending order and existingWeight is 600', () => {
+    const result = getClosestFontWeight(600, [700, 300, 600, 100]);
+    expect(result).toBe(600);
+  });
+
+  it('should return 400 when availableWeights are [100, 300, 400, 600] and existingWeight is 500', () => {
+    const result = getClosestFontWeight(500, [100, 300, 400, 600]);
+    expect(result).toBe(400);
+  });
+
+  it('should return 400 when availableWeights are [600, 300, 400, 100] even when not listed in ascending order and existingWeight is 500', () => {
+    const result = getClosestFontWeight(500, [600, 300, 400, 400]);
+    expect(result).toBe(400);
+  });
+
+  it('should return 800 when availableWeights are [400, 800] and existingWeight is 700', () => {
+    const result = getClosestFontWeight(700, [400, 800]);
+    expect(result).toBe(800);
+  });
+});

--- a/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
+++ b/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
@@ -106,6 +106,10 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
   );
 
   const handlers = useMemo(() => {
+    const htmlFormatters = getHTMLFormatters();
+    const handleResetFontWeight = (weight) =>
+      push(htmlFormatters.setFontWeight, weight);
+
     if (hasCurrentEditor) {
       return {
         // This particular function ignores the flag argument.
@@ -118,10 +122,9 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
         handleClickUnderline: selectionActions.toggleUnderlineInSelection,
         handleSetLetterSpacing: selectionActions.setLetterSpacingInSelection,
         handleSetColor: selectionActions.setColorInSelection,
+        handleResetFontWeight,
       };
     }
-
-    const htmlFormatters = getHTMLFormatters();
 
     return {
       handleClickBold: (flag) => push(htmlFormatters.toggleBold, flag),
@@ -133,6 +136,7 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
       handleSetLetterSpacing: (letterSpacing) =>
         push(htmlFormatters.setLetterSpacing, letterSpacing),
       handleSetColor: (color) => push(htmlFormatters.setColor, color),
+      handleResetFontWeight,
     };
   }, [hasCurrentEditor, selectionActions, push]);
 

--- a/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
+++ b/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
@@ -141,9 +141,11 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
         handleClickUnderline: selectionActions.toggleUnderlineInSelection,
         handleSetLetterSpacing: selectionActions.setLetterSpacingInSelection,
         handleSetColor: selectionActions.setColorInSelection,
-        // clear editor to save any pending updates then update font weight on selectedElements
+        // when editing, resetting font weight needs to save before resetting
         handleResetFontWeight: async (weight) => {
+          // clear editing to save any pending updates
           await clearEditing();
+          // queue push until selectedElements are saved and content is updated
           queuePush(htmlFormatters.setFontWeight, weight);
         },
       };

--- a/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
+++ b/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
@@ -123,8 +123,8 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
     const pushArgs = queuedPushRef.current;
     if (pushArgs) {
       push(...pushArgs);
+      queuedPushRef.current = null;
     }
-    queuedPushRef.current = null;
   }, [selectedElements, queuedPushRef, push]);
 
   const handlers = useMemo(() => {

--- a/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
+++ b/assets/src/edit-story/components/panels/textStyle/useRichTextFormatting.js
@@ -103,9 +103,10 @@ function useRichTextFormatting(selectedElements, pushUpdate) {
 
   const push = useCallback(
     (updater, ...args) =>
-      pushUpdate(({ content }) => {
-        return { content: updater(content, ...args) };
-      }, true),
+      pushUpdate(
+        ({ content }) => ({ content: updater(content, ...args) }),
+        true
+      ),
     [pushUpdate]
   );
 

--- a/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
+++ b/assets/src/edit-story/components/richText/karma/multiSelection.karma.js
@@ -147,7 +147,7 @@ describe('Styling multiple text fields', () => {
       expect(bold.checked).toBe(false);
       expect(italic.checked).toBe(false);
       expect(underline.checked).toBe(false);
-      expect(fontWeight.value).toBe(MULTIPLE_DISPLAY_VALUE);
+      expect(fontWeight.value).toBe('Mixed');
       expect(letterSpacing.value).toBe('');
       expect(letterSpacing.placeholder).toBe(MULTIPLE_DISPLAY_VALUE);
       expect(fontColor.output).toBe('');


### PR DESCRIPTION
## Summary

Bring back fix for #1899 and fix lingering bug. The original fix (#4900) implemented an almost complete fix, but left one bug which reverted any content changes in the currently editing text element when the font family was changed.

This PR re-applies the original fix and resolves the bug with content getting reverted when family changes.

Original fix PR: #4900
Revert PR: #5045 

## Relevant Technical Choices

This was a tricky one because the editor needs to get destroyed so that we can (1) set the font weight to the whole element and (2) make sure any content changes are saved first.

There's no way to have the appropriate content to clean up until after the editor closes, so this PR introduces a "queued push" concept that waits for `selectedElements` to update before resetting the font weight on the element.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

1. Add text element
2. Type Hey. Hit enter then type more text again
3. Change the font weight on part of the text
4. Highlight any part of the text or ensure the cursor is in the editor
4. Go to font picker and select any font family
5. Editor should go away, font family should change, and all font weights should reset to be one single font weight

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1899 
