### PR TITLE
Animation Panel: Effect direction input indexed for clockwise keyboard navigation

### DIFF
--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -66,7 +66,7 @@ const Svg = styled.svg`
 `;
 
 const Icon = styled.div`
-  padding: 6px;
+  padding: 4px;
   border-radius: 4px;
   stroke: #e4e5e6;
   stroke-width: 1px;
@@ -276,6 +276,28 @@ const getPostfixFromCamelCase = (camelCase = '') => {
   return split[split.length - 1];
 };
 
+const STANDARD_NAV_ORDER = [
+  DIRECTION.TOP_TO_BOTTOM,
+  DIRECTION.RIGHT_TO_LEFT,
+  DIRECTION.BOTTOM_TO_TOP,
+  DIRECTION.LEFT_TO_RIGHT,
+];
+
+const SCALE_NAV_ORDER = [
+  SCALE_DIRECTION.SCALE_IN_TOP_LEFT,
+  SCALE_DIRECTION.SCALE_OUT_TOP_RIGHT,
+  SCALE_DIRECTION.SCALE_IN_BOTTOM_RIGHT,
+  SCALE_DIRECTION.SCALE_OUT_BOTTOM_LEFT,
+];
+
+const sortInputOrderForKeyboardUsability = (
+  directions,
+  directionOrder = STANDARD_NAV_ORDER
+) =>
+  directions.sort(
+    (a, b) => directionOrder.indexOf(a) - directionOrder.indexOf(b)
+  );
+
 export const DirectionRadioInput = ({
   value,
   directions = [],
@@ -291,22 +313,21 @@ export const DirectionRadioInput = ({
       !directions.includes(SCALE_DIRECTION.SCALE_OUT) &&
       !directions.includes(SCALE_DIRECTION.SCALE_IN)
     ) {
-      dir.push(...directions);
+      dir.push(...sortInputOrderForKeyboardUsability(directions));
     } else {
-      // Controlling order these get added to flattenedDirections makes sure the indexable order makes sense for keyboard users
+      const scaleDir = [];
+
       directions.includes(SCALE_DIRECTION.SCALE_OUT) &&
-        dir.push(
-          SCALE_DIRECTION_MAP.SCALE_OUT[0],
-          SCALE_DIRECTION_MAP.SCALE_OUT[1]
-        );
+        scaleDir.push(...SCALE_DIRECTION_MAP.SCALE_OUT);
       directions.includes(SCALE_DIRECTION.SCALE_IN) &&
-        dir.push(
-          SCALE_DIRECTION_MAP.SCALE_IN[0],
-          SCALE_DIRECTION_MAP.SCALE_IN[1]
-        );
+        scaleDir.push(...SCALE_DIRECTION_MAP.SCALE_IN);
+      dir.push(
+        ...sortInputOrderForKeyboardUsability(scaleDir, SCALE_NAV_ORDER)
+      );
     }
     return dir;
   }, [directions]);
+
   useRadioNavigation(inputRef);
 
   return (

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -34,7 +34,7 @@ import {
 } from '../../../../animation';
 import useRadioNavigation from '../../form/shared/useRadioNavigation';
 import WithTooltip from '../../tooltip';
-import { useConfig } from '../../../../activation-notice/app/config';
+import { useConfig } from '../../../app/config';
 
 const Svg = styled.svg`
   display: block;

--- a/assets/src/edit-story/components/panels/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/animation/directionRadioInput.js
@@ -34,6 +34,7 @@ import {
 } from '../../../../animation';
 import useRadioNavigation from '../../form/shared/useRadioNavigation';
 import WithTooltip from '../../tooltip';
+import { useConfig } from '../../../../activation-notice/app/config';
 
 const Svg = styled.svg`
   display: block;
@@ -292,11 +293,15 @@ const SCALE_NAV_ORDER = [
 
 const sortInputOrderForKeyboardUsability = (
   directions,
-  directionOrder = STANDARD_NAV_ORDER
-) =>
-  directions.sort(
-    (a, b) => directionOrder.indexOf(a) - directionOrder.indexOf(b)
+  directionOrder,
+  isRTL
+) => {
+  const referenceOrder = isRTL ? directionOrder.reverse() : directionOrder;
+
+  return directions.sort(
+    (a, b) => referenceOrder.indexOf(a) - referenceOrder.indexOf(b)
   );
+};
 
 export const DirectionRadioInput = ({
   value,
@@ -306,6 +311,7 @@ export const DirectionRadioInput = ({
   tooltip,
 }) => {
   const inputRef = useRef();
+  const { isRTL } = useConfig();
 
   const flattenedDirections = useMemo(() => {
     const dir = [];
@@ -313,7 +319,13 @@ export const DirectionRadioInput = ({
       !directions.includes(SCALE_DIRECTION.SCALE_OUT) &&
       !directions.includes(SCALE_DIRECTION.SCALE_IN)
     ) {
-      dir.push(...sortInputOrderForKeyboardUsability(directions));
+      dir.push(
+        ...sortInputOrderForKeyboardUsability(
+          directions,
+          STANDARD_NAV_ORDER,
+          isRTL
+        )
+      );
     } else {
       const scaleDir = [];
 
@@ -322,11 +334,11 @@ export const DirectionRadioInput = ({
       directions.includes(SCALE_DIRECTION.SCALE_IN) &&
         scaleDir.push(...SCALE_DIRECTION_MAP.SCALE_IN);
       dir.push(
-        ...sortInputOrderForKeyboardUsability(scaleDir, SCALE_NAV_ORDER)
+        ...sortInputOrderForKeyboardUsability(scaleDir, SCALE_NAV_ORDER, isRTL)
       );
     }
     return dir;
-  }, [directions]);
+  }, [directions, isRTL]);
 
   useRadioNavigation(inputRef);
 


### PR DESCRIPTION
## Summary
We want to control the order the available directions are navigated by keyboard users  in the animation direction input. This ensures that available options are sorted clockwise around the UI - so top, right, bottom, left. 

## Relevant Technical Choices
- Sort available `directions` by an ordered reference array
- ordering the keyboard navigation of these inputs shows that there's an overlap when you have a value selected but move focus with keyboard, so adjusting button padding to subtract 2px to avoid this overlap.


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Animation direction input (Fly in, rotate, whoosh, scale) now has clockwise keyboard navigation. (top, right, bottom, left)

## Testing Instructions

Select an effect and apply an animation to it that has the ability to set direction (Fly in, rotate, whoosh, scale), use the keyboard to navigate through inputs, see focus update. Your focus should move like a clock hand through the options navigating around the square. 

Verify the same for background animations with pan and zoom. Disabled inputs are not focusable. 

---

<!-- Please reference the issue(s) this PR addresses. -->

addresses #5613 
