### PR TITLE
Infrastructure: Allow specifying PHP version for local dev environment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PHP_VERSION='8.0'

--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-PHP_VERSION='8.0'

--- a/bin/local-env/docker-compose.yml
+++ b/bin/local-env/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   wordpress:
-    image: wordpress
+    image: wordpress:php${PHP_VERSION}
     ports:
       - '127.0.0.1:8899:80'
     environment:
@@ -24,7 +24,7 @@ services:
       - mysql
 
   cli:
-    image: wordpress:cli
+    image: wordpress:cli-php${PHP_VERSION}
     user: xfs
     volumes:
       - wordpress_data:/var/www/html

--- a/bin/local-env/docker-compose.yml
+++ b/bin/local-env/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   wordpress:
-    image: wordpress:php${PHP_VERSION}
+    image: wordpress:php${PHP_VERSION:-7.4}
     ports:
       - '127.0.0.1:8899:80'
     environment:
@@ -24,7 +24,7 @@ services:
       - mysql
 
   cli:
-    image: wordpress:cli-php${PHP_VERSION}
+    image: wordpress:cli-php${PHP_VERSION:-7.4}
     user: xfs
     volumes:
       - wordpress_data:/var/www/html

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -46,3 +46,8 @@ Slow down all interactions by a certain time for easier debugging. Useful in com
 
 **PUPPETEER_DEVTOOLS** (bool):
 Whether to open dev tools during tests. Default: `false`
+
+## Local Environment
+
+**PHP_VERSION** (string):
+PHP version which local environment runs in. Default: `7.4` 

--- a/docs/local-environment.md
+++ b/docs/local-environment.md
@@ -30,6 +30,14 @@ Also, if you need to reset the local environment's database, you can run:
 npm run env:reset-site
 ```
 
+## Specifying PHP Version
+
+It is also possible to run the local environment in different PHP versions, like so: 
+
+```bash
+PHP_VERSION=8.0 npm run env:start
+```
+
 ## Custom Environment
 
 Alternatively, you can use your own local WordPress environment (e.g. using [Local by Flywheel](https://localbyflywheel.com/)) and clone this repository right into your `wp-content/plugins` directory.


### PR DESCRIPTION
## Context

Allow developers to easily define the PHP version with an env variable. 

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

In terminal. 
- Type `export PHP_VERSION=8.0`
- Type `npm run env:start`


### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5626
