### PR TITLE
Page Layouts: Fix repeating dialog

### DIFF
--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
@@ -142,7 +142,6 @@ function PageLayout(props) {
           onClick={handleClick}
           isActive={isActive}
           aria-label={page.title}
-          title={page.title}
           tabIndex="0"
           role="button"
         >

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
@@ -109,11 +109,11 @@ function PageLayout(props) {
 
   const handleKeyUp = useCallback(
     ({ key }) => {
-      if (key === 'Enter') {
+      if (key === 'Enter' && isActive) {
         handleClick();
       }
     },
-    [handleClick]
+    [handleClick, isActive]
   );
 
   return (
@@ -142,8 +142,8 @@ function PageLayout(props) {
           onClick={handleClick}
           isActive={isActive}
           aria-label={page.title}
-          title={page.title}
           tabIndex="0"
+          role="button"
         >
           <PageLayoutTitle>{page.title}</PageLayoutTitle>
         </HoverControls>

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
@@ -142,6 +142,7 @@ function PageLayout(props) {
           onClick={handleClick}
           isActive={isActive}
           aria-label={page.title}
+          title={page.title}
           tabIndex="0"
           role="button"
         >

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
@@ -23,7 +23,7 @@ import styled from 'styled-components';
 /**
  * WordPress dependencies
  */
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { _x, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -125,10 +125,7 @@ function PageLayoutsPane(props) {
           selectItem={handleSelectPageLayoutType}
           deselectItem={() => handleSelectPageLayoutType(null)}
         />
-        <PageLayoutsParentContainer
-          ref={pageLayoutsParentRef}
-          title={__('Page Layouts', 'web-stories')}
-        >
+        <PageLayoutsParentContainer ref={pageLayoutsParentRef}>
           {pageLayoutsParentRef.current && (
             <PageLayouts
               parentRef={pageLayoutsParentRef}

--- a/assets/src/edit-story/components/library/panes/pageLayouts/test/pageLayoutsPane.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/test/pageLayoutsPane.js
@@ -95,7 +95,7 @@ describe('PageLayoutsPane', () => {
   });
 
   it('should render <PageLayoutsPane /> with dummy layouts', async () => {
-    const { queryByText, queryByTitle } = renderWithTemplates();
+    const { queryByText, queryByLabelText } = renderWithTemplates();
 
     await act(async () => {
       // Needed to flush all promises to get templates to resolve
@@ -109,8 +109,8 @@ describe('PageLayoutsPane', () => {
       });
 
     TEMPLATE_NAMES.forEach((name) => {
-      expect(queryByTitle(`${name} Cover`)).toBeInTheDocument();
-      expect(queryByTitle(`${name} Section`)).toBeInTheDocument();
+      expect(queryByLabelText(`${name} Cover`)).toBeInTheDocument();
+      expect(queryByLabelText(`${name} Section`)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION

## Summary

Fixes infinite loop of confirming page layout change dialog and ability to use tab to cycle through page layout panel

## Relevant Technical Choices
- Was originally handling this with keyboard nav for page layouts, but the focus traps + virtualized list for the panel is making it more time intensive. This PR just fixes things to be usable. I figure the arrow nav can come separately when we have more time to properly test it. 

- Tweak to page layout element that handles functionality to be a button for the dom
- Remove redundant title (styled title shows on hover and is announced via aria-label)
- Limit keyUp handler that triggers new page layout or dialog to only when `isActive` is true to control bubbling from repeating.
- 
## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

(If page layouts experiment is true)
Should fix repeating confirmation dialog when swapping page layouts. 
Should be able to tab through page layouts 
Should remove redundant unstyled (default) title on hover of a page layout. 

## Testing Instructions

Confirm the above user facing changes 

---

<!-- Please reference the issue(s) this PR addresses. -->

Addresses #5890 
