### PR TITLE
FTUE: Enhance Keyboard Navigation & Design Updates

### DIFF
--- a/assets/src/design-system/components/button/index.js
+++ b/assets/src/design-system/components/button/index.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { forwardRef } from 'react';
 import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
 /**
@@ -154,18 +155,22 @@ const ButtonOptions = {
   [BUTTON_VARIANTS.ICON]: ButtonIcon,
 };
 
-const Button = ({
-  size = BUTTON_SIZES.MEDIUM,
-  type = BUTTON_TYPES.PLAIN,
-  variant = BUTTON_VARIANTS.RECTANGLE,
-  children,
-  ...rest
-}) => {
+const Button = (
+  {
+    size = BUTTON_SIZES.MEDIUM,
+    type = BUTTON_TYPES.PLAIN,
+    variant = BUTTON_VARIANTS.RECTANGLE,
+    children,
+    ...rest
+  },
+  ref
+) => {
   const isLink = rest.href !== undefined;
   const StyledButton = ButtonOptions[variant];
 
   return (
     <StyledButton
+      ref={ref}
       as={isLink ? 'a' : 'button'}
       size={size}
       type={type}
@@ -184,4 +189,6 @@ Button.propTypes = {
   activeLabelText: PropTypes.string,
 };
 
-export { Button, BUTTON_SIZES, BUTTON_TYPES, BUTTON_VARIANTS };
+const ButtonWithRef = forwardRef(Button);
+
+export { ButtonWithRef as Button, BUTTON_SIZES, BUTTON_TYPES, BUTTON_VARIANTS };

--- a/assets/src/edit-story/components/canvas/navLayer.js
+++ b/assets/src/edit-story/components/canvas/navLayer.js
@@ -24,6 +24,7 @@ import { memo } from 'react';
  */
 import Header from '../header';
 import Carousel from '../carousel';
