### PR TITLE
3P Media: Use videos instead of gifs in library

### DIFF
--- a/assets/src/edit-story/app/media/media3p/constants.js
+++ b/assets/src/edit-story/app/media/media3p/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-export { default as MediaProvider } from './mediaProvider';
-export { default as useLocalMedia } from './local/useLocalMedia';
-export { default as useMedia } from './useMedia';
-export * from './media3p/constants';
+export const ContentType = {
+  IMAGE: 'image',
+  VIDEO: 'video',
+  GIF: 'gif',
+};
+
+export const ProviderType = {
+  UNSPLASH: 'unsplash',
+  COVERR: 'coverr',
+  TENOR: 'tenor',
+};

--- a/assets/src/edit-story/app/media/media3p/providerConfiguration.js
+++ b/assets/src/edit-story/app/media/media3p/providerConfiguration.js
@@ -27,18 +27,7 @@ import {
   TenorAttribution,
   UnsplashAttribution,
 } from './attribution';
-
-const ContentType = {
-  IMAGE: 'image',
-  VIDEO: 'video',
-  GIF: 'gif',
-};
-
-const ProviderType = {
-  UNSPLASH: 'unsplash',
-  COVERR: 'coverr',
-  TENOR: 'tenor',
-};
+import { ContentType, ProviderType } from './constants';
 
 /** @typedef {import('react').React.Component} ReactComponent */
 

--- a/assets/src/edit-story/components/library/panes/media/common/innerElement.js
+++ b/assets/src/edit-story/components/library/panes/media/common/innerElement.js
@@ -118,13 +118,6 @@ function InnerElement({
     }
   }, [resource.poster]);
 
