### PR TITLE
Dashboard: Ensure the full-size WordPress admin menu is scrollable when the window height is short

### DIFF
--- a/assets/src/dashboard/style.css
+++ b/assets/src/dashboard/style.css
@@ -50,6 +50,16 @@ body.web-story_page_stories-dashboard #wpbody-content {
   padding: 0;
 }
 
+@media only screen and (min-width: 960px) {
+  body.web-story_page_stories-dashboard #wpwrap #adminmenuwrap {
+    position: absolute;
+    overflow-y: auto;
+    overflow-x: hidden;
+    top: 0;
+    bottom: 0;
+  }
+}
+
 body.js.web-story_page_stories-dashboard #wpcontent,
 body.js.web-story_page_stories-dashboard #wpbody-content {
   padding: 0;


### PR DESCRIPTION
## Summary

Adds some CSS to enable scrolling when the WordPress admin menu needs it in tablet or desktop mode.

**Scroll Bar for Menu when Height is too short**
![image](https://user-images.githubusercontent.com/1738349/104197172-4e893680-53ea-11eb-8e99-a6c4a618d2d1.png)

**Menu is unchanged in compact mode**
The app is completely unusable if the height is _this_ small in both editor and dashboard. Additionally the WordPress menu has a fixed size where a scroll bar would obstruct the icons.
![image](https://user-images.githubusercontent.com/1738349/104197218-5ba62580-53ea-11eb-9f75-f633f0fbf0a5.png)

**When there is enough vertical clearance, also do nothing**
![image](https://user-images.githubusercontent.com/1738349/104197314-77a9c700-53ea-11eb-9b23-7074b9df6384.png)


## Relevant Technical Choices

These changes are scoped to the WordPress admin menu for dashboard only.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Visit the dashboard
2. Resize your browser to have a smaller vertical height
3. See that you can scroll the WordPress Admin Menu
