### PR TITLE
Design System: DropDown Select Button

### DIFF
--- a/assets/src/design-system/components/dropDown/index.js
+++ b/assets/src/design-system/components/dropDown/index.js
@@ -46,7 +46,6 @@ export const DropDown = ({
   ariaLabel,
   dropDownLabel,
   hint,
-  disabled,
   options = [],
   selectedValue = '',
   ...rest
@@ -73,7 +72,6 @@ export const DropDown = ({
         ariaLabel={ariaLabel}
         dropDownLabel={dropDownLabel}
         isOpen={isOpen.value}
-        disabled={disabled}
         onSelectClick={handleSelectClick}
         ref={selectRef}
         {...rest}

--- a/assets/src/design-system/components/dropDown/index.js
+++ b/assets/src/design-system/components/dropDown/index.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { useCallback, useRef } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
@@ -24,6 +25,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { MENU_OPTIONS } from './types';
+import { DropDownSelect } from './select';
 import useDropDown from './useDropDown';
 
 const DropDownContainer = styled.div``;
@@ -31,22 +33,63 @@ const DropDownContainer = styled.div``;
 /**
  *
  * @param {Object} props All props.
+ * @param {string} props.ariaLabel Specific label to use as select button's aria label only.
+ * @param {boolean} props.disabled If true, menu will not be openable
+ * @param {string} props.dropdownLabel Text shown in button with selected value's label or placeholder. Will be used as aria label if no separate ariaLabel is passed in.
+ * @param {string} props.hint Hint text to display below a dropdown (optional). If not present, no hint text will display.
  * @param {Array} props.options All options, should contain either 1) objects with a label, value, anything else you need can be added and accessed through renderItem or 2) Objects containing a label and options, where options is structured as first option with array of objects containing at least value and label - this will create a nested list.
  * @param {string} props.selectedValue the selected value of the dropDown. Should correspond to a value in the options array of objects.
  *
  */
 
-export const DropDown = ({ options = [], selectedValue = '' }) => {
-  useDropDown({
+export const DropDown = ({
+  ariaLabel,
+  dropDownLabel,
+  hint,
+  disabled,
+  options = [],
+  selectedValue = '',
+  ...rest
+}) => {
+  const selectRef = useRef();
+
+  const { activeOption, isOpen } = useDropDown({
     options,
     selectedValue,
   });
 
-  return <DropDownContainer />;
+  const handleSelectClick = useCallback(
+    (event) => {
+      event.preventDefault();
+      isOpen.set((prevIsOpen) => !prevIsOpen);
+    },
+    [isOpen]
+  );
+
+  return (
+    <DropDownContainer>
+      <DropDownSelect
+        activeItemLabel={activeOption?.label}
+        ariaLabel={ariaLabel}
+        dropDownLabel={dropDownLabel}
+        isOpen={isOpen.value}
+        disabled={disabled}
+        onSelectClick={handleSelectClick}
+        ref={selectRef}
+        {...rest}
+      />
+      {hint && <p>{hint}</p>}
+    </DropDownContainer>
+  );
 };
 
 DropDown.propTypes = {
+  ariaLabel: PropTypes.string,
+  disabled: PropTypes.bool,
+  dropDownLabel: PropTypes.string,
+  hint: PropTypes.string,
   options: MENU_OPTIONS,
+  placeholder: PropTypes.string,
   selectedValue: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.bool,

--- a/assets/src/design-system/components/dropDown/select/index.js
+++ b/assets/src/design-system/components/dropDown/select/index.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { forwardRef } from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const SelectButton = styled.button``;
+
+export const DropDownSelect = forwardRef(function DropDownSelect(
+  {
+    activeItemLabel,
+    ariaLabel,
+    disabled,
+    dropDownLabel,
+    isOpen,
+    onSelectClick,
+    placeholder = '',
+  },
+  ref
+) {
+  return (
+    <SelectButton
+      aria-label={ariaLabel || dropDownLabel}
+      aria-pressed={isOpen}
+      aria-haspopup={true}
+      aria-expanded={isOpen}
+      aria-disabled={disabled}
+      disabled={disabled}
+      onClick={onSelectClick}
+      ref={ref}
+    >
+      {activeItemLabel || placeholder}
+      {dropDownLabel && <span>{dropDownLabel}</span>}
+    </SelectButton>
+  );
+});
+
+DropDownSelect.propTypes = {
+  activeItemLabel: PropTypes.string,
+  ariaLabel: PropTypes.string,
+  dropDownLabel: PropTypes.string,
+  onSelectClick: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
+  disabled: PropTypes.bool,
+  isOpen: PropTypes.bool,
+};

--- a/assets/src/design-system/components/dropDown/test/dropDown.js
+++ b/assets/src/design-system/components/dropDown/test/dropDown.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { renderWithProviders } from '../../../testUtils/renderWithProviders';
+import { DropDown } from '../';
+import { basicDropDownOptions } from '../stories/sampleData';
+
+describe('DropDown <DropDown />', () => {
+  it('should render a closed <DropDown /> menu with a select button on default', () => {
+    const { getByRole, queryAllByRole } = renderWithProviders(
+      <DropDown options={basicDropDownOptions} dropDownLabel={'label'} />
+    );
+
+    const select = getByRole('button');
+    expect(select).toBeDefined();
+
+    const menu = queryAllByRole('listbox');
+    expect(menu).toHaveLength(0);
+  });
+
+  it('should show placeholder value when no selected value is found', () => {
+    const { getByText } = renderWithProviders(
+      <DropDown options={basicDropDownOptions} placeholder={'select a value'} />
+    );
+
+    const placeholder = getByText('select a value');
+    expect(placeholder).toBeDefined();
+  });
+
+  it("should show selectedValue's associated label when selectedValue is present", () => {
+    const { getByText } = renderWithProviders(
+      <DropDown
+        options={basicDropDownOptions}
+        placeholder={'select a value'}
+        dropDownLabel={'label'}
+        selectedValue={basicDropDownOptions[2].value}
+      />
+    );
+
+    const select = getByText(basicDropDownOptions[2].label);
+    expect(select).toBeDefined();
+  });
+
+  it("should show placeholder when selectedValue's associated label cannot be found", () => {
+    const { getByText } = renderWithProviders(
+      <DropDown
+        options={basicDropDownOptions}
+        placeholder={'select a value'}
+        dropDownLabel={'label'}
+        selectedValue={'value that is not found in items'}
+      />
+    );
+
+    const select = getByText('select a value');
+    expect(select).toBeDefined();
+  });
+
+  it('should show label value when provided', () => {
+    const { getByText } = renderWithProviders(
+      <DropDown
+        options={basicDropDownOptions}
+        placeholder={'select a value'}
+        dropDownLabel={'my label'}
+      />
+    );
+
+    const label = getByText('my label');
+    expect(label).toBeDefined();
+  });
+});

--- a/assets/src/design-system/components/dropDown/test/select.js
+++ b/assets/src/design-system/components/dropDown/test/select.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+
+import { fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { renderWithProviders } from '../../../testUtils/renderWithProviders';
+import { DropDownSelect } from '../select';
+
+describe('DropDown <DropDownSelect />', () => {
+  const onClickMock = jest.fn();
+
+  it('should render a <DropDownSelect /> button by default', () => {
+    const { getByRole } = renderWithProviders(
+      <DropDownSelect
+        activeItemLabel={'chosen option'}
+        dropDownLabel={'my label'}
+        onSelectClick={onClickMock}
+        placeholder={'my placeholder'}
+      />
+    );
+
+    const select = getByRole('button');
+    expect(select).toBeInTheDocument();
+  });
+
+  it('should not trigger onSelectClick on click if select is disabled', () => {
+    const { getByLabelText } = renderWithProviders(
+      <DropDownSelect
+        activeItemLabel={'chosen option'}
+        disabled={true}
+        dropDownLabel={'my label'}
+        onSelectClick={onClickMock}
+        placeholder={'my placeholder'}
+      />
+    );
+
+    const select = getByLabelText('my label');
+    fireEvent.click(select);
+
+    expect(onClickMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('should trigger onSelectClick on click', () => {
+    const { getByLabelText } = renderWithProviders(
+      <DropDownSelect
+        activeItemLabel={'chosen option'}
+        ariaLabel={'specific label for aria to override visible label'}
+        dropDownLabel={'my label'}
+        onSelectClick={onClickMock}
+        placeholder={'my placeholder'}
+      />
+    );
+
+    const select = getByLabelText(
+      'specific label for aria to override visible label'
+    );
+    fireEvent.click(select);
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

select button for `<DropDown />`. 

## Relevant Technical Choices

- Copied aria props from the `AdvancedDropDown` in edit-story. 
- Forwarding ref because we need the select button to decide where the popup container will go. 
- Adding relevant tests.

## To-do

Further PRs to be merged into `feature/ds-dropdown/main` to make updates easier to review

- [x]  Keyboard functionality copied in from edit-story
- [x]  Popup copied in from edit-story
- [x]  Menu

## User-facing changes

None, storybook only

## Testing Instructions

- Verify that the added unit tests work 
- You can now see the DropDown in storybook! It looks like a button and some text. (DesignSystem/Components/DropDown)

![Screen Shot 2020-12-18 at 9 39 16 AM](https://user-images.githubusercontent.com/10720454/102639229-f5452480-4115-11eb-9c17-5859c31e4545.png)

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4950 