### PR TITLE
Prepublish Checklist: Story Excerpt/Description warning text update

### DIFF
--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -198,8 +198,11 @@ export const MESSAGES = {
   },
   DISTRIBUTION: {
     MISSING_DESCRIPTION: {
-      MAIN_TEXT: __('Missing story description', 'web-stories'),
-      HELPER_TEXT: __('Add a description for your story.', 'web-stories'),
+      MAIN_TEXT: __('Missing Story Description', 'web-stories'),
+      HELPER_TEXT: __(
+        'Add a Story Description in the Document panel.',
+        'web-stories'
+      ),
     },
   },
   GENERAL_GUIDELINES: {

--- a/assets/src/edit-story/app/prepublish/test/__snapshots__/getPrepublishErrors.js.snap
+++ b/assets/src/edit-story/app/prepublish/test/__snapshots__/getPrepublishErrors.js.snap
@@ -15,8 +15,8 @@ Array [
     "type": "error",
   },
   Object {
-    "help": "Add a description for your story.",
-    "message": "Missing story description",
+    "help": "Add a Story Description in the Document panel.",
+    "message": "Missing Story Description",
     "storyId": 120,
     "type": "warning",
   },

--- a/assets/src/edit-story/components/inspector/document/excerpt.js
+++ b/assets/src/edit-story/components/inspector/document/excerpt.js
@@ -56,7 +56,7 @@ function ExcerptPanel() {
   return (
     <SimplePanel
       name="excerpt"
-      title={__('Excerpt', 'web-stories')}
+      title={__('Story Description', 'web-stories')}
       collapsedByDefault={false}
     >
       <Row>
@@ -64,7 +64,7 @@ function ExcerptPanel() {
           value={excerpt}
           onTextChange={handleTextChange}
           placeholder={__('Write an excerpt', 'web-stories')}
-          aria-label={__('Story Excerpt', 'web-stories')}
+          aria-label={__('Story Description', 'web-stories')}
           maxLength={EXCERPT_MAX_LENGTH}
           rows={4}
         />

--- a/assets/src/edit-story/components/inspector/document/excerpt.js
+++ b/assets/src/edit-story/components/inspector/document/excerpt.js
@@ -63,7 +63,7 @@ function ExcerptPanel() {
         <TextArea
           value={excerpt}
           onTextChange={handleTextChange}
-          placeholder={__('Write an excerpt', 'web-stories')}
+          placeholder={__('Write a description of the story', 'web-stories')}
           aria-label={__('Story Description', 'web-stories')}
           maxLength={EXCERPT_MAX_LENGTH}
           rows={4}
@@ -72,7 +72,7 @@ function ExcerptPanel() {
       <Row>
         <Note>
           {__(
-            'Stories with an excerpt tend to do better on search and have a wider reach.',
+            'Stories with a description tend to do better on search and have a wider reach.',
             'web-stories'
           )}
         </Note>

--- a/assets/src/edit-story/components/inspector/document/test/excerpt.js
+++ b/assets/src/edit-story/components/inspector/document/test/excerpt.js
@@ -64,19 +64,19 @@ describe('ExcerptPanel', () => {
 
   it('should render Excerpt Panel', () => {
     const { getByRole } = setupPanel();
-    const element = getByRole('button', { name: 'Excerpt' });
+    const element = getByRole('button', { name: 'Story Description' });
     expect(element).toBeDefined();
   });
 
   it('should display textbox', () => {
     const { getByRole } = setupPanel();
-    const input = getByRole('textbox', { name: 'Story Excerpt' });
+    const input = getByRole('textbox', { name: 'Story Description' });
     expect(input).toBeDefined();
   });
 
   it('should respect excerpt character limit', async () => {
     const { getByRole, updateStory } = setupPanel();
-    const input = getByRole('textbox', { name: 'Story Excerpt' });
+    const input = getByRole('textbox', { name: 'Story Description' });
 
     const bigExcerpt = ''.padStart(EXCERPT_MAX_LENGTH + 10, '1');
 


### PR DESCRIPTION
## Summary
Updates the copy for "Missing Story Description" warning to have helper text that reads "Add a Story Description in the Document panel." 
Updates the label for the "Excerpt" in the document panel to be "Story Description" for consistency - same update for aria label. Swaps "excerpt" in helper text and placeholder for "description".

<img width="748" alt="Screen Shot 2020-12-02 at 1 35 52 PM" src="https://user-images.githubusercontent.com/10720454/100928362-52e53a00-34a3-11eb-95c5-99c36eaa9d13.png">
Further context: https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/5403

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do


## User-facing changes

The summarized text changes to the prepublish checklist and document panel. 

## Testing Instructions

See that the described text updates are accurate. 

![Screen Shot 2020-12-02 at 1 29 48 PM](https://user-images.githubusercontent.com/10720454/100928276-3b0db600-34a3-11eb-8aae-33bc28e9d562.png)
![Screen Shot 2020-12-02 at 4 42 57 PM](https://user-images.githubusercontent.com/10720454/101060589-cee78c80-354c-11eb-9f4b-4add42d8c9a7.png)


---

<!-- Please reference the issue(s) this PR addresses. -->

Address #5403 
