### PR TITLE
Fix CDN URL for stable releases

### DIFF
--- a/web-stories.php
+++ b/web-stories.php
@@ -52,7 +52,7 @@ define( 'WEBSTORIES_MINIMUM_WP_VERSION', '5.3' );
 
 $cdn_version = 'main';
 
-if ( false !== strpos( WEBSTORIES_VERSION, '+' ) ) {
+if ( false === strpos( WEBSTORIES_VERSION, '+' ) ) {
 	$pieces      = explode( '+', WEBSTORIES_VERSION );
 	$cdn_version = array_shift( $pieces );
 }


### PR DESCRIPTION
## Summary

Noticed when testing the 1.2.1 ZIP file.

If running e.g. 1.2.1 stable, the CDN URL should use that version, not `main`.

`main` should only be used for dev releases that contain a commit hash in the version number.

---

<!-- Please reference the issue(s) this PR addresses. -->

See #5723
