### PR TITLE
Prepublish Text Contrast Check

### DIFF
--- a/assets/src/edit-story/app/index.js
+++ b/assets/src/edit-story/app/index.js
@@ -48,7 +48,7 @@ import { FileProvider } from './file';
 import { useLocalMedia, useMedia, MediaProvider } from './media';
 import { useStory, StoryProvider } from './story';
 import { useSnackbar, SnackbarProvider } from './snackbar';
-import Layout from './layout';
+import Layout, { LayoutProvider } from './layout';
 import { Media3pApiProvider } from './media/media3p/api';
 
 function App({ config }) {
@@ -70,16 +70,18 @@ function App({ config }) {
                             <AutoSaveHandler />
                             <TransformProvider>
                               <DropTargetsProvider>
-                                <PrepublishChecklistProvider>
-                                  <GlobalStyle />
-                                  <DevTools />
-                                  <DefaultMoveableGlobalStyle />
-                                  <CropMoveableGlobalStyle />
-                                  <ModalGlobalStyle />
-                                  <CalendarStyle />
-                                  <KeyboardOnlyOutlines />
-                                  <Layout />
-                                </PrepublishChecklistProvider>
+                                <LayoutProvider>
+                                  <PrepublishChecklistProvider>
+                                    <GlobalStyle />
+                                    <DevTools />
+                                    <DefaultMoveableGlobalStyle />
+                                    <CropMoveableGlobalStyle />
+                                    <ModalGlobalStyle />
+                                    <CalendarStyle />
+                                    <KeyboardOnlyOutlines />
+                                    <Layout />
+                                  </PrepublishChecklistProvider>
+                                </LayoutProvider>
                               </DropTargetsProvider>
                             </TransformProvider>
                           </MediaProvider>

--- a/assets/src/edit-story/app/index.js
+++ b/assets/src/edit-story/app/index.js
@@ -39,7 +39,6 @@ import DevTools from '../components/devTools';
 import StatusCheck from '../components/statusCheck';
 import AutoSaveHandler from '../components/autoSaveHandler';
 import ErrorBoundary from '../components/errorBoundary';
-import { PrepublishChecklistProvider } from '../components/inspector/prepublish';
 import { useHistory, HistoryProvider } from './history';
 import { useAPI, APIProvider } from './api';
 import { useConfig, ConfigProvider } from './config';
@@ -48,7 +47,7 @@ import { FileProvider } from './file';
 import { useLocalMedia, useMedia, MediaProvider } from './media';
 import { useStory, StoryProvider } from './story';
 import { useSnackbar, SnackbarProvider } from './snackbar';
-import Layout, { LayoutProvider } from './layout';
+import Layout from './layout';
 import { Media3pApiProvider } from './media/media3p/api';
 
 function App({ config }) {
@@ -70,18 +69,14 @@ function App({ config }) {
                             <AutoSaveHandler />
                             <TransformProvider>
                               <DropTargetsProvider>
-                                <LayoutProvider>
-                                  <PrepublishChecklistProvider>
-                                    <GlobalStyle />
-                                    <DevTools />
-                                    <DefaultMoveableGlobalStyle />
-                                    <CropMoveableGlobalStyle />
-                                    <ModalGlobalStyle />
-                                    <CalendarStyle />
-                                    <KeyboardOnlyOutlines />
-                                    <Layout />
-                                  </PrepublishChecklistProvider>
-                                </LayoutProvider>
+                                <GlobalStyle />
+                                <DevTools />
+                                <DefaultMoveableGlobalStyle />
+                                <CropMoveableGlobalStyle />
+                                <ModalGlobalStyle />
+                                <CalendarStyle />
+                                <KeyboardOnlyOutlines />
+                                <Layout />
                               </DropTargetsProvider>
                             </TransformProvider>
                           </MediaProvider>

--- a/assets/src/edit-story/app/layout/layout.js
+++ b/assets/src/edit-story/app/layout/layout.js
@@ -39,6 +39,7 @@ import {
 } from '../../constants';
 import withOverlay from '../../components/overlay/withOverlay';
 import CanvasProvider from '../../components/canvas/canvasProvider';
+import { PrepublishChecklistProvider } from '../../components/inspector/prepublish';
 import LayoutProvider from './layoutProvider';
 
 const Editor = withOverlay(styled.section.attrs({
@@ -74,17 +75,19 @@ const Area = styled.div`
 function Layout() {
   return (
     <LayoutProvider>
-      <Editor zIndex={3}>
-        <CanvasProvider>
-          <Area area="lib">
-            <Library />
+      <PrepublishChecklistProvider>
+        <Editor zIndex={3}>
+          <CanvasProvider>
+            <Area area="lib">
+              <Library />
+            </Area>
+            <Workspace />
+          </CanvasProvider>
+          <Area area="metaboxes">
+            <MetaBoxes />
           </Area>
-          <Workspace />
-        </CanvasProvider>
-        <Area area="metaboxes">
-          <MetaBoxes />
-        </Area>
-      </Editor>
+        </Editor>
+      </PrepublishChecklistProvider>
     </LayoutProvider>
   );
 }

--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -166,10 +166,9 @@ export function textElementFontLowContrast(element) {
  * Check the contrast of that luminosity against the luminosity of the text color.
  * If the contrast is too low, return guidance. Otherwise return undefined.
  *
- * @param {Page} page
+ * @param {Page} page The page object being checked for warnings
  * @return {Guidance|undefined} The guidance object for consumption
  */
-
 export async function pageBackgroundTextLowContrast(page) {
   const { pageSize, id: pageId } = page;
   const safeZoneDiff =

--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -167,14 +167,14 @@ function getOverlapBgColor(bgImage, overlapBox) {
   return getImagePartData(bgImage, overlapBox)
     .then((imgData) => {
       const cropCanvas = document.createElement('canvas');
-      cropCanvas.width = overlapBox.sWidth; // size of the new image / text container
-      cropCanvas.height = overlapBox.sHeight;
+      cropCanvas.width = overlapBox.width; // size of the new image / text container
+      cropCanvas.height = overlapBox.height;
       const cropCtx = cropCanvas.getContext('2d');
       const cropImage = new Image();
       cropImage.crossOrigin = 'anonymous';
       cropCtx.putImageData(imgData, 0, 0);
       cropImage.src = cropCanvas.toDataURL();
-      return setOrCreateImage(cropImage.src).then((colors) => colors);
+      return setOrCreateImage(cropImage.src);
     })
     .catch(() => {
       // ignore errors for now
@@ -210,7 +210,7 @@ export function pageBackgroundWithTextLowContrast(page) {
           const bgBox = getBox(bgElem, pageSize.width, pageSize.height);
           const { width, height } = bgBox;
 
-          const bgMediaPos = getMediaSizePositionProps(
+          const bgMediaSize = getMediaSizePositionProps(
             resource,
             width,
             height,
@@ -220,12 +220,12 @@ export function pageBackgroundWithTextLowContrast(page) {
           );
 
           const overlapBox = {
-            sx: Math.abs(bgMediaPos.offsetX) + Math.abs(textBoxBound.startX),
-            sy:
-              Math.abs(bgMediaPos.offsetY) +
+            x: Math.abs(bgMediaSize.offsetX) + Math.abs(textBoxBound.startX),
+            y:
+              Math.abs(bgMediaSize.offsetY) +
               Math.abs(textBoxBound.startY + safeZoneDiff),
-            sWidth: textBoxBound.width,
-            sHeight: textBoxBound.height,
+            width: textBoxBound.width,
+            height: textBoxBound.height,
           };
 
           const [bgImage] = document.querySelectorAll(

--- a/assets/src/edit-story/app/prepublish/warning/index.js
+++ b/assets/src/edit-story/app/prepublish/warning/index.js
@@ -21,7 +21,10 @@ import * as distributionWarnings from './distribution';
 
 export default {
   story: [distributionWarnings.storyMissingExcerpt],
-  page: [accessibilityWarnings.pageTooManyLinks],
+  page: [
+    accessibilityWarnings.pageTooManyLinks,
+    accessibilityWarnings.pageBackgroundWithTextLowContrast,
+  ],
   text: [
     accessibilityWarnings.textElementFontSizeTooSmall,
     accessibilityWarnings.elementLinkTappableRegionTooSmall,

--- a/assets/src/edit-story/app/prepublish/warning/index.js
+++ b/assets/src/edit-story/app/prepublish/warning/index.js
@@ -19,13 +19,12 @@
 import * as accessibilityWarnings from './accessibility';
 import * as distributionWarnings from './distribution';
 
-export const async = {
-  page: [accessibilityWarnings.pageBackgroundTextLowContrast],
-};
-
 export default {
   story: [distributionWarnings.storyMissingExcerpt],
-  page: [accessibilityWarnings.pageTooManyLinks],
+  page: [
+    accessibilityWarnings.pageTooManyLinks,
+    accessibilityWarnings.pageBackgroundTextLowContrast,
+  ],
   text: [
     accessibilityWarnings.textElementFontSizeTooSmall,
     accessibilityWarnings.elementLinkTappableRegionTooSmall,

--- a/assets/src/edit-story/app/prepublish/warning/index.js
+++ b/assets/src/edit-story/app/prepublish/warning/index.js
@@ -19,12 +19,13 @@
 import * as accessibilityWarnings from './accessibility';
 import * as distributionWarnings from './distribution';
 
+export const async = {
+  page: [accessibilityWarnings.pageBackgroundTextLowContrast],
+};
+
 export default {
   story: [distributionWarnings.storyMissingExcerpt],
-  page: [
-    accessibilityWarnings.pageTooManyLinks,
-    accessibilityWarnings.pageBackgroundWithTextLowContrast,
-  ],
+  page: [accessibilityWarnings.pageTooManyLinks],
   text: [
     accessibilityWarnings.textElementFontSizeTooSmall,
     accessibilityWarnings.elementLinkTappableRegionTooSmall,

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -507,16 +507,4 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       ).toBeUndefined();
     });
   });
-
-  describe('font contrast check against background image', () => {
-    it.todo(
-      'should return the average color of the part of the background image with text on it'
-    );
-    it.todo(
-      'should return the luminosity of the part of the background image with text on it'
-    );
-    it.todo(
-      'should return guidance if the contrast between the part of the background image and the text color is too low'
-    );
-  });
 });

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -507,4 +507,16 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       ).toBeUndefined();
     });
   });
+
+  describe('font contrast check against background image', () => {
+    it.todo(
+      'should return the average color of the part of the background image with text on it'
+    );
+    it.todo(
+      'should return the luminosity of the part of the background image with text on it'
+    );
+    it.todo(
+      'should return guidance if the contrast between the part of the background image and the text color is too low'
+    );
+  });
 });

--- a/assets/src/edit-story/components/inspector/prepublish/prepublishChecklistProvider.js
+++ b/assets/src/edit-story/components/inspector/prepublish/prepublishChecklistProvider.js
@@ -24,22 +24,34 @@ import PropTypes from 'prop-types';
 import { useStory } from '../../../app';
 import { getPrepublishErrors } from '../../../app/prepublish';
 import usePrevious from '../../../utils/usePrevious';
+import { useLayout } from '../../../app/layout';
 import Context from './context';
 
 function PrepublishChecklistProvider({ children }) {
+  const { pageSize } = useLayout(({ state: { canvasPageSize } }) => ({
+    pageSize: canvasPageSize,
+  }));
+
   const story = useStory(({ state: { story, pages } }) => {
     return { ...story, pages };
   });
 
-  const [currentList, setCurrentList] = useState(() =>
+  const [currentList, setCurrentList] = useState(() => {
     // use lazy initialization to prevent checklist from running on every update
-    getPrepublishErrors(story)
-  );
+    const pagesWithSize = story.pages.map((page) => ({
+      ...page,
+      pageSize,
+    }));
+    return getPrepublishErrors({ ...story, pages: pagesWithSize });
+  });
 
-  const handleRefreshList = useCallback(
-    () => setCurrentList(getPrepublishErrors(story)),
-    [story]
-  );
+  const handleRefreshList = useCallback(() => {
+    const pagesWithSize = story.pages.map((page) => ({
+      ...page,
+      pageSize,
+    }));
+    setCurrentList(getPrepublishErrors({ ...story, pages: pagesWithSize }));
+  }, [story, pageSize]);
 
   const prevPages = usePrevious(story.pages);
 

--- a/assets/src/edit-story/components/inspector/prepublish/prepublishChecklistProvider.js
+++ b/assets/src/edit-story/components/inspector/prepublish/prepublishChecklistProvider.js
@@ -36,32 +36,29 @@ function PrepublishChecklistProvider({ children }) {
     return { ...story, pages };
   });
 
-  const [currentList, setCurrentList] = useState(() => {
-    // use lazy initialization to prevent checklist from running on every update
-    const pagesWithSize = story.pages.map((page) => ({
-      ...page,
-      pageSize,
-    }));
-    return getPrepublishErrors({ ...story, pages: pagesWithSize });
-  });
+  const [currentList, setCurrentList] = useState([]);
 
-  const handleRefreshList = useCallback(() => {
+  const handleRefreshList = useCallback(async () => {
     const pagesWithSize = story.pages.map((page) => ({
       ...page,
       pageSize,
     }));
-    setCurrentList(getPrepublishErrors({ ...story, pages: pagesWithSize }));
+    setCurrentList(
+      await getPrepublishErrors({ ...story, pages: pagesWithSize })
+    );
   }, [story, pageSize]);
 
   const prevPages = usePrevious(story.pages);
+  const prevPageSize = usePrevious(pageSize);
 
   const refreshOnInitialLoad = prevPages?.length === 0 && story.pages?.length;
+  const refreshOnPageSizeChange = prevPageSize?.width !== pageSize?.width;
 
   useEffect(() => {
-    if (refreshOnInitialLoad) {
+    if (refreshOnInitialLoad || refreshOnPageSizeChange) {
       handleRefreshList();
     }
-  }, [handleRefreshList, refreshOnInitialLoad]);
+  }, [handleRefreshList, refreshOnInitialLoad, refreshOnPageSizeChange]);
 
   return (
     <Context.Provider

--- a/assets/src/edit-story/utils/getMediaBaseColor.js
+++ b/assets/src/edit-story/utils/getMediaBaseColor.js
@@ -33,7 +33,7 @@ const STYLES = {
 const BASE_COLOR_NODE = '__WEB_STORIES_BASE_COLOR__';
 const IMG_NODE = '__WEB_STORIES_IMG_NODE';
 
-function getImgNodeId(elementId) {
+export function getImgNodeId(elementId) {
   if (elementId === undefined) {
     return '__web-stories-base-color';
   }

--- a/assets/src/edit-story/utils/getMediaBaseColor.js
+++ b/assets/src/edit-story/utils/getMediaBaseColor.js
@@ -40,7 +40,7 @@ export function getMediaBaseColor(resource, onBaseColor) {
   );
 }
 
-function setOrCreateImage(src) {
+export function setOrCreateImage(src) {
   return new Promise((resolve, reject) => {
     let imgNode = document.body[BASE_COLOR_NODE];
     if (!imgNode) {

--- a/assets/src/edit-story/utils/getMediaBaseColor.js
+++ b/assets/src/edit-story/utils/getMediaBaseColor.js
@@ -31,43 +31,68 @@ const STYLES = {
 };
 
 const BASE_COLOR_NODE = '__WEB_STORIES_BASE_COLOR__';
+const IMG_NODE = '__WEB_STORIES_IMG_NODE';
+
+function getImgNodeId(elementId) {
+  if (elementId === undefined) {
+    return '__web-stories-base-color';
+  }
+  return `__web-stories-bg-${elementId}`;
+}
+
+function getImgNodeKey(elementId) {
+  if (elementId === undefined) {
+    return BASE_COLOR_NODE;
+  }
+  return `${IMG_NODE}_${elementId}`;
+}
 
 export function getMediaBaseColor(resource, onBaseColor) {
   const { type, src, poster } = resource;
-  setOrCreateImage(type === 'video' ? poster : src).then(
+  setOrCreateImage({
+    src: type === 'video' ? poster : src,
+    width: 10,
+    height: 'auto',
+  }).then(
     (color) => onBaseColor(color),
     () => onBaseColor([255, 255, 255]) // Fallback color is white.
   );
 }
 
-export function setOrCreateImage(src) {
+function defaultImgOnload(nodeKey, resolve, reject) {
+  return () => {
+    const node = document.body[nodeKey];
+    try {
+      resolve(thief.getColor(node.firstElementChild));
+    } catch (e) {
+      reject(e);
+    }
+  };
+}
+
+export function setOrCreateImage(imageData, onloadCallback = defaultImgOnload) {
+  const { src, id, height, width } = imageData;
   return new Promise((resolve, reject) => {
-    let imgNode = document.body[BASE_COLOR_NODE];
+    const NODE_KEY = getImgNodeKey(id);
+    let imgNode = document.body[NODE_KEY];
     if (!imgNode) {
       imgNode = document.createElement('div');
-      imgNode.id = '__web-stories-base-color';
-      Object.assign(imgNode, STYLES);
+      imgNode.id = getImgNodeId(id);
+      Object.assign(imgNode.style, STYLES);
       document.body.appendChild(imgNode);
-      document.body[BASE_COLOR_NODE] = imgNode;
+      document.body[NODE_KEY] = imgNode;
     }
     imgNode.innerHTML = '';
 
     const img = new Image();
     // Necessary to avoid tainting canvas with CORS image data.
     img.crossOrigin = 'anonymous';
-    img.onload = () => {
-      const node = document.body[BASE_COLOR_NODE];
-      try {
-        resolve(thief.getColor(node.firstElementChild));
-      } catch (e) {
-        reject(e);
-      }
-    };
+    img.onload = onloadCallback(NODE_KEY, resolve, reject);
     img.onerror = (e) => {
-      reject(new Error('Base color image error: ' + e.message));
+      reject(new Error('Set image error: ' + e.message));
     };
-    img.width = 10;
-    img.height = 'auto';
+    img.width = width;
+    img.height = height;
     img.src = src;
     imgNode.appendChild(img);
   });

--- a/assets/src/edit-story/utils/getMediaBaseColor.js
+++ b/assets/src/edit-story/utils/getMediaBaseColor.js
@@ -59,10 +59,14 @@ export function getMediaBaseColor(resource, onBaseColor) {
   );
 }
 
-function getDefaultOnloadCallback(nodeKey, resolve) {
+function getDefaultOnloadCallback(nodeKey, resolve, reject) {
   return () => {
-    const node = document.body[nodeKey];
-    resolve(thief.getColor(node.firstElementChild));
+    try {
+      const node = document.body[nodeKey];
+      resolve(thief.getColor(node.firstElementChild));
+    } catch (error) {
+      reject(new Error(`Get color error: `, error.message));
+    }
   };
 }
 
@@ -86,7 +90,7 @@ export function setOrCreateImage(
     const img = new Image();
     // Necessary to avoid tainting canvas with CORS image data.
     img.crossOrigin = 'anonymous';
-    img.addEventListener('load', getOnloadCallback(NODE_KEY, resolve));
+    img.addEventListener('load', getOnloadCallback(NODE_KEY, resolve, reject));
     img.addEventListener('error', (e) => {
       reject(new Error('Set image error: ' + e.message));
     });

--- a/assets/src/edit-story/utils/getMediaBaseColor.js
+++ b/assets/src/edit-story/utils/getMediaBaseColor.js
@@ -59,18 +59,17 @@ export function getMediaBaseColor(resource, onBaseColor) {
   );
 }
 
-function defaultImgOnload(nodeKey, resolve, reject) {
+function getDefaultOnloadCallback(nodeKey, resolve) {
   return () => {
     const node = document.body[nodeKey];
-    try {
-      resolve(thief.getColor(node.firstElementChild));
-    } catch (e) {
-      reject(e);
-    }
+    resolve(thief.getColor(node.firstElementChild));
   };
 }
 
-export function setOrCreateImage(imageData, onloadCallback = defaultImgOnload) {
+export function setOrCreateImage(
+  imageData,
+  getOnloadCallback = getDefaultOnloadCallback
+) {
   const { src, id, height, width } = imageData;
   return new Promise((resolve, reject) => {
     const NODE_KEY = getImgNodeKey(id);
@@ -87,10 +86,10 @@ export function setOrCreateImage(imageData, onloadCallback = defaultImgOnload) {
     const img = new Image();
     // Necessary to avoid tainting canvas with CORS image data.
     img.crossOrigin = 'anonymous';
-    img.onload = onloadCallback(NODE_KEY, resolve, reject);
-    img.onerror = (e) => {
+    img.addEventListener('load', getOnloadCallback(NODE_KEY, resolve));
+    img.addEventListener('error', (e) => {
       reject(new Error('Set image error: ' + e.message));
-    };
+    });
     img.width = width;
     img.height = height;
     img.src = src;


### PR DESCRIPTION
## Summary
I added a text contrast check which checks the contrast/readability between the color palette provided by the part of the background image the text is sitting on and the text color. 

Here's it working: 

![ezgif-7-d5fa3b5f26af](https://user-images.githubusercontent.com/41136059/101434684-3fcdd200-38c8-11eb-86f7-bd71ea217840.gif)

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- add an async calls section to `getPrepublishErrors` so I can use promises to put stuff on the DOM. Update the tests and implementations of `getPrepublishErrors` so it's async.
- Move the layout provider up to `app` so that prepublish can use the page size, important for getting data from the background images
- add helper functions and a text contrast check to `accessibility` in `prepublish` to do background image contrast checking. The helper functions create images based on text placement on the background, and also get the color palettes of the image to compare its luminosity to the font color. Then the colors are compared for contrast issues using the `contrastUtils`. They also help clean up the DOM after the calculations are made.
- refactored `getMediaBaseColor` module a bit to allow custom `onload` so I wasn't duplicating code in `accessibility`

<!-- Please describe your changes. -->

## To-do

- [x] fix CORS issue, thanks Max and Pascal. 🙏
- [x] generalize for other layers (shapes, images, etc.) in between the text and bg image
- [x] generalize for different editor scales
- [x] refactor checklist run for async calls

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
When a user adds a background image to the page and places text on it, it should show a warning if the contrast is too low between the text and the image where the text sits. Same with shapes.

<!-- Please describe your changes. -->

## Testing Instructions
1. Create a new story
2. Add a background image
3. Add text to the page
4. Place the text where it is hard to see, or change the color of the text to match the colors of the image
5. A warning should show in the prepublish checklist that the text contrast is too low
6. Repeat with a shape as a layer behind the text
7. Repeat with an image as a layer behind the text (it can be masked, rotated, flipped or not)

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5380 

