### PR TITLE
Animation: Update BG Zoom

### DIFF
--- a/assets/src/animation/effects/backgroundZoom/animationProps.js
+++ b/assets/src/animation/effects/backgroundZoom/animationProps.js
@@ -17,7 +17,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -27,7 +27,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES } from '../../constants';
+import { FIELD_TYPES, SCALE_DIRECTION } from '../../constants';
 import { AnimationInputPropTypes } from '../types';
 
 export const ZoomEffectInputPropTypes = {
@@ -35,10 +35,16 @@ export const ZoomEffectInputPropTypes = {
 };
 
 export default {
-  normalizedScaleFrom: {
-    label: __('Scale From', 'web-stories'),
-    tooltip: __('Slide between min and max zoom amounts', 'web-stories'),
-    type: FIELD_TYPES.RANGE,
-    defaultValue: 0,
+  zoomDirection: {
+    label: __('Direction', 'web-stories'),
+    tooltip: sprintf(
+      /* translators: 1: scaleIn. 2: scaleOut */
+      __('Valid values are %1$s or %2$s', 'web-stories'),
+      'zoomIn',
+      'zoomOut'
+    ),
+    type: FIELD_TYPES.DIRECTION_PICKER,
+    values: [SCALE_DIRECTION.SCALE_IN, SCALE_DIRECTION.SCALE_OUT],
+    defaultValue: SCALE_DIRECTION.SCALE_OUT,
   },
 };

--- a/assets/src/animation/effects/backgroundZoom/index.js
+++ b/assets/src/animation/effects/backgroundZoom/index.js
@@ -17,13 +17,13 @@
 /**
  * Internal dependencies
  */
-import { BG_MIN_SCALE, BG_MAX_SCALE } from '../../constants';
+import { BG_MIN_SCALE, BG_MAX_SCALE, SCALE_DIRECTION } from '../../constants';
 import { AnimationZoom } from '../../parts/zoom';
 import { lerp } from '../../utils';
 
 export function EffectBackgroundZoom({
   element,
-  normalizedScaleFrom = 0.75,
+  zoomDirection = SCALE_DIRECTION.SCALE_OUT,
   duration = 1000,
   delay,
   easing,
@@ -32,8 +32,9 @@ export function EffectBackgroundZoom({
   // at element scale 400, the range should be [1/4, 1]
   // at element scale 100, the range should be [1, 4]
   const range = [BG_MIN_SCALE / element.scale, BG_MAX_SCALE / element.scale];
+
   return AnimationZoom({
-    zoomFrom: lerp(normalizedScaleFrom, range),
+    zoomFrom: lerp(zoomDirection === SCALE_DIRECTION.SCALE_OUT ? 1 : 0, range),
     zoomTo: 1,
     duration,
     delay,

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -256,18 +256,22 @@ export const DirectionRadioInput = ({ value, directions = [], onChange }) => {
   const flattenedDirections = useMemo(() => {
     const dir = [];
     if (
-      directions.includes(SCALE_DIRECTION.SCALE_IN) &&
-      directions.includes(SCALE_DIRECTION.SCALE_OUT)
+      !directions.includes(SCALE_DIRECTION.SCALE_OUT) &&
+      !directions.includes(SCALE_DIRECTION.SCALE_IN)
     ) {
-      // Controlling order these get added to flattenedDirections makes sure the indexable order makes sense for keyboard users
-      dir.push(
-        SCALE_DIRECTION_MAP.SCALE_IN[0],
-        SCALE_DIRECTION_MAP.SCALE_OUT[0],
-        SCALE_DIRECTION_MAP.SCALE_IN[1],
-        SCALE_DIRECTION_MAP.SCALE_OUT[1]
-      );
-    } else {
       dir.push(...directions);
+    } else {
+      // Controlling order these get added to flattenedDirections makes sure the indexable order makes sense for keyboard users
+      directions.includes(SCALE_DIRECTION.SCALE_OUT) &&
+        dir.push(
+          SCALE_DIRECTION_MAP.SCALE_OUT[0],
+          SCALE_DIRECTION_MAP.SCALE_OUT[1]
+        );
+      directions.includes(SCALE_DIRECTION.SCALE_IN) &&
+        dir.push(
+          SCALE_DIRECTION_MAP.SCALE_IN[0],
+          SCALE_DIRECTION_MAP.SCALE_IN[1]
+        );
     }
     return dir;
   }, [directions]);

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -183,22 +183,10 @@ const PAN_MAPPING = {
 };
 const BACKGROUND_EFFECTS_LIST = [
   'No Effect',
-  getDirectionalEffect(
-    BACKGROUND_ANIMATION_EFFECTS.PAN.value,
-    DIRECTION.LEFT_TO_RIGHT
-  ),
-  getDirectionalEffect(
-    BACKGROUND_ANIMATION_EFFECTS.PAN.value,
-    DIRECTION.RIGHT_TO_LEFT
-  ),
-  getDirectionalEffect(
-    BACKGROUND_ANIMATION_EFFECTS.PAN.value,
-    DIRECTION.BOTTOM_TO_TOP
-  ),
-  getDirectionalEffect(
-    BACKGROUND_ANIMATION_EFFECTS.PAN.value,
-    DIRECTION.TOP_TO_BOTTOM
-  ),
+  PAN_MAPPING[DIRECTION.LEFT_TO_RIGHT],
+  PAN_MAPPING[DIRECTION.RIGHT_TO_LEFT],
+  PAN_MAPPING[DIRECTION.BOTTOM_TO_TOP],
+  PAN_MAPPING[DIRECTION.TOP_TO_BOTTOM],
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_IN}`,
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_OUT}`,
 ];
@@ -219,58 +207,36 @@ export default function EffectChooser({
     loadStylesheet(`${GOOGLE_MENU_FONT_URL}?family=Teko`).catch(function () {});
   }, []);
 
-  const getDisabledBackgroundEffects = useCallback(
-    () => {
-      const disabledDirectionalEffects = Object.entries(
-        disabledTypeOptionsMap
-      ).reduce(
-        (directionalEffects, [effect, directions]) => [
-          ...directionalEffects,
-          ...(directions || []).map((dir) => getDirectionalEffect(effect, dir)),
-        ],
-        []
-      );
-      return BACKGROUND_EFFECTS_LIST.filter((directionalEffect) =>
-        disabledDirectionalEffects.includes(directionalEffect)
-      );
-    },
-
-    // const isDisabled = disabledTypeOptionsMap[
-    //   'effect-background-pan'
-    // ].find((disabledOption) => currentEffect.endsWith(disabledOption));
-
-    // if (isDisabled) {
-    //   return currentEffect;
-    // }
-    // return undefined;
-    // });
-    [disabledTypeOptionsMap]
-  );
+  const getDisabledBackgroundEffects = useCallback(() => {
+    const disabledDirectionalEffects = Object.entries(
+      disabledTypeOptionsMap
+    ).reduce(
+      (directionalEffects, [effect, directions]) => [
+        ...directionalEffects,
+        ...(directions || []).map((dir) => getDirectionalEffect(effect, dir)),
+      ],
+      []
+    );
+    return BACKGROUND_EFFECTS_LIST.filter((directionalEffect) =>
+      disabledDirectionalEffects.includes(directionalEffect)
+    );
+  }, [disabledTypeOptionsMap]);
 
   const availableListOptions = isBackgroundEffects
     ? BACKGROUND_EFFECTS_LIST
     : FOREGROUND_EFFECTS_LIST;
   const listLength = availableListOptions.length;
 
-  const disabledBackgroundEffects = useMemo(() => {
-    if (isBackgroundEffects) {
-      if (disabledTypeOptionsMap?.['effect-background-pan']) {
-        return getDisabledBackgroundEffects();
-      }
-      return [];
-    }
-    return [];
-  }, [
-    disabledTypeOptionsMap,
-    getDisabledBackgroundEffects,
-    isBackgroundEffects,
-  ]);
+  const disabledBackgroundEffects = useMemo(
+    () => (isBackgroundEffects ? getDisabledBackgroundEffects() : []),
+    [getDisabledBackgroundEffects, isBackgroundEffects]
+  );
 
   // set existing active effect with a ref, specify when dropdown is opened which version of an effect it is since some have many options
-  const activeEffectListValue = useMemo(() => `${value} ${direction}`.trim(), [
-    direction,
-    value,
-  ]);
+  const activeEffectListValue = useMemo(
+    () => getDirectionalEffect(value, direction),
+    [direction, value]
+  );
 
   const activeEffectListIndex = useMemo(() => {
     const bgListIndex = BACKGROUND_EFFECTS_LIST.indexOf(activeEffectListValue);
@@ -429,29 +395,33 @@ export default function EffectChooser({
               onClick={(event) =>
                 handleOnSelect(event, BACKGROUND_ANIMATION_EFFECTS.ZOOM.value, {
                   animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
-                  zoomDirection: SCALE_DIRECTION.SCALE_IN.value,
+                  zoomDirection: SCALE_DIRECTION.SCALE_IN,
                 })
               }
               aria-disabled={disabledBackgroundEffects.includes(
-                SCALE_DIRECTION.SCALE_IN
+                getDirectionalEffect(
+                  BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                  SCALE_DIRECTION.SCALE_IN
+                )
               )}
               active={activeEffectListIndex === 5}
             >
               <ContentWrapper>{__('Zoom In', 'web-stories')}</ContentWrapper>
-              <ZoomOutAnimation>
-                {__('Zoom In', 'web-stories')}
-              </ZoomOutAnimation>
+              <ZoomInAnimation>{__('Zoom In', 'web-stories')}</ZoomInAnimation>
             </GridItemHalfRow>
             <GridItemHalfRow
               aria-label={__('Zoom Out Effect', 'web-stories')}
               onClick={(event) =>
                 handleOnSelect(event, BACKGROUND_ANIMATION_EFFECTS.ZOOM.value, {
                   animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
-                  zoomDirection: SCALE_DIRECTION.SCALE_OUT.value,
+                  zoomDirection: SCALE_DIRECTION.SCALE_OUT,
                 })
               }
               aria-disabled={disabledBackgroundEffects.includes(
-                SCALE_DIRECTION.SCALE_OUT
+                getDirectionalEffect(
+                  BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                  SCALE_DIRECTION.SCALE_OUT
+                )
               )}
               active={activeEffectListIndex === 6}
             >

--- a/assets/src/edit-story/components/panels/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/animation/effectPanel.js
@@ -47,10 +47,10 @@ export function getEffectName(type) {
 }
 
 export function getEffectDirection(effect = {}) {
-  if (effect.zoomFrom || effect.zoomFrom === 0) {
-    return effect.zoomFrom;
-  } else if (effect.zoomDir) {
-    return effect.zoomDir;
+  if (effect.zoomDirection) {
+    return effect.zoomDirection;
+  } else if (effect.scaleDirection) {
+    return effect.scaleDirection;
   } else if (effect.flyInDir) {
     return effect.flyInDir;
   } else if (effect.rotateInDir) {

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -36,6 +36,7 @@ import {
   BG_MAX_SCALE,
   BG_MIN_SCALE,
   DIRECTION,
+  SCALE_DIRECTION,
   progress,
   hasOffsets,
   STORY_ANIMATION_STATE,
@@ -166,12 +167,20 @@ function AnimationPanel({
   const disabledTypeOptionsMap = useMemo(() => {
     if (selectedElements[0]?.isBackground) {
       const hasOffset = hasOffsets({ element: selectedElements[0] });
+      const normalizedScale = progress(selectedElements[0]?.scale || 0, [
+        BG_MIN_SCALE,
+        BG_MAX_SCALE,
+      ]);
       return {
         [BACKGROUND_ANIMATION_EFFECTS.PAN.value]: [
           !hasOffset.bottom && DIRECTION.TOP_TO_BOTTOM,
           !hasOffset.left && DIRECTION.RIGHT_TO_LEFT,
           !hasOffset.top && DIRECTION.BOTTOM_TO_TOP,
           !hasOffset.right && DIRECTION.LEFT_TO_RIGHT,
+        ].filter(Boolean),
+        [BACKGROUND_ANIMATION_EFFECTS.ZOOM.value]: [
+          normalizedScale < 0.01 && SCALE_DIRECTION.SCALE_IN,
+          normalizedScale > 0.99 && SCALE_DIRECTION.SCALE_OUT,
         ].filter(Boolean),
       };
     }

--- a/assets/src/edit-story/components/panels/animation/panel.js
+++ b/assets/src/edit-story/components/panels/animation/panel.js
@@ -179,8 +179,8 @@ function AnimationPanel({
           !hasOffset.right && DIRECTION.LEFT_TO_RIGHT,
         ].filter(Boolean),
         [BACKGROUND_ANIMATION_EFFECTS.ZOOM.value]: [
-          normalizedScale < 0.01 && SCALE_DIRECTION.SCALE_IN,
-          normalizedScale > 0.99 && SCALE_DIRECTION.SCALE_OUT,
+          normalizedScale <= 0.01 && SCALE_DIRECTION.SCALE_IN,
+          normalizedScale >= 0.99 && SCALE_DIRECTION.SCALE_OUT,
         ].filter(Boolean),
       };
     }


### PR DESCRIPTION
## Summary
Updates bg zoom to use direction selector instead of scale slider & adds dynamic disable.

## Relevant Technical Choices
Followed existing patterns

## To-do
Merge in the tooltip PR which touches a lot of the same stuff as this PR (and make sure nothing breaks)
https://github.com/google/web-stories-wp/pull/5598

## User-facing changes
BG Zoom should now use a direction selector instead of the slider in the animation's input.

## Testing Instructions
Create new story or edit existing one -> add background media -> add a zoom animation and see that there in/out now -> rescale the bg image and see that the correct directions disable when bg scaled all the way up or down (should be disabled in both direction selector and effect chooser)

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5521 
