### PR TITLE
New snapping guidelines

### DIFF
--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -66,7 +66,7 @@ const Hint = styled.div`
 
 const marginRatio = 100 * (DESIGN_SPACE_MARGIN / PAGE_WIDTH);
 const DesignSpaceGuideline = styled.div`
-  border: 1px solid ${({ theme }) => theme.DEPRECATED_THEME.colors.callout};
+  border: 1px solid ${({ theme }) => theme.colors.border.negativePress};
   left: ${marginRatio}%;
   right: ${marginRatio}%;
   top: 0;

--- a/assets/src/edit-story/components/moveable/moveStyle.js
+++ b/assets/src/edit-story/components/moveable/moveStyle.js
@@ -20,83 +20,105 @@
 import { createGlobalStyle } from 'styled-components';
 
 export const GlobalStyle = createGlobalStyle`
-	.default-moveable .moveable-control,
-	.default-moveable .moveable-line.moveable-rotation-line .moveable-control {
-		background: ${({ theme }) => theme.colors.bg.primary} !important;
-		border: 1px solid ${({ theme }) => theme.colors.border.selection} !important;
-	}
-
-	.default-moveable.type-text .moveable-direction.moveable-n, .default-moveable.type-text .moveable-direction.moveable-s {
-		pointer-events: none;
-	}
-	.default-moveable .moveable-control.moveable-n {
-		display: none !important;
-	}
-
-  .default-moveable .moveable-line {
-    background: ${({ theme }) =>
-      theme.DEPRECATED_THEME.colors.callout} !important;
+  .default-moveable .moveable-control,
+  .default-moveable .moveable-line.moveable-rotation-line .moveable-control {
+    background: ${({ theme }) => theme.colors.bg.primary} !important;
+    border: 1px solid ${({ theme }) =>
+      theme.colors.border.selection} !important;
   }
 
-	.default-moveable .moveable-control.moveable-s,
-	.default-moveable .moveable-control.moveable-e,
-	.default-moveable .moveable-control.moveable-w {
-		border-radius: 4px;
-	}
+  .default-moveable.type-text .moveable-direction.moveable-n, .default-moveable.type-text .moveable-direction.moveable-s {
+    pointer-events: none;
+  }
+  .default-moveable .moveable-control.moveable-n {
+    display: none !important;
+  }
 
-	.default-moveable .moveable-control.moveable-nw,
-	.default-moveable .moveable-control.moveable-ne,
-	.default-moveable .moveable-control.moveable-sw,
-	.default-moveable .moveable-control.moveable-se {
-	  border-radius: 2px;
-	  width: 8px;
-	  height: 8px;
-	  margin-left: -4px;
+  .default-moveable .moveable-line {
+    border: 0;
+    background: transparent !important;
+    width: 1px;
+    height: 1px;
+  }
+
+  .default-moveable .moveable-horizontal {
+    border-bottom: 1px dashed ${({ theme }) =>
+      theme.colors.border.focus} !important;
+  }
+
+  .default-moveable .moveable-vertical {
+    border-right: 1px dashed ${({ theme }) =>
+      theme.colors.border.focus} !important;
+  }
+
+  .default-moveable .moveable-gap {
+    border-color: ${({ theme }) =>
+      theme.colors.border.negativePress} !important;
+  }
+
+  .default-moveable .moveable-target {
+    border-style: solid !important;
+  }
+
+  .default-moveable .moveable-control.moveable-s,
+  .default-moveable .moveable-control.moveable-e,
+  .default-moveable .moveable-control.moveable-w {
+    border-radius: 4px;
+  }
+
+  .default-moveable .moveable-control.moveable-nw,
+  .default-moveable .moveable-control.moveable-ne,
+  .default-moveable .moveable-control.moveable-sw,
+  .default-moveable .moveable-control.moveable-se {
+    border-radius: 2px;
+    width: 8px;
+    height: 8px;
+    margin-left: -4px;
     margin-top: -4px;
-	}
+  }
 
-	.default-moveable .moveable-control.moveable-s {
-		height: 6px !important;
-		width: 16px !important;
-		margin-top: -3px !important;
-	}
+  .default-moveable .moveable-control.moveable-s {
+    height: 6px !important;
+    width: 16px !important;
+    margin-top: -3px !important;
+  }
 
-	.default-moveable .moveable-control.moveable-e {
-		height: 16px !important;
-		width: 6px !important;
-		margin-left: -3px !important;
-	}
+  .default-moveable .moveable-control.moveable-e {
+    height: 16px !important;
+    width: 6px !important;
+    margin-left: -3px !important;
+  }
 
-	.default-moveable .moveable-control.moveable-w {
-		height: 16px !important;
-		width: 6px !important;
-		margin-left: -3px !important;
-	}
+  .default-moveable .moveable-control.moveable-w {
+    height: 16px !important;
+    width: 6px !important;
+    margin-left: -3px !important;
+  }
 
-	.default-moveable.moveable-control-box .moveable-line.moveable-direction {
-		background: ${({ theme }) => theme.colors.border.selection} !important;
-		width: 1px;
-		height: 1px;
-	}
+  .default-moveable.moveable-control-box .moveable-line.moveable-direction {
+    background: ${({ theme }) => theme.colors.border.selection} !important;
+    width: 1px;
+    height: 1px;
+  }
 
-	.default-moveable.moveable-control-box .moveable-line.moveable-rotation-line {
-		background: ${({ theme }) => theme.colors.border.selection} !important;
-		width: 1px;
-		top: -12px;
-		height: 12px;
-	}
+  .default-moveable.moveable-control-box .moveable-line.moveable-rotation-line {
+    background: ${({ theme }) => theme.colors.border.selection} !important;
+    width: 1px;
+    top: -12px;
+    height: 12px;
+  }
 
-	.default-moveable.moveable-control-box .moveable-control.moveable-rotation {
+  .default-moveable.moveable-control-box .moveable-control.moveable-rotation {
     border-radius: 50px;
     width: 10px;
     height: 10px;
     margin-left: -5.5px;
-	}
+  }
 
-	.default-moveable.hide-handles .moveable-line.moveable-rotation-line,
-	.default-moveable.hide-handles .moveable-line.moveable-direction {
-		display: none;
-	}
+  .default-moveable.hide-handles .moveable-line.moveable-rotation-line,
+  .default-moveable.hide-handles .moveable-line.moveable-direction {
+    display: none;
+  }
 
   .default-moveable.visually-hide-handles .moveable-control.moveable-e,
   .default-moveable.visually-hide-handles .moveable-control.moveable-w,
@@ -104,6 +126,6 @@ export const GlobalStyle = createGlobalStyle`
   .default-moveable.visually-hide-handles .moveable-control.moveable-ne,
   .default-moveable.visually-hide-handles .moveable-control.moveable-nw,
   .default-moveable.visually-hide-handles .moveable-control.moveable-sw {
-	  opacity: 0;
-	}
+    opacity: 0;
+  }
 `;


### PR DESCRIPTION
## Context

Implemented new snapping guidelines. This is almost according to Figma, because the Figma UX is still in flux and won't be ready for 1.5. This is just a temporary placeholder to better fit the new design while the final design is being worked out.

## User-facing changes

New guideline style and colors:
![snapping-colors](https://user-images.githubusercontent.com/637548/108290641-d1767d00-715e-11eb-927e-0b92cde2edd4.gif)

## Testing Instructions

### QA

This PR can be tested by following these steps:

1. Drag an element on canvas and observe snapping lines

### UAT

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---


Fixes #6201
