### PR TITLE
Animation Panel: Active "Scale" animations should display "Scale" as active dropdown value

### DIFF
--- a/assets/src/animation/constants.js
+++ b/assets/src/animation/constants.js
@@ -67,7 +67,7 @@ export const ANIMATION_EFFECTS = {
     value: 'effect-whoosh-in',
     name: __('Whoosh In', 'web-stories'),
   },
-  ZOOM: { value: 'effect-zoom', name: __('Zoom', 'web-stories') },
+  ZOOM: { value: 'effect-zoom', name: __('Scale', 'web-stories') },
   ROTATE_IN: {
     value: 'effect-rotate-in',
     name: __('Rotate In', 'web-stories'),
@@ -75,7 +75,10 @@ export const ANIMATION_EFFECTS = {
 };
 
 export const BACKGROUND_ANIMATION_EFFECTS = {
-  ZOOM: { value: 'effect-background-zoom', name: ANIMATION_EFFECTS.ZOOM.name },
+  ZOOM: {
+    value: 'effect-background-zoom',
+    name: __('Zoom', 'web-stories'),
+  },
   PAN: { value: 'effect-background-pan', name: ANIMATION_EFFECTS.PAN.name },
 };
 


### PR DESCRIPTION
## Summary
Follow up to #5343 - missed that the dropdown value "zoom" should be "scale" when "scale in/out" is selected. Updating the user facing text seen in active dropdown of animation panel.

## Relevant Technical Choices

- renaming 'zoom' to 'scale' for the animation effect name so that the correct user facing label shows up when that animation is selected in the dropdown. Split effect name for background animation so that can still be 'zoom' independent of fg animations


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- Select "scale in/out" for a foreground animation, see that "scale" shows up as the selected animation (formerly "Zoom"). 

## Testing Instructions

- Select "scale in/out" for a foreground animation, see that "scale" shows up as the selected animation (formerly "Zoom"). 
- Create a background image animation, set "zoom", see that "zoom" shows up as the selected animation. 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5511 
