### PR TITLE
Design System: Fix Vertical Tooltip Tails

### DIFF
--- a/assets/src/design-system/components/tooltip/index.js
+++ b/assets/src/design-system/components/tooltip/index.js
@@ -137,7 +137,7 @@ function Tooltip({
       >
         <TooltipContainer ref={tooltipRef} placement={placement} shown={shown}>
           <TooltipText
-            as="span"
+            forwardedAs="span"
             size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
           >
             {shortcut ? `${title} (${prettifyShortcut(shortcut)})` : title}

--- a/assets/src/design-system/components/tooltip/tail.js
+++ b/assets/src/design-system/components/tooltip/tail.js
@@ -35,14 +35,14 @@ const getTailPosition = ({ placement, translateX }) => {
     case PLACEMENT.TOP_START:
     case PLACEMENT.TOP_END:
       return css`
-        bottom: -${TAIL_HEIGHT}px;
+        bottom: -${TAIL_HEIGHT - 1}px;
         transform: translateX(${translateX}px) rotate(180deg);
       `;
     case PLACEMENT.BOTTOM:
     case PLACEMENT.BOTTOM_START:
     case PLACEMENT.BOTTOM_END:
       return css`
-        top: -${TAIL_HEIGHT}px;
+        top: -${TAIL_HEIGHT - 1}px;
         transform: translateX(${translateX}px);
       `;
     case PLACEMENT.LEFT:


### PR DESCRIPTION
## Context

What was fine in storybook was off by 1px in actual use of the editor. 
The tail SVG has 1px space so we need to subtract 1 from the delta to avoid the space. This was totally fine in storybook, only the left/right variants had this issue so I thought it was alright. 

## Summary

Fix 1px separation between svg tail and tooltip body 
Fix `as` on span to be `forwardedAs` now that typography styled components are updated this needs to be there for typography settings to come through tooltips. 

Partially fixes #6377 