### PR TITLE
Animation: Background Pan

### DIFF
--- a/assets/src/animation/constants.js
+++ b/assets/src/animation/constants.js
@@ -76,6 +76,7 @@ export const ANIMATION_EFFECTS = {
 
 export const BACKGROUND_ANIMATION_EFFECTS = {
   ZOOM: { value: 'effect-background-zoom', name: ANIMATION_EFFECTS.ZOOM.name },
+  PAN: { value: 'effect-background-pan', name: ANIMATION_EFFECTS.PAN.name },
 };
 
 export const ANIMATION_PARTS = {

--- a/assets/src/animation/effects/backgroundPan/animationProps.js
+++ b/assets/src/animation/effects/backgroundPan/animationProps.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES, DIRECTION } from '../../constants';
+import { AnimationInputPropTypes } from '../types';
+
+export const PanEffectInputPropTypes = {
+  panDir: PropTypes.shape(AnimationInputPropTypes),
+};
+
+export default {
+  panDir: {
+    label: __('Direction', 'web-stories'),
+    type: FIELD_TYPES.DROPDOWN,
+    values: [
+      DIRECTION.TOP_TO_BOTTOM,
+      DIRECTION.BOTTOM_TO_TOP,
+      DIRECTION.LEFT_TO_RIGHT,
+      DIRECTION.RIGHT_TO_LEFT,
+    ],
+    defaultValue: DIRECTION.BOTTOM_TO_TOP,
+  },
+};

--- a/assets/src/animation/effects/backgroundPan/animationProps.js
+++ b/assets/src/animation/effects/backgroundPan/animationProps.js
@@ -37,7 +37,7 @@ export const PanEffectInputPropTypes = {
 export default {
   panDir: {
     label: __('Direction', 'web-stories'),
-    type: FIELD_TYPES.DROPDOWN,
+    type: FIELD_TYPES.DIRECTION_PICKER,
     values: [
       DIRECTION.TOP_TO_BOTTOM,
       DIRECTION.BOTTOM_TO_TOP,

--- a/assets/src/animation/effects/backgroundPan/index.js
+++ b/assets/src/animation/effects/backgroundPan/index.js
@@ -17,17 +17,9 @@
 /**
  * Internal dependencies
  */
-import {
-  FULLBLEED_RATIO,
-  PAGE_HEIGHT,
-  PAGE_WIDTH,
-} from '../../../edit-story/constants';
-import getMediaSizePositionProps from '../../../edit-story/elements/media/getMediaSizePositionProps';
-import { getBox } from '../../../edit-story/units/dimensions';
 import { BACKGROUND_ANIMATION_EFFECTS, DIRECTION } from '../../constants';
 import SimpleAnimation from '../../parts/simpleAnimation';
-
-const FULLBLEED_PAGE_HEIGHT = (1 / FULLBLEED_RATIO) * PAGE_WIDTH;
+import { getMediaBoundOffsets } from '../../utils';
 
 export function EffectBackgroundPan({
   panDir = DIRECTION.RIGHT_TO_LEFT,
@@ -44,42 +36,16 @@ export function EffectBackgroundPan({
   };
 
   const animationName = `direction-${panDir}-${BACKGROUND_ANIMATION_EFFECTS.PAN.value}`;
-  // Get elements box based on a given page size with proper ratio.
-  const box = getBox(element, PAGE_WIDTH, PAGE_HEIGHT);
-  // Calculate image offsets based off given box, focal point
-  const media = getMediaSizePositionProps(
-    element.resource,
-    box.width,
-    box.height,
-    element.scale,
-    element.focalX,
-    element.focalY
-  );
 
-  // Since we don't know the page size at the time this animation will be called,
-  // we want to divide out the page size and make these bounds relative to the element size.
-  const translateToLeftBound = `translate3d(${
-    (media.offsetX / media.width) * 100
-  }%, 0, 0)`;
-  const translateToRightBound = `translate3d(-${
-    ((media.width - (media.offsetX + PAGE_WIDTH)) / media.width) * 100
-  }%, 0, 0)`;
-  const translateToTopBound = `translate3d(0, ${
-    (media.offsetY / media.height) * 100
-  }%, 0)`;
-  const translateToBottomBound = `translate3d(0, -${
-    ((media.height - (media.offsetY + FULLBLEED_PAGE_HEIGHT)) / media.height) *
-    100
-  }%, 0)`;
+  const offsets = getMediaBoundOffsets({ element });
   const translateToOriginX = 'translate3d(0%, 0, 0)';
   const translateToOriginY = 'translate3d(0, 0%, 0)';
-
   const translate = {
     from: {
-      [DIRECTION.RIGHT_TO_LEFT]: translateToRightBound,
-      [DIRECTION.LEFT_TO_RIGHT]: translateToLeftBound,
-      [DIRECTION.BOTTOM_TO_TOP]: translateToBottomBound,
-      [DIRECTION.TOP_TO_BOTTOM]: translateToTopBound,
+      [DIRECTION.RIGHT_TO_LEFT]: `translate3d(${offsets.left}%, 0, 0)`,
+      [DIRECTION.LEFT_TO_RIGHT]: `translate3d(${offsets.right}%, 0, 0)`,
+      [DIRECTION.BOTTOM_TO_TOP]: `translate3d(0, ${offsets.top}%, 0)`,
+      [DIRECTION.TOP_TO_BOTTOM]: `translate3d(0, ${offsets.bottom}%, 0)`,
     },
     to: {
       [DIRECTION.RIGHT_TO_LEFT]: translateToOriginX,

--- a/assets/src/animation/effects/backgroundPan/index.js
+++ b/assets/src/animation/effects/backgroundPan/index.js
@@ -17,6 +17,8 @@
 /**
  * Internal dependencies
  */
+import { getBox } from '../../../edit-story/units/dimensions';
+import getMediaSizePositionProps from '../../../edit-story/elements/media/getMediaSizePositionProps';
 import { BACKGROUND_ANIMATION_EFFECTS, DIRECTION } from '../../constants';
 import SimpleAnimation from '../../parts/simpleAnimation';
 
@@ -25,7 +27,7 @@ export function EffectBackgroundPan({
   duration = 500,
   delay,
   easing,
-  // element,
+  element,
 }) {
   const timings = {
     fill: 'both',
@@ -35,9 +37,23 @@ export function EffectBackgroundPan({
   };
 
   const animationName = `direction-${panDir}-${BACKGROUND_ANIMATION_EFFECTS.PAN.value}`;
+  const box = getBox(element, 66.67, 100);
+  const mediaPosition = getMediaSizePositionProps(
+    element.resource,
+    box.width,
+    box.height,
+    element.scale,
+    element.focalX,
+    element.focalY
+  );
   const keyframes = {
-    transform: [``, ``],
+    transform: [
+      `translateX(${(mediaPosition.offsetX / mediaPosition.width) * 100}%)`,
+      `translateX(0%)`,
+    ],
   };
+
+  // console.log('PAN %X: ', mediaPosition.offsetX / mediaPosition.width);
 
   const { id, WAAPIAnimation, AMPTarget, AMPAnimation } = SimpleAnimation(
     animationName,

--- a/assets/src/animation/effects/backgroundPan/index.js
+++ b/assets/src/animation/effects/backgroundPan/index.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { BACKGROUND_ANIMATION_EFFECTS, DIRECTION } from '../../constants';
+import SimpleAnimation from '../../parts/simpleAnimation';
+
+export function EffectBackgroundPan({
+  panDir = DIRECTION.RIGHT_TO_LEFT,
+  duration = 500,
+  delay,
+  easing,
+  // element,
+}) {
+  const timings = {
+    fill: 'both',
+    duration,
+    delay,
+    easing,
+  };
+
+  const animationName = `direction-${panDir}-${BACKGROUND_ANIMATION_EFFECTS.PAN.value}`;
+  const keyframes = {
+    transform: [``, ``],
+  };
+
+  const { id, WAAPIAnimation, AMPTarget, AMPAnimation } = SimpleAnimation(
+    animationName,
+    keyframes,
+    timings,
+    false,
+    true
+  );
+
+  return {
+    id,
+    WAAPIAnimation,
+    AMPTarget,
+    AMPAnimation,
+    generatedKeyframes: {
+      [animationName]: keyframes,
+    },
+  };
+}

--- a/assets/src/animation/effects/rotateIn/animationProps.js
+++ b/assets/src/animation/effects/rotateIn/animationProps.js
@@ -39,7 +39,7 @@ export const RotateInEffectInputPropTypes = {
 export default {
   rotateInDir: {
     label: __('Direction', 'web-stories'),
-    type: FIELD_TYPES.ROTATION_PICKER,
+    type: FIELD_TYPES.DIRECTION_PICKER,
     values: [DIRECTION.LEFT_TO_RIGHT, DIRECTION.RIGHT_TO_LEFT],
     defaultValue: DIRECTION.LEFT_TO_RIGHT,
   },

--- a/assets/src/animation/effects/whooshIn/animationProps.js
+++ b/assets/src/animation/effects/whooshIn/animationProps.js
@@ -37,7 +37,7 @@ export const WhooshInEffectInputPropTypes = {
 export default {
   whooshInDir: {
     label: __('Direction', 'web-stories'),
-    type: FIELD_TYPES.DROPDOWN,
+    type: FIELD_TYPES.DIRECTION_PICKER,
     values: [DIRECTION.LEFT_TO_RIGHT, DIRECTION.RIGHT_TO_LEFT],
     defaultValue: DIRECTION.LEFT_TO_RIGHT,
   },

--- a/assets/src/animation/parts/index.js
+++ b/assets/src/animation/parts/index.js
@@ -39,6 +39,7 @@ import { EffectWhooshIn } from '../effects/whooshIn';
 import { EffectZoom } from '../effects/zoom';
 import { EffectRotateIn } from '../effects/rotateIn';
 import { EffectBackgroundZoom } from '../effects/backgroundZoom';
+import { EffectBackgroundPan } from '../effects/backgroundPan';
 import flyInProps from '../effects/flyIn/animationProps';
 import panProps from '../effects/pan/animationProps';
 import pulseProps from '../effects/pulse/animationProps';
@@ -46,6 +47,7 @@ import rotateInProps from '../effects/rotateIn/animationProps';
 import whooshInProps from '../effects/whooshIn/animationProps';
 import zoomEffectProps from '../effects/zoom/animationProps';
 import backgroundZoomEffectProps from '../effects/backgroundZoom/animationProps';
+import backgroundPanEffectProps from '../effects/backgroundPan/animationProps';
 
 import { AnimationBounce } from './bounce';
 import { AnimationBlinkOn } from './blinkOn';
@@ -108,6 +110,7 @@ export function AnimationPart(type, args) {
       [ANIMATION_EFFECTS.DROP.value]: EffectDrop,
       [ANIMATION_EFFECTS.ROTATE_IN.value]: EffectRotateIn,
       [BACKGROUND_ANIMATION_EFFECTS.ZOOM.value]: EffectBackgroundZoom,
+      [BACKGROUND_ANIMATION_EFFECTS.PAN.value]: EffectBackgroundPan,
     }[type?.value || type] || throughput;
 
   args.easing = args.easing || BEZIER[args.easingPreset];
@@ -156,6 +159,7 @@ export function getAnimationEffectProps(type) {
     [ANIMATION_EFFECTS.WHOOSH_IN.value]: whooshInProps,
     [ANIMATION_EFFECTS.ZOOM.value]: zoomEffectProps,
     [BACKGROUND_ANIMATION_EFFECTS.ZOOM.value]: backgroundZoomEffectProps,
+    [BACKGROUND_ANIMATION_EFFECTS.PAN.value]: backgroundPanEffectProps,
   };
 
   return {

--- a/assets/src/animation/parts/types.js
+++ b/assets/src/animation/parts/types.js
@@ -22,7 +22,11 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { ANIMATION_TYPES, ANIMATION_EFFECTS } from '../constants';
+import {
+  ANIMATION_TYPES,
+  ANIMATION_EFFECTS,
+  BACKGROUND_ANIMATION_EFFECTS,
+} from '../constants';
 import { GeneralAnimationPropTypes } from '../outputs/types';
 
 export const WAAPIAnimationProps = {
@@ -42,6 +46,7 @@ export const AnimationProps = {
   type: PropTypes.oneOf([
     ...Object.values(ANIMATION_TYPES),
     ...Object.values(ANIMATION_EFFECTS).map((o) => o.value),
+    ...Object.values(BACKGROUND_ANIMATION_EFFECTS).map((o) => o.value),
   ]),
   targets: PropTypes.arrayOf(PropTypes.string),
   ...GeneralAnimationPropTypes,

--- a/assets/src/animation/utils/index.js
+++ b/assets/src/animation/utils/index.js
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export { getMediaBoundOffsets, hasOffsets } from './mediaPositions';
 export { clamp, lerp, progress } from './range';

--- a/assets/src/animation/utils/mediaPositions.js
+++ b/assets/src/animation/utils/mediaPositions.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import {
+  FULLBLEED_RATIO,
+  PAGE_HEIGHT,
+  PAGE_WIDTH,
+} from '../../edit-story/constants';
+import getMediaSizePositionProps from '../../edit-story/elements/media/getMediaSizePositionProps';
+import { getBox } from '../../edit-story/units/dimensions';
+
+const FULLBLEED_PAGE_HEIGHT = (1 / FULLBLEED_RATIO) * PAGE_WIDTH;
+const PRECISION = 1;
+
+export function getMediaBoundOffsets({ element }) {
+  // Get elements box based on a given page size with proper ratio.
+  const box = getBox(element, PAGE_WIDTH, PAGE_HEIGHT);
+  // Calculate image offsets based off given box, focal point
+  const media = getMediaSizePositionProps(
+    element.resource,
+    box.width,
+    box.height,
+    element.scale,
+    element.focalX,
+    element.focalY
+  );
+
+  return {
+    top: (media.offsetY / media.height) * 100,
+    right:
+      -1 * ((media.width - (media.offsetX + PAGE_WIDTH)) / media.width) * 100,
+    left: (media.offsetX / media.width) * 100,
+    bottom:
+      -1 *
+      ((media.height - (media.offsetY + FULLBLEED_PAGE_HEIGHT)) /
+        media.height) *
+      100,
+  };
+}
+
+function mapValues(obj, op) {
+  return Object.entries(obj).reduce((accum, [key, val]) => {
+    accum[key] = op(val);
+    return accum;
+  }, {});
+}
+
+export function hasOffsets({ element }) {
+  const offsets = getMediaBoundOffsets({ element });
+  return mapValues(offsets, (offset) => Math.abs(offset) > PRECISION);
+}

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
@@ -26,6 +26,7 @@ import { DEFAULT_ATTRIBUTES_FOR_MEDIA } from '../../../../constants';
 import objectPick from '../../../../utils/objectPick';
 import objectWithout from '../../../../utils/objectWithout';
 import { canMaskHaveBorder } from '../../../../masks';
+import { removeAnimationsWithElementIds } from './utils';
 
 /**
  * Combine elements by taking properties from a first item and
@@ -127,10 +128,16 @@ function combineElements(state, { firstElement, secondId }) {
     // Update reference to second element
     .map((el) => (el.id === secondId ? newElement : el));
 
+  const newAnimations = removeAnimationsWithElementIds(page.animations, [
+    firstId,
+    secondId,
+  ]);
+
   const newPage = {
     ...page,
     elements,
     ...newPageProps,
+    animations: newAnimations,
   };
 
   const newPages = [

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/setBackgroundElement.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/setBackgroundElement.js
@@ -18,7 +18,7 @@
  * Internal dependencies
  */
 import objectWithout from '../../../../utils/objectWithout';
-import { moveArrayElement } from './utils';
+import { moveArrayElement, removeAnimationsWithElementIds } from './utils';
 
 /**
  * Set background element on the current page to element matching the given id.
@@ -124,9 +124,19 @@ function setBackgroundElement(state, { elementId }) {
     };
   }
 
+  // Remove any applied background animations
+  // or exising element animations.
+  const backgroundElementId = page.elements.find(
+    (element) => element.isBackground
+  );
+  const newAnimations = removeAnimationsWithElementIds(page.animations, [
+    elementId,
+    backgroundElementId.id,
+  ]);
+
   const newPages = [
     ...state.pages.slice(0, pageIndex),
-    newPage,
+    { ...newPage, animations: newAnimations || [] },
     ...state.pages.slice(pageIndex + 1),
   ];
 

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/utils.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/utils.js
@@ -92,6 +92,15 @@ export function updateElementWithUpdater(element, properties) {
   return { ...element, ...allowedProperties };
 }
 
+export function removeAnimationsWithElementIds(animations, ids) {
+  return (animations || []).reduce((accum, animation) => {
+    if (ids.some((id) => animation.targets?.includes(id))) {
+      return accum;
+    }
+    return [...accum, animation];
+  }, []);
+}
+
 export function updateAnimations(oldAnimations, animationUpdates) {
   const newAnimations = oldAnimations.reduce((animations, animation) => {
     const updatedAnimation = animationUpdates[animation.id];

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -197,12 +197,7 @@ const translations = {
   [ROTATION.COUNTER_CLOCKWISE]: __('counterclockwise', 'web-stories'),
 };
 
-export const DirectionRadioInput = ({
-  value,
-  directions = [],
-  onChange,
-  defaultChecked,
-}) => {
+export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
   return (
     <Fieldset>
       <Figure />
@@ -222,7 +217,6 @@ export const DirectionRadioInput = ({
               value={direction}
               onChange={onChange}
               checked={value === direction}
-              defaultChecked={defaultChecked === direction}
             />
             <DirectionIndicator direction={direction} />
           </Label>
@@ -238,7 +232,6 @@ const directionPropType = PropTypes.oneOf([
 ]);
 
 DirectionRadioInput.propTypes = {
-  defaultChecked: directionPropType,
   value: directionPropType,
   directions: PropTypes.arrayOf(directionPropType),
   onChange: PropTypes.func,

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -198,6 +198,7 @@ const translations = {
 };
 
 export const DirectionRadioInput = ({
+  value,
   directions = [],
   onChange,
   defaultChecked,
@@ -220,6 +221,7 @@ export const DirectionRadioInput = ({
               name="direction"
               value={direction}
               onChange={onChange}
+              checked={value === direction}
               defaultChecked={defaultChecked === direction}
             />
             <DirectionIndicator direction={direction} />
@@ -237,6 +239,7 @@ const directionPropType = PropTypes.oneOf([
 
 DirectionRadioInput.propTypes = {
   defaultChecked: directionPropType,
+  value: directionPropType,
   directions: PropTypes.arrayOf(directionPropType),
   onChange: PropTypes.func,
 };

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -54,6 +54,10 @@ import {
   ZoomInAnimation,
   ZoomOutAnimation,
   BaseAnimationCell,
+  PanTopAnimation,
+  PanRightAnimation,
+  PanBottomAnimation,
+  PanLeftAnimation,
 } from './effectChooserElements';
 
 const Container = styled.div`
@@ -146,17 +150,60 @@ export default function EffectChooser({
               <ContentWrapper>{__('Zoom', 'web-stories')}</ContentWrapper>
               <ZoomOutAnimation>{__('Zoom', 'web-stories')}</ZoomOutAnimation>
             </GridItemFullRow>
-            <GridItemFullRow
-              aria-label={__('Pan Effect', 'web-stories')}
+            <GridItem
+              aria-label={__('Pan Left Effect', 'web-stories')}
               onClick={() =>
                 onAnimationSelected({
                   animation: BACKGROUND_ANIMATION_EFFECTS.PAN.value,
+                  panDir: DIRECTION.LEFT_TO_RIGHT,
                 })
               }
             >
-              <ContentWrapper>{__('Pan', 'web-stories')}</ContentWrapper>
-              <ZoomOutAnimation>{__('Pan', 'web-stories')}</ZoomOutAnimation>
-            </GridItemFullRow>
+              <ContentWrapper>{__('Pan Left', 'web-stories')}</ContentWrapper>
+              <PanLeftAnimation>
+                {__('Pan Left', 'web-stories')}
+              </PanLeftAnimation>
+            </GridItem>
+            <GridItem
+              aria-label={__('Pan Right Effect', 'web-stories')}
+              onClick={() =>
+                onAnimationSelected({
+                  animation: BACKGROUND_ANIMATION_EFFECTS.PAN.value,
+                  panDir: DIRECTION.RIGHT_TO_LEFT,
+                })
+              }
+            >
+              <ContentWrapper>{__('Pan Right', 'web-stories')}</ContentWrapper>
+              <PanRightAnimation>
+                {__('Pan Right', 'web-stories')}
+              </PanRightAnimation>
+            </GridItem>
+            <GridItem
+              aria-label={__('Pan Up Effect', 'web-stories')}
+              onClick={() =>
+                onAnimationSelected({
+                  animation: BACKGROUND_ANIMATION_EFFECTS.PAN.value,
+                  panDir: DIRECTION.BOTTOM_TO_TOP,
+                })
+              }
+            >
+              <ContentWrapper>{__('Pan Up', 'web-stories')}</ContentWrapper>
+              <PanBottomAnimation>
+                {__('Pan Up', 'web-stories')}
+              </PanBottomAnimation>
+            </GridItem>
+            <GridItem
+              aria-label={__('Pan Down Effect', 'web-stories')}
+              onClick={() =>
+                onAnimationSelected({
+                  animation: BACKGROUND_ANIMATION_EFFECTS.PAN.value,
+                  panDir: DIRECTION.TOP_TO_BOTTOM,
+                })
+              }
+            >
+              <ContentWrapper>{__('Pan Down', 'web-stories')}</ContentWrapper>
+              <PanTopAnimation>{__('Pan Down', 'web-stories')}</PanTopAnimation>
+            </GridItem>
           </>
         ) : (
           <>

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -134,17 +134,30 @@ export default function EffectChooser({
           <span>{__('No Effect', 'web-stories')}</span>
         </GridItemFullRow>
         {isBackgroundEffects ? (
-          <GridItemFullRow
-            aria-label={__('Zoom Effect', 'web-stories')}
-            onClick={() =>
-              onAnimationSelected({
-                animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
-              })
-            }
-          >
-            <ContentWrapper>{__('Zoom', 'web-stories')}</ContentWrapper>
-            <ZoomOutAnimation>{__('Zoom', 'web-stories')}</ZoomOutAnimation>
-          </GridItemFullRow>
+          <>
+            <GridItemFullRow
+              aria-label={__('Zoom Effect', 'web-stories')}
+              onClick={() =>
+                onAnimationSelected({
+                  animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                })
+              }
+            >
+              <ContentWrapper>{__('Zoom', 'web-stories')}</ContentWrapper>
+              <ZoomOutAnimation>{__('Zoom', 'web-stories')}</ZoomOutAnimation>
+            </GridItemFullRow>
+            <GridItemFullRow
+              aria-label={__('Pan Effect', 'web-stories')}
+              onClick={() =>
+                onAnimationSelected({
+                  animation: BACKGROUND_ANIMATION_EFFECTS.PAN.value,
+                })
+              }
+            >
+              <ContentWrapper>{__('Pan', 'web-stories')}</ContentWrapper>
+              <ZoomOutAnimation>{__('Pan', 'web-stories')}</ZoomOutAnimation>
+            </GridItemFullRow>
+          </>
         ) : (
           <>
             <GridItemFullRow

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
  * External dependencies
  */
 import React, { useEffect, useRef } from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -78,15 +78,20 @@ const GridItem = styled.button.attrs({ role: 'listitem' })`
   overflow: hidden;
   font-family: 'Teko', sans-serif;
   font-size: 20px;
+  line-height: 1;
   color: white;
   text-transform: uppercase;
 
-  &:hover {
+  &:disabled {
+    opacity: 0.6;
+  }
+
+  &:hover:not([disabled]) {
     cursor: pointer;
   }
 
-  &:hover,
-  &:focus {
+  &:hover:not([disabled]),
+  &:focus:not([disabled]) {
     ${BaseAnimationCell} {
       display: inline-block;
     }
@@ -119,6 +124,7 @@ export default function EffectChooser({
   onNoEffectSelected,
   onDismiss,
   isBackgroundEffects = false,
+  disabledTypeOptionsMap,
 }) {
   const ref = useRef();
 
@@ -158,6 +164,9 @@ export default function EffectChooser({
                   panDir: DIRECTION.LEFT_TO_RIGHT,
                 })
               }
+              disabled={disabledTypeOptionsMap[
+                BACKGROUND_ANIMATION_EFFECTS.PAN.value
+              ]?.includes(DIRECTION.LEFT_TO_RIGHT)}
             >
               <ContentWrapper>{__('Pan Left', 'web-stories')}</ContentWrapper>
               <PanLeftAnimation>
@@ -172,6 +181,9 @@ export default function EffectChooser({
                   panDir: DIRECTION.RIGHT_TO_LEFT,
                 })
               }
+              disabled={disabledTypeOptionsMap[
+                BACKGROUND_ANIMATION_EFFECTS.PAN.value
+              ]?.includes(DIRECTION.RIGHT_TO_LEFT)}
             >
               <ContentWrapper>{__('Pan Right', 'web-stories')}</ContentWrapper>
               <PanRightAnimation>
@@ -186,6 +198,9 @@ export default function EffectChooser({
                   panDir: DIRECTION.BOTTOM_TO_TOP,
                 })
               }
+              disabled={disabledTypeOptionsMap[
+                BACKGROUND_ANIMATION_EFFECTS.PAN.value
+              ]?.includes(DIRECTION.BOTTOM_TO_TOP)}
             >
               <ContentWrapper>{__('Pan Up', 'web-stories')}</ContentWrapper>
               <PanBottomAnimation>
@@ -200,6 +215,9 @@ export default function EffectChooser({
                   panDir: DIRECTION.TOP_TO_BOTTOM,
                 })
               }
+              disabled={disabledTypeOptionsMap[
+                BACKGROUND_ANIMATION_EFFECTS.PAN.value
+              ]?.includes(DIRECTION.TOP_TO_BOTTOM)}
             >
               <ContentWrapper>{__('Pan Down', 'web-stories')}</ContentWrapper>
               <PanTopAnimation>{__('Pan Down', 'web-stories')}</PanTopAnimation>
@@ -399,8 +417,11 @@ export default function EffectChooser({
 }
 
 EffectChooser.propTypes = {
-  onAnimationSelected: propTypes.func.isRequired,
-  onNoEffectSelected: propTypes.func.isRequired,
-  onDismiss: propTypes.func,
-  isBackgroundEffects: propTypes.bool,
+  onAnimationSelected: PropTypes.func.isRequired,
+  onNoEffectSelected: PropTypes.func.isRequired,
+  onDismiss: PropTypes.func,
+  isBackgroundEffects: PropTypes.bool,
+  disabledTypeOptionsMap: PropTypes.objectOf(
+    PropTypes.arrayOf(PropTypes.string)
+  ),
 };

--- a/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
@@ -23,7 +23,7 @@ import { __ } from '@wordpress/i18n';
  * External dependencies
  */
 import React, { useRef, useState } from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 /**
  * Internal dependencies
@@ -48,6 +48,7 @@ export default function EffectChooserDropdown({
   onNoEffectSelected,
   isBackgroundEffects = false,
   selectedEffectTitle,
+  disabledTypeOptionsMap,
 }) {
   const selectRef = useRef();
   const dropdownRef = useRef();
@@ -74,6 +75,7 @@ export default function EffectChooserDropdown({
             onAnimationSelected={onAnimationSelected}
             onDismiss={() => setIsOpen(false)}
             isBackgroundEffects={isBackgroundEffects}
+            disabledTypeOptionsMap={disabledTypeOptionsMap}
           />
         </Container>
       </Popup>
@@ -82,8 +84,11 @@ export default function EffectChooserDropdown({
 }
 
 EffectChooserDropdown.propTypes = {
-  onAnimationSelected: propTypes.func.isRequired,
-  isBackgroundEffects: propTypes.bool,
-  selectedEffectTitle: propTypes.string,
-  onNoEffectSelected: propTypes.func.isRequired,
+  onAnimationSelected: PropTypes.func.isRequired,
+  isBackgroundEffects: PropTypes.bool,
+  selectedEffectTitle: PropTypes.string,
+  onNoEffectSelected: PropTypes.func.isRequired,
+  disabledTypeOptionsMap: PropTypes.objectOf(
+    PropTypes.arrayOf(PropTypes.string)
+  ),
 };

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -46,7 +46,13 @@ const Label = styled.label`
   letter-spacing: ${({ theme }) => theme.fonts.body2.letterSpacing};
 `;
 
-function EffectInput({ effectProps, effectConfig, field, onChange }) {
+function EffectInput({
+  effectProps,
+  effectConfig,
+  field,
+  onChange,
+  disabledOptions,
+}) {
   const rangeId = `range-${uuidv4()}`;
   const directionControlOnChange = useCallback(
     ({ nativeEvent: { target } }) => onChange(target.value, true),
@@ -85,10 +91,9 @@ function EffectInput({ effectProps, effectConfig, field, onChange }) {
       return (
         <DirectionRadioInput
           value={effectConfig[field] || effectProps[field].defaultValue}
-          directions={effectProps[field].values}
-          defaultChecked={
-            effectConfig[field] || effectProps[field].defaultValue
-          }
+          directions={effectProps[field].values?.filter(
+            (v) => !disabledOptions.includes(v)
+          )}
           onChange={directionControlOnChange}
         />
       );
@@ -114,6 +119,7 @@ EffectInput.propTypes = {
   effectConfig: PropTypes.shape(GeneralAnimationPropTypes).isRequired,
   field: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  disabledOptions: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default EffectInput;

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -26,7 +26,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { DIRECTION, FIELD_TYPES } from '../../../../animation';
+import { FIELD_TYPES } from '../../../../animation';
 import { GeneralAnimationPropTypes } from '../../../../animation/outputs';
 import { AnimationFormPropTypes } from '../../../../animation/types';
 import { DropDown, BoxedNumeric } from '../../form';
@@ -84,17 +84,8 @@ function EffectInput({ effectProps, effectConfig, field, onChange }) {
     case FIELD_TYPES.DIRECTION_PICKER:
       return (
         <DirectionRadioInput
-          directions={Object.values(DIRECTION)}
-          defaultChecked={
-            effectConfig[field] || effectProps[field].defaultValue
-          }
-          onChange={directionControlOnChange}
-        />
-      );
-    case FIELD_TYPES.ROTATION_PICKER:
-      return (
-        <DirectionRadioInput
-          directions={[DIRECTION.LEFT_TO_RIGHT, DIRECTION.RIGHT_TO_LEFT]}
+          value={effectConfig[field] || effectProps[field].defaultValue}
+          directions={effectProps[field].values}
           defaultChecked={
             effectConfig[field] || effectProps[field].defaultValue
           }

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -67,7 +67,11 @@ const AnimationGridField = styled.div(
   ]
 );
 
-function EffectPanel({ animation: { id, type, ...config }, onChange }) {
+function EffectPanel({
+  animation: { id, type, ...config },
+  onChange,
+  disabledTypeOptionsMap,
+}) {
   const { props } = getAnimationEffectProps(type);
 
   const handleInputChange = useCallback(
@@ -108,6 +112,7 @@ function EffectPanel({ animation: { id, type, ...config }, onChange }) {
         onChange={(value, submitArg) =>
           handleInputChange({ [field]: value }, submitArg)
         }
+        disabledOptions={disabledTypeOptionsMap[type] || []}
       />
     </AnimationGridField>
   ));
@@ -118,6 +123,9 @@ function EffectPanel({ animation: { id, type, ...config }, onChange }) {
 EffectPanel.propTypes = {
   animation: PropTypes.shape(AnimationProps),
   onChange: PropTypes.func.isRequired,
+  disabledTypeOptionsMap: PropTypes.objectOf(
+    PropTypes.arrayOf(PropTypes.string)
+  ),
 };
 
 export default EffectPanel;

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -134,6 +134,7 @@ function AnimationPanel({
           onAnimationSelected={handleAddOrUpdateElementEffect}
           selectedEffectTitle={getEffectName(updatedAnimations[0]?.type)}
           onNoEffectSelected={handleRemoveEffect}
+          isBackgroundEffects={isBackground}
         />
       </Row>
       {updatedAnimations[0] && (

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -33,7 +33,9 @@ import {
   BACKGROUND_ANIMATION_EFFECTS,
   BG_MAX_SCALE,
   BG_MIN_SCALE,
+  DIRECTION,
   progress,
+  hasOffsets,
 } from '../../../../animation';
 import { getAnimationEffectDefaults } from '../../../../animation/parts';
 import StoryPropTypes, { AnimationPropType } from '../../../types';
@@ -121,6 +123,20 @@ function AnimationPanel({
     );
   }, [pushUpdateForObject, updatedAnimations]);
 
+  // Figure out if any options are disabled
+  // for an animation type input
+  const disabledTypeOptionsMap = useMemo(() => {
+    const hasOffset = hasOffsets({ element: selectedElements[0] });
+    return {
+      [BACKGROUND_ANIMATION_EFFECTS.PAN.value]: [
+        !hasOffset.bottom && DIRECTION.TOP_TO_BOTTOM,
+        !hasOffset.left && DIRECTION.RIGHT_TO_LEFT,
+        !hasOffset.top && DIRECTION.BOTTOM_TO_TOP,
+        !hasOffset.right && DIRECTION.LEFT_TO_RIGHT,
+      ].filter(Boolean),
+    };
+  }, [selectedElements]);
+
   return selectedElements.length > 1 ? (
     <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
       <Row>
@@ -135,12 +151,14 @@ function AnimationPanel({
           selectedEffectTitle={getEffectName(updatedAnimations[0]?.type)}
           onNoEffectSelected={handleRemoveEffect}
           isBackgroundEffects={isBackground}
+          disabledTypeOptionsMap={disabledTypeOptionsMap}
         />
       </Row>
       {updatedAnimations[0] && (
         <EffectPanel
           animation={updatedAnimations[0]}
           onChange={handlePanelChange}
+          disabledTypeOptionsMap={disabledTypeOptionsMap}
         />
       )}
     </SimplePanel>

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -126,15 +126,18 @@ function AnimationPanel({
   // Figure out if any options are disabled
   // for an animation type input
   const disabledTypeOptionsMap = useMemo(() => {
-    const hasOffset = hasOffsets({ element: selectedElements[0] });
-    return {
-      [BACKGROUND_ANIMATION_EFFECTS.PAN.value]: [
-        !hasOffset.bottom && DIRECTION.TOP_TO_BOTTOM,
-        !hasOffset.left && DIRECTION.RIGHT_TO_LEFT,
-        !hasOffset.top && DIRECTION.BOTTOM_TO_TOP,
-        !hasOffset.right && DIRECTION.LEFT_TO_RIGHT,
-      ].filter(Boolean),
-    };
+    if (selectedElements[0]?.isBackground) {
+      const hasOffset = hasOffsets({ element: selectedElements[0] });
+      return {
+        [BACKGROUND_ANIMATION_EFFECTS.PAN.value]: [
+          !hasOffset.bottom && DIRECTION.TOP_TO_BOTTOM,
+          !hasOffset.left && DIRECTION.RIGHT_TO_LEFT,
+          !hasOffset.top && DIRECTION.BOTTOM_TO_TOP,
+          !hasOffset.right && DIRECTION.LEFT_TO_RIGHT,
+        ].filter(Boolean),
+      };
+    }
+    return {};
   }, [selectedElements]);
 
   return selectedElements.length > 1 ? (

--- a/assets/src/edit-story/components/panels/animation/test/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/test/directionRadioInput.js
@@ -16,13 +16,34 @@
 /**
  * External dependencies
  */
+import { useState } from 'react';
 import { fireEvent } from '@testing-library/react';
+import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
 import { DIRECTION } from '../../../../../animation';
 import { renderWithTheme } from '../../../../testUtils';
 import { DirectionRadioInput } from '../directionRadioInput';
+
+function DirectionRadioInputUncontrolled({ onChange, directions }) {
+  const [state, setState] = useState(null);
+  return (
+    <DirectionRadioInput
+      value={state}
+      onChange={(e) => {
+        setState(e.target.value);
+        onChange(e);
+      }}
+      directions={directions}
+    />
+  );
+}
+
+DirectionRadioInputUncontrolled.propTypes = {
+  onChange: PropTypes.func,
+  directions: PropTypes.arrayOf(PropTypes.string),
+};
 
 describe('<DirectionRadioInput />', () => {
   it('should render', () => {
@@ -35,6 +56,7 @@ describe('<DirectionRadioInput />', () => {
     const { getAllByRole } = renderWithTheme(
       <DirectionRadioInput
         directions={[DIRECTION.TOP_TO_BOTTOM, DIRECTION.BOTTOM_TO_TOP]}
+        onChange={() => {}}
       />
     );
     const radios = getAllByRole('radio');
@@ -64,7 +86,7 @@ describe('<DirectionRadioInput />', () => {
   it('should update checked when new input clicked', () => {
     const onChange = jest.fn();
     const { getAllByRole, getByRole } = renderWithTheme(
-      <DirectionRadioInput
+      <DirectionRadioInputUncontrolled
         onChange={onChange}
         directions={[DIRECTION.TOP_TO_BOTTOM, DIRECTION.BOTTOM_TO_TOP]}
       />
@@ -89,20 +111,5 @@ describe('<DirectionRadioInput />', () => {
       })
     );
     expect(getByRole('radio', { checked: true })).toBe(radios[0]);
-  });
-
-  it('should allow for a defaultChecked', () => {
-    const directions = Object.values(DIRECTION);
-    const defaultIndex = directions.length - 1;
-    const { getByRole } = renderWithTheme(
-      <DirectionRadioInput
-        defaultChecked={directions[defaultIndex]}
-        directions={directions}
-      />
-    );
-
-    expect(getByRole('radio', { checked: true }).value).toBe(
-      directions[defaultIndex]
-    );
   });
 });

--- a/assets/src/edit-story/elements/media/getMediaSizePositionProps.js
+++ b/assets/src/edit-story/elements/media/getMediaSizePositionProps.js
@@ -50,16 +50,7 @@ function getMediaSizePositionProps(
     0,
     Math.min(mediaHeight * focalY * 0.01 - height * 0.5, mediaHeight - height)
   );
-  // console.log({
-  //   width: mediaWidth,
-  //   height: mediaHeight,
-  //   offsetX,
-  //   offsetY,
-  //   scale,
-  //   focalX,
-  //   focalY,
-  // });
-  // console.log('MEDIA_PROPS %X: ', offsetX);
+
   return {
     width: mediaWidth,
     height: mediaHeight,

--- a/assets/src/edit-story/elements/media/getMediaSizePositionProps.js
+++ b/assets/src/edit-story/elements/media/getMediaSizePositionProps.js
@@ -50,6 +50,16 @@ function getMediaSizePositionProps(
     0,
     Math.min(mediaHeight * focalY * 0.01 - height * 0.5, mediaHeight - height)
   );
+  // console.log({
+  //   width: mediaWidth,
+  //   height: mediaHeight,
+  //   offsetX,
+  //   offsetY,
+  //   scale,
+  //   focalX,
+  //   focalY,
+  // });
+  // console.log('MEDIA_PROPS %X: ', offsetX);
   return {
     width: mediaWidth,
     height: mediaHeight,


### PR DESCRIPTION
## Summary
- Adds Initial background pan effect
- Sets up infra for dynamic disablable options in anim type inputs.

## Relevant Technical Choices
Mostly followed existing patterns. Lemme know if you see a better way to handle disabling options for anim inputs

## To-do


## User-facing changes
none, behind animation flag

## Testing Instructions
Add a pan animation effect to your background. see that it goes from the selected edge to where the background image was initially positioned.

Move background cropping around so that it touches an edge or is too small to pan in a direction. see that the pan options for those directions get disabled in both the direction input and the effect chooser.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3529 
