### PR TITLE
Pre-Publish Checklist: Include font size in text contrast check

### DIFF
--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -24,8 +24,8 @@ import {
 } from '../../../utils/contrastUtils';
 import getBoundRect from '../../../utils/getBoundRect';
 import { MESSAGES, PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
-import { PAGE_RATIO, FULLBLEED_RATIO, DEFAULT_EM } from '../../../constants';
-import { dataToFontSizeEm, getBox } from '../../../units/dimensions';
+import { PAGE_RATIO, FULLBLEED_RATIO } from '../../../constants';
+import { dataToFontSizeY, dataFontEm, getBox } from '../../../units/dimensions';
 import getMediaSizePositionProps from '../../../elements/media/getMediaSizePositionProps';
 import {
   setOrCreateImage,
@@ -60,7 +60,9 @@ function getSpansFromContent(content) {
 }
 
 function getPtFromEditorFontSize(fontSize) {
-  return dataToFontSizeEm(fontSize, 100) * DEFAULT_EM;
+  // get the true font size from the data
+  // 1 point = 1.333333 px
+  return dataFontEm(dataToFontSizeY(fontSize, 100)) * 1.333333;
 }
 
 function getOverlappingArea(a, b) {

--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -24,8 +24,8 @@ import {
 } from '../../../utils/contrastUtils';
 import getBoundRect from '../../../utils/getBoundRect';
 import { MESSAGES, PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
-import { PAGE_RATIO, FULLBLEED_RATIO } from '../../../constants';
-import { getBox } from '../../../units/dimensions';
+import { PAGE_RATIO, FULLBLEED_RATIO, DEFAULT_EM } from '../../../constants';
+import { dataToFontSizeEm, getBox } from '../../../units/dimensions';
 import getMediaSizePositionProps from '../../../elements/media/getMediaSizePositionProps';
 import {
   setOrCreateImage,
@@ -57,6 +57,10 @@ function getSpansFromContent(content) {
   return Array.prototype.slice.call(
     spansFromContentBuffer.getElementsByTagName('span')
   );
+}
+
+function getPtFromEditorFontSize(fontSize) {
+  return dataToFontSizeEm(fontSize, 100) * DEFAULT_EM;
 }
 
 function getOverlappingArea(a, b) {
@@ -256,7 +260,7 @@ function textBgColorsLowContrast({
     const contrastCheck = checkContrastFromLuminances(
       textLuminance,
       backgroundLuminance,
-      fontSize
+      getPtFromEditorFontSize(fontSize)
     );
     return !contrastCheck.WCAG_AA;
   });
@@ -320,7 +324,7 @@ export function textElementFontLowContrast(element) {
     const contrastCheck = checkContrastFromLuminances(
       textLuminance,
       backgroundLuminance,
-      element.fontSize
+      getPtFromEditorFontSize(element.fontSize)
     );
     return !contrastCheck.WCAG_AA;
   });

--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -243,14 +243,20 @@ function getOverlapBgColor({ elementId, pageId, bgImage, bgBox, overlapBox }) {
   });
 }
 
-function textBgColorsLowContrast({ backgroundColor, textColors, ...elements }) {
+function textBgColorsLowContrast({
+  backgroundColor,
+  textColors,
+  fontSize,
+  ...elements
+}) {
   const someTextHasLowContrast = textColors.some((styleColor) => {
     const [r, g, b] = backgroundColor;
     const textLuminance = calculateLuminanceFromStyleColor(styleColor);
     const backgroundLuminance = calculateLuminanceFromRGB({ r, g, b });
     const contrastCheck = checkContrastFromLuminances(
       textLuminance,
-      backgroundLuminance
+      backgroundLuminance,
+      fontSize
     );
     return !contrastCheck.WCAG_AA;
   });
@@ -385,6 +391,7 @@ export async function pageBackgroundTextLowContrast(page) {
             return {
               backgroundColor: resolvedBgColor,
               textColors,
+              fontSize: element.fontSize,
               pageId: page.id,
               elements: [backgroundElement, element],
             };
@@ -393,6 +400,7 @@ export async function pageBackgroundTextLowContrast(page) {
           backgroundColorResult = {
             backgroundColor,
             textColors,
+            fontSize: element.fontSize,
             pageId: page.id,
             elements: [backgroundElement, element],
           };

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -164,7 +164,7 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
       const largeGreyTextEl = {
         ...textEl,
         content: '<span style="color:#777777">I woke up like this</span>',
-        fontSize: 18,
+        fontSize: 84,
       };
       const smallGreyTextEl = {
         ...textEl,
@@ -181,39 +181,25 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
           },
         },
       };
-      expect(
-        await accessibilityChecks.pageBackgroundTextLowContrast({
-          ...whiteBgPage,
-          elements: [bgEl, largeGreyTextEl],
-        })
-      ).toBeUndefined();
-      expect(
-        await accessibilityChecks.pageBackgroundTextLowContrast({
-          ...whiteBgPage,
-          elements: [bgEl, smallGreyTextEl],
-        })
-      ).not.toBeUndefined();
+      const [pass] = await accessibilityChecks.pageBackgroundTextLowContrast({
+        ...whiteBgPage,
+        elements: [bgEl, largeGreyTextEl],
+      });
+      expect(pass).toBeUndefined();
+      const [fail] = await accessibilityChecks.pageBackgroundTextLowContrast({
+        ...whiteBgPage,
+        elements: [bgEl, smallGreyTextEl],
+      });
+      expect(fail).not.toBeUndefined();
     });
 
     it('should return undefined if the contrast is great enough', async () => {
       const whiteBackgroundColor = { color: { r: 255, g: 255, b: 255 } };
-      expect(
-        await accessibilityChecks.pageBackgroundTextLowContrast({
-          ...page,
-          backgroundColor: whiteBackgroundColor,
-        })
-      ).toStrictEqual([
-        {
-          message: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.MAIN_TEXT,
-          help: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.HELPER_TEXT,
-          elements: [
-            { ...bgEl, backgroundColor: whiteBackgroundColor },
-            textEl,
-          ],
-          pageId: page.id,
-          type: 'warning',
-        },
-      ]);
+      const [check] = await accessibilityChecks.pageBackgroundTextLowContrast({
+        ...page,
+        backgroundColor: whiteBackgroundColor,
+      });
+      expect(check).toBeUndefined();
     });
   });
 

--- a/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/test/accessibility.js
@@ -103,46 +103,48 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
   });
 
   describe('pageBackgroundTextLowContrast', () => {
-    it('should return a warning if the default font (no spans, no colors added) does not have high enough contrast with the page', async () => {
-      const bgEl = {
-        x: 1,
-        y: 1,
-        type: 'shape',
-        isBackground: true,
+    const bgEl = {
+      x: 1,
+      y: 1,
+      type: 'shape',
+      isBackground: true,
+      height: PAGE_HEIGHT,
+      width: PAGE_WIDTH,
+      backgroundColor: {
+        color: {
+          r: 255,
+          g: 255,
+          b: 255,
+        },
+      },
+    };
+    const textEl = {
+      type: 'text',
+      backgroundTextMode: 'NONE',
+      content: 'Fill with text',
+      x: 1,
+      y: 1,
+      width: 175,
+      height: 36,
+      fontSize: 12,
+    };
+    const page = {
+      id: 123,
+      pageSize: {
         height: PAGE_HEIGHT,
         width: PAGE_WIDTH,
-        backgroundColor: {
-          color: {
-            r: 255,
-            g: 255,
-            b: 255,
-          },
+      },
+      elements: [bgEl, textEl],
+      backgroundColor: {
+        color: {
+          r: 2,
+          g: 12,
+          b: 1,
         },
-      };
-      const textEl = {
-        type: 'text',
-        backgroundTextMode: 'NONE',
-        content: 'Fill with text',
-        x: 1,
-        y: 1,
-        width: 175,
-        height: 36,
-      };
-      const page = {
-        id: 123,
-        pageSize: {
-          height: PAGE_HEIGHT,
-          width: PAGE_WIDTH,
-        },
-        elements: [bgEl, textEl],
-        backgroundColor: {
-          color: {
-            r: 2,
-            g: 12,
-            b: 1,
-          },
-        },
-      };
+      },
+    };
+
+    it('should return a warning if the default font (no spans, no colors added) does not have high enough contrast with the page', async () => {
       expect(
         await accessibilityChecks.pageBackgroundTextLowContrast(page)
       ).toStrictEqual([
@@ -151,6 +153,61 @@ describe('Pre-publish checklist - accessibility issues (warnings)', () => {
           help: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.HELPER_TEXT,
           elements: [
             { ...bgEl, backgroundColor: page.backgroundColor },
+            textEl,
+          ],
+          pageId: page.id,
+          type: 'warning',
+        },
+      ]);
+    });
+    it('should return undefined if the text size is large enough', async () => {
+      const largeGreyTextEl = {
+        ...textEl,
+        content: '<span style="color:#777777">I woke up like this</span>',
+        fontSize: 18,
+      };
+      const smallGreyTextEl = {
+        ...textEl,
+        content: '<span style="color:#777777">I woke up like this</span>',
+      };
+
+      const whiteBgPage = {
+        ...page,
+        backgroundColor: {
+          color: {
+            r: 255,
+            g: 255,
+            b: 255,
+          },
+        },
+      };
+      expect(
+        await accessibilityChecks.pageBackgroundTextLowContrast({
+          ...whiteBgPage,
+          elements: [bgEl, largeGreyTextEl],
+        })
+      ).toBeUndefined();
+      expect(
+        await accessibilityChecks.pageBackgroundTextLowContrast({
+          ...whiteBgPage,
+          elements: [bgEl, smallGreyTextEl],
+        })
+      ).not.toBeUndefined();
+    });
+
+    it('should return undefined if the contrast is great enough', async () => {
+      const whiteBackgroundColor = { color: { r: 255, g: 255, b: 255 } };
+      expect(
+        await accessibilityChecks.pageBackgroundTextLowContrast({
+          ...page,
+          backgroundColor: whiteBackgroundColor,
+        })
+      ).toStrictEqual([
+        {
+          message: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.MAIN_TEXT,
+          help: MESSAGES.ACCESSIBILITY.LOW_CONTRAST.HELPER_TEXT,
+          elements: [
+            { ...bgEl, backgroundColor: whiteBackgroundColor },
             textEl,
           ],
           pageId: page.id,

--- a/assets/src/edit-story/elements/text/output.js
+++ b/assets/src/edit-story/elements/text/output.js
@@ -27,7 +27,11 @@ import StoryPropTypes from '../../types';
 import generatePatternStyles from '../../utils/generatePatternStyles';
 import { getHTMLFormatters } from '../../components/richText/htmlManipulation';
 import createSolid from '../../utils/createSolid';
-import { dataToEditorX, dataToEditorY, dataToFontSizeEm } from '../../units';
+import {
+  dataToEditorX,
+  dataToEditorY,
+  dataToFontSizeY as dataToFontSize,
+} from '../../units';
 import { BACKGROUND_TEXT_MODE } from '../../constants';
 import {
   generateParagraphTextStyle,
@@ -235,7 +239,7 @@ function TextOutput({ element }) {
       className="fill"
       dataToStyleX={(x) => `${dataToEditorX(x, 100)}%`}
       dataToStyleY={(y) => `${dataToEditorY(y, 100)}%`}
-      dataToFontSizeY={(y) => `${dataToFontSizeEm(y, 100)}em`}
+      dataToFontSizeY={(y) => `${dataToFontSize(y, 100)}em`}
       // Both vertical and horizontal paddings are calculated in % relative to
       // the box's width per CSS rules.
       dataToPaddingX={(x) => `${(x / width) * 100}%`}

--- a/assets/src/edit-story/elements/text/output.js
+++ b/assets/src/edit-story/elements/text/output.js
@@ -27,7 +27,7 @@ import StoryPropTypes from '../../types';
 import generatePatternStyles from '../../utils/generatePatternStyles';
 import { getHTMLFormatters } from '../../components/richText/htmlManipulation';
 import createSolid from '../../utils/createSolid';
-import { dataToEditorX, dataToEditorY } from '../../units';
+import { dataToEditorX, dataToEditorY, dataToFontSizeEm } from '../../units';
 import { BACKGROUND_TEXT_MODE } from '../../constants';
 import {
   generateParagraphTextStyle,
@@ -235,7 +235,7 @@ function TextOutput({ element }) {
       className="fill"
       dataToStyleX={(x) => `${dataToEditorX(x, 100)}%`}
       dataToStyleY={(y) => `${dataToEditorY(y, 100)}%`}
-      dataToFontSizeY={(y) => `${(dataToEditorY(y, 100) / 10).toFixed(6)}em`}
+      dataToFontSizeY={(y) => `${dataToFontSizeEm(y, 100)}em`}
       // Both vertical and horizontal paddings are calculated in % relative to
       // the box's width per CSS rules.
       dataToPaddingX={(x) => `${(x / width) * 100}%`}

--- a/assets/src/edit-story/units/dimensions.js
+++ b/assets/src/edit-story/units/dimensions.js
@@ -81,7 +81,7 @@ export function dataToEditorY(y, pageHeight) {
   return editorPixels((y * pageHeight) / PAGE_HEIGHT);
 }
 
-export function dataToFontSizeEm(v, pageHeight) {
+export function dataToFontSizeY(v, pageHeight) {
   return (dataToEditorY(v, pageHeight) / 10).toFixed(6);
 }
 

--- a/assets/src/edit-story/units/dimensions.js
+++ b/assets/src/edit-story/units/dimensions.js
@@ -81,6 +81,10 @@ export function dataToEditorY(y, pageHeight) {
   return editorPixels((y * pageHeight) / PAGE_HEIGHT);
 }
 
+export function dataToFontSizeEm(v, pageHeight) {
+  return (dataToEditorY(v, pageHeight) / 10).toFixed(6);
+}
+
 /**
  * Converts a "editor" pixel value to the value in the "data" space along
  * the horizontal (X) dimension.

--- a/assets/src/edit-story/units/index.js
+++ b/assets/src/edit-story/units/index.js
@@ -24,5 +24,5 @@ export {
   editorToDataX,
   editorToDataY,
   dataFontEm,
-  dataToFontSizeEm,
+  dataToFontSizeY,
 } from './dimensions';

--- a/assets/src/edit-story/units/index.js
+++ b/assets/src/edit-story/units/index.js
@@ -24,4 +24,5 @@ export {
   editorToDataX,
   editorToDataY,
   dataFontEm,
+  dataToFontSizeEm,
 } from './dimensions';

--- a/assets/src/edit-story/utils/contrastUtils.js
+++ b/assets/src/edit-story/utils/contrastUtils.js
@@ -19,11 +19,6 @@
  */
 
 import * as hues from '@ap.cx/hues';
-/**
- * Internal dependencies
- */
-import { DEFAULT_EM } from '../constants';
-import { dataToEditorY } from '../units';
 
 /**
  * Calculate luminance from RGB Object
@@ -67,6 +62,5 @@ export function calculateLuminanceFromStyleColor(styleColor) {
  */
 export function checkContrastFromLuminances(luminanceA, luminanceB, fontSize) {
   const ratio = hues.contrast(luminanceA, luminanceB);
-  const ptValue = (dataToEditorY(fontSize, 100) / 10) * DEFAULT_EM;
-  return { ratio, WCAG_AA: hues.aa(ratio, ptValue) };
+  return { ratio, WCAG_AA: hues.aa(ratio, fontSize) };
 }

--- a/assets/src/edit-story/utils/contrastUtils.js
+++ b/assets/src/edit-story/utils/contrastUtils.js
@@ -19,6 +19,11 @@
  */
 
 import * as hues from '@ap.cx/hues';
+/**
+ * Internal dependencies
+ */
+import { DEFAULT_EM } from '../constants';
+import { dataToEditorY } from '../units';
 
 /**
  * Calculate luminance from RGB Object
@@ -49,13 +54,19 @@ export function calculateLuminanceFromStyleColor(styleColor) {
 }
 
 /**
+ * 18 point text or 14 point bold text is judged to be large enough to require a lower contrast ratio.
+ * https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html
+ */
+/**
  * Check contrast ratios from luminances for WCAG guidelines
  *
  * @param  {number} luminanceA Luminance A
  * @param  {number} luminanceB Luminance B
+ * @param  {number} fontSize Font size
  * @return {Object} WCAG contrast ratio checks
  */
-export function checkContrastFromLuminances(luminanceA, luminanceB) {
+export function checkContrastFromLuminances(luminanceA, luminanceB, fontSize) {
   const ratio = hues.contrast(luminanceA, luminanceB);
-  return { ratio, WCAG_AA: hues.aa(ratio) };
+  const ptValue = (dataToEditorY(fontSize, 100) / 10) * DEFAULT_EM;
+  return { ratio, WCAG_AA: hues.aa(ratio, ptValue) };
 }

--- a/assets/src/edit-story/utils/test/contrastUtils.js
+++ b/assets/src/edit-story/utils/test/contrastUtils.js
@@ -73,5 +73,22 @@ describe('contrastUtils', () => {
           .WCAG_AA
       ).toStrictEqual(false);
     });
+
+    it('calculate successful contrast check from large font size', () => {
+      const luminanceA = 1;
+      const luminanceB = 0.3;
+      expect(
+        contrastUtils.checkContrastFromLuminances(luminanceA, luminanceB, 24)
+          .WCAG_AA
+      ).toStrictEqual(true);
+    });
+    it('calculate failed contrast check from small font size', () => {
+      const luminanceA = 1;
+      const luminanceB = 0.3;
+      expect(
+        contrastUtils.checkContrastFromLuminances(luminanceA, luminanceB, 12)
+          .WCAG_AA
+      ).toStrictEqual(false);
+    });
   });
 });


### PR DESCRIPTION
## Context
- We are currently not using the text element's `fontSize` value to determine if the contrast is great enough between itself and its background element. This fix should reduce the number of false positives when using decorative text that is still readable due to its large size.

https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- The accessibility standards allow for larger fonts to have a lower contrast ratio. We should let rules of this standard drive the accessibility standards of the editor.
- Do this by providing the normalized font size to the accessibility checking library
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

When the contrast checking was initially implemented we relied on a library that used the element font size to determine if the contrast was acceptable to w3 standards. Due to a lack of support, we swapped out for the current dependency `@ap.cx/hues` which does not document their support of font size [in their README](https://github.com/thierryc/hues#readme), although it makes mention of the standard. The `aa` check does support font size upon observing the source code, however, so I'm leveraging that here.

Hopefully the new unit tests for `contrastUtils` illustrate how the font size impacts the rating. A lower ratio between color luminosities is acceptable with a larger font size. The minimum font size values used there are according to the w3 standard:
https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html

I attempted to convert the element's font size number with the font size that would be displayed by sharing code between `text/output` and `accessibility` through the `units` module. I am intending to comply with the accessibility standards so rather than passing in the font size value from the element raw, I'm trying to convert it to its "pt" size... I _think_ I have it right but would love some input there.

<!-- Please describe your changes. -->

## To-do
- N/A
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A this is a bug fix
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->


### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. create a new story
2. add default text (size 12)
3. change the color of that text to `#777777` (a medium gray)
4. There should be a contrast warning in the checklist
5. change the size to a large font size, >83
6. the contrast warning should not be in the checklist

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5913 
