### PR TITLE
FTUE: Dynamic tip navigation

### DIFF
--- a/assets/src/edit-story/components/helpCenter/constants.js
+++ b/assets/src/edit-story/components/helpCenter/constants.js
@@ -121,8 +121,7 @@ export const Z_INDEX = {
   QUICK_TIP: 2,
 };
 
-// @TODO make this dynamic based off of unread tips.
-export const NAVIGATION_FLOW = [...Object.keys(TIPS), DONE_TIP_ENTRY[0]];
+export const BASE_NAVIGATION_FLOW = Object.keys(TIPS);
 
 export const FOCUSABLE_SELECTORS = [
   'button',
@@ -147,3 +146,8 @@ export const ReadTipsType = PropTypes.shape({
     {}
   ),
 });
+
+export const TIP_KEYS_MAP = Object.keys(TIPS).reduce((keyMap, key) => {
+  keyMap[key] = true;
+  return keyMap;
+}, {});

--- a/assets/src/edit-story/components/helpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/index.js
@@ -33,7 +33,7 @@ import { POPUP_ID } from './constants';
 import { Toggle } from './toggle';
 import { useHelpCenter } from './useHelpCenter';
 import { Popup } from './popup';
-import { forceFocusCompanion, getUnreadTips } from './utils';
+import { forceFocusCompanion } from './utils';
 
 const Wrapper = styled.div`
   position: absolute;
@@ -94,7 +94,7 @@ export const HelpCenter = () => {
           <Toggle
             isOpen={state.isOpen}
             onClick={actions.toggle}
-            notificationCount={getUnreadTips(state).length}
+            notificationCount={state.unreadTipsCount}
             popupId={POPUP_ID}
           />
         </Wrapper>

--- a/assets/src/edit-story/components/helpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/index.js
@@ -33,7 +33,7 @@ import { POPUP_ID } from './constants';
 import { Toggle } from './toggle';
 import { useHelpCenter } from './useHelpCenter';
 import { Popup } from './popup';
-import { forceFocusCompanion } from './utils';
+import { forceFocusCompanion, getUnreadTips } from './utils';
 
 const Wrapper = styled.div`
   position: absolute;
@@ -94,12 +94,7 @@ export const HelpCenter = () => {
           <Toggle
             isOpen={state.isOpen}
             onClick={actions.toggle}
-            notificationCount={
-              // navigation includes 'done' which does not get marked read
-              state.navigationFlow.length -
-              Object.keys(state.readTips).length -
-              1
-            }
+            notificationCount={getUnreadTips(state).length}
             popupId={POPUP_ID}
           />
         </Wrapper>

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
@@ -85,6 +85,14 @@ export const createDynamicNavigationFlow = (previous, next) => {
   };
 };
 
+export function deriveUnreadTipsCount(previous, next) {
+  return {
+    unreadTipsCount:
+      Object.keys(TIP_KEYS_MAP).filter((tip) => !next.readTips[tip])?.length ||
+      0,
+  };
+}
+
 /**
  * Takes an array of effects and returns a composed function
  * that given next and previous state runs through each effect

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
@@ -93,7 +93,7 @@ export const createDynamicNavigationFlow = (previous, next) => {
  * @param {Array<Function>} effects arry of effects
  * @return {Function} (previous, next) => <object in shape of next>
  */
