### PR TITLE
Page Layouts: Adds page type based naming and filtering

### DIFF
--- a/assets/src/dashboard/templates/raw/beauty.json
+++ b/assets/src/dashboard/templates/raw/beauty.json
@@ -265,7 +265,8 @@
         "isDefaultBackground": true,
         "id": "eaf6765f-8506-48c9-a526-15917b431464"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "cover"
     },
     {
       "animations": [
@@ -852,7 +853,8 @@
       ],
       "type": "page",
       "id": "65359a38-f1fa-4048-9b99-9415147b74d3",
-      "backgroundColor": { "color": { "r": 233, "g": 213, "b": 197 } }
+      "backgroundColor": { "color": { "r": 233, "g": 213, "b": 197 } },
+      "pageLayoutType": "quote"
     },
     {
       "animations": [
@@ -1156,7 +1158,8 @@
       ],
       "type": "page",
       "id": "e71288c8-1c09-4abd-8e59-db479c97cef2",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1478,7 +1481,8 @@
         "isDefaultBackground": true,
         "id": "b9d953bb-b69e-4d97-a5b8-61136fe83c0f"
       },
-      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0, "a": 1 } }
+      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0, "a": 1 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1847,7 +1851,8 @@
       ],
       "type": "page",
       "id": "a31f98d0-13a5-4904-860b-61a6ce35d36c",
-      "backgroundColor": { "color": { "r": 243, "g": 217, "b": 225 } }
+      "backgroundColor": { "color": { "r": 243, "g": 217, "b": 225 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -2303,7 +2308,8 @@
       ],
       "type": "page",
       "id": "173b610b-392d-4bd1-a3c4-747c7535ba5c",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "steps"
     },
     {
       "animations": [
@@ -3025,7 +3031,8 @@
       ],
       "type": "page",
       "id": "9845d2e8-8afe-448b-b7c7-ed1b5e30ab69",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -3525,7 +3532,8 @@
       ],
       "type": "page",
       "id": "d605aece-b940-4ae4-8917-562ffba57c53",
-      "backgroundColor": { "color": { "r": 243, "g": 217, "b": 225 } }
+      "backgroundColor": { "color": { "r": 243, "g": 217, "b": 225 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -4044,7 +4052,8 @@
       ],
       "type": "page",
       "id": "edf299b1-e35a-4049-9e66-a08dcee8b936",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "list"
     }
   ],
   "autoAdvance": true,

--- a/assets/src/dashboard/templates/raw/cooking.json
+++ b/assets/src/dashboard/templates/raw/cooking.json
@@ -254,7 +254,8 @@
       ],
       "type": "page",
       "id": "dd6a669f-ff4b-4633-8eb4-c601e98b40f1",
-      "backgroundColor": { "color": { "r": 255, "g": 146, "b": 46 } }
+      "backgroundColor": { "color": { "r": 255, "g": 146, "b": 46 } },
+      "pageLayoutType": "cover"
     },
     {
       "animations": [
@@ -503,7 +504,8 @@
       ],
       "type": "page",
       "id": "434c112e-3463-4dc6-aa8e-cb97f13a4e8e",
-      "backgroundColor": { "color": { "r": 255, "g": 146, "b": 46 } }
+      "backgroundColor": { "color": { "r": 255, "g": 146, "b": 46 } },
+      "pageLayoutType": "quote"
     },
     {
       "animations": [
@@ -943,7 +945,8 @@
       ],
       "type": "page",
       "id": "a378f919-785d-4ff2-8f8c-e7922a221cbf",
-      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } }
+      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1730,7 +1733,8 @@
       ],
       "type": "page",
       "id": "e6314f4e-5a59-425c-a6a3-b0a3ecff301c",
