### PR TITLE
E2E Tests: Reduce percy snapshot flakiness

### DIFF
--- a/assets/src/dashboard/components/fileUpload/index.js
+++ b/assets/src/dashboard/components/fileUpload/index.js
@@ -76,7 +76,7 @@ const UploadLabelAsCta = styled(DefaultButton).attrs({
   }
 `;
 
-const LoadingIndicator = styled.div.attrs({ className: 'loading-indicator' })`
+const LoadingIndicator = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/assets/src/dashboard/components/fileUpload/index.js
+++ b/assets/src/dashboard/components/fileUpload/index.js
@@ -76,7 +76,7 @@ const UploadLabelAsCta = styled(DefaultButton).attrs({
   }
 `;
 
-const LoadingIndicator = styled.div`
+const LoadingIndicator = styled.div.attrs({ className: 'loading-indicator' })`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/tests/e2e/specs/dashboard/integrations/sitekit.js
+++ b/tests/e2e/specs/dashboard/integrations/sitekit.js
@@ -27,8 +27,6 @@ import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
  */
 import { visitDashboard } from '../../../utils';
 
-const percyCSS = `.loading-indicator { display: none; }`;
-
 describe('Site Kit integration with dashboard', () => {
   beforeAll(async () => {
     await activatePlugin('e2e-tests-site-kit-mock');
@@ -49,7 +47,12 @@ describe('Site Kit integration with dashboard', () => {
       text: 'Editor Settings',
     });
 
-    await percySnapshot(page, 'Stories Dashboard with Site Kit', { percyCSS });
+    await page.waitForResponse((response) =>
+      response.url().includes('web-stories/v1/media')
+    );
+    await expect(page).not.toMatch('Loading…');
+
+    await percySnapshot(page, 'Stories Dashboard with Site Kit');
 
     await expect(page).toMatch(
       'Site Kit by Google has already enabled Google Analytics for your Web Stories'

--- a/tests/e2e/specs/dashboard/integrations/sitekit.js
+++ b/tests/e2e/specs/dashboard/integrations/sitekit.js
@@ -50,7 +50,6 @@ describe('Site Kit integration with dashboard', () => {
     await page.waitForResponse((response) =>
       response.url().includes('web-stories/v1/media')
     );
-    await expect(page).not.toMatch('Loading…');
 
     await percySnapshot(page, 'Stories Dashboard with Site Kit');
 

--- a/tests/e2e/specs/dashboard/integrations/sitekit.js
+++ b/tests/e2e/specs/dashboard/integrations/sitekit.js
@@ -27,6 +27,8 @@ import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
  */
 import { visitDashboard } from '../../../utils';
 
+const percyCSS = `.loading-indicator { display: none; }`;
+
 describe('Site Kit integration with dashboard', () => {
   beforeAll(async () => {
     await activatePlugin('e2e-tests-site-kit-mock');
@@ -47,7 +49,7 @@ describe('Site Kit integration with dashboard', () => {
       text: 'Editor Settings',
     });
 
-    await percySnapshot(page, 'Stories Dashboard with Site Kit');
+    await percySnapshot(page, 'Stories Dashboard with Site Kit', { percyCSS });
 
     await expect(page).toMatch(
       'Site Kit by Google has already enabled Google Analytics for your Web Stories'

--- a/tests/e2e/specs/editor/media/insertMovVideo.js
+++ b/tests/e2e/specs/editor/media/insertMovVideo.js
@@ -26,6 +26,8 @@ import { createNewStory, clickButton } from '../../../utils';
 
 const MODAL = '.media-modal';
 
+const percyCSS = `.attachment-details .uploaded { display: none; }`;
+
 describe('Inserting .mov from dialog', () => {
   // Uses the existence of the element's frame element as an indicator for successful insertion.
   it('should not list the .mov', async () => {
@@ -42,7 +44,7 @@ describe('Inserting .mov from dialog', () => {
     );
 
     await expect(page).not.toMatchElement('.type-video.subtype-quicktime');
-    await percySnapshot(page, 'Avoid inserting .mov files');
+    await percySnapshot(page, 'Avoid inserting .mov files', { percyCSS });
 
     const closeBtnSelector = '.media-modal-close';
     await page.click(closeBtnSelector);


### PR DESCRIPTION
## Summary

Improve percy screenshots. To stop differences showing up in percy. 

- Hide date in media dialog. 
- Hide loading message on settings screen. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
