### PR TITLE
Animations: Add Tooltip to Disabled Options

### DIFF
--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -33,6 +33,7 @@ import {
   SCALE_DIRECTION_MAP,
 } from '../../../../animation';
 import useRadioNavigation from '../../form/shared/useRadioNavigation';
+import WithTooltip from '../../tooltip';
 
 const Svg = styled.svg`
   display: block;
@@ -43,7 +44,8 @@ const Svg = styled.svg`
 `;
 
 const Icon = styled.div`
-  padding: 4px;
+  padding: 6px;
+  border-radius: 4px;
   transform: ${({ direction }) => {
     switch (direction) {
       case DIRECTION.RIGHT_TO_LEFT:
@@ -70,7 +72,7 @@ const Icon = styled.div`
 `;
 
 const RotationIcon = () => (
-  <Svg size="19px" viewBox="0 0 19 18">
+  <Svg size="16px" viewBox="0 0 19 18">
     <path
       strokeLinecap="round"
       d="M1 17.5V17.5C1 10.5964 6.59644 5 13.5 5L17.5 5M17.5 5L13.5 1M17.5 5L13.5 9"
@@ -79,7 +81,7 @@ const RotationIcon = () => (
 );
 
 const DirectionIcon = () => (
-  <Svg size="16px" viewBox="0 0 10 11">
+  <Svg size="13px" viewBox="0 0 10 11">
     <path strokeLinecap="round" d="M5 11L5 1M5 1L9 5M5 1L1 5" />
   </Svg>
 );
@@ -96,15 +98,16 @@ const Direction = ({ className, direction, selected }) => (
 );
 
 // Must be a styled component to add component selectors in css
-const DirectionIndicator = styled(Direction)``;
+const DirectionIndicator = styled(Direction)`
+  stroke: #e4e5e6;
+  stroke-width: 1px;
+`;
 
 const Fieldset = styled.fieldset`
   position: relative;
   height: 80px;
   width: 80px;
-  background-color: ${({ theme }) => theme.colors.bg.workspace};
-  border: 1px solid ${({ theme }) => theme.colors.fg.v9};
-  border-radius: 4px;
+  border: 1px solid #393d3f;
 `;
 
 const Figure = styled.div`
@@ -112,9 +115,10 @@ const Figure = styled.div`
   display: block;
   top: 50%;
   left: 50%;
-  width: 18px;
-  height: 26px;
+  width: 8px;
+  height: 8px;
   background: ${({ theme }) => theme.colors.fg.v9};
+  background: #e4e5e6;
   border-radius: 2px;
   transform: translate(-50%, -50%);
 `;
@@ -128,31 +132,31 @@ const Label = styled.label`
       case DIRECTION.RIGHT_TO_LEFT:
         return css`
           top: 50%;
-          right: 0;
+          right: 4px;
           transform: translateY(-50%);
         `;
       case DIRECTION.TOP_TO_BOTTOM:
         return css`
-          top: 0;
+          top: 4px;
           left: 50%;
           transform: translateX(-50%);
         `;
       case DIRECTION.LEFT_TO_RIGHT:
         return css`
           top: 50%;
-          left: 0;
+          left: 4px;
           transform: translateY(-50%);
         `;
       case ROTATION.CLOCKWISE:
         return css`
-          top: 0;
-          left: 0;
+          top: 4px;
+          left: 4px;
           transform: translateX(20%);
         `;
       case ROTATION.COUNTER_CLOCKWISE:
         return css`
-          bottom: 0;
-          right: 0;
+          bottom: 4px;
+          right: 4px;
           transform: translate(-10%, -10%);
         `;
 
@@ -186,19 +190,22 @@ const Label = styled.label`
 
       default:
         return css`
-          bottom: 0;
+          bottom: 4px;
           left: 50%;
           transform: translateX(-50%);
         `;
     }
   }}
 
-  ${DirectionIndicator} {
-    stroke: ${({ theme }) => theme.colors.fg.v9};
-    stroke-width: 1px;
+  input:disabled ~ * > ${DirectionIndicator} {
+    stroke: #5e6668;
   }
 
-  input:focus ~ ${DirectionIndicator} {
+  input:checked:not(:disabled) ~ * > ${DirectionIndicator} {
+    background-color: #51389d;
+  }
+
+  input:focus ~ * > ${DirectionIndicator} {
     outline: 2px auto ${({ theme }) => theme.colors.accent.primary};
   }
 `;
@@ -250,6 +257,12 @@ const valueForInternalValue = (value) => {
   }
 };
 
+const getPrefixFromCamelCase = (camelCase = '') =>
+  camelCase
+    ?.replace(/([a-z])([A-Z])/g, '$1 $2')
+    ?.toLocaleLowerCase()
+    ?.split(' ')?.[0];
+
 export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
   const inputRef = useRef();
 
@@ -282,27 +295,36 @@ export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
       <Figure />
       <HiddenLegend>{__('Which Direction?', 'web-stories')}</HiddenLegend>
       <RadioGroup ref={inputRef}>
-        {flattenedDirections.map((direction) => (
-          <Label
-            key={direction}
-            aria-label={translations[direction]}
-            htmlFor={direction}
-            direction={direction}
-          >
-            <HiddenInput
-              id={direction}
-              type="radio"
-              name="direction"
-              value={valueForInternalValue(direction)}
-              onChange={onChange}
-              checked={value === direction || direction?.includes(value)}
-            />
-            <DirectionIndicator
+        {flattenedDirections.map((direction) => {
+          const isDisabled = disabled.includes(direction);
+          return (
+            <Label
+              key={direction}
+              aria-label={translations[direction]}
+              htmlFor={direction}
               direction={direction}
-              selected={value === direction || direction?.includes(value)}
-            />
-          </Label>
-        ))}
+            >
+              <HiddenInput
+                id={direction}
+                type="radio"
+                name="direction"
+                value={valueForInternalValue(direction)}
+                onChange={onChange}
+                checked={value === direction || direction?.includes(value)}
+                disabled={isDisabled}
+              />
+              <WithTooltip
+                title={isDisabled && tooltip}
+                placement={getPrefixFromCamelCase(direction)}
+              >
+                <DirectionIndicator
+                  direction={direction}
+                  selected={value === direction || direction?.includes(value)}
+                />
+              </WithTooltip>
+            </Label>
+          );
+        })}
       </RadioGroup>
     </Fieldset>
   );
@@ -317,7 +339,9 @@ const directionPropType = PropTypes.oneOf([
 DirectionRadioInput.propTypes = {
   value: directionPropType,
   directions: PropTypes.arrayOf(directionPropType),
+  disabled: PropTypes.arrayOf(directionPropType),
   onChange: PropTypes.func,
+  tooltip: PropTypes.string,
 };
 
 Direction.propTypes = {

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -268,7 +268,7 @@ export const DirectionRadioInput = ({
   value,
   directions = [],
   onChange,
-  disabled,
+  disabled = [],
   tooltip,
 }) => {
   const inputRef = useRef();
@@ -303,7 +303,7 @@ export const DirectionRadioInput = ({
       <HiddenLegend>{__('Which Direction?', 'web-stories')}</HiddenLegend>
       <RadioGroup ref={inputRef}>
         {flattenedDirections.map((direction) => {
-          const isDisabled = disabled.includes(direction);
+          const isDisabled = disabled?.includes(direction);
           return (
             <Label
               key={direction}

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -257,12 +257,24 @@ const valueForInternalValue = (value) => {
       return value;
   }
 };
+const isInternalScaleDirection = (value) =>
+  [...SCALE_DIRECTION_MAP.SCALE_IN, ...SCALE_DIRECTION_MAP.SCALE_OUT].includes(
+    value
+  );
 
-const getPrefixFromCamelCase = (camelCase = '') =>
+const splitCamelCase = (camelCase = '') =>
   camelCase
     ?.replace(/([a-z])([A-Z])/g, '$1 $2')
     ?.toLocaleLowerCase()
-    ?.split(' ')?.[0];
+    ?.split(' ') || [];
+
+const getPrefixFromCamelCase = (camelCase = '') =>
+  splitCamelCase(camelCase)?.[0];
+
+const getPostfixFromCamelCase = (camelCase = '') => {
+  const split = splitCamelCase(camelCase);
+  return split[split.length - 1];
+};
 
 export const DirectionRadioInput = ({
   value,
@@ -303,7 +315,9 @@ export const DirectionRadioInput = ({
       <HiddenLegend>{__('Which Direction?', 'web-stories')}</HiddenLegend>
       <RadioGroup ref={inputRef}>
         {flattenedDirections.map((direction) => {
-          const isDisabled = disabled?.includes(direction);
+          const isDisabled = disabled?.includes(
+            valueForInternalValue(direction)
+          );
           return (
             <Label
               key={direction}
@@ -322,7 +336,11 @@ export const DirectionRadioInput = ({
               />
               <WithTooltip
                 title={isDisabled ? tooltip : ''}
-                placement={getPrefixFromCamelCase(direction)}
+                placement={
+                  isInternalScaleDirection(direction)
+                    ? getPostfixFromCamelCase(direction)
+                    : getPrefixFromCamelCase(direction)
+                }
               >
                 <DirectionIndicator
                   direction={direction}

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -314,7 +314,7 @@ export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
                 disabled={isDisabled}
               />
               <WithTooltip
-                title={isDisabled && tooltip}
+                title={isDisabled ? tooltip : ''}
                 placement={getPrefixFromCamelCase(direction)}
               >
                 <DirectionIndicator

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -41,11 +41,6 @@ const Svg = styled.svg`
   width: ${({ size }) => size};
   fill: none;
   transform-origin: 50% 50%;
-`;
-
-const Icon = styled.div`
-  padding: 6px;
-  border-radius: 4px;
   transform: ${({ direction }) => {
     switch (direction) {
       case DIRECTION.RIGHT_TO_LEFT:
@@ -56,23 +51,41 @@ const Icon = styled.div`
         return 'rotate(90deg)';
       case ROTATION.COUNTER_CLOCKWISE:
         return 'rotateX(180deg) rotateZ(90deg)';
+      case SCALE_DIRECTION.SCALE_OUT_BOTTOM_LEFT:
+        return 'rotate(-135deg)';
+      case SCALE_DIRECTION.SCALE_IN_TOP_LEFT:
+        return 'rotate(135deg)';
+      case SCALE_DIRECTION.SCALE_OUT_TOP_RIGHT:
+        return 'rotate(-315deg)';
+      case SCALE_DIRECTION.SCALE_IN_BOTTOM_RIGHT:
+        return 'rotate(315deg)';
       default:
         return 'rotate(0deg)';
     }
   }};
+`;
 
-  ${({ selected }) =>
+const Icon = styled.div`
+  padding: 6px;
+  border-radius: 4px;
+  stroke: #e4e5e6;
+  stroke-width: 1px;
+  ${({ selected, disabled }) =>
     selected &&
+    !disabled &&
     css`
-      svg {
-        stroke: ${({ theme }) => theme.colors.activeDirection};
-        stroke-width: 2px;
-      }
+      background-color: #51389d;
+    `}
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      stroke: #5e6668;
     `}
 `;
 
-const RotationIcon = () => (
-  <Svg size="16px" viewBox="0 0 19 18">
+const RotationIcon = ({ direction }) => (
+  <Svg size="16px" viewBox="0 0 19 18" direction={direction}>
     <path
       strokeLinecap="round"
       d="M1 17.5V17.5C1 10.5964 6.59644 5 13.5 5L17.5 5M17.5 5L13.5 1M17.5 5L13.5 9"
@@ -80,28 +93,31 @@ const RotationIcon = () => (
   </Svg>
 );
 
-const DirectionIcon = () => (
-  <Svg size="13px" viewBox="0 0 10 11">
+const DirectionIcon = ({ direction }) => (
+  <Svg size="13px" viewBox="0 0 10 11" direction={direction}>
     <path strokeLinecap="round" d="M5 11L5 1M5 1L9 5M5 1L1 5" />
   </Svg>
 );
 
-const Direction = ({ className, direction, selected }) => (
-  <Icon className={className} direction={direction} selected={selected}>
-    {Object.values(DIRECTION).includes(direction) ||
-    Object.values(SCALE_DIRECTION).includes(direction) ? (
-      <DirectionIcon />
+const Direction = ({ className, direction, selected, disabled }) => (
+  <Icon
+    className={className}
+    direction={direction}
+    selected={selected}
+    disabled={disabled}
+  >
+    {[...Object.values(DIRECTION), ...Object.values(SCALE_DIRECTION)].includes(
+      direction
+    ) ? (
+      <DirectionIcon direction={direction} />
     ) : (
-      <RotationIcon />
+      <RotationIcon direction={direction} />
     )}
   </Icon>
 );
 
 // Must be a styled component to add component selectors in css
-const DirectionIndicator = styled(Direction)`
-  stroke: #e4e5e6;
-  stroke-width: 1px;
-`;
+const DirectionIndicator = styled(Direction)``;
 
 const Fieldset = styled.fieldset`
   position: relative;
@@ -162,30 +178,23 @@ const Label = styled.label`
 
       case SCALE_DIRECTION.SCALE_OUT_BOTTOM_LEFT:
         return css`
-          bottom: 0;
-          left: 0;
-          transform: rotate(-135deg);
+          bottom: 4px;
+          left: 4px;
         `;
-
       case SCALE_DIRECTION.SCALE_IN_TOP_LEFT:
         return css`
-          top: 0;
-          left: 0;
-          transform: rotate(135deg);
+          top: 4px;
+          left: 4px;
         `;
-
       case SCALE_DIRECTION.SCALE_OUT_TOP_RIGHT:
         return css`
-          top: 0;
-          right: 0;
-          transform: rotate(-315deg);
+          top: 4px;
+          right: 4px;
         `;
-
       case SCALE_DIRECTION.SCALE_IN_BOTTOM_RIGHT:
         return css`
-          bottom: 0;
-          right: 0;
-          transform: rotate(315deg);
+          bottom: 4px;
+          right: 4px;
         `;
 
       default:
@@ -196,14 +205,6 @@ const Label = styled.label`
         `;
     }
   }}
-
-  input:disabled ~ * > ${DirectionIndicator} {
-    stroke: #5e6668;
-  }
-
-  input:checked:not(:disabled) ~ * > ${DirectionIndicator} {
-    background-color: #51389d;
-  }
 
   input:focus ~ * > ${DirectionIndicator} {
     outline: 2px auto ${({ theme }) => theme.colors.accent.primary};
@@ -263,7 +264,13 @@ const getPrefixFromCamelCase = (camelCase = '') =>
     ?.toLocaleLowerCase()
     ?.split(' ')?.[0];
 
-export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
+export const DirectionRadioInput = ({
+  value,
+  directions = [],
+  onChange,
+  disabled,
+  tooltip,
+}) => {
   const inputRef = useRef();
 
   const flattenedDirections = useMemo(() => {
@@ -320,6 +327,7 @@ export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
                 <DirectionIndicator
                   direction={direction}
                   selected={value === direction || direction?.includes(value)}
+                  disabled={isDisabled}
                 />
               </WithTooltip>
             </Label>
@@ -348,4 +356,13 @@ Direction.propTypes = {
   className: PropTypes.string,
   direction: directionPropType,
   selected: PropTypes.bool,
+  disabled: PropTypes.bool,
+};
+
+DirectionIcon.propTypes = {
+  direction: directionPropType,
+};
+
+RotationIcon.propTypes = {
+  direction: directionPropType,
 };

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -696,9 +696,10 @@ EffectChooser.propTypes = {
   onDismiss: PropTypes.func,
   isBackgroundEffects: PropTypes.bool,
   disabledTypeOptionsMap: PropTypes.objectOf(
-    PropTypes.objectOf(
-      PropTypes.oneOf([PropTypes.string, PropTypes.arrayOf(PropTypes.string)])
-    )
+    PropTypes.shape({
+      tooltip: PropTypes.string,
+      options: PropTypes.arrayOf(PropTypes.string),
+    })
   ),
   value: PropTypes.string,
 };

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -192,11 +192,6 @@ const BACKGROUND_EFFECTS_LIST = [
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_OUT}`,
 ];
 
-const backgroundTooltip = __(
-  'The background image is too small to animate. Double click on the bg & scale the image before applying the animation.',
-  'web-stories'
-);
-
 export default function EffectChooser({
   onAnimationSelected,
   onNoEffectSelected,
@@ -337,9 +332,18 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT]
               )}
-              active={activeEffectListIndex === 1}
+              active={activeEffectListIndex === 2}
             >
-              <WithTooltip title={backgroundTooltip} placement="left">
+              <WithTooltip
+                title={
+                  disabledBackgroundEffects.includes(
+                    PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT]
+                  ) &&
+                  disabledTypeOptionsMap[BACKGROUND_ANIMATION_EFFECTS.PAN.value]
+                    ?.tooltip
+                }
+                placement="left"
+              >
                 <ContentWrapper>{__('Pan Left', 'web-stories')}</ContentWrapper>
                 <PanLeftAnimation>
                   {__('Pan Left', 'web-stories')}
@@ -359,7 +363,16 @@ export default function EffectChooser({
               )}
               active={activeEffectListIndex === 2}
             >
-              <WithTooltip title={backgroundTooltip} placement="left">
+              <WithTooltip
+                title={
+                  disabledBackgroundEffects.includes(
+                    PAN_MAPPING[DIRECTION.RIGHT_TO_LEFT]
+                  ) &&
+                  disabledTypeOptionsMap[BACKGROUND_ANIMATION_EFFECTS.PAN.value]
+                    ?.tooltip
+                }
+                placement="left"
+              >
                 <ContentWrapper>
                   {__('Pan Right', 'web-stories')}
                 </ContentWrapper>
@@ -381,7 +394,16 @@ export default function EffectChooser({
               )}
               active={activeEffectListIndex === 3}
             >
-              <WithTooltip title={backgroundTooltip} placement="left">
+              <WithTooltip
+                title={
+                  disabledBackgroundEffects.includes(
+                    PAN_MAPPING[DIRECTION.BOTTOM_TO_TOP]
+                  ) &&
+                  disabledTypeOptionsMap[BACKGROUND_ANIMATION_EFFECTS.PAN.value]
+                    ?.tooltip
+                }
+                placement="left"
+              >
                 <ContentWrapper>{__('Pan Up', 'web-stories')}</ContentWrapper>
                 <PanBottomAnimation>
                   {__('Pan Up', 'web-stories')}
@@ -401,7 +423,16 @@ export default function EffectChooser({
               )}
               active={activeEffectListIndex === 4}
             >
-              <WithTooltip title={backgroundTooltip} placement="left">
+              <WithTooltip
+                title={
+                  disabledBackgroundEffects.includes(
+                    PAN_MAPPING[DIRECTION.TOP_TO_BOTTOM]
+                  ) &&
+                  disabledTypeOptionsMap[BACKGROUND_ANIMATION_EFFECTS.PAN.value]
+                    ?.tooltip
+                }
+                placement="left"
+              >
                 <ContentWrapper>{__('Pan Down', 'web-stories')}</ContentWrapper>
                 <PanTopAnimation>
                   {__('Pan Down', 'web-stories')}
@@ -665,7 +696,9 @@ EffectChooser.propTypes = {
   onDismiss: PropTypes.func,
   isBackgroundEffects: PropTypes.bool,
   disabledTypeOptionsMap: PropTypes.objectOf(
-    PropTypes.arrayOf(PropTypes.string)
+    PropTypes.objectOf(
+      PropTypes.oneOf([PropTypes.string, PropTypes.arrayOf(PropTypes.string)])
+    )
   ),
   value: PropTypes.string,
 };

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -329,6 +329,19 @@ export default function EffectChooser({
                   panDir: DIRECTION.LEFT_TO_RIGHT,
                 })
               }
+              active={activeEffectListIndex === 1}
+            >
+              <ContentWrapper>{__('Zoom', 'web-stories')}</ContentWrapper>
+              <ZoomOutAnimation>{__('Zoom', 'web-stories')}</ZoomOutAnimation>
+            </GridItemFullRow>
+            <GridItem
+              aria-label={__('Pan Left Effect', 'web-stories')}
+              onClick={(event) =>
+                handleOnSelect(event, PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT], {
+                  animation: BACKGROUND_ANIMATION_EFFECTS.PAN.value,
+                  panDir: DIRECTION.LEFT_TO_RIGHT,
+                })
+              }
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT]
               )}
@@ -338,9 +351,11 @@ export default function EffectChooser({
                 title={
                   disabledBackgroundEffects.includes(
                     PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT]
-                  ) &&
-                  disabledTypeOptionsMap[BACKGROUND_ANIMATION_EFFECTS.PAN.value]
-                    ?.tooltip
+                  )
+                    ? disabledTypeOptionsMap[
+                        BACKGROUND_ANIMATION_EFFECTS.PAN.value
+                      ]?.tooltip
+                    : ''
                 }
                 placement="left"
               >
@@ -361,15 +376,17 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.RIGHT_TO_LEFT]
               )}
-              active={activeEffectListIndex === 2}
+              active={activeEffectListIndex === 3}
             >
               <WithTooltip
                 title={
                   disabledBackgroundEffects.includes(
                     PAN_MAPPING[DIRECTION.RIGHT_TO_LEFT]
-                  ) &&
-                  disabledTypeOptionsMap[BACKGROUND_ANIMATION_EFFECTS.PAN.value]
-                    ?.tooltip
+                  )
+                    ? disabledTypeOptionsMap[
+                        BACKGROUND_ANIMATION_EFFECTS.PAN.value
+                      ]?.tooltip
+                    : ''
                 }
                 placement="left"
               >
@@ -392,15 +409,17 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.BOTTOM_TO_TOP]
               )}
-              active={activeEffectListIndex === 3}
+              active={activeEffectListIndex === 4}
             >
               <WithTooltip
                 title={
                   disabledBackgroundEffects.includes(
                     PAN_MAPPING[DIRECTION.BOTTOM_TO_TOP]
-                  ) &&
-                  disabledTypeOptionsMap[BACKGROUND_ANIMATION_EFFECTS.PAN.value]
-                    ?.tooltip
+                  )
+                    ? disabledTypeOptionsMap[
+                        BACKGROUND_ANIMATION_EFFECTS.PAN.value
+                      ]?.tooltip
+                    : ''
                 }
                 placement="left"
               >
@@ -421,15 +440,17 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.TOP_TO_BOTTOM]
               )}
-              active={activeEffectListIndex === 4}
+              active={activeEffectListIndex === 5}
             >
               <WithTooltip
                 title={
                   disabledBackgroundEffects.includes(
                     PAN_MAPPING[DIRECTION.TOP_TO_BOTTOM]
-                  ) &&
-                  disabledTypeOptionsMap[BACKGROUND_ANIMATION_EFFECTS.PAN.value]
-                    ?.tooltip
+                  )
+                    ? disabledTypeOptionsMap[
+                        BACKGROUND_ANIMATION_EFFECTS.PAN.value
+                      ]?.tooltip
+                    : ''
                 }
                 placement="left"
               >
@@ -439,46 +460,6 @@ export default function EffectChooser({
                 </PanTopAnimation>
               </WithTooltip>
             </GridItem>
-            <GridItemHalfRow
-              aria-label={__('Zoom In Effect', 'web-stories')}
-              onClick={(event) =>
-                handleOnSelect(event, BACKGROUND_ANIMATION_EFFECTS.ZOOM.value, {
-                  animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
-                  zoomDirection: SCALE_DIRECTION.SCALE_IN,
-                })
-              }
-              aria-disabled={disabledBackgroundEffects.includes(
-                getDirectionalEffect(
-                  BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
-                  SCALE_DIRECTION.SCALE_IN
-                )
-              )}
-              active={activeEffectListIndex === 5}
-            >
-              <ContentWrapper>{__('Zoom In', 'web-stories')}</ContentWrapper>
-              <ZoomInAnimation>{__('Zoom In', 'web-stories')}</ZoomInAnimation>
-            </GridItemHalfRow>
-            <GridItemHalfRow
-              aria-label={__('Zoom Out Effect', 'web-stories')}
-              onClick={(event) =>
-                handleOnSelect(event, BACKGROUND_ANIMATION_EFFECTS.ZOOM.value, {
-                  animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
-                  zoomDirection: SCALE_DIRECTION.SCALE_OUT,
-                })
-              }
-              aria-disabled={disabledBackgroundEffects.includes(
-                getDirectionalEffect(
-                  BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
-                  SCALE_DIRECTION.SCALE_OUT
-                )
-              )}
-              active={activeEffectListIndex === 6}
-            >
-              <ContentWrapper>{__('Zoom Out', 'web-stories')}</ContentWrapper>
-              <ZoomOutAnimation>
-                {__('Zoom Out', 'web-stories')}
-              </ZoomOutAnimation>
-            </GridItemHalfRow>
           </>
         ) : (
           <>

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -44,6 +44,7 @@ import {
 } from '../../../../animation';
 import useFocusOut from '../../../utils/useFocusOut';
 import { useKeyDownEffect } from '../../keyboard';
+import WithTooltip from '../../tooltip';
 import {
   GRID_ITEM_HEIGHT,
   PANEL_WIDTH,
@@ -191,6 +192,11 @@ const BACKGROUND_EFFECTS_LIST = [
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_OUT}`,
 ];
 
+const backgroundTooltip = __(
+  'The background image is too small to animate. Double click on the bg & scale the image before applying the animation.',
+  'web-stories'
+);
+
 export default function EffectChooser({
   onAnimationSelected,
   onNoEffectSelected,
@@ -333,10 +339,12 @@ export default function EffectChooser({
               )}
               active={activeEffectListIndex === 1}
             >
-              <ContentWrapper>{__('Pan Left', 'web-stories')}</ContentWrapper>
-              <PanLeftAnimation>
-                {__('Pan Left', 'web-stories')}
-              </PanLeftAnimation>
+              <WithTooltip title={backgroundTooltip} placement="left">
+                <ContentWrapper>{__('Pan Left', 'web-stories')}</ContentWrapper>
+                <PanLeftAnimation>
+                  {__('Pan Left', 'web-stories')}
+                </PanLeftAnimation>
+              </WithTooltip>
             </GridItem>
             <GridItem
               aria-label={__('Pan Right Effect', 'web-stories')}
@@ -351,10 +359,14 @@ export default function EffectChooser({
               )}
               active={activeEffectListIndex === 2}
             >
-              <ContentWrapper>{__('Pan Right', 'web-stories')}</ContentWrapper>
-              <PanRightAnimation>
-                {__('Pan Right', 'web-stories')}
-              </PanRightAnimation>
+              <WithTooltip title={backgroundTooltip} placement="left">
+                <ContentWrapper>
+                  {__('Pan Right', 'web-stories')}
+                </ContentWrapper>
+                <PanRightAnimation>
+                  {__('Pan Right', 'web-stories')}
+                </PanRightAnimation>
+              </WithTooltip>
             </GridItem>
             <GridItem
               aria-label={__('Pan Up Effect', 'web-stories')}
@@ -369,10 +381,12 @@ export default function EffectChooser({
               )}
               active={activeEffectListIndex === 3}
             >
-              <ContentWrapper>{__('Pan Up', 'web-stories')}</ContentWrapper>
-              <PanBottomAnimation>
-                {__('Pan Up', 'web-stories')}
-              </PanBottomAnimation>
+              <WithTooltip title={backgroundTooltip} placement="left">
+                <ContentWrapper>{__('Pan Up', 'web-stories')}</ContentWrapper>
+                <PanBottomAnimation>
+                  {__('Pan Up', 'web-stories')}
+                </PanBottomAnimation>
+              </WithTooltip>
             </GridItem>
             <GridItem
               aria-label={__('Pan Down Effect', 'web-stories')}
@@ -387,8 +401,12 @@ export default function EffectChooser({
               )}
               active={activeEffectListIndex === 4}
             >
-              <ContentWrapper>{__('Pan Down', 'web-stories')}</ContentWrapper>
-              <PanTopAnimation>{__('Pan Down', 'web-stories')}</PanTopAnimation>
+              <WithTooltip title={backgroundTooltip} placement="left">
+                <ContentWrapper>{__('Pan Down', 'web-stories')}</ContentWrapper>
+                <PanTopAnimation>
+                  {__('Pan Down', 'web-stories')}
+                </PanTopAnimation>
+              </WithTooltip>
             </GridItem>
             <GridItemHalfRow
               aria-label={__('Zoom In Effect', 'web-stories')}

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -155,14 +155,13 @@ const NoEffect = styled(GridItemFullRow)`
  */
 
 const getDirectionalEffect = (effect, direction) =>
-  `${effect} ${direction}`.trim();
+  direction ? `${effect} ${direction}`.trim() : effect;
 
 const FOREGROUND_EFFECTS_LIST = [
   'No Effect',
   ANIMATION_EFFECTS.DROP.value,
   ANIMATION_EFFECTS.FADE_IN.value,
   `${ANIMATION_EFFECTS.FLY_IN.value} ${DIRECTION.LEFT_TO_RIGHT}`,
-
   `${ANIMATION_EFFECTS.FLY_IN.value} ${DIRECTION.TOP_TO_BOTTOM}`,
   `${ANIMATION_EFFECTS.FLY_IN.value} ${DIRECTION.BOTTOM_TO_TOP}`,
   `${ANIMATION_EFFECTS.FLY_IN.value} ${DIRECTION.RIGHT_TO_LEFT}`,
@@ -209,15 +208,15 @@ export default function EffectChooser({
   }, []);
 
   const getDisabledBackgroundEffects = useCallback(() => {
-    const disabledDirectionalEffects = Object.entries(
-      disabledTypeOptionsMap
-    ).reduce(
-      (directionalEffects, [effect, directions]) => [
-        ...directionalEffects,
-        ...(directions || []).map((dir) => getDirectionalEffect(effect, dir)),
-      ],
-      []
-    );
+    const disabledDirectionalEffects = Object.entries(disabledTypeOptionsMap)
+      .map(([effect, val]) => [effect, val.options])
+      .reduce(
+        (directionalEffects, [effect, directions]) => [
+          ...directionalEffects,
+          ...(directions || []).map((dir) => getDirectionalEffect(effect, dir)),
+        ],
+        []
+      );
     return BACKGROUND_EFFECTS_LIST.filter((directionalEffect) =>
       disabledDirectionalEffects.includes(directionalEffect)
     );
@@ -295,8 +294,10 @@ export default function EffectChooser({
   }, [focusedValue, focusedIndex, disabledBackgroundEffects]);
 
   const handleOnSelect = useCallback(
-    (event, effect, animation) => {
-      const isEffectDisabled = disabledBackgroundEffects.includes(effect);
+    (event, directionalEffect, animation) => {
+      const isEffectDisabled = disabledBackgroundEffects.includes(
+        directionalEffect
+      );
 
       if (isEffectDisabled) {
         event.preventDefault();
@@ -329,23 +330,10 @@ export default function EffectChooser({
                   panDir: DIRECTION.LEFT_TO_RIGHT,
                 })
               }
-              active={activeEffectListIndex === 1}
-            >
-              <ContentWrapper>{__('Zoom', 'web-stories')}</ContentWrapper>
-              <ZoomOutAnimation>{__('Zoom', 'web-stories')}</ZoomOutAnimation>
-            </GridItemFullRow>
-            <GridItem
-              aria-label={__('Pan Left Effect', 'web-stories')}
-              onClick={(event) =>
-                handleOnSelect(event, PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT], {
-                  animation: BACKGROUND_ANIMATION_EFFECTS.PAN.value,
-                  panDir: DIRECTION.LEFT_TO_RIGHT,
-                })
-              }
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT]
               )}
-              active={activeEffectListIndex === 2}
+              active={activeEffectListIndex === 1}
             >
               <WithTooltip
                 title={
@@ -376,7 +364,7 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.RIGHT_TO_LEFT]
               )}
-              active={activeEffectListIndex === 3}
+              active={activeEffectListIndex === 2}
             >
               <WithTooltip
                 title={
@@ -409,7 +397,7 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.BOTTOM_TO_TOP]
               )}
-              active={activeEffectListIndex === 4}
+              active={activeEffectListIndex === 3}
             >
               <WithTooltip
                 title={
@@ -440,7 +428,7 @@ export default function EffectChooser({
               aria-disabled={disabledBackgroundEffects.includes(
                 PAN_MAPPING[DIRECTION.TOP_TO_BOTTOM]
               )}
-              active={activeEffectListIndex === 5}
+              active={activeEffectListIndex === 4}
             >
               <WithTooltip
                 title={
@@ -460,6 +448,94 @@ export default function EffectChooser({
                 </PanTopAnimation>
               </WithTooltip>
             </GridItem>
+            <GridItemHalfRow
+              aria-label={__('Zoom In Effect', 'web-stories')}
+              onClick={(event) =>
+                handleOnSelect(
+                  event,
+                  getDirectionalEffect(
+                    BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                    SCALE_DIRECTION.SCALE_IN
+                  ),
+                  {
+                    animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                    zoomDirection: SCALE_DIRECTION.SCALE_IN,
+                  }
+                )
+              }
+              aria-disabled={disabledBackgroundEffects.includes(
+                getDirectionalEffect(
+                  BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                  SCALE_DIRECTION.SCALE_IN
+                )
+              )}
+              active={activeEffectListIndex === 5}
+            >
+              <WithTooltip
+                title={
+                  disabledBackgroundEffects.includes(
+                    getDirectionalEffect(
+                      BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                      SCALE_DIRECTION.SCALE_IN
+                    )
+                  )
+                    ? disabledTypeOptionsMap[
+                        BACKGROUND_ANIMATION_EFFECTS.ZOOM.value
+                      ]?.tooltip
+                    : ''
+                }
+                placement="left"
+              >
+                <ContentWrapper>{__('Zoom In', 'web-stories')}</ContentWrapper>
+                <ZoomInAnimation>
+                  {__('Zoom In', 'web-stories')}
+                </ZoomInAnimation>
+              </WithTooltip>
+            </GridItemHalfRow>
+            <GridItemHalfRow
+              aria-label={__('Zoom Out Effect', 'web-stories')}
+              onClick={(event) =>
+                handleOnSelect(
+                  event,
+                  getDirectionalEffect(
+                    BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                    SCALE_DIRECTION.SCALE_OUT
+                  ),
+                  {
+                    animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                    zoomDirection: SCALE_DIRECTION.SCALE_OUT,
+                  }
+                )
+              }
+              aria-disabled={disabledBackgroundEffects.includes(
+                getDirectionalEffect(
+                  BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                  SCALE_DIRECTION.SCALE_OUT
+                )
+              )}
+              active={activeEffectListIndex === 6}
+            >
+              <WithTooltip
+                title={
+                  disabledBackgroundEffects.includes(
+                    getDirectionalEffect(
+                      BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                      SCALE_DIRECTION.SCALE_OUT
+                    )
+                  )
+                    ? disabledTypeOptionsMap[
+                        BACKGROUND_ANIMATION_EFFECTS.ZOOM.value
+                      ]?.tooltip
+                    : ''
+                }
+                placement="left"
+              >
+                <ContentWrapper>{__('Zoom Out', 'web-stories')}</ContentWrapper>
+                <ZoomOutAnimation>
+                  {__('Zoom Out', 'web-stories')}
+                </ZoomOutAnimation>
+              </WithTooltip>
+            </GridItemHalfRow>
           </>
         ) : (
           <>

--- a/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
@@ -111,6 +111,9 @@ EffectChooserDropdown.propTypes = {
   selectedEffectType: PropTypes.string,
   onNoEffectSelected: PropTypes.func.isRequired,
   disabledTypeOptionsMap: PropTypes.objectOf(
-    PropTypes.arrayOf(PropTypes.string)
+    PropTypes.shape({
+      tooltip: PropTypes.string,
+      options: PropTypes.arrayOf(PropTypes.string),
+    })
   ),
 };

--- a/assets/src/edit-story/components/panels/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/animation/effectInput.js
@@ -52,6 +52,7 @@ function EffectInput({
   field,
   onChange,
   disabledOptions,
+  tooltip,
 }) {
   const rangeId = `range-${uuidv4()}`;
 
@@ -94,10 +95,10 @@ function EffectInput({
       return (
         <DirectionRadioInput
           value={valueForField}
-          directions={effectProps[field].values?.filter(
-            (v) => !disabledOptions.includes(v)
-          )}
+          directions={effectProps[field].values}
           onChange={directionControlOnChange}
+          disabled={disabledOptions}
+          tooltip={tooltip}
         />
       );
     default:
@@ -123,6 +124,7 @@ EffectInput.propTypes = {
   field: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   disabledOptions: PropTypes.arrayOf(PropTypes.string),
+  tooltip: PropTypes.string,
 };
 
 export default EffectInput;

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -130,7 +130,7 @@ function EffectPanel({
           handleInputChange({ [field]: value }, submitArg)
         }
         disabledOptions={disabledTypeOptionsMap[type]?.options || []}
-        tooltip={disabledTypeOptionsMap[type]?.tooltip || ''}
+        tooltip={disabledTypeOptionsMap[type]?.tooltip}
       />
     </AnimationGridField>
   ));
@@ -142,9 +142,10 @@ EffectPanel.propTypes = {
   animation: PropTypes.shape(AnimationProps),
   onChange: PropTypes.func.isRequired,
   disabledTypeOptionsMap: PropTypes.objectOf(
-    PropTypes.objectOf(
-      PropTypes.oneOf([PropTypes.string, PropTypes.arrayOf(PropTypes.string)])
-    )
+    PropTypes.shape({
+      tooltip: PropTypes.string,
+      options: PropTypes.arrayOf(PropTypes.string),
+    })
   ),
 };
 

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -129,7 +129,8 @@ function EffectPanel({
         onChange={(value, submitArg) =>
           handleInputChange({ [field]: value }, submitArg)
         }
-        disabledOptions={disabledTypeOptionsMap[type] || []}
+        disabledOptions={disabledTypeOptionsMap[type]?.options || []}
+        tooltip={disabledTypeOptionsMap[type]?.tooltip || ''}
       />
     </AnimationGridField>
   ));
@@ -141,7 +142,9 @@ EffectPanel.propTypes = {
   animation: PropTypes.shape(AnimationProps),
   onChange: PropTypes.func.isRequired,
   disabledTypeOptionsMap: PropTypes.objectOf(
-    PropTypes.arrayOf(PropTypes.string)
+    PropTypes.objectOf(
+      PropTypes.oneOf([PropTypes.string, PropTypes.arrayOf(PropTypes.string)])
+    )
   ),
 };
 

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -51,6 +51,11 @@ import EffectChooserDropdown from './effectChooserDropdown';
 
 const ANIMATION_PROPERTY = 'animation';
 
+const backgroundAnimationTooltip = __(
+  'The bg image is too small to animate. Double click on the bg & scale the image before applying the animation.',
+  'web-stories'
+);
+
 function AnimationPanel({
   selectedElements,
   selectedElementAnimations,
@@ -172,16 +177,22 @@ function AnimationPanel({
         BG_MAX_SCALE,
       ]);
       return {
-        [BACKGROUND_ANIMATION_EFFECTS.PAN.value]: [
-          !hasOffset.bottom && DIRECTION.TOP_TO_BOTTOM,
-          !hasOffset.left && DIRECTION.RIGHT_TO_LEFT,
-          !hasOffset.top && DIRECTION.BOTTOM_TO_TOP,
-          !hasOffset.right && DIRECTION.LEFT_TO_RIGHT,
-        ].filter(Boolean),
-        [BACKGROUND_ANIMATION_EFFECTS.ZOOM.value]: [
-          normalizedScale <= 0.01 && SCALE_DIRECTION.SCALE_IN,
-          normalizedScale >= 0.99 && SCALE_DIRECTION.SCALE_OUT,
-        ].filter(Boolean),
+        [BACKGROUND_ANIMATION_EFFECTS.PAN.value]: {
+          tooltip: backgroundAnimationTooltip,
+          options: [
+            !hasOffset.bottom && DIRECTION.TOP_TO_BOTTOM,
+            !hasOffset.left && DIRECTION.RIGHT_TO_LEFT,
+            !hasOffset.top && DIRECTION.BOTTOM_TO_TOP,
+            !hasOffset.right && DIRECTION.LEFT_TO_RIGHT,
+          ].filter(Boolean),
+        },
+        [BACKGROUND_ANIMATION_EFFECTS.ZOOM.value]: {
+          tooltip: backgroundAnimationTooltip,
+          options: [
+            normalizedScale <= 0.01 && SCALE_DIRECTION.SCALE_IN,
+            normalizedScale >= 0.99 && SCALE_DIRECTION.SCALE_OUT,
+          ].filter(Boolean),
+        },
       };
     }
     return {};

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -52,7 +52,7 @@ import EffectChooserDropdown from './effectChooserDropdown';
 const ANIMATION_PROPERTY = 'animation';
 
 const backgroundAnimationTooltip = __(
-  'The bg image is too small to animate. Double click on the bg & scale the image before applying the animation.',
+  'The background image is too small to animate. Double click on the bg & scale the image before applying the animation.',
   'web-stories'
 );
 


### PR DESCRIPTION
## Summary
- Adds tooltips to disabled background animations and directional options
- Updates styling of the directional selector to latest designs https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories---Post-Stable?node-id=1923%3A424212

## Relevant Technical Choices
NA

## To-do
Accommodate for bg zoom when we update to designs.

## User-facing changes
Hover over a disabled animation and see a tooltip with a helpful message appear.

## Testing Instructions
Create or go to exisiting story in editor -> add some bg media -> go to add an animation to the media -> see that any disabled options have a tooltip -> click on a pan direction that's not disabled -> go to the directional selector and see that any disabled directions also have a tooltip

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5514 
