### PR TITLE
Prepublish checklist: remove text contrast warning for now

### DIFF
--- a/assets/src/edit-story/app/prepublish/warning/index.js
+++ b/assets/src/edit-story/app/prepublish/warning/index.js
@@ -23,7 +23,6 @@ export default {
   story: [distributionWarnings.storyMissingExcerpt],
   page: [accessibilityWarnings.pageTooManyLinks],
   text: [
-    accessibilityWarnings.textElementFontLowContrast,
     accessibilityWarnings.textElementFontSizeTooSmall,
     accessibilityWarnings.elementLinkTappableRegionTooSmall,
   ],


### PR DESCRIPTION
## Summary
- From the ticket: "Showing a text contrast issue without checking for actual bg, just fill, is rarely useful and more confusing." 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- I removed it from the file which imports each check function based on type and left the function itself in for future inspiration. 😎 This way the check is not run during checklist time, but we get to keep the lovely codes.

<!-- Please describe your changes. -->

## To-do
🧉 None
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- Where a user would normally see a text contrast check (i.e. change the text color to white and the fill/highlight color for that text element to gray) is no longer there. 
<!-- Please describe your changes. -->

## Testing Instructions
- enable prepublish checklist
- create a new story
- add a text element
- give the text a color
- give the text element a fill of the same color
- there should be no warning for the text contrast

Before: 
![Screen Shot 2020-12-01 at 3 05 02 PM](https://user-images.githubusercontent.com/41136059/100805341-b90e8600-33eb-11eb-97de-0a42f8a0b699.png)

After:
![Screen Shot 2020-12-01 at 3 42 22 PM](https://user-images.githubusercontent.com/41136059/100805392-d2173700-33eb-11eb-976b-79bb6fcf77a3.png)

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5525 
