### PR TITLE
Karma: Add Copy and Paste tests

### DIFF
--- a/assets/src/edit-story/components/dropTargets/karma/background.karma.js
+++ b/assets/src/edit-story/components/dropTargets/karma/background.karma.js
@@ -458,11 +458,11 @@ function getMediaLibraryElementByIndex(fixture, index) {
   return fixture.querySelectorAll('[data-testid^=mediaElement]')[index];
 }
 
-async function addDummyImage(fixture, index) {
+export async function addDummyImage(fixture, index) {
   await fixture.events.click(getMediaLibraryElementByIndex(fixture, index));
 }
 
-async function dragCanvasElementToDropTarget(
+export async function dragCanvasElementToDropTarget(
   fixture,
   canvasElementId,
   targetId
@@ -544,4 +544,23 @@ function getAllTransformsBetween(startElement, endElement) {
 
 function getComputedStyle(element) {
   return window.getComputedStyle(element);
+}
+
+export async function addBackgroundImage(fixture, options) {
+  await addDummyImage(fixture, 1);
+  const {
+    actions: { updateElementById },
+    state: {
+      currentPage: { elements },
+    },
+  } = await fixture.renderHook(() => useStory());
+  if (options?.properties) {
+    updateElementById({
+      elementId: elements[1].id,
+      properties: options?.properties,
+    });
+  }
+  const backgroundId = await getBackgroundElementId(fixture);
+  await dragCanvasElementToDropTarget(fixture, elements[1].id, backgroundId);
+  await fixture.events.mouse.up();
 }

--- a/assets/src/edit-story/components/panels/design/animation/animation.js
+++ b/assets/src/edit-story/components/panels/design/animation/animation.js
@@ -66,7 +66,6 @@ function AnimationPanel({
 
   const isBackground =
     selectedElements.length === 1 && selectedElements[0].isBackground;
-  const backgroundScale = isBackground && selectedElements[0].scale;
   const updatedAnimations = useMemo(() => {
     // Combining local element updates with the
     // page level applied updates
@@ -107,17 +106,6 @@ function AnimationPanel({
             }
           : {};
 
-      // Background Zoom's `scale from` initial value should match
-      // the current background's scale slider
-      if (
-        isBackground &&
-        animation === BACKGROUND_ANIMATION_EFFECTS.ZOOM.value
-      ) {
-        defaults.normalizedScaleFrom =
-          progress(backgroundScale, [BG_MIN_SCALE, BG_MAX_SCALE]) ||
-          defaults.normalizedScaleFrom;
-      }
-
       pushUpdateForObject(
         ANIMATION_PROPERTY,
         {
@@ -135,12 +123,7 @@ function AnimationPanel({
       // was changed by the effect chooser, so we track it here.
       playUpdatedAnimation.current = true;
     },
-    [
-      selectedElementAnimations,
-      isBackground,
-      pushUpdateForObject,
-      backgroundScale,
-    ]
+    [selectedElementAnimations, pushUpdateForObject]
   );
 
   // Play animation of selected elements when effect chooser signals

--- a/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
+++ b/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
@@ -14,12 +14,118 @@
  * limitations under the License.
  */
 
+/**
+ * Internal dependencies
+ */
+import useInsertElement from '../components/canvas/useInsertElement';
+import { useStory } from '../app/story';
+import { Fixture } from './fixture';
+
 describe('Copy & Paste', () => {
-  // Disable reason: Not implemented yet
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('');
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  it('pastes copied element in a new location and selects it', async () => {
+    const insertElement = await fixture.renderHook(() => useInsertElement());
+    const element = await fixture.act(() =>
+      insertElement('text', {
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 50,
+        content: 'Hello, Stories!',
+      })
+    );
+    await fixture.events.clipboard.copy();
+    await fixture.events.clipboard.paste();
+    const currentPage = await fixture.renderHook(() =>
+      useStory(({ state }) => state.currentPage)
+    );
+
+    // get pasted element
+    // elements = [background, originalElement, pastedElement]
+    const newElements = currentPage.elements
+      .filter((el) => !el.isBackground)
+      .filter((el) => el.id !== element.id);
+    // only one element should have been added
+    expect(newElements.length).toEqual(1);
+
+    // see that the new element retains important properties
+    // and doesn't have the same position as original element
+    const newElement = newElements[0];
+    ['type', 'content', 'width', 'height'].forEach((key) =>
+      expect(newElement[key]).toEqual(element[key])
+    );
+    ['x', 'y'].forEach((key) =>
+      expect(newElement[key]).not.toEqual(element[key])
+    );
+
+    // see that new element gains selection
+    const selection = await fixture.renderHook(() =>
+      useStory(({ state }) => state.selectedElementIds)
+    );
+    expect(selection).toEqual([newElement.id]);
+  });
+
+  it('foreground animations', async () => {
+    const insertElement = await fixture.renderHook(() => useInsertElement());
+    // const element = await fixture.act(() =>
+    await fixture.act(() =>
+      insertElement('text', {
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 50,
+        content: 'Hello, Stories!',
+      })
+    );
+
+    // open effect chooser
+    const effectChooserToggle =
+      fixture.editor.inspector.designPanel.animation.effectChooser;
+    await fixture.events.click(effectChooserToggle, { clickCount: 1 });
+
+    // see that effect chooser is open
+    const effectChooser = fixture.screen.getByRole('list', {
+      name: /Available Animations To Select/,
+    });
+
+    // iterate through children with process
+    // let coppied = element;
+    return Array.from(effectChooser.children)
+      .map((effectButton, i) => async () => {
+        // first button is `none` and doesn't apply animation
+        if (i === 0) {
+          return;
+        }
+        // apply animation to element
+        await fixture.events.click(effectButton, { clickCount: 1 });
+
+        // copy and paste animated element
+        await fixture.events.clipboard.copy();
+        await fixture.events.clipboard.paste();
+
+        // see that current page has new animation
+        const { animations, elements } = await fixture.renderHook(() =>
+          useStory(({ state }) => state.currentPage)
+        );
+
+        // 2 comes from background + initial coppied element
+        expect(elements.length).toEqual(i + 2);
+        expect(animations.length).toEqual(i + 1);
+      })
+      .reduce((p, fn) => p.then(fn), Promise.resolve());
+  });
 });
 
-describe('Duplicate Element', () => {});
+// describe('Duplicate Element', () => {});
 
-describe('Duplicate Page', () => {});
+// describe('Duplicate Page', () => {});

--- a/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
+++ b/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
@@ -39,6 +39,7 @@ function sequencedForEach(htmlCollection, op) {
       .map((htmlElement, i) => async () => {
         await op(htmlElement, i);
       })
+      // [p1, p2, p3, p4] -> promise.resolve().then(p1).then(p2).then(p3).then(p4)
       .reduce((p, fn) => p.then(fn), Promise.resolve())
       .then(res);
   });
@@ -141,13 +142,13 @@ function sequencedForEach(htmlCollection, op) {
           await fixture.events.click(effectButton, { clickCount: 1 });
 
           // copy and paste animated element with Animations
-          const coppied = await fixture.renderHook(() =>
+          const copied = await fixture.renderHook(() =>
             useStory(({ state }) => ({
               elements: state.selectedElements,
               elementAnimations: state.selectedElementAnimations,
             }))
           );
-          expect(coppied.elementAnimations.length).toEqual(1);
+          expect(copied.elementAnimations.length).toEqual(1);
           await action(fixture);
           const pasted = await fixture.renderHook(() =>
             useStory(({ state }) => ({
@@ -163,7 +164,7 @@ function sequencedForEach(htmlCollection, op) {
             id: cId,
             targets: cTargets,
             ...cPersisted
-          } = coppied.elementAnimations[0];
+          } = copied.elementAnimations[0];
           const {
             id: pId,
             targets: pTargets,
@@ -181,9 +182,9 @@ function sequencedForEach(htmlCollection, op) {
             useStory(({ state }) => state.currentPage)
           );
 
-          // 2 comes from background + initial coppied element
+          // 2 comes from background + initial copied element
           expect(elements.length).toEqual(i + 2);
-          // 1 comes from original coppied element animation
+          // 1 comes from original copied element animation
           expect(animations.length).toEqual(i + 1);
         }
       );
@@ -261,13 +262,13 @@ describe('Background Copy & Paste', () => {
       await fixture.events.click(effectButton, { clickCount: 1 });
 
       // copy background element with animation
-      const coppied = await fixture.renderHook(() =>
+      const copied = await fixture.renderHook(() =>
         useStory(({ state }) => ({
           elements: state.selectedElements,
           elementAnimations: state.selectedElementAnimations,
         }))
       );
-      expect(coppied.elementAnimations.length).toEqual(1);
+      expect(copied.elementAnimations.length).toEqual(1);
       await fixture.events.clipboard.copy();
 
       // Go to second page
@@ -289,7 +290,7 @@ describe('Background Copy & Paste', () => {
         id: cId,
         targets: cTargets,
         ...cPersisted
-      } = coppied.elementAnimations[0];
+      } = copied.elementAnimations[0];
       const {
         id: pId,
         targets: pTargets,
@@ -318,7 +319,7 @@ describe('Background Copy & Paste', () => {
       const setSelectedById = await fixture.renderHook(() =>
         useStory(({ actions }) => actions.setSelectedElementsById)
       );
-      setSelectedById({ elementIds: [coppied.elements[0].id] });
+      setSelectedById({ elementIds: [copied.elements[0].id] });
       // reopen effect chooser
       await openEffectChooser();
     });

--- a/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
+++ b/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('Copy & Paste', () => {
+  // Disable reason: Not implemented yet
+  // eslint-disable-next-line jasmine/no-disabled-tests
+  xit('');
+});
+
+describe('Duplicate Element', () => {});
+
+describe('Duplicate Page', () => {});

--- a/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
+++ b/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
@@ -18,80 +18,227 @@
  * Internal dependencies
  */
 import useInsertElement from '../components/canvas/useInsertElement';
+import { addBackgroundImage } from '../components/dropTargets/karma/background.karma';
 import { useStory } from '../app/story';
 import { Fixture } from './fixture';
 
-describe('Copy & Paste', () => {
+/**
+ * Takes an HTMLCollection and sequentially performs an
+ * async action on each element in the collection. 
+ 
+ * Call order of operations is based on the order of
+ * the elements in the collection
+ *
+ * @param {HTMLCollection} htmlCollection - collection of html elements to perform operation on.
+ * @param {(el: HTMLElement, i: number) => Promise<void>} op - async operation
+ * @return {Promise<void>}
+ */
+function sequencedForEach(htmlCollection, op) {
+  return new Promise((res) => {
+    Array.from(htmlCollection)
+      .map((htmlElement, i) => async () => {
+        await op(htmlElement, i);
+      })
+      .reduce((p, fn) => p.then(fn), Promise.resolve())
+      .then(res);
+  });
+}
+
+[
+  {
+    title: 'Foreground Copy & Paste',
+    action: async (fixture) => {
+      await fixture.events.clipboard.copy();
+      await fixture.events.clipboard.paste();
+    },
+  },
+  {
+    title: 'Duplicate',
+    action: async (fixture) => {
+      await fixture.events.keyboard.shortcut('mod+d');
+    },
+  },
+].forEach(({ title, action }) => {
+  describe(title, () => {
+    let fixture;
+    let element;
+
+    beforeEach(async () => {
+      fixture = new Fixture();
+      await fixture.render();
+
+      // Insert selected element to perform operations on.
+      const insertElement = await fixture.renderHook(() => useInsertElement());
+      element = await fixture.act(() =>
+        insertElement('text', {
+          x: 10,
+          y: 10,
+          width: 100,
+          height: 50,
+          content: 'Hello, Stories!',
+        })
+      );
+    });
+
+    afterEach(() => {
+      fixture.restore();
+    });
+
+    it('pastes copied element in a new location and selects it', async () => {
+      await action(fixture);
+      const currentPage = await fixture.renderHook(() =>
+        useStory(({ state }) => state.currentPage)
+      );
+
+      // get pasted element
+      // elements = [background, originalElement, pastedElement]
+      const newElements = currentPage.elements
+        .filter((el) => !el.isBackground)
+        .filter((el) => el.id !== element.id);
+      // only one element should have been added
+      expect(newElements.length).toEqual(1);
+
+      // see that the new element retains important properties
+      // and doesn't have the same position as original element
+      const newElement = newElements[0];
+      ['type', 'content', 'width', 'height'].forEach((key) =>
+        expect(newElement[key]).toEqual(element[key])
+      );
+      ['x', 'y'].forEach((key) =>
+        expect(newElement[key]).not.toEqual(element[key])
+      );
+
+      // see that new element gains selection
+      const selection = await fixture.renderHook(() =>
+        useStory(({ state }) => state.selectedElementIds)
+      );
+      expect(selection).toEqual([newElement.id]);
+    });
+
+    it('retains all foreground animations', async () => {
+      // open effect chooser
+      const effectChooserToggle =
+        fixture.editor.inspector.designPanel.animation.effectChooser;
+      await fixture.events.click(effectChooserToggle, { clickCount: 1 });
+
+      // see that effect chooser is open
+      const effectChooser = fixture.screen.getByRole('list', {
+        name: /Available Animations To Select/,
+      });
+
+      // iterate through children with process
+      await sequencedForEach(
+        effectChooser.children,
+        async (effectButton, i) => {
+          // first button is `none` and doesn't apply animation
+          if (
+            i === 0 ||
+            effectButton.getAttribute('aria-disabled') === 'true'
+          ) {
+            return;
+          }
+          // apply animation to element
+          await fixture.events.click(effectButton, { clickCount: 1 });
+
+          // copy and paste animated element with Animations
+          const coppied = await fixture.renderHook(() =>
+            useStory(({ state }) => ({
+              elements: state.selectedElements,
+              elementAnimations: state.selectedElementAnimations,
+            }))
+          );
+          expect(coppied.elementAnimations.length).toEqual(1);
+          await action(fixture);
+          const pasted = await fixture.renderHook(() =>
+            useStory(({ state }) => ({
+              elements: state.selectedElements,
+              elementAnimations: state.selectedElementAnimations,
+            }))
+          );
+          expect(pasted.elementAnimations.length).toEqual(1);
+
+          // Coppied and Pasted anims should share all attributes
+          // Except `id` & `targets`
+          const {
+            id: cId,
+            targets: cTargets,
+            ...cPersisted
+          } = coppied.elementAnimations[0];
+          const {
+            id: pId,
+            targets: pTargets,
+            ...pPersisted
+          } = pasted.elementAnimations[0];
+          expect(cPersisted).toEqual(pPersisted);
+
+          // pasted animations should contain the newly pasted
+          // element's id as it's only target
+          const pastedElId = pasted.elements[0].id;
+          expect(pTargets).toEqual([pastedElId]);
+
+          // see that current page has new animation
+          const { animations, elements } = await fixture.renderHook(() =>
+            useStory(({ state }) => state.currentPage)
+          );
+
+          // 2 comes from background + initial coppied element
+          expect(elements.length).toEqual(i + 2);
+          // 1 comes from original coppied element animation
+          expect(animations.length).toEqual(i + 1);
+        }
+      );
+    });
+  });
+});
+
+describe('Background Copy & Paste', () => {
   let fixture;
+
+  const goToNextPage = async () => {
+    const nextPageButton = fixture.screen.getByRole('button', {
+      name: /Next Page/,
+    });
+    await fixture.events.click(nextPageButton, { clickCount: 1 });
+  };
+
+  const goToPreviousPage = async () => {
+    const previousPageButton = fixture.screen.getByRole('button', {
+      name: /Previous Page/,
+    });
+    await fixture.events.click(previousPageButton, { clickCount: 1 });
+  };
+
+  const openEffectChooser = async () => {
+    const effectChooserToggle =
+      fixture.editor.inspector.designPanel.animation.effectChooser;
+    await fixture.events.click(effectChooserToggle, { clickCount: 1 });
+  };
 
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+
+    // Create a new blank page to copy to.
+    const addNewPageButton = fixture.screen.getByRole('button', {
+      name: /Add New Page/,
+    });
+    await fixture.events.click(addNewPageButton, { clickCount: 1 });
+
+    // Navigate back to previous page and aff Background image
+    await goToPreviousPage();
+    // we want to zoom in a little bit so background
+    // is big enough for all background animations.
+    // scale is between 100 -> 400
+    await addBackgroundImage(fixture, { properties: { scale: 200 } });
   });
 
   afterEach(() => {
     fixture.restore();
   });
 
-  it('pastes copied element in a new location and selects it', async () => {
-    const insertElement = await fixture.renderHook(() => useInsertElement());
-    const element = await fixture.act(() =>
-      insertElement('text', {
-        x: 10,
-        y: 10,
-        width: 100,
-        height: 50,
-        content: 'Hello, Stories!',
-      })
-    );
-    await fixture.events.clipboard.copy();
-    await fixture.events.clipboard.paste();
-    const currentPage = await fixture.renderHook(() =>
-      useStory(({ state }) => state.currentPage)
-    );
-
-    // get pasted element
-    // elements = [background, originalElement, pastedElement]
-    const newElements = currentPage.elements
-      .filter((el) => !el.isBackground)
-      .filter((el) => el.id !== element.id);
-    // only one element should have been added
-    expect(newElements.length).toEqual(1);
-
-    // see that the new element retains important properties
-    // and doesn't have the same position as original element
-    const newElement = newElements[0];
-    ['type', 'content', 'width', 'height'].forEach((key) =>
-      expect(newElement[key]).toEqual(element[key])
-    );
-    ['x', 'y'].forEach((key) =>
-      expect(newElement[key]).not.toEqual(element[key])
-    );
-
-    // see that new element gains selection
-    const selection = await fixture.renderHook(() =>
-      useStory(({ state }) => state.selectedElementIds)
-    );
-    expect(selection).toEqual([newElement.id]);
-  });
-
-  it('foreground animations', async () => {
-    const insertElement = await fixture.renderHook(() => useInsertElement());
-    // const element = await fixture.act(() =>
-    await fixture.act(() =>
-      insertElement('text', {
-        x: 10,
-        y: 10,
-        width: 100,
-        height: 50,
-        content: 'Hello, Stories!',
-      })
-    );
-
+  it('works for all background animations', async () => {
     // open effect chooser
-    const effectChooserToggle =
-      fixture.editor.inspector.designPanel.animation.effectChooser;
-    await fixture.events.click(effectChooserToggle, { clickCount: 1 });
+    await openEffectChooser();
 
     // see that effect chooser is open
     const effectChooser = fixture.screen.getByRole('list', {
@@ -99,33 +246,81 @@ describe('Copy & Paste', () => {
     });
 
     // iterate through children with process
-    // let coppied = element;
-    return Array.from(effectChooser.children)
-      .map((effectButton, i) => async () => {
-        // first button is `none` and doesn't apply animation
-        if (i === 0) {
-          return;
-        }
-        // apply animation to element
-        await fixture.events.click(effectButton, { clickCount: 1 });
+    await sequencedForEach(effectChooser.children, async (_, i) => {
+      // need to regrab the button because we're openeing
+      // and closing effect chooser causing karma ids to change
+      const effectButton = fixture.screen.getByRole('list', {
+        name: /Available Animations To Select/,
+      }).children[i];
 
-        // copy and paste animated element
-        await fixture.events.clipboard.copy();
-        await fixture.events.clipboard.paste();
+      // first button is `none` and doesn't apply animation
+      if (i === 0 || effectButton.getAttribute('aria-disabled') === 'true') {
+        return;
+      }
+      // apply animation to element
+      await fixture.events.click(effectButton, { clickCount: 1 });
 
-        // see that current page has new animation
-        const { animations, elements } = await fixture.renderHook(() =>
-          useStory(({ state }) => state.currentPage)
-        );
+      // copy background element with animation
+      const coppied = await fixture.renderHook(() =>
+        useStory(({ state }) => ({
+          elements: state.selectedElements,
+          elementAnimations: state.selectedElementAnimations,
+        }))
+      );
+      expect(coppied.elementAnimations.length).toEqual(1);
+      await fixture.events.clipboard.copy();
 
-        // 2 comes from background + initial coppied element
-        expect(elements.length).toEqual(i + 2);
-        expect(animations.length).toEqual(i + 1);
-      })
-      .reduce((p, fn) => p.then(fn), Promise.resolve());
+      // Go to second page
+      await goToNextPage();
+
+      // Paste background with animation to second page
+      await fixture.events.clipboard.paste();
+      const pasted = await fixture.renderHook(() =>
+        useStory(({ state }) => ({
+          elements: state.selectedElements,
+          elementAnimations: state.selectedElementAnimations,
+        }))
+      );
+      expect(pasted.elementAnimations.length).toEqual(1);
+
+      // Coppied and Pasted anims should share all attributes
+      // Except `id` & `targets`
+      const {
+        id: cId,
+        targets: cTargets,
+        ...cPersisted
+      } = coppied.elementAnimations[0];
+      const {
+        id: pId,
+        targets: pTargets,
+        ...pPersisted
+      } = pasted.elementAnimations[0];
+      expect(cPersisted).toEqual(pPersisted);
+
+      // pasted animations should contain the newly pasted
+      // element's id as it's only target
+      const pastedElId = pasted.elements[0].id;
+      expect(pTargets).toEqual([pastedElId]);
+
+      // see that current page has new animation
+      const { animations, elements } = await fixture.renderHook(() =>
+        useStory(({ state }) => state.currentPage)
+      );
+
+      // Pages should only contain background
+      expect(elements.length).toEqual(1);
+      // Pages should only contain background animation
+      expect(animations.length).toEqual(1);
+
+      // Go back to previous page to restart process
+      await goToPreviousPage();
+      // Select Background
+      const setSelectedById = await fixture.renderHook(() =>
+        useStory(({ actions }) => actions.setSelectedElementsById)
+      );
+      setSelectedById({ elementIds: [coppied.elements[0].id] });
+      // reopen effect chooser
+      await openEffectChooser();
+    });
   });
 });
-
-// describe('Duplicate Element', () => {});
-
-// describe('Duplicate Page', () => {});


### PR DESCRIPTION
## Summary
Adds karma tests for copy and paste actions as well as duplicate/clone actions. These both have the same external functionality to the user, but have different internal implementations. These tests verify that both behave the exact same to the user.

This also tests these actions with all foreground and background animations visible in the effect chooser. This is nice cus as we add or remove effects from the effects panel, this test ensures us that none of the outward facing animations break the app on copy & paste or duplicate.

These new tests already pointed out some dead code that wasn't being used for background zoom, so that's nice!

## Relevant Technical Choices
Just followed exiting patterns.

## To-do
Page duplication is similar to copy & paste and duplicate/clone actions, but has a different underlying implementation. 

Here's the ticket to add karma tests for it: https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/5737

Just want to point out here, that these tests don't cover page duplication although the functionality is super similar.

## User-facing changes
None

## Testing Instructions
None - covered in CI karma tests

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5564 
