### PR TITLE
Simplify usage of assets CDN URL

### DIFF
--- a/bin/commander.js
+++ b/bin/commander.js
@@ -34,6 +34,7 @@ import {
   getCurrentVersionNumber,
   updateVersionNumbers,
   updateTemplates,
+  updateCdnUrl,
 } from './utils/index.js';
 
 const PLUGIN_DIR = process.cwd();
@@ -51,7 +52,9 @@ program
     '--nightly',
     'Whether this is a nightly build and thus should append the current revision to the version number.'
   )
-  .description('Bump the version of the plugin')
+  .description('Bump the version of the plugin', {
+    version: 'The version number.',
+  })
   .on('--help', () => {
     console.log('');
     console.log('Examples:');
@@ -125,6 +128,33 @@ program
     console.log(
       `Plugin successfully built! Location: ${relative(process.cwd(), build)}`
     );
+  });
+
+program
+  .command('assets-version')
+  .arguments('<version>')
+  .description('Change the CDN assets version used by the plugin', {
+    version: 'Assets version. Either `main` or an integer.',
+  })
+  .on('--help', () => {
+    console.log('');
+    console.log('Examples:');
+    console.log(
+      '  # Change assets version to `main` (default, for development builds)'
+    );
+    console.log('  $ commander.js assets-version main');
+    console.log('');
+    console.log('  # Change assets version for stable release');
+    console.log('  $ commander.js assets-version 7');
+  })
+  .action((version) => {
+    const pluginFilePath = `${PLUGIN_DIR}/${PLUGIN_FILE}`;
+    updateCdnUrl(
+      pluginFilePath,
+      version === 'main' ? version : parseInt(version)
+    );
+
+    console.log(`Assets CDN URL successfully updated!`);
   });
 
 program

--- a/bin/utils/index.js
+++ b/bin/utils/index.js
@@ -20,3 +20,4 @@ export { default as createBuild } from './createBuild.js';
 export { default as getCurrentVersionNumber } from './getCurrentVersionNumber.js';
 export { default as updateVersionNumbers } from './updateVersionNumbers.js';
 export { default as updateTemplates } from './updateTemplates.js';
+export { default as updateCdnUrl } from './updateCdnUrl.js';

--- a/bin/utils/test/updateCdnUrl.js
+++ b/bin/utils/test/updateCdnUrl.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { __setMockFiles, readFileSync } from 'fs';
+
+/**
+ * Internal dependencies
+ */
+import updateCdnUrl from '../updateCdnUrl';
+
+jest.mock('fs');
+
+const PLUGIN_FILE_CONTENT = `
+<?php
+/**
+ * Main plugin file.
+
+ * Plugin Name: Web Stories
+ * Description: Visual storytelling for WordPress.
+ * Plugin URI: https://github.com/google/web-stories-wp
+ * Author: Google
+ * Author URI: https://opensource.google.com/
+ * Version: 1.0.0-alpha
+ * Requires at least: 5.3
+ * Requires PHP: 5.6
+ * Text Domain: web-stories
+ * Domain Path: /languages/
+ * License: Apache License 2.0
+ * License URI: https://www.apache.org/licenses/LICENSE-2.0
+ */
+
+ define( 'WEBSTORIES_CDN_URL', 'https://wp.stories.google/static/main' );
+`;
+
+describe('updateCdnUrl', () => {
+  const MOCK_FILE_INFO = {
+    '/foo/plugin.php': PLUGIN_FILE_CONTENT,
+  };
+
+  beforeEach(() => {
+    __setMockFiles(MOCK_FILE_INFO);
+  });
+
+  it('should update CDN  URL', () => {
+    updateCdnUrl('/foo/plugin.php', '7.8.9');
+    const pluginFile = readFileSync('/foo/plugin.php');
+
+    expect(pluginFile).toContain(
+      `define( 'WEBSTORIES_CDN_URL', 'https://wp.stories.google/static/7.8.9' );`
+    );
+  });
+});

