### PR TITLE
Fix captions panel crashing in case of mixed multi-selection

### DIFF
--- a/assets/src/edit-story/components/panels/captions/captions.js
+++ b/assets/src/edit-story/components/panels/captions/captions.js
@@ -29,7 +29,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Row, Button, TextInput } from '../../form';
+import {
+  Row,
+  Button,
+  TextInput,
+  MULTIPLE_VALUE,
+  MULTIPLE_DISPLAY_VALUE,
+} from '../../form';
 import { SimplePanel } from '../panel';
 import { getCommonValue } from '../utils';
 import { useMediaPicker } from '../../mediaPicker';
@@ -63,11 +69,14 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
 
   const handleRemoveTrack = useCallback(
     (idToDelete) => {
-      const trackIndex = tracks.findIndex(({ id }) => id === idToDelete);
-      const newTracks = [
-        ...tracks.slice(0, trackIndex),
-        ...tracks.slice(trackIndex + 1),
-      ];
+      let newTracks = [];
+      if (idToDelete) {
+        const trackIndex = tracks.findIndex(({ id }) => id === idToDelete);
+        newTracks = [
+          ...tracks.slice(0, trackIndex),
+          ...tracks.slice(trackIndex + 1),
+        ];
+      }
       pushUpdate({ tracks: newTracks }, true);
     },
     [tracks, pushUpdate]
@@ -82,9 +91,22 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
     buttonInsertText: __('Select caption', 'web-stories'),
   });
 
+  const isMixedValue = tracks === MULTIPLE_VALUE;
   return (
     <SimplePanel name="caption" title={__('Captions', 'web-stories')}>
+      {isMixedValue && (
+        <Row>
+          <BoxedTextInput
+            value={MULTIPLE_DISPLAY_VALUE}
+            disabled
+            aria-label={__('Filename', 'web-stories')}
+            clear
+            onChange={() => handleRemoveTrack()}
+          />
+        </Row>
+      )}
       {tracks &&
+        !isMixedValue &&
         tracks.map(({ id, trackName }) => (
           <Row key={`row-filename-${id}`}>
             <BoxedTextInput

--- a/assets/src/edit-story/components/panels/test/captions.js
+++ b/assets/src/edit-story/components/panels/test/captions.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import Captions from '../captions';
+import { MULTIPLE_DISPLAY_VALUE } from '../../form';
+import ConfigContext from '../../../app/config/context';
+import { renderPanel } from './_utils';
+
+describe('Panels/Captions', () => {
+  const defaultElement = {
+    type: 'video',
+    resource: { posterId: 0, title: '', poster: '', alt: '' },
+    tracks: [],
+  };
+  function renderCaptions(...args) {
+    const configValue = {
+      capabilities: {
+        hasUploadMediaAction: true,
+      },
+    };
+
+    const wrapper = (params) => (
+      <ConfigContext.Provider value={configValue}>
+        {params.children}
+      </ConfigContext.Provider>
+    );
+
+    return renderPanel(Captions, ...args, wrapper);
+  }
+
+  beforeAll(() => {
+    localStorage.setItem(
+      'web_stories_ui_panel_settings:caption',
+      JSON.stringify({ isCollapsed: false })
+    );
+  });
+
+  afterAll(() => {
+    localStorage.clear();
+  });
+
+  it('should render <Captions /> panel', () => {
+    const { getByRole } = renderCaptions([defaultElement]);
+    const imageHolder = getByRole('region', { name: /Captions/i });
+    expect(imageHolder).toBeDefined();
+  });
+
+  it('should display Mixed in case of mixed value multi-selection', () => {
+    const { getByRole } = renderCaptions([
+      defaultElement,
+      {
+        resource: {
+          posterId: 0,
+          title: 'Hello, video!',
+          poster: '',
+          alt: 'Hello!',
+        },
+        tracks: ['Some track here'],
+      },
+    ]);
+    const input = getByRole('textbox', { name: 'Filename' });
+    expect(input).toHaveValue(MULTIPLE_DISPLAY_VALUE);
+  });
+});


### PR DESCRIPTION
## Summary
Adds captions support for multi-selection to fix the crashing, the panel's behavior is now consistent with other panels.

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
1. Add two video elements.
2. Upload captions for one of the videos.
3. Now select both videos
4. Verify the captions field displays "Mixed".
5. Remove the caption. Verify it's possible to upload a captions file in multi-selection

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5365 
