### PR TITLE
Analytics: Improve Site Kit detection to check if its tracking snippet is inserted

### DIFF
--- a/includes/Integrations/Site_Kit.php
+++ b/includes/Integrations/Site_Kit.php
@@ -83,7 +83,11 @@ class Site_Kit {
 	 * @return bool Whether Site Kit's analytics module is active.
 	 */
 	protected function is_analytics_module_active() {
-		return in_array( 'analytics', $this->get_site_kit_active_modules_option(), true );
+		$analytics_module_active = in_array( 'analytics', $this->get_site_kit_active_modules_option(), true );
+		$analytics_options       = get_option( 'googlesitekit_analytics_settings' );
+		$analytics_use_snippet   = ! empty( $analytics_options['useSnippet'] );
+
+		return $analytics_module_active && $analytics_use_snippet;
 	}
 
 	/**

--- a/tests/e2e/plugins/site-kit-mock.php
+++ b/tests/e2e/plugins/site-kit-mock.php
@@ -84,6 +84,19 @@ function mock_enable_active_modules( $current ) {
 }
 add_filter( 'pre_option_googlesitekit_active_modules', __NAMESPACE__ . '\mock_enable_active_modules' );
 
+
+/**
+ * Force analytics snippet to be enabled.
+ *
+ * @param $current
+ *
+ * @return string[]
+ */
+function mock_enable_analytics_settings( $current ) {
+	return [ 'useSnippet' => true ];
+}
+add_filter( 'pre_option_googlesitekit_analytics_settings', __NAMESPACE__ . '\mock_enable_analytics_settings' );
+
 /**
  * Gets the HTML attributes for an AMP tag that may potentially require user consent before loading.
  *

--- a/tests/phpunit/tests/Integrations/Site_Kit.php
+++ b/tests/phpunit/tests/Integrations/Site_Kit.php
@@ -67,6 +67,7 @@ class Site_Kit extends \WP_UnitTestCase {
 	public function test_init_analytics_module_active() {
 		define( 'GOOGLESITEKIT_VERSION', '1.2.3' );
 		update_option( 'googlesitekit_active_modules', [ 'analytics' ], false );
+		update_option( 'googlesitekit_analytics_settings', [ 'useSnippet' => true ], false );
 
 		$analytics = $this->createMock( \Google\Web_Stories\Analytics::class );
 		add_action( 'web_stories_print_analytics', [ $analytics, 'print_analytics_tag' ] );
@@ -142,11 +143,15 @@ class Site_Kit extends \WP_UnitTestCase {
 		$actual_before = $this->call_private_method( $site_kit, 'get_site_kit_active_modules_option' );
 
 		update_option( 'googlesitekit_active_modules', [ 'analytics' ], false );
+		update_option( 'googlesitekit_analytics_settings', [ 'useSnippet' => true ], false );
 
 		$actual_after = $this->call_private_method( $site_kit, 'get_site_kit_active_modules_option' );
 
 		delete_option( 'googlesitekit_active_modules' );
+		delete_option( 'googlesitekit_analytics_settings' );
+
 		update_option( 'googlesitekit-active-modules', [ 'analytics' ], false );
+		update_option( 'googlesitekit_analytics_settings', [ 'useSnippet' => true ], false );
 
 		$actual_after_legacy = $this->call_private_method( $site_kit, 'get_site_kit_active_modules_option' );
 
@@ -228,6 +233,7 @@ class Site_Kit extends \WP_UnitTestCase {
 	public function test_get_plugin_status_analytics_module_active() {
 		define( 'GOOGLESITEKIT_VERSION', '1.2.3' );
 		update_option( 'googlesitekit_active_modules', [ 'analytics' ], false );
+		update_option( 'googlesitekit_analytics_settings', [ 'useSnippet' => true ], false );
 
 		$analytics = $this->createMock( \Google\Web_Stories\Analytics::class );
 		$site_kit  = new \Google\Web_Stories\Integrations\Site_Kit( $analytics );
@@ -236,6 +242,31 @@ class Site_Kit extends \WP_UnitTestCase {
 			'installed'       => true,
 			'active'          => true,
 			'analyticsActive' => true,
+			'link'            => __( 'https://wordpress.org/plugins/google-site-kit/', 'web-stories' ),
+		];
+
+		$actual = $site_kit->get_plugin_status();
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	/**
+	 * @covers ::get_plugin_status
+	 * @covers ::is_analytics_module_active
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_get_plugin_status_analytics_module_no_snippet() {
+		define( 'GOOGLESITEKIT_VERSION', '1.2.3' );
+		update_option( 'googlesitekit_active_modules', [ 'analytics' ], false );
+
+		$analytics = $this->createMock( \Google\Web_Stories\Analytics::class );
+		$site_kit  = new \Google\Web_Stories\Integrations\Site_Kit( $analytics );
+
+		$expected = [
+			'installed'       => true,
+			'active'          => true,
+			'analyticsActive' => false,
 			'link'            => __( 'https://wordpress.org/plugins/google-site-kit/', 'web-stories' ),
 		];
 


### PR DESCRIPTION
## Summary

Improve check for site kit analytics are enabled. Much of this PR, is updating tests to pass as original solution was in the original ticket. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

<!-- How can the changes in this PR be verified? Relevant for QA  and user acceptance testing. -->

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes #6014
