### PR TITLE
Added editor divider

### DIFF
--- a/assets/src/design-system/theme/colors.js
+++ b/assets/src/design-system/theme/colors.js
@@ -103,7 +103,7 @@ const opacity = {
   white64: rgba(standard.white, 0.64),
   white24: rgba(standard.white, 0.24),
   white16: rgba(standard.white, 0.16),
-  white8: rgba(standard.white, 0.8),
+  white8: rgba(standard.white, 0.08),
   black64: rgba(standard.black, 0.64),
   black24: rgba(standard.black, 0.24),
   black10: rgba(standard.black, 0.1),

--- a/assets/src/edit-story/components/layout/index.js
+++ b/assets/src/edit-story/components/layout/index.js
@@ -60,6 +60,20 @@ const Editor = withOverlay(styled.section.attrs({
     minmax(${LIBRARY_MIN_WIDTH}px, ${LIBRARY_MAX_WIDTH}px)
     minmax(${CANVAS_MIN_WIDTH}px, 1fr)
     minmax(${INSPECTOR_MIN_WIDTH}px, ${INSPECTOR_MAX_WIDTH}px);
+
+  ::before {
+    content: '';
+    position: absolute;
+    border-style: solid;
+    border-width: 1px 0 0 1px;
+    border-color: ${({ theme }) => theme.colors.divider.secondary};
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+    z-index: ${({ zIndex }) => zIndex};
+  }
 `);
 
 const Area = styled.div`


### PR DESCRIPTION
## Context

This adds a 1px 8% white border around the editor on the relevant edges of the app. The border is added "on top" of the existing content.

## User-facing changes

Notice a slight border around the editor between the WP menu and the editor app itself:
| Before | After |
|-|-|
| ![Screen Shot 2021-02-17 at 00 20 10](https://user-images.githubusercontent.com/637548/108159896-fa8f0300-70b5-11eb-826f-4673b0380505.png) | ![Screen Shot 2021-02-17 at 00 19 47](https://user-images.githubusercontent.com/637548/108159901-fc58c680-70b5-11eb-906f-53ec1d2294b3.png) |

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6291
