### PR TITLE
Animations Panel: Rename "zoom" foreground animation to "scale"

### DIFF
--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -304,7 +304,7 @@ export default function EffectChooser({
               <ContentWrapper>{__('Whoosh In', 'web-stories')}</ContentWrapper>
             </GridItemHalfRow>
             <GridItemHalfRow
-              aria-label={__('Zoom In Effect', 'web-stories')}
+              aria-label={__('Scale In Effect', 'web-stories')}
               onClick={() =>
                 onAnimationSelected({
                   animation: ANIMATION_EFFECTS.ZOOM.value,
@@ -313,11 +313,11 @@ export default function EffectChooser({
                 })
               }
             >
-              <ContentWrapper>{__('Zoom In', 'web-stories')}</ContentWrapper>
-              <ZoomInAnimation>{__('Zoom In', 'web-stories')}</ZoomInAnimation>
+              <ContentWrapper>{__('Scale In', 'web-stories')}</ContentWrapper>
+              <ZoomInAnimation>{__('Scale In', 'web-stories')}</ZoomInAnimation>
             </GridItemHalfRow>
             <GridItemHalfRow
-              aria-label={__('Zoom Out Effect', 'web-stories')}
+              aria-label={__('Scale Out Effect', 'web-stories')}
               onClick={() =>
                 onAnimationSelected({
                   animation: ANIMATION_EFFECTS.ZOOM.value,
@@ -327,9 +327,9 @@ export default function EffectChooser({
               }
             >
               <ZoomOutAnimation>
-                {__('Zoom Out', 'web-stories')}
+                {__('Scale Out', 'web-stories')}
               </ZoomOutAnimation>
-              <ContentWrapper>{__('Zoom Out', 'web-stories')}</ContentWrapper>
+              <ContentWrapper>{__('Scale Out', 'web-stories')}</ContentWrapper>
             </GridItemHalfRow>
           </>
         )}

--- a/assets/src/edit-story/components/panels/animation/test/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/test/effectChooser.js
@@ -73,7 +73,7 @@ describe('<EffectChooser />', function () {
       <EffectChooser onAnimationSelected={onAnimationSelected} />
     );
 
-    fireEvent.click(getByLabelText('Zoom In Effect'));
+    fireEvent.click(getByLabelText('Scale In Effect'));
 
     expect(onAnimationSelected).toHaveBeenCalledWith({
       animation: ANIMATION_EFFECTS.ZOOM.value,


### PR DESCRIPTION
## Summary

Updates displayed text for zoom animations in editor to be "scale in" and "scale out" instead of "zoom in" and "zoom out" in foreground animations.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Foreground animations in editor now read "scale in" and "scale out" where "zoom in" and "zoom out" were. 
![Screen Shot 2020-11-25 at 11 29 58 AM](https://user-images.githubusercontent.com/10720454/100268106-bf938e00-2f11-11eb-854b-70965d2eb7d8.png)


## Testing Instructions

Verify the above text update. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5343 
