### PR TITLE
Unify poster views for page, thumbnails, preview

### DIFF
--- a/assets/src/edit-story/components/form/media.js
+++ b/assets/src/edit-story/components/form/media.js
@@ -192,7 +192,7 @@ function MediaInput({
   };
 
   const isMenuVisible = isHovering || isFocused;
-
+  const { imgProps } = rest;
   return (
     <Container
       ref={ref}
@@ -204,7 +204,7 @@ function MediaInput({
       {...(canReset && resettableProps)}
     >
       {value && !isMultiple ? (
-        <Img src={value} circle={circle} alt={alt} />
+        <Img src={value} circle={circle} alt={alt} {...imgProps} />
       ) : (
         <DefaultImage size={size} />
       )}

--- a/assets/src/edit-story/components/panels/design/layer/karma/layer.karma.js
+++ b/assets/src/edit-story/components/panels/design/layer/karma/layer.karma.js
@@ -53,4 +53,17 @@ describe('Layer Panel', () => {
 
     await fixture.snapshot();
   });
+
+  it('should allow changing the layer panel height via slider', async () => {
+    expect(layerPanel.resizeHandle).toBeTruthy();
+    const section = layerPanel.resizeHandle.closest('section');
+    const initialHeight = section.clientHeight;
+    await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
+      moveRel(layerPanel.resizeHandle, 3, 3),
+      down(),
+      moveBy(0, -30, { steps: 6 }),
+      up(),
+    ]);
+    expect(section.clientHeight).toBe(initialHeight + 30);
+  });
 });

--- a/assets/src/edit-story/components/panels/design/poster/videoPoster.js
+++ b/assets/src/edit-story/components/panels/design/poster/videoPoster.js
@@ -66,6 +66,7 @@ function VideoPosterPanel({ selectedElements, pushUpdate }) {
           alt={__('Preview poster image', 'web-stories')}
           type={'image'}
           ariaLabel={__('Video poster', 'web-stories')}
+          imgProps={{ style: { objectFit: 'contain' } }}
           canReset
         />
       </Row>

--- a/assets/src/edit-story/components/panels/panel/shared/handle.js
+++ b/assets/src/edit-story/components/panels/panel/shared/handle.js
@@ -75,7 +75,12 @@ function DragHandle({
   useKeyboardHandlers(handle, handleHeightChange);
 
   return (
-    <Handle ref={handle} onDoubleClick={handleDoubleClick} $position={position}>
+    <Handle
+      ref={handle}
+      onClick={(e) => e.stopPropagation()}
+      onDoubleClick={handleDoubleClick}
+      $position={position}
+    >
       <Bar
         role="slider"
         aria-orientation="vertical"

--- a/assets/src/edit-story/elements/video/display.js
+++ b/assets/src/edit-story/elements/video/display.js
@@ -41,6 +41,12 @@ const Image = styled.img`
   max-width: initial;
   max-height: initial;
   ${videoWithScale}
+  ${({ previewMode }) =>
+    previewMode &&
+    `
+    height: inherit;
+    object-fit: contain;
+  `}
 `;
 
 function VideoDisplay({ previewMode, box: { width, height }, element }) {
@@ -88,6 +94,7 @@ function VideoDisplay({ previewMode, box: { width, height }, element }) {
           style={style}
           {...videoProps}
           ref={ref}
+          previewMode={previewMode}
         />
       ) : (
         <Video

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/index.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/index.js
@@ -164,7 +164,7 @@ export class DesignPanel extends Container {
   }
 
   get layerPanel() {
-    // The whole panel is aria-hidden now for accessibiility reasons
+    // The whole panel is aria-hidden now for accessibility reasons
     // thus it cannot be accessed by role:
     return this._get(
       getByLabelText(this._node, 'Layers'),

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/layers.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/layers.js
@@ -41,7 +41,6 @@ export class Layers extends AbstractPanel {
   }
 
   get resizeHandle() {
-    console.log('HEY', this.node);
     return getByLabelText(this.node, /Set panel height/i);
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/layers.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/layers.js
@@ -41,6 +41,7 @@ export class Layers extends AbstractPanel {
   }
 
   get resizeHandle() {
-    return getByLabelText(this.node.ownerDocument, /Set panel height/i);
+    console.log('HEY', this.node);
+    return getByLabelText(this.node, /Set panel height/i);
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/layers.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/layers.js
@@ -39,4 +39,8 @@ export class Layers extends AbstractPanel {
   get layers() {
     return getAllByTestId(this.layersList, 'layer-option');
   }
+
+  get resizeHandle() {
+    return getByLabelText(this.node.ownerDocument, /Set panel height/i);
+  }
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Uses the same logic everywhere for the poster preview as AMP automatically does: `object-fit: contain`.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
1. Add a video
2. Assign a custom poster image that has a different ratio than the video, e.g. take a wide video and add a tall poster image
3. Verify that the poster image looks similar on the editor Page, on Thumbnails in the grid view, design panel poster preview, and page carousel, and also in the preview.


See [this comment](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/1123#issuecomment-611924755) for how it was before.

Now:
- Images look similar in all 3 places.
- ![Screenshot 2021-02-02 at 15 54 39](https://user-images.githubusercontent.com/3294597/106610176-bbfe3200-6566-11eb-89da-691129bca2a8.png)


And here, too:
![Screenshot 2021-02-02 at 15 54 44](https://user-images.githubusercontent.com/3294597/106610186-be608c00-6566-11eb-9d67-d915a7119937.png)

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->
See the instructions above under "Testing instructions"
<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #1123 
