### PR TITLE
Design System: Storybook import update

### DIFF
--- a/assets/src/design-system/components/banner/stories/index.js
+++ b/assets/src/design-system/components/banner/stories/index.js
@@ -23,9 +23,9 @@ import { boolean, text } from '@storybook/addon-knobs';
 /**
  * Internal dependencies
  */
-import { THEME_CONSTANTS } from '../../../';
-import { Text } from '../../';
-import { Banner } from '..';
+import { THEME_CONSTANTS } from '../../../theme';
+import { Text } from '../../typography';
+import { Banner } from '../';
 
 const demoBgUrl = 'https://picsum.photos/id/240/1500/160';
 

--- a/assets/src/design-system/components/checkbox/stories/index.js
+++ b/assets/src/design-system/components/checkbox/stories/index.js
@@ -26,7 +26,7 @@ import { text } from '@storybook/addon-knobs';
  * Internal dependencies
  */
 import { Checkbox } from '..';
-import { Text } from '../..';
+import { Text } from '../../typography';
 import { DarkThemeProvider } from '../../../storybookUtils';
 
 export default {

--- a/assets/src/design-system/components/dialog/index.js
+++ b/assets/src/design-system/components/dialog/index.js
@@ -23,8 +23,9 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { THEME_CONSTANTS } from '../../';
-import { Modal, Headline } from '../';
+import { THEME_CONSTANTS } from '../../theme';
+import { Modal } from '../modal';
+import { Headline } from '../typography';
 
 const DialogBox = styled.div`
   box-sizing: border-box;

--- a/assets/src/design-system/components/dialog/stories/index.js
+++ b/assets/src/design-system/components/dialog/stories/index.js
@@ -24,7 +24,7 @@ import { text } from '@storybook/addon-knobs';
 /**
  * Internal dependencies
  */
-import { THEME_CONSTANTS } from '../../../';
+import { THEME_CONSTANTS } from '../../../theme';
 import { Button, BUTTON_SIZES, BUTTON_TYPES } from '../../button';
 import { Text } from '../../typography';
 import { Dialog } from '..';

--- a/assets/src/design-system/components/input/index.js
+++ b/assets/src/design-system/components/input/index.js
@@ -24,7 +24,7 @@ import { v4 as uuidv4 } from 'uuid';
 /**
  * Internal dependencies
  */
-import { Text } from '..';
+import { Text } from '../typography';
 import { themeHelpers, THEME_CONSTANTS } from '../../theme';
 
 const StyledInput = styled.input(


### PR DESCRIPTION
## Context

some imports were causing a circular error for storybook. This should fix the error that shows up when you click the snackbar dismiss button repeatedly as seen in #6103 
