### PR TITLE
Animation: Effect Chooser Left/Right Arrow Navigation Support

### DIFF
--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -35,6 +35,7 @@ import styled, { css } from 'styled-components';
  * Internal dependencies
  */
 import loadStylesheet from '../../../utils/loadStylesheet';
+import { useConfig } from '../../../app/config';
 import { GOOGLE_MENU_FONT_URL } from '../../../app/font';
 import {
   ANIMATION_EFFECTS,
@@ -200,6 +201,7 @@ export default function EffectChooser({
   value = '',
   direction,
 }) {
+  const { isRTL } = useConfig();
   const [focusedValue, setFocusedValue] = useState(null);
   const ref = useRef();
 
@@ -270,16 +272,19 @@ export default function EffectChooser({
 
   const handleUpDown = useCallback(
     ({ key }) => {
-      if ((key === 'ArrowUp' || key === 'ArrowLeft') && focusedIndex !== 0) {
+      if (
+        ['ArrowUp', isRTL ? 'ArrowRight' : 'ArrowLeft'].includes(key) &&
+        focusedIndex !== 0
+      ) {
         handleMoveFocus(-1);
       } else if (
-        (key === 'ArrowDown' || key === 'ArrowRight') &&
+        ['ArrowDown', isRTL ? 'ArrowLeft' : 'ArrowRight'].includes(key) &&
         focusedIndex < listLength - 1
       ) {
         handleMoveFocus(1);
       }
     },
-    [focusedIndex, handleMoveFocus, listLength]
+    [focusedIndex, handleMoveFocus, listLength, isRTL]
   );
 
   useKeyDownEffect(

--- a/assets/src/edit-story/components/panels/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooser.js
@@ -270,16 +270,24 @@ export default function EffectChooser({
 
   const handleUpDown = useCallback(
     ({ key }) => {
-      if (key === 'ArrowUp' && focusedIndex !== 0) {
+      if ((key === 'ArrowUp' || key === 'ArrowLeft') && focusedIndex !== 0) {
         handleMoveFocus(-1);
-      } else if (key === 'ArrowDown' && focusedIndex < listLength - 1) {
+      } else if (
+        (key === 'ArrowDown' || key === 'ArrowRight') &&
+        focusedIndex < listLength - 1
+      ) {
         handleMoveFocus(1);
       }
     },
     [focusedIndex, handleMoveFocus, listLength]
   );
 
-  useKeyDownEffect(ref, { key: ['up', 'down'] }, handleUpDown, [handleUpDown]);
+  useKeyDownEffect(
+    ref,
+    { key: ['up', 'down', 'left', 'right'] },
+    handleUpDown,
+    [handleUpDown]
+  );
 
   useFocusOut(ref, () => onDismiss?.(), []);
 


### PR DESCRIPTION
## Summary
Adds left/right arrow support to keyboard navigation in the effect chooser.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
In the effect chooser, left/right arrow keys should navigate like up/down keys

## Testing Instructions
Go to story editor -> access the animation panel -> see that left/right keys navigates exactly like up/down

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5616 
