### PR TITLE
Editor: Hidden Padding for Text Fill & Highlight Elements

### DIFF
--- a/assets/src/edit-story/components/panels/design/textStyle/color.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/color.js
@@ -19,7 +19,7 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 /**
  * WordPress dependencies
@@ -112,6 +112,16 @@ function ColorControls({ selectedElements, pushUpdate }) {
     [backgroundTextMode, pushUpdate]
   );
 
+  const handleBackgroundModeButton = useCallback(
+    (value, mode) => {
+      if (!value) {
+        return;
+      }
+      pushUpdate(() => ({ backgroundTextMode: mode }), true);
+    },
+    [pushUpdate]
+  );
+
   return (
     <>
       <Row>
@@ -139,15 +149,7 @@ function ColorControls({ selectedElements, pushUpdate }) {
               __('Set text background mode: %s', 'web-stories'),
               label
             )}
-            onChange={(value) =>
-              value &&
-              pushUpdate(
-                {
-                  backgroundTextMode: mode,
-                },
-                true
-              )
-            }
+            onChange={(value) => handleBackgroundModeButton(value, mode)}
           />
         ))}
         <Space flex="2" />

--- a/assets/src/edit-story/components/panels/design/textStyle/color.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/color.js
@@ -29,7 +29,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { BACKGROUND_TEXT_MODE, HIDDEN_PADDING } from '../../../../constants';
+import { BACKGROUND_TEXT_MODE } from '../../../../constants';
 import { FillNone, FillFilled, FillHighlighted } from '../../../../icons/';
 import { Color, Label, Row, ToggleButton } from '../../../form';
 import { useKeyDownEffect } from '../../../keyboard';
@@ -39,6 +39,7 @@ import {
   getColorPickerActions,
 } from '../../shared';
 import useRichTextFormatting from './useRichTextFormatting';
+import { applyHiddenPadding, removeHiddenPadding } from './utils';
 
 const FillRow = styled(Row)`
   align-items: flex-start;
@@ -105,34 +106,8 @@ function ColorControls({ selectedElements, pushUpdate }) {
             BACKGROUND_TEXT_MODE.FILL,
             BACKGROUND_TEXT_MODE.HIGHLIGHT,
           ].includes(mode)
-            ? {
-                ...(element.padding ?? {}),
-                hasHiddenPadding: true,
-                horizontal:
-                  (element.padding.horizontal || 0) +
-                  (element.padding.hasHiddenPadding
-                    ? 0
-                    : HIDDEN_PADDING.horizontal),
-                vertical:
-                  (element.padding.vertical || 0) +
-                  (element.padding.hasHiddenPadding
-                    ? 0
-                    : HIDDEN_PADDING.vertical),
-              }
-            : {
-                ...(element.padding ?? {}),
-                hasHiddenPadding: false,
-                horizontal:
-                  (element.padding.horizontal || 0) -
-                  (element.padding.hasHiddenPadding
-                    ? HIDDEN_PADDING.horizontal
-                    : 0),
-                vertical:
-                  (element.padding.vertical || 0) -
-                  (element.padding.hasHiddenPadding
-                    ? HIDDEN_PADDING.vertical
-                    : 0),
-              },
+            ? applyHiddenPadding(element)
+            : removeHiddenPadding(element),
         }),
         true
       );

--- a/assets/src/edit-story/components/panels/design/textStyle/padding.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/padding.js
@@ -29,6 +29,7 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { HIDDEN_PADDING } from '../../../../constants';
 import clamp from '../../../../utils/clamp';
 import { Lock, Unlock } from '../../../../icons';
 import {
@@ -40,7 +41,12 @@ import {
 } from '../../../form';
 import { useCommonObjectValue } from '../../shared';
 
-const DEFAULT_PADDING = { horizontal: 0, vertical: 0, locked: true };
+const DEFAULT_PADDING = {
+  horizontal: 0,
+  vertical: 0,
+  locked: true,
+  hasHiddenPadding: false,
+};
 
 const MIN_MAX = {
   PADDING: {
@@ -120,8 +126,11 @@ function PaddingControls({
         'aria-label': __('Horizontal & Vertical padding', 'web-stories'),
         onChange: (value) =>
           handleChange({
-            horizontal: value,
-            vertical: value,
+            horizontal:
+              value +
+              (padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
+            vertical:
+              value + (padding.hasHiddenPadding ? HIDDEN_PADDING.vertical : 0),
           }),
 
         stretch: true,
@@ -131,14 +140,22 @@ function PaddingControls({
         'aria-label': __('Horizontal padding', 'web-stories'),
         onChange: (value) =>
           handleChange({
-            horizontal: value,
+            horizontal:
+              value +
+              (padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
           }),
       };
 
   return (
     <Row>
       <Label>{__('Padding', 'web-stories')}</Label>
-      <BoxedNumeric value={padding.horizontal} {...firstInputProperties} />
+      <BoxedNumeric
+        value={
+          padding.horizontal -
+          (padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0)
+        }
+        {...firstInputProperties}
+      />
       <Space />
       <Toggle
         icon={<Lock />}
@@ -154,7 +171,11 @@ function PaddingControls({
                   locked: true,
                   // When setting the lock, set both dimensions to the value of horizontal
                   horizontal: padding.horizontal,
-                  vertical: padding.horizontal,
+                  vertical:
+                    padding.horizontal +
+                    (padding.hasHiddenPadding
+                      ? HIDDEN_PADDING.vertical - HIDDEN_PADDING.horizontal
+                      : 0),
                 },
             // Not fully sure why this flag is the way it is here, but keeps tests happy
             !lockPadding
@@ -167,10 +188,15 @@ function PaddingControls({
           <Space />
           <BoxedNumeric
             suffix={_x('V', 'The Vertical padding', 'web-stories')}
-            value={padding.vertical}
+            value={
+              padding.vertical -
+              (padding.hasHiddenPadding ? HIDDEN_PADDING.vertical : 0)
+            }
             onChange={(value) =>
               handleChange({
-                vertical: value,
+                vertical:
+                  value +
+                  (padding.hasHiddenPadding ? HIDDEN_PADDING.vertical : 0),
               })
             }
             aria-label={__('Vertical padding', 'web-stories')}

--- a/assets/src/edit-story/components/panels/design/textStyle/padding.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/padding.js
@@ -72,7 +72,7 @@ function PaddingControls({
   pushUpdateForObject,
   pushUpdate,
 }) {
-  const displayPadding = useCommonObjectValue(
+  const displayedPadding = useCommonObjectValue(
     // Map over all elements and update display
     // values to not include hidden padding
     // if hidden padding is present
@@ -86,7 +86,7 @@ function PaddingControls({
 
   // Only if true for all selected elements, will the toggle be true
   // (Note that this behavior is different from aspect lock ratio)
-  const lockPadding = displayPadding.locked === true;
+  const lockPadding = displayedPadding.locked === true;
 
   const handleChange = useCallback(
     (updater, submit = false) => {
@@ -154,7 +154,7 @@ function PaddingControls({
     <Row>
       <Label>{__('Padding', 'web-stories')}</Label>
       <BoxedNumeric
-        value={displayPadding.horizontal}
+        value={displayedPadding.horizontal}
         {...firstInputProperties}
       />
       <Space />
@@ -189,7 +189,7 @@ function PaddingControls({
           <Space />
           <BoxedNumeric
             suffix={_x('V', 'The Vertical padding', 'web-stories')}
-            value={displayPadding.vertical}
+            value={displayedPadding.vertical}
             onChange={(value) =>
               handleChange((el) => ({
                 vertical: value + getHiddenPadding(el, 'vertical'),

--- a/assets/src/edit-story/components/panels/design/textStyle/padding.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/padding.js
@@ -99,19 +99,20 @@ function PaddingControls({
     (updater, submit = false) => {
       pushUpdate((el) => {
         const updates = {};
-        const newPadding = updater(el);
         const { x, y, width, height } = el;
+        const newPadding = updater(el);
 
         if ('horizontal' in newPadding) {
-          updates.x = x - (newPadding.horizontal - el.padding.horizontal || 0);
+          updates.x =
+            x - (newPadding.horizontal - (el.padding.horizontal || 0));
           updates.width =
-            width + (newPadding.horizontal - el.padding.horizontal || 0) * 2;
+            width + (newPadding.horizontal - (el.padding.horizontal || 0)) * 2;
         }
 
         if ('vertical' in newPadding) {
-          updates.y = y - (newPadding.vertical - el.padding.vertical || 0);
+          updates.y = y - (newPadding.vertical - (el.padding.vertical || 0));
           updates.height =
-            height + (newPadding.vertical - el.padding.vertical || 0) * 2;
+            height + (newPadding.vertical - (el.padding.vertical || 0)) * 2;
         }
 
         return updates;
@@ -163,13 +164,11 @@ function PaddingControls({
         suffix: _x('H', 'The Horizontal padding', 'web-stories'),
         'aria-label': __('Horizontal padding', 'web-stories'),
         onChange: (value) =>
-          handleChange((el) => {
-            return {
-              horizontal:
-                value +
-                (el.padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
-            };
-          }),
+          handleChange((el) => ({
+            horizontal:
+              value +
+              (el.padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
+          })),
       };
 
   return (

--- a/assets/src/edit-story/components/panels/design/textStyle/padding.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/padding.js
@@ -29,7 +29,6 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { HIDDEN_PADDING } from '../../../../constants';
 import clamp from '../../../../utils/clamp';
 import { Lock, Unlock } from '../../../../icons';
 import {
@@ -40,6 +39,7 @@ import {
   usePresubmitHandler,
 } from '../../../form';
 import { useCommonObjectValue } from '../../shared';
+import { getHiddenPadding, removeHiddenPadding } from './utils';
 
 const DEFAULT_PADDING = {
   horizontal: 0,
@@ -77,15 +77,7 @@ function PaddingControls({
     // if hidden padding is present
     selectedElements.map((el) => ({
       ...el,
-      padding: {
-        ...el.padding,
-        horizontal:
-          el.padding.horizontal -
-          (el.padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
-        vertical:
-          el.padding.vertical -
-          (el.padding.hasHiddenPadding ? HIDDEN_PADDING.vertical : 0),
-      },
+      padding: removeHiddenPadding(el),
     })),
     'padding',
     DEFAULT_PADDING
@@ -149,12 +141,8 @@ function PaddingControls({
         onChange: (value) =>
           handleChange((el) => {
             return {
-              horizontal:
-                value +
-                (el.padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
-              vertical:
-                value +
-                (el.padding.hasHiddenPadding ? HIDDEN_PADDING.vertical : 0),
+              horizontal: value + getHiddenPadding(el, 'horizontal'),
+              vertical: value + getHiddenPadding(el, 'vertical'),
             };
           }),
 
@@ -165,9 +153,7 @@ function PaddingControls({
         'aria-label': __('Horizontal padding', 'web-stories'),
         onChange: (value) =>
           handleChange((el) => ({
-            horizontal:
-              value +
-              (el.padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
+            horizontal: value + getHiddenPadding(el, 'horizontal'),
           })),
       };
 
@@ -196,9 +182,8 @@ function PaddingControls({
                     horizontal: el.padding.horizontal,
                     vertical:
                       el.padding.horizontal +
-                      (el.padding.hasHiddenPadding
-                        ? HIDDEN_PADDING.vertical - HIDDEN_PADDING.horizontal
-                        : 0),
+                      getHiddenPadding(el, 'vertical') -
+                      getHiddenPadding(el, 'horizontal'),
                   },
             // Not fully sure why this flag is the way it is here, but keeps tests happy
             !lockPadding
@@ -214,9 +199,7 @@ function PaddingControls({
             value={displayPadding.vertical}
             onChange={(value) =>
               handleChange((el) => ({
-                vertical:
-                  value +
-                  (el.padding.hasHiddenPadding ? HIDDEN_PADDING.vertical : 0),
+                vertical: value + getHiddenPadding(el, 'vertical'),
               }))
             }
             aria-label={__('Vertical padding', 'web-stories')}

--- a/assets/src/edit-story/components/panels/design/textStyle/padding.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/padding.js
@@ -80,6 +80,7 @@ function PaddingControls({
   // Only if true for all selected elements, will the toggle be true
   // (Note that this behavior is different from aspect lock ratio)
   const lockPadding = padding.locked === true;
+  const hasHiddenPadding = padding.hasHiddenPadding === true;
 
   const handleChange = useCallback(
     (newPadding, submit = false) => {
@@ -127,10 +128,8 @@ function PaddingControls({
         onChange: (value) =>
           handleChange({
             horizontal:
-              value +
-              (padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
-            vertical:
-              value + (padding.hasHiddenPadding ? HIDDEN_PADDING.vertical : 0),
+              value + (hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
+            vertical: value + (hasHiddenPadding ? HIDDEN_PADDING.vertical : 0),
           }),
 
         stretch: true,
@@ -141,8 +140,7 @@ function PaddingControls({
         onChange: (value) =>
           handleChange({
             horizontal:
-              value +
-              (padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
+              value + (hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0),
           }),
       };
 
@@ -151,8 +149,10 @@ function PaddingControls({
       <Label>{__('Padding', 'web-stories')}</Label>
       <BoxedNumeric
         value={
-          padding.horizontal -
-          (padding.hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0)
+          typeof padding.horizontal === 'number'
+            ? padding.horizontal -
+              (hasHiddenPadding ? HIDDEN_PADDING.horizontal : 0)
+            : padding.horizontal
         }
         {...firstInputProperties}
       />
@@ -173,7 +173,7 @@ function PaddingControls({
                   horizontal: padding.horizontal,
                   vertical:
                     padding.horizontal +
-                    (padding.hasHiddenPadding
+                    (hasHiddenPadding
                       ? HIDDEN_PADDING.vertical - HIDDEN_PADDING.horizontal
                       : 0),
                 },
@@ -189,14 +189,15 @@ function PaddingControls({
           <BoxedNumeric
             suffix={_x('V', 'The Vertical padding', 'web-stories')}
             value={
-              padding.vertical -
-              (padding.hasHiddenPadding ? HIDDEN_PADDING.vertical : 0)
+              typeof padding.vertical === 'number'
+                ? padding.vertical -
+                  (hasHiddenPadding ? HIDDEN_PADDING.vertical : 0)
+                : padding.vertical
             }
             onChange={(value) =>
               handleChange({
                 vertical:
-                  value +
-                  (padding.hasHiddenPadding ? HIDDEN_PADDING.vertical : 0),
+                  value + (hasHiddenPadding ? HIDDEN_PADDING.vertical : 0),
               })
             }
             aria-label={__('Vertical padding', 'web-stories')}

--- a/assets/src/edit-story/components/panels/design/textStyle/padding.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/padding.js
@@ -39,8 +39,9 @@ import {
   usePresubmitHandler,
 } from '../../../form';
 import { useCommonObjectValue } from '../../shared';
+import { metricsForTextPadding } from '../../utils/metricsForTextPadding';
 
-const DEFAULT_PADDING = { horizontal: 0, vertical: 0, locked: true };
+export const DEFAULT_PADDING = { horizontal: 0, vertical: 0, locked: true };
 
 const MIN_MAX = {
   PADDING: {
@@ -77,23 +78,16 @@ function PaddingControls({
 
   const handleChange = useCallback(
     (newPadding, submit = false) => {
-      pushUpdate(({ x, y, width, height }) => {
-        const updates = {};
-
-        if ('horizontal' in newPadding) {
-          updates.x = x - (newPadding.horizontal - padding.horizontal || 0);
-          updates.width =
-            width + (newPadding.horizontal - padding.horizontal || 0) * 2;
-        }
-
-        if ('vertical' in newPadding) {
-          updates.y = y - (newPadding.vertical - padding.vertical || 0);
-          updates.height =
-            height + (newPadding.vertical - padding.vertical || 0) * 2;
-        }
-
-        return updates;
-      });
+      pushUpdate(({ x, y, width, height }) =>
+        metricsForTextPadding({
+          x,
+          y,
+          height,
+          width,
+          currentPadding: padding,
+          newPadding,
+        })
+      );
       pushUpdateForObject('padding', newPadding, DEFAULT_PADDING, submit);
     },
     [pushUpdate, pushUpdateForObject, padding]

--- a/assets/src/edit-story/components/panels/design/textStyle/test/textStyle.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/test/textStyle.js
@@ -41,7 +41,12 @@ jest.mock('../../../../form/dropDown');
 jest.mock('../../../../form/advancedDropDown');
 jest.mock('../../../../form/color/color');
 
-const DEFAULT_PADDING = { horizontal: 0, vertical: 0, locked: true };
+const DEFAULT_PADDING = {
+  horizontal: 0,
+  vertical: 0,
+  locked: true,
+  hasHiddenPadding: false,
+};
 
 function Wrapper({ children }) {
   return (
@@ -183,6 +188,7 @@ describe('Panels/TextStyle', () => {
       height: 171,
       lineHeight: 1,
       padding: {
+        hasHiddenPadding: false,
         horizontal: 0,
         locked: true,
         vertical: 0,

--- a/assets/src/edit-story/components/panels/design/textStyle/utils.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/utils.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { HIDDEN_PADDING } from '../../../../constants';
+
+/**
+ * Applies hidden padding to element padding and sets the hidden
+ * padding flag to true. returns entire element.padding object
+ * while retaining existing properties on it.
+ *
+ * @param {Object} element - story element.
+ * @return {Object} element.padding with hidden padding properties applied
+ */
+export function applyHiddenPadding(element) {
+  return {
+    ...(element.padding ?? {}),
+    hasHiddenPadding: true,
+    ...['vertical', 'horizontal'].reduce((padding, axis) => {
+      padding[axis] =
+        (element?.padding?.[axis] || 0) +
+        (element?.padding?.hasHiddenPadding ? 0 : HIDDEN_PADDING[axis]);
+      return padding;
+    }, {}),
+  };
+}
+
+/**
+ * Removes hidden padding on element padding and sets the hidden
+ * padding flag to false. returns entire element.padding object
+ * while retaining existing properties on it.
+ *
+ * @param {Object} element - story element.
+ * @return {Object} element.padding with hidden padding properties removed
+ */
+export function removeHiddenPadding(element) {
+  return {
+    ...(element.padding ?? {}),
+    hasHiddenPadding: false,
+    ...['vertical', 'horizontal'].reduce((padding, axis) => {
+      padding[axis] =
+        (element?.padding?.[axis] || 0) -
+        (element?.padding?.hasHiddenPadding ? HIDDEN_PADDING[axis] : 0);
+      return padding;
+    }, {}),
+  };
+}
+
+/**
+ * Takes an element and a padding axis and returns the
+ * hidden padding or 0 depending on elements `hasHiddenPadding`
+ * flag.
+ *
+ * @param {Object} element - story element
+ * @param {'horizontal' | 'vertical'} axis - requested padding axis
+ * @return {number} - hidden padding value
+ */
+export function getHiddenPadding(element = {}, axis = 'horizontal') {
+  return element?.padding?.hasHiddenPadding ? HIDDEN_PADDING[axis] : 0;
+}