-      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } }
+      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } },
+      "pageLayoutType": "list"
     },
     {
       "animations": [
@@ -1970,7 +1974,8 @@
         "isDefaultBackground": true,
         "id": "e59627e9-eb83-4ce5-bf83-17f22851ed1c"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -3124,7 +3129,8 @@
       ],
       "type": "page",
       "id": "4ce57acc-c58e-40ab-8a3d-87f6dc5fb106",
-      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } }
+      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } },
+      "pageLayoutType": "list"
     },
     {
       "animations": [
@@ -3882,7 +3888,8 @@
       ],
       "type": "page",
       "id": "c0a40237-d827-4aa3-b3ca-01e668dc90aa",
-      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } }
+      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } },
+      "pageLayoutType": "table"
     },
     {
       "animations": [
@@ -4326,7 +4333,8 @@
       ],
       "type": "page",
       "id": "11f60c54-4345-4979-8f10-edf4b43c7f44",
-      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } }
+      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } },
+      "pageLayoutType": "steps"
     },
     {
       "animations": [
@@ -4976,7 +4984,8 @@
       ],
       "type": "page",
       "id": "e8a21c0b-1db7-4777-b25d-b7d9a51b10fe",
-      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } }
+      "backgroundColor": { "color": { "r": 255, "g": 249, "b": 238 } },
+      "pageLayoutType": "list"
     }
   ],
   "autoAdvance": true,

--- a/assets/src/dashboard/templates/raw/diy.json
+++ b/assets/src/dashboard/templates/raw/diy.json
@@ -215,7 +215,8 @@
       "type": "page",
       "id": "d47afc22-71b7-4303-9917-96f9a31ad38a",
       "backgroundOverlay": "none",
-      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } }
+      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } },
+      "pageLayoutType": "cover"
     },
     {
       "animations": [
@@ -414,7 +415,8 @@
       ],
       "type": "page",
       "id": "6a6ddf2d-7f98-405a-8c95-76b0440f9b30",
-      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } }
+      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -742,7 +744,8 @@
       ],
       "type": "page",
       "id": "6a5fbd97-2e43-4f7a-a672-6b1b90f8a625",
-      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } }
+      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } },
+      "pageLayoutType": "quote"
     },
     {
       "animations": [
@@ -978,7 +981,8 @@
       ],
       "type": "page",
       "id": "3164a2b3-10c7-42b8-bcea-38292c8427f5",
-      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } }
+      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -1343,7 +1347,8 @@
         "isDefaultBackground": true,
         "id": "0f06a768-d7d7-48c3-94fd-0d200978ef7c"
       },
-      "backgroundColor": { "color": { "r": 250, "g": 244, "b": 234, "a": 1 } }
+      "backgroundColor": { "color": { "r": 250, "g": 244, "b": 234, "a": 1 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1663,7 +1668,8 @@
         "isDefaultBackground": true,
         "id": "f903e641-0485-4da0-be58-66e0cc614467"
       },
-      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30, "a": 1 } }
+      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30, "a": 1 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -1934,7 +1940,8 @@
         "isBackground": true,
         "id": "d4d8e43d-57ff-401c-b525-fabfebb77af4",
         "isDefaultBackground": true
-      }
+      },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -2629,7 +2636,8 @@
       ],
       "type": "page",
       "id": "7dc22ed5-579e-4988-9f9c-97b2cd2ff068",
-      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } }
+      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } },
+      "pageLayoutType": "list"
     },
     {
       "animations": [
@@ -2954,7 +2962,8 @@
         "isDefaultBackground": true,
         "id": "e982349a-5439-458d-937e-5a72701cfbad"
       },
-      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30, "a": 1 } }
+      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30, "a": 1 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -3794,7 +3803,8 @@
       ],
       "type": "page",
       "id": "5c295574-87a0-4ae7-b548-699e0bd47fdf",
-      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } }
+      "backgroundColor": { "color": { "r": 33, "g": 31, "b": 30 } },
+      "pageLayoutType": "list"
     }
   ],
   "autoAdvance": true,

--- a/assets/src/dashboard/templates/raw/entertainment.json
+++ b/assets/src/dashboard/templates/raw/entertainment.json
@@ -442,7 +442,8 @@
       ],
       "type": "page",
       "id": "04df622c-0d7f-4760-a06c-e88d9d9ac435",
-      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } }
+      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } },
+      "pageLayoutType": "cover"
     },
     {
       "animations": [
@@ -762,7 +763,8 @@
       "backgroundOverlay": "none",
       "type": "page",
       "id": "9670b092-e11b-433e-aa8a-659e4ee982c9",
-      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } }
+      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -1139,7 +1141,8 @@
       "backgroundOverlay": "none",
       "type": "page",
       "id": "73e07f65-ae5a-4a85-8802-7ea5cfaa45b2",
