### PR TITLE
Updated help toggle design

### DIFF
--- a/assets/src/edit-story/components/helpCenter/toggle/index.js
+++ b/assets/src/edit-story/components/helpCenter/toggle/index.js
@@ -31,6 +31,7 @@ import {
   NotificationBubble,
   Button as dsButton,
 } from '../../../../design-system';
+import { BEZIER } from '../../../../animation';
 
 const Button = styled(dsButton)`
   border: 1px solid ${({ theme }) => theme.colors.border.defaultNormal};
@@ -46,31 +47,30 @@ const Button = styled(dsButton)`
 `;
 
 const Label = styled.span`
-  display: none;
-
-  @media ${({ theme }) => theme.breakpoint.desktop} {
-    display: block;
-    line-height: 20px;
-    text-align: left;
-
-    & ~ div {
-      margin-left: 20px;
-    }
-  }
+  display: block;
+  line-height: 20px;
+  text-align: left;
 `;
 
 const NotificationWrapper = styled.div`
-  margin: -2px 0 -2px 8px;
+  margin: -2px 0 -2px 20px;
 `;
 
-const HelpIcon = styled(Icons.QuestionMarkOutline)`
+const Chevron = styled(Icons.ChevronUpSmall)`
   display: block;
-  margin: -6px 0;
+  margin: -6px 0 -6px 16px;
   width: 32px;
   height: 32px;
+  transform-origin: 50% 50%;
+  transform: rotate(${({ isOpen }) => (isOpen ? 0 : 180)}deg);
+  transition: transform 300ms ${BEZIER.default};
 
-  @media ${({ theme }) => theme.breakpoint.desktop} {
-    display: none;
+  @media ${({ theme }) => theme.breakpoint.mobile} {
+    ${({ hasNotifications }) =>
+      hasNotifications &&
+      css`
+        display: none;
+      `}
   }
 `;
 
@@ -108,12 +108,13 @@ function Toggle({
       variant={BUTTON_VARIANTS.RECTANGLE}
       size={BUTTON_SIZES.MEDIUM}
     >
-      <HelpIcon />
-      <Label>{__('Help Center', 'web-stories')}</Label>
-      {hasNotifications && (
+      <Label>{__('Help', 'web-stories')}</Label>
+      {hasNotifications ? (
         <NotificationWrapper>
           <NotificationBubble notificationCount={notificationCount} />
         </NotificationWrapper>
+      ) : (
+        <Chevron isOpen={isOpen} />
       )}
     </Button>
   );


### PR DESCRIPTION
## Context

This simplifies the help center toggle button design.

## User-facing changes

The button now looks like this:

| | With unread tips | Without unread tips |
|-|-|-|
| Closed | ![Screen Shot 2021-02-12 at 16 19 59](https://user-images.githubusercontent.com/637548/107824122-ef06a980-6d4e-11eb-8a13-f3b70f0a48be.png) | ![Screen Shot 2021-02-12 at 16 20 32](https://user-images.githubusercontent.com/637548/107824114-eada8c00-6d4e-11eb-806e-32c0d90d6438.png) |
| Open | ![Screen Shot 2021-02-12 at 16 20 09](https://user-images.githubusercontent.com/637548/107823882-89b2b880-6d4e-11eb-82a0-bad3203044f2.png) | ![Screen Shot 2021-02-12 at 16 20 37](https://user-images.githubusercontent.com/637548/107823891-8b7c7c00-6d4e-11eb-9b7e-695773541398.png) |

## Testing Instructions

### QA

This PR can be tested by following these steps:

1. Open a story and look at the help center
2. Observe toggle button state in the above 4 contexts regardless of browser width

### UAT

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6374
