### PR TITLE
FTUE: Add and display help center videos

### DIFF
--- a/assets/src/edit-story/components/helpCenter/constants.js
+++ b/assets/src/edit-story/components/helpCenter/constants.js
@@ -21,6 +21,7 @@ import { __ } from '@wordpress/i18n';
 export const TIPS = {
   addBackgroundMedia: {
     title: __('Add background media', 'web-stories'),
+    figure: 'images/help-center/add_bg_module_1.webm',
     description: [
       __(
         'Double click any image or video to enter edit mode. To scale, use the slider. To change the focal point, drag the image or video.',
@@ -30,6 +31,7 @@ export const TIPS = {
   },
   cropSelectedElements: {
     title: __('Crop selected element', 'web-stories'),
+    figure: 'images/help-center/media_edit_mode_module_2.webm',
     description: [
       __(
         'Double click any image or video element to enter edit mode. Then, use the slider to scale the element or move its focal point by dragging it.',
@@ -39,6 +41,7 @@ export const TIPS = {
   },
   cropElementsWithShapes: {
     title: __('Crop elements using shapes', 'web-stories'),
+    figure: 'images/help-center/media_bg_shape_module_3.webm',
     description: [
       __(
         'Select a shape from the Shape menu to create a frame.',
@@ -48,6 +51,7 @@ export const TIPS = {
   },
   safeZone: {
     title: __('Stay within the safe zone', 'web-stories'),
+    figure: 'images/help-center/safe_zone_module_4.webm',
     description: [
       __(
         'Elements work best when you keep them within the safe zone. Outside of the safe zone, elements like links and buttons may get cropped out or not function properly.',
@@ -57,6 +61,7 @@ export const TIPS = {
   },
   previewStory: {
     title: __('Preview your Web Story', 'web-stories'),
+    figure: 'images/help-center/preview_module_5.webm',
     description: [
       __(
         'Use Preview Mode to view your Story before publishing.',
@@ -70,6 +75,7 @@ export const TIPS = {
   },
   addLinks: {
     title: __('Add links to design elements', 'web-stories'),
+    figure: 'images/help-center/add_link_module_6.webm',
     description: [
       __(
         'Go to the <strong>Links</strong> section under the Design tab and enter a URL. To remove a link, select the "X"<screenreader> (Clear)</screenreader> button.',
@@ -79,6 +85,7 @@ export const TIPS = {
   },
   enableSwipe: {
     title: __('Enable swipe-up option', 'web-stories'),
+    figure: 'images/help-center/page_attachment_module_7.webm',
     description: [
       __(
         'Go to the Design tab. Scroll down to <strong>Swipe-up Link</strong> and enter a web address and a call to action to describe the link.',

--- a/assets/src/edit-story/components/helpCenter/quickTip/index.js
+++ b/assets/src/edit-story/components/helpCenter/quickTip/index.js
@@ -30,6 +30,7 @@ import {
 import { NAVIGATION_HEIGHT } from '../navigator/constants';
 import { TranslateWithMarkup } from '../../../../i18n';
 import { GUTTER_WIDTH } from '../constants';
+import { useConfig } from '../../../app';
 import { Transitioner } from './transitioner';
 
 const Panel = styled.div`
@@ -48,9 +49,7 @@ const Overflow = styled.div`
   }
 `;
 
-// @TODO update with actual figure.
-const Figure = styled.div`
-  background-color: ${({ theme }) => theme.colors.bg.secondary};
+const Video = styled.video`
   height: 180px;
   margin-bottom: ${GUTTER_WIDTH}px;
 `;
@@ -73,8 +72,10 @@ export function QuickTip({
   title,
   description,
   isLeftToRightTransition = true,
+  figure,
   ...transitionProps
 }) {
+  const { cdnURL } = useConfig();
   return (
     <Transitioner
       {...transitionProps}
@@ -82,7 +83,11 @@ export function QuickTip({
     >
       <Panel>
         <Overflow>
-          <Figure />
+          {Boolean(figure) && (
+            <Video controls={false} autoPlay loop muted preload noControls>
+              <source src={`${cdnURL}${figure}`} type="video/webm" />
+            </Video>
+          )}
           <Title>{title}</Title>
           {description.map((paragraph, i) => (
             <Paragraph
@@ -109,5 +114,6 @@ QuickTip.propTypes = {
   figureSrc: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.arrayOf(PropTypes.string).isRequired,
+  figure: PropTypes.string,
   isLeftToRightTransition: PropTypes.bool,
 };


### PR DESCRIPTION
## Context
- Follow up PR to the [animated skeleton](https://github.com/google/web-stories-wp/pull/6158) which includes the MP4s provided by design and displays them in the quick tip menu.
- Need this display in order to finish [quick tip screens](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/5886)
- Figma reference [under FTUE](https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories---Post-Stable?node-id=2%3A91941)
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- add paths to relevant images to tip constants
- `useConfig` to get asset path
- add appropriate controls to video (e.g. use html5 video, muted needed for autoplay)

<!-- A brief description of what this PR does. -->

https://user-images.githubusercontent.com/41136059/106676058-7431d780-6573-11eb-81b7-f146fe75887d.mp4


## Relevant Technical Choices
- mp4s were chosen over lottie files to avoid installing a new library needed to display them, and the videos are small, saving on load time and project size
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Turn on Quick Tips/First Time User Experience experiements
2. Open Quick Tips in Editor
3. See beautiful animations play automatically

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

## Reviews

### Does this PR have a security-related impact?
- no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
- no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
- no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #5586 
