### PR TITLE
Media: hide poster images in more places

### DIFF
--- a/includes/Media.php
+++ b/includes/Media.php
@@ -27,6 +27,9 @@
 namespace Google\Web_Stories;
 
 use WP_Post;
+use WP_Query;
+use WP_REST_Request;
+use WP_Screen;
 
 /**
  * Class Media
@@ -204,6 +207,112 @@ class Media {
 		add_filter( 'wp_prepare_attachment_for_js', [ $this, 'wp_prepare_attachment_for_js' ], 10, 2 );
 
 		add_action( 'delete_attachment', [ $this, 'delete_video_poster' ] );
+
+		// Hide video posters from Media grid view.
+		add_filter( 'ajax_query_attachments_args', [ $this, 'filter_ajax_query_attachments_args' ] );
+		// Hide video posters from Media list view.
+		add_filter( 'pre_get_posts', [ $this, 'filter_poster_attachments' ] );
+		// Hide video posters from web-stories/v1/media REST API requests.
+		add_filter( 'rest_attachment_query', [ $this, 'filter_rest_poster_attachments' ], 10, 2 );
+	}
+
+	/**
+	 * Returns the tax query needed to exclude generated video poster images.
+	 *
+	 * @param array $args Existing WP_Query args.
+	 *
+	 * @return array  Tax query arg.
+	 */
+	private function get_poster_tax_query( array $args ) {
+		$tax_query = [
+			[
+				'taxonomy' => self::STORY_MEDIA_TAXONOMY,
+				'field'    => 'slug',
+				'terms'    => [ 'poster-generation' ],
+				'operator' => 'NOT IN',
+			],
+		];
+
+		/**
+		 *  Merge with existing tax query if needed,
+		 * in a nested way so WordPress will run them
+		 * with an 'AND' relation. Example:
+		 *
+		 * [
+		 *   'relation' => 'AND', // implicit.
+		 *   [ this query ],
+		 *   [ [ any ], [ existing ], [ tax queries] ]
+		 * ]
+		 */
+		if ( ! empty( $args['tax_query'] ) ) {
+			$tax_query[] = $args['tax_query'];
+		}
+
+		return $tax_query;
+	}
+
+	/**
+	 * Filters the attachment query args to hide generated video poster images.
+	 *
+	 * Reduces unnecessary noise in the Media grid view.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array $args Query args.
+	 *
+	 * @return array Filtered query args.
+	 */
+	public function filter_ajax_query_attachments_args( array $args ) {
+		$args['tax_query'] = $this->get_poster_tax_query( $args ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+
+		return $args;
+	}
+
+	/**
+	 * Filters the current query to hide generated video poster images.
+	 *
+	 * Reduces unnecessary noise in the Media list view.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param WP_Query $query WP_Query instance, passed by reference.
+	 *
+	 * @return void
+	 */
+	public function filter_poster_attachments( &$query ) {
+		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( ! $current_screen instanceof WP_Screen ) {
+			return;
+		}
+
+		if ( is_admin() && $query->is_main_query() && 'upload' === $current_screen->id ) {
+			$tax_query = $query->get( 'tax_query' );
+
+			$query->set( 'tax_query', $this->get_poster_tax_query( [ 'tax_query' => $tax_query ] ) ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+		}
+	}
+
+	/**
+	 * Filters the current query to hide generated video poster images.
+	 *
+	 * Reduces unnecessary noise in media REST API requests.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param array           $args Query args.
+	 * @param WP_REST_Request $request The current REST request.
+	 *
+	 * @return array Filtered query args.
+	 */
+	public function filter_rest_poster_attachments( array $args, WP_REST_Request $request ) {
+		if ( '/web-stories/v1/media' !== $request->get_route() ) {
+			return $args;
+		}
+
+		$args['tax_query'] = $this->get_poster_tax_query( $args ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+
+		return $args;
 	}
 
 	/**

--- a/includes/REST_API/Stories_Media_Controller.php
+++ b/includes/REST_API/Stories_Media_Controller.php
@@ -62,9 +62,7 @@ class Stories_Media_Controller extends \WP_REST_Attachments_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) {
-		add_action( 'pre_get_posts', [ $this, 'filter_poster_attachments' ] );
 		$response = parent::get_items( $request );
-		remove_action( 'pre_get_posts', [ $this, 'filter_poster_attachments' ] );
 
 		if ( $request['_web_stories_envelope'] && ! is_wp_error( $response ) ) {
 			$response = rest_get_server()->envelope_response( $response, false );
@@ -174,38 +172,5 @@ class Stories_Media_Controller extends \WP_REST_Attachments_Controller {
 	 */
 	protected function get_media_types() {
 		return $this->get_allowed_mime_types();
-	}
-
-	/**
-	 * Filters the current query to hide all automatically extracted poster image attachments.
-	 *
-	 * Reduces unnecessary noise in the media library.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param \WP_Query $query WP_Query instance, passed by reference.
-	 *
-	 * @return void
-	 */
-	public function filter_poster_attachments( &$query ) {
-		$post_type = (array) $query->get( 'post_type' );
-
-		if ( ! in_array( 'any', $post_type, true ) && ! in_array( 'attachment', $post_type, true ) ) {
-			return;
-		}
-
-		$tax_query = $query->get( 'tax_query' );
-		if ( is_string( $tax_query ) || empty( $tax_query ) ) {
-			$tax_query = [];
-		}
-
-		$tax_query[] = [
-			'taxonomy' => Media::STORY_MEDIA_TAXONOMY,
-			'field'    => 'slug',
-			'terms'    => [ 'poster-generation' ],
-			'operator' => 'NOT IN',
-		];
-
-		$query->set( 'tax_query', $tax_query ); // phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts
 	}
 }

--- a/tests/phpunit/tests/Media.php
+++ b/tests/phpunit/tests/Media.php
@@ -37,6 +37,13 @@ class Media extends \WP_UnitTestCase {
 		$this->assertTrue( has_image_size( \Google\Web_Stories\Media::POSTER_SQUARE_IMAGE_SIZE ) );
 		$this->assertTrue( has_image_size( \Google\Web_Stories\Media::STORY_THUMBNAIL_IMAGE_SIZE ) );
 		$this->assertTrue( has_image_size( \Google\Web_Stories\Media::PUBLISHER_LOGO_IMAGE_SIZE ) );
+
+		$this->assertSame( 10, has_action( 'rest_api_init', [ $media, 'rest_api_init' ] ) );
+		$this->assertSame( 10, has_filter( 'wp_prepare_attachment_for_js', [ $media, 'wp_prepare_attachment_for_js' ] ) );
+		$this->assertSame( 10, has_action( 'delete_attachment', [ $media, 'delete_video_poster' ] ) );
+		$this->assertSame( 10, has_filter( 'ajax_query_attachments_args', [ $media, 'filter_ajax_query_attachments_args' ] ) );
+		$this->assertSame( 10, has_filter( 'pre_get_posts', [ $media, 'filter_poster_attachments' ] ) );
+		$this->assertSame( 10, has_filter( 'rest_attachment_query', [ $media, 'filter_rest_poster_attachments' ] ) );
 	}
 	/**
 	 * @covers ::rest_api_init

--- a/tests/phpunit/tests/Media.php
+++ b/tests/phpunit/tests/Media.php
@@ -17,6 +17,7 @@
 
 namespace Google\Web_Stories\Tests;
 
+use WP_Query;
 use WP_REST_Request;
 
 /**
@@ -263,5 +264,201 @@ class Media extends \WP_UnitTestCase {
 		wp_set_object_terms( $poster_attachment_id, 'poster-generation', \Google\Web_Stories\Media::STORY_MEDIA_TAXONOMY );
 		$result3 = $this->call_private_method( $media, 'is_poster', [ $poster_attachment_id ] );
 		$this->assertTrue( $result3 );
+	}
+
+	/**
+	 * @covers ::filter_ajax_query_attachments_args
+	 * @covers ::get_poster_tax_query
+	 */
+	public function test_filter_ajax_query_attachments_args() {
+		$expected = [
+			'tax_query' => [
+				[
+					'taxonomy' => \Google\Web_Stories\Media::STORY_MEDIA_TAXONOMY,
+					'field'    => 'slug',
+					'terms'    => [ 'poster-generation' ],
+					'operator' => 'NOT IN',
+				],
+			],
+		];
+
+		$media  = new \Google\Web_Stories\Media();
+		$actual = $media->filter_ajax_query_attachments_args( [] );
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::filter_ajax_query_attachments_args
+	 * @covers ::get_poster_tax_query
+	 */
+	public function test_filter_ajax_query_attachments_args_existing_tax_query() {
+		$expected = [
+			'tax_query' => [
+				[
+					'taxonomy' => \Google\Web_Stories\Media::STORY_MEDIA_TAXONOMY,
+					'field'    => 'slug',
+					'terms'    => [ 'poster-generation' ],
+					'operator' => 'NOT IN',
+				],
+				[
+					[
+						'taxonomy' => 'category',
+						'field'    => 'slug',
+						'terms'    => [ 'uncategorized' ],
+						'operator' => 'NOT IN',
+					],
+				],
+			],
+		];
+
+		$media  = new \Google\Web_Stories\Media();
+		$actual = $media->filter_ajax_query_attachments_args(
+			[
+				'tax_query' => [
+					[
+						'taxonomy' => 'category',
+						'field'    => 'slug',
+						'terms'    => [ 'uncategorized' ],
+						'operator' => 'NOT IN',
+					],
+				],
+			]
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::filter_poster_attachments
+	 */
+	public function test_filter_poster_attachments_no_screen() {
+		$query    = new WP_Query();
+		$expected = $query->get( 'tax_query' );
+
+		$media = new \Google\Web_Stories\Media();
+		$media->filter_poster_attachments( $query );
+		$actual = $query->get( 'tax_query' );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::filter_poster_attachments
+	 */
+	public function test_filter_poster_attachments_not_main_query() {
+		$GLOBALS['current_screen'] = convert_to_screen( 'upload' );
+
+		$query    = new WP_Query();
+		$expected = $query->get( 'tax_query' );
+
+		$media = new \Google\Web_Stories\Media();
+		$media->filter_poster_attachments( $query );
+		$actual = $query->get( 'tax_query' );
+
+		unset( $GLOBALS['current_screen'] );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::filter_poster_attachments
+	 */
+	public function test_filter_poster_attachments_not_upload_screen() {
+		$GLOBALS['current_screen'] = convert_to_screen( 'post' );
+
+		$query                   = new WP_Query();
+		$GLOBALS['wp_the_query'] = $query;
+		$expected                = $query->get( 'tax_query' );
+
+		$media = new \Google\Web_Stories\Media();
+		$media->filter_poster_attachments( $query );
+		$actual = $query->get( 'tax_query' );
+
+		unset( $GLOBALS['current_screen'], $GLOBALS['wp_the_query'] );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::filter_poster_attachments
+	 */
+	public function test_filter_poster_attachments() {
+		$expected = [
+			[
+				'taxonomy' => \Google\Web_Stories\Media::STORY_MEDIA_TAXONOMY,
+				'field'    => 'slug',
+				'terms'    => [ 'poster-generation' ],
+				'operator' => 'NOT IN',
+			],
+			[
+				[
+					'taxonomy' => 'category',
+					'field'    => 'slug',
+					'terms'    => [ 'uncategorized' ],
+					'operator' => 'NOT IN',
+				],
+			],
+		];
+
+		$GLOBALS['current_screen'] = convert_to_screen( 'upload' );
+
+		$query                   = new WP_Query();
+		$GLOBALS['wp_the_query'] = $query;
+		$query->set(
+			'tax_query',
+			[
+				[
+					'taxonomy' => 'category',
+					'field'    => 'slug',
+					'terms'    => [ 'uncategorized' ],
+					'operator' => 'NOT IN',
+				],
+			]
+		);
+
+		$media = new \Google\Web_Stories\Media();
+		$media->filter_poster_attachments( $query );
+		$actual = $query->get( 'tax_query' );
+
+		unset( $GLOBALS['current_screen'], $GLOBALS['wp_the_query'] );
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::filter_rest_poster_attachments
+	 */
+	public function test_filter_rest_poster_attachments_wrong_route() {
+		$expected = [];
+
+		$media  = new \Google\Web_Stories\Media();
+		$actual = $media->filter_rest_poster_attachments( [], new WP_REST_Request() );
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::filter_rest_poster_attachments
+	 */
+	public function test_filter_rest_poster_attachments() {
+		$expected = [
+			'tax_query' => [
+				[
+					'taxonomy' => \Google\Web_Stories\Media::STORY_MEDIA_TAXONOMY,
+					'field'    => 'slug',
+					'terms'    => [ 'poster-generation' ],
+					'operator' => 'NOT IN',
+				],
+			],
+		];
+
+		$media  = new \Google\Web_Stories\Media();
+		$actual = $media->filter_rest_poster_attachments(
+			[],
+			new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/media' )
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 }

--- a/tests/phpunit/tests/REST_API/Stories_Media_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Media_Controller.php
@@ -212,34 +212,4 @@ class Stories_Media_Controller extends \WP_Test_REST_TestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
 	}
-
-	/**
-	 * @covers ::filter_poster_attachments
-	 */
-	public function test_filter_poster_attachments() {
-		$controller = new \Google\Web_Stories\REST_API\Stories_Media_Controller( 'attachment' );
-		$query      = new \WP_Query();
-		$result     = $controller->filter_poster_attachments( $query );
-		$this->assertNull( $result );
-		$tax_query = $query->get( 'tax_query' );
-		$this->assertSame( '', $tax_query );
-	}
-
-	/**
-	 * @covers ::filter_poster_attachments
-	 */
-	public function test_filter_poster_attachments_with_attachments() {
-		$controller = new \Google\Web_Stories\REST_API\Stories_Media_Controller( 'attachment' );
-		$query      = new \WP_Query();
-		$query->set( 'post_type', 'attachment' );
-		$result = $controller->filter_poster_attachments( $query );
-		$this->assertNull( $result );
-		$tax_query = $query->get( 'tax_query' );
-		$this->assertTrue( is_array( $tax_query ) );
-		$data = array_shift( $tax_query );
-		$this->assertArrayHasKey( 'taxonomy', $data );
-		$this->assertArrayHasKey( 'field', $data );
-		$this->assertArrayHasKey( 'terms', $data );
-		$this->assertArrayHasKey( 'operator', $data );
-	}
 }


### PR DESCRIPTION
## Summary

Hides the generated poster images in more places for better UX.

## Relevant Technical Choices

Made the code more DRY by introducing a private helper method.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

List of items in media grid view, media list view, and story editor media library should be equal, with posters being hidden everywhere.

## Testing Instructions

List of items in media grid view, media list view, and story editor media library should be equal, with posters being hidden everywhere.

Previously: see video _and_ its poster next to it
Now: see only the video

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5761
