### PR TITLE
Make video poster generation more robust

### DIFF
--- a/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
+++ b/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
@@ -38,8 +38,6 @@ function useUploadVideoFrame({ updateMediaElement }) {
   }));
   const setProperties = useCallback(
     (id, properties) => {
-      // function updateElementsByResourceId is defined in
-      // reducers/updateElementsByResourceId.js
       updateElementsByResourceId({ id, properties });
     },
     [updateElementsByResourceId]

--- a/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
+++ b/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
@@ -38,6 +38,10 @@ function useUploadVideoFrame({ updateMediaElement }) {
   }));
   const setProperties = useCallback(
     (id, properties) => {
+      // properties is a function in this case, which will carry the poster
+      // value in the return object.
+      // function updateElementsByResourceId is defined in
+      // reducers/updateElementsByResourceId.js
       updateElementsByResourceId({ id, properties });
     },
     [updateElementsByResourceId]

--- a/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
+++ b/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
@@ -38,8 +38,6 @@ function useUploadVideoFrame({ updateMediaElement }) {
   }));
   const setProperties = useCallback(
     (id, properties) => {
-      // properties is a function in this case, which will carry the poster
-      // value in the return object.
       // function updateElementsByResourceId is defined in
       // reducers/updateElementsByResourceId.js
       updateElementsByResourceId({ id, properties });

--- a/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
@@ -85,6 +85,7 @@ function MediaPane(props) {
     resetWithFetch,
     setMediaType,
     setSearchTerm,
+    uploadVideoPoster,
   } = useLocalMedia(
     ({
       state: {
@@ -95,7 +96,13 @@ function MediaPane(props) {
         mediaType,
         searchTerm,
       },
-      actions: { setNextPage, resetWithFetch, setMediaType, setSearchTerm },
+      actions: {
+        setNextPage,
+        resetWithFetch,
+        setMediaType,
+        setSearchTerm,
+        uploadVideoPoster,
+      },
     }) => {
       return {
         hasMore,
@@ -108,6 +115,7 @@ function MediaPane(props) {
         resetWithFetch,
         setMediaType,
         setSearchTerm,
+        uploadVideoPoster,
       };
     }
   );
@@ -159,6 +167,9 @@ function MediaPane(props) {
         resource,
         mediaPickerEl.sizes?.medium?.url || mediaPickerEl.url
       );
+
+      // Update the video poster on the ride side bar (i.e. Accessibility)
+      uploadVideoPoster(resource.id, mediaPickerEl.url);
     } catch (e) {
       showSnackbar({
         message: e.message,

--- a/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
@@ -168,7 +168,8 @@ function MediaPane(props) {
         mediaPickerEl.sizes?.medium?.url || mediaPickerEl.url
       );
 
-      // Update the video poster on the ride side bar (i.e. Accessibility)
+      // Upload video poster and update media element afterwards, so that the
+      // poster will correctly show up in places like the Accessibility panel.
       uploadVideoPoster(resource.id, mediaPickerEl.url);
     } catch (e) {
       showSnackbar({

--- a/assets/src/edit-story/components/mediaPicker/useMediaPicker.js
+++ b/assets/src/edit-story/components/mediaPicker/useMediaPicker.js
@@ -27,7 +27,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import useLocalMedia from '../../app/media/local/useLocalMedia';
 import { useConfig } from '../../app/config';
 import { useSnackbar } from '../../app/snackbar';
 import { useAPI } from '../../app/api';
@@ -41,9 +40,6 @@ export default function useMediaPicker({
   type = '',
   multiple = false,
 }) {
-  const { uploadVideoPoster } = useLocalMedia((state) => ({
-    uploadVideoPoster: state.actions.uploadVideoPoster,
-  }));
   const {
     actions: { updateMedia },
   } = useAPI();
@@ -61,16 +57,16 @@ export default function useMediaPicker({
   });
   useEffect(() => {
     try {
+      // Handles the video processing logic from 3rd party.
+      // The 'success' listener logic will be triggred once user uploaded a
+      // file from the uploader.
       wp.Uploader.prototype.success = ({ attributes }) => {
         updateMedia(attributes.id, { media_source: 'editor' });
-        if (attributes.type === 'video') {
-          uploadVideoPoster(attributes.id, attributes.url);
-        }
       };
     } catch (e) {
       // Silence.
     }
-  }, [uploadVideoPoster, updateMedia]);
+  }, [updateMedia]);
 
   const openMediaPicker = (evt) => {
     trackEvent('open_media_modal', 'editor');
@@ -99,6 +95,8 @@ export default function useMediaPicker({
     });
 
     // When an image is selected, run a callback.
+    // The onSelect logic is defined in mediaPane.js/onSelect, which handles the
+    // logic when user click on the button `Insert into page`.
     fileFrame.on('select', () => {
       const mediaPickerEl = fileFrame.state().get('selection').first().toJSON();
       onSelect(mediaPickerEl);

--- a/assets/src/edit-story/components/mediaPicker/useMediaPicker.js
+++ b/assets/src/edit-story/components/mediaPicker/useMediaPicker.js
@@ -57,9 +57,11 @@ export default function useMediaPicker({
   });
   useEffect(() => {
     try {
-      // Handles the video processing logic from 3rd party.
-      // The 'success' listener logic will be triggred once user uploaded a
-      // file from the uploader.
+      // Handles the video processing logic from WordPress.
+      // The Uploader.success callback is invoked when a user uploads a file.
+      // Race condition concern: please DO NOT upload video poster on this
+      // callback, becuase the video is not guarantee to be ready at the moment.
+      // We should only upload the video poster on the select event.
       wp.Uploader.prototype.success = ({ attributes }) => {
         updateMedia(attributes.id, { media_source: 'editor' });
       };

--- a/assets/src/edit-story/components/mediaPicker/useMediaPicker.js
+++ b/assets/src/edit-story/components/mediaPicker/useMediaPicker.js
@@ -59,9 +59,8 @@ export default function useMediaPicker({
     try {
       // Handles the video processing logic from WordPress.
       // The Uploader.success callback is invoked when a user uploads a file.
-      // Race condition concern: please DO NOT upload video poster on this
-      // callback, becuase the video is not guarantee to be ready at the moment.
-      // We should only upload the video poster on the select event.
+      // Race condition concern: the video content is not guaranteed to be
+      // available in this callback. For the video poster insertion, please check: assets/src/edit-story/components/library/panes/media/local/mediaPane.js
       wp.Uploader.prototype.success = ({ attributes }) => {
         updateMedia(attributes.id, { media_source: 'editor' });
       };
@@ -97,8 +96,6 @@ export default function useMediaPicker({
     });
 
     // When an image is selected, run a callback.
-    // The onSelect logic is defined in mediaPane.js/onSelect, which handles the
-    // logic when user click on the button `Insert into page`.
     fileFrame.on('select', () => {
       const mediaPickerEl = fileFrame.state().get('selection').first().toJSON();
       onSelect(mediaPickerEl);


### PR DESCRIPTION
## Summary

Handles the race condition when user insert a newly upload video from the uploader.

## Relevant Technical Choices

Move the upload video posters logic from the uploader success listener to the onSelect listener on the `Insert into page` button.

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

1. On the left side bar, click on the `Upload` button.
2. Under `Upload files` tab, hit `Select Files`, select a video to upload.
3. Hit the button `Insert into page`. 
4. The video poster should always show up on the right side bar -> Accessibility.

---

Fixes #5190 
