### PR TITLE
Animations: Copy and Paste Support

### DIFF
--- a/assets/src/animation/effects/backgroundPan/index.js
+++ b/assets/src/animation/effects/backgroundPan/index.js
@@ -37,9 +37,16 @@ export function EffectBackgroundPan({
 
   const animationName = `direction-${panDir}-${BACKGROUND_ANIMATION_EFFECTS.PAN.value}`;
 
-  const offsets = getMediaBoundOffsets({ element });
   const translateToOriginX = 'translate3d(0%, 0, 0)';
   const translateToOriginY = 'translate3d(0, 0%, 0)';
+  const offsets = element
+    ? getMediaBoundOffsets({ element })
+    : {
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      };
   const translate = {
     from: {
       [DIRECTION.RIGHT_TO_LEFT]: `translate3d(${offsets.left}%, 0, 0)`,

--- a/assets/src/edit-story/app/story/storyProvider.js
+++ b/assets/src/edit-story/app/story/storyProvider.js
@@ -101,7 +101,7 @@ function StoryProvider({ storyId, children }) {
     const animations = (currentPage.animations || []).reduce(
       (acc, { targets, ...properties }) => {
         if (targets.some((id) => selection.includes(id))) {
-          return [...acc, { ...properties }];
+          return [...acc, { targets, ...properties }];
         }
 
         return acc;

--- a/assets/src/edit-story/app/story/useStoryReducer/actions.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/actions.js
@@ -131,6 +131,9 @@ const updateStory = (dispatch) => ({ properties }) =>
 const updateAnimationState = (dispatch) => ({ animationState }) =>
   dispatch({ type: types.UPDATE_ANIMATION_STATE, payload: { animationState } });
 
+const addAnimations = (dispatch) => ({ animations }) =>
+  dispatch({ type: types.ADD_ANIMATIONS, payload: { animations } });
+
 export const exposedActions = {
   addPage,
   addPageAt,
@@ -160,6 +163,7 @@ export const exposedActions = {
   removeElementFromSelection,
   toggleElementInSelection,
   updateAnimationState,
+  addAnimations,
   updateStory,
 };
 

--- a/assets/src/edit-story/app/story/useStoryReducer/reducer.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducer.js
@@ -20,6 +20,7 @@
 import * as types from './types';
 import * as reducers from './reducers';
 
+/* eslint-disable complexity */
 function reducer(state, { type, payload }) {
   switch (type) {
     case types.ADD_PAGE: {
@@ -94,6 +95,10 @@ function reducer(state, { type, payload }) {
       return reducers.updateAnimationState(state, payload);
     }
 
+    case types.ADD_ANIMATIONS: {
+      return reducers.addAnimations(state, payload);
+    }
+
     case types.RESTORE: {
       return reducers.restore(state, payload);
     }
@@ -102,5 +107,6 @@ function reducer(state, { type, payload }) {
       return state;
   }
 }
+/* eslint-enable complexity */
 
 export default reducer;

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/addAnimations.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/addAnimations.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Add animations to current page.
+ *
+ * Animations are expected to a be list of element objects with at least an id property.
+ * If any animation id already exists on the page, animation is skipped (not even updated).
+ * If multiple animations in the new list have the same id, only the latter is used.
+ *
+ * If animations aren't a list or an empty list (after duplicates have been filtered), nothing happens.
+ *
+ * Animations will be added to the end of the list of animations on the current page.
+ *
+ * @param {Object} state Current state
+ * @param {Object} payload Action payload
+ * @param {Array.<Object>} payload.animations Elements to insert on the given page.
+ * @return {Object} New state
+ */
+function addAnimations(state, { animations }) {
+  if (!Array.isArray(animations)) {
+    return state;
+  }
+
+  const pageIndex = state.pages.findIndex(({ id }) => id === state.current);
+  const oldPage = state.pages[pageIndex];
+  const existingIds = oldPage.animations.map(({ id }) => id);
+  const filteredAnimations = animations.filter(
+    ({ id }) => !existingIds.includes(id)
+  );
+  // Use only last of multiple animations with same id by turning into an object and getting the values.
+  const deduplicatedAnimations = Object.values(
+    Object.fromEntries(
+      filteredAnimations.map((animation) => [animation.id, animation])
+    )
+  );
+
+  if (deduplicatedAnimations.length === 0) {
+    return state;
+  }
+
+  const newPage = {
+    ...oldPage,
+    animations: [...oldPage.animations, ...deduplicatedAnimations],
+  };
+
+  const newPages = [
+    ...state.pages.slice(0, pageIndex),
+    newPage,
+    ...state.pages.slice(pageIndex + 1),
+  ];
+
+  return {
+    ...state,
+    pages: newPages,
+  };
+}
+
+export default addAnimations;

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/addAnimations.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/addAnimations.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * Internal dependencies
+ */
+import { exclusion } from './utils';
+
+/**
  * Add animations to current page.
  *
  * Animations are expected to a be list of element objects with at least an id property.
@@ -38,24 +43,15 @@ function addAnimations(state, { animations }) {
   const pageIndex = state.pages.findIndex(({ id }) => id === state.current);
   const oldPage = state.pages[pageIndex];
   const oldPageAnimations = oldPage.animations || [];
-  const existingIds = oldPageAnimations.map(({ id }) => id);
-  const filteredAnimations = animations.filter(
-    ({ id }) => !existingIds.includes(id)
-  );
-  // Use only last of multiple animations with same id by turning into an object and getting the values.
-  const deduplicatedAnimations = Object.values(
-    Object.fromEntries(
-      filteredAnimations.map((animation) => [animation.id, animation])
-    )
-  );
+  const newAnimations = exclusion(oldPageAnimations, animations);
 
-  if (deduplicatedAnimations.length === 0) {
+  if (newAnimations.length === 0) {
     return state;
   }
 
   const newPage = {
     ...oldPage,
-    animations: [...oldPageAnimations, ...deduplicatedAnimations],
+    animations: [...oldPageAnimations, ...newAnimations],
   };
 
   const newPages = [

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/addAnimations.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/addAnimations.js
@@ -37,7 +37,8 @@ function addAnimations(state, { animations }) {
 
   const pageIndex = state.pages.findIndex(({ id }) => id === state.current);
   const oldPage = state.pages[pageIndex];
-  const existingIds = oldPage.animations.map(({ id }) => id);
+  const oldPageAnimations = oldPage.animations || [];
+  const existingIds = oldPageAnimations.map(({ id }) => id);
   const filteredAnimations = animations.filter(
     ({ id }) => !existingIds.includes(id)
   );
@@ -54,7 +55,7 @@ function addAnimations(state, { animations }) {
 
   const newPage = {
     ...oldPage,
-    animations: [...oldPage.animations, ...deduplicatedAnimations],
+    animations: [...oldPageAnimations, ...deduplicatedAnimations],
   };
 
   const newPages = [

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/addElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/addElements.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * Internal dependencies
+ */
+import { exclusion } from './utils';
+
+/**
  * Add elements to current page.
  *
  * Elements are expected to a be list of element objects with at least an id property.
@@ -39,22 +44,15 @@ function addElements(state, { elements }) {
 
   const pageIndex = state.pages.findIndex(({ id }) => id === state.current);
   const oldPage = state.pages[pageIndex];
-  const existingIds = oldPage.elements.map(({ id }) => id);
-  const filteredElements = elements.filter(
-    ({ id }) => !existingIds.includes(id)
-  );
-  // Use only last of multiple elements with same id by turning into an object and getting the values.
-  const deduplicatedElements = Object.values(
-    Object.fromEntries(filteredElements.map((element) => [element.id, element]))
-  );
+  const newElements = exclusion(oldPage.elements, elements);
 
-  if (deduplicatedElements.length === 0) {
+  if (newElements.length === 0) {
     return state;
   }
 
   const newPage = {
     ...oldPage,
-    elements: [...oldPage.elements, ...deduplicatedElements],
+    elements: [...oldPage.elements, ...newElements],
   };
 
   const newPages = [
@@ -63,7 +61,7 @@ function addElements(state, { elements }) {
     ...state.pages.slice(pageIndex + 1),
   ];
 
-  const newSelection = deduplicatedElements.map(({ id }) => id);
+  const newSelection = newElements.map(({ id }) => id);
 
   return {
     ...state,

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/index.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/index.js
@@ -40,6 +40,7 @@ export { default as toggleElement } from './toggleElement';
 
 // Manipulate animation state
 export { default as updateAnimationState } from './updateAnimationState';
+export { default as addAnimations } from './addAnimations';
 
 // Manipulate entire internal state.
 export { default as restore } from './restore';

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/test/utils.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/test/utils.js
@@ -23,6 +23,7 @@ import {
   moveArrayElement,
   getAbsolutePosition,
   objectWithout,
+  exclusion,
 } from '../utils';
 import { LAYER_DIRECTIONS } from '../../../../../constants';
 
@@ -202,5 +203,29 @@ describe('objectWithout', () => {
     const result = objectWithout(input, 'c');
     expect(input).toStrictEqual({ a: 1, b: 2 });
     expect(result).toStrictEqual({ a: 1, b: 2 });
+  });
+});
+
+describe('exclusion', () => {
+  it('should return entries from right not present in left', () => {
+    const left = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    const right = [{ id: 'a' }, { id: 'd' }, { id: 'e' }];
+    expect(exclusion(left, right)).toStrictEqual([{ id: 'd' }, { id: 'e' }]);
+  });
+
+  it('should return only last instance of entries with duplicate keys', () => {
+    const left = [];
+    const right = [
+      { id: 'a', prop: 1 },
+      { id: 'a', prop: 2 },
+      { id: 'a', prop: 3 },
+    ];
+    expect(exclusion(left, right)).toStrictEqual([{ id: 'a', prop: 3 }]);
+  });
+
+  it('should return an empty array if no new entries present', () => {
+    const left = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    const right = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    expect(exclusion(left, right)).toStrictEqual([]);
   });
 });

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/utils.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/utils.js
@@ -125,3 +125,36 @@ export function updateAnimations(oldAnimations, animationUpdates) {
 
   return newAnimations;
 }
+
+/**
+ * @typedef {{ id: string, [prop: string]: any}} Entry
+ * @property {string} id - unique identifier for entry
+ */
+
+/**
+ * Remove duplicate entries. Uses last instance if
+ * multiple entries share the same id.
+ *
+ * @param {Array<Entry>} entries - set of entries with possible duplicate Ids
+ * @return {Array<Entry>} New set of entries with only unique Ids
+ */
+export function removeDuplicates(entries = []) {
+  // Use only last of multiple elements with same id by turning into an object and getting the values.
+  return Object.values(
+    Object.fromEntries(entries.map((entry) => [entry.id, entry]))
+  );
+}
+
+/**
+ * Takes to sets of entries and returns unique entries
+ * of right set not present in left set.
+ *
+ * @param {Array<Entry>} left - base set of entries
+ * @param {Array<Entry>} right - new entries
+ * @return {Array<Entry>} - right exclusion of sets set
+ */
+export function exclusion(left = [], right = []) {
+  const rightSet = removeDuplicates(right);
+  const leftJoinKeys = left.map(({ id }) => id);
+  return rightSet.filter(({ id }) => !leftJoinKeys.includes(id));
+}

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/utils.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/utils.js
@@ -147,7 +147,7 @@ export function removeDuplicates(entries = []) {
 
 /**
  * Takes to sets of entries and returns unique entries
- * of right set not present in left set.
+ * (keying on id) of right set not present in left set.
  *
  * @param {Array<Entry>} left - base set of entries
  * @param {Array<Entry>} right - new entries

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/utils.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/utils.js
@@ -127,8 +127,10 @@ export function updateAnimations(oldAnimations, animationUpdates) {
 }
 
 /**
- * @typedef {{ id: string, [prop: string]: any}} Entry
- * @property {string} id - unique identifier for entry
+ * Entry must have {id: string, ...} prop on it. WIP
+ * on enforcing this with jsdocs.
+ *
+ * @typedef {Object.<string, any>} Entry
  */
 
 /**

--- a/assets/src/edit-story/app/story/useStoryReducer/test/addAnimations.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/addAnimations.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { setupReducer } from './_utils';
+
+describe('addAnimations', () => {
+  it('should ignore non-list arguments', () => {
+    const { restore, addAnimations } = setupReducer();
+
+    // Set an initial state with a current page and an animation.
+    const initialState = restore({
+      pages: [{ id: '111', elements: [{ id: '000' }] }],
+      current: '111',
+    });
+
+    const result = addAnimations({ animations: false });
+
+    expect(result).toStrictEqual(initialState);
+  });
+
+  it('should ignore an empty list', () => {
+    const { restore, addAnimations } = setupReducer();
+
+    // Set an initial state with a current page and other animations.
+    const initialState = restore({
+      pages: [{ id: '111', animations: [{ id: '000' }] }],
+      current: '111',
+    });
+
+    const result = addAnimations({ animations: [] });
+
+    expect(result).toStrictEqual(initialState);
+  });
+
+  it('should add all new animations to the current page', () => {
+    const { restore, addAnimations } = setupReducer();
+
+    // Set an initial state with a current page and other animations
+    restore({
+      pages: [{ id: '111', animations: [{ id: '000' }] }],
+      current: '111',
+    });
+
+    const result = addAnimations({
+      animations: [{ id: '123' }, { id: '234' }],
+    });
+
+    expect(result.pages[0]).toStrictEqual({
+      id: '111',
+      animations: [{ id: '000' }, { id: '123' }, { id: '234' }],
+    });
+  });
+
+  it('should skip animations matching existing ids', () => {
+    const { restore, addAnimations } = setupReducer();
+
+    // Set an initial state with a current page and other animations
+    restore({
+      pages: [{ id: '111', animations: [{ id: '000', a: 1 }] }],
+      current: '111',
+    });
+
+    const result = addAnimations({
+      animations: [{ id: '123' }, { id: '000', a: 2 }],
+    });
+
+    expect(result.pages[0]).toStrictEqual({
+      id: '111',
+      animations: [{ id: '000', a: 1 }, { id: '123' }],
+    });
+  });
+
+  it('should only add animations with unique ids (using the latter)', () => {
+    const { restore, addAnimations } = setupReducer();
+
+    // Set an initial state with a current page and other elements.
+    restore({
+      pages: [{ id: '111', animations: [{ id: '000' }] }],
+      current: '111',
+    });
+
+    const result = addAnimations({
+      animations: [
+        { id: '123', a: 1 },
+        { id: '123', a: 2 },
+      ],
+    });
+
+    expect(result.pages[0]).toStrictEqual({
+      id: '111',
+      animations: [{ id: '000' }, { id: '123', a: 2 }],
+    });
+  });
+});

--- a/assets/src/edit-story/app/story/useStoryReducer/types.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/types.js
@@ -43,6 +43,7 @@ export const UPDATE_STORY = 'UPDATE_STORY';
 
 // Manipulate animation state.
 export const UPDATE_ANIMATION_STATE = 'UPDATE_ANIMATION_STATE';
+export const ADD_ANIMATIONS = 'ADD_ANIMATIONS';
 
 // Manipulate entire internal state.
 export const RESTORE = 'RESTORE';

--- a/assets/src/edit-story/components/canvas/useAddPastedElements.js
+++ b/assets/src/edit-story/components/canvas/useAddPastedElements.js
@@ -27,6 +27,7 @@ function useAddPastedElements() {
     updateCurrentPageProperties,
     deleteElementById,
     combineElements,
+    addAnimations,
   } = useStory(
     ({
       state: { currentPage, selectedElements },
@@ -36,6 +37,7 @@ function useAddPastedElements() {
         updateCurrentPageProperties,
         deleteElementById,
         combineElements,
+        addAnimations,
       },
     }) => {
       return {
@@ -46,12 +48,13 @@ function useAddPastedElements() {
         updateCurrentPageProperties,
         deleteElementById,
         combineElements,
+        addAnimations,
       };
     }
   );
 
   const addPastedElements = useBatchingCallback(
-    (elements) => {
+    (elements, animations = []) => {
       if (elements.length === 0) {
         return false;
       }
@@ -91,6 +94,10 @@ function useAddPastedElements() {
       if (nonBackgroundElements.length) {
         addElements({ elements: nonBackgroundElements });
       }
+
+      // Add any animations associated with the new elements
+      addAnimations({ animations });
+
       return true;
     },
     [
@@ -99,6 +106,7 @@ function useAddPastedElements() {
       updateCurrentPageProperties,
       combineElements,
       deleteElementById,
+      addAnimations,
     ]
   );
 

--- a/assets/src/edit-story/components/canvas/useAddPastedElements.js
+++ b/assets/src/edit-story/components/canvas/useAddPastedElements.js
@@ -63,6 +63,7 @@ function useAddPastedElements() {
       const newBackgroundElement = elements.find(
         ({ isBackground }) => isBackground
       );
+      let newAnimations = animations;
       if (newBackgroundElement) {
         const existingBgElement = currentPage.elements[0];
         if (newBackgroundElement.isDefaultBackground) {
@@ -78,6 +79,13 @@ function useAddPastedElements() {
             },
           });
         } else {
+          // Since background will maintain id, we update any
+          // new animations to have the proper target
+          newAnimations = animations.map((animation) =>
+            animation.targets.includes(newBackgroundElement.id)
+              ? { ...animation, targets: [existingBgElement.id] }
+              : animation
+          );
           // The user has pasted a media background from another page:
           // Merge this element into the existing background element on this page
           combineElements({
@@ -96,7 +104,7 @@ function useAddPastedElements() {
       }
 
       // Add any animations associated with the new elements
-      addAnimations({ animations });
+      addAnimations({ animations: newAnimations });
 
       return true;
     },

--- a/assets/src/edit-story/components/canvas/useCanvasCopyPaste.js
+++ b/assets/src/edit-story/components/canvas/useCanvasCopyPaste.js
@@ -37,15 +37,21 @@ import useInsertElement from './useInsertElement';
 function useCanvasGlobalKeys() {
   const addPastedElements = useAddPastedElements();
 
-  const { currentPage, selectedElements, deleteSelectedElements } = useStory(
+  const {
+    currentPage,
+    selectedElements,
+    deleteSelectedElements,
+    selectedElementAnimations,
+  } = useStory(
     ({
-      state: { currentPage, selectedElements },
+      state: { currentPage, selectedElements, selectedElementAnimations },
       actions: { deleteSelectedElements },
     }) => {
       return {
         currentPage,
         selectedElements,
         deleteSelectedElements,
+        selectedElementAnimations,
       };
     }
   );
@@ -61,20 +67,33 @@ function useCanvasGlobalKeys() {
         return;
       }
 
-      addElementsToClipboard(currentPage, selectedElements, evt);
+      addElementsToClipboard(
+        currentPage,
+        selectedElements,
+        selectedElementAnimations,
+        evt
+      );
 
       if (eventType === 'cut') {
         deleteSelectedElements();
       }
       evt.preventDefault();
     },
-    [currentPage, deleteSelectedElements, selectedElements]
+    [
+      currentPage,
+      deleteSelectedElements,
+      selectedElements,
+      selectedElementAnimations,
+    ]
   );
 
   const elementPasteHandler = useBatchingCallback(
     (content) => {
-      const elements = processPastedElements(content, currentPage);
-      return addPastedElements(elements);
+      const { elements, animations } = processPastedElements(
+        content,
+        currentPage
+      );
+      return addPastedElements(elements, animations);
     },
     [addPastedElements, currentPage]
   );

--- a/assets/src/edit-story/utils/copyPaste.js
+++ b/assets/src/edit-story/utils/copyPaste.js
@@ -128,7 +128,7 @@ export function addElementsToClipboard(page, elements, animations, evt) {
       basedOn: element.id,
       id: undefined,
     })),
-    animations: animations,
+    animations,
   };
   const serializedPayload = JSON.stringify(payload).replace(
     /--/g,

--- a/assets/src/edit-story/utils/test/copyPaste.js
+++ b/assets/src/edit-story/utils/test/copyPaste.js
@@ -192,7 +192,7 @@ describe('copyPaste utils', () => {
           id: '1',
         },
       ];
-      addElementsToClipboard(PAGE, elements, evt);
+      addElementsToClipboard(PAGE, elements, [], evt);
 
       expect(setData).toHaveBeenCalledTimes(2);
       expect(setData).toHaveBeenCalledWith('text/plain', 'Fill in some text');
@@ -214,7 +214,7 @@ describe('copyPaste utils', () => {
           isDefaultBackground: true,
         },
       ];
-      addElementsToClipboard(PAGE, elements, evt);
+      addElementsToClipboard(PAGE, elements, [], evt);
 
       expect(setData).toHaveBeenCalledTimes(2);
       expect(setData).toHaveBeenCalledWith('text/plain', 'shape');
@@ -240,7 +240,7 @@ describe('copyPaste utils', () => {
           id: '1',
         },
       ];
-      addElementsToClipboard(PAGE, elements, evt);
+      addElementsToClipboard(PAGE, elements, [], evt);
 
       expect(setData).toHaveBeenCalledTimes(2);
       expect(setData).toHaveBeenCalledWith('text/plain', 'shape');
@@ -254,7 +254,7 @@ describe('copyPaste utils', () => {
           setData,
         },
       };
-      addElementsToClipboard(PAGE, [], evt);
+      addElementsToClipboard(PAGE, [], [], evt);
       expect(setData).toHaveBeenCalledTimes(0);
     });
   });


### PR DESCRIPTION
## Summary
Adds support to relevant element animations with copy and paste. now when copy and pasting elements, all animations should be retained with the newly pasted element.

## Relevant Technical Choices
- Had to modify copy and paste method signatures to support animations.
- Added a wholesale addAnimations action to the reducer that allows us to append new animations to the current pages animation structure.

## To-do
**Follow Up Changes:**
Add karma tests around copy and pasting elements with animations. I don't think any copy and paste stuff has karma tests currently (at least I couldn't find any, please point me in that direction if they exist and I couldn't find them)
https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/5564

## User-facing changes
Now if animations are enabled, copy and paste should retain animations.

## Testing Instructions
enable animations:
- Create an element and go through each possible animation, apply it, and copy and paste the new element to another page. see that the animation is on the newly pasted element
- Create a BG image element and go through the process above with all BG animations
- Test out copy and paste with multiple elements that have animations

disable animations:
- do a couple general copy and paste executions and see that copy and paste still behaves the same as before.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5424 
