### PR TITLE
Dashboard: Add support for Private stories on Dashboard

### DIFF
--- a/assets/src/dashboard/app/views/myStories/header/index.js
+++ b/assets/src/dashboard/app/views/myStories/header/index.js
@@ -58,6 +58,7 @@ import {
   HeaderToggleButtonContainer,
   PageHeading,
 } from '../../shared';
+import { useConfig } from '../../../config';
 
 function Header({
   filter,
@@ -71,6 +72,8 @@ function Header({
   const {
     actions: { scrollToTop },
   } = useLayoutContext();
+
+  const { capabilities: { canReadPrivatePosts } = {} } = useConfig();
 
   const resultsLabel = useDashboardResultsLabel({
     currentFilter: filter.value,
@@ -105,7 +108,8 @@ function Header({
             if (
               storyStatus.status === STORY_STATUS.PRIVATE &&
               (!totalStoriesByStatus.private ||
-                totalStoriesByStatus.private < 1)
+                totalStoriesByStatus.private < 1 ||
+                !canReadPrivatePosts)
             ) {
               return null;
             }
@@ -131,7 +135,7 @@ function Header({
         />
       </HeaderToggleButtonContainer>
     );
-  }, [filter, totalStoriesByStatus, handleClick]);
+  }, [totalStoriesByStatus, canReadPrivatePosts, filter.value, handleClick]);
 
   const onSortChange = useCallback(
     (newSort) => {

--- a/assets/src/dashboard/app/views/myStories/header/index.js
+++ b/assets/src/dashboard/app/views/myStories/header/index.js
@@ -40,6 +40,7 @@ import {
   STORY_STATUSES,
   STORY_SORT_MENU_ITEMS,
   TEXT_INPUT_DEBOUNCE,
+  STORY_STATUS,
 } from '../../../../constants';
 import {
   StoriesPropType,
@@ -101,6 +102,13 @@ function Header({
       <HeaderToggleButtonContainer>
         <ToggleButtonGroup
           buttons={STORY_STATUSES.map((storyStatus) => {
+            if (
+              storyStatus.status === STORY_STATUS.PRIVATE &&
+              (!totalStoriesByStatus.private ||
+                totalStoriesByStatus.private < 1)
+            ) {
+              return null;
+            }
             return {
               handleClick: () => {
                 handleClick(storyStatus.value);
@@ -119,7 +127,7 @@ function Header({
                   : ''
               }`,
             };
-          })}
+          }).filter(Boolean)}
         />
       </HeaderToggleButtonContainer>
     );

--- a/assets/src/dashboard/app/views/myStories/header/test/header.js
+++ b/assets/src/dashboard/app/views/myStories/header/test/header.js
@@ -191,6 +191,39 @@ describe('My Stories <Header />', function () {
     expect(getByText('Private (2)')).toBeInTheDocument();
   });
 
+  it('should not show the private tab even if there are private stories when the user does not have permission.', function () {
+    const { getByText, queryByText } = renderWithProviders(
+      <LayoutProvider>
+        <Header
+          filter={STORY_STATUSES[0]}
+          stories={fakeStories}
+          search={{ keyword: '', setKeyword: jest.fn() }}
+          sort={{ value: STORY_SORT_OPTIONS.NAME, set: jest.fn() }}
+          totalStoriesByStatus={{
+            all: 19,
+            draft: 9,
+            private: 2,
+            [STORY_STATUS.PUBLISHED_AND_FUTURE]: 10,
+          }}
+          view={{
+            style: VIEW_STYLE.GRID,
+            pageSize: { width: 200, height: 300 },
+          }}
+          wpListURL="fakeurltoWordPressList.com"
+        />
+      </LayoutProvider>,
+      {
+        config: {
+          capabilities: { canReadPrivatePosts: false },
+        },
+      }
+    );
+    expect(getByText('All Stories (19)')).toBeInTheDocument();
+    expect(getByText('Drafts (9)')).toBeInTheDocument();
+    expect(getByText('Published (10)')).toBeInTheDocument();
+    expect(queryByText('Private')).not.toBeInTheDocument();
+  });
+
   it('should call the set keyword function when new text is searched', async function () {
     const setKeywordFn = jest.fn();
     const { getByPlaceholderText } = renderWithProviders(

--- a/assets/src/dashboard/app/views/myStories/header/test/header.js
+++ b/assets/src/dashboard/app/views/myStories/header/test/header.js
@@ -137,7 +137,7 @@ describe('My Stories <Header />', function () {
   });
 
   it('should have 3 toggle buttons, one for each status that say how many items belong to that status', function () {
-    const { getByText } = renderWithProviders(
+    const { getByText, queryByText } = renderWithProviders(
       <LayoutProvider>
         <Header
           filter={STORY_STATUSES[0]}
@@ -160,6 +160,35 @@ describe('My Stories <Header />', function () {
     expect(getByText('All Stories (19)')).toBeInTheDocument();
     expect(getByText('Drafts (9)')).toBeInTheDocument();
     expect(getByText('Published (10)')).toBeInTheDocument();
+    expect(queryByText('Private')).not.toBeInTheDocument();
+  });
+
+  it('should show the private tab only when there are private stories.', function () {
+    const { getByText } = renderWithProviders(
+      <LayoutProvider>
+        <Header
+          filter={STORY_STATUSES[0]}
+          stories={fakeStories}
+          search={{ keyword: '', setKeyword: jest.fn() }}
+          sort={{ value: STORY_SORT_OPTIONS.NAME, set: jest.fn() }}
+          totalStoriesByStatus={{
+            all: 19,
+            draft: 9,
+            private: 2,
+            [STORY_STATUS.PUBLISHED_AND_FUTURE]: 10,
+          }}
+          view={{
+            style: VIEW_STYLE.GRID,
+            pageSize: { width: 200, height: 300 },
+          }}
+          wpListURL="fakeurltoWordPressList.com"
+        />
+      </LayoutProvider>
+    );
+    expect(getByText('All Stories (19)')).toBeInTheDocument();
+    expect(getByText('Drafts (9)')).toBeInTheDocument();
+    expect(getByText('Published (10)')).toBeInTheDocument();
+    expect(getByText('Private (2)')).toBeInTheDocument();
   });
 
   it('should call the set keyword function when new text is searched', async function () {

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -111,7 +111,7 @@ export const STORY_SORT_MENU_ITEMS = [
 ];
 
 export const STORY_STATUS = {
-  ALL: 'publish,draft,future',
+  ALL: 'publish,draft,future,private',
   PUBLISHED_AND_FUTURE: 'publish,future',
   DRAFT: 'draft',
   FUTURE: 'future',

--- a/assets/src/dashboard/constants/stories.js
+++ b/assets/src/dashboard/constants/stories.js
@@ -116,6 +116,7 @@ export const STORY_STATUS = {
   DRAFT: 'draft',
   FUTURE: 'future',
   PUBLISH: 'publish',
+  PRIVATE: 'private',
 };
 
 export const STORY_ITEM_CENTER_ACTION_LABELS = {
@@ -139,6 +140,11 @@ export const STORY_STATUSES = [
     label: __('Published', 'web-stories'),
     value: STORY_STATUS.PUBLISHED_AND_FUTURE,
     status: STORY_STATUS.PUBLISHED_AND_FUTURE,
+  },
+  {
+    label: __('Private', 'web-stories'),
+    value: STORY_STATUS.PRIVATE,
+    status: STORY_STATUS.PRIVATE,
   },
 ];
 

--- a/assets/src/dashboard/testUtils/renderWithProviders.js
+++ b/assets/src/dashboard/testUtils/renderWithProviders.js
@@ -39,7 +39,9 @@ const defaultProviderValues = {
     ...externalDesignSystemTheme,
     colors: lightMode,
   },
-  config: {},
+  config: {
+    capabilities: { canReadPrivatePosts: true },
+  },
   api: {},
 };
 

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -333,6 +333,9 @@ class Dashboard {
 			$max_upload_size = 0;
 		}
 
+		$post_type_object = get_post_type_object( Story_Post_Type::POST_TYPE_SLUG );
+		$read_private_posts = current_user_can( $post_type_object->cap->read_private_posts );
+
 		$settings = [
 			'id'         => 'web-stories-dashboard',
 			'config'     => [
@@ -356,9 +359,9 @@ class Dashboard {
 				'maxUpload'           => $max_upload_size,
 				'maxUploadFormatted'  => size_format( $max_upload_size ),
 				'capabilities'        => [
-					'canManageSettings' => current_user_can( 'manage_options' ),
-					'canUploadFiles'    => current_user_can( 'upload_files' ),
-
+					'canManageSettings'   => current_user_can( 'manage_options' ),
+					'canUploadFiles'      => current_user_can( 'upload_files' ),
+					'canReadPrivatePosts' => $read_private_posts,
 				],
 				'siteKitCapabilities' => [
 					'siteKitInstalled'      => $this->is_site_kit_plugin_installed(),

--- a/includes/Dashboard.php
+++ b/includes/Dashboard.php
@@ -30,6 +30,7 @@ namespace Google\Web_Stories;
 
 use Google\Web_Stories\Integrations\Site_Kit;
 use Google\Web_Stories\Traits\Assets;
+use WP_Post_Type;
 use WP_Screen;
 
 /**
@@ -333,8 +334,15 @@ class Dashboard {
 			$max_upload_size = 0;
 		}
 
+		$can_read_private_posts = false;
+
 		$post_type_object = get_post_type_object( Story_Post_Type::POST_TYPE_SLUG );
-		$read_private_posts = current_user_can( $post_type_object->cap->read_private_posts );
+		if (
+			$post_type_object instanceof WP_Post_Type &&
+			property_exists( $post_type_object->cap, 'read_private_posts' )
+		) {
+			$can_read_private_posts = current_user_can( $post_type_object->cap->read_private_posts );
+		}
 
 		$settings = [
 			'id'         => 'web-stories-dashboard',
@@ -361,7 +369,7 @@ class Dashboard {
 				'capabilities'        => [
 					'canManageSettings'   => current_user_can( 'manage_options' ),
 					'canUploadFiles'      => current_user_can( 'upload_files' ),
-					'canReadPrivatePosts' => $read_private_posts,
+					'canReadPrivatePosts' => $can_read_private_posts,
 				],
 				'siteKitCapabilities' => [
 					'siteKitInstalled'      => $this->is_site_kit_plugin_installed(),

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -343,6 +343,7 @@ class Stories_Controller extends Stories_Base_Controller {
 			'publish' => 'publish',
 			'future'  => 'future',
 			'draft'   => 'draft',
+			'private' => 'private',
 		];
 
 		$statuses_count = [];

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -339,7 +339,7 @@ class Stories_Controller extends Stories_Base_Controller {
 
 		// Add counts for other statuses.
 		$statuses = [
-			'all'     => [ 'publish', 'draft', 'future' ],
+			'all'     => [ 'publish', 'draft', 'future', 'private' ],
 			'publish' => 'publish',
 			'future'  => 'future',
 			'draft'   => 'draft',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17278,7 +17278,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gud": {
       "version": "1.0.0",
@@ -24219,6 +24220,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -24233,6 +24235,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -24242,6 +24245,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -24251,6 +24255,7 @@
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -24259,7 +24264,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -29025,7 +29031,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "showdown": {
       "version": "1.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13789,11 +13789,6 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
-    "dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
-    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -16710,6 +16705,11 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "focus-visible": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
+      "integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ=="
     },
     "follow-redirects": {
       "version": "1.12.1",
@@ -32015,40 +32015,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-3.4.3.tgz",
       "integrity": "sha512-nxy+opOxDccWfhMl36J5BSCTpvcj89iaQk2OZWLAtBJQj7ISCtx1gh+rFbdjGfMl6vtCZf6gke/kYvrkVfHMoA=="
-    },
-    "use-deep-compare-effect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/use-deep-compare-effect/-/use-deep-compare-effect-1.6.1.tgz",
-      "integrity": "sha512-VB3b+7tFI81dHm8buGyrpxi8yBhzYZdyMX9iBJra7SMFMZ4ci4FJ1vFc1nvChiB1iLv4GfjqaYfvbNEpTT1rFQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@types/react": "^17.0.0",
-        "dequal": "^2.0.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.12.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
-          "requires": {
-            "regenerator-runtime": "^0.13.4"
-          }
-        },
-        "@types/react": {
-          "version": "17.0.0",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
-          "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
-          "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^3.0.2"
-          }
-        },
-        "csstype": {
-          "version": "3.0.5",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-          "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
-        }
-      }
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.0",

--- a/tests/phpunit/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/tests/REST_API/Stories_Controller.php
@@ -211,7 +211,9 @@ class Stories_Controller extends \WP_Test_REST_TestCase {
 		// Headers.
 		$this->assertArrayHasKey( 'all', $statuses );
 		$this->assertArrayHasKey( 'publish', $statuses );
+		$this->assertArrayHasKey( 'future', $statuses );
 		$this->assertArrayHasKey( 'draft', $statuses );
+		$this->assertArrayHasKey( 'private', $statuses );
 
 		$this->assertEquals( 3, $data['headers']['X-WP-Total'] );
 	}


### PR DESCRIPTION
## Summary

Adds support for Private Stories in Dashboard

If there are private stories show the tab. If there are not, show nothing. Private stories can be marked in the classic WP list view when you quick edit or the Document panel.

<img width="833" alt="Screen Shot 2021-01-05 at 3 38 36 PM" src="https://user-images.githubusercontent.com/1738349/103708160-a7357b00-4f75-11eb-9fe4-1077f6576b26.png">

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

A new Private tab for private stories in the Dashboard My Stories view.

## Testing Instructions

1. Create a new Story
2. Visit the Classic WordPress View and Quick Edit a story
3. Select the Private checkbox on the right.
4. Refresh the Dashboard and see the Private tab

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5650
