### PR TITLE
Editor: Retain Animations on Element receiving new image

### DIFF
--- a/assets/src/edit-story/app/canvas/useAddPastedElements.js
+++ b/assets/src/edit-story/app/canvas/useAddPastedElements.js
@@ -91,6 +91,7 @@ function useAddPastedElements() {
           combineElements({
             firstElement: newBackgroundElement,
             secondId: existingBgElement.id,
+            isCopyAndPasteAction: true,
           });
         }
       }

--- a/assets/src/edit-story/app/canvas/useAddPastedElements.js
+++ b/assets/src/edit-story/app/canvas/useAddPastedElements.js
@@ -91,7 +91,7 @@ function useAddPastedElements() {
           combineElements({
             firstElement: newBackgroundElement,
             secondId: existingBgElement.id,
-            isCopyAndPasteAction: true,
+            shouldRetainAnimations: false,
           });
         }
       }

--- a/assets/src/edit-story/app/story/useStoryReducer/actions.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/actions.js
@@ -92,11 +92,11 @@ const updateSelectedElements = (dispatch) => ({ properties }) =>
 const combineElements = (dispatch) => ({
   firstElement,
   secondId,
-  isCopyAndPasteAction,
+  shouldRetainAnimations,
 }) =>
   dispatch({
     type: types.COMBINE_ELEMENTS,
-    payload: { firstElement, secondId, isCopyAndPasteAction },
+    payload: { firstElement, secondId, shouldRetainAnimations },
   });
 
 const setBackgroundElement = (dispatch) => ({ elementId }) =>

--- a/assets/src/edit-story/app/story/useStoryReducer/actions.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/actions.js
@@ -89,10 +89,14 @@ const updateSelectedElements = (dispatch) => ({ properties }) =>
     payload: { elementIds: null, properties },
   });
 
