### PR TITLE
Design System: Banner font size updates

### DIFF
--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -31,7 +31,7 @@ import { Text } from '../typography';
 
 const Title = styled(Text)`
   grid-area: title;
-  font-weight: 600;
+  font-weight: 700;
   padding-left: 8px;
 `;
 
@@ -102,7 +102,13 @@ export const Banner = forwardRef(
         isDashboard={isDashboard}
         {...rest}
       >
-        <Title size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.LARGE}>
+        <Title
+          size={
+            THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES[
+              isDashboard ? 'LARGE' : 'MEDIUM'
+            ]
+          }
+        >
           {title}
         </Title>
         <CloseButton


### PR DESCRIPTION
## Summary
- Banner font sizes were updates, updating component to reflect. When in editor headline is weight 700, size 16px. When in dashboard, weight is 400, size is 18px.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None, storybook only.

## Testing Instructions

In storybook, see that the above font changes are reflected. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses feedback #5214