--- a/bin/utils/updateCdnUrl.js
+++ b/bin/utils/updateCdnUrl.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { readFileSync, writeFileSync } from 'fs';
+
+const CDN_BASE_URL = 'https://wp.stories.google/static/';
+const CDN_URL_CONSTANT_REGEX = /define\(\s*'WEBSTORIES_CDN_URL',\s*'([^']*)'\s*\);/;
+
+/**
+ * Updates CDN URL in thhe main plugin file.
+ *
+ * Namely, this updates the `WEBSTORIES_CDN_URL` constant in the main plugin file.
+ *
+ * @param {string} pluginFile Path to the plugin file.
+ * @param {string|number} version Desired version number. Either 'main' or an integer.
+ * @return {void}
+ */
+function updateCdnURL(pluginFile, version) {
+  let pluginFileContent = readFileSync(pluginFile, 'utf8');
+
+  pluginFileContent = pluginFileContent.replace(CDN_URL_CONSTANT_REGEX, () => {
+    return `define( 'WEBSTORIES_CDN_URL', '${CDN_BASE_URL}${version}' );`;
+  });
+
+  writeFileSync(pluginFile, pluginFileContent);
+}
+
+export default updateCdnURL;

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,10 @@
 * [Getting Started](./getting-started.md)
 * [Glossary](./glossary.md)
 
+## Maintenance
+
+* [CDN Assets](./cdn.md)
+
 ## Development
 
 * [Architecture](./architecture.md)

--- a/docs/cdn.md
+++ b/docs/cdn.md
@@ -1,0 +1,31 @@
+# CDN
+
+Large assets to be used by the plugin are hosted on the [wp.stories.google](https://wp.stories.google) site instead of being bundled with the plugin.
+
+This includes, but is not limited to, assets for these areas:
+
+* Plugin activation message
+* Get Started story (FTUE)
+* Templates
+
+Assets are versioned. Whenever new assets have been added, or existing assets modified, the version will be incremented upon the next release.
+
+## Adding Assets
+
+First, add the new assets to the CDN by following these steps
+
+1. Switch to the `static-site` branch.  
+  `git checkout static-site`
+2. Modify/add assets as desired in the `public/static/main` folder.
+3. Create a new pull request with these changes.
+
+## Usage in the plugin
+
+By default, the plugin will load assets from the `public/static/main` folder.
+
+Only production builds released on WordPress.org will reference the versioned folder, e.g. `puiblic/static/123`.
+
+## Plugin Release
+
+Upon release, the `public/static/main` folder is compared against the latest version.
+If there are changes in `main`, the folder is copied to `public/static/<latest+1>`.

--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
     "test:e2e:firefox:interactive": "PUPPETEER_PRODUCT=firefox npm run test:e2e:interactive",
     "test:e2e:firefox:debug": "PUPPETEER_PRODUCT=firefox PUPPETEER_HEADLESS=false PUPPETEER_DEVTOOLS=true node --inspect-brk node_modules/.bin/jest --runInBand --config=tests/e2e/jest.config.js",
     "percy": "percy snapshot --config=percy.config.yml .test_artifacts/karma_snapshots/",
+    "workflow:assets-version": "./bin/commander.js assets-version",
     "workflow:version": "./bin/commander.js version",
     "workflow:build-plugin": "./bin/commander.js build-plugin",
     "workflow:fonts": "./bin/commander.js build-fonts",

--- a/web-stories.php
+++ b/web-stories.php
@@ -49,17 +49,7 @@ define( 'WEBSTORIES_PLUGIN_DIR_URL', plugin_dir_url( WEBSTORIES_PLUGIN_FILE ) );
 define( 'WEBSTORIES_ASSETS_URL', WEBSTORIES_PLUGIN_DIR_URL . 'assets' );
 define( 'WEBSTORIES_MINIMUM_PHP_VERSION', '5.6' );
 define( 'WEBSTORIES_MINIMUM_WP_VERSION', '5.3' );
-
-$cdn_version = 'main';
-
-if ( false === strpos( WEBSTORIES_VERSION, '+' ) ) {
-	$pieces      = explode( '+', WEBSTORIES_VERSION );
-	$cdn_version = array_shift( $pieces );
-}
-
-define( 'WEBSTORIES_CDN_URL', 'https://wp.stories.google/static/' . $cdn_version );
-
-unset( $cdn_version );
+define( 'WEBSTORIES_CDN_URL', 'https://wp.stories.google/static/main' );
 
 if ( ! defined( 'WEBSTORIES_DEV_MODE' ) ) {
 	define( 'WEBSTORIES_DEV_MODE', false );


### PR DESCRIPTION
## Summary

Companion PR: #5897

Updates how `WEBSTORIES_CDN_URL` is constructed in the plugin, leveraging the changes on the CDN-side to  improve maintenance.

This is an important step toward full release automation.

Development builds will continue to load images from `public/static/main` like today, whereas stable releases will load them from `public/static/<version>`, where `<version>` is an unsigned integer, e.g.  1, 2, 3, etc.

## Relevant Technical Choices

Redirects have been added on the CDN to ensure old plugin versions continue to work as expected.

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

N/A

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4752
See #5191