### PR TITLE
Design System Storybook: Banner responsive tweaks

### DIFF
--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -38,7 +38,8 @@ const Title = styled(Text)`
 const Content = styled.div`
   grid-area: content;
   margin-bottom: 4px;
-  max-width: 480px;
+  max-width: 408px;
+  min-width: 50%;
 `;
 
 const CloseButton = styled(Button)`
@@ -51,8 +52,8 @@ const Container = styled.div`
   box-sizing: border-box;
   display: grid;
   width: 100%;
-  max-height: 60px;
-  grid-template-columns: 104px 408px auto;
+  min-height: 60px;
+  grid-template-columns: 104px 1fr auto;
   grid-column-gap: 32px;
   grid-template-areas: 'title content closeButton';
   align-items: baseline;
@@ -78,6 +79,7 @@ const Container = styled.div`
       }
       ${Content} {
         margin: 8px auto 18px;
+        max-width: 480px;
       }
     `}
 `;


### PR DESCRIPTION

## Summary
Banner text bleeds through container on small view ports, this shouldn't happen.

## Relevant Technical Choices
- tweak banner grid so that content takes up 1fr and the width is set on the item itself to allow flexibility of space. 
- Make max width the width found in figma, respectively for each dashboard and editor and set min width to 50% of available banner space to let other grid items stay in the viewport for smaller widths.
- Set height as the desired height instead of max height so that when the banner is smaller it can be a little taller to still have the whole text readable.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Storybook only

## Testing Instructions
Shrink browser tab with banner present (storybook/designsystem/components/banner) and see that text stays within container and the 'x' button is always visible. 

<img width="495" alt="Screen Shot 2020-11-30 at 2 54 00 PM" src="https://user-images.githubusercontent.com/10720454/100671409-afb6e800-331d-11eb-9448-0b38e227bf9d.png">
<img width="1040" alt="Screen Shot 2020-11-30 at 2 53 51 PM" src="https://user-images.githubusercontent.com/10720454/100671413-b04f7e80-331d-11eb-97e3-87eae5136e52.png">
<img width="1049" alt="Screen Shot 2020-11-30 at 2 53 45 PM" src="https://user-images.githubusercontent.com/10720454/100671416-b180ab80-331d-11eb-8a5e-0ecc55e3d519.png">
<img width="489" alt="Screen Shot 2020-11-30 at 2 53 35 PM" src="https://user-images.githubusercontent.com/10720454/100671419-b180ab80-331d-11eb-92a9-5985199c86a4.png">

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5495 
