### PR TITLE
Pre-publish: Check background images against page dimensions

### DIFF
--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -161,11 +161,13 @@ function videoElementResolution(element) {
   return undefined;
 }
 
-function imageElementResolution(element) {
-  const heightResTooLow =
-    element.resource?.sizes?.full?.height < 2 * element.height;
-  const widthResTooLow =
-    element.resource?.sizes?.full?.width < 2 * element.width;
+function lowImageResolution(element, { height, width }) {
+  if (!isFinite(height) || !isFinite(width)) {
+    return undefined;
+  }
+
+  const heightResTooLow = height < 2 * element.height;
+  const widthResTooLow = width < 2 * element.width;
 
   if (heightResTooLow || widthResTooLow) {
     return {
@@ -175,25 +177,23 @@ function imageElementResolution(element) {
       help: MESSAGES.MEDIA.LOW_IMAGE_RESOLUTION.HELPER_TEXT,
     };
   }
+
   return undefined;
+}
+
+function imageElementResolution(element) {
+  return lowImageResolution(element, {
+    height: element.resource?.sizes?.full?.height,
+    width: element.resource?.sizes?.full?.width,
+  });
 }
 
 function gifElementResolution(element) {
   // gif/output uses the MP4 video provided by the 3P Media API for displaying gifs
-  const heightResTooLow =
-    element.resource?.output?.sizes?.mp4?.full?.height < 2 * element.height;
-  const widthResTooLow =
-    element.resource?.output?.sizes?.mp4?.full?.width < 2 * element.width;
-
-  if (heightResTooLow || widthResTooLow) {
-    return {
-      type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
-      elementId: element.id,
-      message: MESSAGES.MEDIA.LOW_IMAGE_RESOLUTION.MAIN_TEXT,
-      help: MESSAGES.MEDIA.LOW_IMAGE_RESOLUTION.HELPER_TEXT,
-    };
-  }
-  return undefined;
+  return lowImageResolution(element, {
+    height: element.resource?.output?.sizes?.mp4?.full?.height,
+    width: element.resource?.output?.sizes?.mp4?.full?.width,
+  });
 }
 
 /**

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -145,6 +145,103 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
     expect(result.elementId).toStrictEqual(tooLowResolutionImageElement.id);
   });
 
+  it("should return a undefined if an image element's resolution is high enough (2x pixel density)", () => {
+    const highResolutionImageElement = {
+      id: 910,
+      type: 'image',
+      height: 1000,
+      width: 1000,
+      resource: {
+        sizes: {
+          full: {
+            height: 2000,
+            width: 2000,
+          },
+        },
+      },
+    };
+
+    const result = mediaGuidance.mediaElementResolution(
+      highResolutionImageElement
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("should return a message if a height-constrained background image element's resolution is too low (<2x pixel density)", () => {
+    const tooLowResolutionImageElement = {
+      id: 910,
+      type: 'image',
+      height: 30,
+      width: 200,
+      resource: {
+        sizes: {
+          full: {
+            height: 618,
+            width: 4120,
+          },
+        },
+      },
+      isBackground: true,
+    };
+
+    const result = mediaGuidance.mediaElementResolution(
+      tooLowResolutionImageElement
+    );
+    expect(result).not.toBeUndefined();
+    expect(result.message).toMatchInlineSnapshot(`"Low image resolution"`);
+    expect(result.type).toStrictEqual('guidance');
+    expect(result.elementId).toStrictEqual(tooLowResolutionImageElement.id);
+  });
+
+  it("should return a message if a width-constrained background image element's resolution is too low (<2x pixel density)", () => {
+    const tooLowResolutionImageElement = {
+      id: 910,
+      type: 'image',
+      height: 300,
+      width: 20,
+      resource: {
+        sizes: {
+          full: {
+            height: 6180,
+            width: 412,
+          },
+        },
+      },
+      isBackground: true,
+    };
+
+    const result = mediaGuidance.mediaElementResolution(
+      tooLowResolutionImageElement
+    );
+    expect(result).not.toBeUndefined();
+    expect(result.message).toMatchInlineSnapshot(`"Low image resolution"`);
+    expect(result.type).toStrictEqual('guidance');
+    expect(result.elementId).toStrictEqual(tooLowResolutionImageElement.id);
+  });
+
+  it("should return undefined if a background image element's resolution high enough (2x pixel density)", () => {
+    const highResolutionImageElement = {
+      id: 910,
+      type: 'image',
+      height: 30,
+      width: 20,
+      resource: {
+        sizes: {
+          full: {
+            height: 1236,
+            width: 824,
+          },
+        },
+      },
+      isBackground: true,
+    };
+
+    const result = mediaGuidance.mediaElementResolution(
+      highResolutionImageElement
+    );
+    expect(result).toBeUndefined();
+  });
+
   it('should return a message if any video resolution is too high to display on most mobile devices (>4k)', () => {
     const tooHighVideoResolution = {
       id: 101,


### PR DESCRIPTION
## Summary

Background images don't have accurate `width` and `height` attributes so require checking against page dimensions for image resolution checks.

This may part of the solution to #5377 and #5376 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

Add an image that is high enough resolution for a small image but not for the full page size 2x, but then make it background and it should render an error about being not high resolution enough.

---

<!-- Please reference the issue(s) this PR addresses. -->
