### PR TITLE
Bug: Fix Close Toggle Action for Animation Drop Down

### DIFF
--- a/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/animation/effectChooserDropdown.js
@@ -18,22 +18,21 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-
 /**
  * External dependencies
  */
 import React, { useCallback, useRef, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-
 /**
  * Internal dependencies
  */
-import { DropDownSelect, DropDownTitle } from '../../form/dropDown';
 import { Dropdown as DropdownIcon } from '../../../icons';
 import { isKeyboardUser } from '../../../utils/keyboardOnlyOutline';
-import Popup, { Placement } from '../../popup';
+import { DropDownSelect, DropDownTitle } from '../../form/dropDown';
 import { ScrollBarStyles } from '../../library/common/scrollbarStyles';
+import Popup, { Placement } from '../../popup';
 import EffectChooser from './effectChooser';
 
 const Container = styled.div`
@@ -56,7 +55,18 @@ export default function EffectChooserDropdown({
 }) {
   const selectRef = useRef();
   const dropdownRef = useRef();
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, _setIsOpen] = useState(false);
+
+  // Prevents following race condition:
+  // -> mouseDown on select
+  // -> focusOut popup fires -> isOpen = false
+  // -> mouseUp on select
+  // -> select click fires -> isOpen = !isOpen
+  // while maintaining immediate first call to isOpen setter
+  const [setIsOpen] = useDebouncedCallback(_setIsOpen, 300, {
+    leading: true,
+    trailing: false,
+  });
 
   const closeDropDown = useCallback(() => {
     setIsOpen(false);
@@ -64,7 +74,7 @@ export default function EffectChooserDropdown({
       // Return keyboard focus to button when closing dropdown
       selectRef.current.focus();
     }
-  }, []);
+  }, [setIsOpen]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
Fixes a race condition that wasn't allowing you to close out of the drop down from clicking the animation effect dropdown toggle

## Relevant Technical Choices
Just implemented a similar strategy as in the advanced drop down component. Didn't want to augment the advanced dropdown component further as it's already supporting a lot of use cases and we're gonna update the dropdowns soon to become part of our global component library, so no need for a major update now imo

## To-do
NA

## User-facing changes
Clicking the animation dropdown toggle now works for closing the drop down.

## Testing Instructions
-> Go to Editor
-> Select an element on the page
-> Click on the animation selector toggle to expand the dropdown
-> Click on the animation selector toggle again to close the dropdown
-> see that the dropdown closes when it's open and you click on the toggle

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5533 
