### PR TITLE
Animations: Fix animation inheriting parent transform

### DIFF
--- a/assets/src/animation/effects/drop/index.js
+++ b/assets/src/animation/effects/drop/index.js
@@ -17,7 +17,7 @@
  * Internal dependencies
  */
 import SimpleAnimation from '../../parts/simpleAnimation';
-import { getOffPageOffset, getGlobalSpace } from '../../utils';
+import { getGlobalSpace, getOffPageOffset } from '../../utils';
 
 const getMinTopOffset = (element) =>
   getOffPageOffset({

--- a/assets/src/animation/effects/drop/index.js
+++ b/assets/src/animation/effects/drop/index.js
@@ -17,7 +17,7 @@
  * Internal dependencies
  */
 import SimpleAnimation from '../../parts/simpleAnimation';
-import getOffPageOffset from '../../utils/getOffPageOffset';
+import { getOffPageOffset, getGlobalSpace } from '../../utils';
 
 const getMinTopOffset = (element) =>
   getOffPageOffset({
@@ -31,6 +31,7 @@ export function EffectDrop({
   duration = 1600,
   delay = 0,
 }) {
+  const global = getGlobalSpace(element);
   const minTopOffset = getMinTopOffset(element);
   const { offsetTop } = getOffPageOffset(element);
   const maxBounceHeight =
@@ -40,52 +41,52 @@ export function EffectDrop({
   const keyframes = [
     {
       offset: 0,
-      transform: `translate3d(0, ${maxBounceHeight}%, 0)`,
+      transform: global`translate3d(0, ${maxBounceHeight}%, 0)`,
       easing: 'cubic-bezier(.5, 0, 1, 1)',
     },
     {
       offset: 0.29,
-      transform: 'translate3d(0, 0%, 0)',
+      transform: global`translate3d(0, 0%, 0)`,
       easing: 'cubic-bezier(0, 0, .5, 1)',
     },
     {
       offset: 0.45,
-      transform: `translate3d(0, ${0.2812 * maxBounceHeight}%, 0)`,
+      transform: global`translate3d(0, ${0.2812 * maxBounceHeight}%, 0)`,
       easing: 'cubic-bezier(.5, 0, 1, 1)',
     },
     {
       offset: 0.61,
-      transform: 'translate3d(0, 0%, 0)',
+      transform: global`translate3d(0, 0%, 0)`,
       easing: 'cubic-bezier(0, 0, .5, 1)',
     },
     {
       offset: 0.71,
-      transform: `translate3d(0, ${0.0956 * maxBounceHeight}%, 0)`,
+      transform: global`translate3d(0, ${0.0956 * maxBounceHeight}%, 0)`,
       easing: 'cubic-bezier(.5, 0, 1, 1)',
     },
     {
       offset: 0.8,
-      transform: 'translate3d(0, 0%, 0)',
+      transform: global`translate3d(0, 0%, 0)`,
       easing: 'cubic-bezier(0, 0, .5, 1)',
     },
     {
       offset: 0.85,
-      transform: `translate3d(0, ${0.0359 * maxBounceHeight}%, 0)`,
+      transform: global`translate3d(0, ${0.0359 * maxBounceHeight}%, 0)`,
       easing: 'cubic-bezier(.5, 0, 1, 1)',
     },
     {
       offset: 0.92,
-      transform: 'translate3d(0, 0%, 0)',
+      transform: global`translate3d(0, 0%, 0)`,
       easing: 'cubic-bezier(0, 0, .5, 1)',
     },
     {
       offset: 0.96,
-      transform: `translate3d(0, ${0.0156 * maxBounceHeight}%, 0)`,
+      transform: global`translate3d(0, ${0.0156 * maxBounceHeight}%, 0)`,
       easing: 'cubic-bezier(.5, 0, 1, 1)',
     },
     {
       offset: 1,
-      transform: 'none',
+      transform: global`translate3d(0, 0%, 0)`,
       easing: 'cubic-bezier(0, 0, .5, 1)',
     },
   ];

--- a/assets/src/animation/effects/flyIn/index.js
+++ b/assets/src/animation/effects/flyIn/index.js
@@ -17,9 +17,9 @@
 /**
  * Internal dependencies
  */
+import { DIRECTION } from '../../constants';
 import { AnimationMove } from '../../parts/move';
 import { getOffPageOffset } from '../../utils';
-import { DIRECTION } from '../../constants';
 
 export function EffectFlyIn({
   duration = 600,

--- a/assets/src/animation/effects/flyIn/index.js
+++ b/assets/src/animation/effects/flyIn/index.js
@@ -18,7 +18,7 @@
  * Internal dependencies
  */
 import { AnimationMove } from '../../parts/move';
-import getOffPageOffset from '../../utils/getOffPageOffset';
+import { getOffPageOffset } from '../../utils';
 import { DIRECTION } from '../../constants';
 
 export function EffectFlyIn({
@@ -52,5 +52,6 @@ export function EffectFlyIn({
     duration,
     delay,
     easing,
+    element,
   });
 }

--- a/assets/src/animation/effects/rotateIn/index.js
+++ b/assets/src/animation/effects/rotateIn/index.js
@@ -18,17 +18,13 @@
  * External dependencies
  */
 import { v4 as uuidv4 } from 'uuid';
-
 /**
  * Internal dependencies
  */
-/**
- * Internal dependencies
- */
+import { DIRECTION } from '../../constants';
 import { AnimationMove } from '../../parts/move';
 import { AnimationSpin } from '../../parts/spin';
 import { getOffPageOffset } from '../../utils';
-import { DIRECTION } from '../../constants';
 
 const numberOfRotations = 1;
 const stopAngle = 0;

--- a/assets/src/animation/effects/rotateIn/index.js
+++ b/assets/src/animation/effects/rotateIn/index.js
@@ -27,7 +27,7 @@ import { v4 as uuidv4 } from 'uuid';
  */
 import { AnimationMove } from '../../parts/move';
 import { AnimationSpin } from '../../parts/spin';
-import getOffPageOffset from '../../utils/getOffPageOffset';
+import { getOffPageOffset } from '../../utils';
 import { DIRECTION } from '../../constants';
 
 const numberOfRotations = 1;
@@ -59,6 +59,7 @@ export function EffectRotateIn({
     duration,
     delay,
     easing,
+    element,
   });
 
   const {
@@ -76,6 +77,7 @@ export function EffectRotateIn({
     duration,
     delay,
     easing,
+    element,
   });
 
   return {

--- a/assets/src/animation/effects/twirlIn/index.js
+++ b/assets/src/animation/effects/twirlIn/index.js
@@ -18,6 +18,7 @@
  * Internal dependencies
  */
 import SimpleAnimation from '../../parts/simpleAnimation';
+import { getGlobalSpace } from '../../utils';
 
 const defaultTimings = {
   delay: 0,
@@ -28,21 +29,22 @@ const defaultTimings = {
 
 const animationName = `twirl-in`;
 
-const keyframes = [
-  {
-    transform: 'rotate(-540deg) scale(0.1)',
-    opacity: 0,
-  },
-  {
-    transform: 'none',
-    opacity: 1,
-  },
-];
-
 export function EffectTwirlIn({
   easing = 'cubic-bezier(0.4, 0.4, 0.0, 1)',
+  element,
   ...args
 }) {
+  const global = getGlobalSpace(element);
+  const keyframes = [
+    {
+      transform: global`rotate(-540deg) scale(0.1)`,
+      opacity: 0,
+    },
+    {
+      transform: 'none',
+      opacity: 1,
+    },
+  ];
   const timings = {
     ...defaultTimings,
     ...args,

--- a/assets/src/animation/effects/whooshIn/index.js
+++ b/assets/src/animation/effects/whooshIn/index.js
@@ -54,6 +54,7 @@ export function EffectWhooshIn({
     duration,
     delay,
     easing,
+    element,
   });
 
   const {

--- a/assets/src/animation/effects/whooshIn/index.js
+++ b/assets/src/animation/effects/whooshIn/index.js
@@ -18,15 +18,14 @@
  * External dependencies
  */
 import { v4 as uuidv4 } from 'uuid';
-
 /**
  * Internal dependencies
  */
-import { AnimationMove } from '../../parts/move';
+import { DIRECTION } from '../../constants';
 import { AnimationFade } from '../../parts/fade';
+import { AnimationMove } from '../../parts/move';
 import { AnimationZoom } from '../../parts/zoom';
 import getOffPageOffset from '../../utils/getOffPageOffset';
-import { DIRECTION } from '../../constants';
 
 export function EffectWhooshIn({
   duration = 600,

--- a/assets/src/animation/parts/move/index.js
+++ b/assets/src/animation/parts/move/index.js
@@ -18,7 +18,7 @@
  * Internal dependencies
  */
 import { ANIMATION_TYPES } from '../../constants';
-import { defaultUnit } from '../../utils/defaultUnit';
+import { defaultUnit, getGlobalSpace } from '../../utils';
 import SimpleAnimation from '../simpleAnimation';
 
 const defaults = {
@@ -30,8 +30,10 @@ export function AnimationMove({
   overflowHidden = false,
   offsetX = 0,
   offsetY = 0,
+  element,
   ...args
 }) {
+  const global = getGlobalSpace(element);
   const timings = {
     ...defaults,
     ...args,
@@ -40,11 +42,11 @@ export function AnimationMove({
   const animationName = `x-${offsetX}-y-${offsetY}-${ANIMATION_TYPES.MOVE}`;
   const keyframes = {
     transform: [
-      `translate3d(${defaultUnit(offsetX, 'px')}, ${defaultUnit(
+      global`translate3d(${defaultUnit(offsetX, 'px')}, ${defaultUnit(
         offsetY,
         'px'
       )}, 0)`,
-      'none',
+      global`translate3d(${defaultUnit(0, 'px')}, ${defaultUnit(0, 'px')}, 0)`,
     ],
   };
 

--- a/assets/src/animation/parts/spin/index.js
+++ b/assets/src/animation/parts/spin/index.js
@@ -18,7 +18,7 @@
  * Internal dependencies
  */
 import { ANIMATION_TYPES } from '../../constants';
-import { defaultUnit } from '../../utils/defaultUnit';
+import { defaultUnit, getGlobalSpace } from '../../utils';
 import SimpleAnimation from '../simpleAnimation';
 
 const defaults = {
@@ -26,7 +26,13 @@ const defaults = {
   duration: 1000,
 };
 
-export function AnimationSpin({ rotation = 0, stopAngle = 0, ...args }) {
+export function AnimationSpin({
+  rotation = 0,
+  stopAngle = 0,
+  element,
+  ...args
+}) {
+  const global = getGlobalSpace(element);
   const timings = {
     ...defaults,
     ...args,
@@ -34,8 +40,8 @@ export function AnimationSpin({ rotation = 0, stopAngle = 0, ...args }) {
 
   const animationName = `rot-${rotation}-${ANIMATION_TYPES.SPIN}`;
   const keyframes = [
-    { transform: `rotateZ(${defaultUnit(rotation, 'deg')})` },
-    { transform: `rotateZ(${defaultUnit(stopAngle, 'deg')})` },
+    { transform: global`rotateZ(${defaultUnit(rotation, 'deg')})` },
+    { transform: global`rotateZ(${defaultUnit(stopAngle, 'deg')})` },
   ];
 
   const { id, WAAPIAnimation, AMPTarget, AMPAnimation } = SimpleAnimation(

--- a/assets/src/animation/utils/getGlobalSpace.js
+++ b/assets/src/animation/utils/getGlobalSpace.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Just the functional equivalent of your baseline template literal.
+ *
+ * ```js
+ * const args = ['am', 'dog'];
+ * literal(['I ', ' a '], ...args)  === `I ${args[0]} a ${args[1]}`; // true
+ * ```
+ *
+ * @param {Array<string>} strings strings in template tag
+ * @param {Array<any>} args arguments in template tag
+ * @return {string} string result
+ */
+function literal(strings, ...args) {
+  return strings
+    .reduce((accum, str, i) => accum.concat([str, args[i]]), [])
+    .join('');
+}
+
+/**
+ * Given an element, this function returns a template tag
+ * that wraps any given string in a counter transform to reset the
+ * global coordinate space, then reapplies the original element
+ * transform to retain visual consistency.
+ *
+ * ```js
+ * const glabal = getGlobalSpace(element);
+ * const keyframes = [
+ *   transform: global`translate3d(0, ${pageHeightInElementPercent}%, 0)`,
+ *   transform: 'none'
+ * ];
+ * ```
+ *
+ * @param {*} element story element to derive counter transforms off of.
+ * @return {(s: string[], ...args: any[]) => string} template string tag that resets transform space.
+ */
+export function getGlobalSpace(element = {}) {
+  function global(...template) {
+    return `rotate(${-1 * element?.rotationAngle}deg) 
+    ${literal(...template)} 
+    rotate(${element?.rotationAngle}deg)`;
+  }
+  return element?.rotationAngle ? global : literal;
+}

--- a/assets/src/animation/utils/getGlobalSpace.js
+++ b/assets/src/animation/utils/getGlobalSpace.js
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * @typedef {import('../../edit-story/types').Element} Element
+ */
+
 /**
  * Just the functional equivalent of your baseline template literal.
  *
@@ -25,7 +30,7 @@
  * @param {Array<any>} args arguments in template tag
  * @return {string} string result
  */
-function literal(strings, ...args) {
+export function literal(strings, ...args) {
   return strings
     .reduce((accum, str, i) => accum.concat([str, args[i]]), [])
     .join('');
@@ -45,14 +50,14 @@ function literal(strings, ...args) {
  * ];
  * ```
  *
- * @param {*} element story element to derive counter transforms off of.
+ * @param {Element} element story element to derive counter transforms off of.
  * @return {(s: string[], ...args: any[]) => string} template string tag that resets transform space.
  */
 export function getGlobalSpace(element = {}) {
   function global(...template) {
-    return `rotate(${-1 * element?.rotationAngle}deg) 
-    ${literal(...template)} 
-    rotate(${element?.rotationAngle}deg)`;
+    return `rotate(${-1 * element?.rotationAngle}deg) ${literal(
+      ...template
+    )} rotate(${element?.rotationAngle}deg)`;
   }
   return element?.rotationAngle ? global : literal;
 }

--- a/assets/src/animation/utils/index.js
+++ b/assets/src/animation/utils/index.js
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export { defaultUnit } from './defaultUnit';
+export { getGlobalSpace, literal } from './getGlobalSpace';
+export { default as getOffPageOffset } from './getOffPageOffset';
 export { getTotalDuration } from './getTotalDuration';
 export { getMediaBoundOffsets, hasOffsets } from './mediaPositions';
+export { getExclusion, orderByKeys } from './objectOperations';
 export { clamp, lerp, progress } from './range';
-export { orderByKeys, getExclusion } from './objectOperations';
-export { getGlobalSpace } from './getGlobalSpace';
-export { default as getOffPageOffset } from './getOffPageOffset';
-export { defaultUnit } from './defaultUnit';

--- a/assets/src/animation/utils/index.js
+++ b/assets/src/animation/utils/index.js
@@ -17,3 +17,6 @@ export { getTotalDuration } from './getTotalDuration';
 export { getMediaBoundOffsets, hasOffsets } from './mediaPositions';
 export { clamp, lerp, progress } from './range';
 export { orderByKeys, getExclusion } from './objectOperations';
+export { getGlobalSpace } from './getGlobalSpace';
+export { default as getOffPageOffset } from './getOffPageOffset';
+export { defaultUnit } from './defaultUnit';

--- a/assets/src/animation/utils/test/getGlobalSpace.js
+++ b/assets/src/animation/utils/test/getGlobalSpace.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { getGlobalSpace, literal } from '../';
+
+describe('literal', () => {
+  it('interpolates the same as a template literal given an empty string', () => {
+    expect(literal([''])).toStrictEqual(``);
+  });
+
+  it('interpolates the same as a template literal given some args', () => {
+    const args = ['am', 'dog'];
+    expect(literal(['I ', ' a '], ...args)).toStrictEqual(
+      `I ${args[0]} a ${args[1]}`
+    );
+  });
+});
+
+describe('getGlobalSpace', () => {
+  it('returns original transform if no element rotation present', () => {
+    const global = getGlobalSpace({});
+    expect(global`translate(3px)`).toStrictEqual('translate(3px)');
+  });
+
+  it('wraps the transform in a counter/original transform if rotation present on element', () => {
+    const rotationAngle = 34;
+    const global = getGlobalSpace({
+      rotationAngle,
+    });
+    expect(global`translate(3px)`).toStrictEqual(
+      'rotate(-34deg) translate(3px) rotate(34deg)'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Before this update, if you rotated an element, then applied an animation, the animation would take place under that rotation.

**example**
Rotate an element 35deg, then add animate on the elements y axis (with something like drop), the y axis it's animated along would be rotated 35 deg making it appear to animate in at an angle.

**solution**
This was a natural byproduct of how we set the animation wrappers in the DOM hierarchy. However, I thought of a neat little transform trick to opt out of this behavior without foundationally changing our animation setup or the DOM hierarchy.

This approach adds a counter transform to the element, then applies the animation in the net zero transform space, then reapplies the original transforms. Good news is this approach maintains composability and all that important shtuff, so we're 💯 

## Relevant Technical Choices
Just wrapped all transform & rotation values in the global space wrapper.

## To-do
NA

## User-facing changes
Now element rotation shouldn't influence any animations.

## Testing Instructions
Create a story -> add an element -> rotate the element 34 degrees -> go through applying all animations on the element -> see that the animations are unaffected by the elements rotation as they were previously before

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5601 
Fixes #5534