-      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } }
+      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } },
+      "pageLayoutType": "quote"
     },
     {
       "animations": [
@@ -1523,7 +1526,8 @@
       "backgroundOverlay": "none",
       "type": "page",
       "id": "582c5a25-6f17-4107-8e60-6ae4721c932f",
-      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } }
+      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -2412,7 +2416,8 @@
       "backgroundOverlay": "none",
       "type": "page",
       "id": "7494b712-c8d0-4189-a85c-32aa52a22032",
-      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } }
+      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -2809,7 +2814,8 @@
       "backgroundOverlay": "none",
       "type": "page",
       "id": "fd60f532-b619-4162-8df9-d8241cc88e45",
-      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } }
+      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -3054,7 +3060,8 @@
       "backgroundOverlay": "none",
       "type": "page",
       "id": "877c2ef2-1faa-4a7b-9f5b-364dcfa3d856",
-      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } }
+      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -3699,7 +3706,8 @@
       "backgroundOverlay": "none",
       "type": "page",
       "id": "3d0dbbd3-70c0-4376-b1bf-c8015def1050",
-      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } }
+      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } },
+      "pageLayoutType": "list"
     },
     {
       "animations": [
@@ -4726,7 +4734,8 @@
       "backgroundOverlay": "none",
       "type": "page",
       "id": "f4ea7828-e328-47e6-bf9d-a786ab192ee1",
-      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } }
+      "backgroundColor": { "color": { "r": 0, "g": 0, "b": 0 } },
+      "pageLayoutType": "list"
     }
   ],
   "autoAdvance": true,

--- a/assets/src/dashboard/templates/raw/fashion.json
+++ b/assets/src/dashboard/templates/raw/fashion.json
@@ -237,7 +237,8 @@
       ],
       "type": "page",
       "id": "1f51fc35-c1d6-46ea-9580-b38672124162",
-      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } }
+      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } },
+      "pageLayoutType": "cover"
     },
     {
       "animations": [
@@ -572,7 +573,8 @@
       ],
       "type": "page",
       "id": "cda99980-6722-4141-9616-25e523a98722",
-      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } }
+      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } },
+      "pageLayoutType": "quote"
     },
     {
       "animations": [
@@ -855,7 +857,8 @@
       ],
       "type": "page",
       "id": "99ae5466-855b-4d84-9379-c401969ade38",
-      "backgroundColor": { "color": { "r": 33, "g": 33, "b": 33 } }
+      "backgroundColor": { "color": { "r": 33, "g": 33, "b": 33 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -1540,7 +1543,8 @@
       ],
       "type": "page",
       "id": "22e2ed54-fa70-43c5-81e8-81ad672bd6ad",
-      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } }
+      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } },
+      "pageLayoutType": "list"
     },
     {
       "animations": [
@@ -2003,7 +2007,8 @@
       ],
       "type": "page",
       "id": "06f93f32-41a9-4fcd-9d03-08ea29f591e4",
-      "backgroundColor": { "color": { "r": 33, "g": 33, "b": 33 } }
+      "backgroundColor": { "color": { "r": 33, "g": 33, "b": 33 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -3065,7 +3070,8 @@
       ],
       "type": "page",
       "id": "e39c480a-e017-4c6e-b48c-4dc1ef00f6ab",
-      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } }
+      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } },
+      "pageLayoutType": "list"
     },
     {
       "animations": [
@@ -3599,7 +3605,8 @@
       ],
       "type": "page",
       "id": "050444c7-6097-410f-8147-0c195b051a27",
-      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } }
+      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -4124,7 +4131,8 @@
         "isDefaultBackground": true,
         "id": "452a4add-0155-44fd-8521-042dcbf88594"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -4735,7 +4743,8 @@
       ],
       "type": "page",
       "id": "a9ed1626-720d-4b66-bfbd-40441c83390c",
-      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } }
+      "backgroundColor": { "color": { "r": 255, "g": 236, "b": 227 } },
+      "pageLayoutType": "list"
     }
   ],
   "autoAdvance": true,

--- a/assets/src/dashboard/templates/raw/fitness.json
+++ b/assets/src/dashboard/templates/raw/fitness.json
@@ -172,7 +172,8 @@
         "type": "shape",
         "id": "5e0a9de6-0c71-42fb-8d26-7beb33ce55c0",
         "isDefaultBackground": true
