### PR TITLE
Enable browser spell checking

### DIFF
--- a/assets/src/edit-story/components/richText/editor.js
+++ b/assets/src/edit-story/components/richText/editor.js
@@ -79,7 +79,6 @@ function RichTextEditor({ content, onChange }, ref) {
 
   // Handle basic key commands such as bold, italic and underscore.
   const handleKeyCommand = getHandleKeyCommand();
-
   return (
     <Editor
       ref={editorRef}
@@ -88,6 +87,7 @@ function RichTextEditor({ content, onChange }, ref) {
       handleKeyCommand={handleKeyCommand}
       handlePastedText={handlePastedText}
       customStyleFn={customInlineDisplay}
+      spellCheck
       stripPastedStyles
     />
   );


### PR DESCRIPTION
## Summary

Add the spell check props to the RichTextEditor component.

## Relevant Technical Choices

enable the spellCheck

## To-do

N/A

## User-facing changes

Here will be spell checking in the following elements:
- title
- story excerpt/summary
- image accessibility text
- video title/accessibility text/description
- media search text box - both WP library and 3P media search 

## Testing Instructions

When toggle and focus on the elements above, we should see the spell checking.

---

Fixes #5538 
