### PR TITLE
Fixed autosave to run while user is working

### DIFF
--- a/assets/src/edit-story/components/autoSaveHandler/index.js
+++ b/assets/src/edit-story/components/autoSaveHandler/index.js
@@ -66,7 +66,7 @@ function AutoSaveHandler() {
     );
 
     return () => clearTimeout(timeout);
-  }, [autoSaveInterval, isDraft, status, hasNewChanges, isUploading]);
+  }, [autoSaveInterval, isDraft, hasNewChanges, isUploading]);
 
   return null;
 }

--- a/assets/src/edit-story/components/autoSaveHandler/index.js
+++ b/assets/src/edit-story/components/autoSaveHandler/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 /**
  * Internal dependencies
@@ -46,27 +46,27 @@ function AutoSaveHandler() {
 
   const isDraft = 'draft' === status;
 
+  // Cache it to make it stable in terms of the below timeout
+  const cachedSaveStory = useRef(saveStory);
+  useEffect(() => {
+    cachedSaveStory.current = saveStory;
+  }, [saveStory]);
+
   useEffect(() => {
     // @todo The isDraft check is temporary to ensure only draft gets auto-saved,
     // until the logic for other statuses has been decided.
     if (!isDraft || !hasNewChanges || !autoSaveInterval || isUploading) {
       return undefined;
     }
-    let timeout = setTimeout(() => {
-      saveStory();
-    }, autoSaveInterval * 1000);
+    // This is only a timeout, as `hasNewChanges` will come back false after the save
+    // This timeout will thus only be re-set when some new change occurs after an autosave.
+    let timeout = setTimeout(
+      () => cachedSaveStory.current(),
+      autoSaveInterval * 1000
+    );
 
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [
-    autoSaveInterval,
-    isDraft,
-    saveStory,
-    status,
-    hasNewChanges,
-    isUploading,
-  ]);
+    return () => clearTimeout(timeout);
+  }, [autoSaveInterval, isDraft, status, hasNewChanges, isUploading]);
 
   return null;
 }

--- a/assets/src/edit-story/components/autoSaveHandler/index.js
+++ b/assets/src/edit-story/components/autoSaveHandler/index.js
@@ -58,8 +58,9 @@ function AutoSaveHandler() {
     if (!isDraft || !hasNewChanges || !autoSaveInterval || isUploading) {
       return undefined;
     }
-    // This is only a timeout, as `hasNewChanges` will come back false after the save
-    // This timeout will thus only be re-set when some new change occurs after an autosave.
+    // This is only a timeout (and not an interval), as `hasNewChanges` will come
+    // back false after the save.
+    // This timeout will thus be re-started when some new change occurs after an autosave.
     let timeout = setTimeout(
       () => cachedSaveStory.current(),
       autoSaveInterval * 1000


### PR DESCRIPTION
## Summary

Achieved this by making a stable ref to `saveStory` so the effect will not re-run just because this callback changes - as it changes every time the story changes.

## To-do

* [x] Fix bug
* [x] Add test

## Testing Instructions

1. Create a new story
1. Add an element
1. Move the element around every 10 seconds for a minute
1. Observe, that after about a minute of adding the element in the first place, the story is auto-saved and the "save draft" button becomes inactive until the next change is made

---

Fixes #5459
