### PR TITLE
Telemetry: Let links open in new tab

### DIFF
--- a/assets/src/tracking/trackClick.js
+++ b/assets/src/tracking/trackClick.js
@@ -38,13 +38,24 @@ async function trackClick(event, eventName, eventCategory, url) {
     return Promise.resolve();
   }
 
-  event.preventDefault();
-
   const eventData = {
     send_to: config.trackingId,
     event_category: eventCategory,
     event_label: url,
   };
+
+  const openLinkInNewTab =
+    event.target === '_blank' ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.metaKey ||
+    event.which === 2;
+
+  if (openLinkInNewTab) {
+    return track(eventName, eventData);
+  }
+
+  event.preventDefault();
 
   return track(eventName, eventData).finally(() => {
     document.location = url;

--- a/assets/src/tracking/trackClick.js
+++ b/assets/src/tracking/trackClick.js
@@ -45,7 +45,7 @@ async function trackClick(event, eventName, eventCategory, url) {
   };
 
   const openLinkInNewTab =
-    event.target === '_blank' ||
+    event.currentTarget.target === '_blank' ||
     event.ctrlKey ||
     event.shiftKey ||
     event.metaKey ||


### PR DESCRIPTION
## Summary

Copy and paste from original ticket - #5799

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Opt-in to data sharing in dashboard settings
2. Reload page
3. Click on the "Learn more" link under the monetization section
4. Verify that link opens in new tab
5. CMD+Click on the same link and verify that it still opens in a new tab
6. Repeat in other browsers

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5799
