### PR TITLE
E2E Tests: reduce number of Percy snapshots

### DIFF
--- a/tests/e2e/specs/dashboard/dashboard.js
+++ b/tests/e2e/specs/dashboard/dashboard.js
@@ -34,6 +34,7 @@ describe('Stories Dashboard', () => {
 
     await percySnapshot(page, 'Stories Dashboard', { percyCSS });
   });
+
   it('should be able to open the dashboard on RTL', async () => {
     await activateRTL();
     await visitDashboard();

--- a/tests/e2e/specs/dashboard/integrations/sitekit.js
+++ b/tests/e2e/specs/dashboard/integrations/sitekit.js
@@ -15,13 +15,10 @@
  */
 
 /**
- * External dependencies
- */
-import { percySnapshot } from '@percy/puppeteer';
-/**
  * WordPress dependencies
  */
 import { activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
+
 /**
  * Internal dependencies
  */
@@ -50,8 +47,6 @@ describe('Site Kit integration with dashboard', () => {
     await page.waitForResponse((response) =>
       response.url().includes('web-stories/v1/media')
     );
-
-    await percySnapshot(page, 'Stories Dashboard with Site Kit');
 
     await expect(page).toMatch(
       'Site Kit by Google has already enabled Google Analytics for your Web Stories'

--- a/tests/e2e/specs/dashboard/noJS.js
+++ b/tests/e2e/specs/dashboard/noJS.js
@@ -22,7 +22,7 @@ import { percySnapshot } from '@percy/puppeteer';
 /**
  * Internal dependencies
  */
-import { activateRTL, deactivateRTL, visitDashboard } from '../../utils';
+import { visitDashboard } from '../../utils';
 
 describe('Stories Dashboard with disabled JavaScript', () => {
   it('should display error message', async () => {
@@ -33,25 +33,9 @@ describe('Stories Dashboard with disabled JavaScript', () => {
 
     await expect(page).toMatchElement('.web-stories-wp-no-js');
 
-    // Re-enable javascript for snapsnots.
+    // Re-enable javascript for snapshots.
     await page.setJavaScriptEnabled(true);
 
     await percySnapshot(page, 'Dashboard no js');
-  });
-
-  it('should display error message on RTL', async () => {
-    await activateRTL();
-    // Disable javascript for test.
-    await page.setJavaScriptEnabled(false);
-
-    await visitDashboard();
-
-    await expect(page).toMatchElement('.web-stories-wp-no-js');
-
-    // Re-enable javascript for snapsnots.
-    await page.setJavaScriptEnabled(true);
-
-    await percySnapshot(page, 'Dashboard no js on RTL');
-    await deactivateRTL();
   });
 });

--- a/tests/e2e/specs/dashboard/templates/useTemplate.js
+++ b/tests/e2e/specs/dashboard/templates/useTemplate.js
@@ -24,13 +24,6 @@ import { percySnapshot } from '@percy/puppeteer';
  */
 import { visitDashboard } from '../../../utils';
 
-async function addTextElement() {
-  await expect(page).toClick('button[aria-label="Add new text element"]');
-  await expect(page).toMatchElement('[data-testid="textFrame"]', {
-    text: 'Fill in some text',
-  });
-}
-
 describe('Template', () => {
   it('should be able use existing template for new story', async () => {
     await visitDashboard();
@@ -61,9 +54,5 @@ describe('Template', () => {
     await expect(page).toMatchElement('[data-element-id]');
 
     await percySnapshot(page, 'Story From Template');
-
-    await addTextElement();
-
-    await percySnapshot(page, 'Story From Template: Modified');
   });
 });

--- a/tests/e2e/specs/editor/authorUser.js
+++ b/tests/e2e/specs/editor/authorUser.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { percySnapshot } from '@percy/puppeteer';
-
-/**
  * WordPress dependencies
  */
 import { loginUser, switchUserToAdmin } from '@wordpress/e2e-test-utils';
@@ -60,8 +55,6 @@ describe('Author User', () => {
 
     await addTextElement();
 
-    await percySnapshot(page, 'Author previewing without publishing');
-
     const editorPage = page;
     const previewPage = await previewStory(editorPage);
     await expect(previewPage).toMatchElement('p', {
@@ -83,8 +76,6 @@ describe('Author User', () => {
 
     await publishStory();
 
-    await percySnapshot(page, 'Author previewing after publishing');
-
     const editorPage = page;
     const previewPage = await previewStory(editorPage);
     await expect(previewPage).toMatchElement('p', {
@@ -105,8 +96,6 @@ describe('Author User', () => {
 
     // Make some changes _after_ publishing so previewing will cause an autosave.
     await addTextElement();
-
-    await percySnapshot(page, 'Autosaving and previewing');
 
     const editorPage = page;
     const previewPage = await previewStory(editorPage);

--- a/tests/e2e/specs/editor/editor.js
+++ b/tests/e2e/specs/editor/editor.js
@@ -32,6 +32,7 @@ describe('Story Editor', () => {
 
     await percySnapshot(page, 'Empty Editor');
   });
+
   it('should be able to create a blank story on RTL', async () => {
     await activateRTL();
     await createNewStory();

--- a/tests/e2e/specs/editor/media/insertMediaFromDialog.js
+++ b/tests/e2e/specs/editor/media/insertMediaFromDialog.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { percySnapshot } from '@percy/puppeteer';
-
-/**
  * Internal dependencies
  */
 import { createNewStory, clickButton } from '../../../utils';
@@ -47,7 +42,5 @@ describe('Inserting Media from Dialog', () => {
     await expect(page).toClick('button', { text: 'Insert into page' });
 
     await expect(page).toMatchElement('[data-testid="imageElement"]');
-
-    await percySnapshot(page, 'Inserting Image from Dialog');
   });
 });

--- a/tests/e2e/specs/editor/media/insertMediaFromLibrary.js
+++ b/tests/e2e/specs/editor/media/insertMediaFromLibrary.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { percySnapshot } from '@percy/puppeteer';
-
-/**
  * Internal dependencies
  */
 import { createNewStory } from '../../../utils';
@@ -43,7 +38,5 @@ describe('Inserting Media from Media Library', () => {
     );
 
     await expect(page).toMatchElement('[data-testid="imageElement"]');
-
-    await percySnapshot(page, 'Inserting Image from Media Library');
   });
 });

--- a/tests/e2e/specs/editor/media/insertMovVideo.js
+++ b/tests/e2e/specs/editor/media/insertMovVideo.js
@@ -15,18 +15,11 @@
  */
 
 /**
- * External dependencies
- */
-import { percySnapshot } from '@percy/puppeteer';
-
-/**
  * Internal dependencies
  */
 import { createNewStory, clickButton } from '../../../utils';
 
 const MODAL = '.media-modal';
-
-const percyCSS = `.attachment-details .uploaded { display: none; }`;
 
 describe('Inserting .mov from dialog', () => {
   // Uses the existence of the element's frame element as an indicator for successful insertion.
@@ -44,9 +37,7 @@ describe('Inserting .mov from dialog', () => {
     );
 
     await expect(page).not.toMatchElement('.type-video.subtype-quicktime');
-    await percySnapshot(page, 'Avoid inserting .mov files', { percyCSS });
 
-    const closeBtnSelector = '.media-modal-close';
-    await page.click(closeBtnSelector);
+    expect(page).toClick('.media-modal-close');
   });
 });

--- a/tests/e2e/specs/editor/media/insertWebMVideo.js
+++ b/tests/e2e/specs/editor/media/insertWebMVideo.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { percySnapshot } from '@percy/puppeteer';
-
-/**
  * Internal dependencies
  */
 import {
@@ -52,11 +47,9 @@ describe('Inserting WebM Video', () => {
 
     await expect(page).toMatchElement('[data-testid="videoElement"]');
 
-    // Wait for poster image to be generated.
+    // Wait for poster image to appear.
     await page.waitForSelector('[alt="Preview poster image"]');
     await expect(page).toMatchElement('[alt="Preview poster image"]');
-
-    await percySnapshot(page, 'Inserting Video from Dialog');
   });
 
   it('should insert an video by clicking on media library', async () => {
@@ -71,11 +64,9 @@ describe('Inserting WebM Video', () => {
     await page.waitForSelector('[data-testid="videoElement"]');
     await expect(page).toMatchElement('[data-testid="videoElement"]');
 
-    // Wait for poster image to be generated.
+    // Wait for poster image to appear.
     await page.waitForSelector('[alt="Preview poster image"]');
     await expect(page).toMatchElement('[alt="Preview poster image"]');
-
-    await percySnapshot(page, 'Inserting Video from Media Library');
   });
 
   it('should insert an video by clicking on media library and preview on FE', async () => {

--- a/tests/e2e/specs/editor/metaBoxes.js
+++ b/tests/e2e/specs/editor/metaBoxes.js
@@ -58,8 +58,6 @@ describe('Custom Meta Boxes', () => {
       'button.handlediv[aria-expanded="false"]'
     );
 
-    await percySnapshot(page, 'Custom Meta Boxes Collapsed');
-
     await expect(page).toClick('button.handlediv[aria-expanded="false"]');
     await expect(page).toMatchElement('button.handlediv[aria-expanded="true"]');
 
@@ -76,7 +74,5 @@ describe('Custom Meta Boxes', () => {
       () => document.getElementById('web_stories_test_meta_box_field').value
     );
     await expect(metaBoxValue).toStrictEqual('Meta Box Test Value');
-
-    await percySnapshot(page, 'Custom Meta Boxes Refreshed');
   });
 });

--- a/tests/e2e/specs/editor/noJS.js
+++ b/tests/e2e/specs/editor/noJS.js
@@ -22,7 +22,7 @@ import { percySnapshot } from '@percy/puppeteer';
 /**
  * Internal dependencies
  */
-import { activateRTL, createNewStory, deactivateRTL } from '../../utils';
+import { createNewStory } from '../../utils';
 
 describe('Story Editor with disabled JavaScript', () => {
   it('should display error message', async () => {
@@ -33,25 +33,9 @@ describe('Story Editor with disabled JavaScript', () => {
 
     await expect(page).toMatchElement('.web-stories-wp-no-js');
 
-    // Re-enable javascript for snapsnots.
+    // Re-enable javascript for snapshots.
     await page.setJavaScriptEnabled(true);
 
     await percySnapshot(page, 'Editor no js');
-  });
-
-  it('should display error message on RTL', async () => {
-    await activateRTL();
-    // Disable javascript for test.
-    await page.setJavaScriptEnabled(false);
-
-    await createNewStory();
-
-    await expect(page).toMatchElement('.web-stories-wp-no-js');
-
-    // Re-enable javascript for snapsnots.
-    await page.setJavaScriptEnabled(true);
-
-    await percySnapshot(page, 'Editor no js on RTL');
-    await deactivateRTL();
   });
 });

--- a/tests/e2e/specs/wordpress/adminMenu.js
+++ b/tests/e2e/specs/wordpress/adminMenu.js
@@ -15,11 +15,6 @@
  */
 
 /**
- * External dependencies
- */
-import { percySnapshot } from '@percy/puppeteer';
-
-/**
  * WordPress dependencies
  */
 import { visitAdminPage } from '@wordpress/e2e-test-utils';
@@ -46,10 +41,6 @@ describe('Admin Menu', () => {
     await expect(adminMenuItem).toMatchElement('a', {
       text: 'Settings',
       visible: true,
-    });
-
-    await percySnapshot(page, 'Admin Menu', {
-      percyCSS: `.postbox { display: none; }`,
     });
   });
 

--- a/tests/e2e/specs/wordpress/getStartedStory.js
+++ b/tests/e2e/specs/wordpress/getStartedStory.js
@@ -30,19 +30,21 @@ import {
 
 describe('Get Started Story', () => {
   describe('Admin User', () => {
-    it('should prefill post title and post content', async () => {
+    it('should pre-fill post title and post content', async () => {
       await visitAdminPage(
         'post-new.php',
         'post_type=web-story&web-stories-demo=1'
       );
 
       await expect(page).toMatchElement('input[placeholder="Add title"]');
-      await expect(page).toMatch(/Tips to make the most/i);
-      await expect(page).toMatch(/to make the most of/i);
+      await expect(page).toMatch(
+        /Tips to make the most of the Web Stories Editor/i
+      );
 
       await page.waitForSelector('[data-testid="mediaElement-image"]');
+      await page.waitForSelector('[data-testid="frameElement"]');
 
-      await percySnapshot(page, 'Get Started Story (Admin)');
+      await percySnapshot(page, 'Get Started Story');
     });
   });
 
@@ -55,19 +57,19 @@ describe('Get Started Story', () => {
       await switchUserToAdmin();
     });
 
-    it('should prefill post title and post content', async () => {
+    it('should pre-fill post title and post content', async () => {
       await visitAdminPage(
         'post-new.php',
         'post_type=web-story&web-stories-demo=1'
       );
 
       await expect(page).toMatchElement('input[placeholder="Add title"]');
-      await expect(page).toMatch(/Tips to make the most/i);
-      await expect(page).toMatch(/to make the most of/i);
+      await expect(page).toMatch(
+        /Tips to make the most of the Web Stories Editor/i
+      );
 
       await page.waitForSelector('[data-testid="mediaElement-image"]');
-
-      await percySnapshot(page, 'Get Started Story (Author)');
+      await page.waitForSelector('[data-testid="frameElement"]');
     });
   });
 });


### PR DESCRIPTION
## Summary

Most assertions can be done using JavaScript, with the snapshots adding little to no benefit.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

See #5410
