### PR TITLE
Fix popup location on RTL layouts

### DIFF
--- a/assets/src/edit-story/components/popup/index.js
+++ b/assets/src/edit-story/components/popup/index.js
@@ -59,6 +59,7 @@ const Container = styled.div.attrs(
     },
   })
 )`
+  /*! @noflip */
   left: 0px;
   top: 0px;
   position: fixed;


### PR DESCRIPTION
## Summary

Fixes popup location (e.g. front dropdown, animations dropdown) on RTL layouts

## Relevant Technical Choices

Prevent flipping of the CSS declaration needed for the exact popup positioning.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<img width="958" alt="Screenshot 2020-12-09 at 21 56 16" src="https://user-images.githubusercontent.com/841956/101686459-5eb79a00-3a69-11eb-9940-a347147a17c1.png">

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5428
