### PR TITLE
Pre-Publish: Handle both resource and element alt texts for pre-publish check.

### DIFF
--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -235,7 +235,7 @@ export function elementLinkTappableRegionTooSmall(element) {
  * @return {Guidance|undefined} The guidance object for consumption
  */
 export function imageElementMissingAlt(element) {
-  if (!element.alt?.length) {
+  if (!element.alt?.length && !element.resource?.alt?.length) {
     return {
       message: MESSAGES.ACCESSIBILITY.MISSING_IMAGE_ALT_TEXT.MAIN_TEXT,
       help: MESSAGES.ACCESSIBILITY.MISSING_IMAGE_ALT_TEXT.HELPER_TEXT,

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -495,5 +495,16 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
         accessibilityChecks.imageElementMissingAlt(element)
       ).toBeUndefined();
     });
+
+    it('should return undefined if image element has a resource alt', () => {
+      const element = {
+        id: 'elementid',
+        type: 'image',
+        resource: { alt: 'Image is about things' },
+      };
+      expect(
+        accessibilityChecks.imageElementMissingAlt(element)
+      ).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Handle both sources for an alt message.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

The missing assistive text warning should not show when there is alt text added from the WP media library

## Testing Instructions

1. Got to WP media library in WP admin (NOT the editor), upload an image. See that it has alt text
2. Go to editor
3. Insert image from library
4. Go to checklist, see error message
5. Go to design panel, see that it has alt text

