### PR TITLE
Fix being able to add duplicate color presets

### DIFF
--- a/assets/src/edit-story/components/panels/design/preset/test/utils.js
+++ b/assets/src/edit-story/components/panels/design/preset/test/utils.js
@@ -148,7 +148,7 @@ describe('Panels/StylePreset/utils', () => {
     ).not.toBeDefined();
   });
 
-  it('should get correct text style presets from selected elements', () => {
+  it('should get correct and unique text style presets from selected elements', () => {
     const stylePreset = {
       ...STYLE_PRESET,
       font: {
@@ -167,6 +167,13 @@ describe('Panels/StylePreset/utils', () => {
           horizontal: 0,
         },
         content: '<span style="color: rgb(1,1,1)">Content</span>',
+      },
+      {
+        type: 'text',
+        x: 30,
+        content:
+          '<span style="font-weight: 700; font-style: italic; color: rgb(2,2,2)">Content</span>',
+        ...objectWithout(stylePreset, ['color']),
       },
       {
         type: 'text',
@@ -399,6 +406,28 @@ describe('Panels/StylePreset/utils', () => {
     };
     const expected = {
       colors: [TEST_COLOR, TEST_COLOR_2],
+    };
+    const presets = getShapePresets(elements, stylePresets);
+    expect(presets).toStrictEqual(expected);
+  });
+
+  it('should get duplicate preset only once from shape', () => {
+    const elements = [
+      {
+        type: 'shape',
+        backgroundColor: TEST_COLOR,
+      },
+      {
+        type: 'shape',
+        backgroundColor: TEST_COLOR,
+      },
+    ];
+    const stylePresets = {
+      textStyles: [],
+      colors: [],
+    };
+    const expected = {
+      colors: [TEST_COLOR],
     };
     const presets = getShapePresets(elements, stylePresets);
     expect(presets).toStrictEqual(expected);

--- a/assets/src/edit-story/components/panels/design/preset/utils.js
+++ b/assets/src/edit-story/components/panels/design/preset/utils.js
@@ -139,23 +139,23 @@ export function getTextPresets(elements, stylePresets, type) {
     'style' === type
       ? []
       : elements
-        .map(({ content }) => getHTMLInfo(content).color)
-        .filter((color) => color !== MULTIPLE_VALUE)
-        .filter(
-          (color) => color && !findMatchingColor(color, stylePresets, true)
-        );
+          .map(({ content }) => getHTMLInfo(content).color)
+          .filter((color) => color !== MULTIPLE_VALUE)
+          .filter(
+            (color) => color && !findMatchingColor(color, stylePresets, true)
+          );
 
   const allStyles =
     'color' === type
       ? []
       : elements
-        .map((text) => {
-          return {
-            ...objectPick(text, TEXT_PRESET_STYLES),
-            ...getTextInlineStyles(text.content),
-          };
-        })
-        .filter((preset) => !findMatchingStylePreset(preset, stylePresets));
+          .map((text) => {
+            return {
+              ...objectPick(text, TEXT_PRESET_STYLES),
+              ...getTextInlineStyles(text.content),
+            };
+          })
+          .filter((preset) => !findMatchingStylePreset(preset, stylePresets));
   return {
     colors: getUniquePresets(allColors),
     textStyles: getUniquePresets(allStyles),

--- a/assets/src/edit-story/components/panels/design/preset/utils.js
+++ b/assets/src/edit-story/components/panels/design/preset/utils.js
@@ -129,41 +129,47 @@ function getTextInlineStyles(content) {
   };
 }
 
+function getUniquePresets(presets) {
+  const list = presets.map((preset) => JSON.stringify(preset));
+  return Array.from(new Set(list)).map((preset) => JSON.parse(preset));
+}
+
 export function getTextPresets(elements, stylePresets, type) {
-  // @todo Fix: Currently when two selected elements have the same attributes, two presets are added.
+  const allColors =
+    'style' === type
+      ? []
+      : elements
+        .map(({ content }) => getHTMLInfo(content).color)
+        .filter((color) => color !== MULTIPLE_VALUE)
+        .filter(
+          (color) => color && !findMatchingColor(color, stylePresets, true)
+        );
+
+  const allStyles =
+    'color' === type
+      ? []
+      : elements
+        .map((text) => {
+          return {
+            ...objectPick(text, TEXT_PRESET_STYLES),
+            ...getTextInlineStyles(text.content),
+          };
+        })
+        .filter((preset) => !findMatchingStylePreset(preset, stylePresets));
   return {
-    colors:
-      'style' === type
-        ? []
-        : elements
-            .map(({ content }) => getHTMLInfo(content).color)
-            .filter((color) => color !== MULTIPLE_VALUE)
-            .filter(
-              (color) => color && !findMatchingColor(color, stylePresets, true)
-            ),
-    textStyles:
-      'color' === type
-        ? []
-        : elements
-            .map((text) => {
-              return {
-                ...objectPick(text, TEXT_PRESET_STYLES),
-                ...getTextInlineStyles(text.content),
-              };
-            })
-            .filter((preset) => !findMatchingStylePreset(preset, stylePresets)),
+    colors: getUniquePresets(allColors),
+    textStyles: getUniquePresets(allStyles),
   };
 }
 
 export function getShapePresets(elements, stylePresets) {
+  const colors = elements
+    .map(({ backgroundColor }) => {
+      return backgroundColor ? backgroundColor : null;
+    })
+    .filter((color) => color && !findMatchingColor(color, stylePresets, false));
   return {
-    colors: elements
-      .map(({ backgroundColor }) => {
-        return backgroundColor ? backgroundColor : null;
-      })
-      .filter(
-        (color) => color && !findMatchingColor(color, stylePresets, false)
-      ),
+    colors: getUniquePresets(colors),
   };
 }
 


### PR DESCRIPTION
## Summary
Ensure that only unique color presets are added, even if selecting two elements with the same color and clicking to add presets.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
Test the following with different text styles / colors and also with shapes:
1. Add two or more elements that have identical color or style or background-color.
2. Select both/all elements and click `+` to add color preset.
3. Verify that only unique presets are added -- if two elements have the same background color then the color is not added twice.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5216 
