### PR TITLE
Design System: DropDown Minor Adjustments for Props

### DIFF
--- a/assets/src/design-system/components/dropDown/index.js
+++ b/assets/src/design-system/components/dropDown/index.js
@@ -50,6 +50,8 @@ import useDropDown from './useDropDown';
  * @param {Object} props.menuStylesOverride should be formatted as a css template literal with styled components. Gives access to completely overriding dropdown menu styles (container div > ul > li).
  * @param {Function} props.onMenuItemClick Triggered when a user clicks or presses 'Enter' on an option.
  * @param {Array} props.options All options, should contain either 1) objects with a label, value, anything else you need can be added and accessed through renderItem or 2) Objects containing a label and options, where options is structured as first option with array of objects containing at least value and label - this will create a nested list.
+ * @param {number} props.popupFillWidth Allows for an override of how much of popup width to take up for dropDown.
+ * @param {number} props.popupZIndex Allows for an override of the default popup z index (2).
  * @param {string} props.placement placement passed to popover for where menu should expand, defaults to "bottom_end".
  * @param {Function} props.renderItem If present when menu is open, will override the base list items rendered for each option, the entire item and whether it is selected will be returned and allow you to style list items internal to a list item without affecting dropdown functionality.
  * @param {string} props.selectedValue the selected value of the dropDown. Should correspond to a value in the options array of objects.
@@ -67,6 +69,7 @@ export const DropDown = ({
   options = [],
   placement = PLACEMENT.BOTTOM,
   popupFillWidth = DEFAULT_POPUP_FILL_WIDTH,
+  popupZIndex,
   selectedValue = '',
   ...rest
 }) => {
@@ -108,9 +111,9 @@ export const DropDown = ({
     <DropDownContainer>
       <DropDownSelect
         activeItemLabel={activeOption?.label}
-        aria-pressed={isOpen}
+        aria-pressed={isOpen.value}
         aria-disabled={disabled}
-        aria-expanded={isOpen}
+        aria-expanded={isOpen.value}
         aria-label={ariaLabel || dropDownLabel}
         aria-owns={listId}
         disabled={disabled}
@@ -128,6 +131,7 @@ export const DropDown = ({
           isOpen={isOpen.value}
           placement={placement}
           fillWidth={popupFillWidth}
+          zIndex={popupZIndex}
         >
           <DropDownMenu
             activeValue={activeOption?.value}
@@ -171,6 +175,7 @@ DropDown.propTypes = {
   placeholder: PropTypes.string,
   placement: PropTypes.oneOf(Object.values(PLACEMENT)),
   popupFillWidth: PropTypes.number,
+  popupZIndex: PropTypes.number,
   renderItem: PropTypes.object,
   selectedValue: PropTypes.oneOfType([
     PropTypes.string,

--- a/assets/src/design-system/components/dropDown/select/components.js
+++ b/assets/src/design-system/components/dropDown/select/components.js
@@ -124,7 +124,7 @@ export const LabelText = styled(Text)`
   text-overflow: hidden;
 `;
 
-export const Label = styled.label`
+export const Label = styled.span`
   display: flex;
   align-items: center;
   color: ${({ theme }) => theme.colors.fg.secondary};

--- a/assets/src/design-system/components/dropDown/stories/index.js
+++ b/assets/src/design-system/components/dropDown/stories/index.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { action } from '@storybook/addon-actions';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean, number, select, text } from '@storybook/addon-knobs';
 import styled, { css } from 'styled-components';
 import { useState, forwardRef } from 'react';
 import PropTypes from 'prop-types';
@@ -111,6 +111,7 @@ export const _default = () => {
             setSelectedValue(newValue);
           }}
           placement={select('placement', Object.values(PLACEMENT))}
+          popupZIndex={number('popupZIndex')}
         />
       </Container>
     </DarkThemeProvider>
@@ -139,6 +140,7 @@ export const LightTheme = () => {
           setSelectedValue(newValue);
         }}
         placement={select('placement', Object.values(PLACEMENT))}
+        popupZIndex={number('popupZIndex')}
       />
     </Container>
   );
@@ -167,6 +169,7 @@ export const ShortMenu = () => {
           setSelectedValue(newValue);
         }}
         placement={select('placement', Object.values(PLACEMENT))}
+        popupZIndex={number('popupZIndex')}
       />
     </Container>
   );
@@ -194,6 +197,7 @@ export const NoOptionsMenu = () => {
           setSelectedValue(newValue);
         }}
         placement={select('placement', Object.values(PLACEMENT))}
+        popupZIndex={number('popupZIndex')}
       />
     </Container>
   );
