### PR TITLE
FTUE: REST API endpoint for tips

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -182,6 +182,13 @@ class Plugin {
 	public $svg;
 
 	/**
+	 * User_Preferences.
+	 *
+	 * @var User_Preferences
+	 */
+	public $user_preferences;
+
+	/**
 	 * Initialize plugin functionality.
 	 *
 	 * @since 1.0.0
@@ -251,6 +258,9 @@ class Plugin {
 
 		$this->ad_manager = new Ad_Manager();
 		add_action( 'init', [ $this->ad_manager, 'init' ] );
+
+		$this->user_preferences = new User_Preferences();
+		add_action( 'init', [ $this->user_preferences, 'init' ] );
 
 		$this->svg = new SVG( $this->experiments );
 		add_action( 'init', [ $this->svg, 'init' ] );

--- a/includes/Tracking.php
+++ b/includes/Tracking.php
@@ -47,13 +47,6 @@ class Tracking {
 	const TRACKING_ID = 'UA-168571240-1';
 
 	/**
-	 * Name of the user meta key used for opt-in.
-	 *
-	 * @var string
-	 */
-	const OPTIN_META_KEY = 'web_stories_tracking_optin';
-
-	/**
 	 * Initializes tracking.
 	 *
 	 * Registers the setting in WordPress.
@@ -63,21 +56,6 @@ class Tracking {
 	 * @return void
 	 */
 	public function init() {
-		register_meta(
-			'user',
-			static::OPTIN_META_KEY,
-			[
-				'type'              => 'boolean',
-				'sanitize_callback' => 'rest_sanitize_boolean',
-				'default'           => false,
-				'show_in_rest'      => true,
-				'auth_callback'     => static function() {
-					return current_user_can( 'edit_user', get_current_user_id() );
-				},
-				'single'            => true,
-			]
-		);
-
 		// By not passing an actual script src we can print only the inline script.
 		wp_register_script(
 			self::SCRIPT_HANDLE,
@@ -113,6 +91,6 @@ class Tracking {
 	 * @return bool True if tracking enabled, and False if not.
 	 */
 	public function is_active() {
-		return (bool) get_user_meta( get_current_user_id(), static::OPTIN_META_KEY, true );
+		return (bool) get_user_meta( get_current_user_id(), User_Preferences::OPTIN_META_KEY, true );
 	}
 }

--- a/includes/User_Preferences.php
+++ b/includes/User_Preferences.php
@@ -40,6 +40,13 @@ class User_Preferences {
 	const OPTIN_META_KEY = 'web_stories_tracking_optin';
 
 	/**
+	 * Name of the user meta key used for onboarding.
+	 *
+	 * @var string
+	 */
+	const ONBOARDING_META_KEY = 'web_stories_onboarding';
+
+	/**
 	 * Initializes User_Preferences.
 	 *
 	 * Registers the setting in WordPress.
@@ -57,11 +64,34 @@ class User_Preferences {
 				'sanitize_callback' => 'rest_sanitize_boolean',
 				'default'           => false,
 				'show_in_rest'      => true,
-				'auth_callback'     => static function() {
-					return current_user_can( 'edit_user', get_current_user_id() );
-				},
+				'auth_callback'     => [ $this, 'can_edit_current_user' ],
 				'single'            => true,
 			]
 		);
+
+		register_meta(
+			'user',
+			static::ONBOARDING_META_KEY,
+			[
+				'type'          => 'object',
+				'default'       => [],
+				'show_in_rest'  => [
+					'schema' => [
+						'additionalProperties' => true,
+					],
+				],
+				'auth_callback' => [ $this, 'can_edit_current_user' ],
+				'single'        => true,
+			]
+		);
+	}
+
+	/**
+	 * Auth callback.
+	 *
+	 * @return bool
+	 */
+	public function can_edit_current_user() {
+		return current_user_can( 'edit_user', get_current_user_id() );
 	}
 }

--- a/includes/User_Preferences.php
+++ b/includes/User_Preferences.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * User Preferences class.
+ *
+ * Register user meta.
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories;
+
+/**
+ * User Preferences class.
+ */
+class User_Preferences {
+	/**
+	 * Name of the user meta key used for opt-in.
+	 *
+	 * @var string
+	 */
+	const OPTIN_META_KEY = 'web_stories_tracking_optin';
+
+	/**
+	 * Initializes User_Preferences.
+	 *
+	 * Registers the setting in WordPress.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function init() {
+		register_meta(
+			'user',
+			static::OPTIN_META_KEY,
+			[
+				'type'              => 'boolean',
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'default'           => false,
+				'show_in_rest'      => true,
+				'auth_callback'     => static function() {
+					return current_user_can( 'edit_user', get_current_user_id() );
+				},
+				'single'            => true,
+			]
+		);
+	}
+}

--- a/includes/User_Preferences.php
+++ b/includes/User_Preferences.php
@@ -77,6 +77,7 @@ class User_Preferences {
 				'default'       => [],
 				'show_in_rest'  => [
 					'schema' => [
+						'properties'           => [],
 						'additionalProperties' => true,
 					],
 				],

--- a/includes/uninstall.php
+++ b/includes/uninstall.php
@@ -125,7 +125,7 @@ function delete_stories_post_meta() {
  * @return void
  */
 function delete_stories_user_meta() {
-	delete_metadata( 'user', 0, Tracking::OPTIN_META_KEY, '', true );
+	delete_metadata( 'user', 0, User_Preferences::OPTIN_META_KEY, '', true );
 }
 
 /**

--- a/includes/uninstall.php
+++ b/includes/uninstall.php
@@ -126,6 +126,7 @@ function delete_stories_post_meta() {
  */
 function delete_stories_user_meta() {
 	delete_metadata( 'user', 0, User_Preferences::OPTIN_META_KEY, '', true );
+	delete_metadata( 'user', 0, User_Preferences::ONBOARDING_META_KEY, '', true );
 }
 
 /**

--- a/tests/phpunit/tests/Tracking.php
+++ b/tests/phpunit/tests/Tracking.php
@@ -26,90 +26,17 @@ use WP_REST_Request;
 class Tracking extends \WP_UnitTestCase {
 	protected static $user_id;
 
-	protected static $author_id;
-
 	public static function wpSetUpBeforeClass( $factory ) {
 		self::$user_id = $factory->user->create(
 			[
 				'role' => 'administrator',
 			]
 		);
-
-		self::$author_id = $factory->user->create(
-			[
-				'role' => 'author',
-			]
-		);
 	}
 
 	public static function wpTearDownAfterClass() {
 		self::delete_user( self::$user_id );
-		self::delete_user( self::$author_id );
 	}
-
-	public function tearDown() {
-		unregister_meta_key( 'user', \Google\Web_Stories\Tracking::OPTIN_META_KEY );
-		parent::tearDown();
-	}
-
-	/**
-	 * @covers ::init
-	 */
-	public function test_add_optin_field_to_rest_api() {
-		wp_set_current_user( self::$user_id );
-		( new \Google\Web_Stories\Tracking() )->init();
-		add_user_meta( get_current_user_id(), \Google\Web_Stories\Tracking::OPTIN_META_KEY, true );
-
-		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, sprintf( '/wp/v2/users/%d', self::$user_id ) );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertArrayHasKey( 'meta', $data );
-		$this->assertArrayHasKey( \Google\Web_Stories\Tracking::OPTIN_META_KEY, $data['meta'] );
-		$this->assertTrue( $data['meta'][ \Google\Web_Stories\Tracking::OPTIN_META_KEY ] );
-	}
-
-	/**
-	 * @covers ::init
-	 */
-	public function test_add_optin_field_to_rest_api_for_author_user() {
-		wp_set_current_user( self::$author_id );
-		( new \Google\Web_Stories\Tracking() )->init();
-		add_user_meta( get_current_user_id(), \Google\Web_Stories\Tracking::OPTIN_META_KEY, true );
-
-		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, '/wp/v2/users/me' );
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertArrayHasKey( 'meta', $data );
-		$this->assertArrayHasKey( \Google\Web_Stories\Tracking::OPTIN_META_KEY, $data['meta'] );
-		$this->assertTrue( $data['meta'][ \Google\Web_Stories\Tracking::OPTIN_META_KEY ] );
-	}
-
-	/**
-	 * @covers ::init
-	 */
-	public function test_enables_author_user_to_update_meta_field() {
-		wp_set_current_user( self::$author_id );
-		( new \Google\Web_Stories\Tracking() )->init();
-		add_user_meta( get_current_user_id(), \Google\Web_Stories\Tracking::OPTIN_META_KEY, false );
-
-		$request = new WP_REST_Request( \WP_REST_Server::CREATABLE, '/wp/v2/users/me' );
-		$request->set_body_params(
-			[
-				'meta' => [
-					\Google\Web_Stories\Tracking::OPTIN_META_KEY => true,
-				],
-			]
-		);
-		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
-
-		$this->assertArrayHasKey( 'meta', $data );
-		$this->assertArrayHasKey( \Google\Web_Stories\Tracking::OPTIN_META_KEY, $data['meta'] );
-		$this->assertTrue( $data['meta'][ \Google\Web_Stories\Tracking::OPTIN_META_KEY ] );
-	}
-
 
 	/**
 	 * @covers ::init
@@ -142,7 +69,7 @@ class Tracking extends \WP_UnitTestCase {
 	 */
 	public function test_get_settings_with_optin() {
 		wp_set_current_user( self::$user_id );
-		add_user_meta( get_current_user_id(), \Google\Web_Stories\Tracking::OPTIN_META_KEY, true );
+		add_user_meta( get_current_user_id(), \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, true );
 
 		$settings = ( new \Google\Web_Stories\Tracking() )->get_settings();
 
@@ -151,7 +78,7 @@ class Tracking extends \WP_UnitTestCase {
 			'trackingId'      => \Google\Web_Stories\Tracking::TRACKING_ID,
 		];
 
-		delete_user_meta( get_current_user_id(), \Google\Web_Stories\Tracking::OPTIN_META_KEY );
+		delete_user_meta( get_current_user_id(), \Google\Web_Stories\User_Preferences::OPTIN_META_KEY );
 
 		$this->assertEqualSetsWithIndex( $expected, $settings );
 	}

--- a/tests/phpunit/tests/Uninstall.php
+++ b/tests/phpunit/tests/Uninstall.php
@@ -39,7 +39,7 @@ class Uninstall extends \WP_UnitTestCase {
 		set_transient( 'web_stories_link_data_fdsf', 'hello' );
 		set_site_transient( 'web_stories_updater', 'hello' );
 		self::$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
-		add_user_meta( self::$user_id, \Google\Web_Stories\Tracking::OPTIN_META_KEY, true );
+		add_user_meta( self::$user_id, \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, true );
 	}
 
 	public function test_delete_options() {
@@ -78,7 +78,7 @@ class Uninstall extends \WP_UnitTestCase {
 
 	public function test_delete_stories_user_meta() {
 		\Google\Web_Stories\delete_stories_user_meta();
-		$user_meta = (bool) get_user_meta( self::$user_id, \Google\Web_Stories\Tracking::OPTIN_META_KEY, true );
+		$user_meta = (bool) get_user_meta( self::$user_id, \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, true );
 		$this->assertFalse( $user_meta );
 	}
 

--- a/tests/phpunit/tests/Uninstall.php
+++ b/tests/phpunit/tests/Uninstall.php
@@ -40,6 +40,7 @@ class Uninstall extends \WP_UnitTestCase {
 		set_site_transient( 'web_stories_updater', 'hello' );
 		self::$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		add_user_meta( self::$user_id, \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, true );
+		add_user_meta( self::$user_id, \Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY, [ 'hello' => 'world' ] );
 	}
 
 	public function test_delete_options() {
@@ -78,8 +79,9 @@ class Uninstall extends \WP_UnitTestCase {
 
 	public function test_delete_stories_user_meta() {
 		\Google\Web_Stories\delete_stories_user_meta();
-		$user_meta = (bool) get_user_meta( self::$user_id, \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, true );
-		$this->assertFalse( $user_meta );
+		$user_meta = get_user_meta( self::$user_id );
+		$this->assertArrayNotHasKey( \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, $user_meta );
+		$this->assertArrayNotHasKey( \Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY, $user_meta );
 	}
 
 

--- a/tests/phpunit/tests/User_Preferences.php
+++ b/tests/phpunit/tests/User_Preferences.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests;
+
+use Spy_REST_Server;
+use WP_REST_Request;
+
+/**
+ * @coversDefaultClass \Google\Web_Stories\User_Preferences
+ */
+class User_Preferences extends \WP_UnitTestCase {
+	protected static $user_id;
+
+	protected static $author_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user_id = $factory->user->create(
+			[
+				'role' => 'administrator',
+			]
+		);
+
+		self::$author_id = $factory->user->create(
+			[
+				'role' => 'author',
+			]
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$user_id );
+		self::delete_user( self::$author_id );
+	}
+
+	public function tearDown() {
+		unregister_meta_key( 'user', \Google\Web_Stories\User_Preferences::OPTIN_META_KEY );
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers ::init
+	 */
+	public function test_add_optin_field_to_rest_api() {
+		wp_set_current_user( self::$user_id );
+		( new \Google\Web_Stories\Tracking() )->init();
+		add_user_meta( get_current_user_id(), \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, true );
+
+		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, sprintf( '/wp/v2/users/%d', self::$user_id ) );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'meta', $data );
+		$this->assertArrayHasKey( \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, $data['meta'] );
+		$this->assertTrue( $data['meta'][ \Google\Web_Stories\User_Preferences::OPTIN_META_KEY ] );
+	}
+
+	/**
+	 * @covers ::init
+	 */
+	public function test_add_optin_field_to_rest_api_for_author_user() {
+		wp_set_current_user( self::$author_id );
+		( new \Google\Web_Stories\Tracking() )->init();
+		add_user_meta( get_current_user_id(), \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, true );
+
+		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, '/wp/v2/users/me' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'meta', $data );
+		$this->assertArrayHasKey( \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, $data['meta'] );
+		$this->assertTrue( $data['meta'][ \Google\Web_Stories\User_Preferences::OPTIN_META_KEY ] );
+	}
+
+	/**
+	 * @covers ::init
+	 */
+	public function test_enables_author_user_to_update_meta_field() {
+		wp_set_current_user( self::$author_id );
+		( new \Google\Web_Stories\Tracking() )->init();
+		add_user_meta( get_current_user_id(), \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, false );
+
+		$request = new WP_REST_Request( \WP_REST_Server::CREATABLE, '/wp/v2/users/me' );
+		$request->set_body_params(
+			[
+				'meta' => [
+					\Google\Web_Stories\User_Preferences::OPTIN_META_KEY => true,
+				],
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'meta', $data );
+		$this->assertArrayHasKey( \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, $data['meta'] );
+		$this->assertTrue( $data['meta'][ \Google\Web_Stories\User_Preferences::OPTIN_META_KEY ] );
+	}
+}

--- a/tests/phpunit/tests/User_Preferences.php
+++ b/tests/phpunit/tests/User_Preferences.php
@@ -23,7 +23,7 @@ use WP_REST_Request;
 /**
  * @coversDefaultClass \Google\Web_Stories\User_Preferences
  */
-class User_Preferences extends \WP_Test_REST_TestCase {
+class User_Preferences extends \WP_UnitTestCase {
 	protected static $user_id;
 
 	protected static $author_id;
@@ -142,7 +142,13 @@ class User_Preferences extends \WP_Test_REST_TestCase {
 			]
 		);
 		$response = rest_get_server()->dispatch( $request );
+		if ( is_a( $response, 'WP_REST_Response' ) ) {
+			$response = $response->as_error();
+		}
 
-		$this->assertErrorResponse( 'rest_invalid_type', $response, 400 );
+		$this->assertWPError( $response );
+		$data = $response->get_error_data();
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertEquals( 400, $data['status'] );
 	}
 }

--- a/tests/phpunit/tests/User_Preferences.php
+++ b/tests/phpunit/tests/User_Preferences.php
@@ -23,7 +23,7 @@ use WP_REST_Request;
 /**
  * @coversDefaultClass \Google\Web_Stories\User_Preferences
  */
-class User_Preferences extends \WP_UnitTestCase {
+class User_Preferences extends \WP_Test_REST_TestCase {
 	protected static $user_id;
 
 	protected static $author_id;
@@ -54,10 +54,11 @@ class User_Preferences extends \WP_UnitTestCase {
 
 	/**
 	 * @covers ::init
+	 * @covers ::can_edit_current_user
 	 */
 	public function test_add_optin_field_to_rest_api() {
 		wp_set_current_user( self::$user_id );
-		( new \Google\Web_Stories\Tracking() )->init();
+		( new \Google\Web_Stories\User_Preferences() )->init();
 		add_user_meta( get_current_user_id(), \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, true );
 
 		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, sprintf( '/wp/v2/users/%d', self::$user_id ) );
@@ -66,15 +67,18 @@ class User_Preferences extends \WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'meta', $data );
 		$this->assertArrayHasKey( \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, $data['meta'] );
+		$this->assertArrayHasKey( \Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY, $data['meta'] );
 		$this->assertTrue( $data['meta'][ \Google\Web_Stories\User_Preferences::OPTIN_META_KEY ] );
+		$this->assertEqualSets( [], $data['meta'][ \Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY ] );
 	}
 
 	/**
 	 * @covers ::init
+	 * @covers ::can_edit_current_user
 	 */
 	public function test_add_optin_field_to_rest_api_for_author_user() {
 		wp_set_current_user( self::$author_id );
-		( new \Google\Web_Stories\Tracking() )->init();
+		( new \Google\Web_Stories\User_Preferences() )->init();
 		add_user_meta( get_current_user_id(), \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, true );
 
 		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, '/wp/v2/users/me' );
@@ -83,22 +87,28 @@ class User_Preferences extends \WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'meta', $data );
 		$this->assertArrayHasKey( \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, $data['meta'] );
+		$this->assertArrayHasKey( \Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY, $data['meta'] );
 		$this->assertTrue( $data['meta'][ \Google\Web_Stories\User_Preferences::OPTIN_META_KEY ] );
+		$this->assertEqualSets( [], $data['meta'][ \Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY ] );
 	}
 
 	/**
 	 * @covers ::init
+	 * @covers ::can_edit_current_user
 	 */
 	public function test_enables_author_user_to_update_meta_field() {
 		wp_set_current_user( self::$author_id );
-		( new \Google\Web_Stories\Tracking() )->init();
+		( new \Google\Web_Stories\User_Preferences() )->init();
 		add_user_meta( get_current_user_id(), \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, false );
 
 		$request = new WP_REST_Request( \WP_REST_Server::CREATABLE, '/wp/v2/users/me' );
 		$request->set_body_params(
 			[
 				'meta' => [
-					\Google\Web_Stories\User_Preferences::OPTIN_META_KEY => true,
+					\Google\Web_Stories\User_Preferences::OPTIN_META_KEY      => true,
+					\Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY => [
+						'hello' => 'world',
+					],
 				],
 			]
 		);
@@ -107,6 +117,32 @@ class User_Preferences extends \WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'meta', $data );
 		$this->assertArrayHasKey( \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, $data['meta'] );
+		$this->assertArrayHasKey( \Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY, $data['meta'] );
 		$this->assertTrue( $data['meta'][ \Google\Web_Stories\User_Preferences::OPTIN_META_KEY ] );
+		$this->assertArrayHasKey( 'hello', $data['meta'][ \Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY ] );
+		$this->assertEqualSets( [ 'hello' => 'world' ], $data['meta'][ \Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY ] );
+	}
+
+	/**
+	 * @covers ::init
+	 * @covers ::can_edit_current_user
+	 */
+	public function test_enables_author_user_to_invalid_type() {
+		wp_set_current_user( self::$author_id );
+		( new \Google\Web_Stories\User_Preferences() )->init();
+		add_user_meta( get_current_user_id(), \Google\Web_Stories\User_Preferences::OPTIN_META_KEY, false );
+
+		$request = new WP_REST_Request( \WP_REST_Server::CREATABLE, '/wp/v2/users/me' );
+		$request->set_body_params(
+			[
+				'meta' => [
+					\Google\Web_Stories\User_Preferences::OPTIN_META_KEY      => true,
+					\Google\Web_Stories\User_Preferences::ONBOARDING_META_KEY => false,
+				],
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_type', $response, 400 );
 	}
 }


### PR DESCRIPTION
## Summary

Add new piece of user meta to the user endpoints

## Relevant Technical Choices

- Moved logic from tracking class to new user_perference class. 
- Changed all references, to point to new const on the new class. 
- Name of meta key is `web_stories_onboarding`. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions
In the web stories editor, type the following into the console. 
```
await wp.apiFetch({ path: '/web-stories/v1/users/me', method: 'POST', data: { meta: { web_stories_onboarding: { test: 'wibble', news: 'great' }}}});
```

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5881
