### PR TITLE
Animation: Update the UI of the Scale Animation to use a visual direction picker

### DIFF
--- a/assets/src/animation/constants.js
+++ b/assets/src/animation/constants.js
@@ -104,6 +104,26 @@ export const DIRECTION = {
   LEFT_TO_RIGHT: 'leftToRight',
 };
 
+export const SCALE_DIRECTION = {
+  SCALE_IN: 'scaleIn',
+  SCALE_OUT: 'scaleOut',
+  SCALE_OUT_TOP_RIGHT: 'scaleOutTopRight',
+  SCALE_OUT_BOTTOM_LEFT: 'scaleOutBottomLeft',
+  SCALE_IN_TOP_LEFT: 'scaleInTopLeft',
+  SCALE_IN_BOTTOM_RIGHT: 'scaleInBottomRight',
+};
+
+export const SCALE_DIRECTION_MAP = {
+  SCALE_IN: [
+    SCALE_DIRECTION.SCALE_IN_TOP_LEFT,
+    SCALE_DIRECTION.SCALE_IN_BOTTOM_RIGHT,
+  ],
+  SCALE_OUT: [
+    SCALE_DIRECTION.SCALE_OUT_TOP_RIGHT,
+    SCALE_DIRECTION.SCALE_OUT_BOTTOM_LEFT,
+  ],
+};
+
 export const ROTATION = {
   CLOCKWISE: 'clockwise',
   COUNTER_CLOCKWISE: 'counterClockwise',

--- a/assets/src/animation/effects/zoom/animationProps.js
+++ b/assets/src/animation/effects/zoom/animationProps.js
@@ -27,25 +27,19 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES } from '../../constants';
+import { FIELD_TYPES, SCALE_DIRECTION } from '../../constants';
 import { AnimationInputPropTypes } from '../types';
 
 export const ZoomEffectInputPropTypes = {
-  zoomFrom: PropTypes.shape(AnimationInputPropTypes),
-  zoomTo: PropTypes.shape(AnimationInputPropTypes),
+  scaleDirection: PropTypes.shape(AnimationInputPropTypes),
 };
 
 export default {
-  zoomFrom: {
-    label: __('From', 'web-stories'),
-    tooltip: __('Valid values range from 0 to 1', 'web-stories'),
-    type: FIELD_TYPES.FLOAT,
-    defaultValue: 0,
-  },
-  zoomTo: {
-    label: __('To', 'web-stories'),
-    tooltip: __('Valid values range from 0 to 1', 'web-stories'),
-    type: FIELD_TYPES.FLOAT,
-    defaultValue: 1,
+  scaleDirection: {
+    label: __('Direction', 'web-stories'),
+    tooltip: __('Valid values are scaleIn or scaleOut', 'web-stories'),
+    type: FIELD_TYPES.DIRECTION_PICKER,
+    values: [SCALE_DIRECTION.SCALE_IN, SCALE_DIRECTION.SCALE_OUT],
+    defaultValue: SCALE_DIRECTION.SCALE_IN,
   },
 };

--- a/assets/src/animation/effects/zoom/animationProps.js
+++ b/assets/src/animation/effects/zoom/animationProps.js
@@ -37,7 +37,9 @@ export const ZoomEffectInputPropTypes = {
 export default {
   scaleDirection: {
     label: __('Direction', 'web-stories'),
-    tooltip: __('Valid values are scaleIn or scaleOut', 'web-stories'),
+    tooltip:
+      /* translators: 1: scaleIn. 2: scaleOut */
+      sprintf(__('Valid values are %1$s or %2$s', 'web-stories'), 'scaleIn', 'scaleOut'),
     type: FIELD_TYPES.DIRECTION_PICKER,
     values: [SCALE_DIRECTION.SCALE_IN, SCALE_DIRECTION.SCALE_OUT],
     defaultValue: SCALE_DIRECTION.SCALE_IN,

--- a/assets/src/animation/effects/zoom/animationProps.js
+++ b/assets/src/animation/effects/zoom/animationProps.js
@@ -17,7 +17,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -37,9 +37,12 @@ export const ZoomEffectInputPropTypes = {
 export default {
   scaleDirection: {
     label: __('Direction', 'web-stories'),
-    tooltip:
+    tooltip: sprintf(
       /* translators: 1: scaleIn. 2: scaleOut */
-      sprintf(__('Valid values are %1$s or %2$s', 'web-stories'), 'scaleIn', 'scaleOut'),
+      __('Valid values are %1$s or %2$s', 'web-stories'),
+      'scaleIn',
+      'scaleOut'
+    ),
     type: FIELD_TYPES.DIRECTION_PICKER,
     values: [SCALE_DIRECTION.SCALE_IN, SCALE_DIRECTION.SCALE_OUT],
     defaultValue: SCALE_DIRECTION.SCALE_IN,

--- a/assets/src/animation/effects/zoom/index.js
+++ b/assets/src/animation/effects/zoom/index.js
@@ -18,17 +18,17 @@
  * Internal dependencies
  */
 import { AnimationZoom } from '../../parts/zoom';
+import { SCALE_DIRECTION } from '../../constants';
 
 export function EffectZoom({
-  zoomFrom = 0,
-  zoomTo = 1,
+  scaleDirection = SCALE_DIRECTION.SCALE_IN,
   duration = 1000,
   delay,
   easing,
 }) {
   return AnimationZoom({
-    zoomFrom,
-    zoomTo,
+    zoomFrom: scaleDirection === SCALE_DIRECTION.SCALE_OUT ? 1 / 3 : 3,
+    zoomTo: 1,
     duration,
     delay,
     easing,

--- a/assets/src/animation/effects/zoom/stories/index.js
+++ b/assets/src/animation/effects/zoom/stories/index.js
@@ -18,7 +18,7 @@
  * Internal dependencies
  */
 import { StoryAnimation } from '../../../components';
-import { ANIMATION_EFFECTS } from '../../../constants';
+import { ANIMATION_EFFECTS, SCALE_DIRECTION } from '../../../constants';
 import { AMPStoryWrapper } from '../../../storybookUtils';
 
 export default {
@@ -29,15 +29,13 @@ const animations = [
   {
     targets: ['e1'],
     type: ANIMATION_EFFECTS.ZOOM,
-    zoomFrom: 0.25,
-    zoomTo: 1,
+    scaleDirection: SCALE_DIRECTION.SCALE_IN,
     duration: 4000,
   },
   {
     targets: ['e2'],
     type: ANIMATION_EFFECTS.ZOOM,
-    zoomFrom: 1,
-    zoomTo: 0.25,
+    scaleDirection: SCALE_DIRECTION.SCALE_OUT,
     duration: 4000,
   },
 ];

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -57,6 +57,15 @@ const Icon = styled.div`
         return 'rotate(0deg)';
     }
   }};
+
+  ${({ selected }) =>
+    selected &&
+    css`
+      svg {
+        stroke: ${({ theme }) => theme.colors.activeDirection};
+        stroke-width: 2px;
+      }
+    `}
 `;
 
 const RotationIcon = () => (
@@ -74,8 +83,8 @@ const DirectionIcon = () => (
   </Svg>
 );
 
-const Direction = ({ className, direction }) => (
-  <Icon className={className} direction={direction}>
+const Direction = ({ className, direction, selected }) => (
+  <Icon className={className} direction={direction} selected={selected}>
     {Object.values(DIRECTION).includes(direction) ||
     Object.values(SCALE_DIRECTION).includes(direction) ? (
       <DirectionIcon />
@@ -84,11 +93,6 @@ const Direction = ({ className, direction }) => (
     )}
   </Icon>
 );
-
-Direction.propTypes = {
-  className: PropTypes.string,
-  direction: PropTypes.oneOf(Object.values(DIRECTION)),
-};
 
 // Must be a styled component to add component selectors in css
 const DirectionIndicator = styled(Direction)``;
@@ -155,7 +159,7 @@ const Label = styled.label`
         return css`
           bottom: 0;
           left: 0;
-          transform: rotate(45deg);
+          transform: rotate(-135deg);
         `;
 
       case SCALE_DIRECTION.SCALE_IN_TOP_LEFT:
@@ -169,7 +173,7 @@ const Label = styled.label`
         return css`
           top: 0;
           right: 0;
-          transform: rotate(225deg);
+          transform: rotate(-315deg);
         `;
 
       case SCALE_DIRECTION.SCALE_IN_BOTTOM_RIGHT:
@@ -191,11 +195,6 @@ const Label = styled.label`
   ${DirectionIndicator} {
     stroke: ${({ theme }) => theme.colors.fg.v9};
     stroke-width: 1px;
-  }
-
-  input:checked ~ ${DirectionIndicator} {
-    stroke: ${({ theme }) => theme.colors.activeDirection};
-    stroke-width: 2px;
   }
 
   input:focus ~ ${DirectionIndicator} {
@@ -235,6 +234,21 @@ const translations = {
   [SCALE_DIRECTION.SCALE_OUT]: __('scale out', 'web-stories'),
 };
 
+const valueForInternalValue = (value) => {
+  switch (value) {
+    case SCALE_DIRECTION.SCALE_IN_TOP_LEFT:
+      return SCALE_DIRECTION.SCALE_IN;
+    case SCALE_DIRECTION.SCALE_IN_BOTTOM_RIGHT:
+      return SCALE_DIRECTION.SCALE_IN;
+    case SCALE_DIRECTION.SCALE_OUT_BOTTOM_LEFT:
+      return SCALE_DIRECTION.SCALE_OUT;
+    case SCALE_DIRECTION.SCALE_OUT_TOP_RIGHT:
+      return SCALE_DIRECTION.SCALE_OUT;
+    default:
+      return value;
+  }
+};
+
 export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
   const flattenedDirections = useMemo(() => {
     const dir = [];
@@ -251,35 +265,32 @@ export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
     }
     return dir;
   }, [directions]);
-  console.log(flattenedDirections);
   return (
     <Fieldset>
       <Figure />
       <HiddenLegend>{__('Which Direction?', 'web-stories')}</HiddenLegend>
       <RadioGroup>
-        {flattenedDirections.map(
-          (direction) => (
-            console.warn(value, direction),
-            (
-              <Label
-                key={direction}
-                aria-label={translations[direction]}
-                htmlFor={direction}
-                direction={direction}
-              >
-                <HiddenInput
-                  id={direction}
-                  type="radio"
-                  name="direction"
-                  value={direction}
-                  onChange={onChange}
-                  checked={value === direction}
-                />
-                <DirectionIndicator direction={direction} />
-              </Label>
-            )
-          )
-        )}
+        {flattenedDirections.map((direction) => (
+          <Label
+            key={direction}
+            aria-label={translations[direction]}
+            htmlFor={direction}
+            direction={direction}
+          >
+            <HiddenInput
+              id={direction}
+              type="radio"
+              name="direction"
+              value={valueForInternalValue(direction)}
+              onChange={onChange}
+              checked={value === direction || direction?.includes(value)}
+            />
+            <DirectionIndicator
+              direction={direction}
+              selected={value === direction || direction?.includes(value)}
+            />
+          </Label>
+        ))}
       </RadioGroup>
     </Fieldset>
   );
@@ -295,4 +306,10 @@ DirectionRadioInput.propTypes = {
   value: directionPropType,
   directions: PropTypes.arrayOf(directionPropType),
   onChange: PropTypes.func,
+};
+
+Direction.propTypes = {
+  className: PropTypes.string,
+  direction: directionPropType,
+  selected: PropTypes.bool,
 };

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -16,6 +16,7 @@
 /**
  * External dependencies
  */
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 /**
@@ -25,7 +26,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { DIRECTION, ROTATION } from '../../../../animation';
+import {
+  DIRECTION,
+  ROTATION,
+  SCALE_DIRECTION,
+  SCALE_DIRECTION_MAP,
+} from '../../../../animation';
 
 const Svg = styled.svg`
   display: block;
@@ -70,7 +76,8 @@ const DirectionIcon = () => (
 
 const Direction = ({ className, direction }) => (
   <Icon className={className} direction={direction}>
-    {Object.values(DIRECTION).includes(direction) ? (
+    {Object.values(DIRECTION).includes(direction) ||
+    Object.values(SCALE_DIRECTION).includes(direction) ? (
       <DirectionIcon />
     ) : (
       <RotationIcon />
@@ -143,6 +150,35 @@ const Label = styled.label`
           right: 0;
           transform: translate(-10%, -10%);
         `;
+
+      case SCALE_DIRECTION.SCALE_OUT_BOTTOM_LEFT:
+        return css`
+          bottom: 0;
+          left: 0;
+          transform: rotate(45deg);
+        `;
+
+      case SCALE_DIRECTION.SCALE_IN_TOP_LEFT:
+        return css`
+          top: 0;
+          left: 0;
+          transform: rotate(135deg);
+        `;
+
+      case SCALE_DIRECTION.SCALE_OUT_TOP_RIGHT:
+        return css`
+          top: 0;
+          right: 0;
+          transform: rotate(225deg);
+        `;
+
+      case SCALE_DIRECTION.SCALE_IN_BOTTOM_RIGHT:
+        return css`
+          bottom: 0;
+          right: 0;
+          transform: rotate(315deg);
+        `;
+
       default:
         return css`
           bottom: 0;
@@ -195,32 +231,55 @@ const translations = {
   [DIRECTION.BOTTOM_TO_TOP]: __('bottom to top', 'web-stories'),
   [ROTATION.CLOCKWISE]: __('clockwise', 'web-stories'),
   [ROTATION.COUNTER_CLOCKWISE]: __('counterclockwise', 'web-stories'),
+  [SCALE_DIRECTION.SCALE_IN]: __('scale in', 'web-stories'),
+  [SCALE_DIRECTION.SCALE_OUT]: __('scale out', 'web-stories'),
 };
 
 export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
+  const flattenedDirections = useMemo(() => {
+    const dir = [];
+    if (
+      directions.includes(SCALE_DIRECTION.SCALE_IN) &&
+      directions.includes(SCALE_DIRECTION.SCALE_OUT)
+    ) {
+      dir.push(
+        ...SCALE_DIRECTION_MAP.SCALE_IN,
+        ...SCALE_DIRECTION_MAP.SCALE_OUT
+      );
+    } else {
+      dir.push(...directions);
+    }
+    return dir;
+  }, [directions]);
+  console.log(flattenedDirections);
   return (
     <Fieldset>
       <Figure />
       <HiddenLegend>{__('Which Direction?', 'web-stories')}</HiddenLegend>
       <RadioGroup>
-        {directions.map((direction) => (
-          <Label
-            key={direction}
-            aria-label={translations[direction]}
-            htmlFor={direction}
-            direction={direction}
-          >
-            <HiddenInput
-              id={direction}
-              type="radio"
-              name="direction"
-              value={direction}
-              onChange={onChange}
-              checked={value === direction}
-            />
-            <DirectionIndicator direction={direction} />
-          </Label>
-        ))}
+        {flattenedDirections.map(
+          (direction) => (
+            console.warn(value, direction),
+            (
+              <Label
+                key={direction}
+                aria-label={translations[direction]}
+                htmlFor={direction}
+                direction={direction}
+              >
+                <HiddenInput
+                  id={direction}
+                  type="radio"
+                  name="direction"
+                  value={direction}
+                  onChange={onChange}
+                  checked={value === direction}
+                />
+                <DirectionIndicator direction={direction} />
+              </Label>
+            )
+          )
+        )}
       </RadioGroup>
     </Fieldset>
   );
@@ -229,6 +288,7 @@ export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
 const directionPropType = PropTypes.oneOf([
   ...Object.values(DIRECTION),
   ...Object.values(ROTATION),
+  ...Object.values(SCALE_DIRECTION),
 ]);
 
 DirectionRadioInput.propTypes = {

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -16,7 +16,7 @@
 /**
  * External dependencies
  */
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 /**
@@ -32,6 +32,7 @@ import {
   SCALE_DIRECTION,
   SCALE_DIRECTION_MAP,
 } from '../../../../animation';
+import useRadioNavigation from '../../form/shared/useRadioNavigation';
 
 const Svg = styled.svg`
   display: block;
@@ -250,26 +251,33 @@ const valueForInternalValue = (value) => {
 };
 
 export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
+  const inputRef = useRef();
+
   const flattenedDirections = useMemo(() => {
     const dir = [];
     if (
       directions.includes(SCALE_DIRECTION.SCALE_IN) &&
       directions.includes(SCALE_DIRECTION.SCALE_OUT)
     ) {
+      // Controlling order these get added to flattenedDirections makes sure the indexable order makes sense for keyboard users
       dir.push(
-        ...SCALE_DIRECTION_MAP.SCALE_IN,
-        ...SCALE_DIRECTION_MAP.SCALE_OUT
+        SCALE_DIRECTION_MAP.SCALE_IN[0],
+        SCALE_DIRECTION_MAP.SCALE_OUT[0],
+        SCALE_DIRECTION_MAP.SCALE_IN[1],
+        SCALE_DIRECTION_MAP.SCALE_OUT[1]
       );
     } else {
       dir.push(...directions);
     }
     return dir;
   }, [directions]);
+  useRadioNavigation(inputRef);
+
   return (
     <Fieldset>
       <Figure />
       <HiddenLegend>{__('Which Direction?', 'web-stories')}</HiddenLegend>
-      <RadioGroup>
+      <RadioGroup ref={inputRef}>
         {flattenedDirections.map((direction) => (
           <Label
             key={direction}

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -34,6 +34,7 @@ import {
   ANIMATION_EFFECTS,
   BACKGROUND_ANIMATION_EFFECTS,
   DIRECTION,
+  SCALE_DIRECTION,
 } from '../../../../animation';
 import useFocusOut from '../../../utils/useFocusOut';
 import {
@@ -386,8 +387,7 @@ export default function EffectChooser({
               onClick={() =>
                 onAnimationSelected({
                   animation: ANIMATION_EFFECTS.ZOOM.value,
-                  zoomFrom: 0,
-                  zoomTo: 1,
+                  scaleDirection: SCALE_DIRECTION.SCALE_IN,
                 })
               }
             >
@@ -399,8 +399,7 @@ export default function EffectChooser({
               onClick={() =>
                 onAnimationSelected({
                   animation: ANIMATION_EFFECTS.ZOOM.value,
-                  zoomFrom: 2,
-                  zoomTo: 1,
+                  scaleDirection: SCALE_DIRECTION.SCALE_OUT,
                 })
               }
             >

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -26,7 +26,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES, SCALE_DIRECTION } from '../../../../animation';
+import { FIELD_TYPES } from '../../../../animation';
 import { GeneralAnimationPropTypes } from '../../../../animation/outputs';
 import { AnimationFormPropTypes } from '../../../../animation/types';
 import { DropDown, BoxedNumeric } from '../../form';

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -26,7 +26,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES } from '../../../../animation';
+import { FIELD_TYPES, SCALE_DIRECTION } from '../../../../animation';
 import { GeneralAnimationPropTypes } from '../../../../animation/outputs';
 import { AnimationFormPropTypes } from '../../../../animation/types';
 import { DropDown, BoxedNumeric } from '../../form';
@@ -54,15 +54,18 @@ function EffectInput({
   disabledOptions,
 }) {
   const rangeId = `range-${uuidv4()}`;
+
   const directionControlOnChange = useCallback(
     ({ nativeEvent: { target } }) => onChange(target.value, true),
     [onChange]
   );
+
+  let valueForField = effectConfig[field] || effectProps[field].defaultValue;
   switch (effectProps[field].type) {
     case FIELD_TYPES.DROPDOWN:
       return (
         <DropDown
-          value={effectConfig[field] || effectProps[field].defaultValue}
+          value={valueForField}
           onChange={(value) => onChange(value, true)}
           options={effectProps[field].values.map((v) => ({
             value: v,
@@ -77,7 +80,7 @@ function EffectInput({
           <RangeInput
             id={rangeId}
             aria-label={effectProps[field].label}
-            value={effectConfig[field] || effectProps[field].defaultValue}
+            value={valueForField}
             handleChange={(value) => onChange(value, true)}
             minorStep={0.01}
             majorStep={0.1}
@@ -90,7 +93,7 @@ function EffectInput({
     case FIELD_TYPES.DIRECTION_PICKER:
       return (
         <DirectionRadioInput
-          value={effectConfig[field] || effectProps[field].defaultValue}
+          value={valueForField}
           directions={effectProps[field].values?.filter(
             (v) => !disabledOptions.includes(v)
           )}
@@ -103,7 +106,7 @@ function EffectInput({
           aria-label={effectProps[field].label}
           suffix={effectProps[field].label}
           symbol={effectProps[field].unit}
-          value={effectConfig[field] || effectProps[field].defaultValue}
+          value={valueForField}
           min={0}
           onChange={onChange}
           canBeNegative={false}

--- a/assets/src/edit-story/components/panels/animation/stories/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/stories/directionRadioInput.js
@@ -16,11 +16,12 @@
 /**
  * External dependencies
  */
+import { useState } from 'react';
 import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { DIRECTION, ROTATION } from '../../../../../animation';
+import { DIRECTION, ROTATION, SCALE_DIRECTION } from '../../../../../animation';
 import { DirectionRadioInput } from '../directionRadioInput';
 
 export default {
@@ -50,6 +51,20 @@ export const Rotation = () => {
       <DirectionRadioInput
         directions={[ROTATION.CLOCKWISE, ROTATION.COUNTER_CLOCKWISE]}
         defaultChecked={ROTATION.CLOCKWISE}
+      />
+    </Panel>
+  );
+};
+
+export const Scale = () => {
+  const [value, setValue] = useState(SCALE_DIRECTION.SCALE_IN);
+  return (
+    <Panel>
+      <DirectionRadioInput
+        value={value}
+        onChange={({ target }) => setValue(target.value)}
+        directions={[SCALE_DIRECTION.SCALE_IN, SCALE_DIRECTION.SCALE_OUT]}
+        defaultChecked={SCALE_DIRECTION.SCALE_IN}
       />
     </Panel>
   );

--- a/assets/src/edit-story/components/panels/animation/test/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/test/directionRadioInput.js
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { DIRECTION } from '../../../../../animation';
+import { DIRECTION, SCALE_DIRECTION } from '../../../../../animation';
 import { renderWithTheme } from '../../../../testUtils';
 import { DirectionRadioInput } from '../directionRadioInput';
 
@@ -111,5 +111,19 @@ describe('<DirectionRadioInput />', () => {
       })
     );
     expect(getByRole('radio', { checked: true })).toBe(radios[0]);
+  });
+
+  it('should render the correct number of arrows for scale direction', () => {
+    const onChange = jest.fn();
+    const { getAllByRole } = renderWithTheme(
+      <DirectionRadioInputUncontrolled
+        onChange={onChange}
+        directions={[SCALE_DIRECTION.SCALE_IN, SCALE_DIRECTION.SCALE_OUT]}
+      />
+    );
+
+    const radios = getAllByRole('radio');
+
+    expect(radios).toHaveLength(4);
   });
 });

--- a/assets/src/edit-story/components/panels/animation/test/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/test/effectChooser.js
@@ -21,7 +21,11 @@ import { fireEvent } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { ANIMATION_EFFECTS, DIRECTION } from '../../../../../animation';
+import {
+  ANIMATION_EFFECTS,
+  DIRECTION,
+  SCALE_DIRECTION,
+} from '../../../../../animation';
 import { renderWithTheme } from '../../../../testUtils';
 import EffectChooser from '../effectChooser';
 
@@ -77,8 +81,7 @@ describe('<EffectChooser />', function () {
 
     expect(onAnimationSelected).toHaveBeenCalledWith({
       animation: ANIMATION_EFFECTS.ZOOM.value,
-      zoomFrom: 0,
-      zoomTo: 1,
+      scaleDirection: SCALE_DIRECTION.SCALE_IN,
     });
   });
 });


### PR DESCRIPTION

## Summary

Remove the prior `to` and `from` input fields and replace with a scale-in or scale-out directional picker. In another PR, the dropdown name Zoom has been renamed to Scale.

**Scale In**

<img width="695" alt="Screen Shot 2020-12-06 at 9 49 33 AM" src="https://user-images.githubusercontent.com/1738349/101290254-a2d74000-37c6-11eb-874d-f1eb457a8c75.png">

**Scale Out**

<img width="759" alt="Screen Shot 2020-12-06 at 9 49 23 AM" src="https://user-images.githubusercontent.com/1738349/101290255-a36fd680-37c6-11eb-987c-6b70284e03b7.png">


## Relevant Technical Choices

This one is tricky because we are now using two string-based identifiers to map to numeric values. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

The to and from input fields are gone and now replaced with a picker that sets default values based on the in or out direction.

## Testing Instructions

1. Edit a story and add an object
2. Select scale in or scale out animations
3. See the new picker and the arrows that point inward (either top or bottom) scale in or the arrows that point outward scale out.
4. For scale in you should see the final result (the smaller since it's scaling in) on canvas

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
