### PR TITLE
FTUE: Enable by default

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -218,6 +218,7 @@ class Experiments {
 				'label'       => __( 'Quick Tips', 'web-stories' ),
 				'description' => __( 'Enable quick tips for first time user experience (FTUE)', 'web-stories' ),
 				'group'       => 'editor',
+				'default'     => true,
 			],
 			/**
 			 * Author: @carlos-kelly


### PR DESCRIPTION
## Context
This sets the First Time User Experience (FTUE) Help Center to default. 
After release and confirmation that nothing weird is going on that wasn't caught, we'll want to completely remove the conditional rendering of the help center and have it show by default, for now having a quick way to turn it off is handy.

## Summary

Enables quick tips experiment by default.
![Screen Shot 2021-02-12 at 4 09 46 PM](https://user-images.githubusercontent.com/10720454/107832216-1c525800-6d4d-11eb-96cb-746ee546cf67.png)


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

- [x] Merge outstanding FTUE updates #6371 #6376 

## User-facing changes

- Makes FTUE help center default in editor, will show help center.

- Screencast: https://drive.google.com/file/d/1rAHJzuv9FNzTlVoVP5vHDoJm9zmQmkZv/view?usp=sharing

## Testing Instructions

### QA

This ticket turns on the help center first time user experience that shows on the bottom left (ltr) or right (rtl) of the canvas section of the editor. All functionality from tickets included in MVP of epic should be testable by default at this point. 

- There should be a button that says "help", clicking or hitting enter/space on this button should expand the help center. 
- The help center should have 7 "tips" as a main menu 
- You can click any tip from the main menu and cycle through the available content. 
- Each tip should have an accompanying graphic 
- As you view tips, the 'unread' count on the badge displayed on the 'help' button should decrease. 
- When you have no more unread tips you should no longer see the badge icon but a chevron instead. 
- When you go to the last tip you should see a done screen. 
- You should only see the done screen after you have read all the tips no matter what order you began in. 
- If you exit the help center and come back you should always begin on the main menu that has all 7 tips with arrows displayed. 
- Your read count should be maintained on all sessions. 

If you need to clear out your read tips type this and hit 'enter' in your console: 
`await wp.apiFetch({ path: '/web-stories/v1/users/me', method: 'POST', data: { meta: { web_stories_onboarding: {} }}})` 


<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5978 
