### PR TITLE
Dashboard: Settings Support GA4 Measurement ID for Analytics

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -51,9 +51,15 @@ export const TEXT = {
   ),
   CONTEXT_LINK:
     'https://blog.amp.dev/2019/08/28/analytics-for-your-amp-stories/',
-  SECTION_HEADING: __('Google Analytics Tracking ID', 'web-stories'),
-  PLACEHOLDER: __('Enter your Google Analytics Tracking ID', 'web-stories'),
-  ARIA_LABEL: __('Enter your Google Analytics Tracking ID', 'web-stories'),
+  SECTION_HEADING: __('Google Analytics', 'web-stories'),
+  PLACEHOLDER: __(
+    'Enter your Google Analytics Tracking ID or Measurement ID',
+    'web-stories'
+  ),
+  ARIA_LABEL: __(
+    'Enter your Google Analytics Tracking ID or Measurement ID',
+    'web-stories'
+  ),
   INPUT_ERROR: __('Invalid ID format', 'web-stories'),
   SUBMIT_BUTTON: __('Save', 'web-stories'),
   SITE_KIT_NOT_INSTALLED: __(

--- a/assets/src/dashboard/utils/test/validateGoogleAnalyticsIdFormat.js
+++ b/assets/src/dashboard/utils/test/validateGoogleAnalyticsIdFormat.js
@@ -27,9 +27,11 @@ const idsToValidate = [
   ['clearly wrong', false],
   ['G-9878987', true],
   ['g-9878987', true],
+  ['G-1A2BCD345E', true],
   ['X-8888888', false],
-  ['G-123456', false],
-  ['G-12345678', false],
+  ['G-123456', true],
+  ['G-12345678', true],
+  ['G-abcdefg8910', true],
 ];
 
 describe('validateGoogleAnalyticsIdFormat', () => {

--- a/assets/src/dashboard/utils/test/validateGoogleAnalyticsIdFormat.js
+++ b/assets/src/dashboard/utils/test/validateGoogleAnalyticsIdFormat.js
@@ -25,6 +25,11 @@ const idsToValidate = [
   ['78787878', false],
   ['ua--123448-0', false],
   ['clearly wrong', false],
+  ['G-9878987', true],
+  ['g-9878987', true],
+  ['X-8888888', false],
+  ['G-123456', false],
+  ['G-12345678', false],
 ];
 
 describe('validateGoogleAnalyticsIdFormat', () => {

--- a/assets/src/dashboard/utils/validateGoogleAnalyticsIdFormat.js
+++ b/assets/src/dashboard/utils/validateGoogleAnalyticsIdFormat.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const gaTrackingFormatOrGa4MeasurementId = /^ua-\d+-\d+|g-\d{7}$/;
+const gaTrackingFormatOrGa4MeasurementId = /^ua-\d+-\d+|g-[\w]+$/;
 
 export default function validateGoogleAnalyticsIdFormat(value = '') {
   return Boolean(value.toLowerCase().match(gaTrackingFormatOrGa4MeasurementId));

--- a/assets/src/dashboard/utils/validateGoogleAnalyticsIdFormat.js
+++ b/assets/src/dashboard/utils/validateGoogleAnalyticsIdFormat.js
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-const gaTrackingFormatOrGa4MeasurementId = /^ua-\d+-\d+|g-[\w]+$/;
+const propertyIdOrMeasurementIdFormatRegex = /^ua-\d+-\d+|g-[\w]+$/;
 
 export default function validateGoogleAnalyticsIdFormat(value = '') {
-  return Boolean(value.toLowerCase().match(gaTrackingFormatOrGa4MeasurementId));
+  return Boolean(
+    value.toLowerCase().match(propertyIdOrMeasurementIdFormatRegex)
+  );
 }

--- a/assets/src/dashboard/utils/validateGoogleAnalyticsIdFormat.js
+++ b/assets/src/dashboard/utils/validateGoogleAnalyticsIdFormat.js
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-const googleAnalyticsIdFormatRegex = /^ua-\d+-\d+$/;
+const gaTrackingFormatOrGa4MeasurementId = /^ua-\d+-\d+|g-\d{7}$/;
 
 export default function validateGoogleAnalyticsIdFormat(value = '') {
-  return Boolean(value.toLowerCase().match(googleAnalyticsIdFormatRegex));
+  return Boolean(value.toLowerCase().match(gaTrackingFormatOrGa4MeasurementId));
 }

--- a/tests/e2e/utils/setAnalyticsCode.js
+++ b/tests/e2e/utils/setAnalyticsCode.js
@@ -30,7 +30,7 @@ async function setAnalyticsCode(code) {
   });
 
   const inputSelector =
-    'input[placeholder="Enter your Google Analytics Tracking ID"]';
+    'input[placeholder^="Enter your Google Analytics Tracking ID"]';
 
   await expect(page).toMatchElement(inputSelector);
   await page.evaluate(() => {


### PR DESCRIPTION
## Summary

Allows users to input GA4 Measurement ID for Google Analytics in addition to tracking ID. 

## Relevant Technical Choices

- Update regex used for google analytics to accept tracking id or measurement id patterns. 


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- Users can now also use a GA4 measurement ID for their Google Analytics set on dashboard settings 
- I tweaked the language on settings a bit to reflect the options better (see screenshot)

## Testing Instructions

- Go to dashboard settings and try changing the analytics ID, try this format: `UA-000000-2` (tracking id) and `G-XXXXXXX` (measurement id) and see that both are valid options to save.
![Screen Shot 2021-01-08 at 12 32 31 PM](https://user-images.githubusercontent.com/10720454/104057285-1e098880-51af-11eb-97fd-a3694b72f316.png)


---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5808 
