### PR TITLE
Fixed carousel flicker bug

### DIFF
--- a/assets/src/edit-story/components/carousel/carouselContainer.js
+++ b/assets/src/edit-story/components/carousel/carouselContainer.js
@@ -28,9 +28,11 @@ import CarouselLayout from './carouselLayout';
 import CarouselProvider from './carouselProvider';
 import { VERY_WIDE_WORKSPACE_LIMIT, VERY_WIDE_MARGIN } from './constants';
 
-const Wrapper = styled.section`
-  margin-right: ${({ marginRight }) => marginRight}px;
+const Outer = styled.section`
   height: 100%;
+`;
+const Inner = styled(Outer)`
+  margin-right: ${({ marginRight }) => marginRight}px;
 `;
 
 function CarouselContainer() {
@@ -46,9 +48,11 @@ function CarouselContainer() {
 
   return (
     <CarouselProvider availableSpace={width}>
-      <Wrapper ref={ref} marginRight={margin}>
-        <CarouselLayout />
-      </Wrapper>
+      <Outer ref={ref}>
+        <Inner marginRight={margin}>
+          <CarouselLayout />
+        </Inner>
+      </Outer>
     </CarouselProvider>
   );
 }


### PR DESCRIPTION
## Context

Fixes simple bug

## Relevant Technical Choices

Uses two elements - the outer to evaluate true width and the inner to provide margin.

## Testing Instructions

### QA

This PR can be tested by following these steps:

1. Resize the workspace so an 8px margin is added to the right of the carousel
2. Observe that at no browser width does the carousel flicker as in the reported bug

### UAT

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] ~This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))~
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6197
