### PR TITLE
E2E Tests: Remove assets after every test

### DIFF
--- a/tests/e2e/specs/editor/media/insertMediaFromDialog.js
+++ b/tests/e2e/specs/editor/media/insertMediaFromDialog.js
@@ -17,9 +17,7 @@
 /**
  * Internal dependencies
  */
-import { createNewStory, clickButton } from '../../../utils';
-
-const MODAL = '.media-modal';
+import { createNewStory, uploadMedia, deleteMedia } from '../../../utils';
 
 describe('Inserting Media from Dialog', () => {
   // Uses the existence of the element's frame element as an indicator for successful insertion.
@@ -28,21 +26,12 @@ describe('Inserting Media from Dialog', () => {
 
     await expect(page).not.toMatchElement('[data-testid="FrameElement"]');
 
-    // TODO Use mediaUpload here.
+    const filename = await uploadMedia('example-1.jpg', false);
 
-    // Clicking will only act on the first element.
-    await expect(page).toClick('button', { text: 'Upload' });
-
-    await page.waitForSelector(MODAL, {
-      visible: true,
-    });
-    await expect(page).toClick('button', { text: 'Media Library' });
-
-    await clickButton(
-      '.attachments-browser .attachments .attachment:first-of-type'
-    );
     await expect(page).toClick('button', { text: 'Insert into page' });
 
     await expect(page).toMatchElement('[data-testid="imageElement"]');
+
+    await deleteMedia(filename);
   });
 });

--- a/tests/e2e/specs/editor/media/insertMediaFromLibrary.js
+++ b/tests/e2e/specs/editor/media/insertMediaFromLibrary.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { createNewStory } from '../../../utils';
+import { createNewStory, deleteMedia, uploadMedia } from '../../../utils';
 
 describe('Inserting Media from Media Library', () => {
   // Uses the existence of the element's frame element as an indicator for successful insertion.
@@ -25,6 +25,8 @@ describe('Inserting Media from Media Library', () => {
     await createNewStory();
 
     await expect(page).not.toMatchElement('[data-testid="FrameElement"]');
+
+    const filename = await uploadMedia('example-1.jpg', true);
 
     await page.waitForSelector('[data-testid="mediaElement-image"]');
     // Clicking will only act on the first element.
@@ -38,5 +40,7 @@ describe('Inserting Media from Media Library', () => {
     );
 
     await expect(page).toMatchElement('[data-testid="imageElement"]');
+
+    await deleteMedia(filename);
   });
 });

--- a/tests/e2e/specs/editor/media/insertMovVideo.js
+++ b/tests/e2e/specs/editor/media/insertMovVideo.js
@@ -46,7 +46,11 @@ describe('Inserting .mov from dialog', () => {
 
     await expect(page).not.toMatchElement('.type-video.subtype-quicktime');
 
-    expect(page).toClick('.media-modal-close');
+    await page.keyboard.press('Escape');
+
+    await page.waitForSelector(MODAL, {
+      visible: false,
+    });
 
     await deleteMedia(fileName);
   });

--- a/tests/e2e/specs/editor/media/insertMovVideo.js
+++ b/tests/e2e/specs/editor/media/insertMovVideo.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { createNewStory, clickButton } from '../../../utils';
+import { createNewStory, clickButton, uploadFile, deleteMedia } from '../../../utils';
 
 const MODAL = '.media-modal';
 
@@ -27,12 +27,14 @@ describe('Inserting .mov from dialog', () => {
     await createNewStory();
     await expect(page).not.toMatchElement('[data-testid="FrameElement"]');
 
-    // TODO Use mediaUpload here.
     await expect(page).toClick('button', { text: 'Upload' });
 
     await page.waitForSelector(MODAL, {
       visible: true,
     });
+
+    const fileName = await uploadFile('small-video.mov');
+
     await expect(page).toClick('button', { text: 'Media Library' });
     await clickButton(
       '.attachments-browser .attachments .attachment:first-of-type'
@@ -41,5 +43,7 @@ describe('Inserting .mov from dialog', () => {
     await expect(page).not.toMatchElement('.type-video.subtype-quicktime');
 
     expect(page).toClick('.media-modal-close');
+
+    await deleteMedia(fileName);
   });
 });

--- a/tests/e2e/specs/editor/media/insertMovVideo.js
+++ b/tests/e2e/specs/editor/media/insertMovVideo.js
@@ -39,6 +39,7 @@ describe('Inserting .mov from dialog', () => {
     });
 
     const fileName = await uploadFile('small-video.mov', false);
+    const fileNameNoExt = fileName.replace(/\.[^/.]+$/, '');
 
     await clickButton(
       '.attachments-browser .attachments .attachment:first-of-type'
@@ -52,6 +53,6 @@ describe('Inserting .mov from dialog', () => {
       visible: false,
     });
 
-    await deleteMedia(fileName);
+    await deleteMedia(fileNameNoExt);
   });
 });

