### PR TITLE
Dashboard: Tweaks to FE for Ad Manager & AdSense

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/adNetwork/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/adNetwork/index.js
@@ -201,7 +201,7 @@ function AdNetworkSettings({ adNetwork: adNetworkRaw, handleUpdate }) {
 }
 AdNetworkSettings.propTypes = {
   handleUpdate: PropTypes.func,
-  adNetwork: PropTypes.string,
+  adNetwork: PropTypes.oneOf(Object.values(AD_NETWORK_TYPE)),
 };
 
 export default AdNetworkSettings;

--- a/assets/src/dashboard/app/views/editorSettings/adNetwork/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/adNetwork/stories/index.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import { select } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import { AD_NETWORK_TYPE } from '../../../../../constants';
+import AdNetwork from '../';
+
+export default {
+  title: 'Dashboard/Views/EditorSettings/AdNetwork',
+  component: AdNetwork,
+};
+
+export const _default = () => {
+  return (
+    <AdNetwork
+      adNetwork={select(
+        'adNetwork',
+        Object.values(AD_NETWORK_TYPE),
+        AD_NETWORK_TYPE.NONE
+      )}
+      handleUpdate={(newAdNetwork) => action('update ad network')(newAdNetwork)}
+    />
+  );
+};

--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -42,6 +42,7 @@ export const Main = styled(StandardViewContentGutter)`
   flex-direction: column;
   padding-top: 36px;
   margin-top: 20px;
+  margin-bottom: 56px;
   max-width: 945px;
 `;
 

--- a/assets/src/dashboard/app/views/editorSettings/googleAdManager/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAdManager/stories/index.js
@@ -13,14 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import { text } from '@storybook/addon-knobs';
 
-export const PUBLISHER_LOGO_CONTEXT_MENU_ACTIONS = {
-  REMOVE_LOGO: 'REMOVE_LOGO',
-  SET_DEFAULT: 'SET_DEFAULT',
+/**
+ * Internal dependencies
+ */
+import GoogleAdManager from '../';
+
+export default {
+  title: 'Dashboard/Views/EditorSettings/GoogleAdManager',
+  component: GoogleAdManager,
 };
 
-export const AD_NETWORK_TYPE = {
-  NONE: 'none',
-  ADSENSE: 'adsense',
-  ADMANAGER: 'admanager',
+export const _default = () => {
+  return (
+    <GoogleAdManager
+      slotId={text('slotId', '')}
+      handleUpdate={(newSlotId) =>
+        action('update google ad manager')(newSlotId)
+      }
+    />
+  );
 };

--- a/assets/src/dashboard/app/views/editorSettings/googleAdSense/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAdSense/stories/index.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import GoogleAdSense from '../';
+
+export default {
+  title: 'Dashboard/Views/EditorSettings/GoogleAdSense',
+  component: GoogleAdSense,
+};
+
+export const _default = () => {
+  return (
+    <GoogleAdSense
+      publisherId={text('publisherId', '')}
+      slotId={text('slotId', '')}
+      handleUpdatePublisherId={(newPublisherId) =>
+        action('update publisher id')(newPublisherId)
+      }
+      handleUpdateSlotId={(newSlotId) => action('update slot id')(newSlotId)}
+    />
+  );
+};

--- a/assets/src/dashboard/constants/index.js
+++ b/assets/src/dashboard/constants/index.js
@@ -127,12 +127,6 @@ export const TEXT_INPUT_DEBOUNCE = 300;
 export const MIN_IMG_HEIGHT = 96;
 export const MIN_IMG_WIDTH = 96;
 
-export const AD_NETWORK_TYPE = {
-  NONE: 'none',
-  ADSENSE: 'adsense',
-  ADMANAGER: 'admanager',
-};
-
 export * from './components';
 export * from './direction';
 export * from './pageStructure';


### PR DESCRIPTION
## Summary
Minor front end tweaks to ad manager getting added to settings in Dashboard. 

(@swissspidy  - I figured you had more pressing things to attend to than a few minor front end nits)

## Relevant Technical Choices

- Adding storybook components for ad settings. 
- Moving ad setting to settings constants. 
- Giving main settings wrapper some space at the bottom now that we have a full page of content - prevents weird page growth if you start with ad network of none.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- If you go to dashboard/settings and swap adManagement to 'none' there should still be space at the bottom of the page now so you can see the dropdown better. You might still have to scroll depending on your browser window size but the page itself doesn't have to grow anymore. 

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
