### PR TITLE
Design System: Menu for DropDown

### DIFF
--- a/assets/src/design-system/components/dropDown/constants.js
+++ b/assets/src/design-system/components/dropDown/constants.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const DEFAULT_ANCHOR_HEIGHT = 20;
+export const DEFAULT_DROPDOWN_HEIGHT = 208;
+
+export const KEYS_SHIFT_FOCUS = ['up', 'down', 'left', 'right'];
+export const KEYS_CLOSE_MENU = ['esc', 'tab'];
+export const KEYS_SELECT_ITEM = ['space', 'enter'];

--- a/assets/src/design-system/components/dropDown/index.js
+++ b/assets/src/design-system/components/dropDown/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
@@ -32,8 +32,8 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { Popup, PLACEMENT } from '../popup';
 import { MENU_OPTIONS } from './types';
-import { DropDownMenu } from './menu';
-import { DropDownSelect } from './select';
+import DropDownMenu from './menu';
+import DropDownSelect from './select';
 import useDropDown from './useDropDown';
 
 const DropDownContainer = styled.div``;
@@ -109,7 +109,7 @@ export const DropDown = ({
     }
   }, []);
 
-  const listId = `list-${uuidv4()}`;
+  const listId = useMemo(() => `list-${uuidv4()}`, []);
 
   return (
     <DropDownContainer>

--- a/assets/src/design-system/components/dropDown/index.js
+++ b/assets/src/design-system/components/dropDown/index.js
@@ -17,15 +17,22 @@
 /**
  * External dependencies
  */
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { Popup, PLACEMENT } from '../popup';
 import { MENU_OPTIONS } from './types';
+import { DropDownMenu } from './menu';
 import { DropDownSelect } from './select';
 import useDropDown from './useDropDown';
 
@@ -37,9 +44,15 @@ const DropDownContainer = styled.div``;
  * @param {string} props.ariaLabel Specific label to use as select button's aria label only.
  * @param {boolean} props.disabled If true, menu will not be openable
  * @param {string} props.dropdownLabel Text shown in button with selected value's label or placeholder. Will be used as aria label if no separate ariaLabel is passed in.
+ * @param {string} props.emptyText If the array of options is empty this text will display when menu is expanded.
  * @param {string} props.hint Hint text to display below a dropdown (optional). If not present, no hint text will display.
+ * @param {boolean} props.isKeepMenuOpenOnSelection If true, when a new selection is made the internal functionality to close the menu will not fire, by default is false.
+ * @param {boolean} props.isRTL If true, arrow left will trigger down, arrow right will trigger up.
+ * @param {Object} props.menuStylesOverride should be formatted as a css template literal with styled components. Gives access to completely overriding dropdown menu styles (container div > ul > li).
+ * @param {Function} props.onMenuItemClick Triggered when a user clicks or presses 'Enter' on an option.
  * @param {Array} props.options All options, should contain either 1) objects with a label, value, anything else you need can be added and accessed through renderItem or 2) Objects containing a label and options, where options is structured as first option with array of objects containing at least value and label - this will create a nested list.
  * @param {string} props.placement placement passed to popover for where menu should expand, defaults to "bottom_end".
+ * @param {Function} props.renderItem If present when menu is open, will override the base list items rendered for each option, the entire item and whether it is selected will be returned and allow you to style list items internal to a list item without affecting dropdown functionality.
  * @param {string} props.selectedValue the selected value of the dropDown. Should correspond to a value in the options array of objects.
  *
  */