-export const createEffectRun = (effects = []) => (previous, next) =>
+export const composeEffects = (effects = []) => (previous, next) =>
   effects.reduce(
     (effectedNext, effect) => ({
       ...next,

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
@@ -16,14 +16,17 @@
 /**
  * Internal dependencies
  */
-import { TIPS } from '../constants';
-
-const TIP_KEYS_MAP = Object.keys(TIPS).reduce((keyMap, key) => {
-  keyMap[key] = true;
-  return keyMap;
-}, {});
+import {
+  DONE_TIP_ENTRY,
+  BASE_NAVIGATION_FLOW,
+  TIP_KEYS_MAP,
+} from '../constants';
 
 const isMenuIndex = (previous, next) => next.navigationIndex < 0;
+
+const isComingFromMenu = (previous, next) =>
+  previous.navigationIndex < 0 && next.navigationIndex >= 0;
+
 const navigationFlowTips = (previous, next) =>
   (next.navigationFlow || []).filter((key) => TIP_KEYS_MAP[key]);
 
@@ -62,6 +65,24 @@ export const deriveReadTip = (previous, next) => {
     : next.readTips;
 
   return { readTips };
+};
+
+export const createDynamicNavigationFlow = (previous, next) => {
+  if (!isComingFromMenu(previous, next)) {
+    return {};
+  }
+  const appendedTips = BASE_NAVIGATION_FLOW
+    // Tips before current index
+    .slice(0, next.navigationIndex)
+    // Filter out read tips
+    .filter((tip) => !next.readTips[tip]);
+  return {
+    navigationFlow: [
+      ...BASE_NAVIGATION_FLOW,
+      ...appendedTips,
+      DONE_TIP_ENTRY[0],
+    ],
+  };
 };
 
 /**

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
@@ -22,8 +22,9 @@ import { useEffect, useMemo, useReducer, useState } from 'react';
  */
 import { clamp } from '../../../../animation';
 import { useCurrentUser } from '../../../app';
-import { NAVIGATION_FLOW, TRANSITION_DURATION } from '../constants';
+import { BASE_NAVIGATION_FLOW, TRANSITION_DURATION } from '../constants';
 import {
+  createDynamicNavigationFlow,
   createEffectRun,
   deriveBottomNavigation,
   deriveDisabledButtons,
@@ -46,6 +47,7 @@ export const deriveState = createEffectRun(
   // one after the other.
   [
     resetNavigationIndexOnOpen,
+    createDynamicNavigationFlow,
     deriveBottomNavigation,
     deriveTransitionDirection,
     deriveDisabledButtons,
@@ -66,7 +68,7 @@ const initial = {
     isOpen: false,
     navigationIndex: -1,
     // @TODO make this dynamic based off of unread tips.
-    navigationFlow: NAVIGATION_FLOW,
+    navigationFlow: BASE_NAVIGATION_FLOW,
     isLeftToRightTransition: true,
     hasBottomNavigation: false,
     isPrevDisabled: true,
@@ -177,7 +179,8 @@ export function useHelpCenter() {
             web_stories_onboarding: createBooleanMapFromKey(persistenceKey),
           },
         }).catch(actions.persistingReadTipsError),
-      TRANSITION_DURATION
+      // duration of menu transition which takes the longest
+      TRANSITION_DURATION * 1.2
     );
     return () => clearTimeout(id);
   }, [actions, updateCurrentUser, persistenceKey]);

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
@@ -24,8 +24,8 @@ import { clamp } from '../../../../animation';
 import { useCurrentUser } from '../../../app';
 import { BASE_NAVIGATION_FLOW, TRANSITION_DURATION } from '../constants';
 import {
+  composeEffects,
   createDynamicNavigationFlow,
-  createEffectRun,
   deriveBottomNavigation,
   deriveDisabledButtons,
   deriveReadTip,
@@ -41,7 +41,7 @@ import {
  * @param {*} next - next state
  * @return {*} partial of state
  */
-export const deriveState = createEffectRun(
+export const deriveState = composeEffects(
   // Order matters here as effects run
   // sequentially and alter next state
   // one after the other.
@@ -63,7 +63,7 @@ const reducer = ({ state, actions }, action) => {
   };
 };
 
-const initial = {
+export const initial = {
   state: {
     isOpen: false,
     navigationIndex: -1,

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
@@ -30,6 +30,7 @@ import {
   deriveDisabledButtons,
   deriveReadTip,
   deriveTransitionDirection,
+  deriveUnreadTipsCount,
   resetNavigationIndexOnOpen,
 } from './effects';
 
@@ -52,6 +53,7 @@ export const deriveState = composeEffects(
     deriveTransitionDirection,
     deriveDisabledButtons,
     deriveReadTip,
+    deriveUnreadTipsCount,
   ]
 );
 
@@ -75,6 +77,7 @@ export const initial = {
     isNextDisabled: false,
     readTips: {},
     readError: false,
+    unreadTipsCount: 0,
   },
   // All actions are in the form: externalArgs -> state -> newStatePartial
   //

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/test/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/test/effects.js
@@ -32,6 +32,7 @@ const mockState = (overrides) => ({
 // @TODO describe('deriveTransitionDirection');
 // @TODO describe('deriveDisabledButtons');
 // @TODO describe('deriveReadTip');
+// @TODO describe('deriveUnreadTipsCount');
 
 describe('createDynamicNavigationFlow', () => {
   it('should do nothing if not navigating from the main menu', () => {

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/test/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/test/effects.js
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { createDynamicNavigationFlow } from '../effects';
+import { TIPS, BASE_NAVIGATION_FLOW, DONE_TIP_ENTRY } from '../../constants';
+import { initial, deriveState } from '../';
+
+const mockState = (overrides) => ({
+  ...initial.state,
+  ...overrides,
+});
+
+// @TODO Split deriveState up into more atomic effect unit tests
+// @TODO describe('composeEffects');
+// @TODO describe('resetNavigationIndexOnOpen');
+// @TODO describe('deriveBottomNavigation');
+// @TODO describe('deriveTransitionDirection');
+// @TODO describe('deriveDisabledButtons');
+// @TODO describe('deriveReadTip');
+
+describe('createDynamicNavigationFlow', () => {
+  it('should do nothing if not navigating from the main menu', () => {
+    // case where we stay on menu
+    const onMenuState = mockState({ navigationIndex: -1 });
+    expect(createDynamicNavigationFlow(onMenuState, onMenuState)).toStrictEqual(
+      {}
+    );
+    // case where we navigate to menu
+    const onTipState = mockState({ navigationIndex: 0 });
+    expect(createDynamicNavigationFlow(onTipState, onMenuState)).toStrictEqual(
+      {}
+    );
+    // case where we navigate between tips
+    const onAnotherTipState = mockState({ navigationIndex: 1 });
+    expect(
+      createDynamicNavigationFlow(onTipState, onAnotherTipState)
+    ).toStrictEqual({});
+  });
+
+  it('on navigate from menu, should append unread tips before navigation index to the end of the navigation flow before done tip', () => {
+    const onMenuState = mockState({ navigationIndex: -1 });
+    Object.keys(TIPS).forEach((tip) => {
+      const tipIndex = BASE_NAVIGATION_FLOW.findIndex((v) => v === tip);
+      const tipsBeforeCurrent = BASE_NAVIGATION_FLOW.slice(0, tipIndex);
+      expect(
+        createDynamicNavigationFlow(
+          onMenuState,
+          mockState({ navigationIndex: tipIndex })
+        )
+      ).toStrictEqual({
+        navigationFlow: [
+          ...BASE_NAVIGATION_FLOW,
+          ...tipsBeforeCurrent,
+          DONE_TIP_ENTRY[0],
+        ],
+      });
+    });
+  });
+});
+
+describe('deriveState', () => {
+  it('sets isPrevDisabled to true if navigationIndex becomes 0', () => {
+    const previousState = mockState({ navigationIndex: 5 });
+    const nextState = mockState({ navigationIndex: 0 });
+    const { isPrevDisabled } = deriveState(previousState, nextState);
+    expect(isPrevDisabled).toBe(true);
+  });
+
+  it('sets isPrevDisabled to false if navigationIndex is greater than 0', () => {
+    const previousState = mockState({ navigationIndex: 0 });
+    const nextState = mockState({ navigationIndex: 5 });
+    const { isPrevDisabled } = deriveState(previousState, nextState);
+    expect(isPrevDisabled).toBe(false);
+  });
+
+  it('sets isNextDisabled to true if navigationIndex is on last index in navigation flow', () => {
+    const previousState = mockState({
+      navigationIndex: 0,
+      navigationFlow: ['tip_1', 'tip_2'],
+    });
+    const nextState = mockState({
+      navigationIndex: 1,
+      navigationFlow: ['tip_1', 'tip_2'],
+    });
+    const { isNextDisabled } = deriveState(previousState, nextState);
+    expect(isNextDisabled).toBe(true);
+  });
+
+  it('sets isNextDisabled to false if navigationIndex is not on last index in navigation flow', () => {
+    const previousState = mockState({
+      navigationIndex: 2,
+      navigationFlow: ['tip_1', 'tip_2', 'tip_3'],
+    });
+    const nextState = mockState({
+      navigationIndex: 1,
+      navigationFlow: ['tip_1', 'tip_2', 'tip_3'],
+    });
+    const { isNextDisabled } = deriveState(previousState, nextState);
+    expect(isNextDisabled).toBe(false);
+  });
+
+  it('sets isLeftToRightTransition to true if navigationIndex is increasing', () => {
+    const previousState = mockState({
+      navigationIndex: 0,
+      navigationFlow: ['tip_1', 'tip_2'],
+    });
+    const nextState = mockState({
+      navigationIndex: 1,
+      navigationFlow: ['tip_1', 'tip_2'],
+    });
+    const { isLeftToRightTransition } = deriveState(previousState, nextState);
+    expect(isLeftToRightTransition).toBe(true);
+  });
+
+  it('sets isLeftToRightTransition to false if navigationIndex is decreasing', () => {
+    const previousState = mockState({
+      navigationIndex: 2,
+      navigationFlow: ['tip_1', 'tip_2'],
+    });
+    const nextState = mockState({
+      navigationIndex: 1,
+      navigationFlow: ['tip_1', 'tip_2'],
+    });
+    const { isLeftToRightTransition } = deriveState(previousState, nextState);
+    expect(isLeftToRightTransition).toBe(false);
+  });
+
+  it('sets hasBottomNavigation to true if navigationIndex is not on menu index', () => {
+    const previousState = mockState({
+      navigationIndex: -1,
+    });
+    const nextState = mockState({
+      navigationIndex: 0,
+    });
+    const { hasBottomNavigation } = deriveState(previousState, nextState);
+    expect(hasBottomNavigation).toBe(true);
+  });
+
+  it('sets hasBottomNavigation to false if navigationIndex is on menu index', () => {
+    const previousState = mockState({
+      navigationIndex: 4,
+    });
+    const nextState = mockState({
+      navigationIndex: -1,
+    });
+    const { hasBottomNavigation } = deriveState(previousState, nextState);
+    expect(hasBottomNavigation).toBe(false);
+  });
+
+  it('sets a tip to read if the navigation index is not on the menu or done index', () => {
+    const navigationFlow = Object.keys(TIPS);
+    const previousState = mockState({
+      navigationIndex: -1,
+      navigationFlow: navigationFlow,
+    });
+    const nextState = mockState({
+      navigationIndex: 0,
+      navigationFlow: navigationFlow,
+    });
+    const { readTips } = deriveState(previousState, nextState);
+    expect(readTips[navigationFlow[0]]).toBe(true);
+  });
+
+  it('resets the navigation index to the main menu when opening', () => {
+    const previousState = mockState({
+      isOpen: false,
+      navigationIndex: 4,
+    });
+    const nextState = mockState({
+      isOpen: true,
+      navigationIndex: 4,
+    });
+    const { navigationIndex } = deriveState(previousState, nextState);
+    expect(navigationIndex).toBe(-1);
+  });
+
+  it('retains navigation index when staying open between state transitions', () => {
+    const previousState = mockState({
+      isOpen: true,
+      navigationIndex: 4,
+    });
+    const nextState = mockState({
+      isOpen: true,
+      navigationIndex: 4,
+    });
+    const { navigationIndex } = deriveState(previousState, nextState);
+    expect(navigationIndex).toBe(4);
+  });
+});

--- a/assets/src/edit-story/components/helpCenter/utils.js
+++ b/assets/src/edit-story/components/helpCenter/utils.js
@@ -16,11 +16,7 @@
 /**
  * Internal dependencies
  */
-import { FOCUSABLE_POPUP_CHILDREN_SELECTOR, POPUP_ID, TIPS } from './constants';
-
-export function getUnreadTips(state) {
-  return Object.keys(TIPS).filter((tip) => !state.readTips[tip]) || [];
-}
+import { FOCUSABLE_POPUP_CHILDREN_SELECTOR, POPUP_ID } from './constants';
 
 export function forceFocusCompanion() {
   document.querySelector(FOCUSABLE_POPUP_CHILDREN_SELECTOR)?.focus();

--- a/assets/src/edit-story/components/helpCenter/utils.js
+++ b/assets/src/edit-story/components/helpCenter/utils.js
@@ -16,7 +16,11 @@
 /**
  * Internal dependencies
  */
-import { FOCUSABLE_POPUP_CHILDREN_SELECTOR, POPUP_ID } from './constants';
+import { FOCUSABLE_POPUP_CHILDREN_SELECTOR, POPUP_ID, TIPS } from './constants';
+
+export function getUnreadTips(state) {
+  return Object.keys(TIPS).filter((tip) => !state.readTips[tip]) || [];
+}
 
 export function forceFocusCompanion() {
   document.querySelector(FOCUSABLE_POPUP_CHILDREN_SELECTOR)?.focus();


### PR DESCRIPTION
## Context
New feature created so you can't get to `done` tip without viewing all the tips

## Summary
Evert time you navigate from menu, create a navigation flow that consists of the base navigation flow, the unread tips before the current current tip then the done tip

## Relevant Technical Choices
- Followed existing standards. this is just a new effect since it's derived when state changes. 
- Had some small updates around some tests & behavior that depended on the old navigation flow UX too

## To-do
NA

## User-facing changes
(behind enableQuickTips flag)
Now shouldn't be able to see the done tip without viewing all the unread tips.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
in the editor with quick tips endabled:
-> type this into your console to reset your previously read tips
`await wp.apiFetch({ path: '/web-stories/v1/users/me', method: 'POST', data: { meta: { web_stories_onboarding: {} }}})`
-> Refresh the editor
-> You should now see all of the tips unread
-> No matter which tip you click on from the main menu, you shouldn't be able to get to the `done` tip without going through all unread tips.


<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5888 
