### PR TITLE
Animation: Update effect chooser active state style & persist between selections

### DIFF
--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -97,11 +97,12 @@ const GridItem = styled.button.attrs({ role: 'listitem' })`
 
   &:hover:not([aria-disabled='true']) {
     cursor: pointer;
-    background: ${({ active }) => (active ? '#5732A3' : '#B488FC')};
   }
 
   &:hover:not([aria-disabled='true']),
   &:focus:not([aria-disabled='true']) {
+    background: ${({ active }) => (active ? '#5732A3' : '#B488FC')};
+
     ${BaseAnimationCell} {
       display: inline-block;
     }
@@ -157,8 +158,8 @@ const FOREGROUND_EFFECTS_LIST = [
   ANIMATION_EFFECTS.FADE_IN.value,
   `${ANIMATION_EFFECTS.FLY_IN.value} ${DIRECTION.LEFT_TO_RIGHT}`,
   `${ANIMATION_EFFECTS.FLY_IN.value} ${DIRECTION.TOP_TO_BOTTOM}`,
-  `${ANIMATION_EFFECTS.FLY_IN.value} ${DIRECTION.RIGHT_TO_LEFT}`,
   `${ANIMATION_EFFECTS.FLY_IN.value} ${DIRECTION.BOTTOM_TO_TOP}`,
+  `${ANIMATION_EFFECTS.FLY_IN.value} ${DIRECTION.RIGHT_TO_LEFT}`,
   ANIMATION_EFFECTS.PULSE.value,
   `${ANIMATION_EFFECTS.ROTATE_IN.value} ${DIRECTION.LEFT_TO_RIGHT}`,
   `${ANIMATION_EFFECTS.ROTATE_IN.value} ${DIRECTION.RIGHT_TO_LEFT}`,
@@ -195,7 +196,6 @@ export default function EffectChooser({
 }) {
   const [focusedValue, setFocusedValue] = useState(null);
   const ref = useRef();
-  const previousEffectValueRef = useRef();
 
   useEffect(() => {
     loadStylesheet(`${GOOGLE_MENU_FONT_URL}?family=Teko`).catch(function () {});
@@ -264,19 +264,10 @@ export default function EffectChooser({
     return 0;
   }, [activeEffectListValue]);
 
-  useEffect(() => {
-    previousEffectValueRef.current = activeEffectListValue;
-    return () => {
-      previousEffectValueRef.current = null;
-    };
-  }, [activeEffectListValue]);
-
   // Once the correct effect w/ direction is found, set focusedValue to trigger effect hook to find proper index.
   useEffect(() => {
-    if (previousEffectValueRef.current) {
-      setFocusedValue(previousEffectValueRef.current);
-    }
-  }, []);
+    setFocusedValue(activeEffectListValue);
+  }, [activeEffectListValue, setFocusedValue]);
 
   const focusedIndex = useMemo(() => {
     if (isNullOrUndefinedOrEmptyString(focusedValue)) {

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -29,7 +29,7 @@ import React, {
   useState,
 } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 /**
  * Internal dependencies
@@ -79,7 +79,7 @@ const ContentWrapper = styled.div`
 
 const GridItem = styled.button.attrs({ role: 'listitem' })`
   border: none;
-  background: #333;
+  background: ${({ active }) => (active ? '#5732A3' : '#333')};
   border-radius: 4px;
   height: ${GRID_ITEM_HEIGHT}px;
   position: relative;
@@ -89,6 +89,7 @@ const GridItem = styled.button.attrs({ role: 'listitem' })`
   line-height: 1;
   color: white;
   text-transform: uppercase;
