### PR TITLE
Fix editor shrinking unexpectedly when scrolling Media

### DIFF
--- a/assets/src/edit-story/components/library/panes/shared/libraryMoveable.js
+++ b/assets/src/edit-story/components/library/panes/shared/libraryMoveable.js
@@ -55,6 +55,7 @@ function LibraryMoveable({
 
   const [isDragging, setIsDragging] = useState(false);
   const [didManuallyReset, setDidManuallyReset] = useState(false);
+  const [hover, setHover] = useState(false);
   const cloneRef = useRef(null);
   const targetBoxRef = useRef(null);
   const overlayRef = useRef(null);
@@ -216,28 +217,32 @@ function LibraryMoveable({
         width={width}
         height={height}
         onClick={onClick}
+        onPointerOver={() => setHover(true)}
+        onPointerOut={() => setHover(false)}
       />
-      {(isDragging || active) && (
-        <InOverlay
-          ref={overlayRef}
-          zIndex={1}
-          pointerEvents="initial"
-          render={() => {
-            return <CloneElement ref={cloneRef} {...cloneProps} />;
-          }}
-        />
+      {(isDragging || active || hover) && (
+        <>
+          <InOverlay
+            ref={overlayRef}
+            zIndex={1}
+            pointerEvents="initial"
+            render={() => {
+              return <CloneElement ref={cloneRef} {...cloneProps} />;
+            }}
+          />
+          <Moveable
+            className="default-moveable hide-handles"
+            target={targetBoxRef.current}
+            edge={true}
+            draggable={true}
+            origin={false}
+            pinchable={true}
+            onDragStart={onDragStart}
+            onDrag={onDrag}
+            onDragEnd={onDragEnd}
+          />
+        </>
       )}
-      <Moveable
-        className="default-moveable hide-handles"
-        target={targetBoxRef.current}
-        edge={true}
-        draggable={true}
-        origin={false}
-        pinchable={true}
-        onDragStart={onDragStart}
-        onDrag={onDrag}
-        onDragEnd={onDragEnd}
-      />
     </>
   );
 }


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Hides unused ghost-Moveables.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
1. Scroll down in Media so that new media would be loaded a few times.
2. Now move the cursor on the Page and try to scroll down
3. Verify that no gray area appears and the editor covers the full viewport.
4. Verify that dragging Media to Page is working as expected.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5720 
