### PR TITLE
Embed block previewing not working WordPress 5.3

### DIFF
--- a/assets/src/story-embed-block/block/edit.css
+++ b/assets/src/story-embed-block/block/edit.css
@@ -34,6 +34,17 @@
 .wp-block-web-stories-embed.aligncenter .components-resizable-box__container {
   margin: auto;
 }
+
+.wp-block-web-stories-embed
+  .components-resizable-box__container.hide-resize-handle
+  .components-resizable-box__handle {
+  display: none;
+}
+.wp-block-web-stories-embed
+  .components-resizable-box__container.show-resize-handle
+  .components-resizable-box__handle {
+  display: block;
+}
 /* Embed Preview Component */
 
 .web-stories-embed-preview {

--- a/assets/src/story-embed-block/block/edit.js
+++ b/assets/src/story-embed-block/block/edit.js
@@ -26,7 +26,8 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { ResizableBox } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
+import * as compose from '@wordpress/compose';
+import { withViewportMatch } from '@wordpress/viewport';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
@@ -42,7 +43,13 @@ import './edit.css';
 
 const MIN_SIZE = 20;
 
-function StoryEmbedEdit({ attributes, setAttributes, className, isSelected }) {
+function StoryEmbedEdit({
+  attributes,
+  setAttributes,
+  className,
+  isSelected,
+  _isResizable,
+}) {
   const {
     url: outerURL,
     width = 360,
@@ -61,7 +68,9 @@ function StoryEmbedEdit({ attributes, setAttributes, className, isSelected }) {
   const showLoadingIndicator = isFetchingData;
   const showPlaceholder = !localURL || !outerURL || editingURL || cannotEmbed;
 
-  const isResizable = useViewportMatch('medium');
+  const isResizable = compose.useViewportMatch
+    ? compose.useViewportMatch('medium')
+    : _isResizable;
 
   const ref = useRef();
 
@@ -237,7 +246,7 @@ function StoryEmbedEdit({ attributes, setAttributes, className, isSelected }) {
       />
       <div className={`${className} web-stories-embed align${align}`}>
         <ResizableBox
-          showHandle={isSelected}
+          className={isSelected ? 'show-resize-handle' : 'hide-resize-handle'}
           size={{
             width,
             height,
@@ -289,6 +298,7 @@ StoryEmbedEdit.propTypes = {
   setAttributes: PropTypes.func.isRequired,
   className: PropTypes.string.isRequired,
   isSelected: PropTypes.bool,
+  _isResizable: PropTypes.bool,
 };
 
-export default StoryEmbedEdit;
+export default withViewportMatch({ _isResizable: 'medium' })(StoryEmbedEdit);

--- a/assets/src/story-embed-block/block/embedPlaceholder.js
+++ b/assets/src/story-embed-block/block/embedPlaceholder.js
@@ -90,7 +90,7 @@ const EmbedPlaceholder = ({
 };
 
 EmbedPlaceholder.propTypes = {
-  icon: PropTypes.node,
+  icon: PropTypes.func,
   label: PropTypes.string,
   value: PropTypes.string,
   onSubmit: PropTypes.func,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@wordpress/data": "^4.25.0",
     "@wordpress/element": "^2.18.0",
     "@wordpress/i18n": "^3.16.0",
+    "@wordpress/viewport": "^2.24.0",
     "big.js": "^6.0.2",
     "classnames": "^2.2.6",
     "colorthief": "^2.3.2",


### PR DESCRIPTION
## Summary

3 fixes for WordPress 5.3 compat. 
## Relevant Technical Choices

- Use CSS to hide resize handle instead of prop. 
- Use resize hook and add package. 
- Fix props from object to function. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

- Downgrade to WordPress 5.3
- Create post
- Create web stories block. 
- Input https://stories-new-wordpress-amp.pantheonsite.io/web-stories/auto-draft-9/ to field. 
- Click embed.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5425