+  transition: background 0.1s linear;
 
   &[aria-disabled='true'] {
     opacity: 0.6;
@@ -96,6 +97,7 @@ const GridItem = styled.button.attrs({ role: 'listitem' })`
 
   &:hover:not([aria-disabled='true']) {
     cursor: pointer;
+    background: ${({ active }) => (active ? '#5732A3' : '#B488FC')};
   }
 
   &:hover:not([aria-disabled='true']),
@@ -131,6 +133,17 @@ const GridItemHalfRow = styled(GridItem)`
   grid-column-start: span 2;
 `;
 
+const NoEffect = styled(GridItemFullRow)`
+  ${({ theme }) => css`
+    padding: 8px 15px;
+    height: auto;
+    text-transform: capitalize;
+    font-family: ${theme.fonts.paragraph.small.family};
+    font-size: ${theme.fonts.paragraph.small.size};
+    line-height: ${theme.fonts.paragraph.small.lineHeight};
+    font-weight: normal;
+  `}
+`;
 /**
  * Because the effect chooser is hard coded these two effects lists help keep track of the current index
  * current index is how we track focus for up and down arrows and setting active list item when menu is opened.
@@ -225,7 +238,7 @@ export default function EffectChooser({
   ]);
 
   // set existing active effect with a ref, specify when dropdown is opened which version of an effect it is since some have many options
-  const getPreviousEffectValue = useCallback(() => {
+  const activeEffectListValue = useMemo(() => {
     if (direction || direction === 0) {
       let indicator;
       if (typeof direction === 'number') {
@@ -239,12 +252,24 @@ export default function EffectChooser({
     return value;
   }, [direction, value]);
 
+  const activeEffectListIndex = useMemo(() => {
+    const bgListIndex = BACKGROUND_EFFECTS_LIST.indexOf(activeEffectListValue);
+    if (bgListIndex > -1) {
+      return bgListIndex;
+    }
+    const fgListIndex = FOREGROUND_EFFECTS_LIST.indexOf(activeEffectListValue);
+    if (fgListIndex > -1) {
+      return fgListIndex;
+    }
+    return 0;
+  }, [activeEffectListValue]);
+
   useEffect(() => {
-    previousEffectValueRef.current = getPreviousEffectValue();
+    previousEffectValueRef.current = activeEffectListValue;
     return () => {
       previousEffectValueRef.current = null;
     };
-  }, [getPreviousEffectValue]);
+  }, [activeEffectListValue]);
 
   // Once the correct effect w/ direction is found, set focusedValue to trigger effect hook to find proper index.
   useEffect(() => {
@@ -309,12 +334,13 @@ export default function EffectChooser({
   return (
     <Container ref={ref}>
       <Grid>
-        <GridItemFullRow
+        <NoEffect
           onClick={onNoEffectSelected}
-          aria-label={__('No Effect', 'web-stories')}
+          aria-label={__('None', 'web-stories')}
+          active={activeEffectListIndex === 0}
         >
-          <span>{__('No Effect', 'web-stories')}</span>
-        </GridItemFullRow>
+          <span>{__('None', 'web-stories')}</span>
+        </NoEffect>
         {isBackgroundEffects ? (
           <>
             <GridItemFullRow
@@ -324,6 +350,7 @@ export default function EffectChooser({
                   animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
                 })
               }
+              active={activeEffectListIndex === 1}
             >
               <ContentWrapper>{__('Zoom', 'web-stories')}</ContentWrapper>
               <ZoomOutAnimation>{__('Zoom', 'web-stories')}</ZoomOutAnimation>
@@ -339,6 +366,7 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT]
               )}
+              active={activeEffectListIndex === 2}
             >
               <ContentWrapper>{__('Pan Left', 'web-stories')}</ContentWrapper>
               <PanLeftAnimation>
@@ -356,6 +384,7 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.RIGHT_TO_LEFT]
               )}
+              active={activeEffectListIndex === 3}
             >
               <ContentWrapper>{__('Pan Right', 'web-stories')}</ContentWrapper>
               <PanRightAnimation>
@@ -373,6 +402,7 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.BOTTOM_TO_TOP]
               )}
+              active={activeEffectListIndex === 4}
             >
               <ContentWrapper>{__('Pan Up', 'web-stories')}</ContentWrapper>
               <PanBottomAnimation>
@@ -390,6 +420,7 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.TOP_TO_BOTTOM]
               )}
+              active={activeEffectListIndex === 5}
             >
               <ContentWrapper>{__('Pan Down', 'web-stories')}</ContentWrapper>
               <PanTopAnimation>{__('Pan Down', 'web-stories')}</PanTopAnimation>
@@ -402,6 +433,7 @@ export default function EffectChooser({
               onClick={() =>
                 onAnimationSelected({ animation: ANIMATION_EFFECTS.DROP.value })
               }
+              active={activeEffectListIndex === 1}
             >
               <ContentWrapper>{__('Drop', 'web-stories')}</ContentWrapper>
               <DropAnimation>{__('Drop', 'web-stories')}</DropAnimation>
@@ -413,6 +445,7 @@ export default function EffectChooser({
                   animation: ANIMATION_EFFECTS.FADE_IN.value,
                 })
               }
+              active={activeEffectListIndex === 2}
             >
               <ContentWrapper>{__('Fade in', 'web-stories')}</ContentWrapper>
               <FadeInAnimation>{__('Fade in', 'web-stories')}</FadeInAnimation>
@@ -425,6 +458,7 @@ export default function EffectChooser({
                   flyInDir: DIRECTION.LEFT_TO_RIGHT,
                 })
               }
+              active={activeEffectListIndex === 3}
             >
               <ContentWrapper>{__('Fly in', 'web-stories')}</ContentWrapper>
               <FlyInLeftAnimation>
@@ -439,6 +473,7 @@ export default function EffectChooser({
                   flyInDir: DIRECTION.TOP_TO_BOTTOM,
                 })
               }
+              active={activeEffectListIndex === 4}
             >
               <ContentWrapper>{__('Fly in', 'web-stories')}</ContentWrapper>
               <FlyInTopAnimation>
@@ -453,6 +488,7 @@ export default function EffectChooser({
                   flyInDir: DIRECTION.BOTTOM_TO_TOP,
                 })
               }
+              active={activeEffectListIndex === 5}
             >
               <ContentWrapper>{__('Fly in', 'web-stories')}</ContentWrapper>
               <FlyInBottomAnimation>
@@ -467,6 +503,7 @@ export default function EffectChooser({
                   flyInDir: DIRECTION.RIGHT_TO_LEFT,
                 })
               }
+              active={activeEffectListIndex === 6}
             >
               <ContentWrapper>{__('Fly in', 'web-stories')}</ContentWrapper>
               <FlyInRightAnimation>
@@ -480,6 +517,7 @@ export default function EffectChooser({
                   animation: ANIMATION_EFFECTS.PULSE.value,
                 })
               }
+              active={activeEffectListIndex === 7}
             >
               <ContentWrapper>{__('Pulse', 'web-stories')}</ContentWrapper>
               <PulseAnimation>{__('Pulse', 'web-stories')}</PulseAnimation>
@@ -492,6 +530,7 @@ export default function EffectChooser({
                   rotateInDir: DIRECTION.LEFT_TO_RIGHT,
                 })
               }
+              active={activeEffectListIndex === 8}
             >
               <ContentWrapper>{__('Rotate', 'web-stories')}</ContentWrapper>
               <RotateInLeftAnimation>
@@ -506,6 +545,7 @@ export default function EffectChooser({
                   rotateInDir: DIRECTION.RIGHT_TO_LEFT,
                 })
               }
+              active={activeEffectListIndex === 9}
             >
               <ContentWrapper>{__('Rotate', 'web-stories')}</ContentWrapper>
               <RotateInRightAnimation>
@@ -519,6 +559,7 @@ export default function EffectChooser({
                   animation: ANIMATION_EFFECTS.TWIRL_IN.value,
                 })
               }
+              active={activeEffectListIndex === 10}
             >
               <ContentWrapper>{__('Twirl In', 'web-stories')}</ContentWrapper>
               <TwirlInAnimation>
@@ -533,6 +574,7 @@ export default function EffectChooser({
                   whooshInDir: DIRECTION.LEFT_TO_RIGHT,
                 })
               }
+              active={activeEffectListIndex === 11}
             >
               <ContentWrapper>{__('Whoosh In', 'web-stories')}</ContentWrapper>
               <WhooshInLeftAnimation>
@@ -547,6 +589,7 @@ export default function EffectChooser({
                   whooshInDir: DIRECTION.RIGHT_TO_LEFT,
                 })
               }
+              active={activeEffectListIndex === 12}
             >
               <WhooshInRightAnimation>
                 {__('Whoosh In', 'web-stories')}
@@ -562,6 +605,7 @@ export default function EffectChooser({
                   zoomTo: 1,
                 })
               }
+              active={activeEffectListIndex === 13}
             >
               <ContentWrapper>{__('Scale In', 'web-stories')}</ContentWrapper>
               <ZoomInAnimation>{__('Scale In', 'web-stories')}</ZoomInAnimation>
@@ -575,6 +619,7 @@ export default function EffectChooser({
                   zoomTo: 1,
                 })
               }
+              active={activeEffectListIndex === 14}
             >
               <ZoomOutAnimation>
                 {__('Scale Out', 'web-stories')}

--- a/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
@@ -67,15 +67,17 @@ export default function EffectChooserDropdown({
   }, []);
 
   return (
-    <DropDownSelect
-      aria-label={__('Animation: Effect Chooser', 'web-stories')}
-      ref={selectRef}
-      onClick={() => setIsOpen(!isOpen)}
-    >
-      <DropDownTitle>
-        {selectedEffectTitle || __('Select Animation', 'web-stories')}
-      </DropDownTitle>
-      <DropdownIcon />
+    <>
+      <DropDownSelect
+        aria-label={__('Animation: Effect Chooser', 'web-stories')}
+        ref={selectRef}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <DropDownTitle>
+          {selectedEffectTitle || __('Select Animation', 'web-stories')}
+        </DropDownTitle>
+        <DropdownIcon />
+      </DropDownSelect>
       <Popup
         anchor={selectRef}
         isOpen={isOpen}
@@ -93,7 +95,7 @@ export default function EffectChooserDropdown({
           />
         </Container>
       </Popup>
-    </DropDownSelect>
+    </>
   );
 }
 

--- a/assets/src/edit-story/components/panels/karma/animation.karma.js
+++ b/assets/src/edit-story/components/panels/karma/animation.karma.js
@@ -86,6 +86,8 @@ describe('Animation Panel', function () {
     await fixture.events.click(
       fixture.screen.getByRole('listitem', { name: /Fade In Effect/ })
     );
+    // Wait for the debounce
+    await fixture.events.sleep(200);
 
     const { animationState } = await fixture.renderHook(() =>
       useStory(({ state }) => {


### PR DESCRIPTION
## Summary
Updates the active style of the effect chooser and keeps it open between selecting effects.

## Relevant Technical Choices
Ran into once race condition where react updates were canceling each other out -> focusIn was bubbling up inside the design panel which causes animation state to reset, this was getting batched in the same render as our call to play the selected element animations and cancelling it out.

To fix this I debounced the call to play selected animations and scheduled it on activeElement updating so it only happens after all the manual focus changes are done updating. I really hate this approach and think it needs to be cleaned up to be more more top down, but for now this is all I can think of without making more widespread updates before release.

## To-do
~This is a branch off of some accessibility work that's doing some data management necessary for this ticket, so wait for this PR to get merged in:~
https://github.com/google/web-stories-wp/pull/5570 [was merged]

## User-facing changes
Behind animation flag:
-> effect chooser has new hover and selected state
-> effect chooser stays open between effect selections

## Testing Instructions
enable animations -> go to edit story -> add an animation to an element -> see that the animation selector has new active and hover states, plays the elements animation on selection and doesn't close between animation selections.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5451 
