### PR TITLE
Editor FTUE: Quick tips flag

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -209,6 +209,17 @@ class Experiments {
 	public function get_experiments() {
 		return [
 			/**
+			 * Author: @littlemilkstudio
+			 * Issue: 5880
+			 * Creation date: 2021-01-19
+			 */
+			[
+				'name'        => 'enableQuickTips',
+				'label'       => __( 'Quick Tips', 'web-stories' ),
+				'description' => __( 'Enable quick tips for first time user experience (FTUE)', 'web-stories' ),
+				'group'       => 'editor',
+			],
+			/**
 			 * Author: @carlos-kelly
 			 * Issue: 2081
 			 * Creation date: 2020-05-28


### PR DESCRIPTION
## Summary
Adds `enableQuickTips` experiment which will be used to enable the FTUE component in the editor.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
NA

## Testing Instructions
Should now see this flag in experiments
<img width="704" alt="Screen Shot 2021-01-19 at 12 53 19 PM" src="https://user-images.githubusercontent.com/35983235/105085748-63527380-5a55-11eb-9f9e-206f73d2a594.png">

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5880 
