### PR TITLE
Animation Panel: Give dropdown context with label

### DIFF
--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -325,7 +325,10 @@ export default function EffectChooser({
       <GridLabel>
         <span>{__('Select Animation', 'web-stories')}</span>
       </GridLabel>
-      <Grid ref={ref}>
+      <Grid
+        ref={ref}
+        aria-label={__('Available Animations To Select', 'web-stories')}
+      >
         <NoEffect
           onClick={onNoEffectSelected}
           aria-label={__('None', 'web-stories')}

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -89,7 +89,7 @@ const GridItem = styled.button.attrs({ role: 'listitem' })`
   font-family: 'Teko', sans-serif;
   font-size: 20px;
   line-height: 1;
-  color: white;
+  color: ${({ theme }) => theme.colors.fg.white};
   text-transform: uppercase;
   transition: background 0.1s linear;
 
@@ -190,6 +190,15 @@ const BACKGROUND_EFFECTS_LIST = [
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_IN}`,
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_OUT}`,
 ];
+const GridLabel = styled.div`
+  grid-column-start: span 4;
+
+  span {
+    color: ${({ theme }) => theme.colors.fg.white};
+    font-weight: 500;
+    font-size: 14px;
+  }
+`;
 
 export default function EffectChooser({
   onAnimationSelected,
@@ -313,6 +322,9 @@ export default function EffectChooser({
   return (
     <Container ref={ref}>
       <Grid>
+        <GridLabel>
+          <span>{__('Select Animation', 'web-stories')}</span>
+        </GridLabel>
         <NoEffect
           onClick={onNoEffectSelected}
           aria-label={__('None', 'web-stories')}

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -193,7 +193,6 @@ const PAN_MAPPING = {
 };
 const BACKGROUND_EFFECTS_LIST = [
   false, // arbitrary value to maintain order of focusable children 'No Effect',
-  BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
   PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT],
   PAN_MAPPING[DIRECTION.RIGHT_TO_LEFT],
   PAN_MAPPING[DIRECTION.BOTTOM_TO_TOP],

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -147,6 +147,16 @@ const NoEffect = styled(GridItemFullRow)`
     font-weight: normal;
   `}
 `;
+const GridLabel = styled.div`
+  grid-column-start: span 4;
+  padding: 15px 15px 0 18px;
+  span {
+    color: ${({ theme }) => theme.colors.fg.white};
+    font-weight: 500;
+    font-size: 14px;
+  }
+`;
+
 /**
  * Because the effect chooser is hard coded these two effects lists help keep track of the current index
  * current index is how we track focus for up and down arrows and setting active list item when menu is opened.
@@ -158,7 +168,7 @@ const getDirectionalEffect = (effect, direction) =>
   direction ? `${effect} ${direction}`.trim() : effect;
 
 const FOREGROUND_EFFECTS_LIST = [
-  'No Effect',
+  false, // arbitrary value to maintain order of focusable children 'No Effect',
   ANIMATION_EFFECTS.DROP.value,
   ANIMATION_EFFECTS.FADE_IN.value,
   `${ANIMATION_EFFECTS.FLY_IN.value} ${DIRECTION.LEFT_TO_RIGHT}`,
@@ -182,7 +192,8 @@ const PAN_MAPPING = {
   [DIRECTION.TOP_TO_BOTTOM]: `${BACKGROUND_ANIMATION_EFFECTS.PAN.value} ${DIRECTION.TOP_TO_BOTTOM}`,
 };
 const BACKGROUND_EFFECTS_LIST = [
-  'No Effect',
+  false, // arbitrary value to maintain order of focusable children 'No Effect',
+  BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
   PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT],
   PAN_MAPPING[DIRECTION.RIGHT_TO_LEFT],
   PAN_MAPPING[DIRECTION.BOTTOM_TO_TOP],
@@ -190,15 +201,6 @@ const BACKGROUND_EFFECTS_LIST = [
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_IN}`,
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_OUT}`,
 ];
-const GridLabel = styled.div`
-  grid-column-start: span 4;
-  padding-left: 3px;
-  span {
-    color: ${({ theme }) => theme.colors.fg.white};
-    font-weight: 500;
-    font-size: 14px;
-  }
-`;
 
 export default function EffectChooser({
   onAnimationSelected,
@@ -298,9 +300,9 @@ export default function EffectChooser({
   // Set initial focus
   useEffect(() => {
     if (ref.current && focusedIndex !== null) {
-      ref.current.firstChild?.children?.[focusedIndex]?.focus();
+      ref.current.children?.[focusedIndex]?.focus();
     }
-  }, [focusedValue, focusedIndex, disabledBackgroundEffects]);
+  }, [focusedIndex, disabledBackgroundEffects]);
 
   const handleOnSelect = useCallback(
     (event, directionalEffect, animation) => {
@@ -320,11 +322,11 @@ export default function EffectChooser({
   );
 
   return (
-    <Container ref={ref}>
-      <Grid>
-        <GridLabel>
-          <span>{__('Select Animation', 'web-stories')}</span>
-        </GridLabel>
+    <Container>
+      <GridLabel>
+        <span>{__('Select Animation', 'web-stories')}</span>
+      </GridLabel>
+      <Grid ref={ref}>
         <NoEffect
           onClick={onNoEffectSelected}
           aria-label={__('None', 'web-stories')}

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -192,7 +192,7 @@ const BACKGROUND_EFFECTS_LIST = [
 ];
 const GridLabel = styled.div`
   grid-column-start: span 4;
-
+  padding-left: 3px;
   span {
     color: ${({ theme }) => theme.colors.fg.white};
     font-weight: 500;


### PR DESCRIPTION
## Summary
From the bug ticket: **When many tabs are open the animation panel appears up to the animation section so there is no context where the panel animation belongs to.**

Really, the best way to solve this long term is a new drop down that doesn't obscure the associated label, but since designs are in motion to update the look and feel of the editor, I decided to fix the context without adjusting the root cause as a temporary solution until new drop downs are ready to be implemented in the panels. Worst case with this temporary fix you get a repeat of the context, that's if you ONLY have the animation panel expanded and your screen is really tall, see 3rd screenshot for example. 

## Relevant Technical Choices
- Add in a "label" for the animation dropdown effect chooser to give context to the select menu in the existing functionality of the panels.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

When you open the dropdown to select an animation you now get a label above the first animation selection ("no effect").

## Testing Instructions

Verify that the dropdown now has the label, like these screen shots and that the dropdown is still navigable with keyboard.

<img width="594" alt="Screen Shot 2020-11-30 at 1 37 39 PM" src="https://user-images.githubusercontent.com/10720454/100661975-84c69700-3311-11eb-9e98-0cb73216b8fa.png">
<img width="786" alt="Screen Shot 2020-11-30 at 1 37 55 PM" src="https://user-images.githubusercontent.com/10720454/100661981-85f7c400-3311-11eb-924f-e22dec051160.png">

![Screen Shot 2020-11-30 at 1 38 25 PM](https://user-images.githubusercontent.com/10720454/100662037-9871fd80-3311-11eb-94f2-fb597dce0682.png)




---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5453 