--- a/tests/e2e/specs/editor/media/insertMovVideo.js
+++ b/tests/e2e/specs/editor/media/insertMovVideo.js
@@ -17,7 +17,12 @@
 /**
  * Internal dependencies
  */
-import { createNewStory, clickButton, uploadFile, deleteMedia } from '../../../utils';
+import {
+  createNewStory,
+  clickButton,
+  uploadFile,
+  deleteMedia,
+} from '../../../utils';
 
 const MODAL = '.media-modal';
 
@@ -33,9 +38,8 @@ describe('Inserting .mov from dialog', () => {
       visible: true,
     });
 
-    const fileName = await uploadFile('small-video.mov');
+    const fileName = await uploadFile('small-video.mov', false);
 
-    await expect(page).toClick('button', { text: 'Media Library' });
     await clickButton(
       '.attachments-browser .attachments .attachment:first-of-type'
     );

--- a/tests/e2e/specs/editor/media/svg.js
+++ b/tests/e2e/specs/editor/media/svg.js
@@ -24,8 +24,9 @@ import { percySnapshot } from '@percy/puppeteer';
  */
 import {
   withExperimentalFeatures,
-  uploadFile,
   createNewStory,
+  uploadMedia,
+  deleteMedia,
 } from '../../../utils';
 
 describe('SVG', () => {
@@ -56,16 +57,14 @@ describe('SVG', () => {
 
     await expect(page).not.toMatchElement('[data-testid="FrameElement"]');
 
-    // TODO Use mediaUpload here.
-    await expect(page).toClick('button', { text: 'Upload' });
-    await expect(page).toMatch('Upload to Story');
-
-    await uploadFile('close.svg');
+    const filename = await uploadMedia('close.svg', false);
 
     await expect(page).toClick('button', { text: 'Insert into page' });
 
     await expect(page).toMatchElement('[data-testid="imageElement"]');
 
     await percySnapshot(page, 'Uploading SVG to editor');
+
+    await deleteMedia(filename);
   });
 });

--- a/tests/e2e/utils/uploadFile.js
+++ b/tests/e2e/utils/uploadFile.js
@@ -28,9 +28,10 @@ import { v4 as uuid } from 'uuid';
  * The file should reside in tests/e2e/assets/.
  *
  * @param {string|null} file The file name to upload, for example 'foo.mp4'.
+ * @param {boolean} checkUpload Check upload was successfully.
  * @return {string|null} The name of the file as it was uploaded.
  */
-async function uploadFile(file) {
+async function uploadFile(file, checkUpload = true) {
   const fileExtension = extname(file);
   await page.setDefaultTimeout(10000);
 
@@ -50,7 +51,9 @@ async function uploadFile(file) {
   await expect(page).not.toMatchElement('.media-modal .upload-error');
 
   // Upload successful!
-  await page.waitForSelector(`.media-modal li[aria-label="${newBaseName}"]`);
+  if (checkUpload) {
+    await page.waitForSelector(`.media-modal li[aria-label="${newBaseName}"]`);
+  }
   await page.setDefaultTimeout(3000);
 
   return newFileName;


### PR DESCRIPTION
## Summary

As part of #5623 it is cleaner to import asset on tests only as they are needed.

Requires #5849

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

- Remove these lines 
https://github.com/google/web-stories-wp/blob/413b113b1f81eba2dcc0d3988d10e20a5889f955/bin/local-env/install-wordpress.sh#L173-L175
https://github.com/google/web-stories-wp/blob/413b113b1f81eba2dcc0d3988d10e20a5889f955/bin/local-env/install-wordpress.sh#L160
- Merge #5849 first.

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes  #5623
