### PR TITLE
Pre-Publish Panel: Prevent unintentional re-rendering

### DIFF
--- a/assets/src/edit-story/components/inspector/inspectorProvider.js
+++ b/assets/src/edit-story/components/inspector/inspectorProvider.js
@@ -20,6 +20,7 @@
 import PropTypes from 'prop-types';
 import { useCallback, useState, useRef, useEffect } from 'react';
 import { useDebouncedCallback } from 'use-debounce/lib';
+import useDeepCompareEffect from 'use-deep-compare-effect';
 
 /**
  * WordPress dependencies
@@ -48,9 +49,10 @@ function InspectorProvider({ children }) {
   const {
     actions: { getAuthors },
   } = useAPI();
-  const { selectedElementIds, currentPage } = useStory(({ state }) => ({
+  const { selectedElementIds, currentPage, story } = useStory(({ state }) => ({
     selectedElementIds: state.selectedElementIds,
     currentPage: state.currentPage,
+    story: { ...state.story, pages: state.pages },
   }));
 
   const { checklist, refreshChecklist } = usePrepublishChecklist();
@@ -92,10 +94,13 @@ function InspectorProvider({ children }) {
 
   useEffect(() => {
     tabRef.current = tab;
+  }, [tab]);
+
+  useDeepCompareEffect(() => {
     if (tab === PREPUBLISH) {
       refreshChecklistDebounced();
     }
-  }, [tab, refreshChecklistDebounced, refreshChecklist]);
+  }, [story, refreshChecklistDebounced]);
 
   useEffect(() => {
     if (selectedElementIds.length > 0 && tabRef.current === DOCUMENT) {

--- a/assets/src/edit-story/components/inspector/inspectorProvider.js
+++ b/assets/src/edit-story/components/inspector/inspectorProvider.js
@@ -36,6 +36,7 @@ import { useStory } from '../../app/story';
 
 import { PRE_PUBLISH_MESSAGE_TYPES } from '../../app/prepublish';
 import { Error, Warning } from '../../../design-system/icons/alert';
+import usePrevious from '../../utils/usePrevious';
 import PrepublishInspector, { usePrepublishChecklist } from './prepublish';
 import Context from './context';
 import DesignInspector from './design';
@@ -78,7 +79,7 @@ function InspectorProvider({ children }) {
   const [users, setUsers] = useState([]);
   const [inspectorContentHeight, setInspectorContentHeight] = useState(null);
   const inspectorContentRef = useRef();
-  const tabRef = useRef(tab);
+  const prevTab = usePrevious(tab);
 
   const [isUsersLoading, setIsUsersLoading] = useState(false);
 
@@ -92,10 +93,6 @@ function InspectorProvider({ children }) {
     []
   );
 
-  useEffect(() => {
-    tabRef.current = tab;
-  }, [tab]);
-
   useDeepCompareEffect(() => {
     if (tab === PREPUBLISH) {
       refreshChecklistDebounced();
@@ -103,16 +100,16 @@ function InspectorProvider({ children }) {
   }, [story, refreshChecklistDebounced]);
 
   useEffect(() => {
-    if (selectedElementIds.length > 0 && tabRef.current === DOCUMENT) {
+    if (selectedElementIds.length > 0 && prevTab === DOCUMENT) {
       setTab(DESIGN);
     }
-  }, [selectedElementIds]);
+  }, [selectedElementIds, prevTab]);
 
   useEffect(() => {
-    if (tabRef.current === DOCUMENT) {
+    if (prevTab === DOCUMENT) {
       setTab(DESIGN);
     }
-  }, [currentPage]);
+  }, [currentPage, prevTab]);
 
   const loadUsers = useCallback(() => {
     if (!isUsersLoading && users.length === 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13789,6 +13789,11 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -32003,6 +32008,40 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-3.4.3.tgz",
       "integrity": "sha512-nxy+opOxDccWfhMl36J5BSCTpvcj89iaQk2OZWLAtBJQj7ISCtx1gh+rFbdjGfMl6vtCZf6gke/kYvrkVfHMoA=="
+    },
+    "use-deep-compare-effect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.6.1.tgz",
+      "integrity": "sha512-VB3b+7tFI81dHm8buGyrpxi8yBhzYZdyMX9iBJra7SMFMZ4ci4FJ1vFc1nvChiB1iLv4GfjqaYfvbNEpTT1rFQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": "^17.0.0",
+        "dequal": "^2.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@types/react": {
+          "version": "17.0.0",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
+          "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
+          "requires": {
+            "@types/prop-types": "*",
+            "csstype": "^3.0.2"
+          }
+        },
+        "csstype": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+        }
+      }
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "styled-components": "^5.2.1",
     "use-context-selector": "^1.2.11",
     "use-debounce": "^3.4.3",
+    "use-deep-compare-effect": "^1.6.1",
     "use-reduction": "^2.1.0",
     "uuid": "^8.3.2",
     "valid-url": "^1.0.9",


### PR DESCRIPTION
## Summary

- Fixes a circular rerendering of the prepublish inspector 

## Relevant Technical Choices
- Noticed this while writing a proof of concept for selecting the offending element from the list, and the hover/pointer styles were giving me strange results. I will turn on the react dev tools highlighting from now on when working on prepublish checklist. :)
- I chose a deep compare use effect library so that changes to the story and elements would be detected in a more performant way. 
<!-- Please describe your changes. -->

## To-do
- N/A
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- None
<!-- Please describe your changes. -->

## Testing Instructions
- using React dev tools, turn on `Highlight updates when components render.` under settings
- With the prepublish checklist tab active, see that the checklist is being refreshed on a tick rather than when the story changes
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->


