### PR TITLE
Design System Storybook: Typography theming naming updates

### DIFF
--- a/assets/src/design-system/components/button/index.js
+++ b/assets/src/design-system/components/button/index.js
@@ -40,7 +40,7 @@ const Base = styled.button(
     ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)};
     ${themeHelpers.expandPresetStyles({
       preset: {
-        ...theme.typography.presets.button[
+        ...theme.typography.presets.label[
           size === BUTTON_SIZES.SMALL
             ? THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL
             : THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.MEDIUM

--- a/assets/src/design-system/components/typography/text/index.js
+++ b/assets/src/design-system/components/typography/text/index.js
@@ -45,12 +45,12 @@ export const Text = styled.p`
       `;
     return css`
       ${themeHelpers.expandPresetStyles({
-        preset: theme.typography.presets.text[size],
+        preset: theme.typography.presets.paragraph[size],
         theme,
       })};
       font-weight: ${isBold
         ? theme.typography.weight.bold
-        : theme.typography.presets.text[size].weight};
+        : theme.typography.presets.paragraph[size].weight};
       ${asLink};
     `;
   }}

--- a/assets/src/design-system/theme/typography.js
+++ b/assets/src/design-system/theme/typography.js
@@ -96,7 +96,7 @@ export const typography = {
         letterSpacing: 0,
       },
     },
-    text: {
+    paragraph: {
       [PRESET_SIZES.X_LARGE]: {
         weight: 400,
         size: 24,
@@ -128,7 +128,13 @@ export const typography = {
         letterSpacing: 0.16,
       },
     },
-    button: {
+    label: {
+      [PRESET_SIZES.LARGE]: {
+        weight: 500,
+        size: 18,
+        lineHeight: 24,
+        letterSpacing: 0,
+      },
       [PRESET_SIZES.MEDIUM]: {
         weight: 500,
         size: 16,
@@ -141,11 +147,9 @@ export const typography = {
         lineHeight: 20,
         letterSpacing: 0,
       },
-    },
-    label: {
-      [PRESET_SIZES.SMALL]: {
-        weight: 400,
-        size: 14,
+      [PRESET_SIZES.X_SMALL]: {
+        weight: 500,
+        size: 12,
         lineHeight: 20,
         letterSpacing: 0,
       },


### PR DESCRIPTION
## Summary
Just a little housekeeping to get typography set up current with what figma details: https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Design-System?node-id=3447%3A63065

## Relevant Technical Choices
- catch typography naming up to figma so that we stay current. 
- label was added - consolidated  my 2 keys of button and label to just "label"
- rename "text" to "paragraph"

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None

## Testing Instructions

- Check the design system storybook still loads, this is entirely behind the scenes. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
