### PR TITLE
AMP Optimization: Reduce debug noise

### DIFF
--- a/includes/AMP/Optimization.php
+++ b/includes/AMP/Optimization.php
@@ -60,15 +60,25 @@ class Optimization {
 		$this->get_optimizer()->optimizeDom( $document, $errors );
 
 		if ( count( $errors ) > 0 ) {
-			$error_messages = array_map(
-				static function( Error $error ) {
-					return ' - ' . $error->getCode() . ': ' . $error->getMessage();
-				},
-				iterator_to_array( $errors )
+			$error_messages = array_filter(
+				array_map(
+					static function( Error $error ) {
+						// Hidden because amp-story is a render-delaying extension.
+						if ( 'CannotRemoveBoilerplate' === $error->getCode() ) {
+							return '';
+						}
+
+						return ' - ' . $error->getCode() . ': ' . $error->getMessage();
+					},
+					iterator_to_array( $errors )
+				)
 			);
-			$document->head->appendChild(
-				$document->createComment( "\n" . __( 'AMP optimization could not be completed due to the following:', 'web-stories' ) . "\n" . implode( "\n", $error_messages ) . "\n" )
-			);
+
+			if ( ! empty( $error_messages ) ) {
+				$document->head->appendChild(
+					$document->createComment( "\n" . __( 'AMP optimization could not be completed due to the following:', 'web-stories' ) . "\n" . implode( "\n", $error_messages ) . "\n" )
+				);
+			}
 		}
 	}
 

--- a/tests/phpunit/tests/AMP/Meta_Sanitizer.php
+++ b/tests/phpunit/tests/AMP/Meta_Sanitizer.php
@@ -24,7 +24,7 @@ use Google\Web_Stories\Tests\MarkupComparison;
 use Google\Web_Stories\Tests\ScriptHash;
 
 /**
- * @coversDefaultClass \Google\Web_Stories\AMP\Meta_Sanitizer.
+ * @coversDefaultClass \Google\Web_Stories\AMP\Meta_Sanitizer
  */
 class Meta_Sanitizer extends \WP_UnitTestCase {
 	use MarkupComparison;

--- a/tests/phpunit/tests/AMP/Optimization.php
+++ b/tests/phpunit/tests/AMP/Optimization.php
@@ -67,7 +67,7 @@ class Optimization extends \WP_UnitTestCase {
 		$actual = $document->saveHTML();
 
 		$this->assertContains( 'transformed="self;v=1', $actual );
-		$this->assertContains( 'Cannot remove boilerplate because of an unsupported layout: amp-story', $actual );
+		$this->assertNotContains( 'Cannot remove boilerplate because of an unsupported layout: amp-story', $actual );
 	}
 
 	/**

--- a/tests/phpunit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/tests/AMP/Story_Sanitizer.php
@@ -65,7 +65,7 @@ class Story_Sanitizer extends \WP_UnitTestCase {
 	/**
 	 * @dataProvider get_publisher_logo_data
 	 * @covers ::sanitize
-	 * @covers Sanitization_Utils::add_publisher_logo
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::add_publisher_logo
 	 *
 	 * @param string   $source   Source.
 	 * @param string   $expected Expected.

--- a/tests/phpunit/tests/Story_Renderer/HTML.php
+++ b/tests/phpunit/tests/Story_Renderer/HTML.php
@@ -162,7 +162,7 @@ class HTML extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::add_poster_images
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::add_publisher_logo
 	 * @covers ::get_poster_images
 	 */
 	public function test_add_poster_images() {
@@ -185,7 +185,7 @@ class HTML extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::add_poster_images
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::add_publisher_logo
 	 * @covers ::get_poster_images
 	 */
 	public function test_add_poster_images_overrides_existing_poster() {
@@ -207,7 +207,7 @@ class HTML extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::add_poster_images
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::add_publisher_logo
 	 * @covers ::get_poster_images
 	 */
 	public function test_add_poster_images_no_fallback_image_added() {
@@ -226,7 +226,7 @@ class HTML extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::add_poster_images
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::add_publisher_logo
 	 * @covers ::remove_amp_attr
 	 */
 	public function test_add_poster_images_no_poster_no_amp() {
@@ -257,7 +257,7 @@ class HTML extends WP_UnitTestCase {
 		$actual = $this->setup_renderer( $post );
 
 		$this->assertContains( 'transformed="self;v=1"', $actual );
-		$this->assertContains( 'AMP optimization could not be completed', $actual );
+		$this->assertNotContains( 'AMP optimization could not be completed', $actual );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Do not print `CannotRemoveBoilerplate` debug message, as this error will _always_ be added for stories. Not a big deal, but prevents users from thinking it's a critical error.
