### PR TITLE
Design System: DropDown Base Structure

### DIFF
--- a/assets/src/design-system/components/dropDown/index.js
+++ b/assets/src/design-system/components/dropDown/index.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { MENU_OPTIONS } from './types';
+import useDropDown from './useDropDown';
+
+const DropDownContainer = styled.div``;
+
+/**
+ *
+ * @param {Object} props All props.
+ * @param {Array} props.options All options, should contain either 1) objects with a label, value, anything else you need can be added and accessed through renderItem or 2) Objects containing a label and options, where options is structured as first option with array of objects containing at least value and label - this will create a nested list.
+ * @param {string} props.selectedValue the selected value of the dropDown. Should correspond to a value in the options array of objects.
+ *
+ */
+
+export const DropDown = ({ options = [], selectedValue = '' }) => {
+  useDropDown({
+    options,
+    selectedValue,
+  });
+
+  return <DropDownContainer />;
+};
+
+DropDown.propTypes = {
+  options: MENU_OPTIONS,
+  selectedValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+    PropTypes.number,
+  ]),
+};

--- a/assets/src/design-system/components/dropDown/stories/index.js
+++ b/assets/src/design-system/components/dropDown/stories/index.js
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import { boolean, select, text } from '@storybook/addon-knobs';
+import { useState } from 'react';
+/**
+ * Internal dependencies
+ */
+import { DarkThemeProvider } from '../../../storybookUtils';
+import { PLACEMENT } from '../../popup';
+import { DropDown } from '..';
+import { basicDropDownOptions } from './sampleData';
+
+export default {
+  title: 'DesignSystem/Components/DropDown',
+};
+
+export const _default = () => {
+  const [selectedValue, setSelectedValue] = useState(
+    basicDropDownOptions[2].value
+  );
+  return (
+    <DarkThemeProvider>
+      <DropDown
+        emptyText={'No options available'}
+        options={basicDropDownOptions}
+        hint={text('hint', 'default hint text')}
+        placeholder={text('placeholder', 'select a value')}
+        dropDownLabel={text('dropDownLabel', 'label')}
+        isKeepMenuOpenOnSelection={boolean('isKeepMenuOpenOnSelection')}
+        isRTL={boolean('isRTL')}
+        disabled={boolean('disabled')}
+        selectedValue={selectedValue}
+        onMenuItemClick={(event, newValue) => {
+          action('onMenuItemClick', event);
+          setSelectedValue(newValue);
+        }}
+        placement={select('placement', Object.values(PLACEMENT))}
+      />
+    </DarkThemeProvider>
+  );
+};
+
+export const LightTheme = () => {
+  const [selectedValue, setSelectedValue] = useState(null);
+
+  return (
+    <DropDown
+      emptyText={'No options available'}
+      options={basicDropDownOptions}
+      hint={text('hint', 'default hint text')}
+      placeholder={text('placeholder', 'select a value')}
+      dropDownLabel={text('dropDownLabel', 'label')}
+      isKeepMenuOpenOnSelection={boolean('isKeepMenuOpenOnSelection')}
+      isRTL={boolean('isRTL')}
+      disabled={boolean('disabled')}
+      selectedValue={selectedValue}
+      onMenuItemClick={(event, newValue) => {
+        action('onMenuItemClick', event);
+        setSelectedValue(newValue);
+      }}
+      placement={select('placement', Object.values(PLACEMENT))}
+    />
+  );
+};

