### PR TITLE
Frontend: HTML markers not always replaced 

### DIFF
--- a/includes/Story_Renderer/HTML.php
+++ b/includes/Story_Renderer/HTML.php
@@ -205,6 +205,10 @@ class HTML {
 		$start_tag = '<meta name="web-stories-replace-head-start"/>';
 		$end_tag   = '<meta name="web-stories-replace-head-end"/>';
 
+		// Replace malformed meta tags with correct tags.
+		$content = (string) preg_replace( '/<meta name="web-stories-replace-head-start\s?"\s?\/>/i', $start_tag, $content );
+		$content = (string) preg_replace( '/<meta name="web-stories-replace-head-end\s?"\s?\/>/i', $end_tag, $content );
+
 		$start_tag_pos = strpos( $content, $start_tag );
 		$end_tag_pos   = strpos( $content, $end_tag );
 

--- a/tests/phpunit/tests/Story_Renderer/HTML.php
+++ b/tests/phpunit/tests/Story_Renderer/HTML.php
@@ -91,6 +91,33 @@ class HTML extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::replace_html_head
+	 * @covers ::get_html_head_markup
+	 */
+	public function test_replace_html_head_invalid() {
+		$start_tag = '<meta name="web-stories-replace-head-start " />';
+		$end_tag   = '<meta name="web-stories-replace-head-end" />';
+
+		$post = self::factory()->post->create_and_get(
+			[
+				'post_type'    => Story_Post_Type::POST_TYPE_SLUG,
+				'post_content' => "<html><head>FOO{$start_tag}BAR{$end_tag}BAZ</head><body><amp-story></amp-story></body></html>",
+			]
+		);
+
+		$actual = $this->setup_renderer( $post );
+
+		$this->assertContains( 'FOO', $actual );
+		$this->assertContains( 'BAZ', $actual );
+		$this->assertNotContains( 'BAR', $actual );
+		$this->assertNotContains( $start_tag, $actual );
+		$this->assertNotContains( $end_tag, $actual );
+		$this->assertContains( '<meta name="amp-story-generator-name" content="Web Stories for WordPress"', $actual );
+		$this->assertContains( '<meta name="amp-story-generator-version" content="', $actual );
+		$this->assertSame( 1, did_action( 'web_stories_story_head' ) );
+	}
+
+	/**
 	 * Tests that publisher logo is correctly replaced.
 	 *
 	 * @covers \Google\Web_Stories\Traits\Publisher::get_publisher_logo_placeholder


### PR DESCRIPTION
## Summary

Sometimes a space gets added in weird places in meta tags. 

## Relevant Technical Choices

Do a simple preg_replace to reset meta tags back to what they should be. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5589
