### PR TITLE
Bug: Page should not advance until last animation is completed

### DIFF
--- a/assets/src/animation/utils/getTotalDuration.js
+++ b/assets/src/animation/utils/getTotalDuration.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { getTotalDuration } from './getTotalDuration';
-export { getMediaBoundOffsets, hasOffsets } from './mediaPositions';
-export { clamp, lerp, progress } from './range';
+
+export function getTotalDuration({ animations = [] }) {
+  return animations.reduce(
+    (total, { duration = 0, delay = 0 }) => Math.max(total, duration + delay),
+    0
+  );
+}

--- a/assets/src/animation/utils/test/getTotalDuration.js
+++ b/assets/src/animation/utils/test/getTotalDuration.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getTotalDuration } from '../';
+
+describe('getTotalDuration', () => {
+  it('returns 0 if no animations supplied', () => {
+    expect(getTotalDuration({})).toStrictEqual(0);
+  });
+
+  it('calculates the longest duration properly', () => {
+    expect(
+      getTotalDuration({
+        animations: [
+          { duration: 20, delay: 10 },
+          { duration: 90, delay: 110 },
+          { duration: 50, delay: 5 },
+        ],
+      })
+    ).toStrictEqual(200);
+  });
+
+  it('calculates properly if missing duration or delay on animation', () => {
+    expect(
+      getTotalDuration({
+        animations: [{ duration: 50, delay: 10 }, {}, { duration: 40 }],
+      })
+    ).toStrictEqual(60);
+  });
+});

--- a/assets/src/dashboard/app/views/storyAnimTool/timeline/index.js
+++ b/assets/src/dashboard/app/views/storyAnimTool/timeline/index.js
@@ -26,6 +26,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   clamp,
   getAnimationProps,
+  getTotalDuration,
   ANIMATION_TYPES,
   FIELD_TYPES,
 } from '../../../../../animation';
@@ -158,14 +159,9 @@ function Timeline({
     [story, activePageIndex]
   );
 
-  const totalDuration = useMemo(
-    () =>
-      animations.reduce(
-        (total, { duration, delay }) => Math.max(total, duration + delay),
-        0
-      ),
-    [animations]
-  );
+  const totalDuration = useMemo(() => getTotalDuration({ animations }), [
+    animations,
+  ]);
 
   useEffect(() => {
     if (!(canScrub && isDragging && scrubContainerRef.current)) {

--- a/assets/src/edit-story/output/page.js
+++ b/assets/src/edit-story/output/page.js
@@ -26,7 +26,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { StoryAnimation } from '../../animation';
+import { getTotalDuration, StoryAnimation } from '../../animation';
 import { PAGE_HEIGHT, PAGE_WIDTH } from '../constants';
 import StoryPropTypes from '../types';
 import generatePatternStyles from '../utils/generatePatternStyles';
@@ -40,7 +40,11 @@ function OutputPage({ page, autoAdvance, defaultPageDuration }) {
   const { id, animations, elements, backgroundColor } = page;
 
   const [backgroundElement, ...regularElements] = elements;
-  const longestMediaElement = getLongestMediaElement(elements);
+  const animationDuration = getTotalDuration({ animations }) / 1000;
+  const longestMediaElement = getLongestMediaElement(
+    elements,
+    animationDuration
+  );
 
   // If the background element has base color set, it's media, use that.
   const baseColor = backgroundElement?.resource?.baseColor;
@@ -55,7 +59,7 @@ function OutputPage({ page, autoAdvance, defaultPageDuration }) {
 
   const autoAdvanceAfter = longestMediaElement?.id
     ? `el-${longestMediaElement?.id}-media`
-    : `${defaultPageDuration}s`;
+    : `${animationDuration || defaultPageDuration}s`;
 
   const hasPageAttachment = page.pageAttachment?.url?.length > 0;
 

--- a/assets/src/edit-story/output/page.js
+++ b/assets/src/edit-story/output/page.js
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -37,10 +38,12 @@ import getLongestMediaElement from './utils/getLongestMediaElement';
 const ASPECT_RATIO = `${PAGE_WIDTH}:${PAGE_HEIGHT}`;
 
 function OutputPage({ page, autoAdvance, defaultPageDuration }) {
+  const enableAnimation = useFeature('enableAnimation');
   const { id, animations, elements, backgroundColor } = page;
 
   const [backgroundElement, ...regularElements] = elements;
-  const animationDuration = getTotalDuration({ animations }) / 1000;
+  const animationDuration =
+    enableAnimation && getTotalDuration({ animations }) / 1000;
   const longestMediaElement = getLongestMediaElement(
     elements,
     animationDuration

--- a/assets/src/edit-story/output/utils/getLongestMediaElement.js
+++ b/assets/src/edit-story/output/utils/getLongestMediaElement.js
@@ -23,9 +23,10 @@ import { getDefinitionForType } from '../../elements';
  * Among all elements, returns the media element with the longest duration.
  *
  * @param {Array<Object>} elements List of elements.
+ * @param {number} minDuration Duration that the minimum element must exceed in seconds.
  * @return {Object|undefined} Found element, or undefined if there are no media elements.
  */
-function getLongestMediaElement(elements) {
+function getLongestMediaElement(elements, minDuration = 0) {
   return elements
     .filter(({ type, loop }) => {
       const { isMedia } = getDefinitionForType(type);
@@ -34,6 +35,10 @@ function getLongestMediaElement(elements) {
     })
     .reduce((longest, element) => {
       if (!element?.resource?.length) {
+        return longest;
+      }
+
+      if (element?.resource?.length < minDuration) {
         return longest;
       }
 

--- a/assets/src/edit-story/output/utils/test/getLongestMediaElement.js
+++ b/assets/src/edit-story/output/utils/test/getLongestMediaElement.js
@@ -63,4 +63,27 @@ describe('getLongestMediaElement', () => {
 
     expect(getLongestMediaElement(elements)).toBeUndefined();
   });
+
+  it('should return the media element with the longest duration if longer than minDuration', () => {
+    const elements = [
+      { type: 'video', resource: { length: 1 } },
+      { type: 'video', resource: { length: 10 } },
+      { type: 'video', resource: { length: 15 } },
+    ];
+
+    expect(getLongestMediaElement(elements, 13)).toStrictEqual({
+      type: 'video',
+      resource: { length: 15 },
+    });
+  });
+
+  it('should return undefined if the longest duration is less than the minDuration', () => {
+    const elements = [
+      { type: 'video', resource: { length: 1 } },
+      { type: 'video', resource: { length: 10 } },
+      { type: 'video', resource: { length: 15 } },
+    ];
+
+    expect(getLongestMediaElement(elements, 16)).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
Respects animation duration in calculating auto advance duration for amp-story generation.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
NA, Behind animation flag: Now respects animation duration on calculating page duration.

## Testing Instructions
- enable animation flag
- create new story in the editor with auto advance
- create page with no video & no animations -> click preview -> see that default duration is respected (7s)
- add an animation to page -> click preview -> see that page duration is duration of animation
- add a non looping video to page that's longer than longest animation -> click preview -> see that page duration is duration of video
- add a non looping video to page that's shorter than longest animation -> click preview -> see that page duration is duration of animation



---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5416 
