### PR TITLE
Pre-Publish Checklist: Show Pre-Publish List Errors by Default.

### DIFF
--- a/assets/src/edit-story/components/inspector/karma/inspectorTabs.karma.js
+++ b/assets/src/edit-story/components/inspector/karma/inspectorTabs.karma.js
@@ -113,4 +113,20 @@ describe('Inspector Tabs integration', () => {
       expect(options[0].textContent).toBe('Jane Doe');
     });
   });
+
+  describe('Checklist Panel', function () {
+    it('should show high priority items open in checklist by default', async () => {
+      const { checklistTab } = fixture.editor.inspector;
+
+      await fixture.events.mouse.clickOn(checklistTab);
+
+      await waitFor(() => {
+        expect(
+          fixture.editor.inspector.checklistPanel.node.querySelector(
+            '[class^="checklistTab__Row-"]'
+          )
+        ).not.toBeNull();
+      });
+    });
+  });
 });

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -248,6 +248,7 @@ const ChecklistTab = (props) => {
     <>
       {showHighPriorityItems && (
         <SimplePanel
+          collapsedByDefault={false}
           name="checklist"
           title={
             <TitleWrapper>

--- a/assets/src/edit-story/karma/fixture/containers/checklistPanel.js
+++ b/assets/src/edit-story/karma/fixture/containers/checklistPanel.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Container } from './container';
+
+/**
+ * The editor's checklist.
+ */
+export class ChecklistPanel extends Container {
+  constructor(node, path) {
+    super(node, path);
+  }
+}

--- a/assets/src/edit-story/karma/fixture/containers/inspector.js
+++ b/assets/src/edit-story/karma/fixture/containers/inspector.js
@@ -20,6 +20,7 @@
 import { Container } from './container';
 import { DesignPanel } from './designPanel';
 import { DocumentPanel } from './documentPanel';
+import { ChecklistPanel } from './checklistPanel';
 
 /**
  * The right-hand side inspector containing tabs and panes for design panel
@@ -51,6 +52,18 @@ export class Inspector extends Container {
       this.getByRole('tabpanel', { name: /Document/ }),
       'documentPanel',
       DocumentPanel
+    );
+  }
+
+  get checklistTab() {
+    return this.getByRole('tab', { name: /Checklist/ });
+  }
+
+  get checklistPanel() {
+    return this._get(
+      this.getByRole('tabpanel', { name: /Checklist/ }),
+      'prepublishPanel',
+      ChecklistPanel
     );
   }
 }


### PR DESCRIPTION
## Summary

Shows the error section open by default.

## Relevant Technical Choices

Adds the necessary scaffolding for karma tests.

## To-do

None

## User-facing changes

Now shows the Error section open by default.

## Testing Instructions

1. Create a new story
2. Switch to the checklist tab and see the first (error) section open by default

Likely you already have some local prefs stored. You will probably need to run `localStorage.clear();` inside your dev tools to test this and refresh the window.

Fixes #5399