### PR TITLE
Pre-Publish Checklist: Remove duplicate low image resolution check

### DIFF
--- a/assets/src/edit-story/app/prepublish/warning/index.js
+++ b/assets/src/edit-story/app/prepublish/warning/index.js
@@ -28,13 +28,11 @@ export default {
     accessibilityWarnings.elementLinkTappableRegionTooSmall,
   ],
   image: [
-    accessibilityWarnings.imageElementLowResolution,
     accessibilityWarnings.imageElementMissingAlt,
     accessibilityWarnings.elementLinkTappableRegionTooSmall,
   ],
   shape: [accessibilityWarnings.elementLinkTappableRegionTooSmall],
   gif: [
-    accessibilityWarnings.imageElementLowResolution,
     accessibilityWarnings.imageElementMissingAlt,
     accessibilityWarnings.elementLinkTappableRegionTooSmall,
   ],


### PR DESCRIPTION
## Summary

Remove 1x warning in lieu of just the 2x guidance as per recommendation from team.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

Add a small image and stretch it until it's lower than 2x density. Without this branch, you should just see one low image resolution error. On main, you'd see two (one past 1x, two past 2x).

Here's an example image to use 😄 
![bean furby](https://user-images.githubusercontent.com/3869/100925599-0d227480-3497-11eb-907e-e85817b0f8e7.jpeg)


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5376 
