### PR TITLE
Blocks: React isSecondary prop warning for DOM element

### DIFF
--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -122,6 +122,17 @@ function observeConsoleLogging() {
       return;
     }
 
+    // Ignore warning about isSecondary prop on button component as used by AMP plugin.
+    // The prop is only supported in newer versions of Gutenberg, and as such will trigger
+    // warnings on older WordPress versions (but not on newer ones).
+    if (
+      text.includes(
+        'React does not recognize the `isSecondary` prop on a DOM element.'
+      )
+    ) {
+      return;
+    }
+
     // styled-components warns about dynamically created components.
     // @todo Fix issues.
     if (text.includes(' has been created dynamically.')) {


### PR DESCRIPTION
## Summary

Ignore warning in amp plugin in e2e tests.

## Relevant Technical Choices

It is going to hard to fix this issue upstream. Let's just ignore it for now.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5448