-const combineElements = (dispatch) => ({ firstElement, secondId }) =>
+const combineElements = (dispatch) => ({
+  firstElement,
+  secondId,
+  isCopyAndPasteAction,
+}) =>
   dispatch({
     type: types.COMBINE_ELEMENTS,
-    payload: { firstElement, secondId },
+    payload: { firstElement, secondId, isCopyAndPasteAction },
   });
 
 const setBackgroundElement = (dispatch) => ({ elementId }) =>

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
@@ -130,9 +130,12 @@ function combineElements(state, { firstElement, secondId }) {
     // Update reference to second element
     .map((el) => (el.id === secondId ? newElement : el));
 
+  // First element should always be the image getting applied to
+  // new element. We want to remove any animations it has. Second
+  // element should be an element with or without animations that
+  // we want to retain.
   const newAnimations = removeAnimationsWithElementIds(page.animations, [
     firstId,
-    secondId,
   ]);
 
   const newPage = {

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
@@ -91,7 +91,7 @@ function combineElements(
     'scale',
     'focalX',
     'focalY',
-    'backgroundOverlay',
+    'flip',
     'tracks',
   ];
 
@@ -114,10 +114,7 @@ function combineElements(
 
   const newElement = {
     // First copy everything from existing element except if it was default background and any overlay
-    ...objectWithout(secondElement, [
-      'isDefaultBackground',
-      'backgroundOverlay',
-    ]),
+    ...objectWithout(secondElement, ['isDefaultBackground']),
     // Then set sensible default attributes
     ...DEFAULT_ATTRIBUTES_FOR_MEDIA,
     // Then copy all media-related attributes from new element

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
@@ -50,9 +50,13 @@ import { removeAnimationsWithElementIds } from './utils';
  * @param {Object} payload Action payload
  * @param {string} payload.firstElement Element with properties to merge
  * @param {string} payload.secondId Element to add properties to
+ * @param {boolean} payload.isCopyAndPasteAction Is called from copy and paste
  * @return {Object} New state
  */
-function combineElements(state, { firstElement, secondId }) {
+function combineElements(
+  state,
+  { firstElement, secondId, isCopyAndPasteAction = false }
+) {
   if (!firstElement || !secondId) {
     return state;
   }
@@ -134,9 +138,14 @@ function combineElements(state, { firstElement, secondId }) {
   // new element. We want to remove any animations it has. Second
   // element should be an element with or without animations that
   // we want to retain.
-  const newAnimations = removeAnimationsWithElementIds(page.animations, [
-    firstId,
-  ]);
+  //
+  // We want different behavior for copy and paste where we
+  // replace the element's animation with any coming from the
+  // newly pasted element.
+  const newAnimations = removeAnimationsWithElementIds(
+    page.animations,
+    isCopyAndPasteAction ? [firstId, secondId] : [firstId]
+  );
 
   const newPage = {
     ...page,

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
@@ -91,7 +91,6 @@ function combineElements(
     'scale',
     'focalX',
     'focalY',
-    'flip',
     'tracks',
   ];
 

--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
@@ -50,12 +50,12 @@ import { removeAnimationsWithElementIds } from './utils';
  * @param {Object} payload Action payload
  * @param {string} payload.firstElement Element with properties to merge
  * @param {string} payload.secondId Element to add properties to
- * @param {boolean} payload.isCopyAndPasteAction Is called from copy and paste
+ * @param {boolean} payload.shouldRetainAnimations Is called from copy and paste
  * @return {Object} New state
  */
 function combineElements(
   state,
-  { firstElement, secondId, isCopyAndPasteAction = false }
+  { firstElement, secondId, shouldRetainAnimations = true }
 ) {
   if (!firstElement || !secondId) {
     return state;
@@ -112,7 +112,7 @@ function combineElements(
   const positionProps = objectPick(element, ['width', 'height', 'x', 'y']);
 
   const newElement = {
-    // First copy everything from existing element except if it was default background and any overlay
+    // First copy everything from existing element except if it was default background
     ...objectWithout(secondElement, ['isDefaultBackground']),
     // Then set sensible default attributes
     ...DEFAULT_ATTRIBUTES_FOR_MEDIA,
@@ -140,7 +140,7 @@ function combineElements(
   // newly pasted element.
   const newAnimations = removeAnimationsWithElementIds(
     page.animations,
-    isCopyAndPasteAction ? [firstId, secondId] : [firstId]
+    shouldRetainAnimations ? [firstId] : [firstId, secondId]
   );
 
   const newPage = {

--- a/assets/src/edit-story/app/story/useStoryReducer/test/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/combineElements.js
@@ -183,7 +183,7 @@ describe('combineElements', () => {
     ]);
   });
 
-  it('should remove background overlay if present on second element', () => {
+  it('should not remove background overlay if present on second element', () => {
     const { restore, combineElements } = setupReducer();
 
     const state = getDefaultState3();
@@ -203,6 +203,8 @@ describe('combineElements', () => {
         focalX: 50,
         focalY: 50,
         scale: 100,
+        flip: {},
+        backgroundOverlay: { color: { r: 0, g: 0, b: 0 } },
         x: 10,
         y: 10,
         width: 10,
@@ -334,6 +336,7 @@ describe('combineElements', () => {
           src: '1',
           type: 'image',
         },
+        backgroundOverlay: { color: { r: 0, g: 0, b: 0 } },
         scale: 100,
         type: 'image',
         width: 10,
@@ -434,6 +437,7 @@ describe('combineElements', () => {
           src: '1',
           type: 'image',
         },
+        backgroundOverlay: { color: { r: 0, g: 0, b: 0 } },
         scale: 100,
         type: 'image',
         width: 10,
@@ -536,6 +540,7 @@ describe('combineElements', () => {
           src: '1',
           type: 'image',
         },
+        backgroundOverlay: { color: { r: 0, g: 0, b: 0 } },
         scale: 100,
         type: 'image',
         width: 10,

--- a/assets/src/edit-story/app/story/useStoryReducer/test/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/combineElements.js
@@ -203,7 +203,6 @@ describe('combineElements', () => {
         focalX: 50,
         focalY: 50,
         scale: 100,
-        flip: {},
         backgroundOverlay: { color: { r: 0, g: 0, b: 0 } },
         x: 10,
         y: 10,

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -144,7 +144,11 @@ function DisplayElement({ element, previewMode, isAnimatable = false }) {
   });
 
   const bgOverlayRef = useRef(null);
-  useColorTransformHandler({ id, targetRef: bgOverlayRef });
+  useColorTransformHandler({
+    id,
+    targetRef: bgOverlayRef,
+    resetOnNullTransform: false,
+  });
 
   return (
     <Wrapper ref={wrapperRef} data-element-id={id} {...box}>

--- a/assets/src/edit-story/components/canvas/karma/backgroundCopyPaste.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/backgroundCopyPaste.karma.js
@@ -201,8 +201,9 @@ describe('Background Copy Paste integration', () => {
     );
     expect(await getCanvasBackgroundOverlay()).toHaveStyle(
       'background-image',
-      'linear-gradient(rgba(0, 0, 0, 0) 40%, rgba(0, 0, 0, 0.9) 100%)'
+      'radial-gradient(80% 50%, rgba(0, 0, 0, 0) 25%, rgba(0, 0, 0, 0.6) 100%)'
     );
+    await fixture.events.sleep(10000);
     expect(await getNumElements()).toBe(1);
 
     // Now delete background image and verify that underlying color is still correct

--- a/assets/src/edit-story/elements/shared/useColorTransformHandler.js
+++ b/assets/src/edit-story/elements/shared/useColorTransformHandler.js
@@ -21,13 +21,20 @@ import { useTransformHandler } from '../../components/transform';
 import generatePatternStyles from '../../utils/generatePatternStyles';
 import convertToCSS from '../../utils/convertToCSS';
 
-function useColorTransformHandler({ id, targetRef, expectedStyle }) {
+function useColorTransformHandler({
+  id,
+  targetRef,
+  expectedStyle,
+  resetOnNullTransform = true,
+}) {
   useTransformHandler(id, (transform) => {
     const target =
       undefined !== targetRef?.current ? targetRef.current : targetRef;
     if (target) {
       if (transform === null) {
-        target.style.cssText = '';
+        if (resetOnNullTransform) {
+          target.style.cssText = '';
+        }
       } else {
         const { color, style } = transform;
         // If the transforming style and the expected style don't match, return.


### PR DESCRIPTION
## Summary
Before if you replaced the image on an element, it wiped out both elements animations. Now it should only wipe out the new image elements animations, but retain the animations on the element receiving the replacement image.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
Now if you have an element with an animation, and you drag an image to be placed inside of it (background or foreground), the element with animation should retain its animations.

## Testing Instructions
**Case 1**
-> open the editor.
-> set a bg image
-> apply an animation to it
-> drag new media to replace the bg image
-> see that the bg image retains its animation

**Case 2**
-> open the editor.
-> set a fg image
-> apply an animation to it
-> drag new media to replace the fg image
-> see that the fg image retains its animation

**Case 3**
-> open the editor.
-> set a bg image
-> apply an animation to it
-> add a fg image element
-> apply an animation to the fg image element
-> drag the fg image element to replace the bg image
-> See that the bg image gains the fg element's image, but retains the original bg image animation

**Case 4**
-> open the editor.
-> add a fg image element
-> apply an animation to it
-> add a second fg image element
-> apply an animation to the second fg image element
-> drag the second fg image element to replace the first fg image element's image
-> See that the first fg image gains the second fg element's image, but the first fg element retains it's original animation

**Case 5**
-> open the editor.
-> set a bg image
-> apply an animation to it
-> with the bg image selected click "detach from background"
-> See that the bg animation gets removed when element is moved to fg

**Case 6**
-> open the editor.
-> add a fg image
-> apply an animation to it
-> with the fg image selected click "set as background"
-> See that the foreground animation gets removed

**Added overlay persistence for bg images being swapped too**

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5980 
