### PR TITLE
Remove duplicate video element size on page check

### DIFF
--- a/assets/src/edit-story/app/prepublish/guidance/index.js
+++ b/assets/src/edit-story/app/prepublish/guidance/index.js
@@ -28,7 +28,6 @@ export default {
   ],
   page: [mediaGuidance.videoElementSizeOnPage, textGuidance.pageTooMuchText],
   video: [
-    mediaGuidance.mediaElementSizeOnPage,
     mediaGuidance.mediaElementResolution,
     mediaGuidance.videoElementLength,
   ],

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -95,6 +95,9 @@ export function mediaElementSizeOnPage(element) {
 /**
  * If there is only one video on the page, check it for its size on the page.
  *
+ * Note: when using this check, make sure not to check video elements individually to avoid
+ * duplicate checks.
+ *
  * @param {Page} page The page being checked
  * @return {Guidance|undefined} The guidance object for consumption
  */


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

The "Video or image too small on the page" shows up twice for videos sometimes. This is because we were both running the check on the page and on the elements themselves. This removes the duplicate individual element check for videos since the page check has additional logic around this.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

Add a video to a page and make it small enough for the check to show up. Without this branch the message "Video or image too small on the page" shows up twice. With this branch, it shows up once.

The check will only show up now if there is only one video on the page, as is intended by the still-enabled check which checks all videos on page and only checks size on page if there's one video.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5404 
