### PR TITLE
Page Layouts: Only run `isDefaultPage` if `currentPage` is not null

### DIFF
--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayouts.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayouts.js
@@ -88,9 +88,10 @@ function PageLayouts(props) {
     overscan: 2,
   });
 
-  const requiresConfirmation = useMemo(() => !isDefaultPage(currentPage), [
-    currentPage,
-  ]);
+  const requiresConfirmation = useMemo(
+    () => currentPage && !isDefaultPage(currentPage),
+    [currentPage]
+  );
 
   return (
     <UnitsProvider


### PR DESCRIPTION
## Summary

This should fix flaky e2e tests as seen in #5976

When the story is still being loaded, `currentPage` will be `null`, whereas `isDefaultPage` expects an object.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