@@ -221,6 +225,7 @@ export const ReallyLongLabelsMenu = () => {
           setSelectedValue(newValue);
         }}
         placement={select('placement', Object.values(PLACEMENT))}
+        popupZIndex={number('popupZIndex')}
       />
     </Container>
   );
@@ -248,6 +253,7 @@ export const SubMenus = () => {
           setSelectedValue(newValue);
         }}
         placement={select('placement', Object.values(PLACEMENT))}
+        popupZIndex={number('popupZIndex')}
       />
     </Container>
   );
@@ -292,6 +298,7 @@ export const OverriddenAnimationProofOfConcept = () => {
             setSelectedValue(newValue);
           }}
           placement={select('placement', Object.values(PLACEMENT))}
+          popupZIndex={number('popupZIndex')}
           menuStylesOverride={styleOverrideForAnimationEffectMenu}
           renderItem={RenderItemOverride}
         />

--- a/assets/src/design-system/components/index.js
+++ b/assets/src/design-system/components/index.js
@@ -16,8 +16,10 @@
 
 export * from './button';
 export { Dialog } from './dialog';
+export { DropDown } from './dropDown';
 export { Modal } from './modal';
 export { Pill } from './pill';
+export { Popup, PLACEMENT } from './popup';
 export * as Snackbar from './snackbar';
 export * from './tooltip';
 export { Text, Display, Headline } from './typography';

--- a/assets/src/design-system/components/popup/index.js
+++ b/assets/src/design-system/components/popup/index.js
@@ -28,13 +28,14 @@ import { getTransforms, getOffset } from './utils';
 import { PLACEMENT } from './constants';
 
 // TODO scrollbar update, commented out until design updates are done
-
+const DEFAULT_POPUP_Z_INDEX = 2;
 const Container = styled.div.attrs(
-  ({ x, y, width, height, fillWidth, fillHeight, placement }) => ({
+  ({ x, y, width, height, fillWidth, fillHeight, placement, zIndex }) => ({
     style: {
       transform: `translate(${x}px, ${y}px) ${getTransforms(placement)}`,
       ...(fillWidth ? { width: `${width}px` } : {}),
       ...(fillHeight ? { height: `${height}px` } : {}),
+      zIndex,
     },
   })
 )`
@@ -42,7 +43,6 @@ const Container = styled.div.attrs(
   left: 0px;
   top: 0px;
   position: fixed;
-  z-index: 2;
 
   /*
    * Custom gray scrollbars for Chromium & Firefox.
@@ -76,6 +76,7 @@ function Popup({
   children,
   renderContents,
   placement = PLACEMENT.BOTTOM,
+  zIndex = DEFAULT_POPUP_Z_INDEX,
   spacing,
   isOpen,
   fillWidth = false,
@@ -128,6 +129,7 @@ function Popup({
           fillWidth={fillWidth}
           fillHeight={fillHeight}
           placement={placement}
+          zIndex={zIndex}
         >
           {renderContents
             ? renderContents({ propagateDimensionChange: positionPopup })


### PR DESCRIPTION
## Summary

While trying out new DropDown in dashboard, noticed a few things missing/overlooked. 

## Relevant Technical Choices

1) The select button "label" should just be a span, the aria labelling occurs at the button. 
2) In #5809  when i moved aria values for select menu up to index, i forgot that at that level `isOpen` is an object and we need to ask for the value specifically. 
3) Because the dashboard has a layout that utilizes zIndexes to enforce scrolls/squishes, we really need a way to override default zIndex in dropDown menus (and also all popup usage), so adding in a `popupZIndex` and putting the default as a const in the popup file.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None, storybook only

## Testing Instructions

Spin up storybook locally, go to design-system dropDown, adjust a popupZindex and see that the z-index is updated in the popup container. See that none of the aria values on the select button have a `[object object]` value.

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #4950 
