### PR TITLE
Pre-Publish Checklist: Use full size image for "low image resolution" accessibility check 

### DIFF
--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -124,8 +124,8 @@ export function textElementFontSizeTooSmall(element) {
 export function imageElementLowResolution(element) {
   const scaleMultiplier = element.scale / 100;
   if (
-    element.width * scaleMultiplier > element.resource.width ||
-    element.height * scaleMultiplier > element.resource.height
+    element.width * scaleMultiplier > element.resource?.sizes?.full?.width ||
+    element.height * scaleMultiplier > element.resource?.sizes?.full?.height
   ) {
     return {
       message: MESSAGES.ACCESSIBILITY.LOW_IMAGE_RESOLUTION.MAIN_TEXT,

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -140,8 +140,12 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
         scale: 100,
         resource: {
           type: 'image',
-          width: 99,
-          height: 99,
+          sizes: {
+            full: {
+              width: 99,
+              height: 99,
+            },
+          },
         },
       };
       expect(
@@ -163,8 +167,12 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
         scale: 130,
         resource: {
           type: 'image',
-          width: 100,
-          height: 100,
+          sizes: {
+            full: {
+              width: 100,
+              height: 100,
+            },
+          },
         },
       };
       expect(
@@ -186,8 +194,12 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
         scale: 100,
         resource: {
           type: 'image',
-          width: 100,
-          height: 100,
+          sizes: {
+            full: {
+              width: 100,
+              height: 100,
+            },
+          },
         },
       };
       expect(


### PR DESCRIPTION
## Summary

The check was previously triggering seemingly randomly based on a resolution that wasn't full size. This fixes the check to use full size image for check.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

Pull in an image from the 3p media library and expand it larger and the error should not show up.

Pull in a small image from the wordpress media library and expand it to > 1:1 resolution and warning should show up.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5377 