--- a/assets/src/edit-story/components/panels/design/textStyle/utils.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/utils.js
@@ -27,16 +27,17 @@ import { HIDDEN_PADDING } from '../../../../constants';
  * @return {Object} element.padding with hidden padding properties applied
  */
 export function applyHiddenPadding(element) {
-  return {
-    ...(element.padding ?? {}),
-    hasHiddenPadding: true,
-    ...['vertical', 'horizontal'].reduce((padding, axis) => {
-      padding[axis] =
-        (element?.padding?.[axis] || 0) +
-        (element?.padding?.hasHiddenPadding ? 0 : HIDDEN_PADDING[axis]);
-      return padding;
-    }, {}),
-  };
+  return element?.padding?.hasHiddenPadding
+    ? element.padding
+    : {
+        ...(element.padding ?? {}),
+        hasHiddenPadding: true,
+        ...['vertical', 'horizontal'].reduce((padding, axis) => {
+          padding[axis] =
+            (element?.padding?.[axis] || 0) + HIDDEN_PADDING[axis];
+          return padding;
+        }, {}),
+      };
 }
 
 /**
@@ -48,16 +49,17 @@ export function applyHiddenPadding(element) {
  * @return {Object} element.padding with hidden padding properties removed
  */
 export function removeHiddenPadding(element) {
-  return {
-    ...(element.padding ?? {}),
-    hasHiddenPadding: false,
-    ...['vertical', 'horizontal'].reduce((padding, axis) => {
-      padding[axis] =
-        (element?.padding?.[axis] || 0) -
-        (element?.padding?.hasHiddenPadding ? HIDDEN_PADDING[axis] : 0);
-      return padding;
-    }, {}),
-  };
+  return element?.padding?.hasHiddenPadding
+    ? {
+        ...(element.padding ?? {}),
+        hasHiddenPadding: false,
+        ...['vertical', 'horizontal'].reduce((padding, axis) => {
+          padding[axis] =
+            (element?.padding?.[axis] || 0) - HIDDEN_PADDING[axis];
+          return padding;
+        }, {}),
+      }
+    : element.padding;
 }
 
 /**

--- a/assets/src/edit-story/components/panels/utils/metricsForTextPadding.js
+++ b/assets/src/edit-story/components/panels/utils/metricsForTextPadding.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function metricsForTextPadding({
+  currentPadding,
+  newPadding,
+  x,
+  y,
+  width,
+  height,
+}) {
+  const updates = {};
+
+  if ('horizontal' in newPadding) {
+    updates.x = x - (newPadding.horizontal - currentPadding.horizontal || 0);
+    updates.width =
+      width + (newPadding.horizontal - currentPadding.horizontal || 0) * 2;
+  }
+
+  if ('vertical' in newPadding) {
+    updates.y = y - (newPadding.vertical - currentPadding.vertical || 0);
+    updates.height =
+      height + (newPadding.vertical - currentPadding.vertical || 0) * 2;
+  }
+
+  return updates;
+}

--- a/assets/src/edit-story/components/panels/utils/metricsForTextPadding.js
+++ b/assets/src/edit-story/components/panels/utils/metricsForTextPadding.js
@@ -25,15 +25,15 @@ export function metricsForTextPadding({
   const updates = {};
 
   if ('horizontal' in newPadding) {
-    updates.x = x - (newPadding.horizontal - currentPadding.horizontal || 0);
+    updates.x = x - (newPadding.horizontal - (currentPadding.horizontal || 0));
     updates.width =
-      width + (newPadding.horizontal - currentPadding.horizontal || 0) * 2;
+      width + (newPadding.horizontal - (currentPadding.horizontal || 0)) * 2;
   }
 
   if ('vertical' in newPadding) {
-    updates.y = y - (newPadding.vertical - currentPadding.vertical || 0);
+    updates.y = y - (newPadding.vertical - (currentPadding.vertical || 0));
     updates.height =
-      height + (newPadding.vertical - currentPadding.vertical || 0) * 2;
+      height + (newPadding.vertical - (currentPadding.vertical || 0)) * 2;
   }
 
   return updates;

--- a/assets/src/edit-story/components/panels/utils/test/metricsForTextPadding.js
+++ b/assets/src/edit-story/components/panels/utils/test/metricsForTextPadding.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { metricsForTextPadding } from '../metricsForTextPadding';
+
+describe('metricsForTextPadding()', function () {
+  it('should calculate metrics for new padding with no existing padding.', function () {
+    expect(
+      metricsForTextPadding({
+        newPadding: { horizontal: 10, vertical: 8 },
+        currentPadding: { horizontal: 0, vertical: 0 },
+        width: 100,
+        height: 100,
+        y: 30,
+        x: 20,
+      })
+    ).toStrictEqual({
+      height: 116,
+      width: 120,
+      x: 10,
+      y: 22,
+    });
+  });
+
+  it('should calculate metrics for shrinking (new padding is smaller than current).', function () {
+    expect(
+      metricsForTextPadding({
+        newPadding: { horizontal: 10, vertical: 8 },
+        currentPadding: { horizontal: 32, vertical: 14 },
+        width: 100,
+        height: 100,
+        y: 30,
+        x: 20,
+      })
+    ).toStrictEqual({
+      height: 88,
+      width: 56,
+      x: 42,
+      y: 36,
+    });
+  });
+
+  it('should calculate metrics for growing (new padding is smaller than current).', function () {
+    expect(
+      metricsForTextPadding({
+        newPadding: { horizontal: 64, vertical: 28 },
+        currentPadding: { horizontal: 32, vertical: 14 },
+        width: 100,
+        height: 100,
+        y: 30,
+        x: 40,
+      })
+    ).toStrictEqual({
+      height: 128,
+      width: 164,
+      x: 8,
+      y: 16,
+    });
+  });
+});

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -78,6 +78,6 @@ export const FONT_WEIGHT = {
 };
 
 export const HIDDEN_PADDING = {
-  horizontal: 6,
-  vertical: 2,
+  horizontal: 8,
+  vertical: 4,
 };

--- a/assets/src/edit-story/constants.js
+++ b/assets/src/edit-story/constants.js
@@ -76,3 +76,8 @@ export const FONT_WEIGHT = {
   MEDIUM: 500,
   BOLD: 700,
 };
+
+export const HIDDEN_PADDING = {
+  horizontal: 6,
+  vertical: 2,
+};


### PR DESCRIPTION
## Summary
Adds a padding to text elements with bg fill and highlight that appears on the element, but is not visible in the inspector. The hidden padding is currently set to 6x2 in editor coordinates.

## Relevant Technical Choices
Applied the extra padding to the elements padding in the story data so that we didn't have to alter our positioning system at all, then added a flag that hidden padding is present on the element data so we can subtract it out in the padding input.

Wanted to maintain backwards compatibility, so if users have an existing story before this change with `0` padding on bg fill text that's pixel perfect, this doesn't alter it, but if they reapply fill or highlight to the text, the updated hidden padding will be present.

## To-do
NA

## User-facing changes
Text with bg fill or highlight should now have a little extra spacing around the text to be visually pleasant to user. Other than that there should be no visible changes to the inspector panel behavior.

## Testing Instructions
-> Go to story editor
-> Add text element
-> Apply BG Fill to text and see that the bounding box grows a little bit, but still has a value of `0` in the padding input
-> Apply BG highlight from BG Fill an see that element retains the same size and `0` for input padding.
-> Mess with different combinations of selected elements (locked, unlocked, same padding, different padding) and see that the padding input has not changed (There's a lot of combinations of scenarios you can create here, but don't worry if you don't think of all of them because the unit tests are pretty thorough going through these scenarios)

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4972 
See #4980
