### PR TITLE
Media: Only run `filter_poster_attachments` for the editor

### DIFF
--- a/includes/Media.php
+++ b/includes/Media.php
@@ -213,41 +213,11 @@ class Media {
 			false
 		);
 
-		add_action( 'pre_get_posts', [ $this, 'filter_poster_attachments' ] );
-
 		add_action( 'rest_api_init', [ $this, 'rest_api_init' ] );
 
 		add_filter( 'wp_prepare_attachment_for_js', [ $this, 'wp_prepare_attachment_for_js' ], 10, 2 );
 
 		add_action( 'delete_attachment', [ $this, 'delete_video_poster' ] );
-	}
-
-	/**
-	 * Filters the current query to hide all automatically extracted poster image attachments.
-	 *
-	 * Reduces unnecessary noise in the media library.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param \WP_Query $query WP_Query instance, passed by reference.
-	 *
-	 * @return void
-	 */
-	public function filter_poster_attachments( &$query ) {
-		$post_type = (array) $query->get( 'post_type' );
-
-		if ( ! in_array( 'any', $post_type, true ) && ! in_array( 'attachment', $post_type, true ) ) {
-			return;
-		}
-
-		$meta_query = (array) $query->get( 'meta_query' );
-
-		$meta_query[] = [
-			'key'     => self::POSTER_POST_META_KEY,
-			'compare' => 'NOT EXISTS',
-		];
-
-		$query->set( 'meta_query', $meta_query ); // phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts
 	}
 
 	/**

--- a/includes/REST_API/Stories_Media_Controller.php
+++ b/includes/REST_API/Stories_Media_Controller.php
@@ -26,6 +26,7 @@
 
 namespace Google\Web_Stories\REST_API;
 
+use Google\Web_Stories\Media;
 use Google\Web_Stories\Traits\Types;
 use WP_Error;
 use WP_REST_Request;
@@ -61,7 +62,9 @@ class Stories_Media_Controller extends \WP_REST_Attachments_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
+		add_action( 'pre_get_posts', [ $this, 'filter_poster_attachments' ] );
 		$response = parent::get_items( $request );
+		remove_action( 'pre_get_posts', [ $this, 'filter_poster_attachments' ] );
 
 		if ( $request['_web_stories_envelope'] && ! is_wp_error( $response ) ) {
 			$response = rest_get_server()->envelope_response( $response, false );
@@ -170,5 +173,33 @@ class Stories_Media_Controller extends \WP_REST_Attachments_Controller {
 	 */
 	protected function get_media_types() {
 		return $this->get_allowed_mime_types();
+	}
+
+	/**
+	 * Filters the current query to hide all automatically extracted poster image attachments.
+	 *
+	 * Reduces unnecessary noise in the media library.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WP_Query $query WP_Query instance, passed by reference.
+	 *
+	 * @return void
+	 */
+	public function filter_poster_attachments( &$query ) {
+		$post_type = (array) $query->get( 'post_type' );
+
+		if ( ! in_array( 'any', $post_type, true ) && ! in_array( 'attachment', $post_type, true ) ) {
+			return;
+		}
+
+		$meta_query = (array) $query->get( 'meta_query' );
+
+		$meta_query[] = [
+			'key'     => Media::POSTER_POST_META_KEY,
+			'compare' => 'NOT EXISTS',
+		];
+
+		$query->set( 'meta_query', $meta_query ); // phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts
 	}
 }


### PR DESCRIPTION
## Summary

Move filter to controller class, so it does not effect other places that call wp_queries on attachments. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5546
