### PR TITLE
Bug: Persist Delay and Duration between Effect Chooser Direction Changes

### DIFF
--- a/assets/src/edit-story/components/panels/design/animation/animation.js
+++ b/assets/src/edit-story/components/panels/design/animation/animation.js
@@ -80,8 +80,6 @@ function AnimationPanel({
       .filter((a) => !a.delete);
   }, [selectedElements, selectedElementAnimations]);
 
-  const elAnimationId = updatedAnimations[0]?.id;
-
   const handlePanelChange = useCallback(
     (animation, submitArg = false) => {
       if (shallowEqual(animation, updatedAnimations[0])) {
@@ -99,8 +97,15 @@ function AnimationPanel({
         return;
       }
 
-      const id = elAnimationId || uuidv4();
+      const id = selectedElementAnimations[0]?.id || uuidv4();
       const defaults = getAnimationEffectDefaults(animation);
+      const persisted =
+        selectedElementAnimations[0]?.type === animation
+          ? {
+              duration: selectedElementAnimations[0]?.duration,
+              delay: selectedElementAnimations[0]?.delay,
+            }
+          : {};
 
       // Background Zoom's `scale from` initial value should match
       // the current background's scale slider
@@ -119,6 +124,7 @@ function AnimationPanel({
           id,
           type: animation,
           ...defaults,
+          ...persisted,
           ...options,
         },
         null,
@@ -129,7 +135,12 @@ function AnimationPanel({
       // was changed by the effect chooser, so we track it here.
       playUpdatedAnimation.current = true;
     },
-    [elAnimationId, isBackground, pushUpdateForObject, backgroundScale]
+    [
+      selectedElementAnimations,
+      isBackground,
+      pushUpdateForObject,
+      backgroundScale,
+    ]
   );
 
   // Play animation of selected elements when effect chooser signals


### PR DESCRIPTION
## Summary
Now if you maintain the same animation, but change its direction through the effect chooser, it should maintain duration and delay.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
Duration and delay maintained if you change direction through animation effect chooser

## Testing Instructions
-> Go to story editor
-> Select foreground element
-> Apply `fly in` from the left animation
-> update `duration` and `delay` to a new value
-> reopen effect chooser and select `fly in` but from another direction
-> exit out of the effect chooser and see that the `duration` & `delay` values didn't get reset
-> open the effect chooser and select a completely different animation like `fade in`
-> close the effect chooser and see that `delay` & `duration` are set to the recommended values for `fade in`

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5523 