@@ -49,6 +62,8 @@ export const DropDown = ({
   disabled,
   dropDownLabel,
   hint,
+  isKeepMenuOpenOnSelection,
+  onMenuItemClick,
   options = [],
   placement = PLACEMENT.BOTTOM_END,
   selectedValue = '',
@@ -56,7 +71,9 @@ export const DropDown = ({
 }) => {
   const selectRef = useRef();
 
-  const { activeOption, isOpen } = useDropDown({
+  const [anchorHeight, setAnchorHeight] = useState(null);
+
+  const { activeOption, isOpen, normalizedOptions } = useDropDown({
     options,
     selectedValue,
   });
@@ -68,6 +85,31 @@ export const DropDown = ({
     },
     [isOpen]
   );
+
+  const handleDismissMenu = useCallback(() => {
+    isOpen.set(false);
+    selectRef.current.focus();
+  }, [isOpen]);
+
+  const handleMenuItemClick = useCallback(
+    (event, menuItem) => {
+      onMenuItemClick && onMenuItemClick(event, menuItem);
+
+      if (!isKeepMenuOpenOnSelection) {
+        handleDismissMenu();
+      }
+    },
+    [handleDismissMenu, isKeepMenuOpenOnSelection, onMenuItemClick]
+  );
+
+  useEffect(() => {
+    if (selectRef?.current) {
+      const { height = null } = selectRef?.current?.getBoundingClientRect();
+      setAnchorHeight(height);
+    }
+  }, []);
+
+  const listId = `list-${uuidv4()}`;
 
   return (
     <DropDownContainer>
@@ -88,7 +130,20 @@ export const DropDown = ({
           placement={placement}
           fillWidth={240}
         >
-          <div role="listbox" />
+          <DropDownMenu
+            activeValue={activeOption?.value}
+            anchorHeight={anchorHeight}
+            listId={listId}
+            menuAriaLabel={sprintf(
+              /* translators: %s: dropdown aria label or general dropdown label if there is no specific aria label. */
+              __('%s Option List Selector', 'web-stories'),
+              ariaLabel || dropDownLabel
+            )}
+            onDismissMenu={handleDismissMenu}
+            onMenuItemClick={handleMenuItemClick}
+            options={normalizedOptions}
+            {...rest}
+          />
         </Popup>
       )}
       {hint && <p>{hint}</p>}
@@ -101,9 +156,14 @@ DropDown.propTypes = {
   disabled: PropTypes.bool,
   dropDownLabel: PropTypes.string,
   hint: PropTypes.string,
+  isKeepMenuOpenOnSelection: PropTypes.bool,
+  isRTL: PropTypes.bool,
+  menuStylesOverride: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   options: MENU_OPTIONS,
+  onMenuItemClick: PropTypes.func,
   placeholder: PropTypes.string,
   placement: PropTypes.oneOf(Object.values(PLACEMENT)),
+  renderItem: PropTypes.object,
   selectedValue: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.bool,

--- a/assets/src/design-system/components/dropDown/menu/components.js
+++ b/assets/src/design-system/components/dropDown/menu/components.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_ANCHOR_HEIGHT, DEFAULT_DROPDOWN_HEIGHT } from '../constants';
+
+export const MenuContainer = styled.div(
+  ({
+    anchorHeight = DEFAULT_ANCHOR_HEIGHT,
+    dropdownHeight = DEFAULT_DROPDOWN_HEIGHT,
+    styleOverride = '',
+  }) => `
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    width: 100%;
+    max-height: ${dropdownHeight}px;
+    overflow-y: scroll;
+    z-index: 2; 
+    margin-top: ${anchorHeight + 8}px;
+    ${styleOverride}`
+);
+MenuContainer.propTypes = {
+  anchorHeight: PropTypes.number,
+  dropdownHeight: PropTypes.number,
+  styleOverride: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+};
+
+export const EmptyList = styled.div``;
+
+export const List = styled.ul`
+  list-style-type: none;
+  padding: 0;
+`;
+
+export const GroupLabel = styled.li``;
+
+export const ListItem = styled.li`
+  width: 100%;
+`;

--- a/assets/src/design-system/components/dropDown/menu/components.js
+++ b/assets/src/design-system/components/dropDown/menu/components.js
@@ -23,6 +23,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { DEFAULT_ANCHOR_HEIGHT, DEFAULT_DROPDOWN_HEIGHT } from '../constants';
+import { Text } from '../../typography';
 
 export const MenuContainer = styled.div(
   ({
@@ -47,9 +48,7 @@ MenuContainer.propTypes = {
   styleOverride: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 };
 
-export const EmptyList = styled.div``;
-
-export const List = styled.ul`
+export const ListGroup = styled.ul`
   list-style-type: none;
   padding: 0;
 `;
@@ -59,3 +58,6 @@ export const GroupLabel = styled.li``;
 export const ListItem = styled.li`
   width: 100%;
 `;
+
+export const NoOptionsContainer = styled.div``;
+export const NoOptionsMessage = styled(Text)``;

--- a/assets/src/design-system/components/dropDown/menu/components.js
+++ b/assets/src/design-system/components/dropDown/menu/components.js
@@ -53,7 +53,7 @@ export const ListGroup = styled.ul`
   padding: 0;
 `;
 
-export const GroupLabel = styled.li``;
+export const ListItemLabel = styled.li``;
 
 export const ListItem = styled.li`
   width: 100%;

--- a/assets/src/design-system/components/dropDown/menu/defaultListItem.js
+++ b/assets/src/design-system/components/dropDown/menu/defaultListItem.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Checkmark } from '../../../icons';
+import { DROP_DOWN_ITEM } from '../types';
+import { ListItem } from './components';
+
+export const DefaultListItem = forwardRef(function DefaultListItem(
+  { option, isSelected, ...rest },
+  ref
+) {
+  return (
+    <ListItem {...rest} ref={ref}>
+      {isSelected && (
+        <Checkmark
+          data-testid={'dropdownMenuItem_active_icon'}
+          aria-label={__('Selected', 'web-stories')}
+        />
+      )}
+      {option?.label}
+    </ListItem>
+  );
+});
+
+DefaultListItem.propTypes = {
+  option: DROP_DOWN_ITEM,
+  isSelected: PropTypes.bool,
+};

--- a/assets/src/design-system/components/dropDown/menu/emptyList.js
+++ b/assets/src/design-system/components/dropDown/menu/emptyList.js
@@ -13,40 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * External dependencies
  */
-import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { Checkmark } from '../../../icons';
-import { DROP_DOWN_ITEM } from '../types';
-import { ListItem } from './components';
+import { NoOptionsContainer, NoOptionsMessage } from './components';
 
-const DefaultListItem = ({ option, isSelected, ...rest }, ref) => (
-  <ListItem {...rest} ref={ref}>
-    {isSelected && (
-      <Checkmark
-        data-testid={'dropdownMenuItem_active_icon'}
-        aria-label={__('Selected', 'web-stories')}
-      />
-    )}
-    {option?.label}
-  </ListItem>
-);
-
-export default forwardRef(DefaultListItem);
-
-DefaultListItem.propTypes = {
-  option: DROP_DOWN_ITEM,
-  isSelected: PropTypes.bool,
+const EmptyList = ({ emptyText }) => {
+  if (!emptyText) {
+    return null;
+  }
+  return (
+    <NoOptionsContainer>
+      <NoOptionsMessage>{emptyText} </NoOptionsMessage>
+    </NoOptionsContainer>
+  );
 };
+
+EmptyList.propTypes = {
+  emptyText: PropTypes.string,
+};
+
+export default EmptyList;

--- a/assets/src/design-system/components/dropDown/menu/groupLabel.js
+++ b/assets/src/design-system/components/dropDown/menu/groupLabel.js
@@ -21,21 +21,21 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { GroupLabel } from './components';
+import { ListItemLabel } from './components';
 
-const MenuLabel = ({ label }) => {
+const GroupLabel = ({ label }) => {
   if (!label) {
     return null;
   }
   return (
-    <GroupLabel id={`dropDownMenuLabel-${label}`} role="presentation">
+    <ListItemLabel id={`dropDownMenuLabel-${label}`} role="presentation">
       {label}
-    </GroupLabel>
+    </ListItemLabel>
   );
 };
 
-MenuLabel.propTypes = {
+GroupLabel.propTypes = {
   label: PropTypes.string,
 };
 
-export default MenuLabel;
+export default GroupLabel;

--- a/assets/src/design-system/components/dropDown/menu/index.js
+++ b/assets/src/design-system/components/dropDown/menu/index.js
@@ -17,19 +17,19 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
  */
 import { MENU_OPTIONS, DROP_DOWN_VALUE_TYPE } from '../types';
-import { getInset } from '../utils';
-import { EmptyList, GroupLabel, MenuContainer, List } from './components';
+import { MenuContainer } from './components';
 import useDropDownMenu from './useDropDownMenu';
-import { DefaultListItem } from './defaultListItem';
+import EmptyList from './emptyList';
+import ListGroupings from './listGroupings';
 
-export const DropDownMenu = ({
+const DropDownMenu = ({
   anchorHeight,
   dropDownHeight,
   emptyText,
@@ -40,11 +40,10 @@ export const DropDownMenu = ({
   listId,
   onMenuItemClick,
   onDismissMenu,
-  renderItem = DefaultListItem,
+  renderItem,
   activeValue,
   menuAriaLabel,
 }) => {
-  const ListItem = renderItem;
   const listRef = useRef();
   const optionsRef = useRef([]);
 
@@ -81,63 +80,6 @@ export const DropDownMenu = ({
     listEl.scrollTo(0, highlighedOptionEl.offsetTop - listEl.clientHeight / 2);
   }, [focusedIndex]);
 
-  const renderMenuLabel = (label) => {
-    return (
-      <GroupLabel id={`dropDownMenuLabel-${label}`} role="presentation">
-        {label}
-      </GroupLabel>
-    );
-  };
-
-  const renderMenuItem = useCallback(
-    (option, optionIndex, groupIndex = 0) => {
-      const isSelected = option.value === activeValue;
-      const optionInset = getInset(options, groupIndex, optionIndex);
-      return (
-        <ListItem
-          aria-posinset={optionInset}
-          aria-selected={isSelected}
-          aria-setsize={listLength}
-          id={`dropDownMenuItem-${option.value}`}
-          key={option.value}
-          role={hasMenuRole ? 'menuitem' : 'option'}
-          onClick={(event) => handleMenuItemSelect(event, option)}
-          tabIndex={0}
-          ref={(el) => (optionsRef.current[optionInset] = el)}
-          option={option}
-          isSelected={isSelected}
-        />
-      );
-    },
-    [activeValue, options, listLength, hasMenuRole, handleMenuItemSelect]
-  );
-
-  const MenuContent = useMemo(() => {
-    if (!options || options.length === 0) {
-      return <EmptyList>{emptyText}</EmptyList>;
-    }
-    const isManyGroups = options.length > 1;
-    return options.map(({ label, group }, groupIndex) => {
-      const groupAria = isManyGroups
-        ? { 'aria-label': label }
-        : { 'aria-labelledby': listId };
-
-      return (
-        <List
-          key={label || `menuGroup_${groupIndex}`}
-          role="group"
-          isNested={isManyGroups}
-          {...groupAria}
-        >
-          {label && renderMenuLabel(label)}
-          {group.map((groupOption, optionIndex) =>
-            renderMenuItem(groupOption, optionIndex, groupIndex)
-          )}
-        </List>
-      );
-    });
-  }, [options, emptyText, renderMenuItem, listId]);
-
   return (
     <MenuContainer
       id={listId}
@@ -148,7 +90,19 @@ export const DropDownMenu = ({
       role={hasMenuRole ? 'menu' : 'listbox'}
       aria-label={menuAriaLabel}
     >
-      {MenuContent}
+      {!options || options.length === 0 ? (
+        <EmptyList emptyText={emptyText} />
+      ) : (
+        <ListGroupings
+          options={options}
+          activeValue={activeValue}
+          listLength={listLength}
+          hasMenuRole={hasMenuRole}
+          handleMenuItemSelect={handleMenuItemSelect}
+          renderItem={renderItem}
+          optionsRef={optionsRef}
+        />
+      )}
     </MenuContainer>
   );
 };
@@ -168,3 +122,5 @@ DropDownMenu.propTypes = {
   renderItem: PropTypes.object,
   activeValue: DROP_DOWN_VALUE_TYPE,
 };
+
+export default DropDownMenu;

--- a/assets/src/design-system/components/dropDown/menu/index.js
+++ b/assets/src/design-system/components/dropDown/menu/index.js
@@ -96,6 +96,7 @@ const DropDownMenu = ({
         <ListGroupings
           options={options}
           activeValue={activeValue}
+          listId={listId}
           listLength={listLength}
           hasMenuRole={hasMenuRole}
           handleMenuItemSelect={handleMenuItemSelect}

--- a/assets/src/design-system/components/dropDown/menu/index.js
+++ b/assets/src/design-system/components/dropDown/menu/index.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { MENU_OPTIONS, DROP_DOWN_VALUE_TYPE } from '../types';
+import { getInset } from '../utils';
+import { EmptyList, GroupLabel, MenuContainer, List } from './components';
+import useDropDownMenu from './useDropDownMenu';
+import { DefaultListItem } from './defaultListItem';
+
+export const DropDownMenu = ({
+  anchorHeight,
+  dropDownHeight,
+  emptyText,
+  menuStylesOverride,
+  hasMenuRole,
+  isRTL,
+  options = [],
+  listId,
+  onMenuItemClick,
+  onDismissMenu,
+  renderItem = DefaultListItem,
+  activeValue,
+  menuAriaLabel,
+}) => {
+  const ListItem = renderItem;
+  const listRef = useRef();
+  const optionsRef = useRef([]);
+
+  const handleMenuItemSelect = useCallback(
+    (event, { value }) => onMenuItemClick(event, value),
+    [onMenuItemClick]
+  );
+
+  const { focusedIndex, listLength } = useDropDownMenu({
+    activeValue,
+    handleMenuItemSelect,
+    isRTL,
+    options,
+    listRef,
+    onDismissMenu,
+  });
+
+  useEffect(() => {
+    const listEl = listRef.current;
+    if (!listEl || focusedIndex === null) {
+      return;
+    }
+    if (focusedIndex === -1) {
+      listEl.scrollTo(0, 0);
+      return;
+    }
+
+    const highlighedOptionEl = optionsRef.current[focusedIndex];
+    if (!highlighedOptionEl) {
+      return;
+    }
+
+    highlighedOptionEl.focus();
+    listEl.scrollTo(0, highlighedOptionEl.offsetTop - listEl.clientHeight / 2);
+  }, [focusedIndex]);
+
+  const renderMenuLabel = (label) => {
+    return (
+      <GroupLabel id={`dropDownMenuLabel-${label}`} role="presentation">
+        {label}
+      </GroupLabel>
+    );
+  };
+
+  const renderMenuItem = useCallback(
+    (option, optionIndex, groupIndex = 0) => {
+      const isSelected = option.value === activeValue;
+      const optionInset = getInset(options, groupIndex, optionIndex);
+      return (
+        <ListItem
+          aria-posinset={optionInset}
+          aria-selected={isSelected}
+          aria-setsize={listLength}
+          id={`dropDownMenuItem-${option.value}`}
+          key={option.value}
+          role={hasMenuRole ? 'menuitem' : 'option'}
+          onClick={(event) => handleMenuItemSelect(event, option)}
+          tabIndex={0}
+          ref={(el) => (optionsRef.current[optionInset] = el)}
+          option={option}
+          isSelected={isSelected}
+        />
+      );
+    },
+    [activeValue, options, listLength, hasMenuRole, handleMenuItemSelect]
+  );
+
+  const MenuContent = useMemo(() => {
+    if (!options || options.length === 0) {
+      return <EmptyList>{emptyText}</EmptyList>;
+    }
+    const isManyGroups = options.length > 1;
+    return options.map(({ label, group }, groupIndex) => {
+      const groupAria = isManyGroups
+        ? { 'aria-label': label }
+        : { 'aria-labelledby': listId };
+
+      return (
+        <List
+          key={label || `menuGroup_${groupIndex}`}
+          role="group"
+          isNested={isManyGroups}
+          {...groupAria}
+        >
+          {label && renderMenuLabel(label)}
+          {group.map((groupOption, optionIndex) =>
+            renderMenuItem(groupOption, optionIndex, groupIndex)
+          )}
+        </List>
+      );
+    });
+  }, [options, emptyText, renderMenuItem, listId]);
+
+  return (
+    <MenuContainer
+      id={listId}
+      anchorHeight={anchorHeight}
+      dropDownHeight={dropDownHeight}
+      styleOverride={menuStylesOverride}
+      ref={listRef}
+      role={hasMenuRole ? 'menu' : 'listbox'}
+      aria-label={menuAriaLabel}
+    >
+      {MenuContent}
+    </MenuContainer>
+  );
+};
+
+DropDownMenu.propTypes = {
+  anchorHeight: PropTypes.number,
+  dropDownHeight: PropTypes.number,
+  emptyText: PropTypes.string,
+  menuStylesOverride: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  hasMenuRole: PropTypes.bool,
+  isRTL: PropTypes.bool,
+  options: MENU_OPTIONS,
+  listId: PropTypes.string.isRequired,
+  menuAriaLabel: PropTypes.string,
+  onMenuItemClick: PropTypes.func.isRequired,
+  onDismissMenu: PropTypes.func.isRequired,
+  renderItem: PropTypes.object,
+  activeValue: DROP_DOWN_VALUE_TYPE,
+};

--- a/assets/src/design-system/components/dropDown/menu/list.js
+++ b/assets/src/design-system/components/dropDown/menu/list.js
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import MenuLabel from './menuLabel';
+import { ListGroup } from './components';
 
 const List = ({ isManyGroups, label, listId, children }) => {
   const groupAria = isManyGroups
@@ -29,10 +30,10 @@ const List = ({ isManyGroups, label, listId, children }) => {
     : { 'aria-labelledby': listId };
 
   return (
-    <List role="group" isNested={isManyGroups} {...groupAria}>
+    <ListGroup role="group" isNested={isManyGroups} {...groupAria}>
       {label && <MenuLabel label={label} />}
       {children}
-    </List>
+    </ListGroup>
   );
 };
 List.propTypes = {

--- a/assets/src/design-system/components/dropDown/menu/list.js
+++ b/assets/src/design-system/components/dropDown/menu/list.js
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import MenuLabel from './menuLabel';
+import GroupLabel from './groupLabel';
 import { ListGroup } from './components';
 
 const List = ({ isManyGroups, label, listId, children }) => {
@@ -31,7 +31,7 @@ const List = ({ isManyGroups, label, listId, children }) => {
 
   return (
     <ListGroup role="group" isNested={isManyGroups} {...groupAria}>
-      {label && <MenuLabel label={label} />}
+      {label && <GroupLabel label={label} />}
       {children}
     </ListGroup>
   );

--- a/assets/src/design-system/components/dropDown/menu/list.js
+++ b/assets/src/design-system/components/dropDown/menu/list.js
@@ -13,40 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * External dependencies
  */
-import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { Checkmark } from '../../../icons';
-import { DROP_DOWN_ITEM } from '../types';
-import { ListItem } from './components';
+import MenuLabel from './menuLabel';
 
-const DefaultListItem = ({ option, isSelected, ...rest }, ref) => (
-  <ListItem {...rest} ref={ref}>
-    {isSelected && (
-      <Checkmark
-        data-testid={'dropdownMenuItem_active_icon'}
-        aria-label={__('Selected', 'web-stories')}
-      />
-    )}
-    {option?.label}
-  </ListItem>
-);
+const List = ({ isManyGroups, label, listId, children }) => {
+  const groupAria = isManyGroups
+    ? { 'aria-label': label }
+    : { 'aria-labelledby': listId };
 
-export default forwardRef(DefaultListItem);
-
-DefaultListItem.propTypes = {
-  option: DROP_DOWN_ITEM,
-  isSelected: PropTypes.bool,
+  return (
+    <List role="group" isNested={isManyGroups} {...groupAria}>
+      {label && <MenuLabel label={label} />}
+      {children}
+    </List>
+  );
 };
+List.propTypes = {
+  isManyGroups: PropTypes.bool,
+  label: PropTypes.string,
+  listId: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+export default List;

--- a/assets/src/design-system/components/dropDown/menu/listGroupings.js
+++ b/assets/src/design-system/components/dropDown/menu/listGroupings.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+
+import { getInset } from '../utils';
+import { DROP_DOWN_VALUE_TYPE, MENU_OPTIONS } from '../types';
+import MenuLabel from './menuLabel';
+import DefaultListItem from './defaultListItem';
+import { ListGroup } from './components';
+
+const ListGroupings = ({
+  options,
+  activeValue,
+  listLength,
+  hasMenuRole,
+  handleMenuItemSelect,
+  renderItem,
+  optionsRef,
+}) => {
+  const ListItem = renderItem || DefaultListItem;
+  const isManyGroups = useMemo(() => options?.length > 1, [options.length]);
+
+  return options.map(({ label, group }, groupIndex) => (
+    <ListGroup key={label || `menuGroup_${groupIndex}`} isNested={isManyGroups}>
+      <MenuLabel label={label} />
+
+      {group.map((groupOption, optionIndex) => {
+        const isSelected = groupOption.value === activeValue;
+        const optionInset = getInset(options, groupIndex, optionIndex);
+
+        return (
+          <ListItem
+            key={groupOption.value}
+            aria-posinset={optionInset}
+            aria-selected={isSelected}
+            aria-setsize={listLength}
+            id={`dropDownMenuItem-${groupOption.value}`}
+            isSelected={isSelected}
+            onClick={(event) => handleMenuItemSelect(event, groupOption)}
+            option={groupOption}
+            optionInset={optionInset}
+            listLength={listLength}
+            role={hasMenuRole ? 'menuitem' : 'option'}
+            ref={(el) => (optionsRef.current[optionInset] = el)}
+            tabIndex={0}
+          />
+        );
+      })}
+    </ListGroup>
+  ));
+};
+ListGroupings.propTypes = {
+  options: MENU_OPTIONS,
+  isManyGroups: PropTypes.bool,
+  activeValue: DROP_DOWN_VALUE_TYPE,
+  listLength: PropTypes.number,
+  hasMenuRole: PropTypes.bool,
+  handleMenuItemSelect: PropTypes.func.isRequired,
+  renderItem: PropTypes.object,
+  optionsRef: PropTypes.object,
+};
+export default ListGroupings;

--- a/assets/src/design-system/components/dropDown/menu/listGroupings.js
+++ b/assets/src/design-system/components/dropDown/menu/listGroupings.js
@@ -25,14 +25,14 @@ import PropTypes from 'prop-types';
 
 import { getInset } from '../utils';
 import { DROP_DOWN_VALUE_TYPE, MENU_OPTIONS } from '../types';
-import MenuLabel from './menuLabel';
 import DefaultListItem from './defaultListItem';
-import { ListGroup } from './components';
+import List from './list';
 
 const ListGroupings = ({
   options,
   activeValue,
   listLength,
+  listId,
   hasMenuRole,
   handleMenuItemSelect,
   renderItem,
@@ -42,9 +42,12 @@ const ListGroupings = ({
   const isManyGroups = useMemo(() => options?.length > 1, [options.length]);
 
   return options.map(({ label, group }, groupIndex) => (
-    <ListGroup key={label || `menuGroup_${groupIndex}`} isNested={isManyGroups}>
-      <MenuLabel label={label} />
-
+    <List
+      key={label || `menuGroup_${groupIndex}`}
+      isManyGroups={isManyGroups}
+      label={label}
+      listId={listId}
+    >
       {group.map((groupOption, optionIndex) => {
         const isSelected = groupOption.value === activeValue;
         const optionInset = getInset(options, groupIndex, optionIndex);
@@ -67,7 +70,7 @@ const ListGroupings = ({
           />
         );
       })}
-    </ListGroup>
+    </List>
   ));
 };
 ListGroupings.propTypes = {

--- a/assets/src/design-system/components/dropDown/menu/menuLabel.js
+++ b/assets/src/design-system/components/dropDown/menu/menuLabel.js
@@ -13,40 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * External dependencies
  */
-import { forwardRef } from 'react';
 import PropTypes from 'prop-types';
-
-/**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { Checkmark } from '../../../icons';
-import { DROP_DOWN_ITEM } from '../types';
-import { ListItem } from './components';
+import { GroupLabel } from './components';
 
-const DefaultListItem = ({ option, isSelected, ...rest }, ref) => (
-  <ListItem {...rest} ref={ref}>
-    {isSelected && (
-      <Checkmark
-        data-testid={'dropdownMenuItem_active_icon'}
-        aria-label={__('Selected', 'web-stories')}
-      />
-    )}
-    {option?.label}
-  </ListItem>
-);
-
-export default forwardRef(DefaultListItem);
-
-DefaultListItem.propTypes = {
-  option: DROP_DOWN_ITEM,
-  isSelected: PropTypes.bool,
+const MenuLabel = ({ label }) => {
+  if (!label) {
+    return null;
+  }
+  return (
+    <GroupLabel id={`dropDownMenuLabel-${label}`} role="presentation">
+      {label}
+    </GroupLabel>
+  );
 };
+
+MenuLabel.propTypes = {
+  label: PropTypes.string,
+};
+
+export default MenuLabel;

--- a/assets/src/design-system/components/dropDown/menu/useDropDownMenu.js
+++ b/assets/src/design-system/components/dropDown/menu/useDropDownMenu.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import useFocusOut from '../../../utils/useFocusOut';
+import { isNullOrUndefinedOrEmptyString } from '../../../utils/isNullOrUndefinedOrEmptyString';
+import { useKeyDownEffect } from '../../keyboard';
+import {
+  KEYS_CLOSE_MENU,
+  KEYS_SELECT_ITEM,
+  KEYS_SHIFT_FOCUS,
+} from '../constants';
+
+export default function useDropDownMenu({
+  activeValue,
+  handleMenuItemSelect,
+  isRTL,
+  options = [],
+  listRef,
+  onDismissMenu,
+}) {
+  const allOptions = useMemo(
+    () => options.flatMap((optionSet) => optionSet.group),
+    [options]
+  );
+
+  const listLength = allOptions.length;
+  const [focusedValue, setFocusedValue] = useState(activeValue);
+
+  const focusedIndex = useMemo(() => {
+    if (isNullOrUndefinedOrEmptyString(focusedValue)) {
+      return 0;
+    }
+    const foundIndex = allOptions.findIndex((option) => {
+      return option?.value?.toString() === focusedValue.toString();
+    });
+    return foundIndex;
+  }, [allOptions, focusedValue]);
+
+  const handleMoveFocus = useCallback(
+    (offset) => setFocusedValue(allOptions[focusedIndex + offset].value),
+    [allOptions, focusedIndex]
+  );
+
+  const handleFocusChange = useCallback(
+    ({ key }) => {
+      if (
+        ['ArrowUp', isRTL ? 'ArrowRight' : 'ArrowLeft'].includes(key) &&
+        focusedIndex !== 0
+      ) {
+        handleMoveFocus(-1);
+      } else if (
+        ['ArrowDown', isRTL ? 'ArrowLeft' : 'ArrowRight'].includes(key) &&
+        focusedIndex < listLength - 1
+      ) {
+        handleMoveFocus(1);
+      }
+    },
+    [focusedIndex, handleMoveFocus, isRTL, listLength]
+  );
+
+  const handleMenuItemEnter = useCallback(
+    (event) => handleMenuItemSelect(event, { value: focusedValue }),
+    [focusedValue, handleMenuItemSelect]
+  );
+
+  useKeyDownEffect(
+    listRef,
+    { key: KEYS_SELECT_ITEM, shift: true },
+    handleMenuItemEnter,
+    [handleMenuItemEnter]
+  );
+
+  useKeyDownEffect(listRef, { key: KEYS_CLOSE_MENU }, () => onDismissMenu?.(), [
+    onDismissMenu,
+  ]);
+
+  useKeyDownEffect(listRef, { key: KEYS_SHIFT_FOCUS }, handleFocusChange, [
+    handleFocusChange,
+  ]);
+
+  useFocusOut(listRef, () => onDismissMenu?.(), []);
+
+  return useMemo(
+    () => ({
+      focusedValue,
+      focusedIndex,
+      listLength,
+    }),
+    [focusedIndex, focusedValue, listLength]
+  );
+}

--- a/assets/src/design-system/components/dropDown/select/index.js
+++ b/assets/src/design-system/components/dropDown/select/index.js
@@ -23,7 +23,7 @@ import PropTypes from 'prop-types';
 
 const SelectButton = styled.button``;
 
-export const DropDownSelect = forwardRef(function DropDownSelect(
+const DropDownSelect = (
   {
     activeItemLabel,
     ariaLabel,
@@ -34,23 +34,23 @@ export const DropDownSelect = forwardRef(function DropDownSelect(
     placeholder = '',
   },
   ref
-) {
-  return (
-    <SelectButton
-      aria-label={ariaLabel || dropDownLabel}
-      aria-pressed={isOpen}
-      aria-haspopup={true}
-      aria-expanded={isOpen}
-      aria-disabled={disabled}
-      disabled={disabled}
-      onClick={onSelectClick}
-      ref={ref}
-    >
-      {activeItemLabel || placeholder}
-      {dropDownLabel && <span>{dropDownLabel}</span>}
-    </SelectButton>
-  );
-});
+) => (
+  <SelectButton
+    aria-label={ariaLabel || dropDownLabel}
+    aria-pressed={isOpen}
+    aria-haspopup={true}
+    aria-expanded={isOpen}
+    aria-disabled={disabled}
+    disabled={disabled}
+    onClick={onSelectClick}
+    ref={ref}
+  >
+    {activeItemLabel || placeholder}
+    {dropDownLabel && <span>{dropDownLabel}</span>}
+  </SelectButton>
+);
+
+export default forwardRef(DropDownSelect);
 
 DropDownSelect.propTypes = {
   activeItemLabel: PropTypes.string,

--- a/assets/src/design-system/components/dropDown/stories/index.js
+++ b/assets/src/design-system/components/dropDown/stories/index.js
@@ -145,11 +145,9 @@ export const SubMenus = () => {
   );
 };
 
-const RenderItemOverride = forwardRef(function RenderItemOverride(
-  { option, isSelected, ...rest },
-  ref
-) {
-  return (
+// eslint-disable-next-line react/display-name
+const RenderItemOverride = forwardRef(
+  ({ option, isSelected, ...rest }, ref) => (
     <StyledEffectListItem
       ref={ref}
       width={option.width}
@@ -158,8 +156,8 @@ const RenderItemOverride = forwardRef(function RenderItemOverride(
     >
       {option.label}
     </StyledEffectListItem>
-  );
-});
+  )
+);
 RenderItemOverride.propTypes = {
   option: DROP_DOWN_ITEM,
   isSelected: PropTypes.bool,

--- a/assets/src/design-system/components/dropDown/stories/index.js
+++ b/assets/src/design-system/components/dropDown/stories/index.js
@@ -19,18 +19,59 @@
  */
 import { action } from '@storybook/addon-actions';
 import { boolean, select, text } from '@storybook/addon-knobs';
-import { useState } from 'react';
+import styled, { css } from 'styled-components';
+import { useState, forwardRef } from 'react';
+import PropTypes from 'prop-types';
+
 /**
  * Internal dependencies
  */
 import { DarkThemeProvider } from '../../../storybookUtils';
 import { PLACEMENT } from '../../popup';
+import { DROP_DOWN_ITEM } from '../types';
 import { DropDown } from '..';
-import { basicDropDownOptions } from './sampleData';
+import {
+  basicDropDownOptions,
+  effectChooserOptions,
+  nestedDropDownOptions,
+} from './sampleData';
 
 export default {
   title: 'DesignSystem/Components/DropDown',
 };
+
+const StyledEffectListItem = styled.li`
+  border: none;
+  background: ${({ active }) => (active ? '#5732A3' : '#333')};
+  border-radius: 4px;
+  height: 48px;
+  position: relative;
+  overflow: hidden;
+  font-family: 'Teko', sans-serif;
+  font-size: 20px;
+  line-height: 1;
+  color: white;
+  text-transform: uppercase;
+  transition: background 0.1s linear;
+  grid-column-start: ${({ width }) => (width === 'full' ? 'span 4' : 'span 2')};
+  &:focus {
+    background: ${({ active }) => (active ? '#5732A3' : '#B488FC')};
+  }
+`;
+
+const styleOverrideForAnimationEffectMenu = css`
+  width: 276px;
+  display: inline-block;
+  background: black;
+  ul {
+    display: grid;
+    justify-content: center;
+    gap: 15px 3px;
+    grid-template-columns: repeat(4, 58px);
+    padding: 15px;
+    position: relative;
+  }
+`;
 
 export const _default = () => {
   const [selectedValue, setSelectedValue] = useState(
@@ -78,5 +119,73 @@ export const LightTheme = () => {
       }}
       placement={select('placement', Object.values(PLACEMENT))}
     />
+  );
+};
+
+export const SubMenus = () => {
+  const [selectedValue, setSelectedValue] = useState('dog-2');
+
+  return (
+    <DropDown
+      emptyText={'No options available'}
+      options={nestedDropDownOptions}
+      hint={text('hint', 'default hint text')}
+      placeholder={text('placeholder', 'select a value')}
+      dropDownLabel={text('dropDownLabel', 'label')}
+      isKeepMenuOpenOnSelection={boolean('isKeepMenuOpenOnSelection')}
+      isRTL={boolean('isRTL')}
+      disabled={boolean('disabled')}
+      selectedValue={selectedValue}
+      onMenuItemClick={(event, newValue) => {
+        action('onMenuItemClick', event);
+        setSelectedValue(newValue);
+      }}
+      placement={select('placement', Object.values(PLACEMENT))}
+    />
+  );
+};
+
+const RenderItemOverride = forwardRef(function RenderItemOverride(
+  { option, isSelected, ...rest },
+  ref
+) {
+  return (
+    <StyledEffectListItem
+      ref={ref}
+      width={option.width}
+      active={isSelected}
+      {...rest}
+    >
+      {option.label}
+    </StyledEffectListItem>
+  );
+});
+RenderItemOverride.propTypes = {
+  option: DROP_DOWN_ITEM,
+  isSelected: PropTypes.bool,
+};
+
+export const OverriddenAnimationProofOfConcept = () => {
+  const [selectedValue, setSelectedValue] = useState(null);
+  return (
+    <DarkThemeProvider>
+      <DropDown
+        emptyText={'No options available'}
+        options={effectChooserOptions}
+        hint={text('hint', 'default hint text')}
+        placeholder={text('placeholder', 'select a value')}
+        dropDownLabel={text('dropDownLabel', 'label')}
+        isKeepMenuOpenOnSelection={boolean('isKeepMenuOpenOnSelection', true)}
+        disabled={boolean('disabled')}
+        selectedValue={selectedValue}
+        onMenuItemClick={(event, newValue) => {
+          action('onMenuItemClick', event);
+          setSelectedValue(newValue);
+        }}
+        placement={select('placement', Object.values(PLACEMENT))}
+        menuStylesOverride={styleOverrideForAnimationEffectMenu}
+        renderItem={RenderItemOverride}
+      />
+    </DarkThemeProvider>
   );
 };

--- a/assets/src/design-system/components/dropDown/test/dropDown.js
+++ b/assets/src/design-system/components/dropDown/test/dropDown.js
@@ -17,8 +17,12 @@
 /**
  * External dependencies
  */
-
-import { fireEvent } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -27,7 +31,16 @@ import { renderWithProviders } from '../../../testUtils/renderWithProviders';
 import { DropDown } from '../';
 import { basicDropDownOptions } from '../stories/sampleData';
 
+// TODO: fix tests to wait properly for menu to hide
+/* eslint-disable jest/no-disabled-tests */
 describe('DropDown <DropDown />', () => {
+  // Mock scrollTo
+  const scrollTo = jest.fn();
+  Object.defineProperty(window.Element.prototype, 'scrollTo', {
+    writable: true,
+    value: scrollTo,
+  });
+
   it('should render a closed <DropDown /> menu with a select button on default', () => {
     const { getByRole, queryAllByRole } = renderWithProviders(
       <DropDown options={basicDropDownOptions} dropDownLabel={'label'} />
@@ -106,5 +119,270 @@ describe('DropDown <DropDown />', () => {
 
     const menu = getByRole('listbox');
     expect(menu).toBeInTheDocument();
+  });
+  it('should show an active icon on list item that is active', () => {
+    const { getByRole } = renderWithProviders(
+      <DropDown
+        emptyText={'No options available'}
+        dropDownLabel={'label'}
+        isKeepMenuOpenOnSelection={false}
+        options={basicDropDownOptions}
+        selectedValue={basicDropDownOptions[2].value}
+      />
+    );
+
+    const select = getByRole('button');
+    expect(select).toBeInTheDocument();
+    fireEvent.click(select);
+
+    const activeMenuItem = getByRole('option', {
+      name: `Selected ${basicDropDownOptions[2].label}`,
+    });
+    expect(activeMenuItem).toBeInTheDocument();
+
+    // We can't really validate this number anyway in JSDom (no actual
+    // layout is happening), so just expect it to be called
+    expect(scrollTo).toHaveBeenCalledWith(0, expect.any(Number));
+  });
+
+  it('should clean badly grouped data', () => {
+    const nestedOptions = [
+      {
+        label: 'section 1',
+        options: [
+          { value: 'one', label: '1' },
+          { value: 'two', label: '2' },
+        ],
+        somethingExtra: [1, 2, 3, 4, 5],
+      },
+      {
+        label: 'section 2',
+        options: [
+          { value: 'three', label: '3' },
+          { value: 'four', label: '4' },
+          { value: 'five', label: '5' },
+        ],
+      },
+      'should be ignored',
+    ];
+    const { getByRole, getAllByRole, queryAllByText } = renderWithProviders(
+      <DropDown
+        emptyText={'No options available'}
+        dropDownLabel={'label'}
+        isKeepMenuOpenOnSelection={false}
+        options={nestedOptions}
+      />
+    );
+
+    const select = getByRole('button');
+    expect(select).toBeInTheDocument();
+    fireEvent.click(select);
+
+    const menuItems = getAllByRole('option');
+    expect(menuItems).toHaveLength(5);
+
+    const menuLabels = getAllByRole('presentation');
+    expect(menuLabels).toHaveLength(2);
+
+    expect(queryAllByText('should be ignored')).toHaveLength(0);
+  });
+
+  // Mouse events
+  it('should not expand menu when disabled is true', () => {
+    const { getByRole, queryAllByRole } = renderWithProviders(
+      <DropDown
+        options={basicDropDownOptions}
+        dropDownLabel={'my label'}
+        disabled={true}
+      />
+    );
+
+    const select = getByRole('button');
+    expect(select).toBeInTheDocument();
+
+    fireEvent.click(select);
+
+    const menu = queryAllByRole('listbox');
+    expect(menu).toHaveLength(0);
+  });
+
+  it('should trigger onMenuItemClick when item is clicked', () => {
+    const onClickMock = jest.fn();
+
+    const { getByRole, getAllByRole } = renderWithProviders(
+      <DropDown
+        options={basicDropDownOptions}
+        selectedValue={null}
+        dropDownLabel={'my dropDown label'}
+        onMenuItemClick={onClickMock}
+      />
+    );
+
+    // Fire click event
+    const select = getByRole('button');
+    fireEvent.click(select);
+
+    const menu = getByRole('listbox');
+    expect(menu).toBeInTheDocument();
+
+    const menuItems = getAllByRole('option');
+    expect(menuItems).toHaveLength(12);
+
+    fireEvent.click(menuItems[3]);
+
+    // first prop we get back is the event
+    expect(onClickMock).toHaveBeenCalledWith(
+      expect.anything(),
+      basicDropDownOptions[3].value
+    );
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.skip('should close active menu when select is clicked', async () => {
+    const wrapper = renderWithProviders(
+      <DropDown
+        dropDownLabel={'label'}
+        options={basicDropDownOptions}
+        selectedValue={basicDropDownOptions[1].value}
+      />
+    );
+    const select = wrapper.getByRole('button');
+    fireEvent.click(select);
+
+    const menu = wrapper.getByRole('listbox');
+    expect(menu).toBeInTheDocument();
+
+    fireEvent.click(select);
+
+    await waitForElementToBeRemoved(() =>
+      expect(wrapper.queryByRole('listbox')).not.toBeInTheDocument()
+    );
+  });
+
+  // Keyboard events
+
+  it.skip('should trigger onMenuItemClick when using the down arrow plus enter key and keep menu open when isKeepMenuOpenOnSelection is true', async () => {
+    const onClickMock = jest.fn();
+    const { getByRole, getAllByRole } = await renderWithProviders(
+      <DropDown
+        emptyText={'No options available'}
+        dropDownLabel={'label'}
+        isKeepMenuOpenOnSelection={true}
+        options={basicDropDownOptions}
+        onMenuItemClick={onClickMock}
+        selectedValue={null}
+      />
+    );
+    const selectButton = getByRole('button');
+    fireEvent.click(selectButton);
+
+    const menu = getByRole('listbox');
+    expect(menu).toBeInTheDocument();
+
+    const menuItems = getAllByRole('option');
+    expect(menuItems).toHaveLength(12);
+    // focus first element in menu
+    act(() => {
+      fireEvent.keyDown(menu, {
+        key: 'ArrowDown',
+      });
+    });
+
+    expect(menuItems[0]).toHaveFocus();
+
+    // focus second element in menu
+    act(() => {
+      fireEvent.keyDown(menu, {
+        key: 'ArrowDown',
+      });
+    });
+    expect(menuItems[1]).toHaveFocus();
+
+    act(() => {
+      fireEvent.keyDown(menu, { key: 'Enter' });
+    });
+
+    // The second item in the menu.
+    // first prop we get back is the event
+    expect(onClickMock).toHaveBeenCalledWith(
+      expect.anything(),
+      basicDropDownOptions[1].value
+    );
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+
+    expect(menu).toBeInTheDocument();
+  });
+
+  it.skip('should trigger onMenuItemClick when using the down arrow plus enter key and close menu', async () => {
+    const onClickMock = jest.fn();
+
+    const { getByRole } = await renderWithProviders(
+      <DropDown
+        emptyText={'No options available'}
+        dropDownLabel={'label'}
+        options={basicDropDownOptions}
+        onMenuItemClick={onClickMock}
+        selectedValue={basicDropDownOptions[0].value}
+      />
+    );
+    const selectButton = getByRole('button');
+    fireEvent.click(selectButton);
+
+    const menu = getByRole('listbox');
+    expect(menu).toBeInTheDocument();
+
+    // focus first element in menu
+    act(() => {
+      fireEvent.keyDown(menu, {
+        key: 'ArrowDown',
+      });
+    });
+
+    // focus second element in menu
+    act(() => {
+      fireEvent.keyDown(menu, {
+        key: 'ArrowDown',
+      });
+    });
+
+    act(() => {
+      fireEvent.keyDown(menu, { key: 'Enter' });
+    });
+
+    // The second item in the menu.
+    // first prop we get back is the event
+    expect(onClickMock).toHaveBeenCalledWith(
+      expect.anything(),
+      basicDropDownOptions[2].value
+    );
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => expect(menu).not.toBeInTheDocument());
+  });
+
+  it.skip('should trigger onDismissMenu when esc key is pressed', async () => {
+    const { getByRole } = await renderWithProviders(
+      <DropDown
+        dropDownLabel={'label'}
+        options={basicDropDownOptions}
+        selectedValue={basicDropDownOptions[1].value}
+      />
+    );
+    const select = getByRole('button');
+    fireEvent.click(select);
+
+    const menu = getByRole('listbox');
+    expect(menu).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.keyDown(menu, {
+        key: 'Escape',
+      });
+    });
+
+    await waitFor(() => expect(menu).not.toBeInTheDocument());
   });
 });

--- a/assets/src/design-system/components/dropDown/test/dropDown.js
+++ b/assets/src/design-system/components/dropDown/test/dropDown.js
@@ -17,12 +17,7 @@
 /**
  * External dependencies
  */
-import {
-  act,
-  fireEvent,
-  waitFor,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
+import { fireEvent } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -31,8 +26,6 @@ import { renderWithProviders } from '../../../testUtils/renderWithProviders';
 import { DropDown } from '../';
 import { basicDropDownOptions } from '../stories/sampleData';
 
-// TODO: fix tests to wait properly for menu to hide
-/* eslint-disable jest/no-disabled-tests */
 describe('DropDown <DropDown />', () => {
   // Mock scrollTo
   const scrollTo = jest.fn();
@@ -40,6 +33,8 @@ describe('DropDown <DropDown />', () => {
     writable: true,
     value: scrollTo,
   });
+
+  jest.useFakeTimers();
 
   it('should render a closed <DropDown /> menu with a select button on default', () => {
     const { getByRole, queryAllByRole } = renderWithProviders(
@@ -239,7 +234,7 @@ describe('DropDown <DropDown />', () => {
     expect(onClickMock).toHaveBeenCalledTimes(1);
   });
 
-  it.skip('should close active menu when select is clicked', async () => {
+  it('should close active menu when select is clicked', () => {
     const wrapper = renderWithProviders(
       <DropDown
         dropDownLabel={'label'}
@@ -253,136 +248,144 @@ describe('DropDown <DropDown />', () => {
     const menu = wrapper.getByRole('listbox');
     expect(menu).toBeInTheDocument();
 
+    // wait for debounced callback to allow a select click handler to process
+    jest.runOnlyPendingTimers();
+
     fireEvent.click(select);
 
-    await waitForElementToBeRemoved(() =>
-      expect(wrapper.queryByRole('listbox')).not.toBeInTheDocument()
-    );
-  });
-
-  // Keyboard events
-
-  it.skip('should trigger onMenuItemClick when using the down arrow plus enter key and keep menu open when isKeepMenuOpenOnSelection is true', async () => {
-    const onClickMock = jest.fn();
-    const { getByRole, getAllByRole } = await renderWithProviders(
-      <DropDown
-        emptyText={'No options available'}
-        dropDownLabel={'label'}
-        isKeepMenuOpenOnSelection={true}
-        options={basicDropDownOptions}
-        onMenuItemClick={onClickMock}
-        selectedValue={null}
-      />
-    );
-    const selectButton = getByRole('button');
-    fireEvent.click(selectButton);
-
-    const menu = getByRole('listbox');
-    expect(menu).toBeInTheDocument();
-
-    const menuItems = getAllByRole('option');
-    expect(menuItems).toHaveLength(12);
-    // focus first element in menu
-    act(() => {
-      fireEvent.keyDown(menu, {
-        key: 'ArrowDown',
-      });
-    });
-
-    expect(menuItems[0]).toHaveFocus();
-
-    // focus second element in menu
-    act(() => {
-      fireEvent.keyDown(menu, {
-        key: 'ArrowDown',
-      });
-    });
-    expect(menuItems[1]).toHaveFocus();
-
-    act(() => {
-      fireEvent.keyDown(menu, { key: 'Enter' });
-    });
-
-    // The second item in the menu.
-    // first prop we get back is the event
-    expect(onClickMock).toHaveBeenCalledWith(
-      expect.anything(),
-      basicDropDownOptions[1].value
-    );
-
-    expect(onClickMock).toHaveBeenCalledTimes(1);
-
-    expect(menu).toBeInTheDocument();
-  });
-
-  it.skip('should trigger onMenuItemClick when using the down arrow plus enter key and close menu', async () => {
-    const onClickMock = jest.fn();
-
-    const { getByRole } = await renderWithProviders(
-      <DropDown
-        emptyText={'No options available'}
-        dropDownLabel={'label'}
-        options={basicDropDownOptions}
-        onMenuItemClick={onClickMock}
-        selectedValue={basicDropDownOptions[0].value}
-      />
-    );
-    const selectButton = getByRole('button');
-    fireEvent.click(selectButton);
-
-    const menu = getByRole('listbox');
-    expect(menu).toBeInTheDocument();
-
-    // focus first element in menu
-    act(() => {
-      fireEvent.keyDown(menu, {
-        key: 'ArrowDown',
-      });
-    });
-
-    // focus second element in menu
-    act(() => {
-      fireEvent.keyDown(menu, {
-        key: 'ArrowDown',
-      });
-    });
-
-    act(() => {
-      fireEvent.keyDown(menu, { key: 'Enter' });
-    });
-
-    // The second item in the menu.
-    // first prop we get back is the event
-    expect(onClickMock).toHaveBeenCalledWith(
-      expect.anything(),
-      basicDropDownOptions[2].value
-    );
-
-    expect(onClickMock).toHaveBeenCalledTimes(1);
-
-    await waitFor(() => expect(menu).not.toBeInTheDocument());
-  });
-
-  it.skip('should trigger onDismissMenu when esc key is pressed', async () => {
-    const { getByRole } = await renderWithProviders(
-      <DropDown
-        dropDownLabel={'label'}
-        options={basicDropDownOptions}
-        selectedValue={basicDropDownOptions[1].value}
-      />
-    );
-    const select = getByRole('button');
-    fireEvent.click(select);
-
-    const menu = getByRole('listbox');
-    expect(menu).toBeInTheDocument();
-
-    act(() => {
-      fireEvent.keyDown(menu, {
-        key: 'Escape',
-      });
-    });
-
-    await waitFor(() => expect(menu).not.toBeInTheDocument());
+    expect(wrapper.queryByRole('listbox')).not.toBeInTheDocument();
   });
 });
+
+// TODO: Keyboard events need mock useKeyDownEffect
+// https://github.com/google/web-stories-wp/issues/5764
+
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable jest/no-commented-out-tests */
+// it('should trigger onMenuItemClick when using the down arrow plus enter key and keep menu open when isKeepMenuOpenOnSelection is true', async () => {
+//   const onClickMock = jest.fn();
+//   const { getByRole, getAllByRole } = await renderWithProviders(
+//     <DropDown
+//       emptyText={'No options available'}
+//       dropDownLabel={'label'}
+//       isKeepMenuOpenOnSelection={true}
+//       options={basicDropDownOptions}
+//       onMenuItemClick={onClickMock}
+//       selectedValue={null}
+//     />
+//   );
+//   const selectButton = getByRole('button');
+//   fireEvent.click(selectButton);
+
+//   const menu = getByRole('listbox');
+//   expect(menu).toBeInTheDocument();
+
+//   const menuItems = getAllByRole('option');
+//   expect(menuItems).toHaveLength(12);
+
+//   // wait for debounced callback to allow a select click handler to process
+//   jest.runOnlyPendingTimers();
+
+//   // focus first element in menu
+//   act(() => {
+//     fireEvent.keyDown(menu, {
+//       key: 'ArrowDown',
+//     });
+//   });
+
+//   expect(menuItems[0]).toHaveFocus();
+
+//   // focus second element in menu
+//   act(() => {
+//     fireEvent.keyDown(menu, {
+//       key: 'ArrowDown',
+//     });
+//   });
+//   expect(menuItems[1]).toHaveFocus();
+
+//   act(() => {
+//     fireEvent.keyDown(menu, { key: 'Enter' });
+//   });
+
+//   // The second item in the menu.
+//   // first prop we get back is the event
+//   expect(onClickMock).toHaveBeenCalledWith(
+//     expect.anything(),
+//     basicDropDownOptions[1].value
+//   );
+
+//   expect(onClickMock).toHaveBeenCalledTimes(1);
+
+//   expect(menu).toBeInTheDocument();
+// });
+
+// it('should trigger onMenuItemClick when using the down arrow plus enter key and close menu', async () => {
+//   const onClickMock = jest.fn();
+
+//   const { getByRole } = await renderWithProviders(
+//     <DropDown
+//       emptyText={'No options available'}
+//       dropDownLabel={'label'}
+//       options={basicDropDownOptions}
+//       onMenuItemClick={onClickMock}
+//       selectedValue={basicDropDownOptions[0].value}
+//     />
+//   );
+//   const selectButton = getByRole('button');
+//   fireEvent.click(selectButton);
+
+//   const menu = getByRole('listbox');
+//   expect(menu).toBeInTheDocument();
+
+//   // focus first element in menu
+//   act(() => {
+//     fireEvent.keyDown(menu, {
+//       key: 'ArrowDown',
+//     });
+//   });
+
+//   // focus second element in menu
+//   act(() => {
+//     fireEvent.keyDown(menu, {
+//       key: 'ArrowDown',
+//     });
+//   });
+
+//   act(() => {
+//     fireEvent.keyDown(menu, { key: 'Enter' });
+//   });
+
+//   // The second item in the menu.
+//   // first prop we get back is the event
+//   expect(onClickMock).toHaveBeenCalledWith(
+//     expect.anything(),
+//     basicDropDownOptions[2].value
+//   );
+
+//   expect(onClickMock).toHaveBeenCalledTimes(1);
+
+//   await waitFor(() => expect(menu).not.toBeInTheDocument());
+// });
+
+// it('should trigger onDismissMenu when esc key is pressed', async () => {
+//   const wrapper = await renderWithProviders(
+//     <DropDown
+//       dropDownLabel={'label'}
+//       options={basicDropDownOptions}
+//       selectedValue={basicDropDownOptions[1].value}
+//     />
+//   );
+//   const select = wrapper.getByRole('button');
+//   fireEvent.click(select);
+
+//   const menu = wrapper.queryByRole('listbox');
+//   expect(menu).toBeInTheDocument();
+
+//   act(() => {
+//     fireEvent.keyDown(menu, {
+//       key: 'Escape',
+//     });
+//   });
+
+//   await waitFor(() => expect(menu).not.toBeInTheDocument());
+// });

--- a/assets/src/design-system/components/dropDown/test/menu.js
+++ b/assets/src/design-system/components/dropDown/test/menu.js
@@ -26,7 +26,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { renderWithProviders } from '../../../testUtils/renderWithProviders';
-import { DropDownMenu } from '../menu';
+import DropDownMenu from '../menu';
 import { basicDropDownOptions } from '../stories/sampleData';
 import { getOptions } from '../utils';
 
@@ -98,10 +98,8 @@ describe('DropDown <DropDownMenu />', () => {
   });
 
   it('should override list items when renderMenu is present', () => {
-    const OverrideRenderItem = forwardRef(function DefaultListItem(
-      { isSelected, ...rest },
-      ref
-    ) {
+    // eslint-disable-next-line react/display-name
+    const OverrideRenderItem = forwardRef(({ isSelected, ...rest }, ref) => {
       return (
         <li {...rest} ref={ref}>
           {isSelected ? 'I AM SELECTED' : 'I AM EXTRA CONTENT'}

--- a/assets/src/design-system/components/dropDown/test/menu.js
+++ b/assets/src/design-system/components/dropDown/test/menu.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+
+import { fireEvent } from '@testing-library/react';
+import { forwardRef } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { renderWithProviders } from '../../../testUtils/renderWithProviders';
+import { DropDownMenu } from '../menu';
+import { basicDropDownOptions } from '../stories/sampleData';
+import { getOptions } from '../utils';
+
+const groupedOptions = getOptions(basicDropDownOptions);
+
+describe('DropDown <DropDownMenu />', () => {
+  const onClickMock = jest.fn();
+
+  // Mock scrollTo
+  const scrollTo = jest.fn();
+  Object.defineProperty(window.Element.prototype, 'scrollTo', {
+    writable: true,
+    value: scrollTo,
+  });
+
+  it('should render a <DropDownMenu /> list with 12 items', () => {
+    const { getByRole, queryAllByRole } = renderWithProviders(
+      <DropDownMenu
+        hasMenuRole={false}
+        emptyText={'No options available'}
+        options={groupedOptions}
+        onMenuItemClick={onClickMock}
+        onDismissMenu={() => {}}
+        activeValue={null}
+      />
+    );
+
+    const menu = getByRole('listbox');
+    expect(menu).toBeInTheDocument();
+
+    const options = queryAllByRole('option');
+    expect(options).toHaveLength(12);
+  });
+
+  it('should return an emptyText message when there are no items to display', () => {
+    const { getByText } = renderWithProviders(
+      <DropDownMenu
+        hasMenuRole={false}
+        emptyText={'No options available'}
+        options={[]}
+        onMenuItemClick={onClickMock}
+        onDismissMenu={() => {}}
+        activeValue={null}
+      />
+    );
+
+    const emptyMessage = getByText('No options available');
+    expect(emptyMessage).toBeTruthy();
+  });
+
+  it('should trigger onMenuItemClick when list item is clicked', () => {
+    const { queryAllByRole } = renderWithProviders(
+      <DropDownMenu
+        hasMenuRole={false}
+        emptyText={'No options available'}
+        options={groupedOptions}
+        onMenuItemClick={onClickMock}
+        onDismissMenu={() => {}}
+        activeValue={null}
+      />
+    );
+
+    const option3 = queryAllByRole('option')[2];
+    expect(option3).toHaveTextContent(basicDropDownOptions[2].label);
+
+    fireEvent.click(option3);
+
+    expect(onClickMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should override list items when renderMenu is present', () => {
+    const OverrideRenderItem = forwardRef(function DefaultListItem(
+      { isSelected, ...rest },
+      ref
+    ) {
+      return (
+        <li {...rest} ref={ref}>
+          {isSelected ? 'I AM SELECTED' : 'I AM EXTRA CONTENT'}
+        </li>
+      );
+    });
+    OverrideRenderItem.propTypes = {
+      isSelected: PropTypes.bool,
+    };
+
+    const { queryAllByText } = renderWithProviders(
+      <DropDownMenu
+        hasMenuRole={false}
+        emptyText={'No options available'}
+        options={groupedOptions}
+        onMenuItemClick={onClickMock}
+        onDismissMenu={() => {}}
+        activeValue={basicDropDownOptions[2].value}
+        renderItem={OverrideRenderItem}
+      />
+    );
+
+    const itemsNotSelected = queryAllByText('I AM EXTRA CONTENT');
+    const itemsSelected = queryAllByText('I AM SELECTED');
+
+    expect(itemsNotSelected).toHaveLength(11);
+    expect(itemsSelected).toHaveLength(1);
+  });
+});

--- a/assets/src/design-system/components/dropDown/test/select.js
+++ b/assets/src/design-system/components/dropDown/test/select.js
@@ -24,7 +24,7 @@ import { fireEvent } from '@testing-library/react';
  * Internal dependencies
  */
 import { renderWithProviders } from '../../../testUtils/renderWithProviders';
-import { DropDownSelect } from '../select';
+import DropDownSelect from '../select';
 
 describe('DropDown <DropDownSelect />', () => {
   const onClickMock = jest.fn();

--- a/assets/src/design-system/components/dropDown/test/useDropDownMenu.js
+++ b/assets/src/design-system/components/dropDown/test/useDropDownMenu.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+
+import useDropDownMenu from '../menu/useDropDownMenu';
+import {
+  basicDropDownOptions,
+  nestedDropDownOptions,
+} from '../stories/sampleData';
+import { getOptions } from '../utils';
+
+describe('useDropDownMenu()', function () {
+  it('should have the default options initially selected', function () {
+    const { result } = renderHook(() =>
+      useDropDownMenu({
+        handleMenuItemSelect: () => {},
+        options: getOptions(basicDropDownOptions),
+        listRef: { current: null },
+        onDismissMenu: () => {},
+      })
+    );
+
+    expect(result.current.focusedIndex).toBe(0);
+    expect(result.current.focusedValue).toBeUndefined();
+  });
+
+  it('should return focused index matching activeValue passed in initially if present', function () {
+    const { result } = renderHook(() =>
+      useDropDownMenu({
+        activeValue: basicDropDownOptions[2].value,
+        handleMenuItemSelect: () => {},
+        options: getOptions(basicDropDownOptions),
+        listRef: { current: null },
+        onDismissMenu: () => {},
+      })
+    );
+
+    expect(result.current.focusedIndex).toBe(2);
+    expect(result.current.focusedValue).toBe(basicDropDownOptions[2].value);
+  });
+
+  it('should return focused index matching activeValue passed in initially if present in a nested list', function () {
+    const { result } = renderHook(() =>
+      useDropDownMenu({
+        activeValue: 'dog-2',
+        handleMenuItemSelect: () => {},
+        options: getOptions(nestedDropDownOptions),
+        listRef: { current: null },
+        onDismissMenu: () => {},
+      })
+    );
+
+    expect(result.current.focusedIndex).toBe(15);
+    expect(result.current.focusedValue).toBe('dog-2');
+  });
+});

--- a/assets/src/design-system/components/dropDown/test/utils.js
+++ b/assets/src/design-system/components/dropDown/test/utils.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { getOptions } from '../utils';
+import { getOptions, getInset } from '../utils';
 
 const basicDropDownOptions = [
   {
@@ -157,5 +157,14 @@ describe('DropDown/utils getOptions', () => {
         label: 'tricky content',
       },
     ]);
+  });
+});
+
+describe('DropDown/utils getInset', () => {
+  it('should take sanitized dropDown options and structure placement by group', () => {
+    const sanitizedOptions = getOptions(basicDropDownOptions);
+    const option = getInset(sanitizedOptions, 0, 2);
+
+    expect(option).toBe(2);
   });
 });

--- a/assets/src/design-system/components/dropDown/utils.js
+++ b/assets/src/design-system/components/dropDown/utils.js
@@ -47,3 +47,9 @@ export const getOptions = (groups) => {
     return [{ group: onlyValidOptions }];
   }
 };
+
+export const getInset = (groups, i, j) =>
+  groups
+    .slice(0, i)
+    .map(({ group }) => group.length)
+    .reduce((a, b) => a + b, 0) + j;

--- a/assets/src/design-system/utils/isNullOrUndefinedOrEmptyString.js
+++ b/assets/src/design-system/utils/isNullOrUndefinedOrEmptyString.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const isNullOrUndefinedOrEmptyString = (val) =>
+  val === null || val === undefined || val === '';

--- a/assets/src/design-system/utils/useFocusOut.js
+++ b/assets/src/design-system/utils/useFocusOut.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useLayoutEffect } from 'react';
+
+function useFocusOut(ref, callback, deps) {
+  useLayoutEffect(() => {
+    const node = ref.current;
+    if (!node) {
+      return undefined;
+    }
+
+    const onFocusOut = (evt) => {
+      // If focus moves somewhere outside the node, callback time!
+      if (evt.relatedTarget && !node.contains(evt.relatedTarget)) {
+        callback(evt);
+      }
+    };
+
+    const onDocumentClick = (evt) => {
+      // If something outside the target node is clicked, callback time!
+      const isInNode = node.contains(evt.target);
+      if (!isInNode) {
+        callback(evt);
+      }
+    };
+
+    node.addEventListener('focusout', onFocusOut);
+    // Often elements are removed in pointerdown handlers elsewhere, causing them
+    // to fail the node.contains check regardless of being inside target ref or not.
+    // By checking the click target in the capture phase, we circumvent that completely.
+    const opts = { capture: true };
+    const doc = node.ownerDocument;
+    doc.addEventListener('pointerdown', onDocumentClick, opts);
+
+    return () => {
+      node.removeEventListener('focusout', onFocusOut);
+      doc.removeEventListener('pointerdown', onDocumentClick, opts);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps || []);
+}
+
+export default useFocusOut;


### PR DESCRIPTION
## Summary

Adds menu functionality to `<DropDown />`. 

There's a variety of dropdown versions used throughout the dashboard and the editor currently. The idea here is to be able to decrease the amount of "one off" dropdowns in play by creating something with functionality that doesn't change but appearance that can.

In the new designs we have 2 types of dropdowns: 1) that has a single list and 2) one with sublists that will need to have sub list titles displayed. In each of these there can only be one option selected at a time.

Separately we have our typeahead/search dropdown, because the search functionality adds a good amount of complexity (lists that we should virtualize, the ability to have multiple values selected) this "version" of a dropdown shouldn't be considered a version at all, but it's own thing.

Lastly, we have popover menus which are only a thing in the dashboard right now, these are essentially just the "menu" part of the dropdown, these are separate from the dropdown too. As this is still a draft, I'm weighing pros vs cons of pulling out the useDropdownMenu hook I created to be shared.

## Relevant Technical Choices

-  `<DropDownMenu />` is responsible for the menu itself. It renders a list with its items by default. It can be overridden by including a renderItem component in <Dropdown />. There's examples of this in storybook and in tests. You can also override the styles by using menuStylesOverride with styled component's CSS prop. These overrides are here because it seems in our existing ecosystem one of the leading causes of making new dropDowns is the styling will vary (IE animation effects).

- `dropDown/menu/useDropDownMenu` takes over all of the keyboard functionality. In Menu we pass the hook props and it returns to us the focusedIndex (focusedValue is also available, but I've found it unnecessary to grab yet). Inside the hook we're finding the proper index to focus in the menu and focusing it and using the listRef that belongs to the <ul> inside of Menu to handle keyboard navigation. Having this logic separate from the UI should make things easier to share and avoid needless duplication of functionality.

## To-do

- [ ] Disabled item handling 
- [ ] Styles

## User-facing changes

None, changes live in storybook

## Testing Instructions

Run storybook locally and navigate to designsystem/components/dropdown. These dropdown demos should mimic our existing dropdown functionality.

- On default, if no value is currently selected the first list item should be focused
- On default, when a new item is selected the menu should close
- if isKeepMenuOpenOnSelection is true, the menu should not close when a new item is selected
- A menu should not open if the disabled knob is true in storybook
- 'No options available' should show up when menu is expanded if there are no items in an array
- If there is a currently selected value when a menu is opened it should be in focus and in view.
- You should be able to navigate dropdown list with your arrow keys. If isRTL knob is false then Up and Left arrows should move you up in the list. If isRTL knob is true then Up and Right arrows should move you up the list. (And respectfully, Down and Right arrows move you down, or Down and Left arrows move you down if isRTL is true).
- You should be able to select a new item by pressing Enter
- You should be able to close the menu by pressing Tab or Escape

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4950 
