### PR TITLE
Pre-Publish: Updated styling of dialog for missing title.

### DIFF
--- a/assets/src/edit-story/components/header/karma/publish.karma.js
+++ b/assets/src/edit-story/components/header/karma/publish.karma.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+
+describe('Publish integration', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  describe('CUJ: Creator can Preview & Publish Their Story: Publish story', () => {
+    it('should be warned when trying to publish without a title', async () => {
+      await fixture.events.focus(fixture.editor.canvas.header.publish);
+      await fixture.events.keyboard.press('Enter');
+
+      await fixture.events.sleep(1500);
+
+      await fixture.snapshot('Publish without title dialog');
+
+      await fixture.events.click(
+        fixture.editor.getByRoleIn(fixture.document, 'button', {
+          name: /Add a title/i,
+        })
+      );
+
+      await fixture.events.sleep(500);
+
+      await fixture.snapshot('Adding a title');
+    });
+  });
+});

--- a/assets/src/edit-story/components/header/titleMissingDialog.js
+++ b/assets/src/edit-story/components/header/titleMissingDialog.js
@@ -15,63 +15,84 @@
  */
 
 /**
- * External dependencies
- */
-import PropTypes from 'prop-types';
-import styled from 'styled-components';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { ThemeProvider } from 'styled-components';
+
+/**
  * Internal dependencies
  */
 import { TranslateWithMarkup } from '../../../i18n';
-import { Plain } from '../button';
-import Dialog from '../dialog';
 import Link from '../link';
+import {
+  Button,
+  BUTTON_SIZES,
+  BUTTON_TYPES,
+  Dialog,
+  Text,
+  theme as designSystemTheme,
+  THEME_CONSTANTS,
+} from '../../../design-system';
 
-const Paragraph = styled.p`
-  font-family: ${({ theme }) => theme.fonts.body1.family};
-  font-size: ${({ theme }) => theme.fonts.body1.size};
-  line-height: ${({ theme }) => theme.fonts.body1.lineHeight};
-  letter-spacing: ${({ theme }) => theme.fonts.body1.letterSpacing};
-`;
+const link = __(
+  'https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/#title',
+  'web-stories'
+);
+
+const robotoTransitionalTheme = {
+  ...designSystemTheme,
+  typography: {
+    ...designSystemTheme.typography,
+    family: { primary: '"Roboto", sans-serif' },
+  },
+};
 
 function TitleMissingDialog({ open, onIgnore, onFix, onClose }) {
-  const link = __(
-    'https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/#title',
-    'web-stories'
-  );
   return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      title={__('Missing title', 'web-stories')}
-      actions={
-        <>
-          <Plain onClick={onFix}>{__('Add a title', 'web-stories')}</Plain>
-          <Plain onClick={onIgnore}>
-            {__('Publish without title', 'web-stories')}
-          </Plain>
-        </>
-      }
-    >
-      <Paragraph>
-        <TranslateWithMarkup
-          mapping={{
-            a: <Link href={link} target="_blank" rel="noopener noreferrer" />,
-          }}
-        >
-          {__(
-            'We recommend adding a title to the story prior to publishing. <a>Learn more</a>.',
-            'web-stories'
-          )}
-        </TranslateWithMarkup>
-      </Paragraph>
-    </Dialog>
+    <ThemeProvider theme={robotoTransitionalTheme}>
+      <Dialog
+        onClose={onClose}
+        isOpen={open}
+        title={__('Missing title', 'web-stories')}
+        actions={
+          <>
+            <Button
+              size={BUTTON_SIZES.SMALL}
+              type={BUTTON_TYPES.TERTIARY}
+              onClick={onIgnore}
+            >
+              {__('Publish without title', 'web-stories')}
+            </Button>
+            <Button
+              size={BUTTON_SIZES.SMALL}
+              type={BUTTON_TYPES.PRIMARY}
+              onClick={onFix}
+            >
+              {__('Add a title', 'web-stories')}
+            </Button>
+          </>
+        }
+      >
+        <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
+          <TranslateWithMarkup
+            mapping={{
+              a: <Link href={link} target="_blank" rel="noopener noreferrer" />,
+            }}
+          >
+            {__(
+              'We recommend adding a title to the story prior to publishing. <a>Learn more</a>.',
+              'web-stories'
+            )}
+          </TranslateWithMarkup>
+        </Text>
+      </Dialog>
+    </ThemeProvider>
   );
 }
 


### PR DESCRIPTION
## Summary

Updates the dialog to match the new design language.

<img width="567" alt="Screen Shot 2020-12-15 at 7 48 00 AM" src="https://user-images.githubusercontent.com/1738349/102223813-cf681780-3eaa-11eb-8cea-bab3fbaed8c7.png">


## Relevant Technical Choices

Currently includes the new theme provider with Roboto fonts.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

New styling for the dialog.

## Testing Instructions

1. Create a new story
2. Attempt to publish _with no_ title
3. See the dialog no longer stands out as white, but matches the editor


See #5644