### PR TITLE
Track Quick Tips Users Have Read

### DIFF
--- a/assets/src/edit-story/app/api/apiProvider.js
+++ b/assets/src/edit-story/app/api/apiProvider.js
@@ -271,6 +271,17 @@ function APIProvider({ children }) {
     });
   }, [currentUser]);
 
+  const updateCurrentUser = useCallback(
+    (data) => {
+      return apiFetch({
+        path: currentUser,
+        method: 'POST',
+        data,
+      });
+    },
+    [currentUser]
+  );
+
   // See https://github.com/WordPress/gutenberg/blob/148e2b28d4cdd4465c4fe68d97fcee154a6b209a/packages/edit-post/src/store/effects.js#L72-L126
   const saveMetaBoxes = useCallback(
     (story, formData) => {
@@ -332,6 +343,7 @@ function APIProvider({ children }) {
       getStatusCheck,
       getPageLayouts,
       getCurrentUser,
+      updateCurrentUser,
     },
   };
 

--- a/assets/src/edit-story/app/currentUser/currentUserProvider.js
+++ b/assets/src/edit-story/app/currentUser/currentUserProvider.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 /**
  * Internal dependencies
@@ -29,7 +29,7 @@ import Context from './context';
 function CurrentUserProvider({ children }) {
   const [currentUser, setCurrentUser] = useState({});
   const {
-    actions: { getCurrentUser },
+    actions: { getCurrentUser, updateCurrentUser: _updateCurrentUser },
   } = useAPI();
 
   useEffect(() => {
@@ -38,9 +38,17 @@ function CurrentUserProvider({ children }) {
     }
   }, [currentUser, getCurrentUser]);
 
+  const updateCurrentUser = useCallback(
+    (data) => _updateCurrentUser(data).then(setCurrentUser),
+    [_updateCurrentUser]
+  );
+
   const state = {
     state: {
       currentUser,
+    },
+    actions: {
+      updateCurrentUser,
     },
   };
 

--- a/assets/src/edit-story/components/helpCenter/companion/index.js
+++ b/assets/src/edit-story/components/helpCenter/companion/index.js
@@ -23,15 +23,15 @@ import PropTypes from 'prop-types';
  */
 import { Menu } from '../menu';
 import { QuickTip } from '../quickTip';
-import { TIPS, DONE_TIP_ENTRY } from '../constants';
+import { TIPS, DONE_TIP_ENTRY, ReadTipsType } from '../constants';
 
 const TIP_MAP = { ...TIPS, [DONE_TIP_ENTRY[0]]: DONE_TIP_ENTRY[1] };
 
 export function Companion({
-  read,
   tipKey,
   onTipSelect,
   isLeftToRightTransition,
+  readTips,
 }) {
   const tip = tipKey && TIP_MAP[tipKey];
   return (
@@ -44,18 +44,13 @@ export function Companion({
           {...tip}
         />
       ) : (
-        <Menu
-          read={read}
-          key={'menu'}
-          transitionKey={'menu'}
-          onTipSelect={onTipSelect}
-        />
+        <Menu key="menu" readTips={readTips} onTipSelect={onTipSelect} />
       )}
     </TransitionGroup>
   );
 }
 Companion.propTypes = {
-  read: PropTypes.arrayOf(PropTypes.string).isRequired,
+  readTips: ReadTipsType,
   tipKey: PropTypes.oneOf(Object.keys(TIP_MAP)),
   onTipSelect: PropTypes.func.isRequired,
   isLeftToRightTransition: PropTypes.bool.isRequired,

--- a/assets/src/edit-story/components/helpCenter/companion/index.js
+++ b/assets/src/edit-story/components/helpCenter/companion/index.js
@@ -27,7 +27,12 @@ import { TIPS, DONE_TIP_ENTRY } from '../constants';
 
 const TIP_MAP = { ...TIPS, [DONE_TIP_ENTRY[0]]: DONE_TIP_ENTRY[1] };
 
-export function Companion({ tipKey, onTipSelect, isLeftToRightTransition }) {
+export function Companion({
+  read,
+  tipKey,
+  onTipSelect,
+  isLeftToRightTransition,
+}) {
   const tip = tipKey && TIP_MAP[tipKey];
   return (
     <TransitionGroup>
@@ -39,12 +44,18 @@ export function Companion({ tipKey, onTipSelect, isLeftToRightTransition }) {
           {...tip}
         />
       ) : (
-        <Menu key={'menu'} transitionKey={'menu'} onTipSelect={onTipSelect} />
+        <Menu
+          read={read}
+          key={'menu'}
+          transitionKey={'menu'}
+          onTipSelect={onTipSelect}
+        />
       )}
     </TransitionGroup>
   );
 }
 Companion.propTypes = {
+  read: PropTypes.arrayOf(PropTypes.string).isRequired,
   tipKey: PropTypes.oneOf(Object.keys(TIP_MAP)),
   onTipSelect: PropTypes.func.isRequired,
   isLeftToRightTransition: PropTypes.bool.isRequired,

--- a/assets/src/edit-story/components/helpCenter/constants.js
+++ b/assets/src/edit-story/components/helpCenter/constants.js
@@ -16,12 +16,16 @@
 /**
  * External dependencies
  */
-import { __ } from '@web-stories-wp/i18n';
+import PropTypes from 'prop-types';
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
 
 export const TIPS = {
   addBackgroundMedia: {
     title: __('Add background media', 'web-stories'),
-    figure: 'images/help-center/add_bg_module_1.webm',
+    figureSrc: 'images/help-center/add_bg_module_1.webm',
     description: [
       __(
         'Double click any image or video to enter edit mode. To scale, use the slider. To change the focal point, drag the image or video.',
@@ -31,7 +35,7 @@ export const TIPS = {
   },
   cropSelectedElements: {
     title: __('Crop selected element', 'web-stories'),
-    figure: 'images/help-center/media_edit_mode_module_2.webm',
+    figureSrc: 'images/help-center/media_edit_mode_module_2.webm',
     description: [
       __(
         'Double click any image or video element to enter edit mode. Then, use the slider to scale the element or move its focal point by dragging it.',
@@ -41,7 +45,7 @@ export const TIPS = {
   },
   cropElementsWithShapes: {
     title: __('Crop elements using shapes', 'web-stories'),
-    figure: 'images/help-center/media_bg_shape_module_3.webm',
+    figureSrc: 'images/help-center/media_bg_shape_module_3.webm',
     description: [
       __(
         'Select a shape from the Shape menu to create a frame.',
@@ -51,7 +55,7 @@ export const TIPS = {
   },
   safeZone: {
     title: __('Stay within the safe zone', 'web-stories'),
-    figure: 'images/help-center/safe_zone_module_4.webm',
+    figureSrc: 'images/help-center/safe_zone_module_4.webm',
     description: [
       __(
         'Elements work best when you keep them within the safe zone. Outside of the safe zone, elements like links and buttons may get cropped out or not function properly.',
@@ -61,7 +65,7 @@ export const TIPS = {
   },
   previewStory: {
     title: __('Preview your Web Story', 'web-stories'),
-    figure: 'images/help-center/preview_module_5.webm',
+    figureSrc: 'images/help-center/preview_module_5.webm',
     description: [
       __(
         'Use Preview Mode to view your Story before publishing.',
@@ -75,7 +79,7 @@ export const TIPS = {
   },
   addLinks: {
     title: __('Add links to design elements', 'web-stories'),
-    figure: 'images/help-center/add_link_module_6.webm',
+    figureSrc: 'images/help-center/add_link_module_6.webm',
     description: [
       __(
         'Go to the <strong>Links</strong> section under the Design tab and enter a URL. To remove a link, select the "X"<screenreader> (Clear)</screenreader> button.',
@@ -85,7 +89,7 @@ export const TIPS = {
   },
   enableSwipe: {
     title: __('Enable swipe-up option', 'web-stories'),
-    figure: 'images/help-center/page_attachment_module_7.webm',
+    figureSrc: 'images/help-center/page_attachment_module_7.webm',
     description: [
       __(
         'Go to the Design tab. Scroll down to <strong>Swipe-up Link</strong> and enter a web address and a call to action to describe the link.',
@@ -133,3 +137,13 @@ export const POPUP_ID = 'help_center_companion';
 export const FOCUSABLE_POPUP_CHILDREN_SELECTOR = FOCUSABLE_SELECTORS.map(
   (selector) => `#${POPUP_ID} ${selector}`
 ).join(', ');
+
+export const ReadTipsType = PropTypes.shape({
+  ...Object.keys(TIPS).reduce(
+    (accum, tipKey) => ({
+      ...accum,
+      [tipKey]: PropTypes.bool,
+    }),
+    {}
+  ),
+});

--- a/assets/src/edit-story/components/helpCenter/constants.js
+++ b/assets/src/edit-story/components/helpCenter/constants.js
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __ } from '@web-stories-wp/i18n';
 
 export const TIPS = {
   addBackgroundMedia: {

--- a/assets/src/edit-story/components/helpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/index.js
@@ -88,7 +88,7 @@ export const HelpCenter = () => {
               isPrevDisabled={state.isPrevDisabled}
             >
               <Companion
-                read={state.read}
+                readTips={state.readTips}
                 tipKey={state.navigationFlow[state.navigationIndex]}
                 onTipSelect={actions.goToTip}
                 isLeftToRightTransition={state.isLeftToRightTransition}
@@ -100,7 +100,9 @@ export const HelpCenter = () => {
             onClick={actions.toggle}
             notificationCount={
               // navigation includes 'done' which does not get marked read
-              state.navigationFlow.length - state.read.length - 1
+              state.navigationFlow.length -
+              Object.keys(state.readTips).length -
+              1
             }
             popupId={POPUP_ID}
           />

--- a/assets/src/edit-story/components/helpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/index.js
@@ -88,6 +88,7 @@ export const HelpCenter = () => {
               isPrevDisabled={state.isPrevDisabled}
             >
               <Companion
+                read={state.read}
                 tipKey={state.navigationFlow[state.navigationIndex]}
                 onTipSelect={actions.goToTip}
                 isLeftToRightTransition={state.isLeftToRightTransition}
@@ -97,7 +98,10 @@ export const HelpCenter = () => {
           <Toggle
             isOpen={state.isOpen}
             onClick={actions.toggle}
-            notificationCount={1}
+            notificationCount={
+              // navigation includes 'done' which does not get marked read
+              state.navigationFlow.length - state.read.length - 1
+            }
             popupId={POPUP_ID}
           />
         </Wrapper>

--- a/assets/src/edit-story/components/helpCenter/menu/index.js
+++ b/assets/src/edit-story/components/helpCenter/menu/index.js
@@ -23,7 +23,7 @@ import { __ } from '@web-stories-wp/i18n';
  * Internal dependencies
  */
 import { noop } from '../../../utils/noop';
-import { GUTTER_WIDTH } from '../constants';
+import { GUTTER_WIDTH, ReadTipsType } from '../constants';
 import { Footer } from './footer';
 import { Header } from './header';
 import { Tips } from './tips';
@@ -35,18 +35,18 @@ const Container = styled.div`
   overflow-y: scroll;
 `;
 
-export function Menu({ onTipSelect = noop, read, ...transitionProps }) {
+export function Menu({ onTipSelect = noop, readTips, ...transitionProps }) {
   return (
     <Transitioner {...transitionProps}>
       <Container aria-label={__('Help Center Main Menu', 'web-stories')}>
         <Header />
-        <Tips read={read} onTipSelect={onTipSelect} />
+        <Tips readTips={readTips} onTipSelect={onTipSelect} />
         <Footer />
       </Container>
     </Transitioner>
   );
 }
 Menu.propTypes = {
-  read: PropTypes.arrayOf(PropTypes.string).isRequired,
+  readTips: ReadTipsType,
   onTipSelect: PropTypes.func.isRequired,
 };

--- a/assets/src/edit-story/components/helpCenter/menu/index.js
+++ b/assets/src/edit-story/components/helpCenter/menu/index.js
@@ -35,17 +35,18 @@ const Container = styled.div`
   overflow-y: scroll;
 `;
 
-export function Menu({ onTipSelect = noop, ...transitionProps }) {
+export function Menu({ onTipSelect = noop, read, ...transitionProps }) {
   return (
     <Transitioner {...transitionProps}>
       <Container aria-label={__('Help Center Main Menu', 'web-stories')}>
         <Header />
-        <Tips onTipSelect={onTipSelect} />
+        <Tips read={read} onTipSelect={onTipSelect} />
         <Footer />
       </Container>
     </Transitioner>
   );
 }
 Menu.propTypes = {
+  read: PropTypes.arrayOf(PropTypes.string).isRequired,
   onTipSelect: PropTypes.func.isRequired,
 };

--- a/assets/src/edit-story/components/helpCenter/menu/tips.js
+++ b/assets/src/edit-story/components/helpCenter/menu/tips.js
@@ -67,10 +67,10 @@ const StyledArrow = styled(Icons.ArrowAlt)`
   transform: rotate(180deg);
 `;
 
-function Tip({ children, onClick }) {
+function Tip({ children, onClick, unread }) {
   return (
     <StyledButton size={BUTTON_SIZES.SMALL} onClick={onClick}>
-      <ButtonText unread={true}>{children}</ButtonText>
+      <ButtonText unread={unread}>{children}</ButtonText>
       <StyledArrow />
     </StyledButton>
   );
@@ -78,10 +78,11 @@ function Tip({ children, onClick }) {
 Tip.propTypes = {
   children: PropTypes.node,
   onClick: PropTypes.func,
+  unread: PropTypes.bool.isRequired,
 };
 
 const TIPS_ITERABLE = Object.entries(TIPS);
-export function Tips({ onTipSelect = () => {} }) {
+export function Tips({ onTipSelect = () => {}, read }) {
   return (
     <Panel>
       {TIPS_ITERABLE.map(([key, tip]) => (
@@ -99,5 +100,6 @@ export function Tips({ onTipSelect = () => {} }) {
   );
 }
 Tips.propTypes = {
+  read: PropTypes.string.isRequired,
   onTipSelect: PropTypes.func,
 };

--- a/assets/src/edit-story/components/helpCenter/menu/tips.js
+++ b/assets/src/edit-story/components/helpCenter/menu/tips.js
@@ -28,7 +28,7 @@ import {
   themeHelpers,
 } from '../../../../design-system';
 import { forceFocusCompanion } from '../utils';
-import { TIPS } from '../constants';
+import { ReadTipsType, TIPS } from '../constants';
 
 const Panel = styled.div`
   padding: 24px 0;
@@ -67,7 +67,7 @@ const StyledArrow = styled(Icons.ArrowAlt)`
   transform: rotate(180deg);
 `;
 
-function Tip({ children, onClick, unread }) {
+function Tip({ children, onClick, unread = true }) {
   return (
     <StyledButton size={BUTTON_SIZES.SMALL} onClick={onClick}>
       <ButtonText unread={unread}>{children}</ButtonText>
@@ -78,15 +78,16 @@ function Tip({ children, onClick, unread }) {
 Tip.propTypes = {
   children: PropTypes.node,
   onClick: PropTypes.func,
-  unread: PropTypes.bool.isRequired,
+  unread: PropTypes.bool,
 };
 
 const TIPS_ITERABLE = Object.entries(TIPS);
-export function Tips({ onTipSelect = () => {}, read }) {
+export function Tips({ onTipSelect = () => {}, readTips }) {
   return (
     <Panel>
       {TIPS_ITERABLE.map(([key, tip]) => (
         <Tip
+          unread={!readTips[key]}
           key={key}
           onClick={() => {
             forceFocusCompanion();
@@ -100,6 +101,6 @@ export function Tips({ onTipSelect = () => {}, read }) {
   );
 }
 Tips.propTypes = {
-  read: PropTypes.string.isRequired,
+  readTips: ReadTipsType,
   onTipSelect: PropTypes.func,
 };

--- a/assets/src/edit-story/components/helpCenter/quickTip/index.js
+++ b/assets/src/edit-story/components/helpCenter/quickTip/index.js
@@ -69,11 +69,10 @@ const Paragraph = styled(Text)`
 `;
 
 export function QuickTip({
-  figureSrc,
   title,
   description,
   isLeftToRightTransition = true,
-  figure,
+  figureSrc,
   ...transitionProps
 }) {
   const { cdnURL } = useConfig();
@@ -84,9 +83,16 @@ export function QuickTip({
     >
       <Panel>
         <Overflow>
-          {Boolean(figure) && (
-            <Video controls={false} autoPlay loop muted preload noControls>
-              <source src={`${cdnURL}${figure}`} type="video/webm" />
+          {Boolean(figureSrc) && (
+            <Video
+              controls={false}
+              autoPlay
+              loop
+              muted
+              noControls
+              preload="true"
+            >
+              <source src={`${cdnURL}${figureSrc}`} type="video/webm" />
             </Video>
           )}
           <Title>{title}</Title>
@@ -112,9 +118,8 @@ export function QuickTip({
 }
 
 QuickTip.propTypes = {
-  figureSrc: PropTypes.string.isRequired,
+  figureSrc: PropTypes.string,
   title: PropTypes.string.isRequired,
   description: PropTypes.arrayOf(PropTypes.string).isRequired,
-  figure: PropTypes.string,
   isLeftToRightTransition: PropTypes.bool,
 };

--- a/assets/src/edit-story/components/helpCenter/test/useHelpCenter.js
+++ b/assets/src/edit-story/components/helpCenter/test/useHelpCenter.js
@@ -21,6 +21,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
  * Internal dependencies
  */
 import APIContext from '../../../app/api/context';
+import { CurrentUserProvider } from '../../../app/currentUser';
 import { DONE_TIP_ENTRY } from '../constants';
 import { useHelpCenter, deriveState } from '../useHelpCenter';
 
@@ -128,17 +129,22 @@ describe('deriveState', () => {
 });
 
 function setup() {
+  const currentUser = { meta: {} };
+  const currentUserPromise = jest.fn(
+    () => new Promise((resolve) => resolve(currentUser))
+  );
   const apiContextValue = {
+    state: {
+      currentUser,
+    },
     actions: {
-      getCurrentUser: jest.fn(
-        () => new Promise((resolve) => resolve({ meta: {} }))
-      ),
-      updateCurrentUser: jest.fn(() => new Promise((resolve) => resolve())),
+      updateCurrentUser: currentUserPromise,
+      getCurrentUser: currentUserPromise,
     },
   };
   const wrapper = ({ children }) => (
     <APIContext.Provider value={apiContextValue}>
-      {children}
+      <CurrentUserProvider>{children}</CurrentUserProvider>
     </APIContext.Provider>
   );
 

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter.js
@@ -172,7 +172,7 @@ export function useHelpCenter() {
         meta: {
           web_stories_onboarding: createBooleanMapFromKey(persistenceKey),
         },
-      }).catch(actions.persitingReadTipsError);
+      }).catch(actions.persistingReadTipsError);
   }, [actions, updateCurrentUser, persistenceKey]);
 
   // Components wrapped in a Transition no longer recieve

--- a/assets/src/edit-story/karma/fixture/fixture.js
+++ b/assets/src/edit-story/karma/fixture/fixture.js
@@ -760,7 +760,15 @@ class APIProviderFixture {
       );
 
       const updateCurrentUser = useCallback(
-        () => jasmine.createSpy('updateCurrentUser'),
+        () =>
+          asyncResponse({
+            id: 1,
+            meta: {
+              web_stories_tracking_optin: false,
+              web_stories_onboarding: {},
+              web_stories_media_optimization: true,
+            },
+          }),
         []
       );
 

--- a/assets/src/edit-story/karma/fixture/fixture.js
+++ b/assets/src/edit-story/karma/fixture/fixture.js
@@ -759,6 +759,11 @@ class APIProviderFixture {
         []
       );
 
+      const updateCurrentUser = useCallback(
+        () => jasmine.createSpy('updateCurrentUser'),
+        []
+      );
+
       const getStatusCheck = useCallback(
         () =>
           asyncResponse({
@@ -787,6 +792,7 @@ class APIProviderFixture {
           getStatusCheck,
           getPageLayouts,
           getCurrentUser,
+          updateCurrentUser,
         },
       };
       return (


### PR DESCRIPTION
## Context
We need to persist which tips in the help center users have read so we can determine other visual states of the help center for the MVP, such as when to have it open by default.
We need to do this without cookies so this state will persist across browsers, so we added to the current user endpoint in [this ticket](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/5881). In this PR I'm using that endpoint to get which tips are currently read, and to update which tips have been read.

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- update `useHelpCenter` to add a `read` status which tracks the keys of read tips
- use this status to update the notification count and display of tips in the menu (bubble/no bubble)
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
I liked how the actions were provided to the navigator in the `helpCenter/index`: 
```
<Navigator
    onNext={actions.goToNext}
    onPrev={actions.goToPrev}
    onAllTips={actions.goToMenu}
    onClose={actions.close}
    hasBottomNavigation={state.hasBottomNavigation}
    isNextDisabled={state.isNextDisabled}
    isPrevDisabled={state.isPrevDisabled}
  >
    <Companion
      tipKey={state.navigationFlow[state.navigationIndex]}
      onTipSelect={actions.goToTip}
      isLeftToRightTransition={state.isLeftToRightTransition}
    />
  </Navigator>
```
I didn't want to add another action which would just be coupled to the calls for `goToNext`, `goToPrev` and `goToTip` and complicate the variable space in the `helpCenter` component. ~So, I added two effects to the `useHelpCenter` hook:~

~1. update the initial `read` state after getting the `meta.web_stories_onboarding` data from the REST API endpoint.~
~2. update the `read` state of each tip as they are viewed (i.e. the navigation index changes)~

Based on Max's feedback and comments about the state, I refactored the original impl to use `deriveState` to update a new `readTips` state (derived from `navigationIndex`), which is used by a `useEffect` which persists the state using `useAPI`. Currently just saving an error state as `true`/`false` if any of the REST calls catch.

**NOTE**
write

```
await wp.apiFetch({ path: '/web-stories/v1/users/me', method: 'POST', data: { meta: { web_stories_onboarding: {} }}})
```

in your console to clear your read tips.

<!-- Please describe your changes. -->

## To-do
N/A
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes


https://user-images.githubusercontent.com/41136059/107083793-61a5e100-67b3-11eb-976b-8b9d97dfa355.mov


https://user-images.githubusercontent.com/41136059/107083797-636fa480-67b3-11eb-9ffb-b40f41bbdaf5.mov



<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
- Feature will be tested as part of MVP

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

- Feature will be tested as part of MVP

## Reviews

### Does this PR have a security-related impact?
no 
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
Yes. we use the existing `users/me` endpoint `GET` and `POST`.

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5887 