-      }
+      },
+      "pageLayoutType": "cover"
     },
     {
       "animations": [
@@ -366,7 +367,8 @@
       ],
       "type": "page",
       "id": "708fbc22-f0ca-40ec-9a57-21d9eb0be6b7",
-      "backgroundColor": { "color": { "r": 26, "g": 26, "b": 26 } }
+      "backgroundColor": { "color": { "r": 26, "g": 26, "b": 26 } },
+      "pageLayoutType": "quote"
     },
     {
       "animations": [
@@ -617,7 +619,8 @@
         "isDefaultBackground": true,
         "id": "c324efb7-dd3a-4cce-b780-f3fde3cc94f2"
       },
-      "backgroundColor": { "color": { "r": 16, "g": 16, "b": 16, "a": 1 } }
+      "backgroundColor": { "color": { "r": 16, "g": 16, "b": 16, "a": 1 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -897,7 +900,8 @@
         "type": "shape",
         "id": "aef43d55-bf5e-4175-8975-1637ce53d9ca",
         "isDefaultBackground": true
-      }
+      },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1225,7 +1229,8 @@
         "isDefaultBackground": true,
         "id": "ff86e4bb-4a5c-446d-81c5-0bcd77bd8086"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "steps"
     },
     {
       "animations": [
@@ -1526,7 +1531,8 @@
         "isDefaultBackground": true,
         "id": "506b7e72-d072-474a-9fd7-289c1ba8b707"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1820,7 +1826,8 @@
         "type": "shape",
         "id": "6b7a12c9-81f2-4cf8-8868-6f5d741646e1",
         "isDefaultBackground": true
-      }
+      },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -2237,7 +2244,8 @@
       ],
       "type": "page",
       "id": "d65c11a1-5f71-48ff-8579-85d53f18d461",
-      "backgroundColor": { "color": { "r": 26, "g": 26, "b": 26 } }
+      "backgroundColor": { "color": { "r": 26, "g": 26, "b": 26 } },
+      "pageLayoutType": "list"
     }
   ],
   "autoAdvance": true,

--- a/assets/src/dashboard/templates/raw/travel.json
+++ b/assets/src/dashboard/templates/raw/travel.json
@@ -366,7 +366,8 @@
         "isDefaultBackground": true,
         "id": "e36e376f-3cdb-43f8-b1c7-cdf3a0098132"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "cover"
     },
     {
       "animations": [
@@ -602,7 +603,8 @@
       ],
       "type": "page",
       "id": "3cdf0fde-f515-477d-8688-472c4cc5a8b3",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "quote"
     },
     {
       "animations": [
@@ -864,7 +866,8 @@
       ],
       "type": "page",
       "id": "80b4f7b3-c54a-4e40-9a75-c937cedfed4b",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1065,7 +1068,8 @@
         "isDefaultBackground": true,
         "id": "3769638a-e9e5-4ff0-96dc-9b3df5d78215"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1313,7 +1317,8 @@
         "isDefaultBackground": true,
         "id": "4d03120b-e736-4b71-b5bc-81159357f030"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -1613,7 +1618,8 @@
         "isDefaultBackground": true,
         "id": "64ea1430-5f03-4155-be5d-16faaa4b098e"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1878,7 +1884,8 @@
       ],
       "type": "page",
       "id": "7b7d7662-fb1f-46b5-94e0-b01029a666a5",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "steps"
     },
     {
       "animations": [
@@ -2192,7 +2199,8 @@
         "isDefaultBackground": true,
         "id": "6f8d6dec-a10b-43d5-a74f-0bac45722dab"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -2805,7 +2813,8 @@
       ],
       "type": "page",
       "id": "78da0e6c-6bc7-4680-90a8-2b6bf6e98aaa",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "list"
     },
     {
       "animations": [
@@ -3475,7 +3484,8 @@
       ],
       "type": "page",
       "id": "9a45a0b2-0261-4298-aef7-c08b99771787",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "list"
     }
   ],
   "autoAdvance": true,

--- a/assets/src/dashboard/templates/raw/wellbeing.json
+++ b/assets/src/dashboard/templates/raw/wellbeing.json
@@ -307,7 +307,8 @@
       ],
       "type": "page",
       "id": "80cd76d6-6c52-4892-98d7-f414dbb7619e",
