### PR TITLE
Embed block missing component ToolbarGroup in WP 5.3 

### DIFF
--- a/assets/src/story-embed-block/block/embedControls.js
+++ b/assets/src/story-embed-block/block/embedControls.js
@@ -23,14 +23,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import {
-  Button,
-  ToolbarGroup,
-  BaseControl,
-  TextControl,
-  PanelBody,
-  PanelRow,
-} from '@wordpress/components';
+import * as Components from '@wordpress/components';
 import {
   BlockControls,
   InspectorControls,
@@ -41,6 +34,12 @@ import { withInstanceId } from '@wordpress/compose';
 import { createRef, useCallback } from '@wordpress/element';
 
 const POSTER_ALLOWED_MEDIA_TYPES = ['image'];
+
+// eslint-disable-next-line react/jsx-no-useless-fragment
+const FallbackComponent = ({ children }) => <>{children}</>;
+
+const { Button, BaseControl, TextControl, PanelBody, PanelRow } = Components;
+const ToolbarGroup = Components.ToolbarGroup || FallbackComponent;
 
 const EmbedControls = (props) => {
   const {
@@ -182,6 +181,10 @@ const EmbedControls = (props) => {
       </InspectorControls>
     </>
   );
+};
+
+FallbackComponent.propTypes = {
+  children: PropTypes.node,
 };
 
 EmbedControls.propTypes = {

--- a/assets/src/story-embed-block/block/embedControls.js
+++ b/assets/src/story-embed-block/block/embedControls.js
@@ -38,7 +38,7 @@ const POSTER_ALLOWED_MEDIA_TYPES = ['image'];
 const FallbackComponent = ({ children }) => children;
 
 const { Button, BaseControl, TextControl, PanelBody, PanelRow } = Components;
-// ToolbarGroup is only available in Gutenberg 7.0 or later, so it does not exsit in WP 5.3.
+// ToolbarGroup is only available in Gutenberg 7.0 or later, so it does not exist in WP 5.3.
 const ToolbarGroup = Components.ToolbarGroup || FallbackComponent;
 
 const EmbedControls = (props) => {

--- a/assets/src/story-embed-block/block/embedControls.js
+++ b/assets/src/story-embed-block/block/embedControls.js
@@ -39,6 +39,7 @@ const POSTER_ALLOWED_MEDIA_TYPES = ['image'];
 const FallbackComponent = ({ children }) => <>{children}</>;
 
 const { Button, BaseControl, TextControl, PanelBody, PanelRow } = Components;
+// ToolbarGroup is only available in Gutenberg 7.0 or later, so it does not exsit in WP 5.3.
 const ToolbarGroup = Components.ToolbarGroup || FallbackComponent;
 
 const EmbedControls = (props) => {

--- a/assets/src/story-embed-block/block/embedControls.js
+++ b/assets/src/story-embed-block/block/embedControls.js
@@ -35,8 +35,7 @@ import { createRef, useCallback } from '@wordpress/element';
 
 const POSTER_ALLOWED_MEDIA_TYPES = ['image'];
 
-// eslint-disable-next-line react/jsx-no-useless-fragment
-const FallbackComponent = ({ children }) => <>{children}</>;
+const FallbackComponent = ({ children }) => children;
 
 const { Button, BaseControl, TextControl, PanelBody, PanelRow } = Components;
 // ToolbarGroup is only available in Gutenberg 7.0 or later, so it does not exsit in WP 5.3.


### PR DESCRIPTION
## Summary

See https://github.com/google/web-stories-wp/issues/5447#issuecomment-734874801

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

- Downgrade to WordPress 5.3
- Create post
- Create web stories block. 
- Input https://stories-new-wordpress-amp.pantheonsite.io/web-stories/auto-draft-9/ to field. 
- Click embed.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5447
