### PR TITLE
Frontend: Do not pass charset when assembling document 

### DIFF
--- a/includes/Story_Renderer/HTML.php
+++ b/includes/Story_Renderer/HTML.php
@@ -85,7 +85,7 @@ class HTML {
 			return $markup;
 		}
 
-		$document = Document::fromHtml( $markup, get_bloginfo( 'charset' ) );
+		$document = Document::fromHtml( $markup );
 
 		// This  should never actually happen.
 		if ( ! $document ) {


### PR DESCRIPTION
## Summary

Remove param being passed to `Document::fromHtml` method. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5286