-      "backgroundColor": { "color": { "r": 31, "g": 42, "b": 46 } }
+      "backgroundColor": { "color": { "r": 31, "g": 42, "b": 46 } },
+      "pageLayoutType": "cover"
     },
     {
       "animations": [
@@ -564,7 +565,8 @@
       ],
       "type": "page",
       "id": "e96638f8-1f19-4f34-b7e6-963329aa12fd",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "quote"
     },
     {
       "animations": [
@@ -942,7 +944,8 @@
       ],
       "type": "page",
       "id": "e6b3eacb-1032-4965-8e57-efe5dbe8b1b7",
-      "backgroundColor": { "color": { "r": 31, "g": 42, "b": 46 } }
+      "backgroundColor": { "color": { "r": 31, "g": 42, "b": 46 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1245,7 +1248,8 @@
         "isDefaultBackground": true,
         "id": "e4224ca8-e130-44df-a647-57d7a6dba4f4"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1659,7 +1663,8 @@
       ],
       "type": "page",
       "id": "1a57cf2b-d1d0-432c-8b97-3794c41e2098",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -1927,7 +1932,8 @@
         "isDefaultBackground": true,
         "id": "aceee55e-9440-4b53-90b7-4480bb1722ee"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "editorial"
     },
     {
       "animations": [
@@ -2125,7 +2131,8 @@
         "isDefaultBackground": true,
         "id": "fadc0093-2969-4c68-a93a-443622c08d81"
       },
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255, "a": 1 } },
+      "pageLayoutType": "section"
     },
     {
       "animations": [
@@ -2623,7 +2630,8 @@
       ],
       "type": "page",
       "id": "a3dd6d21-4f75-4d8a-bacb-ef9d14f61503",
-      "backgroundColor": { "color": { "r": 31, "g": 42, "b": 46 } }
+      "backgroundColor": { "color": { "r": 31, "g": 42, "b": 46 } },
+      "pageLayoutType": "steps"
     },
     {
       "animations": [
@@ -3293,7 +3301,8 @@
       ],
       "type": "page",
       "id": "d17e5002-9a42-41ea-a7fc-c2fddc7b58e6",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "list"
     },
     {
       "animations": [
@@ -3865,7 +3874,8 @@
       ],
       "type": "page",
       "id": "47783f6c-471c-427c-804e-532ace8261d1",
-      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } }
+      "backgroundColor": { "color": { "r": 255, "g": 255, "b": 255 } },
+      "pageLayoutType": "list"
     }
   ],
   "autoAdvance": true,

--- a/assets/src/dashboard/templates/test/raw.js
+++ b/assets/src/dashboard/templates/test/raw.js
@@ -20,6 +20,11 @@
 import { readdirSync, readFileSync } from 'fs';
 import { resolve, basename } from 'path';
 
+/**
+ * Internal dependencies
+ */
+import { PAGE_LAYOUT_TYPES } from '../../../edit-story/components/library/panes/pageLayouts/constants';
+
 describe('Raw template files', () => {
   const templates = readdirSync(
     resolve(process.cwd(), 'assets/src/dashboard/templates/raw')
@@ -63,6 +68,32 @@ describe('Raw template files', () => {
             );
           }
         }
+      }
+    }
+  );
+
+  // @see https://github.com/google/web-stories-wp/pull/5889
+  it.each(templates)(
+    '%s template should contain pageLayoutType',
+    (template) => {
+      const templateContent = readFileSync(
+        resolve(
+          process.cwd(),
+          `assets/src/dashboard/templates/raw/${template}`
+        ),
+        'utf8'
+      );
+      const templateData = JSON.parse(templateContent);
+
+      for (const page of templateData.pages) {
+        expect(page).toStrictEqual(
+          expect.objectContaining({
+            pageLayoutType: expect.any(String),
+          })
+        );
+        expect(Object.keys(PAGE_LAYOUT_TYPES)).toStrictEqual(
+          expect.arrayContaining([page.pageLayoutType])
+        );
       }
     }
   );

--- a/assets/src/edit-story/components/library/panes/pageLayouts/constants.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/constants.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const PAGE_LAYOUT_TYPES = {
+  cover: { title: __('Cover', 'web-stories') },
+  section: { title: __('Section', 'web-stories') },
+  quote: { title: __('Quote', 'web-stories') },
+  editorial: { title: __('Editorial', 'web-stories') },
+  list: { title: __('List', 'web-stories') },
+  table: { title: __('Table', 'web-stories') },
+  steps: { title: __('Steps', 'web-stories') },
+};

