### PR TITLE
Animation Panel: Direction picker keyboard functionality

### DIFF
--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -16,7 +16,7 @@
 /**
  * External dependencies
  */
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 /**
@@ -32,6 +32,7 @@ import {
   SCALE_DIRECTION,
   SCALE_DIRECTION_MAP,
 } from '../../../../animation';
+import useRadioNavigation from '../../form/shared/useRadioNavigation';
 
 const Svg = styled.svg`
   display: block;
@@ -250,26 +251,33 @@ const valueForInternalValue = (value) => {
 };
 
 export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
+  const inputRef = useRef();
+
   const flattenedDirections = useMemo(() => {
     const dir = [];
     if (
       directions.includes(SCALE_DIRECTION.SCALE_IN) &&
       directions.includes(SCALE_DIRECTION.SCALE_OUT)
     ) {
+      // Controlling order these get added to flattenedDirections makes sure the indexable order makes sense for keyboard users
       dir.push(
-        ...SCALE_DIRECTION_MAP.SCALE_IN,
-        ...SCALE_DIRECTION_MAP.SCALE_OUT
+        SCALE_DIRECTION_MAP.SCALE_IN[0],
+        SCALE_DIRECTION_MAP.SCALE_OUT[0],
+        SCALE_DIRECTION_MAP.SCALE_IN[1],
+        SCALE_DIRECTION_MAP.SCALE_OUT[1]
       );
     } else {
       dir.push(...directions);
     }
     return dir;
   }, [directions]);
+  useRadioNavigation(inputRef);
+
   return (
     <Fieldset>
       <Figure />
       <HiddenLegend>{__('Which Direction?', 'web-stories')}</HiddenLegend>
-      <RadioGroup>
+      <RadioGroup ref={inputRef}>
         {flattenedDirections.map((direction) => (
           <Label
             key={direction}


### PR DESCRIPTION
## Summary
Enables keyboard usability for animation direction picker (as seen in whoosh, rotate, scale/zoom).

## Relevant Technical Choices
- Use the useRadioNavigation hook from form/shared to keep focus on directionRadioInput in animation panel when animations are updated. 
- Specified order to create scale flattenedDirections because otherwise arrows will index both scale _in_ values first and it gets a little weird trying to key through that way. Theres definitely a better way to do this, but i just wanted it to work for now.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

You can set animation direction with keyboard now

## Testing Instructions

1. Select an element and set an animation on it that has direction (whoosh, rotate, scale/zoom). 
2. Click into one of the other inputs associated with the animation and then tab+shift into the direction or click into the direction input and then use the keys. 
3. The active (or one of the active ones if on scale) should become focused, now you can arrow through the options and set a new value by using the spacebar. Tab or tab+shift to exit the direction input.

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5574 
