### PR TITLE
Animation: Play selected element's new animation effect on selection

### DIFF
--- a/assets/src/animation/components/WAAPIWrapper.js
+++ b/assets/src/animation/components/WAAPIWrapper.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 /**
@@ -62,10 +62,15 @@ function WAAPIWrapper({ children, target }) {
     actions: { getAnimationParts, hoistWAAPIAnimation },
   } = useStoryAnimationContext();
 
+  const hoistAnimation = useCallback(
+    (animation) => hoistWAAPIAnimation({ animation, elementId: target }),
+    [target, hoistWAAPIAnimation]
+  );
+
   return (
     <ComposableWrapper
       animationParts={getAnimationParts(target)}
-      hoistAnimation={hoistWAAPIAnimation}
+      hoistAnimation={hoistAnimation}
     >
       {children}
     </ComposableWrapper>

--- a/assets/src/animation/components/provider.js
+++ b/assets/src/animation/components/provider.js
@@ -58,7 +58,15 @@ const createOnFinishPromise = (animation) => {
   });
 };
 
-function Provider({ animations, elements, children, onWAAPIFinish }) {
+const ALL_ELEMENTS = 'all_elements';
+
+function Provider({
+  animations,
+  elements,
+  children,
+  onWAAPIFinish,
+  selectedElements = ALL_ELEMENTS,
+}) {
   const enableAnimation = useFeature('enableAnimation');
 
   const elementsMap = useMemo(() => {
@@ -115,7 +123,10 @@ function Provider({ animations, elements, children, onWAAPIFinish }) {
 
   const hoistWAAPIAnimation = useCallback((WAPPIAnimation) => {
     const symbol = Symbol();
-    WAAPIAnimationMap.current.set(symbol, WAPPIAnimation);
+    WAAPIAnimationMap.current.set(symbol, {
+      animation: WAPPIAnimation,
+      element,
+    });
 
     setWAAPIAnimations(Array.from(WAAPIAnimationMap.current.values()));
     return () => {
@@ -127,7 +138,7 @@ function Provider({ animations, elements, children, onWAAPIFinish }) {
 
   const WAAPIAnimationMethods = useMemo(() => {
     const play = () =>
-      WAAPIAnimations.forEach((animation) => {
+      WAAPIAnimations.forEach(({ animation, element }) => {
         // Sometimes an animation part can get into a
         // stuck state where executing `play` doesn't
         // trigger the animation. A workaround to avoid
@@ -138,9 +149,9 @@ function Provider({ animations, elements, children, onWAAPIFinish }) {
         animation?.play();
       });
     const pause = () =>
-      WAAPIAnimations.forEach((animation) => animation?.pause());
+      WAAPIAnimations.forEach(({ animation, element }) => animation?.pause());
     const setCurrentTime = (time) =>
-      WAAPIAnimations.forEach((animation) => {
+      WAAPIAnimations.forEach(({ animation, element }) => {
         const { duration, delay } =
           (animation.effect?.timing || animation.effect?.getTiming()) ?? {};
         const animationEndTime = (delay || 0) + (duration || 0);
@@ -224,6 +235,10 @@ Provider.propTypes = {
   elements: PropTypes.arrayOf(StoryPropTypes.element),
   children: PropTypes.node.isRequired,
   onWAAPIFinish: PropTypes.func,
+  selectedElements: PropTypes.oneOfType([
+    ALL_ELEMENTS,
+    PropTypes.arrayOf(StoryPropTypes.element.id),
+  ]),
 };
 
 export default Provider;

--- a/assets/src/animation/components/test/provider.js
+++ b/assets/src/animation/components/test/provider.js
@@ -208,9 +208,9 @@ describe('StoryAnimation.Provider', () => {
 
       let unhoist;
       act(() => {
-        unhoist = result.current.actions.hoistWAAPIAnimation(
-          mockWAAPIAnimation()
-        );
+        unhoist = result.current.actions.hoistWAAPIAnimation({
+          animation: mockWAAPIAnimation(),
+        });
       });
       expect(typeof unhoist).toBe('function');
     });
@@ -233,9 +233,9 @@ describe('StoryAnimation.Provider', () => {
       const cancel = jest.fn();
       act(() => {
         let unhoist;
-        unhoist = result.current.actions.hoistWAAPIAnimation(
-          mockWAAPIAnimation({ cancel })
-        );
+        unhoist = result.current.actions.hoistWAAPIAnimation({
+          animation: mockWAAPIAnimation({ cancel }),
+        });
         unhoist();
       });
       expect(cancel).toHaveBeenCalledWith();
@@ -266,7 +266,7 @@ describe('StoryAnimation.Provider', () => {
           },
         });
         act(() => {
-          result.current.actions.hoistWAAPIAnimation(animation);
+          result.current.actions.hoistWAAPIAnimation({ animation });
         });
         return animation;
       });
@@ -313,7 +313,7 @@ describe('StoryAnimation.Provider', () => {
       const unhoists = animations.map((animation) => {
         let unhoist;
         act(() => {
-          unhoist = result.current.actions.hoistWAAPIAnimation(animation);
+          unhoist = result.current.actions.hoistWAAPIAnimation({ animation });
         });
         return unhoist;
       });
@@ -359,7 +359,7 @@ describe('StoryAnimation.Provider', () => {
         );
         animations.forEach((animation) => {
           act(() => {
-            result.current.actions.hoistWAAPIAnimation(animation);
+            result.current.actions.hoistWAAPIAnimation({ animation });
           });
         });
 

--- a/assets/src/animation/constants.js
+++ b/assets/src/animation/constants.js
@@ -132,6 +132,7 @@ export const STORY_ANIMATION_STATE = {
   PAUSED: 'paused',
   SCRUBBING: 'scrubbing',
   PLAYING: 'playing',
+  PLAYING_SELECTED: 'playing-selected',
 };
 
 export const BG_MIN_SCALE = 100;

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/setSelectedElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/setSelectedElements.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { STORY_ANIMATION_STATE } from '../../../../../animation';
 import { intersect } from './utils';
 
 /**
@@ -64,6 +65,7 @@ function setSelectedElements(state, { elementIds }) {
 
   return {
     ...state,
+    animationState: STORY_ANIMATION_STATE.RESET,
     selection: newSelection,
   };
 }

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/updateElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/updateElements.js
@@ -46,9 +46,11 @@ function updateElements(
   { elementIds, properties: propertiesOrUpdater }
 ) {
   if (
-    [STORY_ANIMATION_STATE.PLAYING, STORY_ANIMATION_STATE.SCRUBBING].includes(
-      state.animationState
-    )
+    [
+      STORY_ANIMATION_STATE.PLAYING,
+      STORY_ANIMATION_STATE.PLAYING_SELECTED,
+      STORY_ANIMATION_STATE.SCRUBBING,
+    ].includes(state.animationState)
   ) {
     return state;
   }

--- a/assets/src/edit-story/app/story/useStoryReducer/test/setSelectedElementsById.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/setSelectedElementsById.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { STORY_ANIMATION_STATE } from '../../../../../animation';
 import { setupReducer } from './_utils';
 
 describe('setSelectedElementsById', () => {
@@ -144,5 +145,64 @@ describe('setSelectedElementsById', () => {
     const result = setSelectedElementsById({ elementIds: ['e2', 'e1', 'e3'] });
 
     expect(result.selection).toStrictEqual(['e2', 'e3']);
+  });
+
+  it('should not update animationState if nothing has changed', () => {
+    const {
+      restore,
+      setSelectedElementsById,
+      updateAnimationState,
+    } = setupReducer();
+
+    // Set an initial state.
+    restore({
+      pages: [
+        {
+          id: '111',
+          elements: [
+            { id: 'e1', isBackground: true },
+            { id: 'e2' },
+            { id: 'e3' },
+          ],
+        },
+      ],
+      current: '111',
+      selection: ['e3'],
+    });
+
+    updateAnimationState({ animationState: STORY_ANIMATION_STATE.PLAYING });
+    const result = setSelectedElementsById({ elementIds: ['e3'] });
+
+    expect(result.animationState).toStrictEqual(STORY_ANIMATION_STATE.PLAYING);
+  });
+
+  it('should reset animationState if selection has changed', () => {
+    const {
+      restore,
+      setSelectedElementsById,
+      updateAnimationState,
+    } = setupReducer();
+
+    // Set an initial state.
+    restore({
+      animationState: STORY_ANIMATION_STATE.PLAYING,
+      pages: [
+        {
+          id: '111',
+          elements: [
+            { id: 'e1', isBackground: true },
+            { id: 'e2' },
+            { id: 'e3' },
+          ],
+        },
+      ],
+      current: '111',
+      selection: ['e2'],
+    });
+
+    updateAnimationState({ animationState: STORY_ANIMATION_STATE.PLAYING });
+    const result = setSelectedElementsById({ elementIds: ['e3'] });
+
+    expect(result.animationState).toStrictEqual(STORY_ANIMATION_STATE.RESET);
   });
 });

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { memo, useCallback, useEffect } from 'react';
+import { memo, useCallback, useEffect, useMemo } from 'react';
 
 /**
  * WordPress dependencies
@@ -104,13 +104,11 @@ function DisplayLayer() {
     currentPage,
     animationState,
     updateAnimationState,
-    selectedElementAnimations,
     selectedElements,
   } = useStory(({ state, actions }) => {
     return {
       currentPage: state.currentPage,
       animationState: state.animationState,
-      selectedElementAnimations: state.selectedElementAnimations,
       selectedElements: state.selectedElements,
       updateAnimationState: actions.updateAnimationState,
     };
@@ -131,11 +129,16 @@ function DisplayLayer() {
     [updateAnimationState]
   );
 
+  const animatedElements = useMemo(() => selectedElements.map((el) => el.id), [
+    selectedElements,
+  ]);
+
   return (
     <StoryAnimation.Provider
       animations={currentPage?.animations}
       elements={currentPage?.elements}
       onWAAPIFinish={resetAnimationState}
+      selectedElementIds={animatedElements}
     >
       <Layer
         data-testid="DisplayLayer"

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -100,15 +100,21 @@ function DisplayPage({
 }
 
 function DisplayLayer() {
-  const { currentPage, animationState, updateAnimationState } = useStory(
-    ({ state, actions }) => {
-      return {
-        currentPage: state.currentPage,
-        animationState: state.animationState,
-        updateAnimationState: actions.updateAnimationState,
-      };
-    }
-  );
+  const {
+    currentPage,
+    animationState,
+    updateAnimationState,
+    selectedElementAnimations,
+    selectedElements,
+  } = useStory(({ state, actions }) => {
+    return {
+      currentPage: state.currentPage,
+      animationState: state.animationState,
+      selectedElementAnimations: state.selectedElementAnimations,
+      selectedElements: state.selectedElements,
+      updateAnimationState: actions.updateAnimationState,
+    };
+  });
   const {
     editingElement,
     setPageContainer,

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -50,6 +50,7 @@ function DisplayPage({
 
   useEffect(() => {
     switch (animationState) {
+      case STORY_ANIMATION_STATE.PLAYING_SELECTED:
       case STORY_ANIMATION_STATE.PLAYING:
         WAAPIAnimationMethods.play();
         return;
@@ -137,7 +138,11 @@ function DisplayLayer() {
       animations={currentPage?.animations}
       elements={currentPage?.elements}
       onWAAPIFinish={resetAnimationState}
-      selectedElementIds={animatedElements}
+      selectedElementIds={
+        animationState === STORY_ANIMATION_STATE.PLAYING_SELECTED
+          ? animatedElements
+          : []
+      }
     >
       <Layer
         data-testid="DisplayLayer"

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -124,10 +124,9 @@ function DisplayLayer() {
     }) => ({ editingElement, setPageContainer, setFullbleedContainer })
   );
 
-  const resetAnimationState = useCallback(
-    () => updateAnimationState({ animationState: STORY_ANIMATION_STATE.RESET }),
-    [updateAnimationState]
-  );
+  const resetAnimationState = useCallback(() => {
+    updateAnimationState({ animationState: STORY_ANIMATION_STATE.RESET });
+  }, [updateAnimationState]);
 
   const animatedElements = useMemo(() => selectedElements.map((el) => el.id), [
     selectedElements,

--- a/assets/src/edit-story/components/canvas/pagemenu/index.js
+++ b/assets/src/edit-story/components/canvas/pagemenu/index.js
@@ -167,10 +167,12 @@ function PageMenu() {
   const toggleAnimationState = useCallback(
     () =>
       updateAnimationState({
-        animationState:
-          animationState === STORY_ANIMATION_STATE.PLAYING
-            ? STORY_ANIMATION_STATE.RESET
-            : STORY_ANIMATION_STATE.PLAYING,
+        animationState: [
+          STORY_ANIMATION_STATE.PLAYING,
+          STORY_ANIMATION_STATE.PLAYING_SELECTED,
+        ].includes(animationState)
+          ? STORY_ANIMATION_STATE.RESET
+          : STORY_ANIMATION_STATE.PLAYING,
       }),
     [animationState, updateAnimationState]
   );
@@ -245,7 +247,10 @@ function PageMenu() {
           </WithTooltip>
           <Space />
           {enableAnimation &&
-            (animationState === STORY_ANIMATION_STATE.PLAYING ? (
+            ([
+              STORY_ANIMATION_STATE.PLAYING,
+              STORY_ANIMATION_STATE.PLAYING_SELECTED,
+            ].includes(animationState) ? (
               <WithTooltip
                 style={{ marginLeft: 'auto' }}
                 title={__('Stop', 'web-stories')}

--- a/assets/src/edit-story/components/canvas/selection.js
+++ b/assets/src/edit-story/components/canvas/selection.js
@@ -28,6 +28,7 @@ function Selection() {
     selectedElements: state.state.selectedElements,
     isAnimating: [
       STORY_ANIMATION_STATE.PLAYING,
+      STORY_ANIMATION_STATE.PLAYING_SELECTED,
       STORY_ANIMATION_STATE.SCRUBBING,
     ].includes(state.state.animationState),
   }));

--- a/assets/src/edit-story/components/inspector/design/useDesignPanels.js
+++ b/assets/src/edit-story/components/inspector/design/useDesignPanels.js
@@ -35,6 +35,7 @@ function useDesignPanels() {
     selectedElementAnimations,
     deleteSelectedElements,
     updateElementsById,
+    updateAnimationState,
   } = useStory(
     ({
       state: {
@@ -42,7 +43,11 @@ function useDesignPanels() {
         selectedElements,
         selectedElementAnimations,
       },
-      actions: { deleteSelectedElements, updateElementsById },
+      actions: {
+        deleteSelectedElements,
+        updateElementsById,
+        updateAnimationState,
+      },
     }) => {
       return {
         selectedElementIds,
@@ -50,6 +55,7 @@ function useDesignPanels() {
         selectedElementAnimations,
         deleteSelectedElements,
         updateElementsById,
+        updateAnimationState,
       };
     }
   );
@@ -109,6 +115,7 @@ function useDesignPanels() {
       deleteSelectedElements,
       selectedElements,
       selectedElementAnimations,
+      updateAnimationState,
     },
   };
 }

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -119,7 +119,7 @@ function AnimationPanel({
   useEffect(() => {
     if (playUpdatedAnimation.current) {
       updateAnimationState({
-        animationState: STORY_ANIMATION_STATE.PLAYING,
+        animationState: STORY_ANIMATION_STATE.PLAYING_SELECTED,
       });
       playUpdatedAnimation.current = false;
     }

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useCallback, useMemo, useEffect } from 'react';
+import { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -52,7 +52,7 @@ function AnimationPanel({
   selectedElements,
   selectedElementAnimations,
   pushUpdateForObject,
-  updateAnimationState,
+  // updateAnimationState,
 }) {
   const handlePanelChange = useCallback(
     (animation, submitArg = false) => {
@@ -161,7 +161,7 @@ function AnimationPanel({
       <Row>
         <EffectChooserDropdown
           onAnimationSelected={handleAddOrUpdateElementEffect}
-          selectedEffectTitle={getEffectName(updatedAnimationType)}
+          selectedEffectTitle={getEffectName(updatedAnimations[0]?.type)}
           onNoEffectSelected={handleRemoveEffect}
           isBackgroundEffects={isBackground}
           disabledTypeOptionsMap={disabledTypeOptionsMap}
@@ -182,7 +182,7 @@ AnimationPanel.propTypes = {
   selectedElements: PropTypes.arrayOf(StoryPropTypes.element).isRequired,
   selectedElementAnimations: PropTypes.arrayOf(AnimationPropType),
   pushUpdateForObject: PropTypes.func.isRequired,
-  updateAnimationState: PropTypes.func,
+  // updateAnimationState: PropTypes.func,
 };
 
 export default AnimationPanel;

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -52,8 +52,9 @@ function AnimationPanel({
   selectedElements,
   selectedElementAnimations,
   pushUpdateForObject,
-  // updateAnimationState,
+  updateAnimationState,
 }) {
+  const playUpdatedAnimation = useRef(false);
   const handlePanelChange = useCallback(
     (animation, submitArg = false) => {
       pushUpdateForObject(ANIMATION_PROPERTY, animation, null, submitArg);
@@ -109,17 +110,20 @@ function AnimationPanel({
         null,
         true
       );
+
+      playUpdatedAnimation.current = true;
     },
     [elAnimationId, isBackground, pushUpdateForObject, backgroundScale]
   );
 
-  // const updatedAnimationType = updatedAnimations[0]?.type;
-  // useEffect(() => {
-  //   console.log('Animation Type Update');
-  //   updateAnimationState({
-  //     animationState: STORY_ANIMATION_STATE.PLAYING_SELECTED,
-  //   });
-  // }, [updatedAnimationType, updateAnimationState]);
+  useEffect(() => {
+    if (playUpdatedAnimation.current) {
+      updateAnimationState({
+        animationState: STORY_ANIMATION_STATE.PLAYING,
+      });
+      playUpdatedAnimation.current = false;
+    }
+  }, [selectedElementAnimations, updateAnimationState]);
 
   const handleRemoveEffect = useCallback(() => {
     pushUpdateForObject(
@@ -182,7 +186,7 @@ AnimationPanel.propTypes = {
   selectedElements: PropTypes.arrayOf(StoryPropTypes.element).isRequired,
   selectedElementAnimations: PropTypes.arrayOf(AnimationPropType),
   pushUpdateForObject: PropTypes.func.isRequired,
-  // updateAnimationState: PropTypes.func,
+  updateAnimationState: PropTypes.func,
 };
 
 export default AnimationPanel;

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -22,7 +22,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * External dependencies
  */
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -36,6 +36,7 @@ import {
   DIRECTION,
   progress,
   hasOffsets,
+  STORY_ANIMATION_STATE,
 } from '../../../../animation';
 import { getAnimationEffectDefaults } from '../../../../animation/parts';
 import StoryPropTypes, { AnimationPropType } from '../../../types';
