### PR TITLE
Pre-Publish Checklist: Remove page icon

### DIFF
--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -104,6 +104,7 @@ const PageIndicator = styled(Label)`
     padding-top: 9px;
   }
   margin-bottom: 8px;
+  margin-left: 16px;
   display: flex;
   align-items: center;
   svg {

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -29,7 +29,6 @@ import { v4 as uuidv4 } from 'uuid';
  * Internal dependencies
  */
 import { SimplePanel } from '../../panels/panel';
-import { Rectangle } from '../../../icons';
 import { Checkmark as CheckmarkIcon } from '../../../../design-system/icons';
 import { PRE_PUBLISH_MESSAGE_TYPES, types } from '../../../app/prepublish';
 import { Label } from '../../form';
@@ -296,7 +295,6 @@ const ChecklistTab = (props) => {
       return (
         <Fragment key={`guidance-page-group-${pageNum}`}>
           <PageIndicator>
-            <Rectangle />
             {sprintf(
               /* translators: %s: page number. */
               __('Page %s', 'web-stories'),


### PR DESCRIPTION
## Summary

Remove the rectangle svg from the checklist in the editor.

## Relevant Technical Choices

none

## To-do

none

## User-facing changes

Removes the rectangle that preceded the page title

## Testing Instructions

1. run the editor
2. make an incomplete page
3. open the checklist
4. scroll to the bottom to see the suggested page fixes. There should be no rectangle

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/22185279/104509304-b6847c00-55a6-11eb-8aae-e7342816850e.png)|![image](https://user-images.githubusercontent.com/22185279/104509181-863cdd80-55a6-11eb-8a4b-120b0993876a.png)|

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5652 
