### PR TITLE
Exclude stories from WordPress search results

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -177,6 +177,7 @@ class Story_Post_Type {
 				],
 				'public'                => true,
 				'has_archive'           => true,
+				'exclude_from_search'   => true,
 				'show_ui'               => true,
 				'show_in_rest'          => true,
 				'rest_controller_class' => Stories_Controller::class,


### PR DESCRIPTION
## Summary

Remove stories for search results.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

N/A

## Testing Instructions

1. On the frontend of the WordPress site, use search form
1. Verify that no stories appear in search results

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #5731
