### PR TITLE
Pre-Publish Checklist: Panel width causing content shift

### DIFF
--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -58,7 +58,8 @@ const TitleWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  width: 215px;
+  width: 200px;
+  max-width: calc(100% - 10px);
 `;
 
 const PanelTitle = styled.span`
@@ -73,6 +74,8 @@ const Row = styled.div`
   margin-bottom: 16px;
   margin-left: ${({ pageGroup }) => (pageGroup ? '16px' : '0')};
   font-size: ${({ theme }) => theme.fonts.body2.size};
+  width: calc(100% - 10px);
+  max-width: 210px;
 `;
 
 const HelperText = styled.span`

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -58,6 +58,7 @@ const TitleWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  width: 215px;
 `;
 
 const PanelTitle = styled.span`


### PR DESCRIPTION
## Summary
This is kind of dirty, all ears for a better solution - ultimately I think this is going to need to be resolved when we get a new panel component and that the checklist design should be an acceptance criteria for that new panel structure since the checklist's labeling and content is different from the other things in panels so far.  

Basically, there's a content shift happening in the checklist if you only have, say, 1 high priority but 10 recommended changes to make because when you expand recommended you're going to need to scroll to see the rest of the recommended, and the scrollbar is taking up space where before it wasn't causing the content to shift. 

The checklist panel doesn't have the ability to override scrollbar styling itself and if I update that in the `InspectorPane` it affects all the other panels which I don't want to do. 

My solution decreases the likelihood of a content shift while still letting the content be legible on smaller viewports. 

## Relevant Technical Choices

There's 2 areas shifting in the checklist, the section titles and the section rows. 
Set width of 200 and max width of 100% - 10px for the titles so that when scrollbars appear or disappear the little number badge on the right side of the label that's getting flex positioned `justify-content: space-between` from the shared panel component can only go as far as 200 which prevents shifting content.

similar for the rows, setting max-width of 210px and width of 100%-10px so that it never grows beyond 210px, the default width of 100% - 10px makes the panel respect constraints on smaller viewports. 

## To-do
This panel structure is different from others in the editor - the label has nested content that can shift, and the panel row content isn't set in a flex box with widths specified, when the new panel is set up within the new structure we should make sure we have this use case when we stress test it. I think this is just new functionality.

## User-facing changes

pre-publish checklist content shouldn't shift anymore (desktop viewport sizes only).

## Testing Instructions

- Make sure the prepublish checklist experiment flag is true
- Create a new story
- Go to the prepublish checklist and verify that you have some high priority items to fix (like no title) and at least 5 recommended items to fix. The quantity is important so that you have to scroll to see the rest of them when everything is expanded.
- Now collapse both, open just high priority. 
- Now also expand recommended and notice the high priority content isn't shifting. 

(this update only fixes desktop viewport sizes).

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5400 
