### PR TITLE
Animation: Updated Rotation Effect Inputs to Match Latest Designs

### DIFF
--- a/assets/src/animation/effects/rotateIn/animationProps.js
+++ b/assets/src/animation/effects/rotateIn/animationProps.js
@@ -32,8 +32,6 @@ import { AnimationInputPropTypes } from '../types';
 
 export const RotateInEffectInputPropTypes = {
   rotateInDir: PropTypes.shape(AnimationInputPropTypes),
-  stopAngle: PropTypes.shape(AnimationInputPropTypes),
-  numberOfRotations: PropTypes.shape(AnimationInputPropTypes),
 };
 
 export default {
@@ -42,15 +40,5 @@ export default {
     type: FIELD_TYPES.DIRECTION_PICKER,
     values: [DIRECTION.LEFT_TO_RIGHT, DIRECTION.RIGHT_TO_LEFT],
     defaultValue: DIRECTION.LEFT_TO_RIGHT,
-  },
-  stopAngle: {
-    label: __('Angle', 'web-stories'),
-    type: FIELD_TYPES.NUMBER,
-    defaultValue: 0,
-  },
-  numberOfRotations: {
-    label: __('Rotations', 'web-stories'),
-    type: FIELD_TYPES.NUMBER,
-    defaultValue: 1,
   },
 };

--- a/assets/src/animation/effects/rotateIn/index.js
+++ b/assets/src/animation/effects/rotateIn/index.js
@@ -30,11 +30,12 @@ import { AnimationSpin } from '../../parts/spin';
 import getOffPageOffset from '../../utils/getOffPageOffset';
 import { DIRECTION } from '../../constants';
 
+const numberOfRotations = 1;
+const stopAngle = 0;
+
 export function EffectRotateIn({
   duration = 1000,
   rotateInDir = DIRECTION.LEFT_TO_RIGHT,
-  numberOfRotations = 1,
-  stopAngle = 0,
   easing = 'cubic-bezier(0.4, 0.4, 0.0, 1)',
   delay,
   element,


### PR DESCRIPTION
## Summary
Just removes `angle` and `rotations` from the rotations effect to match the latest designs here:
https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories---Post-Stable?node-id=1923%3A424212

Implicitly eliminates the ability for the user to break the animation contract that everything animates into its final state.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
Rotation animation effect should no longer have a `angle` & `rotations` input.

## Testing Instructions
Create new story or edit exisiting one -> select a foreground shape -> apply rotation animation to it -> should no longer see `angle` or `rotations` inputs.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5600 
