### PR TITLE
Animations: Add WAAPI polyfill to editor

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -22,7 +22,6 @@ import { ThemeProvider } from 'styled-components';
 import { addDecorator, addParameters } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
-import 'web-animations-js/web-animations-next-lite.min.js';
 
 /**
  * Internal dependencies

--- a/assets/src/animation/components/provider.js
+++ b/assets/src/animation/components/provider.js
@@ -27,6 +27,8 @@ import {
   useState,
 } from 'react';
 import { v4 as uuidv4 } from 'uuid';
+import 'web-animations-js/web-animations-next-lite.min.js';
+
 /**
  * Internal dependencies
  */

--- a/assets/src/dashboard/index.js
+++ b/assets/src/dashboard/index.js
@@ -21,7 +21,6 @@ import Modal from 'react-modal';
 import { StrictMode } from 'react';
 import { render } from 'react-dom';
 import { FlagsProvider } from 'flagged';
-import 'web-animations-js/web-animations-next-lite.min.js';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/index.js
+++ b/assets/src/edit-story/index.js
@@ -21,7 +21,6 @@ import Modal from 'react-modal';
 import { StrictMode } from 'react';
 import { render } from 'react-dom';
 import { FlagsProvider } from 'flagged';
-import 'web-animations-js/web-animations-next-lite.min.js';
 
 /**
  * Internal dependencies

--- a/assets/src/edit-story/index.js
+++ b/assets/src/edit-story/index.js
@@ -21,6 +21,7 @@ import Modal from 'react-modal';
 import { StrictMode } from 'react';
 import { render } from 'react-dom';
 import { FlagsProvider } from 'flagged';
+import 'web-animations-js/web-animations-next-lite.min.js';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## Summary
Adds WAAPI polyfill to editor

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
NA

## Testing Instructions
I wasn't seeing any issues on safari 13.1.2 before this change, so maybe try running the editor (with a story with animations) on an older version of safari and seeing that there's no reference error: `ReferenceError: Can't find variable: KeyframeEffect`

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5800 
