### PR TITLE
PHP 8 Compatibility: Include missing file from mbstring polyfill

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -160,7 +160,7 @@ return [
 			->files()
 			->ignoreVCS( true )
 			->ignoreDotFiles( true )
-			->name( '*.php' )
+			->name( '/\.*.php8?/' )
 			->in( 'vendor/symfony/polyfill-mbstring/Resources' )
 			->append(
 				[


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli-bundle/pull/263 for details.

Looks like the polyfill contains a `mb_convert_variables.php8` file that is included on PHP > 8. It needs to be included in our scoper config as welll.