### PR TITLE
Update UI for In-Use Fonts for Text Sets

### DIFF
--- a/assets/src/edit-story/components/library/common/section.js
+++ b/assets/src/edit-story/components/library/common/section.js
@@ -20,7 +20,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-const Container = styled.div`
+export const Container = styled.div`
   position: relative;
   margin-top: 28px;
   margin-bottom: 28px;
@@ -30,7 +30,7 @@ const Container = styled.div`
   }
 `;
 
-const Title = styled.h2`
+export const Title = styled.h2`
   flex: 1 1 auto;
   color: ${({ theme }) => theme.colors.fg.white};
   font-family: ${({ theme }) => theme.fonts.label.family};

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * External dependencies
  */
 import { useState, useMemo, useCallback } from 'react';
@@ -24,12 +29,9 @@ import { v4 as uuidv4 } from 'uuid';
 import { useVirtual } from 'react-virtual';
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-/**
  * Internal dependencies
  */
+import { FullWidthWrapper } from '../../common/styles';
 import PillGroup from '../../shared/pillGroup';
 import localStore, {
   LOCAL_STORAGE_PREFIX,
@@ -47,7 +49,6 @@ import {
   Container as SectionContainer,
   Title as SectionTitle,
 } from '../../../common/section';
-import { PANE_PADDING } from '../../shared';
 import TextSet from './textSet';
 
 const TEXT_SET_ROW_GAP = 12;
@@ -79,12 +80,6 @@ const TitleBar = styled.div`
     margin-top: 14px;
     margin-bottom: 28px;
   }
-`;
-
-/* Undo the -1.5em set by the Pane */
-const CategoryWrapper = styled.div`
-  margin-left: -${PANE_PADDING};
-  margin-right: -${PANE_PADDING};
 `;
 
 const CATEGORIES = {
@@ -165,14 +160,14 @@ function TextSets({ paneRef }) {
           label={__('Match fonts from story', 'web-stories')}
         />
       </TitleBar>
-      <CategoryWrapper>
+      <FullWidthWrapper>
         <PillGroup
           items={categories}
           selectedItemId={selectedCat}
           selectItem={handleSelectedCategory}
           deselectItem={() => handleSelectedCategory(null)}
         />
-      </CategoryWrapper>
+      </FullWidthWrapper>
       <UnitsProvider
         pageSize={{
           width: TEXT_SET_SIZE,

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -27,13 +27,10 @@ import { useVirtual } from 'react-virtual';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-
 /**
  * Internal dependencies
  */
-import { Section } from '../../../common';
 import PillGroup from '../../shared/pillGroup';
-import { FullWidthWrapper } from '../../common/styles';
 import localStore, {
   LOCAL_STORAGE_PREFIX,
 } from '../../../../../utils/localStore';
@@ -45,6 +42,11 @@ import {
   getInUseFontsForPages,
   getTextSetsForFonts,
 } from '../../../../../utils/getInUseFonts';
+import Switch from '../../../../switch';
+import {
+  Container as SectionContainer,
+  Title as SectionTitle,
+} from '../../../common/section';
 import TextSet from './textSet';
 
 const TEXT_SET_ROW_GAP = 12;
@@ -69,6 +71,21 @@ const TextSetRow = styled.div`
   column-gap: 12px;
 `;
 
+const TitleBar = styled.div`
+  display: flex;
+
+  label {
+    margin-top: 14px;
+    margin-bottom: 28px;
+  }
+`;
+
+/* Undo the -1.5em set by the Pane */
+const CategoryWrapper = styled.div`
+  margin-left: -${PANE_PADDING};
+  margin-right: -${PANE_PADDING};
+`;
+
 const CATEGORIES = {
   contact: __('Contact', 'web-stories'),
   editorial: __('Editorial', 'web-stories'),
@@ -78,11 +95,11 @@ const CATEGORIES = {
   step: __('Steps', 'web-stories'),
   table: __('Table', 'web-stories'),
   quote: __('Quote', 'web-stories'),
-  inUse: __('Fonts In Use', 'web-stories'),
 };
 
 function TextSets({ paneRef }) {
   const { textSets } = useLibrary(({ state: { textSets } }) => ({ textSets }));
+  const [showInUse, setShowInUse] = useState(false);
 
   const allTextSets = useMemo(() => Object.values(textSets).flat(), [textSets]);
   const storyPages = useStory(({ state: { pages } }) => pages);
@@ -96,17 +113,17 @@ function TextSets({ paneRef }) {
     () =>
       getTextSetsForFonts({
         fonts: getInUseFontsForPages(storyPages),
-        textSets: allTextSets,
+        textSets: selectedCat ? textSets[selectedCat] : allTextSets,
       }),
-    [allTextSets, storyPages]
+    [allTextSets, storyPages, selectedCat, textSets]
   );
 
   const filteredTextSets = useMemo(() => {
-    if (selectedCat === 'inUse') {
+    if (showInUse) {
       return getTextSetsForInUseFonts();
     }
     return selectedCat ? textSets[selectedCat] : allTextSets;
-  }, [selectedCat, textSets, allTextSets, getTextSetsForInUseFonts]);
+  }, [selectedCat, textSets, allTextSets, getTextSetsForInUseFonts, showInUse]);
 
   const categories = useMemo(
     () => [
@@ -114,7 +131,6 @@ function TextSets({ paneRef }) {
         id: cat,
         label: CATEGORIES[cat] ?? cat,
       })),
-      { id: 'inUse', label: CATEGORIES.inUse },
     ],
     [textSets]
   );
@@ -137,15 +153,25 @@ function TextSets({ paneRef }) {
   const title = useMemo(() => __('Text Sets', 'web-stories'), []);
 
   return (
-    <Section id={sectionId} title={title}>
-      <FullWidthWrapper>
+    <SectionContainer id={sectionId}>
+      <TitleBar>
+        <SectionTitle>{title}</SectionTitle>
+        <Switch
+          onChange={(value) => {
+            requestAnimationFrame(() => setShowInUse(value));
+          }}
+          value={showInUse}
+          label={__('Match fonts from story', 'web-stories')}
+        />
+      </TitleBar>
+      <CategoryWrapper>
         <PillGroup
           items={categories}
           selectedItemId={selectedCat}
           selectItem={handleSelectedCategory}
           deselectItem={() => handleSelectedCategory(null)}
         />
-      </FullWidthWrapper>
+      </CategoryWrapper>
       <UnitsProvider
         pageSize={{
           width: TEXT_SET_SIZE,
@@ -181,7 +207,7 @@ function TextSets({ paneRef }) {
           })}
         </TextSetContainer>
       </UnitsProvider>
-    </Section>
+    </SectionContainer>
   );
 }
 

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -47,6 +47,7 @@ import {
   Container as SectionContainer,
   Title as SectionTitle,
 } from '../../../common/section';
+import { PANE_PADDING } from '../../shared';
 import TextSet from './textSet';
 
 const TEXT_SET_ROW_GAP = 12;


### PR DESCRIPTION
## Summary

- Updates the UI from a toggle button to a checkbox

<img width="419" alt="Screen Shot 2020-11-23 at 3 49 11 PM" src="https://user-images.githubusercontent.com/1738349/100019386-8e954b00-2da3-11eb-83d2-a43ef3d3fb5f.png">

## Relevant Technical Choices

- None

## To-do

- None

## User-facing changes

Cosmetic changes around a pill turning into a checkbox to enable filtering by in-use fonts

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

1. Create or open a story
2. Add a text box with "Roboto"
3. Switch the toggle switch on "Match Fonts from Story"
4. See relevant text sets that include Roboto for any filtered category

<!-- Please reference the issue(s) this PR addresses. -->

#5122 
