### PR TITLE
Try: Material UI in Design System

### DIFF
--- a/assets/src/design-system/components/typeahead/index.js
+++ b/assets/src/design-system/components/typeahead/index.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { v4 as uuidv4 } from 'uuid';
+import { TextField } from '@material-ui/core';
+import { Autocomplete } from '@material-ui/lab';
+import styled, { css } from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { themeHelpers, THEME_CONSTANTS } from '../../theme';
+import { Text } from '../typography';
+
+const StyledAutocomplete = styled(Autocomplete)(
+  ({ theme }) => css`
+    .MuiAutocomplete-fullWidth,
+    .MuiAutocomplete-root,
+    .MuiAutocomplete-input {
+      height: 36px;
+      padding: 0 !important;
+    }
+    .MuiInputBase-root {
+      padding: 8px 12px;
+      height: 36px;
+      border-radius: ${theme.borders.radius.small};
+      color: ${theme.colors.fg.primary};
+      background-color: ${theme.colors.bg.primary};
+      ${themeHelpers.expandPresetStyles({
+        preset:
+          theme.typography.presets.paragraph[
+            THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL
+          ],
+        theme,
+      })}
+      &:hover {
+        border: 1px solid ${theme.colors.border.defaultHover};
+      }
+    }
+    .MuiAutocomplete-input {
+      padding: 0;
+      height: 100%;
+    }
+  `
+);
+
+const Typeahead = ({ options, label, ...rest }) => {
+  const uuid = useMemo(() => `list-${uuidv4()}`, []);
+  return (
+    <>
+      <Text>{label}</Text>
+      <StyledAutocomplete
+        id={uuid}
+        options={options}
+        getOptionLabel={(option) => option?.label}
+        fullWidth={true}
+        renderInput={(params) => <TextField {...params} variant="outlined" />}
+        {...rest}
+      />
+    </>
+  );
+};
+
+Typeahead.propTypes = {
+  options: PropTypes.array.isRequired,
+  label: PropTypes.string,
+};
+export default Typeahead;

--- a/assets/src/design-system/components/typeahead/stories/index.js
+++ b/assets/src/design-system/components/typeahead/stories/index.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { text } from '@storybook/addon-knobs';
+import styled from 'styled-components';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+
+/**
+ * Internal dependencies
+ */
+import Typeahead from '..';
+import {
+  basicDropDownOptions,
+  nestedDropDownOptions,
+} from '../../../storybookUtils/sampleData';
+
+export default {
+  title: 'DesignSystem/Components/Typeahead2',
+};
+
+const Container = styled.div`
+  width: ${({ narrow }) => (narrow ? 150 : 400)}px;
+  height: 100vh;
+  padding: 12px 24px;
+  background-color: ${({ theme }) => theme.colors.bg.primary};
+`;
+
+// something like this could live in our theme, be passed in our theme values
+// and override all mui components we use while leaving us able to use our theme values outside of material ui for custom components.
+const muiTheme = createMuiTheme({
+  palette: {},
+  overrides: {
+    // Style sheet name
+    MuiInput: {
+      // Name of the rule
+      focused: {
+        // Some CSS
+        color: 'secondary',
+      },
+    },
+  },
+});
+
+export const _default = () => {
+  return (
+    <Container>
+      <ThemeProvider theme={muiTheme}>
+        <Typeahead
+          options={basicDropDownOptions}
+          label={text('label', 'Search')}
+        />
+      </ThemeProvider>
+    </Container>
+  );
+};
+
+export const GroupedSearch = () => {
+  return (
+    <Container>
+      <Typeahead
+        options={nestedDropDownOptions}
+        label={text('label', 'Search')}
+        groupBy={(option) => option.group}
+      />
+    </Container>
+  );
+};

