### PR TITLE
Pre-Publish Checklist: Fix story title too long error message

### DIFF
--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -238,7 +238,7 @@ export const MESSAGES = {
       HELPER_TEXT: sprintf(
         /* translators: 1: minimum number of story characters. */
         __('Story title should have %d characters or fewer.', 'web-stories'),
-        MAX_STORY_CHARACTERS
+        MAX_STORY_TITLE_LENGTH_CHARS
       ),
     },
   },

--- a/assets/src/edit-story/app/prepublish/guidance/test/general.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/general.js
@@ -62,6 +62,7 @@ describe('Pre-publish checklist - general guidelines (guidance)', () => {
     expect(test).not.toBeUndefined();
     expect(test.type).toStrictEqual(PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE);
     expect(test.message).toMatchInlineSnapshot(`"Story title too long"`);
+    expect(test.help).toMatch(/40 characters/);
     expect(test.storyId).toStrictEqual(testStory.id);
     expect(testUndefined).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

Fixes wording of story title too long prepublish error to say 40 characters instead of 200.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5378 
