### PR TITLE
Workspace: Disable tooltip when Publish Checklist Flag is off

### DIFF
--- a/assets/src/edit-story/components/header/buttons/publish.js
+++ b/assets/src/edit-story/components/header/buttons/publish.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { useCallback, useState } from 'react';
-
+import { useFeatures } from 'flagged';
 /**
  * WordPress dependencies
  */
@@ -56,9 +56,12 @@ function Publish() {
   const { capabilities } = useConfig();
 
   const { checklist, refreshChecklist } = usePrepublishChecklist();
-  const tooltip =
-    checklist.some(({ type }) => PRE_PUBLISH_MESSAGE_TYPES.ERROR === type) &&
-    __('There are items in the checklist to resolve', 'web-stories');
+  const { showPrePublishTab } = useFeatures();
+
+  const tooltip = showPrePublishTab
+    ? checklist.some(({ type }) => PRE_PUBLISH_MESSAGE_TYPES.ERROR === type) &&
+      __('There are items in the checklist to resolve', 'web-stories')
+    : null;
 
   const refreshPostEditURL = useRefreshPostEditURL(storyId);
   const hasFutureDate = Date.now() < Date.parse(date);


### PR DESCRIPTION
## Summary

Ensures the tooltip for pre-publish checklist does not show up when the flag is off.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Ensures the tooltip for pre-publish checklist does not show up when the flag is off.

## Testing Instructions

1. Keep the flag for the pre-publish checklist off
2. When you hover over the publish button in the editor, you should see no tooltip

