### PR TITLE
Embed block: fix embedding stories with plain permalinks

### DIFF
--- a/assets/src/story-embed-block/block/edit.js
+++ b/assets/src/story-embed-block/block/edit.js
@@ -99,7 +99,7 @@ function StoryEmbedEdit({
       try {
         setIsFetchingData(true);
         // Normalize input URL.
-        const urlToEmbed = encodeURIComponent((new URL(url)).toString());
+        const urlToEmbed = encodeURIComponent(new URL(url).toString());
 
         const data = await apiFetch({
           path: `web-stories/v1/embed?url=${urlToEmbed}`,

--- a/assets/src/story-embed-block/block/edit.js
+++ b/assets/src/story-embed-block/block/edit.js
@@ -98,10 +98,11 @@ function StoryEmbedEdit({
 
       try {
         setIsFetchingData(true);
-        const urlObj = new URL(url);
+        // Normalize input URL.
+        const urlToEmbed = encodeURIComponent((new URL(url)).toString());
 
         const data = await apiFetch({
-          path: `web-stories/v1/embed?url=${urlObj.toString()}`,
+          path: `web-stories/v1/embed?url=${urlToEmbed}`,
         });
 
         setCannotEmbed(!data?.title);

--- a/includes/REST_API/Embed_Controller.php
+++ b/includes/REST_API/Embed_Controller.php
@@ -222,8 +222,12 @@ class Embed_Controller extends WP_REST_Controller {
 
 			// In case of subdirectory configs, set the path.
 			if ( ! is_subdomain_install() ) {
+				// Get "sub-site" part of "http://example.org/sub-site/web-stories/my-story/".
+				// But given just "http://example.org/web-stories/my-story/", don't treat "web-stories" as site path.
+				// This differs from the logic in get_oembed_response_data_for_url() which does not do this.
+				// TODO: Investigate possible core bug in get_oembed_response_data_for_url()?
 				$path    = explode( '/', ltrim( $url_parts['path'], '/' ) );
-				$path    = reset( $path );
+				$path    = count( $path ) > 2 ? reset( $path ) : false;
 				$network = get_network();
 				if ( $path && $network instanceof \WP_Network ) {
 					$qv['path'] = $network->path . $path . '/';
@@ -277,7 +281,6 @@ class Embed_Controller extends WP_REST_Controller {
 				}
 			}
 		}
-
 
 		if ( $switched_blog ) {
 			restore_current_blog();

--- a/includes/REST_API/Embed_Controller.php
+++ b/includes/REST_API/Embed_Controller.php
@@ -93,7 +93,7 @@ class Embed_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_proxy_item( $request ) {
-		$url = untrailingslashit( $request['url'] );
+		$url = urldecode( untrailingslashit( $request['url'] ) );
 
 		if ( empty( $url ) ) {
 			return new WP_Error( 'rest_invalid_url', __( 'Invalid URL', 'web-stories' ), [ 'status' => 404 ] );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,7 +16,9 @@
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 	</rule>
 
-	<rule ref="WordPress-VIP-Go" />
+	<rule ref="WordPress-VIP-Go">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/tests/phpstan/stubs/wpdotcom.php
+++ b/tests/phpstan/stubs/wpdotcom.php
@@ -6,3 +6,14 @@
  */
 function wpcom_vip_url_to_postid( $url ) {
 }
+
+/**
+ * @param string       $page_path Page path.
+ * @param string       $output    Optional. The required return type. One of OBJECT, ARRAY_A, or ARRAY_N, which
+ *                                correspond to a WP_Post object, an associative array, or a numeric array,
+ *                                respectively. Default OBJECT.
+ * @param string|array $post_type Optional. Post type or array of post types. Default 'page'.
+ * @return WP_Post|array|null WP_Post (or array) on success, or null on failure.
+ */
+function wpcom_vip_get_page_by_path( $page_path, $output = OBJECT, $post_type = 'page' ) {
+}

--- a/tests/phpunit/tests/Discovery.php
+++ b/tests/phpunit/tests/Discovery.php
@@ -85,13 +85,16 @@ class Discovery extends \WP_UnitTestCase {
 
 	public function setUp() {
 		parent::setUp();
+
 		$this->set_permalink_structure( '/%postname%/' );
 		$this->go_to( get_permalink( self::$story_id ) );
 	}
 
 	public function tearDown() {
+		$this->set_permalink_structure( '' );
 		// Set by go_to();
 		$_SERVER['REQUEST_URI'] = '';
+
 		parent::tearDown();
 	}
 

--- a/tests/phpunit/tests/REST_API/Embed_Controller.php
+++ b/tests/phpunit/tests/REST_API/Embed_Controller.php
@@ -112,6 +112,7 @@ class Embed_Controller extends \WP_Test_REST_TestCase {
 		$story_post_type->remove_caps_from_roles();
 
 		$this->set_permalink_structure( '' );
+		$_SERVER['REQUEST_URI'] = '';
 
 		parent::tearDown();
 	}

--- a/tests/phpunit/tests/REST_API/Embed_Controller.php
+++ b/tests/phpunit/tests/REST_API/Embed_Controller.php
@@ -173,14 +173,16 @@ class Embed_Controller extends \WP_Test_REST_TestCase {
 		return rest_get_server()->dispatch( $request );
 	}
 
-	public function test_not_logged_in() {
+	public function test_missing_param() {
 		$response = $this->dispatch_request();
-		$this->assertEquals( 400, $response->get_status() );
+
+		$this->assertErrorResponse( 'rest_missing_callback_param', $response, 400 );
 	}
 
-	public function test_not_logged_in_empty_string() {
+	public function test_not_logged_in() {
 		$response = $this->dispatch_request( '' );
-		$this->assertEquals( 401, $response->get_status() );
+
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
 	}
 
 	public function test_without_permission() {
@@ -188,37 +190,33 @@ class Embed_Controller extends \WP_Test_REST_TestCase {
 
 		$response = $this->dispatch_request( self::VALID_URL );
 
-		$this->assertEquals( 403, $response->get_status() );
-		$data = $response->get_data();
-		$this->assertEquals( $data['code'], 'rest_forbidden' );
+		$this->assertEquals( 0, $this->request_count );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
 
 	public function test_url_empty_string() {
 		wp_set_current_user( self::$editor );
+
 		$response = $this->dispatch_request( '' );
-		$data     = $response->get_data();
 
 		$this->assertEquals( 0, $this->request_count );
-		$this->assertEquals( 404, $response->get_status() );
-		$this->assertEquals( $data['code'], 'rest_invalid_url' );
+		$this->assertErrorResponse( 'rest_invalid_url', $response, 404 );
 	}
 
 	public function test_invalid_url() {
 		wp_set_current_user( self::$editor );
-		$response = $this->dispatch_request( self::INVALID_URL );
-		$data     = $response->get_data();
 
-		$this->assertEquals( 404, $response->get_status() );
-		$this->assertEquals( $data['code'], 'rest_invalid_url' );
+		$response = $this->dispatch_request( self::INVALID_URL );
+
+		$this->assertErrorResponse( 'rest_invalid_url', $response, 404 );
 	}
 
 	public function test_empty_url() {
 		wp_set_current_user( self::$editor );
-		$response = $this->dispatch_request( self::VALID_URL_EMPTY_DOCUMENT );
-		$data     = $response->get_data();
 
-		$this->assertEquals( 404, $response->get_status() );
-		$this->assertEquals( $data['code'], 'rest_invalid_story' );
+		$response = $this->dispatch_request( self::VALID_URL_EMPTY_DOCUMENT );
+
+		$this->assertErrorResponse( 'rest_invalid_story', $response, 404 );
 	}
 
 	public function test_valid_url() {

--- a/tests/phpunit/tests/REST_API/Embed_Controller.php
+++ b/tests/phpunit/tests/REST_API/Embed_Controller.php
@@ -89,7 +89,6 @@ class Embed_Controller extends \WP_Test_REST_TestCase {
 		do_action( 'rest_api_init', $wp_rest_server );
 
 		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
-
 		$this->request_count = 0;
 
 		$experiments = $this->createMock( \Google\Web_Stories\Experiments::class );
@@ -111,6 +110,8 @@ class Embed_Controller extends \WP_Test_REST_TestCase {
 
 		$story_post_type = new Story_Post_type( $experiments, $meta_boxes );
 		$story_post_type->remove_caps_from_roles();
+
+		$this->set_permalink_structure( '' );
 
 		parent::tearDown();
 	}

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -78,6 +78,8 @@ class Story_Post_Type extends \WP_UnitTestCase {
 
 	public function tearDown() {
 		$this->set_permalink_structure( '' );
+		$_SERVER['REQUEST_URI'] = '';
+
 		parent::tearDown();
 	}
 

--- a/tests/phpunit/tests/Story_Post_Type.php
+++ b/tests/phpunit/tests/Story_Post_Type.php
@@ -76,6 +76,11 @@ class Story_Post_Type extends \WP_UnitTestCase {
 		set_post_thumbnail( self::$story_id, $poster_attachment_id );
 	}
 
+	public function tearDown() {
+		$this->set_permalink_structure( '' );
+		parent::tearDown();
+	}
+
 	/**
 	 * @covers ::init
 	 */


### PR DESCRIPTION
## Summary

Fixes embedding local stories with plain permalinks.

## Relevant Technical Choices

1. Encodes URLs for transimission
1. Adds some custom logic to parse URLs because `url_to_postid()` does not recognize plain permalinks like `https://example.com/?web-story=my-story`.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

N/A

## Testing Instructions

1. Disable pretty permalinks in the WordPress settings
1. Create a new blog post and insert a Web Stories embed block
1. Paste the URL of a web story on the same site
1. Verify that the embed is working

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5560
