### PR TITLE
Karma: Suppress useLayoutEffect warnings in tests

### DIFF
--- a/assets/src/edit-story/output/utils/getStoryMarkup.js
+++ b/assets/src/edit-story/output/utils/getStoryMarkup.js
@@ -35,6 +35,10 @@ import OutputStory from '../story';
  * @return {string} Story markup.
  */
 export default function getStoryMarkup(story, pages, metadata, featureFlags) {
+  // Note that react-dom/server will warn about useLayoutEffect usage here.
+  // Not because of any wrongdoing in our code, but mostly because
+  // of its own profiler.
+  // See https://github.com/facebook/react/issues/14927
   return renderToStaticMarkup(
     <FlagsProvider features={featureFlags}>
       <OutputStory story={story} pages={pages} metadata={metadata} />

--- a/karma-dashboard.config.cjs
+++ b/karma-dashboard.config.cjs
@@ -171,6 +171,11 @@ module.exports = function (config) {
     // Allow not having any tests
     failOnEmptyTestSuite: false,
 
+    // Prevent duplicate logging to console
+    browserConsoleLogOptions: {
+      terminal: false,
+    },
+
     // Bump browserNoActivityTimeout to 100s to prevent Github Actions timeout
     browserNoActivityTimeout: 100000,
 

--- a/karma-edit-story.config.cjs
+++ b/karma-edit-story.config.cjs
@@ -171,6 +171,11 @@ module.exports = function (config) {
     // Allow not having any tests
     failOnEmptyTestSuite: false,
 
+    // Prevent duplicate logging to console
+    browserConsoleLogOptions: {
+      terminal: false,
+    },
+
     // Bump browserNoActivityTimeout to 100s to prevent Github Actions timeout
     browserNoActivityTimeout: 100000,
 

--- a/karma/fixture/init.js
+++ b/karma/fixture/init.js
@@ -104,8 +104,31 @@ beforeAll(() => {
     return karmaPuppeteer.saveSnapshot(currentSpec?.fullName, name);
   };
 
+  /*eslint-disable no-console*/
+
+  // Suppress react-dom/server error messages during tests.
+  withCleanupAll(() => {
+    const originalConsoleError = console.error;
+
+    console.error = (...args) => {
+      if (
+        args[0].includes('Warning: useLayoutEffect does nothing on the server')
+      ) {
+        return;
+      }
+
+      originalConsoleError(...args);
+    };
+
+    return () => {
+      console.error = originalConsoleError;
+    };
+  });
+
+  /*eslint-enable no-console*/
+
   // Disable transitions. These add unnecessarily flakiness into integration
-  // tests and snashots/screenshots.
+  // tests and snapshots/screenshots.
   withCleanupAll(() => {
     const testRootStyles = document.createElement('style');
     testRootStyles.setAttribute('data-desc', 'Karma test-root styles');


### PR DESCRIPTION
## Summary

Prevents tons of `Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format` messages from polluting tests output.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
