### PR TITLE
Editor: ensure global variables are defined

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -400,6 +400,14 @@ class Story_Post_Type {
 			// custom editor after the 'current_screen' action when we can be certain the
 			// $post_type, $post_type_object, $post globals are all set by WordPress.
 			if ( did_action( 'current_screen' ) ) {
+
+				// Some plugins cause the following globals to be absent at this point,
+				// so edit-story.php and get_editor_settings() won't be able to access them.
+				// Explicitly set the globals to prevent issues when loading the editor.
+
+				$GLOBALS['post']             = $post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$GLOBALS['post_type']        = $post->post_type; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$GLOBALS['post_type_object'] = get_post_type_object( $post->post_type ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/admin/edit-story.php';
 			}
 

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -399,7 +399,7 @@ class Story_Post_Type {
 			// Since the 'replace_editor' filter can be run multiple times, only load the
 			// custom editor after the 'current_screen' action and when we can be certain the
 			// $post_type, $post_type_object, $post globals are all set by WordPress.
-			if ( null !== $GLOBALS['post'] && did_action( 'current_screen' ) ) {
+			if ( $post === $GLOBALS['post'] && did_action( 'current_screen' ) ) {
 				require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/admin/edit-story.php';
 			}
 

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -397,17 +397,9 @@ class Story_Post_Type {
 		if ( self::POST_TYPE_SLUG === get_post_type( $post ) ) {
 
 			// Since the 'replace_editor' filter can be run multiple times, only load the
-			// custom editor after the 'current_screen' action when we can be certain the
-			// $post_type, $post_type_object, $post globals are all set by WordPress.
-			if ( did_action( 'current_screen' ) ) {
-
-				// Some plugins cause the following globals to be absent at this point,
-				// so edit-story.php and get_editor_settings() won't be able to access them.
-				// Explicitly set the globals to prevent issues when loading the editor.
-
-				$GLOBALS['post']             = $post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$GLOBALS['post_type']        = $post->post_type; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-				$GLOBALS['post_type_object'] = get_post_type_object( $post->post_type ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			// custom editor after the 'current_screen' action and when we can be certain the
+			// $post global is available.
+			if ( null !== $GLOBALS['post'] && did_action( 'current_screen' ) ) {
 				require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/admin/edit-story.php';
 			}
 

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -399,7 +399,7 @@ class Story_Post_Type {
 			// Since the 'replace_editor' filter can be run multiple times, only load the
 			// custom editor after the 'current_screen' action and when we can be certain the
 			// $post_type, $post_type_object, $post globals are all set by WordPress.
-			if ( $post === $GLOBALS['post'] && did_action( 'current_screen' ) ) {
+			if ( isset( $GLOBALS['post'] ) && $post === $GLOBALS['post'] && did_action( 'current_screen' ) ) {
 				require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/admin/edit-story.php';
 			}
 

--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -398,7 +398,7 @@ class Story_Post_Type {
 
 			// Since the 'replace_editor' filter can be run multiple times, only load the
 			// custom editor after the 'current_screen' action and when we can be certain the
-			// $post global is available.
+			// $post_type, $post_type_object, $post globals are all set by WordPress.
 			if ( null !== $GLOBALS['post'] && did_action( 'current_screen' ) ) {
 				require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/admin/edit-story.php';
 			}

--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -29,6 +29,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
+// These globals are guaranteed to exist at this point, due to
+// Story_Post_Type::replace_editor() explicitly defining them.
 global $post_type, $post_type_object, $post;
 
 $rest_base = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;

--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -29,8 +29,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
-// These globals are guaranteed to exist at this point, due to
-// Story_Post_Type::replace_editor() explicitly defining them.
 global $post_type, $post_type_object, $post;
 
 $rest_base = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;


### PR DESCRIPTION
## Summary

This fixes an incompatibility with a plugin mentioned in #5964, which somehow causes the global `$post` variable (and others) to be `null`.

I have not yet found the reason why said plugin does this, but explicitly defining the globals this way resolves the issue.

## Relevant Technical Choices

Explicitly define globals, suppressing PHPCS errors accordingly.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

N/A

## Testing Instructions

N/A

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5964
