### PR TITLE
Experiments: fix checks for experiments enabled by default

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -397,6 +397,19 @@ class Experiments {
 	}
 
 	/**
+	 * Returns an experiment by name.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param string $name Experiment name.
+	 * @return array|null Experiment if found, null otherwise.
+	 */
+	protected function get_experiment( $name ) {
+		$experiment = wp_list_filter( $this->get_experiments(), [ 'name' => $name ] );
+		return ! empty( $experiment ) ? array_shift( $experiment ) : null;
+	}
+
+	/**
 	 * Checks whether an experiment is enabled.
 	 *
 	 * @since 1.0.0
@@ -406,6 +419,16 @@ class Experiments {
 	 * @return bool Whether the experiment is enabled.
 	 */
 	public function is_experiment_enabled( $name ) {
+		$experiment = $this->get_experiment( $name );
+
+		if ( ! $experiment ) {
+			return false;
+		}
+
+		if ( array_key_exists( 'default', $experiment ) ) {
+			return (bool) $experiment['default'];
+		}
+
 		$experiments = get_option( Settings::SETTING_NAME_EXPERIMENTS );
 		return ! empty( $experiments[ $name ] );
 	}

--- a/tests/phpunit/tests/Experiments.php
+++ b/tests/phpunit/tests/Experiments.php
@@ -96,14 +96,61 @@ class Experiments extends \WP_UnitTestCase {
 	 * @covers ::display_experiment_field
 	 */
 	public function test_display_experiment_field() {
-		update_option( \Google\Web_Stories\Settings::SETTING_NAME_EXPERIMENTS, [ 'fooExperiment' => true ], false );
-		$experiments = new \Google\Web_Stories\Experiments();
-		$output      = get_echo(
+		$experiments = $this->createPartialMock(
+			\Google\Web_Stories\Experiments::class,
+			[ 'get_experiments' ]
+		);
+		$experiments->method( 'get_experiments' )
+					->willReturn(
+						[
+							[
+								'name'        => 'foo',
+								'label'       => 'Foo Label',
+								'description' => 'Foo Desc',
+							],
+						]
+					);
+
+		$output = get_echo(
 			[ $experiments, 'display_experiment_field' ],
 			[
 				[
-					'label' => 'Experiment',
-					'id'    => 'fooExperiment',
+					'label' => 'Foo Label',
+					'id'    => 'foo',
+				],
+			]
+		);
+
+		$this->assertNotContains( "checked='checked'", $output );
+	}
+
+	/**
+	 * @covers ::display_experiment_field
+	 */
+	public function test_display_experiment_field_enabled() {
+		$experiments = $this->createPartialMock(
+			\Google\Web_Stories\Experiments::class,
+			[ 'get_experiments' ]
+		);
+		$experiments->method( 'get_experiments' )
+					->willReturn(
+						[
+							[
+								'name'        => 'foo',
+								'label'       => 'Foo Label',
+								'description' => 'Foo Desc',
+							],
+						]
+					);
+
+		update_option( \Google\Web_Stories\Settings::SETTING_NAME_EXPERIMENTS, [ 'foo' => true ], false );
+
+		$output = get_echo(
+			[ $experiments, 'display_experiment_field' ],
+			[
+				[
+					'label' => 'Foo Label',
+					'id'    => 'foo',
 				],
 			]
 		);
@@ -114,18 +161,33 @@ class Experiments extends \WP_UnitTestCase {
 	 * @covers ::display_experiment_field
 	 */
 	public function test_display_experiment_field_enabled_by_default() {
-		update_option( \Google\Web_Stories\Settings::SETTING_NAME_EXPERIMENTS, [ 'fooExperiment' => true ], false );
-		$experiments = new \Google\Web_Stories\Experiments();
-		$output      = get_echo(
+		$experiments = $this->createPartialMock(
+			\Google\Web_Stories\Experiments::class,
+			[ 'get_experiments' ]
+		);
+		$experiments->method( 'get_experiments' )
+					->willReturn(
+						[
+							[
+								'name'        => 'foo',
+								'label'       => 'Foo Label',
+								'description' => 'Foo Desc',
+							],
+						]
+					);
+
+		$output = get_echo(
 			[ $experiments, 'display_experiment_field' ],
 			[
 				[
-					'label'   => 'Experiment',
-					'id'      => 'fooExperiment',
+					'label'   => 'Foo Label',
+					'id'      => 'foo',
 					'default' => true,
 				],
 			]
 		);
+
+		$this->assertContains( "checked='checked'", $output );
 		$this->assertContains( 'disabled', $output );
 	}
 
@@ -180,5 +242,36 @@ class Experiments extends \WP_UnitTestCase {
 		update_option( \Google\Web_Stories\Settings::SETTING_NAME_EXPERIMENTS, [ 'enableBookmarkActions' => true ], false );
 		$experiments = new \Google\Web_Stories\Experiments();
 		$this->assertTrue( $experiments->is_experiment_enabled( 'enableBookmarkActions' ) );
+	}
+
+	/**
+	 * @covers ::is_experiment_enabled
+	 * @covers ::get_experiment
+	 */
+	public function test_is_experiment_enabled_default_experiment() {
+		$experiments = $this->createPartialMock(
+			\Google\Web_Stories\Experiments::class,
+			[ 'get_experiments' ]
+		);
+		$experiments->method( 'get_experiments' )
+					->willReturn(
+						[
+							[
+								'name'        => 'foo',
+								'label'       => 'Foo Label',
+								'description' => 'Foo Desc',
+							],
+							[
+								'name'        => 'bar',
+								'label'       => 'Bar Label',
+								'description' => 'Bar Desc',
+								'default'     => true,
+							],
+						]
+					);
+
+		$this->assertFalse( $experiments->is_experiment_enabled( 'foo' ) );
+		$this->assertTrue( $experiments->is_experiment_enabled( 'bar' ) );
+		$this->assertFalse( $experiments->is_experiment_enabled( 'baz' ) );
 	}
 }


### PR DESCRIPTION
## Summary

Using `Experiments::is_experiment_enabled()` in code somewhere should work for experiments with `'default' => true`.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
