### PR TITLE
FTUE: Update Tip 7 Text

### DIFF
--- a/assets/src/edit-story/components/helpCenter/constants.js
+++ b/assets/src/edit-story/components/helpCenter/constants.js
@@ -92,7 +92,7 @@ export const TIPS = {
     figureSrc: 'images/help-center/page_attachment_module_7.webm',
     description: [
       __(
-        'Go to the Design tab. Scroll down to <strong>Swipe-up Link</strong> and enter a web address and a call to action to describe the link.',
+        'Go to the Design tab. Navigate to <strong>Page Attachment</strong> and enter a web address and a call to action to describe the link.',
         'web-stories'
       ),
     ],


### PR DESCRIPTION
## Context

Per feedback on bug bash, updating text on tip seven from `Scroll down to Swipe-up Link and enter...` to `Navigate to Page Attachment and enter...`

![Screen Shot 2021-02-12 at 12 28 27 PM](https://user-images.githubusercontent.com/10720454/107813893-42b4cb00-6d2e-11eb-9073-1537350549da.png)

Fixes #6369 
