### PR TITLE
Display correct panels for 3rd-party gif background

### DIFF
--- a/assets/src/edit-story/components/inspector/design/getDesignPanelsForSelection.js
+++ b/assets/src/edit-story/components/inspector/design/getDesignPanelsForSelection.js
@@ -86,7 +86,7 @@ function getDesignPanelsForSelection(elements) {
         type: PanelTypes.VIDEO_ACCESSIBILITY,
         Panel: VideoAccessibilityPanel,
       });
-    } else if ('image' === elements[0].type) {
+    } else if (['gif', 'image'].includes(elements[0].type)) {
       panels.push({
         type: PanelTypes.IMAGE_ACCESSIBILITY,
         Panel: ImageAccessibilityPanel,


### PR DESCRIPTION
## Summary
Displays correct panels for 3rd party gif background.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
- Add a gif from 3rd party integration Media
- Set it as background
- Verify no Color Presets panel appears & that Accessibility panel is available.
- Add alt text via the accessibility panel.
- Now detach the background, verify the accessibility text is still there.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5842 