--- a/assets/src/design-system/storybookUtils/sampleData.js
+++ b/assets/src/design-system/storybookUtils/sampleData.js
@@ -135,35 +135,22 @@ export const effectChooserOptions = [
 ];
 
 export const nestedDropDownOptions = [
-  {
-    label: 'aliens',
-    options: [
-      { value: 'alien-1', label: 'ET' },
-      { value: 'alien-2', label: 'Stitch' },
-      { value: 'alien-3', label: 'Groot' },
-      { value: 'alien-4', label: 'The Worm Guys' },
-      { value: 'alien-5', label: "Na'vi" },
-      { value: 'alien-6', label: 'Arachnids' },
-      { value: 'alien-7', label: 'The Predator' },
-      { value: 'alien-8', label: 'Xenomorph' },
-    ],
-  },
-  {
-    label: 'dragons',
-    options: [
-      { value: 'dragon-1', label: 'Smaug' },
-      { value: 'dragon-2', label: 'Mushu' },
-      { value: 'dragon-3', label: 'Toothless' },
-      { value: 'dragon-4', label: 'Falkor' },
-      { value: 'dragon-5', label: 'Drogon' },
-      { value: 'dragon-6', label: 'Kalessin' },
-    ],
-  },
-  {
-    label: 'dogs',
-    options: [
-      { value: 'dog-1', label: 'Snoopy' },
-      { value: 'dog-2', label: 'Scooby' },
-    ],
-  },
+  { value: 'alien-1', label: 'ET', group: 'aliens' },
+  { value: 'alien-2', label: 'Stitch', group: 'aliens' },
+  { value: 'alien-3', label: 'Groot', group: 'aliens' },
+  { value: 'alien-4', label: 'The Worm Guys', group: 'aliens' },
+  { value: 'alien-5', label: "Na'vi", group: 'aliens' },
+  { value: 'alien-6', label: 'Arachnids', group: 'aliens' },
+  { value: 'alien-7', label: 'The Predator', group: 'aliens' },
+  { value: 'alien-8', label: 'Xenomorph', group: 'aliens' },
+
+  { value: 'dragon-1', label: 'Smaug', group: 'dragons' },
+  { value: 'dragon-2', label: 'Mushu', group: 'dragons' },
+  { value: 'dragon-3', label: 'Toothless', group: 'dragons' },
+  { value: 'dragon-4', label: 'Falkor', group: 'dragons' },
+  { value: 'dragon-5', label: 'Drogon', group: 'dragons' },
+  { value: 'dragon-6', label: 'Kalessin', group: 'dragons' },
+
+  { value: 'dog-1', label: 'Snoopy', group: 'dogs' },
+  { value: 'dog-2', label: 'Scooby', group: 'dogs' },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -4832,6 +4832,86 @@
         }
       }
     },
+    "@material-ui/core": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.3.tgz",
+      "integrity": "sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/styles": "^4.11.3",
+        "@material-ui/system": "^4.11.3",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.11.2",
+        "@types/react-transition-group": "^4.2.0",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "1.16.1-lts",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0",
+        "react-transition-group": "^4.4.0"
+      }
+    },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.57",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.57.tgz",
+      "integrity": "sha512-qo/IuIQOmEKtzmRD2E4Aa6DB4A87kmY6h0uYhjUmrrgmEAgbbw9etXpWPVXuRK6AGIQCjFzV6WO2i21m1R4FCw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "@material-ui/styles": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.3.tgz",
+      "integrity": "sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/hash": "^0.8.0",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.11.2",
+        "clsx": "^1.0.4",
+        "csstype": "^2.5.2",
+        "hoist-non-react-statics": "^3.3.2",
+        "jss": "^10.5.1",
+        "jss-plugin-camel-case": "^10.5.1",
+        "jss-plugin-default-unit": "^10.5.1",
+        "jss-plugin-global": "^10.5.1",
+        "jss-plugin-nested": "^10.5.1",
+        "jss-plugin-props-sort": "^10.5.1",
+        "jss-plugin-rule-value-function": "^10.5.1",
+        "jss-plugin-vendor-prefixer": "^10.5.1",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
+      "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.2",
+        "csstype": "^2.5.2",
+        "prop-types": "^15.7.2"
+      }
+    },
+    "@material-ui/types": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
+    },
+    "@material-ui/utils": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+      "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      }
+    },
     "@mdx-js/loader": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-1.6.22.tgz",
@@ -8561,6 +8641,14 @@
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.0.tgz",
       "integrity": "sha512-nvw+F81OmyzpyIE1S0xWpLonLUZCMewslPuA8BtjSKc5XEbn8zEQBXS7KuOLHTNnSOEM2Pum50gHOoZ62tqTRg==",
       "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
       "requires": {
         "@types/react": "*"
       }
