### PR TITLE
Pre-Publish Checklist: select offending elements from tab

### DIFF
--- a/assets/src/edit-story/app/prepublish/guidance/test/text.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/text.js
@@ -23,25 +23,27 @@ import { pageTooMuchText, storyTooLittleText } from '../text';
 describe('Pre-publish checklist - text guidelines (guidance)', () => {
   describe('pageTooMuchText', () => {
     it('should return a guidance if too much text', () => {
+      const testElements = [
+        {
+          id: '25b6f99b-3f69-4351-9e18-31b8ef1d1a61',
+          type: 'text',
+          content:
+            '<span style="font-weight: 400; color: #fff; letter-spacing: 0.09em">FRESH</span>\n<span style="font-weight: 400; color: #fff; letter-spacing: 0.09em">&amp;&nbsp;</span>\n<span style="font-weight: 400; color: #fff; letter-spacing: 0.09em">BRIGHT</span>',
+        },
+        {
+          id: 'd886c844-5b5c-4b27-a9c3-332df2aed3f3',
+          type: 'text',
+          content:
+            "<span style=\"color: #28292b\">this is a lot of text that should</span>&nbsp;not pass the test because it's too much text. not pass the test because it's too much text. not pass the test because it's too much text. a little more.",
+        },
+      ];
       const page = {
         id: 'd886c844-5b5c-4b27-a9c3-332df2aeaaaa',
-        elements: [
-          {
-            id: '25b6f99b-3f69-4351-9e18-31b8ef1d1a61',
-            type: 'text',
-            content:
-              '<span style="font-weight: 400; color: #fff; letter-spacing: 0.09em">FRESH</span>\n<span style="font-weight: 400; color: #fff; letter-spacing: 0.09em">&amp;&nbsp;</span>\n<span style="font-weight: 400; color: #fff; letter-spacing: 0.09em">BRIGHT</span>',
-          },
-          {
-            id: 'd886c844-5b5c-4b27-a9c3-332df2aed3f3',
-            type: 'text',
-            content:
-              "<span style=\"color: #28292b\">this is a lot of text that should</span>&nbsp;not pass the test because it's too much text. not pass the test because it's too much text. not pass the test because it's too much text. a little more.",
-          },
-        ],
+        elements: testElements,
       };
       expect(pageTooMuchText(page)).toStrictEqual({
         pageId: page.id,
+        elements: testElements,
         type: 'guidance',
         message: MESSAGES.TEXT.TOO_MUCH_PAGE_TEXT.MAIN_TEXT,
         help: MESSAGES.TEXT.TOO_MUCH_PAGE_TEXT.HELPER_TEXT,

--- a/assets/src/edit-story/app/prepublish/guidance/text.js
+++ b/assets/src/edit-story/app/prepublish/guidance/text.js
@@ -51,6 +51,7 @@ export function pageTooMuchText(page) {
   if (characterCount > MAX_PAGE_CHARACTER_COUNT) {
     return {
       pageId: page.id,
+      elements: page.elements.filter((element) => element.type === 'text'),
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       message: MESSAGES.TEXT.TOO_MUCH_PAGE_TEXT.MAIN_TEXT,
       help: MESSAGES.TEXT.TOO_MUCH_PAGE_TEXT.HELPER_TEXT,

--- a/assets/src/edit-story/app/prepublish/types.js
+++ b/assets/src/edit-story/app/prepublish/types.js
@@ -21,8 +21,13 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
+import StoryPropTypes from '../../types';
 import { PRE_PUBLISH_MESSAGE_TYPES } from './constants';
 
+/**
+ * @typedef {import('../../types').Page} Page
+ * @typedef {import('../../types').Element} Element
+ */
 /**
  * Guidance return object
  *
@@ -30,6 +35,8 @@ import { PRE_PUBLISH_MESSAGE_TYPES } from './constants';
  * @property {string} type The type/severity of the message [error, warning, guidance]
  * @property {string} message The main text describing the error
  * @property {string} help The descriptive text describing the error
+ * @property {Page[]} [pages] The page objects containing elements which failed checks
+ * @property {Element[]} [elements] The element objects which failed checks
  * @property {string} [pageId] The ID of the page being checked
  * @property {string} [elementId] The ID of the element being checked
  * @property {string} [storyId] The ID of the story element being checked
@@ -42,7 +49,8 @@ export const GuidancePropType = PropTypes.shape({
     PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
   ]).isRequired,
-  pageId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  pages: PropTypes.arrayOf(StoryPropTypes.page),
+  elements: PropTypes.arrayOf(StoryPropTypes.element),
   page: PropTypes.number,
   elementId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   storyId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),

--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -232,7 +232,7 @@ function getOverlapBgColor({ elementId, pageId, bgImage, bgBox, overlapBox }) {
   });
 }
 
-function textBgColorsLowContrast({ backgroundColor, textColors, ...ids }) {
+function textBgColorsLowContrast({ backgroundColor, textColors, ...elements }) {
   const someTextHasLowContrast = textColors.some((styleColor) => {
     const [r, g, b] = backgroundColor;
     const textLuminance = calculateLuminanceFromStyleColor(styleColor);
@@ -249,7 +249,7 @@ function textBgColorsLowContrast({ backgroundColor, textColors, ...ids }) {
       message: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.MAIN_TEXT,
       help: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.HELPER_TEXT,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
-      ...ids,
+      ...elements,
     };
   }
   return undefined;
@@ -335,11 +335,8 @@ export async function pageBackgroundTextLowContrast(page) {
   page.elements.forEach((element, index) => {
     if (element.type === 'text' && element.backgroundTextMode === 'NONE') {
       const potentialBackgroundElements = page.elements.slice(0, index);
-
       const spans = getSpansFromContent(element.content);
-      const textColors = spans.map(
-        (span) => span.style?.color || 'rgb(0, 0, 0)'
-      );
+      const textColors = spans.map((span) => span.style?.color).filter(Boolean);
 
       const textBackgrounds = getBackgroundsForElement(
         element,
@@ -371,14 +368,16 @@ export async function pageBackgroundTextLowContrast(page) {
             return {
               backgroundColor: resolvedBgColor,
               textColors,
-              ...ids,
+              pageId: page.id,
+              elements: [backgroundElement, element],
             };
           });
         } else if (backgroundColor !== undefined) {
           backgroundColorResult = {
             backgroundColor,
             textColors,
-            ...ids,
+            pageId: page.id,
+            elements: [backgroundElement, element],
           };
         }
 

--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -496,18 +496,16 @@ export function videoElementMissingCaptions(element) {
  * @return {Guidance|undefined} The guidance object for consumption
  */
 export function pageTooManyLinks(page) {
-  let linkCount = 0;
-  page.elements.forEach((element) => {
-    if (element.link?.url?.length) {
-      linkCount += 1;
-    }
+  const elementsWithLinks = page.elements.filter((element) => {
+    return Boolean(element.link?.url?.length);
   });
 
-  if (linkCount > MAX_PAGE_LINKS) {
+  if (elementsWithLinks.length > MAX_PAGE_LINKS) {
     return {
       message: MESSAGES.ACCESSIBILITY.TOO_MANY_LINKS.MAIN_TEXT,
       help: MESSAGES.ACCESSIBILITY.TOO_MANY_LINKS.HELPER_TEXT,
       pageId: page.id,
+      elements: elementsWithLinks,
       type: PRE_PUBLISH_MESSAGE_TYPES.WARNING,
     };
   }

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -316,6 +316,33 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
 
   describe('pageTooManyLinks', () => {
     it('should return a warning if page has too many links', () => {
+      const linkElements = [
+        {
+          type: 'text',
+          link: {
+            url: 'https://google.com',
+          },
+        },
+        {
+          type: 'image',
+          link: {
+            url: 'https://google.com',
+          },
+        },
+        {
+          type: 'text',
+          link: {
+            url: 'https://google.com',
+          },
+        },
+        {
+          type: 'text',
+          link: {
+            url: 'https://google.com',
+          },
+        },
+      ];
+
       const page = {
         id: 'pageid',
         elements: [
@@ -324,39 +351,17 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
           {
             type: 'text',
             link: {
-              url: 'https://google.com',
-            },
-          },
-          {
-            type: 'image',
-            link: {
-              url: 'https://google.com',
-            },
-          },
-          {
-            type: 'text',
-            link: {
               url: '',
             },
           },
-          {
-            type: 'text',
-            link: {
-              url: 'https://google.com',
-            },
-          },
-          {
-            type: 'text',
-            link: {
-              url: 'https://google.com',
-            },
-          },
+          ...linkElements,
         ],
       };
       expect(accessibilityChecks.pageTooManyLinks(page)).toStrictEqual({
         message: MESSAGES.ACCESSIBILITY.TOO_MANY_LINKS.MAIN_TEXT,
         help: MESSAGES.ACCESSIBILITY.TOO_MANY_LINKS.HELPER_TEXT,
         pageId: page.id,
+        elements: linkElements,
         type: 'warning',
       });
     });

--- a/assets/src/edit-story/components/inspector/karma/prepublishSelect.karma.js
+++ b/assets/src/edit-story/components/inspector/karma/prepublishSelect.karma.js
@@ -90,7 +90,7 @@ describe('Pre-publish checklist select offending elements onClick', () => {
       const doInsert = () =>
         insertElement('text', {
           font: TEXT_ELEMENT_DEFAULT_FONT,
-          fontSize: 10,
+          fontSize: 14,
           content:
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
           x: 40,
@@ -104,7 +104,6 @@ describe('Pre-publish checklist select offending elements onClick', () => {
       const element4 = await fixture.act(doInsert);
 
       await openPrepublishPanel();
-
       await openRecommendedPanel();
 
       let storyContext = await fixture.renderHook(() => useStory());
@@ -113,7 +112,7 @@ describe('Pre-publish checklist select offending elements onClick', () => {
         MESSAGES.TEXT.TOO_MUCH_PAGE_TEXT.MAIN_TEXT
       );
       await fixture.events.mouse.clickOn(tooMuchTextOnPage);
-      await fixture.events.sleep(500);
+      await fixture.events.sleep(1000);
       storyContext = await fixture.renderHook(() => useStory());
       expect(storyContext.state.selectedElementIds.length).toEqual(4);
       expect(
@@ -217,6 +216,8 @@ describe('Pre-publish checklist select offending elements onClick', () => {
       expect(storyContext.state.selectedElementIds[0]).not.toEqual(
         tooSmallLinkElement.id
       );
+      await fixture.events.keyboard.press('tab');
+      await fixture.events.keyboard.press('tab');
       await fixture.events.keyboard.press('tab');
       await fixture.events.keyboard.press('tab');
       await fixture.events.keyboard.press('Enter');

--- a/assets/src/edit-story/components/inspector/karma/prepublishSelect.karma.js
+++ b/assets/src/edit-story/components/inspector/karma/prepublishSelect.karma.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+import { MESSAGES } from '../../../app/prepublish/constants';
+import { useStory } from '../../../app';
+
+describe('Pre-publish checklist select offending elements onClick', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  describe('Prepublish checklist tab', () => {
+    it('should select the offending elements', async () => {
+      const { checklistTab } = fixture.editor.inspector;
+
+      await fixture.editor.library.textTab.click();
+
+      await waitFor(() =>
+        expect(fixture.editor.library.text.textSets.length).toBeTruthy()
+      );
+
+      // four paragraphs will cause the "too much text on page" error
+      await fixture.events.click(
+        fixture.editor.library.text.preset('Paragraph')
+      );
+      await fixture.events.click(
+        fixture.editor.library.text.preset('Paragraph')
+      );
+      await fixture.events.click(
+        fixture.editor.library.text.preset('Paragraph')
+      );
+      await fixture.events.click(
+        fixture.editor.library.text.preset('Paragraph')
+      );
+
+      // Click prepublish tab
+      await fixture.events.mouse.clickOn(checklistTab);
+      await waitFor(() => fixture.editor.inspector.checklistTab);
+      expect(checklistTab).toHaveFocus();
+      await fixture.events.mouse.clickOn(
+        fixture.editor.inspector.checklistPanel.recommended
+      );
+      await fixture.events.sleep(500);
+      const tooMuchTextOnPage = fixture.screen.getByText(
+        MESSAGES.TEXT.TOO_MUCH_PAGE_TEXT.MAIN_TEXT
+      );
+      let storyContext = await fixture.renderHook(() => useStory());
+      expect(storyContext.state.selectedElementIds.length).toEqual(1);
+      await fixture.events.mouse.clickOn(tooMuchTextOnPage);
+      await fixture.events.sleep(500);
+      storyContext = await fixture.renderHook(() => useStory());
+      expect(storyContext.state.selectedElementIds.length).toEqual(4);
+    });
+  });
+});

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -209,37 +209,51 @@ const ChecklistTab = (props) => {
     [checklist]
   );
 
+  const selectElement = useCallback(
+    ({ elementId, elements, pageId }) => {
+      if (pageId) {
+        setCurrentPage({ pageId });
+      }
+      if (Array.isArray(elements)) {
+        setSelectedElementsById({
+          elementIds: elements.map(({ id }) => id),
+        });
+      } else if (elementId) {
+        setSelectedElementsById({ elementIds: [elementId] });
+      }
+    },
+    [setCurrentPage, setSelectedElementsById]
+  );
+
   const getOnClick = useCallback(
     ({ elementId, pageId, elements }) => {
       if (!elementId && !pageId && !elements) {
         return undefined;
       }
-      return (event) => {
-        if (event.key === undefined || event.key === 'Enter') {
-          if (pageId) {
-            setCurrentPage({ pageId });
-          }
-          if (Array.isArray(elements)) {
-            setSelectedElementsById({
-              elementIds: elements.map(({ id }) => id),
-            });
-          } else if (elementId) {
-            setSelectedElementsById({ elementIds: [elementId] });
-          }
-        }
-      };
+      return () => selectElement({ elementId, pageId, elements });
     },
-    [setCurrentPage, setSelectedElementsById]
+    [selectElement]
+  );
+
+  const getHandleKeyPress = useCallback(
+    ({ elementId, elements, pageId }) => (event) => {
+      if (event.key === 'Enter') {
+        selectElement({ elementId, elements, pageId });
+      }
+    },
+    [selectElement]
   );
 
   const renderRow = useCallback(
     ({ message, help, id, pageGroup, ...args }) => {
       const onClick = getOnClick(args);
+      const handleKeyPress = getHandleKeyPress(args);
       return (
         <Row
-          tabIndex={onClick ? 0 : -1}
+          tabIndex={0}
           onClick={onClick}
-          onKeyDown={onClick}
+          // note: onKeyDown does not work for "Enter"
+          onKeyUp={handleKeyPress}
           aria-label={
             onClick ? __('Select element for error', 'web-stories') : undefined
           }
@@ -251,7 +265,7 @@ const ChecklistTab = (props) => {
         </Row>
       );
     },
-    [getOnClick]
+    [getOnClick, getHandleKeyPress]
   );
 
   const renderPageGroupedRow = useCallback(

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -140,6 +140,15 @@ const EmptyParagraph = styled.p`
   margin: 0;
 `;
 
+const VisuallyHidden = styled.span`
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+`;
+
 function annotateNumber(number) {
   if (number <= MAX_NUMBER_FOR_BADGE) {
     return number;
@@ -264,15 +273,12 @@ const ChecklistTab = (props) => {
           pageGroup={pageGroup}
         >
           {message}
-          <HelperText
-            aria-label={
-              onClick
-                ? __('Select offending element', 'web-stories')
-                : undefined
-            }
-          >
-            {help}
-          </HelperText>
+          <HelperText>{help}</HelperText>
+          {onClick && (
+            <VisuallyHidden>
+              {__('Select offending element', 'web-stories')}
+            </VisuallyHidden>
+          )}
         </Row>
       );
     },

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -70,7 +70,7 @@ const PanelTitle = styled.span`
 
 const Row = styled.div.attrs({ role: 'listitem' })`
   &:not(:first-child) {
-    padding-top: 9px;
+    margin-top: 9px;
   }
   margin-bottom: 16px;
   margin-left: ${({ pageGroup }) => (pageGroup ? '16px' : '0')};
@@ -79,6 +79,7 @@ const Row = styled.div.attrs({ role: 'listitem' })`
   max-width: 210px;
   &:focus {
     outline: 2px solid ${({ theme }) => theme.colors.accent.primary};
+    outline-offset: 5px;
   }
   ${({ onClick }) =>
     Boolean(onClick) &&

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -68,7 +68,7 @@ const PanelTitle = styled.span`
     error ? theme.colors.fg.negative : theme.colors.fg.warning};
 `;
 
-const Row = styled.div.attrs({ role: 'listitem' })`
+const Row = styled.div`
   &:not(:first-child) {
     margin-top: 9px;
   }
@@ -237,10 +237,15 @@ const ChecklistTab = (props) => {
   );
 
   const getHandleKeyPress = useCallback(
-    ({ elementId, elements, pageId }) => (event) => {
-      if (event.key === 'Enter') {
-        selectElement({ elementId, elements, pageId });
+    ({ elementId, elements, pageId }) => {
+      if (!elementId && !pageId && !elements) {
+        return undefined;
       }
+      return (event) => {
+        if (event.key === 'Enter') {
+          selectElement({ elementId, elements, pageId });
+        }
+      };
     },
     [selectElement]
   );
@@ -255,14 +260,19 @@ const ChecklistTab = (props) => {
           onClick={onClick}
           // note: onKeyDown does not work for "Enter"
           onKeyUp={handleKeyPress}
-          aria-label={
-            onClick ? __('Select element for error', 'web-stories') : undefined
-          }
-          key={`guidance-${id}`}
+          key={id}
           pageGroup={pageGroup}
         >
           {message}
-          <HelperText>{help}</HelperText>
+          <HelperText
+            aria-label={
+              onClick
+                ? __('Select offending element', 'web-stories')
+                : undefined
+            }
+          >
+            {help}
+          </HelperText>
         </Row>
       );
     },

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -68,7 +68,13 @@ const PanelTitle = styled.span`
     error ? theme.colors.fg.negative : theme.colors.fg.warning};
 `;
 
-const Row = styled.div`
+const Row = styled.button`
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 0;
+  color: ${({ theme }) => theme.colors.fg.white};
+  line-height: 24px;
   &:not(:first-child) {
     margin-top: 9px;
   }
@@ -325,6 +331,7 @@ const ChecklistTab = (props) => {
       </EmptyLayout>
     );
   }
+
   return (
     <>
       {showHighPriorityItems && (

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -273,8 +273,7 @@ const ChecklistTab = (props) => {
         <Row
           tabIndex={0}
           onClick={onClick}
-          // note: onKeyDown does not work for "Enter"
-          onKeyUp={handleKeyPress}
+          onKeyDown={handleKeyPress}
           key={id}
           pageGroup={pageGroup}
         >

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -77,6 +77,9 @@ const Row = styled.div.attrs({ role: 'listitem' })`
   font-size: ${({ theme }) => theme.fonts.body2.size};
   width: calc(100% - 10px);
   max-width: 210px;
+  &:focus {
+    outline: 2px solid ${({ theme }) => theme.colors.accent.primary};
+  }
   ${({ onClick }) =>
     Boolean(onClick) &&
     `&:hover {
@@ -211,14 +214,18 @@ const ChecklistTab = (props) => {
       if (!elementId && !pageId && !elements) {
         return undefined;
       }
-      return () => {
-        if (pageId) {
-          setCurrentPage({ pageId });
-        }
-        if (Array.isArray(elements)) {
-          setSelectedElementsById({ elementIds: elements.map(({ id }) => id) });
-        } else if (elementId) {
-          setSelectedElementsById({ elementIds: [elementId] });
+      return (event) => {
+        if (event.key === undefined || event.key === 'Enter') {
+          if (pageId) {
+            setCurrentPage({ pageId });
+          }
+          if (Array.isArray(elements)) {
+            setSelectedElementsById({
+              elementIds: elements.map(({ id }) => id),
+            });
+          } else if (elementId) {
+            setSelectedElementsById({ elementIds: [elementId] });
+          }
         }
       };
     },
@@ -226,16 +233,24 @@ const ChecklistTab = (props) => {
   );
 
   const renderRow = useCallback(
-    ({ message, help, id, pageGroup, ...args }) => (
-      <Row
-        onClick={getOnClick(args)}
-        key={`guidance-${id}`}
-        pageGroup={pageGroup}
-      >
-        {message}
-        <HelperText>{help}</HelperText>
-      </Row>
-    ),
+    ({ message, help, id, pageGroup, ...args }) => {
+      const onClick = getOnClick(args);
+      return (
+        <Row
+          tabIndex={onClick ? 0 : -1}
+          onClick={onClick}
+          onKeyDown={onClick}
+          aria-label={
+            onClick ? __('Select element for error', 'web-stories') : undefined
+          }
+          key={`guidance-${id}`}
+          pageGroup={pageGroup}
+        >
+          {message}
+          <HelperText>{help}</HelperText>
+        </Row>
+      );
+    },
     [getOnClick]
   );
 

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -68,7 +68,7 @@ const PanelTitle = styled.span`
     error ? theme.colors.fg.negative : theme.colors.fg.warning};
 `;
 
-const Row = styled.div`
+const Row = styled.div.attrs({ role: 'listitem' })`
   &:not(:first-child) {
     padding-top: 9px;
   }

--- a/assets/src/edit-story/components/inspector/stories/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/stories/checklistTab.js
@@ -21,9 +21,9 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import ChecklistTab from '../prepublish/checklistTab';
-import { getPrepublishErrors } from '../../../app/prepublish';
 
 const Container = styled.div`
+  background: ${({ theme }) => theme.colors.bg.workspace};
   color: ${({ theme }) => theme.colors.fg.white};
   font-family: ${({ theme }) => theme.fonts.body1.family};
   width: 280px;
@@ -32,11 +32,6 @@ const Container = styled.div`
 export default {
   title: 'Stories Editor/Components/Checklist Tab',
   component: ChecklistTab,
-  parameters: {
-    backgrounds: {
-      default: 'Dark',
-    },
-  },
   decorators: [
     (Story) => (
       <Container>
@@ -47,47 +42,111 @@ export default {
 };
 
 export const _default = () => {
-  const testStory = {
-    id: 120,
-    pages: [{ id: 123, elements: [] }],
-  };
-  const checklist = getPrepublishErrors(testStory);
-  return <ChecklistTab checklist={checklist} />;
+  const defaultChecklist = [
+    {
+      type: 'error',
+      storyId: 120,
+      message: 'Missing story cover image',
+      help:
+        'Used as the cover for the Story and is representative of the story. Should not have the Story title pre-embedded on it or any other burned-in text. Should be at least 640x853px in size and maintain a 3:4 aspect ratio.',
+    },
+    {
+      type: 'error',
+      storyId: 120,
+      message: 'Missing story title',
+      help:
+        'Keep the title clear and clean, ideally under 10 words in less than 40 characters.',
+    },
+    {
+      message: 'Missing Story Description',
+      help: 'Add a Story Description in the Document panel.',
+      storyId: 120,
+      type: 'warning',
+    },
+    {
+      type: 'guidance',
+      storyId: 120,
+      message: 'Story too short',
+      help: 'Use between 4 and 30 pages in your story.',
+    },
+    {
+      storyId: 120,
+      type: 'guidance',
+      message: 'Too little text',
+      help:
+        'The entire story should have a minimum of 100 characters of text in total.',
+    },
+  ];
+  return <ChecklistTab checklist={defaultChecklist} />;
 };
 
 export const withPages = () => {
-  const testStory = {
-    id: 120,
-    excerpt: 'Test',
-    pages: [
-      {
-        id: 921,
-        elements: [
-          {
-            id: 891,
-            type: 'text',
-            fontSize: 11,
-            content:
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
-          },
-        ],
-      },
-      {
-        id: 456,
-        elements: [
-          {
-            id: 123,
-            type: 'image',
-            height: 50,
-            width: 50,
-            x: 0,
-            y: 0,
-          },
-        ],
-      },
-    ],
-  };
-  const checklist = getPrepublishErrors(testStory);
+  const checklist = [
+    {
+      type: 'error',
+      storyId: 120,
+      message: 'Missing story cover image',
+      help:
+        'Used as the cover for the Story and is representative of the story. Should not have the Story title pre-embedded on it or any other burned-in text. Should be at least 640x853px in size and maintain a 3:4 aspect ratio.',
+    },
+    {
+      type: 'error',
+      storyId: 120,
+      message: 'Missing story title',
+      help:
+        'Keep the title clear and clean, ideally under 10 words in less than 40 characters.',
+    },
+    {
+      message: 'Font size too small',
+      help: 'Text should have size 12 or larger.',
+      elementId: 891,
+      type: 'warning',
+      page: 1,
+      pageId: 921,
+    },
+    {
+      message: 'Image missing description',
+      help:
+        'Add meaningful assistive text to images to optimize accessibility and indexability.',
+      elementId: 123,
+      type: 'warning',
+      page: 2,
+      pageId: 456,
+    },
+    {
+      type: 'guidance',
+      storyId: 120,
+      message: 'Story too short',
+      help: 'Use between 4 and 30 pages in your story.',
+    },
+    {
+      pageId: 921,
+      elements: [
+        {
+          id: 891,
+          type: 'text',
+          fontSize: 11,
+          content:
+            '<span>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</span>',
+        },
+      ],
+      type: 'guidance',
+      message: 'Too much text on page',
+      help:
+        'Keep text to max 200 characters per page. Consider using a page attachment, breaking up the text into multiple screens, or keeping the total number of pages with a lot of text to less than 10% of the pages in the story.',
+      page: 1,
+    },
+    {
+      type: 'guidance',
+      elementId: 123,
+      message: 'Video or image too small on the page',
+      help:
+        'Use full screen videos and images where possible to keep to an immersive feeling. <a>(more info)</a>',
+
+      page: 2,
+      pageId: 456,
+    },
+  ];
   return <ChecklistTab checklist={checklist} />;
 };
 

--- a/assets/src/edit-story/karma/fixture/containers/checklistPanel.js
+++ b/assets/src/edit-story/karma/fixture/containers/checklistPanel.js
@@ -20,8 +20,7 @@
 import { Container } from './container';
 
 /**
- * The editor's canvas. Includes: display, frames, editor layers, carousel,
- * navigation buttons, page menu.
+ * The prepublish checklist panel. Includes: checklist items and collapsible critical/recommended panels
  */
 export class ChecklistPanel extends Container {
   constructor(node, path) {

--- a/assets/src/edit-story/karma/fixture/containers/checklistPanel.js
+++ b/assets/src/edit-story/karma/fixture/containers/checklistPanel.js
@@ -20,10 +20,15 @@
 import { Container } from './container';
 
 /**
- * The editor's checklist.
+ * The editor's canvas. Includes: display, frames, editor layers, carousel,
+ * navigation buttons, page menu.
  */
 export class ChecklistPanel extends Container {
   constructor(node, path) {
     super(node, path);
+  }
+
+  get recommended() {
+    return this.getByRole('button', { name: /Recommended/ });
   }
 }


### PR DESCRIPTION
## Summary
- This is step 1 of a 2-step enhancement to select and highlight the offending elements in the editor when clicking on the checklist. (details in ticket [here](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/5629))
- I wrote a doc to be reviewed by UX [here](https://docs.google.com/document/d/1soSgYqJoIRwiyWZxs2FBVTuw2-EQf4KJQQG3HBnUhM4/edit) so that the behavior could be reviewed outside of the code review. The designs for the feature are still TBD.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- This first implementation I wanted to keep simple, so the logic lives in the checklist tab for now, where we can use hooks to send the user to the correct page and highlight the elements. We were already providing the element ID and page ID from the checks so it was just a matter of providing those details.
- I made changes to the return object for a couple of the checks so that the checklist could highlight multiple elements when it's not so clear what elements are offending the checklist--"page has too much text", for example.
- This step does not include opening the correct panels or highlighting specific parts of the editor. It just selects the offending elements. I think this looks confusing if you're already selecting the offending element. And also, not everything is clickable yet... Nor is it obvious that a user could click on the rows in the checklist tab. I think there are multiple ways to improve this incrementally, probably by adding a new "highlighted" state which can put notices or styles next to/on top of elements as well as panels and inputs in the editor. Working in the background on improving the way we run the checklist so that the side-effects are cheaper and we could potentially have these highlights appear live (not recommended at the moment). I have an [extremely rough draft here](https://docs.google.com/document/d/1-9mnhzx28dFtlPI3gFFL3YDHX16nyy_F5hGL7Ajg-RI/edit?usp=sharing) where I've started collecting my thoughts about that problem. 
<!-- Please describe your changes. -->

## To-do
- [x] karma test - text (select multiple elements)
- [x] karma test - media (select single element)
- [x] karma test - keyboard controls
- [x] keyboard controls

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- When hovering on a row in the checklist tab that will highlight elements when clicked, a user will see a pointer cursor instead of their normal cursor.
- Clicking on certain rows in the checklist tab should navigate the user to the page it's concerned about, and select all the elements that the checklist is describing.
<!-- Please describe your changes. -->

## Testing Instructions
1. Create a new story
2. Add an element to the editor that offends the checklist e.g. add a few text boxes with lots of text, add 4-5 element links to a page, a low resolution image, a video, etc.
3. Open the checklist tab-- there should be checks there that are describing the elements that were added in step 2. Clicking on the checklist tab row should open the correct page and select all the offending elements. i.e. if you added 4-5 links to a single page, it should select all the links

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5629 
