### PR TITLE
FTUE: Smart persisted expanded state

### DIFF
--- a/assets/src/edit-story/components/helpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/index.js
@@ -23,7 +23,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { ThemeGlobals, useFocusOut } from '../../../design-system';
+import { ThemeGlobals } from '../../../design-system';
 import { Z_INDEX } from '../canvas/layout';
 import DirectionAware from '../directionAware';
 import { Navigator } from './navigator';
@@ -50,8 +50,6 @@ export const HelpCenter = () => {
   const ref = useRef(null);
   const { enableQuickTips } = useFeatures();
   const { state, actions } = useHelpCenter();
-
-  useFocusOut(ref, actions.close, []);
 
   // Set Focus on the expanded companion
   // whenever it opens

--- a/assets/src/edit-story/components/helpCenter/menu/header.js
+++ b/assets/src/edit-story/components/helpCenter/menu/header.js
@@ -28,8 +28,9 @@ const Panel = styled.div`
   border-bottom: 1px solid ${({ theme }) => theme.colors.bg.tertiary};
 `;
 
-const Heading = styled.h4`
+const Heading = styled.h1`
   ${themeHelpers.expandTextPreset(({ label }, { MEDIUM }) => label[MEDIUM])}
+  color: ${({ theme }) => theme.colors.fg.primary};
   line-height: 32px;
   margin: 0 0 8px 0;
 `;

--- a/assets/src/edit-story/components/helpCenter/popup.js
+++ b/assets/src/edit-story/components/helpCenter/popup.js
@@ -18,6 +18,8 @@
  */
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
+import { __ } from '@web-stories-wp/i18n';
+
 /**
  * Internal dependencies
  */
@@ -62,7 +64,12 @@ export function Popup({ isOpen, popupId, children }) {
       unmountOnExit
     >
       {(state) => (
-        <Controller id={popupId} role="dialog" state={state}>
+        <Controller
+          id={popupId}
+          role="dialog"
+          aria-label={__('Help Center', 'web-stories')}
+          state={state}
+        >
           {children}
         </Controller>
       )}

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
@@ -16,6 +16,7 @@
 /**
  * Internal dependencies
  */
+import localStore, { LOCAL_STORAGE_PREFIX } from '../../../utils/localStore';
 import {
   DONE_TIP_ENTRY,
   BASE_NAVIGATION_FLOW,
@@ -29,6 +30,9 @@ const isComingFromMenu = (previous, next) =>
 
 const navigationFlowTips = (previous, next) =>
   (next.navigationFlow || []).filter((key) => TIP_KEYS_MAP[key]);
+
+const isInitialHydrate = (previous, next) =>
+  !previous.isHydrated && next.isHydrated;
 
 export const resetNavigationIndexOnOpen = (previous, next) => {
   const isOpening = !previous.isOpen && next.isOpen;
@@ -91,6 +95,17 @@ export function deriveUnreadTipsCount(previous, next) {
       Object.keys(TIP_KEYS_MAP).filter((tip) => !next.readTips[tip])?.length ||
       0,
   };
+}
+
+export function deriveAutoOpen(previous, next) {
+  if (isInitialHydrate(previous, next)) {
+    const ftueLocalStore = localStore.getItemByKey(LOCAL_STORAGE_PREFIX.FTUE);
+    const maxUnreadTips = Object.keys(TIP_KEYS_MAP).length;
+    const hasNewTips =
+      (ftueLocalStore?.unreadTipsCount || maxUnreadTips) < next.unreadTipsCount;
+    return hasNewTips ? { isOpen: true } : {};
+  }
+  return {};
 }
 
 /**

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
@@ -16,7 +16,6 @@
 /**
  * Internal dependencies
  */
-import localStore, { LOCAL_STORAGE_PREFIX } from '../../../utils/localStore';
 import {
   DONE_TIP_ENTRY,
   BASE_NAVIGATION_FLOW,
@@ -99,10 +98,7 @@ export function deriveUnreadTipsCount(previous, next) {
 
 export function deriveAutoOpen(previous, next) {
   if (isInitialHydrate(previous, next)) {
-    const ftueLocalStore = localStore.getItemByKey(LOCAL_STORAGE_PREFIX.FTUE);
-    const maxUnreadTips = Object.keys(TIP_KEYS_MAP).length;
-    const hasNewTips =
-      (ftueLocalStore?.unreadTipsCount || maxUnreadTips) < next.unreadTipsCount;
+    const hasNewTips = previous.unreadTipsCount < next.unreadTipsCount;
     return hasNewTips ? { isOpen: true } : {};
   }
   return {};

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
@@ -108,7 +108,7 @@ export function deriveAutoOpen(previous, next) {
 // If all tips are read, we want the popup closed regardless of user setting.
 export function deriveInitialOpen(persisted) {
   const hasUnreadTips = Boolean(persisted?.unreadTipsCount);
-  return hasUnreadTips && persisted?.isOpen
+  return hasUnreadTips && persisted?.isOpen !== undefined
     ? {
         isOpen: persisted?.isOpen,
       }

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/effects.js
@@ -104,6 +104,25 @@ export function deriveAutoOpen(previous, next) {
   return {};
 }
 
+// If there are any unread tips, we respect users last open setting.
+// If all tips are read, we want the popup closed regardless of user setting.
+export function deriveInitialOpen(persisted) {
+  const hasUnreadTips = Boolean(persisted?.unreadTipsCount);
+  return hasUnreadTips && persisted?.isOpen
+    ? {
+        isOpen: persisted?.isOpen,
+      }
+    : {};
+}
+
+export function deriveInitialUnreadTipsCount(persisted) {
+  return persisted?.unreadTipsCount
+    ? {
+        unreadTipsCount: persisted?.unreadTipsCount,
+      }
+    : {};
+}
+
 /**
  * Takes an array of effects and returns a composed function
  * that given next and previous state runs through each effect

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useReducer, useEffect, useState, useMemo } from 'react';
+import { useReducer, useEffect, useState, useMemo, useRef } from 'react';
 import { trackEvent } from '@web-stories-wp/tracking';
 
 /**
@@ -222,8 +222,16 @@ export function useHelpCenter() {
   }, [actions, currentUser, isHydrated]);
 
   const persistenceKey = createKeyFromBooleanMap(store.state.readTips);
+  const isInitialHydrationUpdate = useRef(false);
   useEffect(() => {
-    if (!persistenceKey) {
+    if (!persistenceKey && !isHydrated) {
+      return () => {};
+    }
+
+    // We don't want to persist when the update is from
+    // the initial hydrate call
+    if (!isInitialHydrationUpdate.current) {
+      isInitialHydrationUpdate.current = true;
       return () => {};
     }
     // The call to `updateCurrentUser` causes the entire app to rerender
@@ -241,7 +249,7 @@ export function useHelpCenter() {
       TRANSITION_DURATION * 1.2
     );
     return () => clearTimeout(id);
-  }, [actions, updateCurrentUser, persistenceKey]);
+  }, [actions, updateCurrentUser, persistenceKey, isHydrated]);
 
   // Components wrapped in a Transition no longer receive
   // prop updates once they start exiting. To work around

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
@@ -78,7 +78,7 @@ const deriveInitialState = composeEffects([
   deriveInitialUnreadTipsCount,
 ]);
 
-const persisted = localStore.getItemByKey(LOCAL_STORAGE_PREFIX.FTUE);
+const persisted = localStore.getItemByKey(LOCAL_STORAGE_PREFIX.HELP_CENTER);
 
 export const initialState = {
   isOpen: false,
@@ -194,8 +194,8 @@ export function useHelpCenter() {
   const { isHydrated, unreadTipsCount } = store.state;
   useEffect(() => {
     if (isHydrated) {
-      const local = localStore.getItemByKey(LOCAL_STORAGE_PREFIX.FTUE);
-      localStore.setItemByKey(LOCAL_STORAGE_PREFIX.FTUE, {
+      const local = localStore.getItemByKey(LOCAL_STORAGE_PREFIX.HELP_CENTER);
+      localStore.setItemByKey(LOCAL_STORAGE_PREFIX.HELP_CENTER, {
         ...local,
         unreadTipsCount,
       });
@@ -205,8 +205,8 @@ export function useHelpCenter() {
   // Persist user updates to isOpen
   const { isOpen } = store.state;
   useEffect(() => {
-    const local = localStore.getItemByKey(LOCAL_STORAGE_PREFIX.FTUE);
-    localStore.setItemByKey(LOCAL_STORAGE_PREFIX.FTUE, {
+    const local = localStore.getItemByKey(LOCAL_STORAGE_PREFIX.HELP_CENTER);
+    localStore.setItemByKey(LOCAL_STORAGE_PREFIX.HELP_CENTER, {
       ...local,
       isOpen,
     });

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/index.js
@@ -37,6 +37,8 @@ import {
   deriveUnreadTipsCount,
   resetNavigationIndexOnOpen,
   deriveAutoOpen,
+  deriveInitialOpen,
+  deriveInitialUnreadTipsCount,
 } from './effects';
 
 /**
@@ -71,30 +73,29 @@ const reducer = ({ state, actions }, action) => {
   };
 };
 
+const deriveInitialState = composeEffects([
+  deriveInitialOpen,
+  deriveInitialUnreadTipsCount,
+]);
+
 const persisted = localStore.getItemByKey(LOCAL_STORAGE_PREFIX.FTUE);
 
-// If there are any unread tips, we respect users last open setting.
-// If all tips are read, we want the popup closed regardless of user setting.
-const deriveInitialOpen = (local) => {
-  const hasUnreadTips = Boolean(local?.unreadTipsCount);
-  const lastIsOpen = local?.isOpen ?? false;
-  return hasUnreadTips ? lastIsOpen : false;
+export const initialState = {
+  isOpen: false,
+  navigationIndex: -1,
+  navigationFlow: BASE_NAVIGATION_FLOW,
+  isLeftToRightTransition: true,
+  hasBottomNavigation: false,
+  isPrevDisabled: true,
+  isNextDisabled: false,
+  readTips: {},
+  readError: false,
+  unreadTipsCount: persisted?.unreadTipsCount ?? 0,
+  isHydrated: false,
 };
 
 export const initial = {
-  state: {
-    isOpen: deriveInitialOpen(persisted),
-    navigationIndex: -1,
-    navigationFlow: BASE_NAVIGATION_FLOW,
-    isLeftToRightTransition: true,
-    hasBottomNavigation: false,
-    isPrevDisabled: true,
-    isNextDisabled: false,
-    readTips: {},
-    readError: false,
-    unreadTipsCount: persisted?.unreadTipsCount ?? 0,
-    isHydrated: false,
-  },
+  state: deriveInitialState(persisted, initialState),
   // All actions are in the form: externalArgs -> state -> newStatePartial
   //
   // Actions should only update the part of state they directly effect.

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/test/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/test/effects.js
@@ -99,26 +99,26 @@ describe('deriveInitialOpen', () => {
   });
 
   it('doesnt update anything if there is no persisted isOpen', () => {
-    expect(deriveInitialOpen({ unreadTipCount: 0 })).toStrictEqual({});
-    expect(deriveInitialOpen({ unreadTipCount: 1 })).toStrictEqual({});
+    expect(deriveInitialOpen({ unreadTipsCount: 0 })).toStrictEqual({});
+    expect(deriveInitialOpen({ unreadTipsCount: 1 })).toStrictEqual({});
   });
 
   it('doesnt update anything if there are no unread tips', () => {
     expect(
-      deriveInitialOpen({ unreadTipCount: 0, isOpen: true })
+      deriveInitialOpen({ unreadTipsCount: 0, isOpen: true })
     ).toStrictEqual({});
     expect(
-      deriveInitialOpen({ unreadTipCount: 0, isOpen: false })
+      deriveInitialOpen({ unreadTipsCount: 0, isOpen: false })
     ).toStrictEqual({});
   });
 
   it('respects persisted isOpen if there are unread tips', () => {
     expect(
-      deriveInitialOpen({ unreadTipCount: 1, isOpen: true })
+      deriveInitialOpen({ unreadTipsCount: 1, isOpen: true })
     ).toStrictEqual({ isOpen: true });
 
     expect(
-      deriveInitialOpen({ unreadTipCount: 1, isOpen: false })
+      deriveInitialOpen({ unreadTipsCount: 1, isOpen: false })
     ).toStrictEqual({ isOpen: false });
   });
 });

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/test/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/test/effects.js
@@ -26,6 +26,8 @@ import {
 import {
   composeEffects,
   createDynamicNavigationFlow,
+  deriveInitialOpen,
+  deriveInitialUnreadTipsCount,
   deriveBottomNavigation,
   deriveDisabledButtons,
   deriveReadTip,
@@ -33,9 +35,11 @@ import {
   deriveUnreadTipsCount,
   resetNavigationIndexOnOpen,
 } from '../effects';
+import { TIPS, BASE_NAVIGATION_FLOW, DONE_TIP_ENTRY } from '../../constants';
+import { initialState} from '../';
 
 const mockState = (overrides = {}) => ({
-  ...initial.state,
+  ...initialState,
   ...overrides,
 });
 
@@ -80,6 +84,53 @@ describe('composeEffects', () => {
       mockEffects.slice(0, i).forEach((effect) => {
         expect(mockEffect).toHaveBeenCalledAfter(effect);
       });
+    });
+  });
+});
+
+describe('deriveInitialOpen', () => {
+  it('doesnt update anything if no persisted state', () => {
+    expect(deriveInitialOpen({})).toStrictEqual({});
+  });
+
+  it('doesnt update anything if there is no persisted unreadTipsCount', () => {
+    expect(deriveInitialOpen({ isOpen: true })).toStrictEqual({});
+    expect(deriveInitialOpen({ isOpen: false })).toStrictEqual({});
+  });
+
+  it('doesnt update anything if there is no persisted isOpen', () => {
+    expect(deriveInitialOpen({ unreadTipCount: 0 })).toStrictEqual({});
+    expect(deriveInitialOpen({ unreadTipCount: 1 })).toStrictEqual({});
+  });
+
+  it('doesnt update anything if there are no unread tips', () => {
+    expect(
+      deriveInitialOpen({ unreadTipCount: 0, isOpen: true })
+    ).toStrictEqual({});
+    expect(
+      deriveInitialOpen({ unreadTipCount: 0, isOpen: false })
+    ).toStrictEqual({});
+  });
+
+  it('respects persisted isOpen if there are unread tips', () => {
+    expect(
+      deriveInitialOpen({ unreadTipCount: 1, isOpen: true })
+    ).toStrictEqual({ isOpen: true });
+
+    expect(
+      deriveInitialOpen({ unreadTipCount: 1, isOpen: false })
+    ).toStrictEqual({ isOpen: false });
+  });
+});
+
+describe('deriveInitialUnreadTipsCount', () => {
+  it('doesnt update anything if no persisted state', () => {
+    expect(deriveInitialUnreadTipsCount({})).toStrictEqual({});
+  });
+
+  it('updates unreadTipsCount if its persisted', () => {
+    expect(deriveInitialUnreadTipsCount({ unreadTipsCount: 2 })).toStrictEqual({
+      unreadTipsCount: 2,
     });
   });
 });

--- a/assets/src/edit-story/components/helpCenter/useHelpCenter/test/effects.js
+++ b/assets/src/edit-story/components/helpCenter/useHelpCenter/test/effects.js
@@ -16,7 +16,7 @@
 /**
  * Internal dependencies
  */
-import { initial } from '../';
+import { initialState } from '../';
 import {
   BASE_NAVIGATION_FLOW,
   DONE_TIP_ENTRY,
@@ -26,17 +26,15 @@ import {
 import {
   composeEffects,
   createDynamicNavigationFlow,
-  deriveInitialOpen,
-  deriveInitialUnreadTipsCount,
   deriveBottomNavigation,
   deriveDisabledButtons,
+  deriveInitialOpen,
+  deriveInitialUnreadTipsCount,
   deriveReadTip,
   deriveTransitionDirection,
   deriveUnreadTipsCount,
   resetNavigationIndexOnOpen,
 } from '../effects';
-import { TIPS, BASE_NAVIGATION_FLOW, DONE_TIP_ENTRY } from '../../constants';
-import { initialState} from '../';
 
 const mockState = (overrides = {}) => ({
   ...initialState,

--- a/assets/src/edit-story/utils/localStore.js
+++ b/assets/src/edit-story/utils/localStore.js
@@ -25,6 +25,7 @@ export const LOCAL_STORAGE_PREFIX = {
   TERMS_MEDIA3P: 'web_stories_media3p_terms_agreement',
   VIDEO_OPTIMIZATION_DIALOG_DISMISSED:
     'web_stories_video_optimization_dialog_dismissed',
+  FTUE: 'web_stories_ftue',
 };
 
 function getItemByKey(key) {

--- a/assets/src/edit-story/utils/localStore.js
+++ b/assets/src/edit-story/utils/localStore.js
@@ -25,7 +25,7 @@ export const LOCAL_STORAGE_PREFIX = {
   TERMS_MEDIA3P: 'web_stories_media3p_terms_agreement',
   VIDEO_OPTIMIZATION_DIALOG_DISMISSED:
     'web_stories_video_optimization_dialog_dismissed',
-  FTUE: 'web_stories_ftue',
+  HELP_CENTER: 'web_stories_help_center',
 };
 
 function getItemByKey(key) {


### PR DESCRIPTION
## Context
Requested enhancement for FTUE opening/closing behavior to have smart persistence.

## Summary
Adds smart opening behavior requested in ticket & unit tests.

## Relevant Technical Choices
Realized initial state could follow our effects pattern, it's just a single composed effect that runs on initialization tho where `previous` is the persisted state and `next` is the initial state. 

Allows us to only have to test the pure fn effects since every other mechanism already has testing from this PR: https://github.com/google/web-stories-wp/pull/6401
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
FTUE now has smart persistence for opening/closing. so it takes into account your last state in the last browser session as well as some other logic to compute if it should initialize to open or not.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
-> Go to editor and see ftue toggle.
-> With all your tips read, make sure the companion is collapsed
-> copy and paste this into your console (`cmnd + option + i` to open) and press `enter` to reset your read tips on the endpoint: 
```
await wp.apiFetch({ path: '/web-stories/v1/users/me', method: 'POST', data: { meta: { web_stories_onboarding: {} }}})
```
-> refresh your browser. FTUE should now auto animate open when it receives a response from the Backend telling it there are new unread tips
-> read 1 or two tips, but not all.
-> leave ftue companion open and refresh page. ftue companion should load open on mount
-> Close ftue companion and refresh page. ftue companion should load closed on mount
-> open the ftue companion and read through all the tips
-> with the companion open, refresh the browser. ftue companion should load closed/collapsed on mount

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Follow testing instructions above

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5971 
