### PR TITLE
Dashboard: replace 'scroll to top button' with button and icon from design system

### DIFF
--- a/assets/src/dashboard/components/scrollToTop/index.js
+++ b/assets/src/dashboard/components/scrollToTop/index.js
@@ -50,7 +50,7 @@ const StyledButton = styled(Button)(
 
 const DropUpArrowIcon = styled(Icons.ChevronUp)`
   position: relative;
-  transform: scale(2);
+  transform: scale(2.4);
 `;
 
 const ScrollToTop = () => {

--- a/assets/src/dashboard/components/scrollToTop/index.js
+++ b/assets/src/dashboard/components/scrollToTop/index.js
@@ -73,6 +73,7 @@ const ScrollToTop = () => {
 
   return (
     <StyledButton
+      aria-hidden={isVisible}
       aria-label={__('scroll back to top', 'web-stories')}
       data-testid="scroll-to-top-button"
       isVisible={isVisible}

--- a/assets/src/dashboard/components/scrollToTop/index.js
+++ b/assets/src/dashboard/components/scrollToTop/index.js
@@ -18,55 +18,39 @@
  * External dependencies
  */
 import { useEffect, useState } from 'react';
-import styled from 'styled-components';
-import { rgba } from 'polished';
+import styled, { css } from 'styled-components';
 import { useDebouncedCallback } from 'use-debounce';
 import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
  */
-import { ChevronLeft } from '../../icons';
 import { useLayoutContext } from '../layout';
-import { KEYBOARD_USER_SELECTOR } from '../../constants';
+import { Button, BUTTON_VARIANTS, Icons } from '../../../design-system';
 
-const ScrollButton = styled.button`
-  position: fixed;
-  right: 40px;
-  bottom: 40px;
-  height: 50px;
-  width: 50px;
-  display: flex;
-  align-self: center;
-  justify-content: space-around;
-  align-items: center;
-  contain: content;
-  padding: 8px;
-  pointer-events: ${({ isVisible }) => (isVisible ? 'auto' : 'none')};
-  cursor: pointer;
-  border-radius: 50%;
-  border: ${({ theme }) => theme.DEPRECATED_THEME.borders.transparent};
-  box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
-  color: ${({ theme }) => theme.DEPRECATED_THEME.colors.gray900};
-  background-color: ${({ theme }) => theme.DEPRECATED_THEME.colors.white};
-  opacity: ${({ isVisible }) => Number(isVisible)};
-  transition: opacity 300ms ease-in-out;
+const StyledButton = styled(Button)(
+  ({ isVisible }) => css`
+    position: fixed;
+    right: 40px;
+    bottom: 40px;
+    height: 50px;
+    width: 50px;
+    display: flex;
+    align-self: center;
+    justify-content: space-around;
+    align-items: center;
+    contain: content;
+    padding: 8px;
+    pointer-events: ${isVisible ? 'auto' : 'none'};
+    box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
+    opacity: ${Number(isVisible)};
+    transition: opacity 300ms ease-in-out;
+  `
+);
 
-  ${KEYBOARD_USER_SELECTOR} &:focus {
-    outline: ${({ theme }) =>
-      `2px solid ${rgba(
-        theme.DEPRECATED_THEME.colors.bluePrimary,
-        0.85
-      )} !important`};
-  }
-`;
-
-const DropUpArrowIcon = styled(ChevronLeft)`
-  top: -2px;
+const DropUpArrowIcon = styled(Icons.ChevronUp)`
   position: relative;
-  transform: rotate(-90deg);
-  width: 100%;
-  height: 100%;
+  transform: scale(2);
 `;
 
 const ScrollToTop = () => {
@@ -88,14 +72,15 @@ const ScrollToTop = () => {
   }, [handleScroll]);
 
   return (
-    <ScrollButton
+    <StyledButton
+      aria-label={__('scroll back to top', 'web-stories')}
       data-testid="scroll-to-top-button"
       isVisible={isVisible}
       onClick={scrollToTop}
-      title={__('scroll back to top', 'web-stories')}
+      variant={BUTTON_VARIANTS.CIRCLE}
     >
-      <DropUpArrowIcon aria-hidden={true} />
-    </ScrollButton>
+      <DropUpArrowIcon aria-hidden />
+    </StyledButton>
   );
 };
 


### PR DESCRIPTION
## Context

Integrating design system into the Dashboard.

## Summary

Replace the 'Scroll to Top' button and icon with the button and icon from the design system.

## Relevant Technical Choices

n/a

## To-do

none

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/22185279/107823531-32f0b300-6d3d-11eb-9826-c46d354db444.png)|![image](https://user-images.githubusercontent.com/22185279/107823723-7519f480-6d3d-11eb-89d9-0a496f2add08.png)|

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

1. visit dashboard
2. scroll to bottom so that the button is displayed (bottom right side of screen)

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. visit dashboard
2. scroll to bottom so that the button is displayed (bottom right side of screen)

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6100
