### PR TITLE
E2E Tests: Update CI build matrix

### DIFF
--- a/.github/workflows/continuous-integration-e2e.yml
+++ b/.github/workflows/continuous-integration-e2e.yml
@@ -14,8 +14,13 @@ jobs:
     strategy:
       matrix:
         # TODO: add back Firefox once support is more mature.
-        browser: ['chrome']
-        wp: ['latest', '5.4']
+        include:
+          - browser: 'chrome'
+            wp: 'latest'
+            coverage: true
+          - browser: 'chrome'
+            wp: '5.4'
+            coverage: false
 
     steps:
       - name: Checkout
@@ -89,11 +94,11 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E }}
           PUPPETEER_PRODUCT: ${{ matrix.browser }}
-        if: ${{ matrix.wp == 'latest' }}
+        if: ${{ matrix.coverage }}
 
       - name: Run E2E tests
         run: npm run test:e2e
-        if: ${{ matrix.wp != 'latest' }}
+        if: ${{ ! matrix.coverage }}
 
       - name: Stop Docker environment
         run: npm run env:stop

--- a/.github/workflows/continuous-integration-e2e.yml
+++ b/.github/workflows/continuous-integration-e2e.yml
@@ -9,12 +9,13 @@ on:
 
 jobs:
   e2e:
-    name: ${{ matrix.browser }}
+    name: '${{ matrix.browser }} - WP ${{ matrix.wp }}'
     runs-on: ubuntu-latest
     strategy:
       matrix:
         # TODO: add back Firefox once support is more mature.
         browser: ['chrome']
+        wp: ['latest', '5.3']
 
     steps:
       - name: Checkout
@@ -81,6 +82,7 @@ jobs:
         run: npm run env:start
         env:
           COMPOSE_INTERACTIVE_NO_CLI: true
+          WP_VERSION: ${{ matrix.wp }}
 
       - name: Run E2E tests
         run: npm run test:e2e:percy

--- a/.github/workflows/continuous-integration-e2e.yml
+++ b/.github/workflows/continuous-integration-e2e.yml
@@ -84,11 +84,16 @@ jobs:
           COMPOSE_INTERACTIVE_NO_CLI: true
           WP_VERSION: ${{ matrix.wp }}
 
-      - name: Run E2E tests
+      - name: Run E2E tests with percy
         run: npm run test:e2e:percy
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN_E2E }}
           PUPPETEER_PRODUCT: ${{ matrix.browser }}
+        if: ${{ matrix.wp == 'latest' }}
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+        if: ${{ matrix.wp != 'latest' }}
 
       - name: Stop Docker environment
         run: npm run env:stop

--- a/.github/workflows/continuous-integration-e2e.yml
+++ b/.github/workflows/continuous-integration-e2e.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # TODO: add back Firefox once support is more mature.
         browser: ['chrome']
-        wp: ['latest', '5.3']
+        wp: ['latest', '5.4']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Update the e2e tests to run in latest and 5.4.

## Relevant Technical Choices

After much testing, updating the support matrix to support 5.3 didn't work. There are a number of issues with 5.3 that need to be fixed and conditional logic added. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5338
