### PR TITLE
Dashboard: Add minimum width

### DIFF
--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -49,7 +49,9 @@ import {
   NavListItem,
 } from './navigationComponents';
 
-export const AppFrame = styled.div({});
+export const AppFrame = styled.div`
+  overflow-x: scroll;
+`;
 
 export const PageContent = styled.div`
   position: relative;
@@ -59,9 +61,11 @@ export const PageContent = styled.div`
   left: ${({ fullWidth }) =>
     fullWidth ? '0' : `${DASHBOARD_LEFT_NAV_WIDTH}px`};
 
-  @media ${({ theme }) => theme.DEPRECATED_THEME.breakpoint.tablet} {
+  @media screen and (max-width: ${THEME_CONSTANTS.BREAKPOINTS.TABLET
+      .maxWidth}px) {
     left: 0;
     width: 100%;
+    min-width: ${THEME_CONSTANTS.BREAKPOINTS.TABLET.minWidth}px;
   }
 `;
 

--- a/assets/src/dashboard/components/tooltip/index.js
+++ b/assets/src/dashboard/components/tooltip/index.js
@@ -66,12 +66,17 @@ export default function Tooltip({ children, content, position }) {
   }, [content]);
 
   const offset = useMemo(() => {
-    if (!showTooltip) {
-      return {};
-    }
     let metrics = {};
 
-    if (!contentRef.current || !containerRef.current) {
+    if (!showTooltip && position === 'right') {
+      // have the tooltip render near where it will be displayed
+      // so that it doesn't interrupt the flow before being shown
+      metrics = {
+        right: 0,
+      };
+    }
+
+    if (!showTooltip || !contentRef.current || !containerRef.current) {
       return metrics;
     }
 

--- a/assets/src/dashboard/components/tooltip/index.js
+++ b/assets/src/dashboard/components/tooltip/index.js
@@ -94,6 +94,7 @@ export default function Tooltip({ children, content, position }) {
         top: containerRect.height + 1,
       };
     }
+
     return metrics;
   }, [position, showTooltip]);
 

--- a/assets/src/design-system/theme/constants/breakpoints.js
+++ b/assets/src/design-system/theme/constants/breakpoints.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,18 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Internal dependencies
- */
-import { BREAKPOINTS } from './breakpoints';
-import * as TYPOGRAPHY from './typography';
-import * as WP_ADMIN from './wpAdmin';
-import { Z_INDEX } from './zIndex';
-
-export const THEME_CONSTANTS = {
-  BREAKPOINTS,
-  TYPOGRAPHY,
-  Z_INDEX,
-  WP_ADMIN,
+export const BREAKPOINTS = {
+  TABLET: {
+    maxWidth: 1120,
+    minWidth: 768,
+  },
 };


### PR DESCRIPTION
## Context

Per discussion with Sam, we should implement a minimum width in the dashboard so that when viewports shrink to a certain size the contents will scroll horizontally.

## Summary

- Add tablet breakpoints and a minimum width to the dashboard.
- Update initial tooltip position so that it doesn't add extra space to a parent container with a fixed width (doesn't need to be an immediate parent).

## Relevant Technical Choices

The tooltip doesn't have `display: none` so it can still interrupt the flow. When rendering the tooltip: if it is supposed to be aligned with the right corner I decided to add a `right: 0` property so that the tooltip didn't leak the wrong way over and add extra unneeded space.

If the tooltip were to be aligned "right" but the content was on the left side of the screen, it will still spill over (like before).

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/22185279/106662413-94f03200-655f-11eb-9043-ba8640f52702.png)|![image](https://user-images.githubusercontent.com/22185279/106662468-a76a6b80-655f-11eb-87ab-e60b1392c7c8.png)|

## To-do

none

## User-facing changes

There is now a minimum width on the dashboard. Once the screen is shrunken down past `768px` they will be able scroll it.
![scrolly-boi](https://user-images.githubusercontent.com/22185279/106662807-19db4b80-6560-11eb-9b13-e5eb9d05a84f.gif)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
1. Run app
2. Go to dashboard
3. Decrease window size past `768px`. You should be able to scroll horizontally. The content will not shrink past 768px.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to dashboard
2. Decrease window size past `768px`. You should be able to scroll horizontally. The content will not shrink past 768px.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6098 