-  useEffect(() => {
-    // assign poster for gifs
-    if (type === ContentType.GIF && resource.output.poster) {
-      newVideoPosterRef.current = resource.output.poster;
-    }
-  }, [type, resource.output]);
-
   const makeMediaVisible = () => {
     if (mediaElement.current) {
       mediaElement.current.style.opacity = 1;
@@ -247,7 +240,7 @@ function InnerElement({
           },
         }}
         onClick={onClick(
-          type === ContentType.IMAGE ? thumbnailURL : poster,
+          type === ContentType.IMAGE ? thumbnailURL : posterSrc,
           mediaBaseColor.current
         )}
         cloneElement={CloneImg}

--- a/assets/src/edit-story/components/library/panes/media/common/innerElement.js
+++ b/assets/src/edit-story/components/library/panes/media/common/innerElement.js
@@ -30,6 +30,7 @@ import StoryPropTypes from '../../../../../types';
 import LibraryMoveable from '../../shared/libraryMoveable';
 import resourceList from '../../../../../utils/resourceList';
 import { useDropTargets } from '../../../../dropTargets';
+import { ContentType } from '../../../../../app/media';
 
 const styledTiles = css`
   width: 100%;
@@ -104,7 +105,9 @@ function InnerElement({
   };
 
   useAverageColor(
-    ['video', 'gif'].includes(type) ? hiddenPoster : mediaElement,
+    [ContentType.VIDEO, ContentType.GIF].includes(type)
+      ? hiddenPoster
+      : mediaElement,
     setAverageColor
   );
 
@@ -117,7 +120,7 @@ function InnerElement({
 
   useEffect(() => {
     // assign poster for gifs
-    if (type === 'gif' && resource.output.poster) {
+    if (type === ContentType.GIF && resource.output.poster) {
       newVideoPosterRef.current = resource.output.poster;
     }
   }, [type, resource.output]);
@@ -131,7 +134,7 @@ function InnerElement({
   let media;
   const thumbnailURL = getSmallestUrlForWidth(width, resource);
   const { lengthFormatted, poster, mimeType, output } = resource;
-  const posterSrc = type === 'gif' ? output.poster : poster;
+  const posterSrc = type === ContentType.GIF ? output.poster : poster;
   const displayPoster = posterSrc ?? newVideoPosterRef.current;
 
   const commonProps = {
@@ -152,21 +155,21 @@ function InnerElement({
   };
   const videoProps = {
     ...commonProps,
-    loop: type === 'gif',
+    loop: type === ContentType.GIF,
     muted: true,
     preload: 'none',
     poster: displayPoster,
     showWithoutDelay: Boolean(newVideoPosterRef.current),
   };
 
-  if (type === 'image') {
+  if (type === ContentType.IMAGE) {
     media = <Image key={src} {...imageProps} ref={mediaElement} />;
     cloneProps.src = thumbnailURL;
-  } else if (['gif', 'video'].includes(type)) {
+  } else if ([ContentType.VIDEO, ContentType.GIF].includes(type)) {
     media = (
       <>
         <Video key={src} {...videoProps} ref={mediaElement}>
-          {type === 'gif' ? (
+          {type === ContentType.GIF ? (
             <>
               <source
                 src={getSmallestUrlForWidth(width, {
@@ -207,7 +210,10 @@ function InnerElement({
   }
 
   const dragHandler = (event) => {
-    if (['video', 'gif'].includes(type) && !mediaElement.current?.paused) {
+    if (
+      [ContentType.VIDEO, ContentType.GIF].includes(type) &&
+      !mediaElement.current?.paused
+    ) {
       mediaElement.current.pause();
     }
     if (!draggingResource) {
@@ -241,7 +247,7 @@ function InnerElement({
           },
         }}
         onClick={onClick(
-          type === 'image' ? thumbnailURL : poster,
+          type === ContentType.IMAGE ? thumbnailURL : poster,
           mediaBaseColor.current
         )}
         cloneElement={CloneImg}

--- a/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
@@ -30,6 +30,7 @@ import DropDownMenu from '../local/dropDownMenu';
 import { KEYBOARD_USER_SELECTOR } from '../../../../../utils/keyboardOnlyOutline';
 import { useKeyDownEffect } from '../../../../../../design-system';
 import useRovingTabIndex from '../../../../../utils/useRovingTabIndex';
+import { ContentType } from '../../../../../app/media';
 import Attribution from './attribution';
 import InnerElement from './innerElement';
 
@@ -147,7 +148,7 @@ const MediaElement = ({
   activeRef.current = active;
 
   useEffect(() => {
-    if (!['video', 'gif'].includes(type)) {
+    if (![ContentType.VIDEO, ContentType.GIF].includes(type)) {
       return undefined;
     }
     const resetHoverTime = () => {

--- a/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
+++ b/assets/src/edit-story/components/library/panes/media/common/mediaElement.js
@@ -147,7 +147,7 @@ const MediaElement = ({
   activeRef.current = active;
 
   useEffect(() => {
-    if (type !== 'video') {
+    if (!['video', 'gif'].includes(type)) {
       return undefined;
     }
     const resetHoverTime = () => {


### PR DESCRIPTION
## Context
- Try displaying the gifs as videos to enhance the performance of the Tenor gif media tab.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- Change the elements which display the images in the 3P media tab to display the Tenor gifs as videos.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- `InnerElement` is the renderer for the images in the 3P media tab. I changed the render function there so the `gif` would display as a video (with both webm/mp4s from Tenor)
- The videos are in the `resource.output.sizes` property from past work to display gifs as videos in the published output. I reuse those here to display them as videos in the 3P media tab.
- The gif's poster is in the `output` property and comes from Tenor. I use that in the same way as the Coverr video-- instead of waiting for the video to load to show the poster, use the poster's `onLoad` to show the preview/poster. I edited `mediaElement` so the media would play when hovering. 
- The gif poster is also used as the ghost image when being dragged.

<!-- Please describe your changes. -->

## To-do
- N/A
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- The gif video resources now only play on hover
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

This is a performance enhancement and should have no impact on the user other than loading and showing the posters in the tab should be less heavy than before, so I did not include a QA step. There has been a visual change in that the gifs no longer automatically play, so that should be validated. 

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5006 
