### PR TITLE
[WIP] Implemented first rough edition of this precision snapping

### DIFF
--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -61,6 +61,22 @@ const EmptyFrame = styled.div`
   pointer-events: none;
 `;
 
+function getDataCoordinates({ x, y, width, height, rotationAngle }) {
+  // Any rotation is ignored for this purpose
+  if (rotationAngle !== 0) {
+    return null;
+  }
+
+  return {
+    'data-top': y,
+    'data-middle': y + Math.floor(height / 2),
+    'data-bottom': y + height,
+    'data-left': x,
+    'data-center': x + Math.floor(width / 2),
+    'data-right': x + width,
+  };
+}
+
 function FrameElement({ element }) {
   const { id, type } = element;
   const { Frame, isMaskable, Controls } = getDefinitionForType(type);
@@ -129,6 +145,7 @@ function FrameElement({ element }) {
         ref={elementRef}
         data-element-id={id}
         {...box}
+        {...getDataCoordinates(element)}
         onMouseDown={(evt) => {
           if (isSelected) {
             elementRef.current.focus({ preventScroll: true });

--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -30,7 +30,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { STORY_ANIMATION_STATE } from '../../../animation';
-import { PAGE_WIDTH, DESIGN_SPACE_MARGIN } from '../../constants';
+import { PAGE_WIDTH, PAGE_HEIGHT, DESIGN_SPACE_MARGIN } from '../../constants';
 import { useStory, useDropTargets } from '../../app';
 import withOverlay from '../overlay/withOverlay';
 import PageMenu from './pagemenu';
@@ -70,7 +70,14 @@ const Hint = styled.div`
 `;
 
 const marginRatio = 100 * (DESIGN_SPACE_MARGIN / PAGE_WIDTH);
-const DesignSpaceGuideline = styled.div`
+const DesignSpaceGuideline = styled.div.attrs({
+  'data-top': 0,
+  'data-middle': PAGE_HEIGHT / 2,
+  'data-bottom': PAGE_HEIGHT,
+  'data-left': DESIGN_SPACE_MARGIN,
+  'data-center': PAGE_WIDTH / 2,
+  'data-right': PAGE_WIDTH - DESIGN_SPACE_MARGIN,
+})`
   border: 1px solid ${({ theme }) => theme.colors.callout};
   left: ${marginRatio}%;
   right: ${marginRatio}%;

--- a/assets/src/edit-story/components/canvas/singleSelectionMoveable/index.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMoveable/index.js
@@ -193,6 +193,10 @@ function SingleSelectionMoveable({
   );
 
   const snapProps = useSnapping({
+    ref: moveable,
+    target: targetEl,
+    selectedElement,
+    pushTransform,
     isDragging,
     otherNodes,
     canSnap: canSnap && actionsEnabled,

--- a/assets/src/edit-story/components/canvas/utils/useSnapping.js
+++ b/assets/src/edit-story/components/canvas/utils/useSnapping.js
@@ -17,17 +17,66 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 /**
  * Internal dependencies
  */
-import { FULLBLEED_RATIO } from '../../../constants';
+import {
+  PAGE_WIDTH,
+  PAGE_HEIGHT,
+  FULLBLEED_RATIO,
+  OVERFLOW_HEIGHT,
+} from '../../../constants';
 import { useGlobalIsKeyPressed } from '../../keyboard';
 import { useDropTargets } from '../../dropTargets';
 import useCanvas from '../useCanvas';
 
-function useSnapping({ isDragging, canSnap, otherNodes }) {
+function isNear(a, b) {
+  return Math.abs(a - b) < 3;
+}
+
+function selectNearest(coord, candidates, otherwise = null) {
+  const result = candidates.find(([key]) => isNear(coord, key));
+  return result?.[1] ?? otherwise;
+}
+
+function getRelativeRect(target, container) {
+  const containerRect = container.getBoundingClientRect();
+  let targetRect;
+  if (Array.isArray(target)) {
+    // TODO handle array
+    targetRect = {};
+  } else {
+    targetRect = target.getBoundingClientRect();
+  }
+  return {
+    top: Math.round(targetRect.top) - containerRect.top,
+    right: Math.round(targetRect.right) - containerRect.left,
+    bottom: Math.round(targetRect.bottom) - containerRect.top,
+    left: Math.round(targetRect.left) - containerRect.left,
+  };
+}
+
+function getSnappingElements(elements, gaps) {
+  // If there are any gap snaps, remove all elements snapping in this dimension
+  // otherwise use them all
+  const allElements = elements.flat();
+  if (gaps.length) {
+    return allElements.filter(({ type }) => type !== gaps[0].type);
+  }
+  return allElements;
+}
+
+function useSnapping({
+  ref,
+  target,
+  selectedElement,
+  pushTransform,
+  isDragging,
+  canSnap,
+  otherNodes,
+}) {
   const {
     canvasWidth,
     canvasHeight,
@@ -66,8 +115,167 @@ function useSnapping({ isDragging, canSnap, otherNodes }) {
     },
     [designSpaceGuideline]
   );
+
+  const getSnapCoord = useCallback(
+    ({ type, pos, element }) => {
+      if (!element.dataset.top) {
+        return null;
+      }
+      const targetRect = getRelativeRect(target, ref.current.props.container);
+      const elementRect = getRelativeRect(element, ref.current.props.container);
+      switch (type) {
+        case 'vertical': {
+          const snappingSide = selectNearest(
+            pos[0],
+            [
+              [targetRect.left, 'left'],
+              [targetRect.right, 'right'],
+            ],
+            'center'
+          );
+          const coordinate = selectNearest(
+            pos[0],
+            [
+              [elementRect.left, element.dataset.left],
+              [elementRect.right, element.dataset.right],
+            ],
+            element.dataset.center
+          );
+          return {
+            [snappingSide]: parseInt(coordinate),
+          };
+        }
+        case 'horizontal': {
+          const snappingSide = selectNearest(
+            pos[1],
+            [
+              [targetRect.top, 'top'],
+              [targetRect.bottom, 'bottom'],
+            ],
+            'middle'
+          );
+          const coordinate = selectNearest(
+            pos[1],
+            [
+              [elementRect.top, element.dataset.top],
+              [elementRect.bottom, element.dataset.bottom],
+            ],
+            element.dataset.middle
+          );
+          return {
+            [snappingSide]: parseInt(coordinate),
+          };
+        }
+        default:
+          // Should never happen
+          return null;
+      }
+    },
+    [target, ref]
+  );
+
+  const { verticalGuidelines, horizontalGuidelines } = useMemo(() => {
+    if (!canSnap) {
+      return {
+        verticalGuidelines: [],
+        horizontalGuidelines: [],
+      };
+    }
+
+    const canvasRect = canvasContainer.getBoundingClientRect();
+    const pageRect = pageContainer.getBoundingClientRect();
+    const offsetX = Math.ceil(pageRect.x - canvasRect.x);
+    const offsetY = Math.floor(pageRect.y - canvasRect.y);
+    const fullBleedOffset = (canvasWidth / FULLBLEED_RATIO - canvasHeight) / 2;
+    return {
+      verticalGuidelines: [
+        offsetX,
+        offsetX + canvasWidth / 2,
+        offsetX + canvasWidth,
+      ],
+      horizontalGuidelines: [
+        offsetY - fullBleedOffset,
+        offsetY,
+        offsetY + canvasHeight / 2,
+        offsetY + canvasHeight,
+        offsetY + canvasHeight + fullBleedOffset,
+      ],
+    };
+  }, [canSnap, canvasHeight, canvasWidth, canvasContainer, pageContainer]);
+
+  const getGuidelineCoord = useCallback(
+    ({ type, pos }) => {
+      if (!verticalGuidelines.length && !horizontalGuidelines) {
+        return null;
+      }
+      const targetRect = getRelativeRect(target, ref.current.props.container);
+      switch (type) {
+        case 'vertical': {
+          const snappingSide = selectNearest(
+            pos[0],
+            [
+              [targetRect.left, 'left'],
+              [targetRect.right, 'right'],
+            ],
+            'center'
+          );
+          const coordinate = selectNearest(pos[0], [
+            [verticalGuidelines[0], 0],
+            [verticalGuidelines[1], PAGE_WIDTH / 2],
+            [verticalGuidelines[2], PAGE_WIDTH],
+          ]);
+          return {
+            [snappingSide]: coordinate,
+          };
+        }
+        case 'horizontal': {
+          const snappingSide = selectNearest(
+            pos[1],
+            [
+              [targetRect.top, 'top'],
+              [targetRect.bottom, 'bottom'],
+            ],
+            'middle'
+          );
+          const coordinate = selectNearest(pos[1], [
+            [horizontalGuidelines[0], -OVERFLOW_HEIGHT],
+            [horizontalGuidelines[1], 0],
+            [horizontalGuidelines[2], PAGE_HEIGHT / 2],
+            [horizontalGuidelines[3], PAGE_HEIGHT],
+            [horizontalGuidelines[4], PAGE_HEIGHT + OVERFLOW_HEIGHT],
+          ]);
+          return {
+            [snappingSide]: coordinate,
+          };
+        }
+        default:
+          // Should never happen
+          return null;
+      }
+    },
+    [verticalGuidelines, horizontalGuidelines, ref, target]
+  );
+
   const handleSnap = useCallback(
-    ({ elements }) =>
+    ({ elements, guidelines, gaps }) => {
+      // Only use this snapping transform for non-rotated elements
+      if (selectedElement.rotationAngle === 0) {
+        const snappingElements = getSnappingElements(elements, gaps);
+        const regularAssign = (aggr, o) => ({ ...aggr, ...o });
+        const reverseAssign = (aggr, o) => ({ ...o, ...aggr });
+        // Gather all the snapping coordinates from elements
+        // but give preference to the first found matches
+        const elementSnapCoords = snappingElements
+          .map(getSnapCoord)
+          .reduce(reverseAssign, {});
+        // Override with snapping coordinates from guidelines if any
+        const snapCoords = guidelines
+          .map(getGuidelineCoord)
+          .reduce(regularAssign, elementSnapCoords);
+
+        // Now store this for transform
+        pushTransform(selectedElement.id, { snap: snapCoords });
+      }
       // Show design space if we're snapping to any of its edges
       toggleDesignSpace(
         elements
@@ -75,8 +283,16 @@ function useSnapping({ isDragging, canSnap, otherNodes }) {
           .some(
             ({ center, element }) => element === designSpaceGuideline && !center
           )
-      ),
-    [toggleDesignSpace, designSpaceGuideline]
+      );
+    },
+    [
+      toggleDesignSpace,
+      designSpaceGuideline,
+      getSnapCoord,
+      getGuidelineCoord,
+      pushTransform,
+      selectedElement,
+    ]
   );
 
   // Always hide design space guideline when dragging stops
@@ -89,28 +305,6 @@ function useSnapping({ isDragging, canSnap, otherNodes }) {
   if (!canvasContainer || !pageContainer) {
     return {};
   }
-
-  const canvasRect = canvasContainer.getBoundingClientRect();
-  const pageRect = pageContainer.getBoundingClientRect();
-
-  const offsetX = Math.ceil(pageRect.x - canvasRect.x);
-  const offsetY = Math.floor(pageRect.y - canvasRect.y);
-
-  const verticalGuidelines = canSnap
-    ? [offsetX, offsetX + canvasWidth / 2, offsetX + canvasWidth]
-    : [];
-
-  const fullBleedOffset = (canvasWidth / FULLBLEED_RATIO - canvasHeight) / 2;
-
-  const horizontalGuidelines = canSnap
-    ? [
-        offsetY - fullBleedOffset,
-        offsetY,
-        offsetY + canvasHeight / 2,
-        offsetY + canvasHeight,
-        offsetY + canvasHeight + fullBleedOffset,
-      ]
-    : [];
 
   const elementGuidelines = canSnap
     ? [...otherNodes, designSpaceGuideline]

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -33,6 +33,9 @@ export const PAGE_HEIGHT = 618;
 export const ALLOWED_EDITOR_PAGE_WIDTHS = [412, 268, 223];
 
 export const FULLBLEED_RATIO = 9 / 16;
+export const OVERFLOW_HEIGHT = Math.ceil(
+  (PAGE_WIDTH / FULLBLEED_RATIO - PAGE_HEIGHT) / 2
+);
 
 export const DESIGN_SPACE_MARGIN = 48;
 

--- a/assets/src/edit-story/elements/shared/index.js
+++ b/assets/src/edit-story/elements/shared/index.js
@@ -41,14 +41,14 @@ export const elementFillContent = css`
 export const elementWithPosition = css`
   position: absolute;
   z-index: 1;
-  left: ${({ x }) => `${x}px`};
-  top: ${({ y }) => `${y}px`};
+  left: ${({ x }) => `${Math.round(x)}px`};
+  top: ${({ y }) => `${Math.round(y)}px`};
 `;
 
 // TODO: removed round/ceil, calculateFitTextFontSize needs to be improved?
 export const elementWithSize = css`
-  width: ${({ width }) => `${width}px`};
-  height: ${({ height }) => `${height}px`};
+  width: ${({ width }) => `${Math.round(width)}px`};
+  height: ${({ height }) => `${Math.round(height)}px`};
 `;
 
 export const elementWithRotation = css`


### PR DESCRIPTION
## Summary

Implement precision-snapping for moveable elements.

Only implemented for non-rotated single element selections while moving. So not working for resize, not for multi-selection and not for any rotated elements.

## Relevant Technical Choices

* Stores the real-world coordinates of non-rotated elements as data-attributes on frame elements
* Uses these to update a snap transform property about the latest snap-coordinates
* Uses this property to update final position coordinates based on snap-coordinates if exists

## To-do

* [x] Single-selection drag
* [ ] Single-selection resize
* [ ] Clean-up logic and refactor to smaller hooks
* [ ] Unit-test relevant logic
* [ ] Integration-test relevant functionality
* [ ] ~Multi-selection drag~
* [ ] ~Multi-selection resize~
* [ ] ~Rotated elements being moved/resized~
* [ ] ~Rotated elements being snapped to while moving/resizing~

I'm not sure the latter 4 are possible - nor even desired? They're pretty special cases and I see more issues than solutions if implemented.

## User-facing changes

* When dragging elements to align to each other using snapping guidelines, they'll actually have the exact same coordinates regardless of canvas zoom.

## Testing Instructions

* See parent ticket, #4813

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4813
