### PR TITLE
Pre-Publish Checklist: Add indicator for pre-publish checklist warnings

### DIFF
--- a/assets/src/edit-story/components/header/buttons/publish.js
+++ b/assets/src/edit-story/components/header/buttons/publish.js
@@ -37,6 +37,7 @@ import TitleMissingDialog from '../titleMissingDialog';
 import useHeader from '../use';
 import { usePrepublishChecklist } from '../../inspector/prepublish';
 import { PRE_PUBLISH_MESSAGE_TYPES } from '../../../app/prepublish';
+import { ButtonContent, WarningIcon } from './styles';
 
 function Publish() {
   const { isSaving, date, storyId, saveStory, title } = useStory(
@@ -105,7 +106,10 @@ function Publish() {
       onClick={handlePublish}
       isDisabled={!capabilities?.hasPublishAction || isSaving || isUploading}
     >
-      {text}
+      <ButtonContent>
+        {text}
+        {tooltip && <WarningIcon />}
+      </ButtonContent>
     </Primary>
   );
 

--- a/assets/src/edit-story/components/header/buttons/styles.js
+++ b/assets/src/edit-story/components/header/buttons/styles.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { ReactComponent as Warning } from '../../../../design-system/icons/alert/warning.svg';
+
+export const WarningIcon = styled(Warning)`
+  color: white;
+  width: 14px;
+  height: 14px;
+  margin-left: 8px;
+`;
+
+export const ButtonContent = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;

--- a/assets/src/edit-story/components/header/buttons/styles.js
+++ b/assets/src/edit-story/components/header/buttons/styles.js
@@ -22,10 +22,10 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { ReactComponent as Warning } from '../../../../design-system/icons/alert/warning.svg';
+import { Warning } from '../../../../design-system/icons';
 
 export const WarningIcon = styled(Warning)`
-  color: white;
+  color: $(({theme}) => theme.colors.fg.white);
   width: 14px;
   height: 14px;
   margin-left: 8px;


### PR DESCRIPTION
## Summary

Adds warning indicators when there are errors with the pre-publish checklist.

![image-1](https://user-images.githubusercontent.com/1738349/100890897-587c5900-347e-11eb-81d3-3622f001d276.png)
![image](https://user-images.githubusercontent.com/1738349/100890898-5914ef80-347e-11eb-94cc-b51dcdff141c.png)


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Edit a new story
2. See the button for Publish has both a tooltip and a Warning Icon
3. Publish the story anyway with the warnings
4. See the button for Update also has both a tooltip and a Warning Icon
---

<!-- Please reference the issue(s) this PR addresses. -->

#5547 
#5532 