+import { HelpCenter } from '../helpCenter';
 import { Layer, HeadArea, CarouselArea, Z_INDEX } from './layout';
 
 function NavLayer() {
@@ -37,6 +38,7 @@ function NavLayer() {
         <Header />
       </HeadArea>
       <CarouselArea pointerEvents="initial">
+        <HelpCenter />
         <Carousel />
       </CarouselArea>
     </Layer>

--- a/assets/src/edit-story/components/carousel/carouselLayout.js
+++ b/assets/src/edit-story/components/carousel/carouselLayout.js
@@ -18,17 +18,15 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { rgba } from 'polished';
 
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { useConfig } from '../../app';
 import { CarouselScrollForward, CarouselScrollBack } from './carouselScroll';
 import CarouselMenu from './carouselMenu';
 import CarouselList from './carouselList';
@@ -60,53 +58,28 @@ const Area = styled.div`
   flex-direction: column;
 `;
 
-const EditorVersion = styled.div`
-  display: inline-block;
-  position: absolute;
-  bottom: 0;
-  z-index: 1;
-  margin-left: 14px;
-  margin-bottom: 10px;
-  pointer-events: none;
-  font-size: ${({ theme }) => theme.fonts.version.size};
-  font-family: ${({ theme }) => theme.fonts.version.family};
-  line-height: ${({ theme }) => theme.fonts.version.lineHeight};
-  letter-spacing: ${({ theme }) => theme.fonts.version.letterSpacing};
-  color: ${({ theme }) => rgba(theme.colors.fg.white, 0.3)};
-`;
-
 function CarouselLayout() {
   const { numPages } = useCarousel(({ state: { numPages } }) => ({ numPages }));
-  const { version } = useConfig();
 
   if (numPages <= 0) {
     return null;
   }
 
   return (
-    <>
-      <Wrapper aria-label={__('Page Carousel', 'web-stories')}>
-        <Area area="prev-navigation">
-          <CarouselScrollBack />
-        </Area>
-        <Area area="carousel">
-          <CarouselList />
-        </Area>
-        <Area area="next-navigation">
-          <CarouselScrollForward />
-        </Area>
-        <Area area="menu">
-          <CarouselMenu />
-        </Area>
-      </Wrapper>
-      <EditorVersion>
-        {sprintf(
-          /* translators: %s: editor version. */
-          __('Version %s', 'web-stories'),
-          version
-        )}
-      </EditorVersion>
-    </>
+    <Wrapper aria-label={__('Page Carousel', 'web-stories')}>
+      <Area area="prev-navigation">
+        <CarouselScrollBack />
+      </Area>
+      <Area area="carousel">
+        <CarouselList />
+      </Area>
+      <Area area="next-navigation">
+        <CarouselScrollForward />
+      </Area>
+      <Area area="menu">
+        <CarouselMenu />
+      </Area>
+    </Wrapper>
   );
 }
 

--- a/assets/src/edit-story/components/helpCenter/constants.js
+++ b/assets/src/edit-story/components/helpCenter/constants.js
@@ -119,3 +119,17 @@ export const Z_INDEX = {
 
 // @TODO make this dynamic based off of unread tips.
 export const NAVIGATION_FLOW = [...Object.keys(TIPS), DONE_TIP_ENTRY[0]];
+
+export const FOCUSABLE_SELECTORS = [
+  'button',
+  '[href]',
+  'input',
+  'select',
+  'textarea',
+  '[tabindex]:not([tabindex="-1"])',
+];
+
+export const POPUP_ID = 'help_center_companion';
+export const FOCUSABLE_POPUP_CHILDREN_SELECTOR = FOCUSABLE_SELECTORS.map(
+  (selector) => `#${POPUP_ID} ${selector}`
+).join(', ');

--- a/assets/src/edit-story/components/helpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/index.js
@@ -16,9 +16,11 @@
 /**
  * External dependencies
  */
-import { useRef } from 'react';
+import { useRef, useEffect } from 'react';
 import { useFeatures } from 'flagged';
-import styled, { ThemeProvider } from 'styled-components';
+import styled, { ThemeProvider, StyleSheetManager } from 'styled-components';
+import stylisRTLPlugin from 'stylis-plugin-rtl';
+
 /**
  * Internal dependencies
  */
@@ -27,66 +29,79 @@ import {
   ThemeGlobals,
   useFocusOut,
 } from '../../../design-system';
+import { useConfig } from '../../app/config';
+import { Z_INDEX } from '../canvas/layout';
 import { Navigator } from './navigator';
 import { Companion } from './companion';
+import { POPUP_ID } from './constants';
 import { Toggle } from './toggle';
 import { useHelpCenter } from './useHelpCenter';
 import { Popup } from './popup';
+import { forceFocusCompanion } from './utils';
 
 const Wrapper = styled.div`
   position: absolute;
   bottom: 16px;
-  left: 12px;
-  z-index: 10;
-
-  @media ${({ theme }) => theme.breakpoint.tablet} {
-    bottom: 24px;
-    left: 24px;
-  }
-
-  @media ${({ theme }) => theme.breakpoint.desktop} {
-    bottom: 36px;
-    left: 8px;
-  }
+  left: 8px;
+  /**
+   * sibling inherits parent z-index of Z_INDEX.EDIT
+   * so this needs to be placed above that while still
+   * retaining its postion in the DOM for focus purposes
+   */
+  z-index: ${Z_INDEX.EDIT + 1};
 `;
 
-const POPUP_ID = 'help_center_companion';
+const withRTLPlugins = [stylisRTLPlugin];
+const withoutRTLPlugins = [];
 
 export const HelpCenter = () => {
+  const { isRTL } = useConfig();
   const ref = useRef(null);
   const { enableQuickTips } = useFeatures();
   const { state, actions } = useHelpCenter();
 
   useFocusOut(ref, actions.close, []);
 
+  // Set Focus on the expanded companion
+  // whenever it opens
+  useEffect(() => {
+    if (state.isOpen) {
+      forceFocusCompanion();
+    }
+  }, [state.isOpen]);
+
   return enableQuickTips ? (
-    <ThemeProvider theme={dsTheme}>
-      <ThemeGlobals.OverrideFocusOutline />
-      <Wrapper ref={ref}>
-        <Popup popupId={POPUP_ID} isOpen={state.isOpen}>
-          <Navigator
-            onNext={actions.goToNext}
-            onPrev={actions.goToPrev}
-            onAllTips={actions.goToMenu}
-            onClose={actions.close}
-            hasBottomNavigation={state.hasBottomNavigation}
-            isNextDisabled={state.isNextDisabled}
-            isPrevDisabled={state.isPrevDisabled}
-          >
-            <Companion
-              tipKey={state.navigationFlow[state.navigationIndex]}
-              onTipSelect={actions.goToTip}
-              isLeftToRightTransition={state.isLeftToRightTransition}
-            />
-          </Navigator>
-        </Popup>
-        <Toggle
-          isOpen={state.isOpen}
-          onClick={actions.toggle}
-          notificationCount={1}
-          popupId={POPUP_ID}
-        />
-      </Wrapper>
-    </ThemeProvider>
+    <StyleSheetManager
+      stylisPlugins={isRTL ? withRTLPlugins : withoutRTLPlugins}
+    >
+      <ThemeProvider theme={dsTheme}>
+        <ThemeGlobals.OverrideFocusOutline />
+        <Wrapper ref={ref}>
+          <Popup popupId={POPUP_ID} isOpen={state.isOpen}>
+            <Navigator
+              onNext={actions.goToNext}
+              onPrev={actions.goToPrev}
+              onAllTips={actions.goToMenu}
+              onClose={actions.close}
+              hasBottomNavigation={state.hasBottomNavigation}
+              isNextDisabled={state.isNextDisabled}
+              isPrevDisabled={state.isPrevDisabled}
+            >
+              <Companion
+                tipKey={state.navigationFlow[state.navigationIndex]}
+                onTipSelect={actions.goToTip}
+                isLeftToRightTransition={state.isLeftToRightTransition}
+              />
+            </Navigator>
+          </Popup>
+          <Toggle
+            isOpen={state.isOpen}
+            onClick={actions.toggle}
+            notificationCount={1}
+            popupId={POPUP_ID}
+          />
+        </Wrapper>
+      </ThemeProvider>
+    </StyleSheetManager>
   ) : null;
 };

--- a/assets/src/edit-story/components/helpCenter/menu/tips.js
+++ b/assets/src/edit-story/components/helpCenter/menu/tips.js
@@ -27,6 +27,7 @@ import {
   Icons,
   themeHelpers,
 } from '../../../../design-system';
+import { forceFocusCompanion } from '../utils';
 import { TIPS } from '../constants';
 
 const Panel = styled.div`
@@ -84,7 +85,13 @@ export function Tips({ onTipSelect = () => {} }) {
   return (
     <Panel>
       {TIPS_ITERABLE.map(([key, tip]) => (
-        <Tip key={key} onClick={() => onTipSelect(key)}>
+        <Tip
+          key={key}
+          onClick={() => {
+            forceFocusCompanion();
+            onTipSelect(key);
+          }}
+        >
           {tip.title}
         </Tip>
       ))}

--- a/assets/src/edit-story/components/helpCenter/navigator/bottomNavigation.js
+++ b/assets/src/edit-story/components/helpCenter/navigator/bottomNavigation.js
@@ -88,6 +88,7 @@ export function BottomNavigation({
     >
       <BottomNavButtons>
         <NavButton
+          aria-label={__('Navigate to Help Center Main Menu', 'web-stories')}
           onClick={() => {
             forceFocusCompanion();
             onAllTips();
@@ -103,6 +104,7 @@ export function BottomNavigation({
       <BottomNavButtons>
         <NavButton
           ref={prevButtonRef}
+          aria-label={__('Navigate to Previous Tip', 'web-stories')}
           onClick={onPrev}
           type={BUTTON_TYPES.PLAIN}
           size={BUTTON_SIZES.SMALL}
@@ -112,6 +114,7 @@ export function BottomNavigation({
         </NavButton>
         <NavButton
           ref={nextButtonRef}
+          aria-label={__('Navigate to Next Tip', 'web-stories')}
           onClick={onNext}
           type={BUTTON_TYPES.PLAIN}
           size={BUTTON_SIZES.SMALL}

--- a/assets/src/edit-story/components/helpCenter/navigator/topNavigation.js
+++ b/assets/src/edit-story/components/helpCenter/navigator/topNavigation.js
@@ -31,6 +31,7 @@ import {
   BUTTON_VARIANTS,
   Icons,
 } from '../../../../design-system';
+import { forceFocusCompanionToggle } from '../utils';
 import { NavBar, NavButton } from './components';
 
 const TopNavButtons = styled.div`
@@ -47,7 +48,10 @@ export function TopNavigation({ onClose }) {
       <Label>{__('Quick Tips', 'web-stories')}</Label>
       <TopNavButtons>
         <NavButton
-          onClick={onClose}
+          onClick={() => {
+            forceFocusCompanionToggle();
+            onClose();
+          }}
           type={BUTTON_TYPES.PLAIN}
           size={BUTTON_SIZES.SMALL}
           variant={BUTTON_VARIANTS.CIRCLE}

--- a/assets/src/edit-story/components/helpCenter/navigator/topNavigation.js
+++ b/assets/src/edit-story/components/helpCenter/navigator/topNavigation.js
@@ -48,6 +48,7 @@ export function TopNavigation({ onClose }) {
       <Label>{__('Quick Tips', 'web-stories')}</Label>
       <TopNavButtons>
         <NavButton
+          aria-label={__('Close Help Center', 'web-stories')}
           onClick={() => {
             forceFocusCompanionToggle();
             onClose();

--- a/assets/src/edit-story/components/helpCenter/toggle/index.js
+++ b/assets/src/edit-story/components/helpCenter/toggle/index.js
@@ -57,7 +57,7 @@ const Label = styled.span`
 
   @media ${({ theme }) => theme.breakpoint.desktop} {
     display: block;
-    min-width: 115px;
+    min-width: 65px;
     text-align: left;
   }
 `;
@@ -131,7 +131,7 @@ function Toggle({
       size={BUTTON_SIZES.MEDIUM}
     >
       <HelpIcon />
-      <Label>{__('Help Center', 'web-stories')}</Label>
+      <Label>{__('Help', 'web-stories')}</Label>
       {hasNotifications && (
         <NotificationWrapper>
           <NotificationBubble notificationCount={notificationCount} />

--- a/assets/src/edit-story/components/helpCenter/utils.js
+++ b/assets/src/edit-story/components/helpCenter/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,31 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  * Internal dependencies
  */
-import Inspector from '../inspector';
-import Canvas from '../canvas';
-import RichTextProvider from '../richText/provider';
-import ErrorBoundary from '../errorBoundary';
-import { CanvasArea, InspectorArea } from './layout';
+import { FOCUSABLE_POPUP_CHILDREN_SELECTOR, POPUP_ID } from './constants';
 
-function Workspace() {
-  return (
-    <RichTextProvider>
-      <CanvasArea>
-        <ErrorBoundary>
-          <Canvas />
-        </ErrorBoundary>
-      </CanvasArea>
-      <InspectorArea>
-        <ErrorBoundary>
-          <Inspector />
-        </ErrorBoundary>
-      </InspectorArea>
-    </RichTextProvider>
-  );
+export function forceFocusCompanion() {
+  document.querySelector(FOCUSABLE_POPUP_CHILDREN_SELECTOR)?.focus();
 }
 
-export default Workspace;
+export function forceFocusCompanionToggle() {
+  document.querySelector(`[aria-owns=${POPUP_ID}]`)?.focus();
+}


### PR DESCRIPTION
## Context
Enhancements and design updates for FTUE. FTUE was keyboard accessible originally, this just makes the experience a little more pleasant by keeping focus inside the help center no matter what actions you take.

## Summary
- Enhances keyboard navigation experience
- Adds small design requests.

## Relevant Technical Choices
Just moved the Help center to the place in the DOM it should be so it's focus index resembles its visual placement. I figured it should gain focus right before the carousel in the bottom navigation of the editor, so moved it there.

## To-do
NA

## User-facing changes
Better keyboard nav and design updates:
https://user-images.githubusercontent.com/35983235/107077289-de33c200-67a9-11eb-859d-653f7a879f48.mp4


<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
- Enable quick tips
- Go to Editor
- Click on title for story
- Tab a couple times and see that FTUE is now keyboard navigable in the visual order of the rest of the nav layer
- Press enter when Help Toggle is Focused
- See that expanded companion's first focusable element is now focused and interactable.
- mess around with it some more through the keyboard and see that keyboard navigation is pleasant

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6192 
Fixes #6191 
