### PR TITLE
Text Sets: Add extra safety measures to avoid crashes

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -132,7 +132,7 @@ function TextSets({ paneRef }) {
   );
 
   const rowVirtualizer = useVirtual({
-    size: Math.ceil(filteredTextSets.length / 2),
+    size: Math.ceil((filteredTextSets || []).length / 2),
     parentRef: paneRef,
     estimateSize: useCallback(() => TEXT_SET_SIZE + TEXT_SET_ROW_GAP, []),
     overscan: 5,
@@ -185,14 +185,14 @@ function TextSets({ paneRef }) {
                 height={virtualRow.size}
                 translateY={virtualRow.start}
               >
-                {filteredTextSets[firstColumnIndex].length > 0 && (
+                {(filteredTextSets[firstColumnIndex] || []).length > 0 && (
                   <TextSet
                     key={firstColumnIndex}
                     elements={filteredTextSets[firstColumnIndex]}
                   />
                 )}
                 {filteredTextSets[secondColumnIndex] &&
-                  filteredTextSets[secondColumnIndex].length > 0 && (
+                  (filteredTextSets[secondColumnIndex] || []).length > 0 && (
                     <TextSet
                       key={secondColumnIndex}
                       elements={filteredTextSets[secondColumnIndex]}


### PR DESCRIPTION
## Summary
Just takes some precautions around indexing length on filtered text sets in the text pane.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
NA

## Testing Instructions
(I wasn't able to reproduce this from the get go, so kind of a week test but 🤷 )
-> open editor
-> click on the `T` to go to the text presets
-> See that theres no error

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5730 
