### PR TITLE
prepublish(inc): get the part of the background image behind the text

### DIFF
--- a/assets/src/edit-story/app/prepublish/warning/index.js
+++ b/assets/src/edit-story/app/prepublish/warning/index.js
@@ -21,7 +21,10 @@ import * as distributionWarnings from './distribution';
 
 export default {
   story: [distributionWarnings.storyMissingExcerpt],
-  page: [accessibilityWarnings.pageTooManyLinks],
+  page: [
+    accessibilityWarnings.pageTooManyLinks,
+    accessibilityWarnings.pageBackgroundWithTextLowContrast,
+  ],
   text: [
     accessibilityWarnings.textElementFontLowContrast,
     accessibilityWarnings.textElementFontSizeTooSmall,

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -545,4 +545,16 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       ).toBeUndefined();
     });
   });
+
+  describe('font contrast check against background image', () => {
+    it.todo(
+      'should return the average color of the part of the background image with text on it'
+    );
+    it.todo(
+      'should return the luminosity of the part of the background image with text on it'
+    );
+    it.todo(
+      'should return guidance if the contrast between the part of the background image and the text color is too low'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- _DRAFT NOTES_: I'm starting by checking the part of background image that the text sits on. There are many edge cases to this problem which I'll ramble about below. I wanted to put this out in a draft because of various issues.

So, to start, I have how to get the part of the image that the text is sitting on so I can calculate contrast.

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5380 

