### PR TITLE
Shapes: Fix drop-targeting for flipped elements

### DIFF
--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
@@ -99,6 +99,10 @@ function combineElements(state, { firstElement, secondId }) {
       propsFromFirst.push('border');
       propsFromFirst.push('borderRadius');
     }
+  } else {
+    // If we're dropping into background, maintain the flip, too.
+    // @todo This behavior has been since the beginning, however, it's not consistent with how other elements behave -- needs confirmation.
+    propsFromFirst.push('flip');
   }
   const mediaProps = objectPick(element, propsFromFirst);
 

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
@@ -87,7 +87,6 @@ function combineElements(state, { firstElement, secondId }) {
     'scale',
     'focalX',
     'focalY',
-    'flip',
     'backgroundOverlay',
     'tracks',
   ];
@@ -113,7 +112,6 @@ function combineElements(state, { firstElement, secondId }) {
     ]),
     // Then set sensible default attributes
     ...DEFAULT_ATTRIBUTES_FOR_MEDIA,
-    flip: {},
     // Then copy all media-related attributes from new element
     ...mediaProps,
     // Only copy position properties for backgrounds, as they're ignored while being background

--- a/assets/src/edit-story/app/story/useStoryReducer/test/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/combineElements.js
@@ -127,11 +127,14 @@ describe('combineElements', () => {
         focalX: 20,
         focalY: 50,
         scale: 100,
-        flip: {},
         x: 20,
         y: 20,
         width: 20,
         height: 20,
+        flip: {
+          vertical: false,
+          horizontal: true,
+        },
       },
     ]);
   });
@@ -167,12 +170,15 @@ describe('combineElements', () => {
         focalX: 20,
         focalY: 50,
         scale: 100,
-        flip: {},
         x: 20,
         y: 20,
         width: 20,
         height: 20,
         tracks: ['track-1'],
+        flip: {
+          vertical: false,
+          horizontal: true,
+        },
       },
     ]);
   });
