### PR TITLE
Fix deprecation warning for embed block on WordPress 5.6

### DIFF
--- a/assets/src/story-embed-block/block/embedControls.js
+++ b/assets/src/story-embed-block/block/embedControls.js
@@ -37,9 +37,17 @@ const POSTER_ALLOWED_MEDIA_TYPES = ['image'];
 
 const FallbackComponent = ({ children }) => children;
 
-const { Button, BaseControl, TextControl, PanelBody, PanelRow } = Components;
-// ToolbarGroup is only available in Gutenberg 7.0 or later, so it does not exist in WP 5.3.
-const ToolbarGroup = Components.ToolbarGroup || FallbackComponent;
+// Note: ToolbarGroup and ToolbarButton are only available in Gutenberg 7.0 or later,
+// so they do not exist in WP 5.3.
+const {
+  Button,
+  BaseControl,
+  TextControl,
+  PanelBody,
+  PanelRow,
+  ToolbarGroup = FallbackComponent,
+  ToolbarButton,
+} = Components;
 
 const EmbedControls = (props) => {
   const {
@@ -79,12 +87,26 @@ const EmbedControls = (props) => {
     <>
       <BlockControls>
         <ToolbarGroup>
-          <Button
-            className="components-toolbar__control"
-            label={__('Edit URL', 'web-stories')}
-            icon="edit"
-            onClick={switchBackToURLInput}
-          />
+          {/*
+          Using ToolbarButton if available is mandatory as other usage is deprecated
+          for accessibility reasons and causes console warnings.
+          See https://github.com/WordPress/gutenberg/pull/23316
+          See https://developer.wordpress.org/block-editor/components/toolbar-button/#inside-blockcontrols
+          */}
+          {ToolbarButton ? (
+            <ToolbarButton
+              title={__('Edit URL', 'web-stories')}
+              icon="edit"
+              onClick={switchBackToURLInput}
+            />
+          ) : (
+            <Button
+              className="components-toolbar__control"
+              label={__('Edit URL', 'web-stories')}
+              icon="edit"
+              onClick={switchBackToURLInput}
+            />
+          )}
         </ToolbarGroup>
       </BlockControls>
       <InspectorControls>


### PR DESCRIPTION
## Summary

Fixes a deprecation warning in the embed block, which causes e2e tests against WordPress 5.6 to fail.

I thought we were running e2e tests against 5.6,  but neither #5423 / #5338 nor #5350 / #4788 did actually do that.

Hence we are only noticing this now that 5.6 is released.

## Relevant Technical Choices

If `ToolbarButton` is not available, use regular button.

Simplifies fallback for `ToolbarGroup`.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None

## Testing Instructions

Verify that there are no deprecation warnings in the console when editing the block

E2E tests should pass

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
