### PR TITLE
Fix z-index for media more button

### DIFF
--- a/assets/src/edit-story/components/library/karma/mediaTab.karma.js
+++ b/assets/src/edit-story/components/library/karma/mediaTab.karma.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+
+describe('Library Media Tab', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  describe('CUJ: Creator Can Add Image/Video to Page: Can edit/delete media', () => {
+    it('should open the edit/delete menu', async () => {
+      const mediaItem = fixture.editor.library.media.item(0);
+      // Hover the media
+      await fixture.events.mouse.moveRel(mediaItem, 10, 10, { steps: 2 });
+      await waitFor(() =>
+        expect(
+          fixture.screen.getByRole('button', { name: 'More' })
+        ).toBeDefined()
+      );
+      const moreButton = fixture.screen.getByRole('button', { name: 'More' });
+      await fixture.events.mouse.seq(({ moveRel, down, up }) => [
+        moveRel(moreButton, 5, 5),
+        down(),
+        up(),
+      ]);
+      expect(
+        fixture.screen.getByRole('menuitem', { name: 'Edit' })
+      ).toBeDefined();
+      expect(
+        fixture.screen.getByRole('menuitem', { name: 'Delete' })
+      ).toBeDefined();
+    });
+  });
+});

--- a/assets/src/edit-story/components/library/panes/media/local/dropDownMenu.js
+++ b/assets/src/edit-story/components/library/panes/media/local/dropDownMenu.js
@@ -48,6 +48,10 @@ const DropDownContainer = styled.div`
   margin-top: 10px;
 `;
 
+const MenuContainer = styled.div`
+  z-index: 1;
+`;
+
 /**
  * Get a More icon that displays a dropdown menu on click.
  *
@@ -104,7 +108,7 @@ function DropDownMenu({
   // Keep icon and menu displayed if menu is open (even if user's mouse leaves the area).
   return (
     !resource.local && ( // Don't show menu if resource not uploaded to server yet.
-      <div>
+      <MenuContainer>
         {(display || isMenuOpen) && (
           <>
             <MoreButton
@@ -140,7 +144,7 @@ function DropDownMenu({
         {showEditDialog && (
           <MediaEditDialog resource={resource} onClose={onEditDialogClose} />
         )}
-      </div>
+      </MenuContainer>
     )
   );
 }


### PR DESCRIPTION
## Summary
Fixes z-index for media more button to be on top of Moveable target.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
- Open media tab.
- Hover on media item and click on "more" button
- Verify the menu with "Edit" and "Delete" options appearing.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5893 
