### PR TITLE
Animation: Update Pulse Preset

### DIFF
--- a/assets/src/animation/effects/pulse/animationProps.js
+++ b/assets/src/animation/effects/pulse/animationProps.js
@@ -43,7 +43,7 @@ export default {
     defaultValue: 0.05,
   },
   iterations: {
-    label: __('# of Pulses', 'web-stories'),
+    label: __('Pulses', 'web-stories'),
     type: FIELD_TYPES.NUMBER,
     defaultValue: 1,
   },

--- a/assets/src/animation/effects/pulse/index.js
+++ b/assets/src/animation/effects/pulse/index.js
@@ -21,7 +21,7 @@ import { AnimationPulse } from '../../parts/pulse';
 
 export function EffectPulse({
   iterations = 1,
-  scale = 0.5,
+  scale = 0.05,
   duration = 600,
   delay,
   easing,

--- a/assets/src/animation/parts/pulse/index.js
+++ b/assets/src/animation/parts/pulse/index.js
@@ -20,11 +20,9 @@
 import { ANIMATION_TYPES } from '../../constants';
 import SimpleAnimation from '../simpleAnimation';
 
-export const PULSE_INTENSITY = 0.1;
-
 export function generatePulseKeyframes(scale) {
   const baseScale = 1.0;
-  const intensity = PULSE_INTENSITY * scale;
+  const intensity = scale;
 
   return [
     { transform: `scale(${baseScale})`, offset: 0.0 },

--- a/assets/src/animation/parts/pulse/test/index.js
+++ b/assets/src/animation/parts/pulse/test/index.js
@@ -17,14 +17,14 @@
 /**
  * Internal dependencies
  */
-import { PULSE_INTENSITY, generatePulseKeyframes } from '../index';
+import { generatePulseKeyframes } from '../index';
 
 describe('Pulse Effect', () => {
   describe('generatePulseKeyframes', () => {
     it('should return correct keyframes based on scale', () => {
       // scale > 1
       let scale = 2;
-      let intensity = PULSE_INTENSITY * scale;
+      let intensity = scale;
       let shrink = 1 - intensity;
       let expand = 1 + intensity;
 
@@ -37,7 +37,7 @@ describe('Pulse Effect', () => {
 
       // scale < 1
       scale = 0.5;
-      intensity = PULSE_INTENSITY * scale;
+      intensity = scale;
       shrink = 1 - intensity;
       expand = 1 + intensity;
 


### PR DESCRIPTION
## Summary
Makes pulse animation effect match amp's. Previously we were multiplying the input scale by a factor to lessen it. This removes that factor and makes `scale` input on the pulse animation true to the actual scale it will pulse to. 

Let me know if this is the desired behavior.

## Relevant Technical Choices
NA

## To-do
verify with @samitron7 

## User-facing changes
behind animation flag:
-> `scale` deviation input on `pulse` animation should now default to the same value in amp presets.
-> `scale` input should now be more accurate representation of scale change that occurs.

## Testing Instructions
enable animations -> go to editor -> add pulse animation to an element -> see that it's visible

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5526 
