### PR TITLE
Animations: Page Duplication Support

### DIFF
--- a/assets/src/edit-story/elements/index.js
+++ b/assets/src/edit-story/elements/index.js
@@ -34,7 +34,7 @@ import * as shapeElement from './shape';
 import * as videoElement from './video';
 import * as gifElement from './gif';
 
-export const createNewElement = (type, attributes = {}, overrides = {}) => {
+export const createNewElement = (type, attributes = {}) => {
   const element = getDefinitionForType(type);
   if (!element) {
     throw new Error(`Unknown element type: ${type}`);
@@ -45,7 +45,6 @@ export const createNewElement = (type, attributes = {}, overrides = {}) => {
     ...attributes,
     type,
     id: uuidv4(),
-    ...overrides,
   };
 };
 
@@ -79,9 +78,9 @@ export const duplicatePage = (oldPage) => {
   // Ensure all existing elements get new ids
   let elementIdTransferMap = {};
   const elements = oldElements.map(({ type, ...attrs }) => {
-    const id = uuidv4();
-    elementIdTransferMap[attrs.id] = id;
-    return createNewElement(type, attrs, { id });
+    const newElement = createNewElement(type, attrs);
+    elementIdTransferMap[attrs.id] = newElement.id;
+    return newElement;
   });
   const animations = (oldAnimations || [])
     .map((animation) => ({

--- a/assets/src/edit-story/elements/test/index.js
+++ b/assets/src/edit-story/elements/test/index.js
@@ -45,18 +45,6 @@ describe('Element', () => {
       expect(textElement.font).toMatchObject(TEXT_ELEMENT_DEFAULT_FONT);
     });
 
-    it('exposes optional overrides', () => {
-      const atts = {
-        x: 10,
-        y: 10,
-        width: 100,
-        height: 100,
-      };
-      const overrides = { id: 'a' };
-      const textElement = createNewElement('text', atts, overrides);
-      expect(textElement.id).toStrictEqual('a');
-    });
-
     it('should throw if trying to create unknown element type', () => {
       const unknownElementCreator = () => createNewElement('puppy');
       expect(unknownElementCreator).toThrow(/unknown element type: puppy/i);

--- a/assets/src/edit-story/elements/test/index.js
+++ b/assets/src/edit-story/elements/test/index.js
@@ -45,6 +45,18 @@ describe('Element', () => {
       expect(textElement.font).toMatchObject(TEXT_ELEMENT_DEFAULT_FONT);
     });
 
+    it('exposes optional overrides', () => {
+      const atts = {
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 100,
+      };
+      const overrides = { id: 'a' };
+      const textElement = createNewElement('text', atts, overrides);
+      expect(textElement.id).toStrictEqual('a');
+    });
+
     it('should throw if trying to create unknown element type', () => {
       const unknownElementCreator = () => createNewElement('puppy');
       expect(unknownElementCreator).toThrow(/unknown element type: puppy/i);
@@ -83,6 +95,7 @@ describe('Element', () => {
         id: expect.not.stringMatching(oldPage.id),
         type: 'page',
         otherProperty: '45',
+        animations: [],
         elements: [
           expect.objectContaining({
             id: expect.not.stringMatching(oldElements[0].id),
@@ -105,6 +118,34 @@ describe('Element', () => {
           }),
         ],
       });
+    });
+
+    it('should update animation ids to new element ids', () => {
+      const oldElements = [
+        { id: 'a', isBackground: true, x: 10, y: 20, type: 'shape' },
+        { id: 'b', x: 110, y: 120, type: 'text' },
+        { id: 'c', x: 210, y: 220, type: 'image' },
+      ];
+      const oldAnimations = [
+        { id: 'anim_id', targets: ['a'], duration: 1000, type: 'ANIM_TYPE' },
+      ];
+      const oldPage = {
+        id: '1',
+        type: 'page',
+        elements: oldElements,
+        animations: oldAnimations,
+        otherProperty: '45',
+      };
+      const newPage = duplicatePage(oldPage);
+
+      // Expect same structure but new id's!
+      expect(newPage.animations).toStrictEqual([
+        {
+          ...oldAnimations[0],
+          id: expect.any(String),
+          targets: [newPage.elements[0].id],
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds animation compatibility to page duplication.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
Behind animation experiment: animations now retained on page duplication.

## Testing Instructions
Enable Animations:
- Create a Page with elements with every animation type
- Duplicate the page and see that all animations are on the duplicated page
- Create a story from a template
- Duplicate a page & see that animations are retained.

Disable Animations:
- Duplicate a page and see that it still functions as normal

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5501 
