### PR TITLE
Improved check for is_amp_endpoint / amp_is_request not existing. 

### DIFF
--- a/includes/Story_Renderer/Embed.php
+++ b/includes/Story_Renderer/Embed.php
@@ -29,6 +29,7 @@ namespace Google\Web_Stories\Story_Renderer;
 
 use Google\Web_Stories\Embed_Base;
 use Google\Web_Stories\Model\Story;
+use function Google\Web_Stories\is_amp;
 
 /**
  * Class Embed
@@ -89,10 +90,7 @@ class Embed {
 		// This CSS is used for AMP and non-AMP.
 		wp_enqueue_style( Embed_Base::SCRIPT_HANDLE );
 
-		if (
-			( function_exists( 'amp_is_request' ) && amp_is_request() ) ||
-			( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() )
-		) {
+		if ( is_amp() ) {
 			ob_start();
 			?>
 			<div class="<?php echo esc_attr( "$class web-stories-embed web-stories-embed-amp $align" ); ?>">

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -217,6 +217,26 @@ function rest_preload_api_request( $memo, $path ) {
 	return $memo;
 }
 
+/**
+ * Determine whether the current response being served as AMP.
+ *
+ * @since 1.3.0
+ *
+ * @return bool Whether it is singular story post (and thus an AMP endpoint).
+ */
+function is_amp() {
+	// Check for `amp_is_request()` first since `is_amp_endpoint()` is deprecated.
+	if ( function_exists( '\amp_is_request' ) ) {
+		return amp_is_request();
+	}
+
+	if ( function_exists( '\is_amp_endpoint' ) ) {
+		return is_amp_endpoint();
+	}
+
+	return is_singular( Story_Post_Type::POST_TYPE_SLUG );
+}
+
 global $web_stories;
 
 $web_stories = new Plugin();

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -225,7 +225,7 @@ function rest_preload_api_request( $memo, $path ) {
  * @return bool Whether it is singular story post (and thus an AMP endpoint).
  */
 function is_amp() {
-	if( is_singular( Story_Post_Type::POST_TYPE_SLUG ) ){
+	if ( is_singular( Story_Post_Type::POST_TYPE_SLUG ) ) {
 		return true;
 	}
 

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -225,6 +225,10 @@ function rest_preload_api_request( $memo, $path ) {
  * @return bool Whether it is singular story post (and thus an AMP endpoint).
  */
 function is_amp() {
+	if( is_singular( Story_Post_Type::POST_TYPE_SLUG ) ){
+		return true;
+	}
+
 	// Check for `amp_is_request()` first since `is_amp_endpoint()` is deprecated.
 	if ( function_exists( '\amp_is_request' ) ) {
 		return amp_is_request();
@@ -234,7 +238,7 @@ function is_amp() {
 		return is_amp_endpoint();
 	}
 
-	return is_singular( Story_Post_Type::POST_TYPE_SLUG );
+	return false;
 }
 
 global $web_stories;


### PR DESCRIPTION
## Summary

Instead of waiting on `is_amp_endpoint` / `amp_is_request` function to exist, use function in our namespace that will always exist. That way, it doesn't matter when these functions are called. If `is_amp_endpoint` / `amp_is_request` does exist, then filter the behaviour of our functions to return the same value. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