--- a/assets/src/design-system/components/dropDown/stories/sampleData.js
+++ b/assets/src/design-system/components/dropDown/stories/sampleData.js
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const basicDropDownOptions = [
+  {
+    label: 'label item one',
+    value: 'label-item-one',
+  },
+  {
+    label: 'label item two',
+    value: 'label-item-two',
+  },
+  {
+    label: 'label item three',
+    value: 'label-item-three',
+  },
+  {
+    label: 'label item four (disabled)',
+    value: 'label-item-four',
+    disabled: true,
+  },
+  {
+    label: 'label item five (value is a number)',
+    value: 5,
+  },
+  {
+    label: 'label item six (value is a boolean)',
+    value: true,
+  },
+  {
+    label: 'drafts',
+    value: 'drafts',
+  },
+  {
+    label: 'cats',
+    value: 'cats',
+  },
+  {
+    label: 'dogs',
+    value: 'dogs',
+  },
+  {
+    label: 'parakeets',
+    value: 'parakeets',
+  },
+  {
+    label: 'lemurs',
+    value: 'lemurs',
+  },
+  {
+    label: 'ocelots',
+    value: 'ocelots',
+  },
+];
+
+export const effectChooserOptions = [
+  {
+    value: 'none',
+    label: 'none',
+    width: 'full',
+  },
+  {
+    value: 'drop in',
+    label: 'drop',
+    width: 'full',
+  },
+  {
+    value: 'fly in left-to-right',
+    label: 'fly in',
+    width: 'half',
+  },
+  {
+    value: 'fly in top-to-bottom',
+    label: 'fly in',
+    width: 'half',
+  },
+  {
+    value: 'fly in right-to-left',
+    label: 'fly in',
+    width: 'half',
+  },
+  {
+    value: 'fly in bottom-to-top',
+    label: 'fly in',
+    width: 'half',
+  },
+  {
+    value: 'pulse',
+    label: 'pulse',
+    width: 'full',
+  },
+  {
+    value: 'rotate in left-to-right',
+    label: 'rotate in',
+    width: 'half',
+  },
+  {
+    value: 'rotate in right-to-left',
+    label: 'rotate in',
+    width: 'half',
+  },
+  {
+    value: 'twirl',
+    label: 'twirl',
+    width: 'full',
+  },
+];
+
+export const nestedDropDownOptions = [
+  {
+    label: 'aliens',
+    options: [
+      { value: 'alien-1', label: 'ET' },
+      { value: 'alien-2', label: 'Stitch' },
+      { value: 'alien-3', label: 'Groot' },
+      { value: 'alien-4', label: 'The Worm Guys' },
+      { value: 'alien-5', label: "Na'vi" },
+      { value: 'alien-6', label: 'Arachnids' },
+      { value: 'alien-7', label: 'The Predator' },
+      { value: 'alien-8', label: 'Xenomorph' },
+    ],
+  },
+  {
+    label: 'dragons',
+    options: [
+      { value: 'dragon-1', label: 'Smaug' },
+      { value: 'dragon-2', label: 'Mushu' },
+      { value: 'dragon-3', label: 'Toothless' },
+      { value: 'dragon-4', label: 'Falkor' },
+      { value: 'dragon-5', label: 'Drogon' },
+      { value: 'dragon-6', label: 'Kalessin' },
+    ],
+  },
+  {
+    label: 'dogs',
+    options: [
+      { value: 'dog-1', label: 'Snoopy' },
+      { value: 'dog-2', label: 'Scooby' },
+    ],
+  },
+  {
+    label: 'tricky content',
+    options: [
+      { value: 0, label: '0 as a number' },
+      { value: false, label: 'false as a boolean' },
+      { value: true, label: 'true as a boolean' },
+      { value: undefined, label: "undefined and shouldn't come through" },
+    ],
+  },
+];

