### PR TITLE
Pre-Publish Checklist: Update cover image size on upload

### DIFF
--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -29,8 +29,8 @@ export const MAX_STORY_TITLE_LENGTH_WORDS = 10;
 export const MAX_STORY_TITLE_LENGTH_CHARS = 40;
 const COVER_DIMENSION_WIDTH_PX = 640;
 const COVER_DIMENSION_HEIGHT_PX = 853;
-const ASPECT_RATIO_LEFT = 3;
-const ASPECT_RATIO_RIGHT = 4;
+export const ASPECT_RATIO_LEFT = 3;
+export const ASPECT_RATIO_RIGHT = 4;
 const PUBLISHER_LOGO_DIMENSION = 96;
 const PUBLISHER_LOGO_RATIO = 1;
 const MIN_FONT_SIZE = 12;
@@ -91,11 +91,8 @@ export const MESSAGES = {
     COVER_WRONG_ASPECT_RATIO: {
       MAIN_TEXT: __('Story cover image wrong aspect ratio', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: minimum cover dimension width X minimum cover dimension height. 2: cover dimensions aspect ratio. */
-        __(
-          'Should be at least %1$s and maintain a %2$s aspect ratio.',
-          'web-stories'
-        ),
+        /* translators: 1: cover dimensions aspect ratio. */
+        __('Should maintain a %2$s aspect ratio.', 'web-stories'),
         `${COVER_DIMENSION_WIDTH_PX}x${COVER_DIMENSION_HEIGHT_PX}px`,
         `${ASPECT_RATIO_LEFT}:${ASPECT_RATIO_RIGHT}`
       ),

--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -91,9 +91,8 @@ export const MESSAGES = {
     COVER_WRONG_ASPECT_RATIO: {
       MAIN_TEXT: __('Story cover image wrong aspect ratio', 'web-stories'),
       HELPER_TEXT: sprintf(
-        /* translators: 1: cover dimensions aspect ratio. */
-        __('Should maintain a %2$s aspect ratio.', 'web-stories'),
-        `${COVER_DIMENSION_WIDTH_PX}x${COVER_DIMENSION_HEIGHT_PX}px`,
+        /* translators: %s: cover dimensions aspect ratio. */
+        __('Should maintain a %s aspect ratio.', 'web-stories'),
         `${ASPECT_RATIO_LEFT}:${ASPECT_RATIO_RIGHT}`
       ),
     },

--- a/assets/src/edit-story/app/prepublish/error/metadata.js
+++ b/assets/src/edit-story/app/prepublish/error/metadata.js
@@ -17,8 +17,14 @@
 /**
  * Internal dependencies
  */
+import { greatestCommonDivisor } from '../../../utils/greatestCommonDivisor';
 import isElementBelowLimit from '../../../utils/isElementBelowLimit';
-import { PRE_PUBLISH_MESSAGE_TYPES, MESSAGES } from '../constants';
+import {
+  PRE_PUBLISH_MESSAGE_TYPES,
+  MESSAGES,
+  ASPECT_RATIO_LEFT,
+  ASPECT_RATIO_RIGHT,
+} from '../constants';
 
 const FEATURED_MEDIA_RESOURCE_MIN_HEIGHT = 853;
 const FEATURED_MEDIA_RESOURCE_MIN_WIDTH = 640;
@@ -100,6 +106,39 @@ export function storyCoverPortraitSize(story) {
       storyId: story.id,
       message: MESSAGES.CRITICAL_METADATA.COVER_TOO_SMALL.MAIN_TEXT,
       help: MESSAGES.CRITICAL_METADATA.COVER_TOO_SMALL.HELPER_TEXT,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Check that the story's cover resource has the correct aspect ratio.
+ * If the resource is too small in either dimension, return an error message.
+ * Otherwise, return undefined.
+ *
+ * @param {Story} story The story being checked for critical metadata
+ * @return {Guidance|undefined} Guidance object for consumption
+ */
+export function storyCoverAspectRatio(story) {
+  if (
+    hasNoFeaturedMedia(story) ||
+    !story.featuredMedia?.width ||
+    !story.featuredMedia?.height
+  ) {
+    return undefined;
+  }
+  const gcd = greatestCommonDivisor(
+    story.featuredMedia?.width,
+    story.featuredMedia?.height
+  );
+  const leftRatio = story.featuredMedia?.width / gcd;
+  const rightRatio = story.featuredMedia?.height / gcd;
+  if (leftRatio !== ASPECT_RATIO_LEFT || rightRatio !== ASPECT_RATIO_RIGHT) {
+    return {
+      type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
+      storyId: story.id,
+      message: MESSAGES.CRITICAL_METADATA.COVER_WRONG_ASPECT_RATIO.MAIN_TEXT,
+      help: MESSAGES.CRITICAL_METADATA.COVER_WRONG_ASPECT_RATIO.HELPER_TEXT,
     };
   }
   return undefined;

--- a/assets/src/edit-story/app/prepublish/error/test/metadata.js
+++ b/assets/src/edit-story/app/prepublish/error/test/metadata.js
@@ -203,4 +203,26 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
     expect(test.message).toMatchInlineSnapshot(`"Story cover image too small"`);
     expect(test.storyId).toStrictEqual(testStory.id);
   });
+
+  it("should return an error-type guidance message if the story's cover image has the wrong ratio", () => {
+    const testStory = {
+      id: 456,
+      featuredMedia: { height: 960, width: 960, url: 'featured-media.com/img' },
+    };
+    const testHappy = metadataGuidelines.storyCoverPortraitSize({
+      id: 345,
+      featuredMedia: {
+        url: 'featured-media.com/img',
+        height: 960,
+        width: 720,
+      },
+    });
+    const test = metadataGuidelines.storyCoverAspectRatio(testStory);
+    expect(testHappy).toBeUndefined();
+    expect(test).not.toBeUndefined();
+    expect(test.message).toMatchInlineSnapshot(
+      `"Story cover image wrong aspect ratio"`
+    );
+    expect(test.storyId).toStrictEqual(testStory.id);
+  });
 });

--- a/assets/src/edit-story/components/inspector/document/publish/index.js
+++ b/assets/src/edit-story/components/inspector/document/publish/index.js
@@ -105,9 +105,9 @@ function PublishPanel() {
         properties: {
           featuredMedia: {
             id: image.id,
-            height: image.sizes?.medium?.height || image.height,
-            url: image.sizes?.medium?.url || image.url,
-            width: image.sizes?.medium?.width || image.width,
+            height: image.sizes?.full?.height || image.height,
+            url: image.sizes?.full?.url || image.url,
+            width: image.sizes?.full?.width || image.width,
           },
         },
       }),

