### PR TITLE
Frontend: Add support for WordPress 5.7 Robots API

### DIFF
--- a/.github/workflows/continuous-integration-unit-php.yml
+++ b/.github/workflows/continuous-integration-unit-php.yml
@@ -40,7 +40,6 @@ jobs:
 
           - php: '7.4'
             wp: 'trunk'
-            experimental: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/continuous-integration-unit-php.yml
+++ b/.github/workflows/continuous-integration-unit-php.yml
@@ -40,6 +40,7 @@ jobs:
 
           - php: '7.4'
             wp: 'trunk'
+            experimental: true
 
     steps:
       - name: Checkout

--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -60,7 +60,6 @@ class Discovery {
 		add_action( 'web_stories_story_head', 'rsd_link' );
 		add_action( 'web_stories_story_head', 'wlwmanifest_link' );
 		add_action( 'web_stories_story_head', 'adjacent_posts_rel_link_wp_head', 10, 0 );
-		add_action( 'web_stories_story_head', 'noindex', 1 );
 		add_action( 'web_stories_story_head', 'wp_generator' );
 		add_action( 'web_stories_story_head', 'rel_canonical' );
 		add_action( 'web_stories_story_head', 'wp_shortlink_wp_head', 10, 0 );
@@ -69,6 +68,8 @@ class Discovery {
 		// Add support for WP 5.7. See https://core.trac.wordpress.org/ticket/51511.
 		if ( function_exists( '\wp_robots' ) ) {
 			add_action( 'web_stories_story_head', 'wp_robots', 1 );
+		} else {
+			add_action( 'web_stories_story_head', 'noindex', 1 );
 		}
 	}
 

--- a/includes/Discovery.php
+++ b/includes/Discovery.php
@@ -66,6 +66,10 @@ class Discovery {
 		add_action( 'web_stories_story_head', 'wp_shortlink_wp_head', 10, 0 );
 		add_action( 'web_stories_story_head', 'wp_site_icon', 99 );
 		add_action( 'web_stories_story_head', 'wp_oembed_add_discovery_links' );
+		// Add support for WP 5.7. See https://core.trac.wordpress.org/ticket/51511.
+		if ( function_exists( '\wp_robots' ) ) {
+			add_action( 'web_stories_story_head', 'wp_robots', 1 );
+		}
 	}
 
 	/**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -61,3 +61,7 @@ parameters:
     # wp_die() is called with [ 'exit' => false ]
     - message: '#^Unreachable statement - code above always terminates.$#'
       path: includes/Story_Renderer/HTML.php
+
+    # wp_robots() is called.
+    - message: '/^Parameter #2 \$function_to_add of function add_action expects callable\(\): mixed, \S+ given\.$/'
+      path: includes/Discovery.php


### PR DESCRIPTION
## Summary

After [this](https://github.com/WordPress/wordpress-develop/commit/176a1f53f04cde92e7297b5214c03beb9e2ba5c8) change in WordPress core in [#51511](https://core.trac.wordpress.org/ticket/51511), unit tests are failing. This fix works around this and adds support for the api. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #
