### PR TITLE
Design System: Add input component

### DIFF
--- a/assets/src/design-system/components/index.js
+++ b/assets/src/design-system/components/index.js
@@ -18,6 +18,7 @@ export * from './button';
 export * from './checkbox';
 export { Dialog } from './dialog';
 export { DropDown } from './dropDown';
+export { Input } from './input';
 export { Modal } from './modal';
 export { Pill } from './pill';
 export { Popup, PLACEMENT } from './popup';

--- a/assets/src/design-system/components/input/index.js
+++ b/assets/src/design-system/components/input/index.js
@@ -58,13 +58,12 @@ const StyledInput = styled.input(
       color: ${theme.colors.fg.disable};
       border-color: ${theme.colors.border.disable};
     }
+
+    & + p {
+      color: ${theme.colors.fg[hasError ? 'negative' : 'tertiary']};
+    }
   `
 );
-
-const Hint = styled(Text)`
-  color: ${({ hasError, theme }) =>
-    theme.colors.fg[hasError ? 'negative' : 'tertiary']};
-`;
 
 export const Input = ({ disabled, hasError, hint, id, label, ...props }) => {
   const inputId = useMemo(() => id || uuidv4(), [id]);
@@ -82,7 +81,7 @@ export const Input = ({ disabled, hasError, hint, id, label, ...props }) => {
         hasError={hasError}
         {...props}
       />
-      {hint && <Hint hasError={hasError}>{hint}</Hint>}
+      {hint && <Text hasError={hasError}>{hint}</Text>}
     </Container>
   );
 };

--- a/assets/src/design-system/components/input/index.js
+++ b/assets/src/design-system/components/input/index.js
@@ -27,12 +27,10 @@ import { v4 as uuidv4 } from 'uuid';
 import { Text } from '..';
 import { themeHelpers, THEME_CONSTANTS } from '../../theme';
 
-const Container = styled.div`
-  margin: 0 12px;
-`;
-
 const StyledInput = styled.input(
   ({ hasError, theme }) => css`
+    box-sizing: border-box;
+    width: 100%;
     margin: 12px 0;
     padding: 8px 12px;
     ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)};
@@ -69,7 +67,7 @@ export const Input = ({ disabled, hasError, hint, id, label, ...props }) => {
   const inputId = useMemo(() => id || uuidv4(), [id]);
 
   return (
-    <Container>
+    <div>
       {label && (
         <Text htmlFor={inputId} as="label" disabled={disabled}>
           {label}
@@ -82,11 +80,12 @@ export const Input = ({ disabled, hasError, hint, id, label, ...props }) => {
         {...props}
       />
       {hint && <Text hasError={hasError}>{hint}</Text>}
-    </Container>
+    </div>
   );
 };
 
 Input.propTypes = {
+  'aria-label': PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   hasError: PropTypes.bool,
   hint: PropTypes.string,

--- a/assets/src/design-system/components/input/index.js
+++ b/assets/src/design-system/components/input/index.js
@@ -65,6 +65,7 @@ const StyledInput = styled.input(
     }
 
     :disabled {
+      color: ${theme.colors.fg.disable};
       border-color: ${theme.colors.border.disable};
     }
 

--- a/assets/src/design-system/components/input/index.js
+++ b/assets/src/design-system/components/input/index.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import propTypes from 'prop-types';
+import { useMemo } from 'react';
+import styled, { css } from 'styled-components';
+import { v4 as uuidv4 } from 'uuid';
+/**
+ * Internal dependencies
+ */
+import { Text } from '..';
+import { themeHelpers, THEME_CONSTANTS } from '../../theme';
+
+const Container = styled.div`
+  margin: 0 12px;
+`;
+
+const Label = styled.label(
+  ({ disabled, theme }) =>
+    disabled &&
+    css`
+      ${Text} {
+        color: ${theme.colors.fg.disable};
+      }
+    `
+);
+
+const StyledInput = styled.input(
+  ({ hasError, theme }) => css`
+    margin: 12px 0;
+    padding: 8px 12px;
+    ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)};
+    ${themeHelpers.expandPresetStyles({
+      preset: {
+        ...theme.typography.presets.label[
+          THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL
+        ],
+      },
+      theme,
+    })};
+    background-color: ${theme.colors.bg.primary};
+    border: 2px solid
+      ${theme.colors.border[hasError ? 'negativeNormal' : 'defaultNormal']};
+    border-radius: ${theme.borders.radius.small};
+    color: ${theme.colors.fg.primary};
+
+    :active {
+      border-color: ${theme.colors.border.defaultActive};
+    }
+
+    :disabled {
+      border-color: ${theme.colors.border.disable};
+    }
+
+    & + ${Text} {
+      color: ${theme.colors.fg[hasError ? 'negative' : 'tertiary']};
+    }
+  `
+);
+
+export const Input = ({ disabled, hint, id, label, ...props }) => {
+  const inputId = useMemo(() => id || uuidv4(), [id]);
+
+  return (
+    <Container>
+      {label && (
+        <Label htmlFor={inputId} disabled={disabled}>
+          <Text as="span">{label}</Text>
+        </Label>
+      )}
+      <StyledInput id={inputId} disabled={disabled} {...props} />
+      {hint && <Text>{hint}</Text>}
+    </Container>
+  );
+};
+
+Input.propTypes = {
+  disabled: propTypes.bool,
+  hasError: propTypes.bool,
+  hint: propTypes.string,
+  id: propTypes.string,
+  label: propTypes.string,
+};

--- a/assets/src/design-system/components/input/index.js
+++ b/assets/src/design-system/components/input/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import { useMemo } from 'react';
 import styled, { css } from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
@@ -30,16 +30,6 @@ import { themeHelpers, THEME_CONSTANTS } from '../../theme';
 const Container = styled.div`
   margin: 0 12px;
 `;
-
-const Label = styled.label(
-  ({ disabled, theme }) =>
-    disabled &&
-    css`
-      ${Text} {
-        color: ${theme.colors.fg.disable};
-      }
-    `
-);
 
 const StyledInput = styled.input(
   ({ hasError, theme }) => css`
@@ -68,33 +58,39 @@ const StyledInput = styled.input(
       color: ${theme.colors.fg.disable};
       border-color: ${theme.colors.border.disable};
     }
-
-    & + ${Text} {
-      color: ${theme.colors.fg[hasError ? 'negative' : 'tertiary']};
-    }
   `
 );
 
-export const Input = ({ disabled, hint, id, label, ...props }) => {
+const Hint = styled(Text)`
+  color: ${({ hasError, theme }) =>
+    theme.colors.fg[hasError ? 'negative' : 'tertiary']};
+`;
+
+export const Input = ({ disabled, hasError, hint, id, label, ...props }) => {
   const inputId = useMemo(() => id || uuidv4(), [id]);
 
   return (
     <Container>
       {label && (
-        <Label htmlFor={inputId} disabled={disabled}>
-          <Text as="span">{label}</Text>
-        </Label>
+        <Text htmlFor={inputId} as="label" disabled={disabled}>
+          {label}
+        </Text>
       )}
-      <StyledInput id={inputId} disabled={disabled} {...props} />
-      {hint && <Text>{hint}</Text>}
+      <StyledInput
+        id={inputId}
+        disabled={disabled}
+        hasError={hasError}
+        {...props}
+      />
+      {hint && <Hint hasError={hasError}>{hint}</Hint>}
     </Container>
   );
 };
 
 Input.propTypes = {
-  disabled: propTypes.bool,
-  hasError: propTypes.bool,
-  hint: propTypes.string,
-  id: propTypes.string,
-  label: propTypes.string,
+  disabled: PropTypes.bool,
+  hasError: PropTypes.bool,
+  hint: PropTypes.string,
+  id: PropTypes.string,
+  label: PropTypes.string,
 };

--- a/assets/src/design-system/components/input/index.js
+++ b/assets/src/design-system/components/input/index.js
@@ -84,6 +84,17 @@ export const Input = ({ disabled, hasError, hint, id, label, ...props }) => {
   );
 };
 
+/**
+ * Custom propTypes validator used to check if either `label`
+ * or `aria-label` have been passed to the component.
+ * This also checks that they are of the correct type.
+ *
+ * @param {Object} props the props supplied to the component.
+ * @param {string} _ the name of the prop.
+ * @param {string} componentName the name of the component.
+ * @return {Error|null} Returns an error if the conditions have not been met.
+ * Otherwise, returns null.
+ */
 export const labelAccessibilityValidator = function (props, _, componentName) {
   if (!props.label && !props['aria-label']) {
     return new Error(

--- a/assets/src/design-system/components/input/index.js
+++ b/assets/src/design-system/components/input/index.js
@@ -84,11 +84,35 @@ export const Input = ({ disabled, hasError, hint, id, label, ...props }) => {
   );
 };
 
+export const labelAccessibilityValidator = function (props, _, componentName) {
+  if (!props.label && !props['aria-label']) {
+    return new Error(
+      `\`label\` or \`aria-label\` must be supplied to \`${componentName}\`. Validation failed.`
+    );
+  }
+
+  if (props.label && typeof props.label !== 'string') {
+    return new Error(
+      `Invalid prop \`label\` of type \`${typeof props.label}\` supplied to \`${componentName}\`, expected \`string\`.`
+    );
+  }
+
+  if (props['aria-label'] && typeof props['aria-label'] !== 'string') {
+    return new Error(
+      `Invalid prop \`aria-label\` of type \`${typeof props[
+        'aria-label'
+      ]}\` supplied to \`${componentName}\`, expected \`string\`.`
+    );
+  }
+
+  return null;
+};
+
 Input.propTypes = {
-  'aria-label': PropTypes.string.isRequired,
+  'aria-label': labelAccessibilityValidator,
   disabled: PropTypes.bool,
   hasError: PropTypes.bool,
   hint: PropTypes.string,
   id: PropTypes.string,
-  label: PropTypes.string,
+  label: labelAccessibilityValidator,
 };

--- a/assets/src/design-system/components/input/stories/index.js
+++ b/assets/src/design-system/components/input/stories/index.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useState } from 'react';
+import styled from 'styled-components';
+import { action } from '@storybook/addon-actions';
+import { text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import { Input } from '..';
+import { DarkThemeProvider } from '../../../storybookUtils';
+import { Headline } from '../../..';
+
+export default {
+  title: 'DesignSystem/Components/Input',
+  component: Input,
+};
+
+const Container = styled.div`
+  display: grid;
+  row-gap: 20px;
+  padding: 20px 50px;
+  background-color: ${({ theme }) => theme.colors.bg.primary};
+  border: 1px solid ${({ theme }) => theme.colors.standard.black};
+`;
+
+const Row = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-column: 1 / -1;
+
+  label {
+    display: flex;
+    align-items: center;
+  }
+`;
+
+export const _default = () => {
+  const [inputState, setInputState] = useState({
+    oneLight: 'Text',
+    twoLight: 'we have an error',
+    threeLight: 'disabled',
+    oneDark: 'Dark mode text',
+    twoDark: '',
+    threeDark: '',
+  });
+
+  const handleChange = (event) => {
+    const name = event.target.name;
+    const value = event.target.value;
+
+    action(event.target.name)(event);
+    setInputState((prevState) => ({
+      ...prevState,
+      [name]: value,
+    }));
+  };
+
+  return (
+    <>
+      <Headline as="h1">{'Input'}</Headline>
+      <br />
+      <Container>
+        <Row>
+          <Input
+            id="one-light"
+            name="oneLight"
+            value={inputState.oneLight}
+            onChange={handleChange}
+            label={text('Input 1 Label')}
+            hint={text('Hint', 'Hint')}
+            placeholder="placeholder"
+          />
+          <Input
+            id="two-light"
+            name="twoLight"
+            value={inputState.twoLight}
+            onChange={handleChange}
+            label={text('Input 2 Label', 'Error')}
+            hint={text('Hint', 'Hint')}
+            placeholder="placeholder"
+            hasError
+          />
+          <Input
+            id="three-light"
+            name="threeLight"
+            value={inputState.threeLight}
+            onChange={handleChange}
+            label={text('Input 3 Label', 'Disabled')}
+            hint={text('Hint', 'Hint')}
+            placeholder="placeholder"
+            disabled
+          />
+        </Row>
+      </Container>
+      <DarkThemeProvider>
+        <Container darkMode>
+          <Row>
+            <Input
+              id="one-dark"
+              name="oneDark"
+              value={inputState.oneDark}
+              onChange={handleChange}
+              label={text('Input 1 Label')}
+              hint={text('Hint', 'Hint')}
+              placeholder="placeholder"
+            />
+            <Input
+              id="two-dark"
+              name="twoDark"
+              value={inputState.twoDark}
+              onChange={handleChange}
+              label={text('Input 2 Label', 'Error')}
+              hint={text('Hint', 'Hint')}
+              placeholder="placeholder"
+              hasError
+            />
+            <Input
+              id="three-dark"
+              name="threeDark"
+              value={inputState.threeDark}
+              onChange={handleChange}
+              label={text('Input 3 Label', 'Disabled')}
+              hint={text('Hint', 'Hint')}
+              placeholder="placeholder"
+              disabled
+            />
+          </Row>
+        </Container>
+      </DarkThemeProvider>
+    </>
+  );
+};

--- a/assets/src/design-system/components/input/stories/index.js
+++ b/assets/src/design-system/components/input/stories/index.js
@@ -85,7 +85,7 @@ export const _default = () => {
             name="oneLight"
             value={inputState.oneLight}
             onChange={handleChange}
-            label={text('Input 1 Label')}
+            label={text('Input 1 Label', 'Normal')}
             hint={text('Hint', 'Hint')}
             placeholder="placeholder"
           />
@@ -119,7 +119,7 @@ export const _default = () => {
               name="oneDark"
               value={inputState.oneDark}
               onChange={handleChange}
-              label={text('Input 1 Label')}
+              label={text('Input 1 Label', 'Normal')}
               hint={text('Hint', 'Hint')}
               placeholder="placeholder"
             />

--- a/assets/src/design-system/components/input/stories/index.js
+++ b/assets/src/design-system/components/input/stories/index.js
@@ -46,6 +46,7 @@ const Row = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-column: 1 / -1;
+  grid-column-gap: 60px;
 
   label {
     display: flex;
@@ -81,6 +82,7 @@ export const _default = () => {
       <Container>
         <Row>
           <Input
+            aria-label="input-one"
             id="one-light"
             name="oneLight"
             value={inputState.oneLight}
@@ -90,6 +92,7 @@ export const _default = () => {
             placeholder="placeholder"
           />
           <Input
+            aria-label="input-two"
             id="two-light"
             name="twoLight"
             value={inputState.twoLight}
@@ -100,6 +103,7 @@ export const _default = () => {
             hasError
           />
           <Input
+            aria-label="disabled-input-one"
             id="three-light"
             name="threeLight"
             value={inputState.threeLight}
@@ -115,6 +119,7 @@ export const _default = () => {
         <Container darkMode>
           <Row>
             <Input
+              aria-label="input-three"
               id="one-dark"
               name="oneDark"
               value={inputState.oneDark}
@@ -124,6 +129,7 @@ export const _default = () => {
               placeholder="placeholder"
             />
             <Input
+              aria-label="input-four"
               id="two-dark"
               name="twoDark"
               value={inputState.twoDark}
@@ -134,6 +140,7 @@ export const _default = () => {
               hasError
             />
             <Input
+              aria-label="disabled-input-two"
               id="three-dark"
               name="threeDark"
               value={inputState.threeDark}

--- a/assets/src/design-system/components/input/test/input.js
+++ b/assets/src/design-system/components/input/test/input.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Input } from '../';
+import { renderWithProviders } from '../../../testUtils/renderWithProviders';
+
+describe('Input', () => {
+  it('should render the input', () => {
+    const { getByPlaceholderText } = renderWithProviders(
+      <Input placeholder="my placeholder" />
+    );
+
+    expect(getByPlaceholderText('my placeholder')).toBeInTheDocument();
+  });
+
+  it('should render a label', () => {
+    const { getByText } = renderWithProviders(
+      <Input label="This is my input label" />
+    );
+
+    expect(getByText('This is my input label')).toBeInTheDocument();
+  });
+
+  it('should render a hint', () => {
+    const { getByText } = renderWithProviders(
+      <Input hint="This is my input hint" />
+    );
+
+    expect(getByText('This is my input hint')).toBeInTheDocument();
+  });
+});

--- a/assets/src/design-system/components/input/test/input.js
+++ b/assets/src/design-system/components/input/test/input.js
@@ -21,13 +21,13 @@
 /**
  * Internal dependencies
  */
-import { Input } from '../';
+import { Input, labelAccessibilityValidator } from '../';
 import { renderWithProviders } from '../../../testUtils/renderWithProviders';
 
 describe('Input', () => {
   it('should render the input', () => {
     const { getByPlaceholderText } = renderWithProviders(
-      <Input placeholder="my placeholder" />
+      <Input aria-label="test" placeholder="my placeholder" />
     );
 
     expect(getByPlaceholderText('my placeholder')).toBeInTheDocument();
@@ -43,9 +43,37 @@ describe('Input', () => {
 
   it('should render a hint', () => {
     const { getByText } = renderWithProviders(
-      <Input hint="This is my input hint" />
+      <Input aria-label="test" hint="This is my input hint" />
     );
 
     expect(getByText('This is my input hint')).toBeInTheDocument();
+  });
+});
+
+describe('labelAccessibilityValidator', () => {
+  it('should return null if `label` or `aria-label` are passed in as a prop', () => {
+    expect(
+      labelAccessibilityValidator({ label: 'test' }, '', 'Test')
+    ).toBeNull();
+    expect(
+      labelAccessibilityValidator({ 'aria-label': 'test' }, '', 'Test')
+    ).toBeNull();
+    expect(
+      labelAccessibilityValidator(
+        { label: 'test', 'aria-label': 'test' },
+        '',
+        'Test'
+      )
+    ).toBeNull();
+  });
+
+  it.each`
+    propName
+    ${'label'}
+    ${'aria-label'}
+  `('should throw an error if `label` is not a string type', ({ propName }) => {
+    expect(
+      labelAccessibilityValidator({ [propName]: 2 }, '', 'Test')
+    ).toStrictEqual(expect.any(Error));
   });
 });

--- a/assets/src/design-system/components/typography/index.js
+++ b/assets/src/design-system/components/typography/index.js
@@ -16,4 +16,5 @@
 
 export { Display } from './display';
 export { Headline } from './headline';
+export { Link } from './link';
 export { Text } from './text';

--- a/assets/src/design-system/components/typography/link/index.js
+++ b/assets/src/design-system/components/typography/link/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,28 @@
  * limitations under the License.
  */
 
-export * from './button';
-export * from './checkbox';
-export { Dialog } from './dialog';
-export { DropDown } from './dropDown';
-export { Input } from './input';
-export { Modal } from './modal';
-export { Pill } from './pill';
-export { Popup, PLACEMENT } from './popup';
-export * as Snackbar from './snackbar';
-export * from './tooltip';
-export * from './keyboard';
-export * from './keyboard/gridview';
-export * from './notificationBubble';
-export { Display, Headline, Link, Text } from './typography';
+/**
+ * External dependencies
+ */
+import styled, { css } from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { themeHelpers } from '../../../theme';
+import { defaultTypographyStyle } from '../styles';
+
+export const Link = styled.a`
+  ${defaultTypographyStyle};
+  ${({ theme }) => css`
+    color: ${theme.colors.fg.linkNormal};
+    text-decoration: none;
+    cursor: pointer;
+
+    :hover {
+      color: ${theme.colors.fg.linkHover};
+    }
+
+    ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)}
+  `};
+`;

--- a/assets/src/design-system/components/typography/link/index.js
+++ b/assets/src/design-system/components/typography/link/index.js
@@ -17,17 +17,26 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
 /**
  * Internal dependencies
  */
-import { themeHelpers } from '../../../theme';
+import { THEME_CONSTANTS, themeHelpers } from '../../../theme';
 import { defaultTypographyStyle } from '../styles';
 
 export const Link = styled.a`
-  ${defaultTypographyStyle};
-  ${({ theme }) => css`
+  ${({ isBold, size, theme }) => css`
+    ${defaultTypographyStyle};
+    ${themeHelpers.expandPresetStyles({
+      preset: theme.typography.presets.paragraph[size],
+      theme,
+    })};
+    font-weight: ${isBold
+      ? theme.typography.weight.bold
+      : theme.typography.presets.paragraph[size].weight};
+
     color: ${theme.colors.fg.linkNormal};
     text-decoration: none;
     cursor: pointer;
@@ -39,3 +48,13 @@ export const Link = styled.a`
     ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)}
   `};
 `;
+
+Link.propTypes = {
+  isBold: PropTypes.bool,
+  size: PropTypes.oneOf(THEME_CONSTANTS.TYPOGRAPHY.TEXT_SIZES),
+};
+Link.defaultProps = {
+  as: 'p',
+  isBold: false,
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.MEDIUM,
+};

--- a/assets/src/design-system/components/typography/link/stories/index.js
+++ b/assets/src/design-system/components/typography/link/stories/index.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+
+/**
+ * Internal dependencies
+ */
+import { Link } from '../';
+import { THEME_CONSTANTS } from '../../../../';
+
+export default {
+  title: 'DesignSystem/Components/Typography/Link',
+  component: Link,
+};
+
+const textPresetSizes = THEME_CONSTANTS.TYPOGRAPHY.TEXT_SIZES;
+
+export const _default = () => (
+  <>
+    {textPresetSizes.map((presetSize) => (
+      <Link
+        key={`${presetSize}_text_link`}
+        size={presetSize}
+        href="#"
+        onClick={(event) => {
+          event.preventDefault();
+          action(`${presetSize} anchor clicked! Do something.`)(event);
+        }}
+      >
+        {`${presetSize} - Click here for more information`}
+        <br />
+      </Link>
+    ))}
+  </>
+);

--- a/assets/src/design-system/components/typography/text/index.js
+++ b/assets/src/design-system/components/typography/text/index.js
@@ -52,7 +52,7 @@ const Label = styled.label`
     disabled ? theme.colors.fg.disable : 'auto'};
 `;
 
-const Anchor = styled.a`
+const Link = styled.a`
   ${({ theme }) => css`
     color: ${theme.colors.fg.linkNormal};
     text-decoration: none;
@@ -69,7 +69,7 @@ const Anchor = styled.a`
 export const Text = ({ as, disabled, ...props }) => {
   switch (as) {
     case 'a':
-      return <Anchor {...props} />;
+      return <Link {...props} />;
     case 'label':
       return <Label disabled={disabled} {...props} />;
     case 'span':

--- a/assets/src/design-system/components/typography/text/index.js
+++ b/assets/src/design-system/components/typography/text/index.js
@@ -57,7 +57,8 @@ const Anchor = styled.a`
     color: ${theme.colors.fg.linkNormal};
     text-decoration: none;
     cursor: pointer;
-    &:hover {
+
+    :hover {
       color: ${theme.colors.fg.linkHover};
     }
 

--- a/assets/src/design-system/components/typography/text/index.js
+++ b/assets/src/design-system/components/typography/text/index.js
@@ -26,36 +26,62 @@ import PropTypes from 'prop-types';
 import { THEME_CONSTANTS, themeHelpers } from '../../../theme';
 import { defaultTypographyStyle } from '../styles';
 
-export const Text = styled.p`
+const textCss = ({ isBold, size, theme }) => css`
   ${defaultTypographyStyle}
-  ${({ as, isBold, size, theme }) => {
-    const asLink =
-      as === 'a' &&
-      css`
-        color: ${theme.colors.fg.linkNormal};
-        text-decoration: none;
-        cursor: pointer;
-        &:hover {
-          color: ${theme.colors.fg.linkHover};
-        }
-
-        ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)}
-      `;
-    return css`
-      ${themeHelpers.expandPresetStyles({
-        preset: theme.typography.presets.paragraph[size],
-        theme,
-      })};
-      font-weight: ${isBold
-        ? theme.typography.weight.bold
-        : theme.typography.presets.paragraph[size].weight};
-      ${asLink};
-    `;
-  }}
+  ${themeHelpers.expandPresetStyles({
+    preset: theme.typography.presets.paragraph[size],
+    theme,
+  })};
+  font-weight: ${isBold
+    ? theme.typography.weight.bold
+    : theme.typography.presets.paragraph[size].weight};
 `;
 
+const Paragraph = styled.p`
+  ${textCss};
+`;
+
+const Span = styled.span`
+  ${textCss};
+`;
+
+const Label = styled.label`
+  ${textCss};
+
+  color: ${({ disabled, theme }) =>
+    disabled ? theme.colors.fg.disable : 'auto'};
+`;
+
+const Anchor = styled.a`
+  ${({ theme }) => css`
+    color: ${theme.colors.fg.linkNormal};
+    text-decoration: none;
+    cursor: pointer;
+    &:hover {
+      color: ${theme.colors.fg.linkHover};
+    }
+
+    ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)}
+  `};
+`;
+
+export const Text = ({ as, disabled, ...props }) => {
+  switch (as) {
+    case 'a':
+      return <Anchor {...props} />;
+    case 'label':
+      return <Label disabled={disabled} {...props} />;
+    case 'span':
+      return <Span {...props} />;
+    default:
+      return <Paragraph {...props} />;
+  }
+};
+
 Text.propTypes = {
-  as: PropTypes.oneOf(['p', 'a', 'span']),
+  as: PropTypes.oneOf(['p', 'a', 'span', 'label']),
+  /** only applies to label styling */
+  disabled: PropTypes.bool,
   isBold: PropTypes.bool,
   size: PropTypes.oneOf(THEME_CONSTANTS.TYPOGRAPHY.TEXT_SIZES),
 };

--- a/assets/src/design-system/components/typography/text/index.js
+++ b/assets/src/design-system/components/typography/text/index.js
@@ -52,24 +52,8 @@ const Label = styled.label`
     disabled ? theme.colors.fg.disable : 'auto'};
 `;
 
-const Link = styled.a`
-  ${({ theme }) => css`
-    color: ${theme.colors.fg.linkNormal};
-    text-decoration: none;
-    cursor: pointer;
-
-    :hover {
-      color: ${theme.colors.fg.linkHover};
-    }
-
-    ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)}
-  `};
-`;
-
 export const Text = ({ as, disabled, ...props }) => {
   switch (as) {
-    case 'a':
-      return <Link {...props} />;
     case 'label':
       return <Label disabled={disabled} {...props} />;
     case 'span':
@@ -80,7 +64,7 @@ export const Text = ({ as, disabled, ...props }) => {
 };
 
 Text.propTypes = {
-  as: PropTypes.oneOf(['p', 'a', 'span', 'label']),
+  as: PropTypes.oneOf(['p', 'span', 'label']),
   /** only applies to label styling */
   disabled: PropTypes.bool,
   isBold: PropTypes.bool,

--- a/assets/src/design-system/components/typography/text/stories/index.js
+++ b/assets/src/design-system/components/typography/text/stories/index.js
@@ -24,6 +24,7 @@ import { action } from '@storybook/addon-actions';
  * Internal dependencies
  */
 import { Text } from '../';
+import { Headline } from '../..';
 import { THEME_CONSTANTS } from '../../../../';
 
 export default {
@@ -31,6 +32,7 @@ export default {
   component: Text,
 };
 
+const booleanOptions = [true, false];
 const textPresetSizes = THEME_CONSTANTS.TYPOGRAPHY.TEXT_SIZES;
 const textRenderAsOptions = ['p', 'a', 'span'];
 
@@ -78,6 +80,37 @@ export const Link = () => (
         onClick={action('anchor clicked! Do something.')}
       >
         {`${presetSize} - Click here for more information`}
+        <br />
+      </Text>
+    ))}
+  </>
+);
+
+export const Label = () => (
+  <>
+    <Headline as="h1">{'Label'}</Headline>
+    {textPresetSizes.map((presetSize) => (
+      <Text
+        key={`${presetSize}_text_link`}
+        size={presetSize}
+        as={select('label', textRenderAsOptions, 'label')}
+        isBold={select('isBold', booleanOptions, false)}
+      >
+        {`${presetSize} - Och glasen glittrar tyst på vårt bord`}
+        <br />
+      </Text>
+    ))}
+    <br />
+    <Headline as="h1">{'Label - Disabled'}</Headline>
+    {textPresetSizes.map((presetSize) => (
+      <Text
+        key={`${presetSize}_text_link_disabled`}
+        size={presetSize}
+        as={select('label', textRenderAsOptions, 'label')}
+        isBold={select('isBold', booleanOptions, false)}
+        disabled
+      >
+        {`${presetSize} - Och glasen glittrar tyst på vårt bord`}
         <br />
       </Text>
     ))}

--- a/assets/src/design-system/components/typography/text/stories/index.js
+++ b/assets/src/design-system/components/typography/text/stories/index.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import { select } from '@storybook/addon-knobs';
-import { action } from '@storybook/addon-actions';
 
 /**
  * Internal dependencies
@@ -64,23 +63,6 @@ export const Bold = () => (
       >
         {presetSize} <br />
         {'Regnet slår mot rutorna nu, men natten är ljus, i ett land utan ljud'}
-      </Text>
-    ))}
-  </>
-);
-
-export const Link = () => (
-  <>
-    {textPresetSizes.map((presetSize) => (
-      <Text
-        key={`${presetSize}_text_link`}
-        size={presetSize}
-        as={select('as', textRenderAsOptions, 'a')}
-        href="#"
-        onClick={action('anchor clicked! Do something.')}
-      >
-        {`${presetSize} - Click here for more information`}
-        <br />
       </Text>
     ))}
   </>


### PR DESCRIPTION
## Summary

Adds a checkbox component to the design system.
[Designs](https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Design-System?node-id=1533%3A260040)

## Relevant Technical Choices

- Using a label with a memoized uuid as the `htmlFor` property to make sure screen readers can associate the label to the input. This can be overridden using the `id` property

## To-do

none

## User-facing changes

none

## Testing Instructions

The input can be seen in storybook under `
- go to Design System -> Components -> Checkbox

![input](https://user-images.githubusercontent.com/22185279/105771099-4a4a3680-5f1d-11eb-8e04-77945a768c23.gif)

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #4949
