### PR TITLE
Normalize metrics of text box when padding and fill modes change.

### DIFF
--- a/assets/src/edit-story/components/panels/design/textStyle/color.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/color.js
@@ -19,7 +19,7 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 /**
  * WordPress dependencies
@@ -112,6 +112,16 @@ function ColorControls({ selectedElements, pushUpdate }) {
     [backgroundTextMode, pushUpdate]
   );
 
+  const handleBackgroundModeButton = useCallback(
+    (value, mode) => {
+      if (!value) {
+        return;
+      }
+      pushUpdate(() => ({ backgroundTextMode: mode }), true);
+    },
+    [pushUpdate]
+  );
+
   return (
     <>
       <Row>
@@ -139,15 +149,7 @@ function ColorControls({ selectedElements, pushUpdate }) {
               __('Set text background mode: %s', 'web-stories'),
               label
             )}
-            onChange={(value) =>
-              value &&
-              pushUpdate(
-                {
-                  backgroundTextMode: mode,
-                },
-                true
-              )
-            }
+            onChange={(value) => handleBackgroundModeButton(value, mode)}
           />
         ))}
         <Space flex="2" />

--- a/assets/src/edit-story/components/panels/design/textStyle/padding.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/padding.js
@@ -39,8 +39,9 @@ import {
   usePresubmitHandler,
 } from '../../../form';
 import { useCommonObjectValue } from '../../shared';
+import { metricsForTextPadding } from '../../utils/metricsForTextPadding';
 
-const DEFAULT_PADDING = { horizontal: 0, vertical: 0, locked: true };
+export const DEFAULT_PADDING = { horizontal: 0, vertical: 0, locked: true };
 
 const MIN_MAX = {
   PADDING: {
@@ -77,23 +78,16 @@ function PaddingControls({
 
   const handleChange = useCallback(
     (newPadding, submit = false) => {
-      pushUpdate(({ x, y, width, height }) => {
-        const updates = {};
-
-        if ('horizontal' in newPadding) {
-          updates.x = x - (newPadding.horizontal - padding.horizontal || 0);
-          updates.width =
-            width + (newPadding.horizontal - padding.horizontal || 0) * 2;
-        }
-
-        if ('vertical' in newPadding) {
-          updates.y = y - (newPadding.vertical - padding.vertical || 0);
-          updates.height =
-            height + (newPadding.vertical - padding.vertical || 0) * 2;
-        }
-
-        return updates;
-      });
+      pushUpdate(({ x, y, width, height }) =>
+        metricsForTextPadding({
+          x,
+          y,
+          height,
+          width,
+          currentPadding: padding,
+          newPadding,
+        })
+      );
       pushUpdateForObject('padding', newPadding, DEFAULT_PADDING, submit);
     },
     [pushUpdate, pushUpdateForObject, padding]

--- a/assets/src/edit-story/components/panels/utils/metricsForTextPadding.js
+++ b/assets/src/edit-story/components/panels/utils/metricsForTextPadding.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function metricsForTextPadding({
+  currentPadding,
+  newPadding,
+  x,
+  y,
+  width,
+  height,
+}) {
+  const updates = {};
+
+  if ('horizontal' in newPadding) {
+    updates.x = x - (newPadding.horizontal - currentPadding.horizontal || 0);
+    updates.width =
+      width + (newPadding.horizontal - currentPadding.horizontal || 0) * 2;
+  }
+
+  if ('vertical' in newPadding) {
+    updates.y = y - (newPadding.vertical - currentPadding.vertical || 0);
+    updates.height =
+      height + (newPadding.vertical - currentPadding.vertical || 0) * 2;
+  }
+
+  return updates;
+}

--- a/assets/src/edit-story/components/panels/utils/test/metricsForTextPadding.js
+++ b/assets/src/edit-story/components/panels/utils/test/metricsForTextPadding.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { metricsForTextPadding } from '../metricsForTextPadding';
+
+describe('metricsForTextPadding()', function () {
+  it('should calculate metrics for new padding with no existing padding.', function () {
+    expect(
+      metricsForTextPadding({
+        newPadding: { horizontal: 10, vertical: 8 },
+        currentPadding: { horizontal: 0, vertical: 0 },
+        width: 100,
+        height: 100,
+        y: 30,
+        x: 20,
+      })
+    ).toStrictEqual({
+      height: 116,
+      width: 120,
+      x: 10,
+      y: 22,
+    });
+  });
+
+  it('should calculate metrics for shrinking (new padding is smaller than current).', function () {
+    expect(
+      metricsForTextPadding({
+        newPadding: { horizontal: 10, vertical: 8 },
+        currentPadding: { horizontal: 32, vertical: 14 },
+        width: 100,
+        height: 100,
+        y: 30,
+        x: 20,
+      })
+    ).toStrictEqual({
+      height: 88,
+      width: 56,
+      x: 42,
+      y: 36,
+    });
+  });
+
+  it('should calculate metrics for growing (new padding is smaller than current).', function () {
+    expect(
+      metricsForTextPadding({
+        newPadding: { horizontal: 64, vertical: 28 },
+        currentPadding: { horizontal: 32, vertical: 14 },
+        width: 100,
+        height: 100,
+        y: 30,
+        x: 40,
+      })
+    ).toStrictEqual({
+      height: 128,
+      width: 164,
+      x: 8,
+      y: 16,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Normalizes the spacing of text boxes when fill mode or padding is changed.

This set ups the base for applying behind-the-scenes padding on text boxes when the highlight or fill mode is applied.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Create a new story or edit an existing story
2. Add some text boxes
3. Add a highlight or fill mode to the text box and see the text stays in place
4. Add some padding to the text box and see the text stays in place and the frame grows around it
---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