@@ -197,7 +203,6 @@ describe('combineElements', () => {
         focalX: 50,
         focalY: 50,
         scale: 100,
-        flip: {},
         x: 10,
         y: 10,
         width: 10,
@@ -227,7 +232,6 @@ describe('combineElements', () => {
         focalX: 50,
         focalY: 50,
         scale: 100,
-        flip: {},
         x: 10,
         y: 10,
         width: 10,
@@ -263,7 +267,6 @@ describe('combineElements', () => {
         focalX: 50,
         focalY: 50,
         scale: 100,
-        flip: {},
         x: 30,
         y: 30,
         width: 30,
@@ -324,7 +327,6 @@ describe('combineElements', () => {
       expect(result.pages[0].elements[0]).toStrictEqual({
         id: '123',
         isBackground: true,
-        flip: {},
         focalX: 50,
         focalY: 50,
         height: 10,
@@ -353,7 +355,6 @@ describe('combineElements', () => {
       });
 
       expect(result.pages[0].elements[1]).toStrictEqual({
-        flip: {},
         focalX: 50,
         focalY: 50,
         height: 10,
@@ -404,7 +405,6 @@ describe('combineElements', () => {
         width: 10,
         x: 10,
         y: 10,
-        flip: {},
         focalX: 50,
         focalY: 50,
       });
@@ -427,7 +427,6 @@ describe('combineElements', () => {
       expect(result.pages[0].elements[0]).toStrictEqual({
         id: '123',
         isBackground: true,
-        flip: {},
         focalX: 50,
         focalY: 50,
         height: 10,
@@ -456,7 +455,6 @@ describe('combineElements', () => {
       });
 
       expect(result.pages[0].elements[2]).toStrictEqual({
-        flip: {},
         focalX: 50,
         focalY: 50,
         height: 10,
@@ -509,7 +507,6 @@ describe('combineElements', () => {
         width: 10,
         x: 10,
         y: 10,
-        flip: {},
         focalX: 50,
         focalY: 50,
       });
@@ -532,7 +529,6 @@ describe('combineElements', () => {
       expect(result.pages[0].elements[0]).toStrictEqual({
         id: '123',
         isBackground: true,
-        flip: {},
         focalX: 50,
         focalY: 50,
         height: 10,
@@ -561,7 +557,6 @@ describe('combineElements', () => {
       });
 
       expect(result.pages[0].elements[2]).toStrictEqual({
-        flip: {},
         focalX: 50,
         focalY: 50,
         height: 10,
@@ -614,7 +609,6 @@ describe('combineElements', () => {
         width: 10,
         x: 10,
         y: 10,
-        flip: {},
         focalX: 50,
         focalY: 50,
       });
@@ -658,6 +652,10 @@ function getDefaultState1() {
             y: 20,
             width: 20,
             height: 20,
+            flip: {
+              vertical: false,
+              horizontal: true,
+            },
           },
         ],
       },

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -41,6 +41,7 @@ import {
   getResponsiveBorder,
   shouldDisplayBorder,
 } from '../../utils/elementBorder';
+import getTransformFlip from '../../elements/shared/getTransformFlip';
 
 const Wrapper = styled.div`
   ${elementWithPosition}
@@ -62,6 +63,8 @@ const ReplacementContainer = styled.div`
   transition: opacity 0.25s cubic-bezier(0, 0, 0.54, 1);
   pointer-events: none;
   opacity: ${({ hasReplacement }) => (hasReplacement ? 1 : 0)};
+  transform: ${({ flip }) => (flip ? getTransformFlip(flip) : null)};
+  height: 100%;
 `;
 
 function AnimationWrapper({ children, id, isAnimatable }) {
@@ -108,6 +111,7 @@ function DisplayElement({ element, previewMode, isAnimatable = false }) {
     isBackground,
     backgroundOverlay,
     border = {},
+    flip,
   } = element;
   const { Display } = getDefinitionForType(type);
   const { Display: Replacement } =
@@ -164,7 +168,10 @@ function DisplayElement({ element, previewMode, isAnimatable = false }) {
           <Display element={element} previewMode={previewMode} box={box} />
         </WithMask>
         {!previewMode && (
-          <ReplacementContainer hasReplacement={Boolean(replacementElement)}>
+          <ReplacementContainer
+            flip={flip}
+            hasReplacement={Boolean(replacementElement)}
+          >
             {replacementElement && (
               <WithMask
                 element={replacementElement}

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -61,7 +61,7 @@ const EmptyFrame = styled.div`
 `;
 
 function FrameElement({ element }) {
-  const { id, type } = element;
+  const { id, type, flip } = element;
   const { Frame, isMaskable, Controls } = getDefinitionForType(type);
   const elementRef = useRef();
   const [hovering, setHovering] = useState(false);
@@ -151,7 +151,7 @@ function FrameElement({ element }) {
         isAnimating={isAnimating}
         data-testid="frameElement"
       >
-        <WithMask element={element} fill={true}>
+        <WithMask element={element} fill={true} flip={flip}>
           {Frame ? (
             <Frame wrapperRef={elementRef} element={element} box={box} />
           ) : (

--- a/assets/src/edit-story/masks/frame.js
+++ b/assets/src/edit-story/masks/frame.js
@@ -26,6 +26,7 @@ import { useRef, useEffect, useState } from 'react';
  */
 import StoryPropTypes from '../types';
 import { useDropTargets } from '../app';
+import getTransformFlip from '../elements/shared/getTransformFlip';
 import { getElementMask, MaskTypes } from './';
 
 const FILL_STYLE = {
@@ -74,6 +75,14 @@ function WithDropTarget({ element, children, hover }) {
     return children;
   }
 
+  const pathProps = {
+    vectorEffect: 'non-scaling-stroke',
+    fill: 'none',
+    strokeLinecap: 'round',
+    strokeLinejoin: 'round',
+    d: mask?.path,
+    stroke: '#0063F9',
+  };
   return (
     <>
       {children}
@@ -88,13 +97,8 @@ function WithDropTarget({ element, children, hover }) {
       >
         {/** Suble indicator that the element has a drop target */}
         <DropTargetPath
-          vectorEffect="non-scaling-stroke"
+          {...pathProps}
           strokeWidth="4"
-          fill="none"
-          stroke="#0063F9"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d={mask?.path}
           style={
             (hover && !draggingResource) ||
             (Boolean(draggingResource) &&
@@ -107,13 +111,8 @@ function WithDropTarget({ element, children, hover }) {
         {/** Drop target shown when an element is in the drop target area  */}
         <DropTargetPath
           ref={pathRef}
-          vectorEffect="non-scaling-stroke"
+          {...pathProps}
           strokeWidth="48"
-          fill="none"
-          stroke="#0063F9"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          d={mask?.path}
           active={activeDropTargetId === element.id}
         />
       </DropTargetSVG>
@@ -130,14 +129,17 @@ WithDropTarget.propTypes = {
 export default function WithMask({ element, fill, style, children, ...rest }) {
   const [hover, setHover] = useState(false);
   const { isBackground } = element;
+  const { flip } = rest;
 
   const mask = getElementMask(element);
+  const flipStyle = flip ? { transform: getTransformFlip(flip) } : null;
   if (!mask?.type || (isBackground && mask.type !== MaskTypes.RECTANGLE)) {
     return (
       <div
         style={{
           ...(fill ? FILL_STYLE : {}),
           ...style,
+          ...flipStyle,
         }}
         {...rest}
       >
@@ -156,6 +158,7 @@ export default function WithMask({ element, fill, style, children, ...rest }) {
       style={{
         ...(fill ? FILL_STYLE : {}),
         ...style,
+        ...flipStyle,
         ...(!isBackground ? { clipPath: `url(#${maskId})` } : {}),
       }}
       {...rest}


### PR DESCRIPTION
## Summary
- Retains the flip of the element that's drop-targeted into.
- Displays the frame of the element flipped, too.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- Flipped element's drop-target frame is now displayed the same way as the element itself.
- Flipping is retained when another element is dropped into this element.
<!-- Please describe your changes. -->

## Testing Instructions
- Add a non-rectangular shape, flip it
- Hover over the flipped shape, verify the frame is also displayed flipped-
- Add an image
- Drop-target the image into the flipped shape
- Verify the shaped image is still flipped.
<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #1111 