--- a/assets/src/design-system/components/dropDown/test/useDropDown.js
+++ b/assets/src/design-system/components/dropDown/test/useDropDown.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+
+import useDropDown from '../useDropDown';
+import {
+  basicDropDownOptions,
+  nestedDropDownOptions,
+} from '../stories/sampleData';
+
+describe('useDropDown()', function () {
+  it('should return falsy for activeOption when no selectedValue is present', function () {
+    const { result } = renderHook(() => useDropDown({ options: [] }));
+
+    expect(result.current.activeOption).toBeFalsy();
+  });
+
+  it('should return object from options containing selectedValue as active option', function () {
+    const { result } = renderHook(() =>
+      useDropDown({
+        selectedValue: basicDropDownOptions[2].value,
+        options: basicDropDownOptions,
+      })
+    );
+
+    expect(result.current.activeOption).toMatchObject(basicDropDownOptions[2]);
+  });
+
+  it('should return falsy for activeOption when selectedValue is not present in options', function () {
+    const { result } = renderHook(() =>
+      useDropDown({
+        selectedValue: 'bogus value',
+        options: basicDropDownOptions,
+      })
+    );
+
+    expect(result.current.activeOption).toBeFalsy();
+  });
+
+  it('should return an empty array when no options are present', function () {
+    const { result } = renderHook(() =>
+      useDropDown({ selectedValue: null, options: [] })
+    );
+
+    expect(result.current.normalizedOptions).toStrictEqual([]);
+  });
+
+  it('should return an empty array when only bad options are present', function () {
+    const { result } = renderHook(() =>
+      useDropDown({
+        selectedValue: null,
+        options: [
+          'things that are not good for a dropDown',
+          1,
+          { 500: '', foo: () => {} },
+        ],
+      })
+    );
+
+    expect(result.current.normalizedOptions).toStrictEqual([]);
+  });
+
+  it('should return only sanitized options that meet requirements', function () {
+    const { result } = renderHook(() =>
+      useDropDown({ selectedValue: null, options: nestedDropDownOptions })
+    );
+
+    expect(result.current.normalizedOptions).toStrictEqual([
+      {
+        group: [
+          { label: 'ET', value: 'alien-1' },
+          { label: 'Stitch', value: 'alien-2' },
+          { label: 'Groot', value: 'alien-3' },
+          { label: 'The Worm Guys', value: 'alien-4' },
+          { label: "Na'vi", value: 'alien-5' },
+          { label: 'Arachnids', value: 'alien-6' },
+          { label: 'The Predator', value: 'alien-7' },
+          { label: 'Xenomorph', value: 'alien-8' },
+        ],
+        label: 'aliens',
+      },
+      {
+        group: [
+          { label: 'Smaug', value: 'dragon-1' },
+          { label: 'Mushu', value: 'dragon-2' },
+          { label: 'Toothless', value: 'dragon-3' },
+          { label: 'Falkor', value: 'dragon-4' },
+          { label: 'Drogon', value: 'dragon-5' },
+          { label: 'Kalessin', value: 'dragon-6' },
+        ],
+        label: 'dragons',
+      },
+      {
+        group: [
+          { label: 'Snoopy', value: 'dog-1' },
+          { label: 'Scooby', value: 'dog-2' },
+        ],
+        label: 'dogs',
+      },
+      {
+        group: [
+          { label: '0 as a number', value: 0 },
+          { label: 'false as a boolean', value: false },
+          { label: 'true as a boolean', value: true },
+        ],
+        label: 'tricky content',
+      },
+    ]);
+  });
+});

