### PR TITLE
Improve generated video poster file name

### DIFF
--- a/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
+++ b/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
@@ -101,8 +101,8 @@ function useUploadVideoFrame({ updateMediaElement }) {
   /**
    * Helper function get the file name from url.
    *
-   * @param url
-   * @return {string}
+   * @param {string} url URL to file.
+   * @return {string} Filename excluding file extendation.
    */
   const getFileName = (url) =>
     url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('.'));

--- a/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
+++ b/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
@@ -46,6 +46,7 @@ function useUploadVideoFrame({ updateMediaElement }) {
   const processData = async (id, src) => {
     try {
       const obj = await getFirstFrameOfVideo(src);
+      obj.name = getFileName(src) + '-poster.jpeg';
       const {
         id: posterId,
         source_url: poster,
@@ -96,6 +97,15 @@ function useUploadVideoFrame({ updateMediaElement }) {
       // TODO Display error message to user as video poster upload has as failed.
     }
   };
+
+  /**
+   * Helper function get the file name from url.
+   *
+   * @param url
+   * @return {string}
+   */
+  const getFileName = (url) =>
+    url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('.'));
 
   /**
    * Uploads the video's first frame as an attachment.

--- a/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
+++ b/assets/src/edit-story/app/media/utils/useUploadVideoFrame.js
@@ -99,10 +99,10 @@ function useUploadVideoFrame({ updateMediaElement }) {
   };
 
   /**
-   * Helper function get the file name from url.
+   * Helper function get the file name without the extension from a url.
    *
    * @param {string} url URL to file.
-   * @return {string} Filename excluding file extendation.
+   * @return {string} File name without the extension.
    */
   const getFileName = (url) =>
     url.substring(url.lastIndexOf('/') + 1, url.lastIndexOf('.'));


### PR DESCRIPTION
## Summary

Add a better file name to poster. 

## Relevant Technical Choices

This change is simple, take the video's file name and add -image.jpeg to it. So `amazing-video.mp4` becomes `amazing-video-poster.jpeg`. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #3228
