### PR TITLE
Alert icon should always have 100% opacity

### DIFF
--- a/assets/src/edit-story/components/tabview/index.js
+++ b/assets/src/edit-story/components/tabview/index.js
@@ -73,27 +73,27 @@ const Tab = styled.li.attrs(({ isActive }) => ({
     height: 28px;
     transform-origin: center center;
     transition: transform 0.3s ease;
+  }
 
-    &.alert {
-      width: ${ALERT_ICON_SIZE}px;
-      height: auto;
-      position: absolute;
-      left: calc(100% + ${ALERT_ICON_SIZE / 2}px);
-      top: calc(
-        50% -
-          ${({ isActive }) =>
-            isActive
-              ? `${ALERT_ICON_SIZE / 2 - 1}px`
-              : `${ALERT_ICON_SIZE / 2}px`}
-      );
-      overflow: visible;
-      opacity: 1;
-      &.warning {
-        color: ${({ theme }) => theme.colors.fg.warning};
-      }
-      &.error {
-        color: ${({ theme }) => theme.colors.fg.negative};
-      }
+  svg.alert {
+    width: ${ALERT_ICON_SIZE}px;
+    height: auto;
+    position: absolute;
+    left: calc(100% + ${ALERT_ICON_SIZE / 2}px);
+    top: calc(
+      50% -
+        ${({ isActive }) =>
+          isActive
+            ? `${ALERT_ICON_SIZE / 2 - 1}px`
+            : `${ALERT_ICON_SIZE / 2}px`}
+    );
+    overflow: visible;
+    opacity: 1;
+    &.warning {
+      color: ${({ theme }) => theme.colors.fg.warning};
+    }
+    &.error {
+      color: ${({ theme }) => theme.colors.fg.negative};
     }
   }
 

--- a/assets/src/edit-story/components/tabview/index.js
+++ b/assets/src/edit-story/components/tabview/index.js
@@ -56,29 +56,16 @@ const Tab = styled.li.attrs(({ isActive }) => ({
   font-family: ${({ theme }) => theme.fonts.tab.family};
   font-size: ${({ theme }) => theme.fonts.tab.size};
   font-weight: ${({ theme }) => theme.fonts.tab.weight};
-  opacity: 0.84;
   padding: 12px 0px;
   margin: 0px 16px;
   margin-bottom: -1px;
   position: relative;
-
-  ${({ isActive }) =>
-    !isActive &&
-    `
-    opacity: .34;
-    &:hover { opacity: 1; }
-  `}
 
   ${({ isActive, theme }) =>
     isActive &&
     `
     border-bottom: 1px solid ${theme.colors.accent.primary};
   `}
-
-  &:active,
-  &:hover {
-    opacity: 0.84;
-  }
 
   svg {
     display: block;
@@ -108,6 +95,18 @@ const Tab = styled.li.attrs(({ isActive }) => ({
         color: ${({ theme }) => theme.colors.fg.negative};
       }
     }
+  }
+
+  span,
+  svg:not(.alert) {
+    opacity: ${({ isActive }) => (isActive ? '0.84' : '0.34')};
+  }
+
+  &:hover span,
+  &:hover svg:not(.alert),
+  &:active span,
+  &:active svg:not(.alert) {
+    opacity: 0.84;
   }
 `;
 
@@ -195,7 +194,7 @@ function TabView({
           aria-selected={tab === id}
           onClick={() => tabChanged(id)}
         >
-          {title}
+          {Boolean(title) && <span>{title}</span>}
           {Boolean(Icon) && <Icon isActive={id === tab} />}
         </Tab>
       ))}


### PR DESCRIPTION
## Summary
- improve the visibility of the alert icon on the prepublish checklist
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- added a span wrapper for the title, managing hover/active states and opacity vs text color was much longer and more confusing

<!-- Please describe your changes. -->

## To-do
💅
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- The alert icon should always be at 100% opacity
![Screen Recording 2020-11-30 at 7 12 20 PM](https://user-images.githubusercontent.com/41136059/100690121-1ac6e580-3343-11eb-8a80-a89edbc6b547.gif)

<!-- Please describe your changes. -->

## Testing Instructions
- create a new story
- alert icon should be visible at 100% opacity
- to confirm, inspect the element, it will show that the color is a hex value (no transparency) and the value for the opacity property is 1, as well.
![Screen Shot 2020-11-30 at 7 35 47 PM](https://user-images.githubusercontent.com/41136059/100690313-73967e00-3343-11eb-9ad5-a19825c92384.png)

- follow instructions to remove errors
- warning icon should have similar properties, but a different color
![Screen Shot 2020-11-30 at 7 49 25 PM](https://user-images.githubusercontent.com/41136059/100691118-3af7a400-3345-11eb-8f27-798282662e3a.png)


<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5373