--- a/assets/src/design-system/components/dropDown/test/utils.js
+++ b/assets/src/design-system/components/dropDown/test/utils.js
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getOptions } from '../utils';
+
+const basicDropDownOptions = [
+  {
+    label: 'label item one',
+    value: 'label-item-one',
+  },
+  {
+    label: 'label item two',
+    value: 'label-item-two',
+  },
+  {
+    label: 'label item three',
+    value: 'label-item-three',
+  },
+];
+
+describe('DropDown/utils getOptions', () => {
+  it('should shape and sanititize basic dropDown options', () => {
+    const groupedOptions = getOptions(basicDropDownOptions);
+
+    expect(groupedOptions).toStrictEqual([
+      {
+        group: [
+          {
+            label: 'label item one',
+            value: 'label-item-one',
+          },
+          {
+            label: 'label item two',
+            value: 'label-item-two',
+          },
+          {
+            label: 'label item three',
+            value: 'label-item-three',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should shape and sanititize basic dropDown options even when some data is bad', () => {
+    const groupedOptions = getOptions([
+      ...basicDropDownOptions,
+      'just a string',
+      { label: 'bad data sneaking through', somethingNew: [1, 2, 3] },
+    ]);
+
+    expect(groupedOptions).toStrictEqual([
+      {
+        group: [
+          {
+            label: 'label item one',
+            value: 'label-item-one',
+          },
+          {
+            label: 'label item two',
+            value: 'label-item-two',
+          },
+          {
+            label: 'label item three',
+            value: 'label-item-three',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should shape and sanititize nested dropDown options', () => {
+    const nestedDropDownOptions = [
+      'something terrible',
+      ['lions', 'tigers', 'bears'],
+      {
+        label: 'aliens',
+        options: [
+          { value: 'alien-1', label: 'ET' },
+          { value: 'alien-2', label: 'Stitch' },
+          { value: 'alien-3', label: 'Groot' },
+        ],
+      },
+      {
+        label: 'dogs',
+        options: [
+          { value: 'dog-1', label: 'Snoopy' },
+          { value: 'dog-2', label: 'Scooby' },
+        ],
+      },
+      {
+        label: 'tricky content',
+        options: [
+          { value: 0, label: '0 as a number' },
+          { value: false, label: 'false as a boolean' },
+          { value: true, label: 'true as a boolean' },
+          { value: undefined, label: "undefined and shouldn't come through" },
+        ],
+      },
+    ];
+
+    const groupedOptions = getOptions(nestedDropDownOptions);
+
+    expect(groupedOptions).toStrictEqual([
+      {
+        group: [
+          { label: 'ET', value: 'alien-1' },
+          { label: 'Stitch', value: 'alien-2' },
+          { label: 'Groot', value: 'alien-3' },
+        ],
+        label: 'aliens',
+      },
+      {
+        group: [
+          {
+            label: 'Snoopy',
+            value: 'dog-1',
+          },
+          {
+            label: 'Scooby',
+            value: 'dog-2',
+          },
+        ],
+        label: 'dogs',
+      },
+      {
+        group: [
+          {
+            label: '0 as a number',
+            value: 0,
+          },
+          {
+            label: 'false as a boolean',
+            value: false,
+          },
+          {
+            label: 'true as a boolean',
+            value: true,
+          },
+        ],
+        label: 'tricky content',
+      },
+    ]);
+  });
+});

--- a/assets/src/design-system/components/dropDown/types.js
+++ b/assets/src/design-system/components/dropDown/types.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+export const DROP_DOWN_VALUE_TYPE = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number,
+  PropTypes.bool,
+]);
+
+export const DROP_DOWN_ITEM = PropTypes.shape({
+  label: PropTypes.string,
+  value: DROP_DOWN_VALUE_TYPE,
+});
+
+export const DROP_DOWN_ITEMS = PropTypes.arrayOf(DROP_DOWN_ITEM);
+
+export const NESTED_DROP_DOWN_ITEM = PropTypes.shape({
+  group: PropTypes.shape({ label: PropTypes.string, options: DROP_DOWN_ITEMS }),
+});
+
+export const NESTED_DROP_DOWN_ITEMS = PropTypes.arrayOf(NESTED_DROP_DOWN_ITEM);
+
+export const MENU_OPTIONS = PropTypes.oneOfType([
+  DROP_DOWN_ITEMS,
+  NESTED_DROP_DOWN_ITEMS,
+]);

--- a/assets/src/design-system/components/dropDown/useDropDown.js
+++ b/assets/src/design-system/components/dropDown/useDropDown.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useMemo, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+
+/**
+ * Internal dependencies
+ */
+import { getOptions } from './utils';
+
+export default function useDropDown({ options = [], selectedValue }) {
+  const [isOpen, _setIsOpen] = useState(false);
+
+  const [setIsOpen] = useDebouncedCallback(_setIsOpen, 300, {
+    leading: true,
+    trailing: false,
+  });
+
+  const normalizedOptions = useMemo(() => {
+    if (!options || options.length == 0) {
+      return [];
+    }
+    return getOptions(options);
+  }, [options]);
+
+  const activeOption = useMemo(() => {
+    if (!selectedValue || normalizedOptions.length === 0) {
+      return null;
+    }
+
+    return normalizedOptions
+      .flatMap((optionSet) => optionSet.group)
+      .find((option) => {
+        return (
+          option?.value?.toString().toLowerCase() ===
+          selectedValue.toString().toLowerCase()
+        );
+      });
+  }, [selectedValue, normalizedOptions]);
+
+  return useMemo(
+    () => ({
+      activeOption,
+      isOpen: {
+        value: isOpen,
+        set: setIsOpen,
+      },
+      normalizedOptions,
+    }),
+    [activeOption, isOpen, normalizedOptions, setIsOpen]
+  );
+}

--- a/assets/src/design-system/components/dropDown/useDropDown.js
+++ b/assets/src/design-system/components/dropDown/useDropDown.js
@@ -25,12 +25,20 @@ import { useDebouncedCallback } from 'use-debounce';
 import { getOptions } from './utils';
 
 export default function useDropDown({ options = [], selectedValue }) {
-  const [isOpen, _setIsOpen] = useState(false);
+  const [_isOpen, _setIsOpen] = useState(false);
 
   const [setIsOpen] = useDebouncedCallback(_setIsOpen, 300, {
     leading: true,
     trailing: false,
   });
+
+  const isOpen = useMemo(
+    () => ({
+      value: _isOpen,
+      set: setIsOpen,
+    }),
+    [_isOpen, setIsOpen]
+  );
 
   const normalizedOptions = useMemo(() => {
     if (!options || options.length == 0) {
@@ -54,15 +62,5 @@ export default function useDropDown({ options = [], selectedValue }) {
       });
   }, [selectedValue, normalizedOptions]);
 
-  return useMemo(
-    () => ({
-      activeOption,
-      isOpen: {
-        value: isOpen,
-        set: setIsOpen,
-      },
-      normalizedOptions,
-    }),
-    [activeOption, isOpen, normalizedOptions, setIsOpen]
-  );
+  return { activeOption, normalizedOptions, isOpen };
 }

--- a/assets/src/design-system/components/dropDown/utils.js
+++ b/assets/src/design-system/components/dropDown/utils.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const getOptions = (groups) => {
+  const isNested = groups.some((group) => Array.isArray(group?.options));
+  if (isNested) {
+    return groups.reduce((prev, current) => {
+      // Determine if this nested group contains options as objects that contain a valid value key.
+      const onlyValidOptions =
+        current?.options &&
+        current.options.filter(
+          (option) => typeof option === 'object' && option?.value?.toString()
+        );
+      // If there aren't any valid options to return, just return the previously reduced array as is
+      if (!Array.isArray(onlyValidOptions)) {
+        return prev;
+      }
+
+      // Otherwise add the validated options to the reduced array as a new object containing group and label
+      return prev.concat({
+        group: onlyValidOptions,
+        label: current?.label,
+      });
+    }, []);
+  } else {
+    // Double check that all data in groups should be treated as options to sanitize data
+    const onlyValidOptions = groups.filter(
+      (option) => typeof option === 'object' && option?.value
+    );
+
+    if (!Array.isArray(onlyValidOptions) || onlyValidOptions.length === 0) {
+      return [];
+    }
+    return [{ group: onlyValidOptions }];
+  }
+};

--- a/assets/src/design-system/storybookUtils/darkThemeProvider.js
+++ b/assets/src/design-system/storybookUtils/darkThemeProvider.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+
+import { ThemeProvider } from 'styled-components';
+import PropTypes from 'prop-types';
+/**
+ * Internal dependencies
+ */
+import { theme } from '../theme';
+
+export const DarkThemeProvider = ({ children }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+DarkThemeProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/assets/src/design-system/storybookUtils/index.js
+++ b/assets/src/design-system/storybookUtils/index.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DarkThemeProvider } from './darkThemeProvider';


### PR DESCRIPTION
## Summary

Initial structure for dropDown in design system. Includes storybook set up and base component as <DropDown />. Options are getting structured in useDropDown hook and tested. Adds a storybook util to simplify dark theme demos in storybook.

## Relevant Technical Choices

Adds initial files for `<DropDown />` in design system. Focuses on necessary scaffolding of types, setting up storybook, and sanitizing option data so that `DropDown` can handle flat lists as well as nested. (I did include all of the props I want on DropDown in storybook even though it's not supported yet, since I'm portioning out PR #5654 to be readable I did this to avoid merge conflicts.)

All in all, `DropDown/index` is responsible for functionality that controls both the Select button and the Menu list. This is where we set if the menu is open, what the selected item is (derived from the selectedValue passed in) and from that what text to render in the button. It also sets up how to handle selections and dismissal as well as position of the menu which is rendered within a popup menu copied in from the editor. It is responsible for data sanitization of options so that flat option lists and grouped lists can be handled the same.

## To-do

Further PRs to be merged into `feature/ds-dropdown/main` to make updates easier to review

- [x] Select button 
- [x] Keyboard functionality copied in from edit-story
- [x] Popup copied in from edit-story
- [x] Menu

## User-facing changes

None, storybook only

## Testing Instructions

Run new unit tests, see that `options` comes back structured as outlined.

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4950 