--- a/assets/src/edit-story/utils/greatestCommonDivisor.js
+++ b/assets/src/edit-story/utils/greatestCommonDivisor.js
@@ -13,18 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Internal dependencies
- */
-import * as metadataErrors from './metadata';
 
-export default {
-  story: [
-    metadataErrors.storyCoverAttached,
-    metadataErrors.storyTitle,
-    metadataErrors.storyCoverPortraitSize,
-    metadataErrors.storyCoverAspectRatio,
-    metadataErrors.publisherLogoSize,
-    metadataErrors.linkInPageAttachmentRegion,
-  ],
-};
+/**
+ * Returns the greatest common divisor for two integers. Useful for determining
+ * aspect ratios without dealing with float precision issues.
+ *
+ * @param {number} x The left number value
+ * @param {number} y The right number value
+ * @return {number|null} The largest positive number that divides both x and y.
+ */
+export function greatestCommonDivisor(x, y) {
+  return y ? greatestCommonDivisor(y, x % y) : x;
+}

--- a/assets/src/edit-story/utils/test/greatestCommonDivisor.js
+++ b/assets/src/edit-story/utils/test/greatestCommonDivisor.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+
+import { greatestCommonDivisor } from '../greatestCommonDivisor';
+
+describe('greatestCommonDivisor', function () {
+  it('should return the greatest common divisor', function () {
+    expect(greatestCommonDivisor(1920, 1080)).toBe(120);
+  });
+
+  it('should return the left value if no right value is present', function () {
+    expect(greatestCommonDivisor(1920)).toBe(1920);
+  });
+
+  it('should return null if null is provided', function () {
+    expect(greatestCommonDivisor(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Passes the metrics of the full size of the image so the pre-publish checklist can properly validate the size

## Relevant Technical Choices

—

## To-do

—

## User-facing changes

Fixes the validation of cover images on selection. Previously it would only validate correctly on refresh.

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

1. Go to Document tab, select a cover image
2. Select an image that is large, but not 3:4 aspect ratio
3. See that error title _no longer_ says "Story cover image too small" when it should be "Story cover image wrong aspect ratio"

