### PR TITLE
Design System: Fix disabled button style

### DIFF
--- a/assets/src/design-system/components/button/index.js
+++ b/assets/src/design-system/components/button/index.js
@@ -68,22 +68,22 @@ const Base = styled.button(
 const primaryColors = ({ theme }) => css`
   background-color: ${theme.colors.interactiveBg.brandNormal};
   color: ${theme.colors.interactiveFg.brandNormal};
-  &:hover,
-  &:focus {
-    background-color: ${theme.colors.interactiveBg.brandHover};
-    color: ${theme.colors.interactiveFg.brandHover};
-  }
   &:active {
     background-color: ${theme.colors.interactiveBg.active};
     color: ${theme.colors.interactiveFg.active};
+  }
+  &:hover:enabled,
+  &:focus:enabled {
+    background-color: ${theme.colors.interactiveBg.brandHover};
+    color: ${theme.colors.interactiveFg.brandHover};
   }
 `;
 
 const secondaryColors = ({ theme }) => css`
   background-color: ${theme.colors.interactiveBg.secondaryNormal};
 
-  &:hover,
-  &:focus {
+  &:hover:enabled,
+  &:focus:enabled {
     background-color: ${theme.colors.interactiveBg.secondaryHover};
   }
 `;
@@ -91,13 +91,13 @@ const secondaryColors = ({ theme }) => css`
 const tertiaryColors = ({ theme }) => css`
   background-color: ${theme.colors.interactiveBg.tertiaryNormal};
 
-  &:hover,
-  &:focus {
-    background-color: ${theme.colors.interactiveBg.tertiaryHover};
-  }
-
   &:disabled {
     background-color: ${theme.colors.interactiveBg.tertiaryNormal};
+  }
+
+  &:hover:enabled,
+  &:focus:enabled {
+    background-color: ${theme.colors.interactiveBg.tertiaryHover};
   }
 `;
 


### PR DESCRIPTION
## Context

There's an edge case where a button is enabled, it is clicked and on that click becomes disabled where the color of the button is getting set by `:hover` but it should only do so when `:enabled`. This fixes that. 

## Summary

Adds some `:enabled` specification to button pseudo classes. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- Currently this use case is only present on dashboard -> settings.

**Update**
![updated button focus disable](https://user-images.githubusercontent.com/10720454/108098824-14dac980-7041-11eb-92de-142245042072.gif)

**Previous**
![button disable focus old](https://user-images.githubusercontent.com/10720454/108098847-1b694100-7041-11eb-9d46-c8776db6bde0.gif)


## Testing Instructions

- Go to dashboard settings and update any input, click 'save' and see that the text on the button remains visible.

### QA

This PR can be tested by following these steps:

1. Go to dashboard settings and update any input, click 'save' and see that the text on the button remains visible.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6405
