### PR TITLE
ESLint: Force usage of new i18n package

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -418,6 +418,31 @@
         "header/header": "off",
         "prettier/prettier": "off"
       }
+    },
+    {
+      "files": [
+        "assets/src/animation/**/*.js",
+        "assets/src/dashboard/**/*.js",
+        "assets/src/design-system/**/*.js",
+        "assets/src/edit-story/**/*.js",
+        "packages/**/*.js"
+      ],
+      "excludedFiles": [
+        "packages/i18n/**/*.js"
+      ],
+      "rules":{
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "@wordpress/i18n",
+                "message": "Use @web-stories-wp/i18n instead."
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Context

There's a new thin wrapper around `@wordpress/i18n`: `@web-stories-wp/i18n`. This package should be used from now on.

## Summary

New non-WP-specific code should use `@web-stories-wp/i18n` instead of `@wordpress/i18n`. This ESLint config update enables that.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

N/A

## Testing Instructions

N/A

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

See #6183
