### PR TITLE
Animations: Update page advancement calculation

### DIFF
--- a/assets/src/edit-story/output/page.js
+++ b/assets/src/edit-story/output/page.js
@@ -44,9 +44,13 @@ function OutputPage({ page, autoAdvance, defaultPageDuration }) {
   const [backgroundElement, ...regularElements] = elements;
   const animationDuration =
     enableAnimation && getTotalDuration({ animations }) / 1000;
+  const nonMediaPageDuration = Math.max(
+    animationDuration || 0,
+    defaultPageDuration
+  );
   const longestMediaElement = getLongestMediaElement(
     elements,
-    animationDuration
+    nonMediaPageDuration
   );
 
   // If the background element has base color set, it's media, use that.
@@ -62,7 +66,7 @@ function OutputPage({ page, autoAdvance, defaultPageDuration }) {
 
   const autoAdvanceAfter = longestMediaElement?.id
     ? `el-${longestMediaElement?.id}-media`
-    : `${animationDuration || defaultPageDuration}s`;
+    : `${nonMediaPageDuration}s`;
 
   const hasPageAttachment = page.pageAttachment?.url?.length > 0;
 


### PR DESCRIPTION
## Summary
Previous Behavior:
- if animation or media present, use max duration of either for page duration
- if neither is present, use auto advance duration for page duration

Updated Behavior:
- use the max of auto advance duration, media duration and animation duration
- this only applies if the story is set to auto-advance, if set to manual advance then ignore all this. :)

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
behind animations experiment:
page advancement should now fit description above.

## Testing Instructions
Enable animations -> open editor -> add elements with video, animation & mess with page auto advance duration and press `preview` -> see page duration in the preview follows these rules:
- uses the max of auto advance duration, media duration and animation duration
- this only applies if the story is set to auto-advance, if set to manual advance then ignore all this. :)


---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5590 