--- a/assets/src/edit-story/components/library/panes/pageLayouts/constants.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/constants.js
@@ -20,11 +20,11 @@
 import { __ } from '@wordpress/i18n';
 
 export const PAGE_LAYOUT_TYPES = {
-  cover: { title: __('Cover', 'web-stories') },
-  section: { title: __('Section', 'web-stories') },
-  quote: { title: __('Quote', 'web-stories') },
-  editorial: { title: __('Editorial', 'web-stories') },
-  list: { title: __('List', 'web-stories') },
-  table: { title: __('Table', 'web-stories') },
-  steps: { title: __('Steps', 'web-stories') },
+  cover: { name: __('Cover', 'web-stories') },
+  section: { name: __('Section', 'web-stories') },
+  quote: { name: __('Quote', 'web-stories') },
+  editorial: { name: __('Editorial', 'web-stories') },
+  list: { name: __('List', 'web-stories') },
+  table: { name: __('Table', 'web-stories') },
+  steps: { name: __('Steps', 'web-stories') },
 };

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
@@ -142,6 +142,7 @@ function PageLayout(props) {
           onClick={handleClick}
           isActive={isActive}
           aria-label={page.title}
+          title={page.title}
           tabIndex="0"
         >
           <PageLayoutTitle>{page.title}</PageLayoutTitle>

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
@@ -72,9 +72,9 @@ function PageLayoutsPane(props) {
 
   const pills = useMemo(
     () =>
-      Object.entries(PAGE_LAYOUT_TYPES).map(([key, { title }]) => ({
+      Object.entries(PAGE_LAYOUT_TYPES).map(([key, { name }]) => ({
         id: key,
-        label: title,
+        label: name,
       })),
     []
   );
@@ -93,12 +93,12 @@ function PageLayoutsPane(props) {
           }
 
           // translation not required because page layout title is already translated
-          const pageLayoutTitle = PAGE_LAYOUT_TYPES[page.pageLayoutType].title;
+          const pageLayoutName = PAGE_LAYOUT_TYPES[page.pageLayoutType].name;
           return [
             ...acc,
             {
               ...page,
-              title: `${template.title} ${pageLayoutTitle}`,
+              title: `${template.title} ${pageLayoutName}`,
             },
           ];
         }, []);

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
@@ -85,14 +85,15 @@ function PageLayoutsPane(props) {
         const templatePages = template.pages.reduce((acc, page) => {
           // skip unselected page layout types if not matching
           if (
-            selectedPageLayoutType &&
-            page.pageLayoutType !== selectedPageLayoutType
+            !page.pageLayoutType ||
+            (selectedPageLayoutType &&
+              page.pageLayoutType !== selectedPageLayoutType)
           ) {
             return acc;
           }
 
           // translation not required because page layout title is already translated
-          const pageLayoutTitle = PAGE_LAYOUT_TYPES[page.pageLayoutType]?.title;
+          const pageLayoutTitle = PAGE_LAYOUT_TYPES[page.pageLayoutType].title;
           return [
             ...acc,
             {

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
@@ -23,7 +23,7 @@ import styled from 'styled-components';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -33,6 +33,7 @@ import { Pane } from '../shared';
 import PillGroup from '../shared/pillGroup';
 import paneId from './paneId';
 import PageLayouts from './pageLayouts';
+import { PAGE_LAYOUT_TYPES } from './constants';
 
 export const StyledPane = styled(Pane)`
   height: 100%;
@@ -60,51 +61,54 @@ function PageLayoutsPane(props) {
     actions: { getTemplates },
   } = useAPI();
   const [templates, setTemplates] = useState([]);
-  const [selectedTemplateId, setSelectedTemplateId] = useState(null);
+  const [selectedPageLayoutType, setSelectedPageLayoutType] = useState(null);
 
   const pageLayoutsParentRef = useRef();
 
+  // load and process templates
   useEffect(() => {
     getTemplates().then((result) => setTemplates(result));
-  }, [getTemplates]);
+  }, [getTemplates, setTemplates]);
 
   const pills = useMemo(
     () =>
-      templates.map((template) => ({
-        id: template.id,
-        label: template.title,
+      Object.entries(PAGE_LAYOUT_TYPES).map(([key, { title }]) => ({
+        id: key,
+        label: title,
       })),
-    [templates]
+    []
   );
 
-  const filteredPages = useMemo(() => {
-    if (selectedTemplateId) {
-      const template = templates.find(
-        (template) => template.id === selectedTemplateId
-      );
-      if (template) {
-        return template.pages;
-      }
-    }
-    return templates.reduce(
-      (pages, template) => [
-        ...pages,
-        ...template.pages.map((page, index) => ({
-          ...page,
-          title: sprintf(
-            /* translators: 1: template name. 2: page number. */
-            __(`%1$s Page %2$s`, 'web-stories'),
-            template.title,
-            index + 1
-          ),
-        })),
-      ],
-      []
-    );
-  }, [templates, selectedTemplateId]);
+  const filteredPages = useMemo(
+    () =>
+      templates.reduce((pages, template) => {
+        const templatePages = template.pages.reduce((acc, page) => {
+          // skip unselected page layout types if not matching
+          if (
+            selectedPageLayoutType &&
+            page.pageLayoutType !== selectedPageLayoutType
+          ) {
+            return acc;
+          }
 
-  const handleSelectTemplate = useCallback((templateId) => {
-    setSelectedTemplateId(templateId);
+          // translation not required because page layout title is already translated
+          const pageLayoutTitle = PAGE_LAYOUT_TYPES[page.pageLayoutType]?.title;
+          return [
+            ...acc,
+            {
+              ...page,
+              title: `${template.title} ${pageLayoutTitle}`,
+            },
+          ];
+        }, []);
+
+        return [...pages, ...templatePages];
+      }, []),
+    [templates, selectedPageLayoutType]
+  );
+
+  const handleSelectPageLayoutType = useCallback((key) => {
+    setSelectedPageLayoutType(key);
   }, []);
 
   return (
@@ -112,13 +116,13 @@ function PageLayoutsPane(props) {
       <PaneInner>
         <PillGroup
           items={pills}
-          selectedItemId={selectedTemplateId}
-          selectItem={handleSelectTemplate}
-          deselectItem={() => handleSelectTemplate(null)}
+          selectedItemId={selectedPageLayoutType}
+          selectItem={handleSelectPageLayoutType}
+          deselectItem={() => handleSelectPageLayoutType(null)}
         />
         <PageLayoutsParentContainer
           ref={pageLayoutsParentRef}
-          title={__('Page layouts', 'web-stories')}
+          title={__('Page Layouts', 'web-stories')}
         >
           {pageLayoutsParentRef.current && (
             <PageLayouts

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
@@ -23,7 +23,7 @@ import styled from 'styled-components';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -92,13 +92,17 @@ function PageLayoutsPane(props) {
             return acc;
           }
 
-          // translation not required because page layout title is already translated
           const pageLayoutName = PAGE_LAYOUT_TYPES[page.pageLayoutType].name;
           return [
             ...acc,
             {
               ...page,
-              title: `${template.title} ${pageLayoutName}`,
+              title: sprintf(
+                /* translators: 1: template name. 2: page layout name. */
+                __('%1$s %2$s', 'web-stories', 'web-stories'),
+                template.title,
+                pageLayoutName
+              ),
             },
           ];
         }, []);

--- a/assets/src/edit-story/components/library/panes/pageLayouts/test/pageLayoutsPane.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/test/pageLayoutsPane.js
@@ -28,18 +28,23 @@ import APIContext from '../../../../../app/api/context';
 import StoryContext from '../../../../../app/story/context';
 import { createPage } from '../../../../../elements';
 import PageLayoutsPane from '../pageLayoutsPane';
+import { PAGE_LAYOUT_TYPES } from '../constants';
 
 const createTemplate = (title, id) => ({
   title,
   id,
-  pages: [{ id: 1 }, { id: 2 }, { id: 3 }],
+  pages: [
+    { id: 1, pageLayoutType: 'cover' },
+    { id: 2, pageLayoutType: 'section' },
+    { id: 3, pageLayoutType: 'quote' },
+  ],
 });
+
+const TEMPLATE_NAMES = ['List', 'Grid', 'Masonary'];
 
 const configValue = {
   api: {},
 };
-
-const TEMPLATE_NAMES = ['List', 'Grid', 'Masonary'];
 
 function flushPromiseQueue() {
   return new Promise((resolve) => resolve());
@@ -90,8 +95,10 @@ describe('PageLayoutsPane', () => {
       await flushPromiseQueue();
     });
 
-    TEMPLATE_NAMES.forEach((name) => {
-      expect(queryByText(name)).toBeInTheDocument();
-    });
+    Object.values(PAGE_LAYOUT_TYPES)
+      .map(({ name }) => name)
+      .forEach((name) => {
+        expect(queryByText(name)).toBeInTheDocument();
+      });
   });
 });

--- a/assets/src/edit-story/components/library/panes/pageLayouts/test/pageLayoutsPane.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/test/pageLayoutsPane.js
@@ -26,6 +26,7 @@ import { renderWithTheme } from '../../../../../testUtils';
 import ConfigContext from '../../../../../app/config/context';
 import APIContext from '../../../../../app/api/context';
 import StoryContext from '../../../../../app/story/context';
+import TransformContext from '../../../../transform/context';
 import { createPage } from '../../../../../elements';
 import PageLayoutsPane from '../pageLayoutsPane';
 import { PAGE_LAYOUT_TYPES } from '../constants';
@@ -34,9 +35,8 @@ const createTemplate = (title, id) => ({
   title,
   id,
   pages: [
-    { id: 1, pageLayoutType: 'cover' },
-    { id: 2, pageLayoutType: 'section' },
-    { id: 3, pageLayoutType: 'quote' },
+    createPage({ pageLayoutType: 'cover' }),
+    createPage({ pageLayoutType: 'section' }),
   ],
 });
 
@@ -44,6 +44,11 @@ const TEMPLATE_NAMES = ['List', 'Grid', 'Masonary'];
 
 const configValue = {
   api: {},
+};
+const transformValue = {
+  actions: {
+    registerTransformHandler: () => {},
+  },
 };
 
 function flushPromiseQueue() {
@@ -70,13 +75,15 @@ describe('PageLayoutsPane', () => {
     };
 
     return renderWithTheme(
-      <ConfigContext.Provider value={configValue}>
-        <APIContext.Provider value={apiValue}>
-          <StoryContext.Provider value={storyContext}>
-            <PageLayoutsPane isActive={true} />
-          </StoryContext.Provider>
-        </APIContext.Provider>
-      </ConfigContext.Provider>
+      <TransformContext.Provider value={transformValue}>
+        <ConfigContext.Provider value={configValue}>
+          <APIContext.Provider value={apiValue}>
+            <StoryContext.Provider value={storyContext}>
+              <PageLayoutsPane isActive={true} />
+            </StoryContext.Provider>
+          </APIContext.Provider>
+        </ConfigContext.Provider>
+      </TransformContext.Provider>
     );
   }
 
@@ -88,7 +95,7 @@ describe('PageLayoutsPane', () => {
   });
 
   it('should render <PageLayoutsPane /> with dummy layouts', async () => {
-    const { queryByText } = renderWithTemplates();
+    const { queryByText, queryByTitle } = renderWithTemplates();
 
     await act(async () => {
       // Needed to flush all promises to get templates to resolve
@@ -100,5 +107,10 @@ describe('PageLayoutsPane', () => {
       .forEach((name) => {
         expect(queryByText(name)).toBeInTheDocument();
       });
+
+    TEMPLATE_NAMES.forEach((name) => {
+      expect(queryByTitle(`${name} Cover`)).toBeInTheDocument();
+      expect(queryByTitle(`${name} Section`)).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

Changes Page Layouts filter pills to being based on page type instead of template name. All templates have been categorized by the types specified in the [figma](https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories---Post-Stable?node-id=2%3A98474).

This also fixes page names when filtering and changes titles/hover text to be the page name instead of just "Page layouts".

## Relevant Technical Choices

* Karma tests are still pending for page layouts so I was unable to update them for this change in functionality, but will add karma tests for these in that work.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->


## User-facing changes

<!-- Please describe your changes. -->


## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->
Filter page layouts by each of the pills and verify that all items in each filter match the ones specified in [figma](https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories---Post-Stable?node-id=2%3A98474)

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5872
