### PR TITLE
Pre-Publish Checklist: Add an underline and title to clickable elements

### DIFF
--- a/assets/src/edit-story/components/inspector/karma/prepublishSelect.karma.js
+++ b/assets/src/edit-story/components/inspector/karma/prepublishSelect.karma.js
@@ -228,9 +228,9 @@ describe('Pre-publish checklist select offending elements onClick', () => {
       await fixture.events.keyboard.press('tab');
       await fixture.events.keyboard.press('tab');
 
-      const linkTooSmallRow = fixture.screen.getByText(
-        MESSAGES.ACCESSIBILITY.LINK_REGION_TOO_SMALL.MAIN_TEXT
-      );
+      const linkTooSmallRow = fixture.screen
+        .getByText(MESSAGES.ACCESSIBILITY.LINK_REGION_TOO_SMALL.MAIN_TEXT)
+        .closest('button');
 
       expect(document.activeElement).toEqual(linkTooSmallRow);
       await fixture.events.keyboard.press('Enter');

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -87,11 +87,12 @@ const Row = styled.button`
     outline: 2px solid ${({ theme }) => theme.colors.accent.primary};
     outline-offset: 5px;
   }
-  ${({ onClick }) =>
-    Boolean(onClick) &&
-    `&:hover {
-      cursor: pointer;
-    }`}
+`;
+
+const Underline = styled.u`
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 const HelperText = styled.span`
@@ -269,6 +270,7 @@ const ChecklistTab = (props) => {
     ({ message, help, id, pageGroup, ...args }) => {
       const onClick = getOnClick(args);
       const handleKeyPress = getHandleKeyPress(args);
+      const accessibleText = __('Select offending element', 'web-stories');
       return (
         <Row
           tabIndex={0}
@@ -277,13 +279,13 @@ const ChecklistTab = (props) => {
           key={id}
           pageGroup={pageGroup}
         >
-          {message}
-          <HelperText>{help}</HelperText>
-          {onClick && (
-            <VisuallyHidden>
-              {__('Select offending element', 'web-stories')}
-            </VisuallyHidden>
+          {onClick ? (
+            <Underline title={accessibleText}>{message}</Underline>
+          ) : (
+            message
           )}
+          <HelperText>{help}</HelperText>
+          {onClick && <VisuallyHidden>{accessibleText}</VisuallyHidden>}
         </Row>
       );
     },

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -89,10 +89,9 @@ const Row = styled.button`
   }
 `;
 
-const Underline = styled.u`
-  &:hover {
-    cursor: pointer;
-  }
+const Underline = styled.span`
+  text-decoration: underline;
+  cursor: pointer;
 `;
 
 const HelperText = styled.span`


### PR DESCRIPTION
## Summary
- Per bug bash 1.3-b on 13-01-2021, adds an underline and title to the clickable rows in the prepublish checklist
![underline_test](https://user-images.githubusercontent.com/41136059/104501806-6fde5400-559d-11eb-8226-bad4bc85573e.gif)

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do
- N/A
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- user will now see an underline on clickable rows in the prepublish checklist
<!-- Please describe your changes. -->

## Testing Instructions
- create a new story
- add some text and reduce font size to <10pt font
- an error should appear in the prepublish checklist (font too small), since that row refers to a selectable element, it should be underlined and hovering on the underlined part should show a title - "Select offending element"
- 
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5923
