### PR TITLE
CI: Cancel previous workflows

### DIFF
--- a/.github/workflows/cancel-previous-workflows.yml
+++ b/.github/workflows/cancel-previous-workflows.yml
@@ -1,0 +1,24 @@
+name: Cancel previous workflows
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - closed
+      - reopened
+      - synchronize
+
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      # See https://github.com/marketplace/actions/cancel-workflow-action#advanced
+      # See https://api.github.com/repos/google/web-stories-wp/actions/workflows
+      - uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          workflow_id: 1281821,1281822,1281825,1281827,1281828,1281829,1281830,1281831,1281832,1328070,1680114,1680115,1740093,2802791
+          access_token: ${{ github.token }}


### PR DESCRIPTION
This way we cancel any previous runs that are not completed for a given workflow, hopefully speeding up CI and reducing the number of queued items at any given time
