### PR TITLE
Pre-Publish Checklist: Fix background contrast check giving false positives

### DIFF
--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { PAGE_HEIGHT, PAGE_WIDTH } from '../../../../constants';
 import { MESSAGES } from '../../constants';
 import * as accessibilityChecks from '../accessibility';
 
@@ -98,6 +99,64 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       expect(
         accessibilityChecks.textElementFontLowContrast(element)
       ).toBeUndefined();
+    });
+  });
+
+  describe('pageBackgrounTextLowContrast', () => {
+    it('should return a warning if the default font (no spans, no colors added) does not have high enough contrast with the page', async () => {
+      const bgEl = {
+        x: 1,
+        y: 1,
+        type: 'shape',
+        isBackground: true,
+        height: PAGE_HEIGHT,
+        width: PAGE_WIDTH,
+        backgroundColor: {
+          color: {
+            r: 255,
+            g: 255,
+            b: 255,
+          },
+        },
+      };
+      const textEl = {
+        type: 'text',
+        backgroundTextMode: 'NONE',
+        content: 'Fill with text',
+        x: 1,
+        y: 1,
+        width: 175,
+        height: 36,
+      };
+      const page = {
+        id: 123,
+        pageSize: {
+          height: PAGE_HEIGHT,
+          width: PAGE_WIDTH,
+        },
+        elements: [bgEl, textEl],
+        backgroundColor: {
+          color: {
+            r: 2,
+            g: 12,
+            b: 1,
+          },
+        },
+      };
+      expect(
+        await accessibilityChecks.pageBackgroundTextLowContrast(page)
+      ).toStrictEqual([
+        {
+          message: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.MAIN_TEXT,
+          help: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.HELPER_TEXT,
+          elements: [
+            { ...bgEl, backgroundColor: page.backgroundColor },
+            textEl,
+          ],
+          pageId: page.id,
+          type: 'warning',
+        },
+      ]);
     });
   });
 

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -102,7 +102,7 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
     });
   });
 
-  describe('pageBackgrounTextLowContrast', () => {
+  describe('pageBackgroundTextLowContrast', () => {
     it('should return a warning if the default font (no spans, no colors added) does not have high enough contrast with the page', async () => {
       const bgEl = {
         x: 1,


### PR DESCRIPTION
## Context
I'm noting that there are/may be other issues because of this particular check's potentiality for failing edge cases and I want to keep each PR scoped to known and tractable issues. 

The intention of this fix is to address a more obvious bug where the accessibility check is not using the correct background color for shape/background overlays and the color of the text wasn't getting picked out at all. 

## Summary
- use the `page` object's background color instead of the background color of the background `shape` element. 
- add the default black text color to be compared to background colors
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- The `backgroundColor` for shape backgrounds was replaced with the page's background color because the `backgroundColor` property for [shape backgrounds never gets updated and is inactive](https://github.com/google/web-stories-wp/issues/5905#issuecomment-771227657):
> But the deprecated (and utterly inactive) backgroundColor property on the default background element is definitely making things harder to spot. We should probably address that at some point...

- Text elements aren't always have a `span` or a `style.color`. This meant in the original implementation we were seeing no text color associated with the default text element, for example, or text elements that do not have color styles on their spans. By default the color of this text is black. I fixed the logic to push the default text color into the array to be compared to the background colors.

<!-- Please describe your changes. -->

## To-do
- [x] make a techdebt ticket for addressing the inactive `backgroundColor` property on the background element (done [here](https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/6315))
- [x] unit test for regression
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a new story
2. Add a black background
3. Click the + symbol to add the default text element
4. The text contrast check should appear in the prepublish checklist where it didn't before

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5905 
