### PR TITLE
Design Panel: replace purples with blues in Animation panel

### DIFF
--- a/assets/src/edit-story/components/panels/design/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/design/animation/directionRadioInput.js
@@ -73,11 +73,11 @@ const Icon = styled.div`
   border-radius: 4px;
   stroke: #e4e5e6;
   stroke-width: 1px;
-  ${({ selected, disabled }) =>
+  ${({ selected, disabled, theme }) =>
     selected &&
     !disabled &&
     css`
-      background-color: #1a73e8;
+      background-color: ${theme.colors.accent.primary};
     `}
 
   ${({ disabled }) =>

--- a/assets/src/edit-story/components/panels/design/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/design/animation/directionRadioInput.js
@@ -77,7 +77,7 @@ const Icon = styled.div`
     selected &&
     !disabled &&
     css`
-      background-color: #51389d;
+      background-color: #1a73e8;
     `}
 
   ${({ disabled }) =>

--- a/assets/src/edit-story/components/panels/design/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooser.js
@@ -83,7 +83,8 @@ const ContentWrapper = styled.div`
 
 const GridItem = styled.button.attrs({ role: 'listitem' })`
   border: none;
-  background: ${({ active }) => (active ? '#1A73E8' : '#333')};
+  background: ${({ active, theme }) =>
+    active ? theme.colors.accent.primary : '#333'};
   border-radius: 4px;
   height: ${GRID_ITEM_HEIGHT}px;
   position: relative;
@@ -105,7 +106,8 @@ const GridItem = styled.button.attrs({ role: 'listitem' })`
 
   &:hover:not([aria-disabled='true']),
   &:focus:not([aria-disabled='true']) {
-    background: ${({ active }) => (active ? '#1A73E8' : '#1C73E8')};
+    background: ${({ active, theme }) =>
+      active ? theme.colors.accent.primary : '#1C73E8'};
 
     ${BaseAnimationCell} {
       display: inline-block;

--- a/assets/src/edit-story/components/panels/design/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooser.js
@@ -83,7 +83,7 @@ const ContentWrapper = styled.div`
 
 const GridItem = styled.button.attrs({ role: 'listitem' })`
   border: none;
-  background: ${({ active }) => (active ? '#5732A3' : '#333')};
+  background: ${({ active }) => (active ? '#1A73E8' : '#333')};
   border-radius: 4px;
   height: ${GRID_ITEM_HEIGHT}px;
   position: relative;
@@ -105,7 +105,7 @@ const GridItem = styled.button.attrs({ role: 'listitem' })`
 
   &:hover:not([aria-disabled='true']),
   &:focus:not([aria-disabled='true']) {
-    background: ${({ active }) => (active ? '#5732A3' : '#B488FC')};
+    background: ${({ active }) => (active ? '#1A73E8' : '#1C73E8')};
 
     ${BaseAnimationCell} {
       display: inline-block;


### PR DESCRIPTION
## Summary

Replaces the purple accent colors with blue accent colors in the animation section in the inspector. Sam likes these colors for now - we will be migrating to the new color palette soon: https://xwp.slack.com/archives/C01ESBB8ZN1/p1610645691003100?thread_ts=1610643192.002700&cid=C01ESBB8ZN1

## Relevant Technical Choices

none

## To-do

none

## User-facing changes

- dropdown now shows blue instead of purple when animations are selected
- dropdown now shows blue instead of purple when animations are hovered
- animation direction inputs are blue instead of purple when selected

## Testing Instructions

- go to editor
- add text to a story
- focus that text
- go to animation panel in inspector
- open dropdown. Should see blue when hovering and selecting an animation
- after selecting one of `fly, whoosh, scale, rotate` you should see the animation directions. Click those buttons to see the blues

![blues](https://user-images.githubusercontent.com/22185279/104628448-7a5c2480-5655-11eb-8641-c25812c6b2dd.gif)

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5875