@@ -12901,6 +12989,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -13723,6 +13816,15 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
+      }
+    },
+    "css-vendor": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.3",
+        "is-in-browser": "^1.0.2"
       }
     },
     "css-what": {
@@ -18389,6 +18491,11 @@
       "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
       "dev": true
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -18499,6 +18606,14 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
+    },
+    "indefinite-observable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-2.0.1.tgz",
+      "integrity": "sha512-G8vgmork+6H9S8lUAg1gtXEj2JxIQTo0g2PbFiYOdjkziSI0F7UYBiVwhZRuixhBCNGczAls34+5HJPyZysvxQ==",
+      "requires": {
+        "symbol-observable": "1.2.0"
+      }
     },
     "indent-string": {
       "version": "4.0.0",
@@ -18922,6 +19037,11 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
       "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
       "dev": true
+    },
+    "is-in-browser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-map": {
       "version": "2.0.2",
@@ -22164,6 +22284,92 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jss": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
+      "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
+        "indefinite-observable": "^2.0.1",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+        }
+      }
+    },
+    "jss-plugin-camel-case": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.1.tgz",
+      "integrity": "sha512-9+oymA7wPtswm+zxVti1qiowC5q7bRdCJNORtns2JUj/QHp2QPXYwSNRD8+D2Cy3/CEMtdJzlNnt5aXmpS6NAg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.5.1"
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.1.tgz",
+      "integrity": "sha512-D48hJBc9Tj3PusvlillHW8Fz0y/QqA7MNmTYDQaSB/7mTrCZjt7AVRROExoOHEtd2qIYKOYJW3Jc2agnvsXRlQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.1"
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.5.1.tgz",
+      "integrity": "sha512-jX4XpNgoaB8yPWw/gA1aPXJEoX0LNpvsROPvxlnYe+SE0JOhuvF7mA6dCkgpXBxfTWKJsno7cDSCgzHTocRjCQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.1"
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.5.1.tgz",
+      "integrity": "sha512-xXkWKOCljuwHNjSYcXrCxBnjd8eJp90KVFW1rlhvKKRXnEKVD6vdKXYezk2a89uKAHckSvBvBoDGsfZrldWqqQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.1",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.1.tgz",
+      "integrity": "sha512-t+2vcevNmMg4U/jAuxlfjKt46D/jHzCPEjsjLRj/J56CvP7Iy03scsUP58Iw8mVnaV36xAUZH2CmAmAdo8994g==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.1"
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.1.tgz",
+      "integrity": "sha512-3gjrSxsy4ka/lGQsTDY8oYYtkt2esBvQiceGBB4PykXxHoGRz14tbCK31Zc6DHEnIeqsjMUGbq+wEly5UViStQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.5.1",
+        "tiny-warning": "^1.0.2"
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.1.tgz",
+      "integrity": "sha512-cLkH6RaPZWHa1TqSfd2vszNNgxT1W0omlSjAd6hCFHp3KIocSrW21gaHjlMU26JpTHwkc+tJTCQOmE/O1A4FKQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.8",
+        "jss": "10.5.1"
       }
     },
     "jssha": {
@@ -25822,6 +26028,11 @@
       "requires": {
         "@babel/runtime": "^7.12.5"
       }
+    },
+    "popper.js": {
+      "version": "1.16.1-lts",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+      "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -31787,6 +31998,11 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "dev": true
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tinycolor2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   "dependencies": {
     "@ap.cx/hues": "^2.4.0",
     "@ffmpeg/ffmpeg": "^0.9.6",
+    "@material-ui/core": "^4.11.3",
+    "@material-ui/lab": "^4.0.0-alpha.57",
     "@wordpress/api-fetch": "^3.21.1",
     "@wordpress/block-editor": "^5.2.1",
     "@wordpress/blocks": "^6.25.0",


### PR DESCRIPTION
## Context
Discussion on Slack this week has led us to try out using material ui again (see this thread: https://github.com/google/web-stories-wp/issues/324) now that we're consolidating our components from the editor and the dashboard into one design system. 

## Summary

This is a super rough proof of concept for using material ui as a base for our design system components since there's a significant amount of overlap between our styles internally and material ui as a whole. There's some discrepancies. If we were to go this route, I'd be in favor of using material ui components where the overrides don't out number the ways the component is helpful and that leaves us room to DIY anything that makes sense for our use cases. 

My point in this POC isn't merge-able code, but just a way to make a choice to move forward.  

If we were to use material ui I'd say we just [override their palette with our theme](https://material-ui.com/customization/globals/#css), nest the material ui theme inside our styled theme for continuity, override everything that makes sense at the root (disabled, focus colors) and then override everything else needed to use a component in our design system component and then the app using it can just import that component and call it a day. 

Pros I see: Decreases dev time (once you figure out the material ui API) for more complicated components, like this typeahead. Decreases edge cases and QA time. 

Cons I see: Increases bundle size :( - we'd have to redo a handful of components (wouldn't be that bad)

Here's a rough sketch of what the typeahead would end up looking like - the colors and icons are wrong, just as a loose proof of concept. 
