### PR TITLE
Design System: Buttons updated to match latest figma colors

### DIFF
--- a/assets/src/design-system/components/button/index.js
+++ b/assets/src/design-system/components/button/index.js
@@ -55,6 +55,7 @@ const Base = styled.button(
     }
     &:active {
       background-color: ${theme.colors.interactiveBg.active};
+      color: ${theme.colors.interactiveFg.active};
     }
 
     &:disabled {
@@ -63,19 +64,21 @@ const Base = styled.button(
       color: ${theme.colors.fg.disable};
     }
 
-    transition: background-color 0.6s ease 0s;
+    transition: background-color 0.6s ease 0s, color 0.6s ease 0s;
   `
 );
 
 const primaryColors = ({ theme }) => css`
   background-color: ${theme.colors.interactiveBg.brandNormal};
-
+  color: ${theme.colors.interactiveFg.brandNormal};
   &:hover,
   &:focus {
     background-color: ${theme.colors.interactiveBg.brandHover};
+    color: ${theme.colors.interactiveFg.brandHover};
   }
   &:active {
     background-color: ${theme.colors.interactiveBg.active};
+    color: ${theme.colors.interactiveFg.active};
   }
 `;
 

--- a/assets/src/design-system/theme/colors.js
+++ b/assets/src/design-system/theme/colors.js
@@ -26,7 +26,7 @@ import { rgba } from 'polished';
 const brand = {
   gray: {
     90: '#131516',
-    80: '#26292A',
+    80: '#2F3131',
     70: '#393D3F',
     60: '#4B5253',
     50: '#5E6668',
@@ -131,6 +131,11 @@ const darkTheme = {
     negative: brand.red[90],
     storyPreview: '#202125',
   },
+  interactiveFg: {
+    active: brand.gray[5],
+    brandNormal: brand.gray[90],
+    brandHover: brand.gray[90],
+  },
   interactiveBg: {
     active: brand.violet[70],
     disable: brand.gray[80],
@@ -194,6 +199,11 @@ const lightTheme = {
     positive: brand.green[10],
     negative: brand.red[10],
     storyPreview: '#202125',
+  },
+  interactiveFg: {
+    active: brand.gray[90],
+    brandNormal: brand.gray[90],
+    brandHover: brand.gray[90],
   },
   interactiveBg: {
     active: brand.violet[10],


### PR DESCRIPTION
## Summary
Primary button colors got updated, tweaking design system button and colors to follow suit. 

## Relevant Technical Choices

There is a deviation from the light/dark pattern matching for fg color of buttons, so to keep the theme accurate I have added an interactiveFg section to light/dark theme colors to allow us to change fg color specific to interactiveBg. I only added what I needed for this (primary button usage of brand and all button usage of active). Some of the color overrides in the primary button are redundant, but I think having them there makes it easier to read. 

## To-do

## User-facing changes

N/A - changes I made only affect storybook. The light theme that is in use on the dashboard dialogs isn't impacted. 

## Testing Instructions

- Spin up storybook, go to designsystem/components/button and see that the default (dark theme) primary button reflects the latest[ button colors in figma](https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Design-System?node-id=3438%3A125786). Specifically, by normal button text is black, and when the button is active it's white.

![Screen Shot 2020-12-14 at 10 58 54 AM](https://user-images.githubusercontent.com/10720454/102117311-64abd300-3dfb-11eb-83b1-c7c1fbcddad3.png)
![Screen Shot 2020-12-14 at 10 59 33 AM](https://user-images.githubusercontent.com/10720454/102117377-77bea300-3dfb-11eb-9098-d2a8028be64f.png)

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
