### PR TITLE
Only show design safe zone if actually dragging

### DIFF
--- a/assets/src/edit-story/components/canvas/utils/useSnapping.js
+++ b/assets/src/edit-story/components/canvas/utils/useSnapping.js
@@ -75,13 +75,15 @@ function useSnapping({
     ({ elements }) =>
       // Show design space if we're snapping to any of its edges
       toggleDesignSpace(
-        elements
-          .flat()
-          .some(
-            ({ center, element }) => element === designSpaceGuideline && !center
-          )
+        isDragging &&
+          elements
+            .flat()
+            .some(
+              ({ center, element }) =>
+                element === designSpaceGuideline && !center
+            )
       ),
-    [toggleDesignSpace, designSpaceGuideline]
+    [toggleDesignSpace, isDragging, designSpaceGuideline]
   );
 
   // Always hide design space guideline when dragging stops


### PR DESCRIPTION
## Summary

Snap event is thrown by moveable even if dragging never starts. This makes sure that design guideline is only shown if snapping occurs **and** user is actually dragging something.

| Before | After |
|-|-|
| ![design-guideline-before](https://user-images.githubusercontent.com/637548/104775243-064d7980-5746-11eb-98e8-99c463f77211.gif) | ![design-guideline-after](https://user-images.githubusercontent.com/637548/104775246-077ea680-5746-11eb-9292-d2aa947dd25f.gif) |

## Testing Instructions

* Place an element so it aligns with the design guideline
* Unselect the element
* Re-select the element using the mouse, but with just a single fast click, no dragging.
* Observe that no design guideline is displayed let alone stuck afterward.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5456
