### PR TITLE
Pre-Publish Checklist: Ignore background images when checking for too small on the page

### DIFF
--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -44,6 +44,12 @@ const MAX_VIDEO_LENGTH_SECONDS = 60;
  * @return {Guidance|undefined} The guidance object for consumption
  */
 export function mediaElementSizeOnPage(element) {
+  // Background elements behave differently since they will always be full screen. They have rect
+  // information that's not valid when the image is applied as a background.
+  if (element.isBackground) {
+    return undefined;
+  }
+
   // use the bounding rectangle for rotated elements
   const { startX, startY, endX, endY } = getBoundRect([element]);
   // get the intersecting area of the element's rectangle and the safe zone's rectangle

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -54,6 +54,20 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
     expect(result.elementId).toStrictEqual(tooSmallVideoElement.id);
   });
 
+  it('should ignore too small element if it is a background', () => {
+    const tooSmallImageElement = {
+      id: 123,
+      type: 'image',
+      height: 50,
+      width: 50,
+      x: 0,
+      y: 0,
+      isBackground: true,
+    };
+    const result = mediaGuidance.mediaElementSizeOnPage(tooSmallImageElement);
+    expect(result).toBeUndefined();
+  });
+
   it('should return a message if a video element is less than 480p', () => {
     const tooLowResolutionVideoElement = {
       id: 789,


### PR DESCRIPTION
## Summary

Background images retain their previous bounding rect information when they are made into background images. Since background images are always full screen, the too small on page guidance is irrelevant.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5374
