### PR TITLE
Add #development=1 to rendered previewLink

### DIFF
--- a/assets/src/edit-story/components/header/buttons/preview.js
+++ b/assets/src/edit-story/components/header/buttons/preview.js
@@ -123,7 +123,7 @@ function Preview() {
       setPreviewLinkToOpenViaDialog(null);
       // Ensure that this method is as safe as possible and pass the random
       // target in case the normal target is not openable.
-      const decoratedPreviewLink = decoratedPreviewLink(
+      const decoratedPreviewLink = decoratePreviewLink(
         previewLinkToOpenViaDialog
       );
       window.open(decoratedPreviewLink, PREVIEW_TARGET + Math.random());

--- a/assets/src/edit-story/components/header/test/buttons.js
+++ b/assets/src/edit-story/components/header/test/buttons.js
@@ -94,15 +94,7 @@ function setupButtons({
 
 describe('buttons', () => {
   const FUTURE_DATE = '2022-01-01T20:20:20Z';
-  const PREVIEW_POPUP = {
-    document: {
-      write: jest.fn(),
-    },
-    location: {
-      href: 'about:blank',
-      replace: jest.fn(),
-    },
-  };
+  let previewPopup;
   let modalWrapper;
 
   beforeAll(() => {
@@ -115,6 +107,18 @@ describe('buttons', () => {
   afterAll(() => {
     document.documentElement.removeChild(modalWrapper);
     MockDate.reset();
+  });
+
+  beforeEach(() => {
+    previewPopup = {
+      document: {
+        write: jest.fn(),
+      },
+      location: {
+        href: 'about:blank',
+        replace: jest.fn(),
+      },
+    };
   });
 
   it('should display Publish button when in draft mode', () => {
@@ -335,17 +339,15 @@ describe('buttons', () => {
       },
     }));
 
-    const popup = PREVIEW_POPUP;
-
-    const mockedOpen = jest.fn(() => popup);
+    const mockedOpen = jest.fn(() => previewPopup);
     const windowSpy = jest.spyOn(global, 'open').mockImplementation(mockedOpen);
 
     fireEvent.click(previewButton);
 
     expect(saveStory).toHaveBeenCalledWith();
     expect(mockedOpen).toHaveBeenCalledWith('about:blank', 'story-preview');
-    expect(popup.location.replace).toHaveBeenCalledWith(
-      'https://example.com/?preview=true'
+    expect(previewPopup.location.replace).toHaveBeenCalledWith(
+      'https://example.com/?preview=true#development=1'
     );
 
     windowSpy.mockRestore();
@@ -368,16 +370,14 @@ describe('buttons', () => {
       },
     }));
 
-    const popup = PREVIEW_POPUP;
-
-    const mockedOpen = jest.fn(() => popup);
+    const mockedOpen = jest.fn(() => previewPopup);
     const windowSpy = jest.spyOn(global, 'open').mockImplementation(mockedOpen);
 
     fireEvent.click(previewButton);
 
     expect(autoSave).toHaveBeenCalledWith();
-    expect(popup.location.replace).toHaveBeenCalledWith(
-      'https://example.com?preview_id=1679&preview_nonce=b5ea827939&preview=true'
+    expect(previewPopup.location.replace).toHaveBeenCalledWith(
+      'https://example.com/?preview_id=1679&preview_nonce=b5ea827939&preview=true#development=1'
     );
 
     windowSpy.mockRestore();


### PR DESCRIPTION
## Context

See #50.

## Summary

Add `#development=1` to URLs of story previews which triggers amp-story's multi-aspect preview mode.

## Relevant Technical Choices

Adds the URL transformation in `buttons/preview.js` instead of the stored `story.previewLink` to be more resilient to future API changes and to support existing stories.

## To-do

N/A

## User-facing changes

Clicking "Preview" button now shows a different but more useful UI for creators.

## Testing Instructions

### QA

This PR can be tested by following these steps:

1. Open any story and Click the "Preview" button.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #50