@@ -51,6 +52,7 @@ function AnimationPanel({
   selectedElements,
   selectedElementAnimations,
   pushUpdateForObject,
+  updateAnimationState,
 }) {
   const handlePanelChange = useCallback(
     (animation, submitArg = false) => {
@@ -111,6 +113,14 @@ function AnimationPanel({
     [elAnimationId, isBackground, pushUpdateForObject, backgroundScale]
   );
 
+  // const updatedAnimationType = updatedAnimations[0]?.type;
+  // useEffect(() => {
+  //   console.log('Animation Type Update');
+  //   updateAnimationState({
+  //     animationState: STORY_ANIMATION_STATE.PLAYING_SELECTED,
+  //   });
+  // }, [updatedAnimationType, updateAnimationState]);
+
   const handleRemoveEffect = useCallback(() => {
     pushUpdateForObject(
       ANIMATION_PROPERTY,
@@ -151,7 +161,7 @@ function AnimationPanel({
       <Row>
         <EffectChooserDropdown
           onAnimationSelected={handleAddOrUpdateElementEffect}
-          selectedEffectTitle={getEffectName(updatedAnimations[0]?.type)}
+          selectedEffectTitle={getEffectName(updatedAnimationType)}
           onNoEffectSelected={handleRemoveEffect}
           isBackgroundEffects={isBackground}
           disabledTypeOptionsMap={disabledTypeOptionsMap}
@@ -172,6 +182,7 @@ AnimationPanel.propTypes = {
   selectedElements: PropTypes.arrayOf(StoryPropTypes.element).isRequired,
   selectedElementAnimations: PropTypes.arrayOf(AnimationPropType),
   pushUpdateForObject: PropTypes.func.isRequired,
+  updateAnimationState: PropTypes.func,
 };
 
 export default AnimationPanel;

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -111,11 +111,15 @@ function AnimationPanel({
         true
       );
 
+      // There's nothing unique to the animation data to signify that it
+      // was changed by the effect chooser, so we track it here.
       playUpdatedAnimation.current = true;
     },
     [elAnimationId, isBackground, pushUpdateForObject, backgroundScale]
   );
 
+  // Play animation of selected elements when effect chooser signals
+  // that it has changed the data and the data comes back changed.
   useEffect(() => {
     if (playUpdatedAnimation.current) {
       updateAnimationState({


### PR DESCRIPTION
## Summary
- Sets up foundation to play animations for selected elements.
- Plays selected elements animation when the effect chooser updates an animation.

## Relevant Technical Choices
Had to add element Ids to the stored WAAPI animations so that we could target specific animations relative to elementId, whereas before these only needed to be aggregate methods.

## To-do
NA

## User-facing changes
NA - behind animation feature flag.

## Testing Instructions
turn on animation feature flag -> go to story editor:
1) add an animation to a selected element -> see animation play
2) use play button in editor -> see that it behaves as it did before
3) add an animation to a selected element -> while selected element is playing click outside of page canvas -> see that animation stops & resets

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5357  
