### PR TITLE
Text Sets: Use background color instead of shape for roboto cover

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/textSets/raw/cover.json
+++ b/assets/src/edit-story/components/library/panes/text/textSets/raw/cover.json
@@ -189,36 +189,8 @@
             "horizontal": false
           },
           "rotationAngle": 0,
-          "lockAspectRatio": false,
-          "backgroundColor": {
-            "color": {
-              "r": 0,
-              "g": 0,
-              "b": 0
-            }
-          },
-          "type": "shape",
-          "x": 41,
-          "y": 337,
-          "width": 112,
-          "height": 32,
-          "scale": 100,
-          "focalX": 50,
-          "focalY": 50,
-          "mask": {
-            "type": "rectangle"
-          },
-          "id": "7739a64c-76d0-49d4-91fe-a177500601c7"
-        },
-        {
-          "opacity": 100,
-          "flip": {
-            "vertical": false,
-            "horizontal": false
-          },
-          "rotationAngle": 0,
-          "lockAspectRatio": false,
-          "backgroundTextMode": "NONE",
+          "lockAspectRatio": true,
+          "backgroundTextMode": "FILL",
           "font": {
             "family": "Roboto",
             "weights": [100, 300, 400, 500, 700, 900],
@@ -257,32 +229,34 @@
               "lGap": 0
             }
           },
-          "fontSize": 16,
+          "fontSize": 18,
           "backgroundColor": {
             "color": {
-              "r": 196,
-              "g": 196,
-              "b": 196
+              "r": 0,
+              "g": 0,
+              "b": 0,
+              "a": 1
             }
           },
-          "lineHeight": 1.5,
+          "lineHeight": 1.8,
           "textAlign": "center",
           "padding": {
-            "locked": true,
-            "horizontal": 0,
+            "locked": false,
+            "horizontal": 3,
             "vertical": 0
           },
           "type": "text",
           "content": "<span style=\"font-weight: 900; color: #fff\">CATEGORY</span>",
           "fontWeight": 400,
           "x": 41,
-          "y": 345,
-          "width": 112,
-          "height": 19,
+          "y": 348,
+          "width": 114,
+          "height": 21,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,
-          "id": "ff9919e1-95ae-4276-9330-10a36a8d51d9"
+          "id": "ff9919e1-95ae-4276-9330-10a36a8d51d9",
+          "marginOffset": 11.306249999999999
         },
         {
           "opacity": 100,


### PR DESCRIPTION
## Summary

Replace background shape on roboto cover set with a background color. It looks a little narrow in the editor but it renders accurately in preview. 

## Relevant Technical Choices

- adjust font size and line height to 18px
- padding and text element width/height to get [same proportions as figma](https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories-Post-Stable?node-id=2%3A34118)


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- 'CATEGORY' text is now 18px w/ background color

## Testing Instructions

- Create a new story or go to an existing one and click or drag the roboto cover text set onto a page
- See that there is no longer a rectangle shape in the layers when you use the roboto cover text set and instead there's a black background color.

**No more rectangle shape layer:**
![Screen Shot 2020-11-24 at 1 08 06 PM](https://user-images.githubusercontent.com/10720454/100146429-230cb580-2e57-11eb-8205-e4a4fdcfb78b.png)

**In the editor:** 
![Screen Shot 2020-11-24 at 1 04 30 PM](https://user-images.githubusercontent.com/10720454/100146431-23a54c00-2e57-11eb-9e23-8649a6f2c2c9.png)

**In preview:** 
![Screen Shot 2020-11-24 at 1 04 20 PM](https://user-images.githubusercontent.com/10720454/100146433-23a54c00-2e57-11eb-98c0-187d1060fb6d.png)

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5222 
