### PR TITLE
Design System: Add selection border

### DIFF
--- a/assets/src/design-system/theme/colors.js
+++ b/assets/src/design-system/theme/colors.js
@@ -173,6 +173,7 @@ const darkTheme = {
     negativeHover: brand.red[30],
     negativePress: brand.red[20],
     negativeActive: brand.red[10],
+    selection: brand.blue[30],
   },
   divider: {
     primary: opacity.white24,
@@ -248,6 +249,7 @@ const lightTheme = {
     negativeHover: brand.red[30],
     negativePress: brand.red[40],
     negativeActive: brand.red[90],
+    selection: brand.blue[40],
   },
   divider: {
     primary: opacity.black24,

--- a/assets/src/design-system/theme/helpers/index.js
+++ b/assets/src/design-system/theme/helpers/index.js
@@ -18,3 +18,4 @@ export * from './outline';
 export { expandPresetStyles, expandTextPreset } from './expandPresetStyles';
 export { fullSizeAbsolute, fullSizeRelative } from './fullSize';
 export { centerContent } from './centerContent';
+export { visuallyHidden } from './visuallyHidden';

--- a/assets/src/design-system/theme/helpers/visuallyHidden.js
+++ b/assets/src/design-system/theme/helpers/visuallyHidden.js
@@ -16,17 +16,17 @@
 /**
  * External dependencies
  */
-import styled from 'styled-components';
-
-/**
- * Internal dependencies
- */
-import { visuallyHidden } from '../theme/helpers';
+import { css } from 'styled-components';
 
 /**
  * Useful for rendering content for screen
  * readers only
  */
-export const VisuallyHidden = styled.span`
-  ${visuallyHidden};
+export const visuallyHidden = css`
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
 `;


### PR DESCRIPTION
## Context

Two misc things for the design system that have no tickets. 

## Summary

Adds a new border prop for these two tickets: #6250 and #6239 (`border.selection`) 
Moves the `visuallyHidden` css used in `VisuallyHidden` span to `themeHelpers` so that it's not always tied to a span and easier to reuse in those cases. 

![Screen Shot 2021-02-08 at 5 35 31 PM](https://user-images.githubusercontent.com/10720454/107299254-29610580-6a34-11eb-8164-9e7b71f8fd19.png)

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. See new border color in storybook. 
2. visually hidden styles on FTUE are in tact. 

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1. 

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

