### PR TITLE
Misc. Sizing Clean Up for Updated Icons

### DIFF
--- a/assets/src/design-system/components/checkbox/index.js
+++ b/assets/src/design-system/components/checkbox/index.js
@@ -43,7 +43,7 @@ const Border = styled.div(
 
 const StyledCheckmark = styled(Checkmark)`
   height: auto;
-  width: 16px;
+  width: 32px;
   color: ${({ theme }) => theme.colors.fg.primary};
 `;
 

--- a/assets/src/design-system/components/toggle/index.js
+++ b/assets/src/design-system/components/toggle/index.js
@@ -35,9 +35,9 @@ const CIRCLE_FINAL_POSITION =
   CIRCLE_INITIAL_POSITION -
   (CIRCLE_DIAMETER / 2 - CIRCLE_INITIAL_POSITION / 2);
 
-const ICON_WIDTH = 7;
-const ICON_TOP_POSITION = 8;
-const ICON_LEFT_POSITION = 30.5;
+const ICON_WIDTH = 18;
+const ICON_TOP_POSITION = 2;
+const ICON_LEFT_POSITION = 26;
 
 const Background = styled.div(
   ({ theme }) => css`

--- a/assets/src/edit-story/components/header/buttons/styles.js
+++ b/assets/src/edit-story/components/header/buttons/styles.js
@@ -25,10 +25,9 @@ import styled from 'styled-components';
 import { Icons } from '../../../../design-system';
 
 export const WarningIcon = styled(Icons.ExclamationTriangle)`
-  color: $(({theme}) => theme.DEPRECATED_THEME.colors.fg.white);
-  width: 14px;
-  height: 14px;
-  margin-left: 8px;
+  color: ${({ theme }) => theme.DEPRECATED_THEME.colors.fg.white};
+  width: 32px !important;
+  padding-left: 8px;
 `;
 
 export const ButtonContent = styled.div`

--- a/assets/src/edit-story/components/helpCenter/toggle/index.js
+++ b/assets/src/edit-story/components/helpCenter/toggle/index.js
@@ -52,13 +52,7 @@ const Label = styled.span`
     display: block;
     min-width: 65px;
     text-align: left;
-  }
-`;
-
-const Space = styled.div`
-  width: 89px;
-  @media ${({ theme }) => theme.breakpoint.desktop} {
-    width: 48px;
+    padding-right: 20px;
   }
 `;
 
@@ -119,7 +113,6 @@ function Toggle({
       size={BUTTON_SIZES.MEDIUM}
     >
       <Label>{__('Help Center', 'web-stories')}</Label>
-      <Space />
       <IconWrapper>
         {hasNotifications ? (
           <NotificationWrapper>


### PR DESCRIPTION
## Context
Few small tweaks that need to be made for icon update in design system, publish/update button and help center. 
Figured this was easier than telling @barklund where the updates were needed when he already did the bulk of the effort on this task that wasn't planned on. 

## Summary

- make checkmark bigger in design system (used on dashboard/settings and telemetry banner)
- make toggle checkmark bigger (only exists in storybook)
- tweak prepublish alert icon that shows up on publisher or update button to be better size
- move space for help center toggle to be padding instead of a div

