### PR TITLE
Design System: Typography updates from Figma

### DIFF
--- a/assets/src/dashboard/app/views/shared/telemetryBanner.js
+++ b/assets/src/dashboard/app/views/shared/telemetryBanner.js
@@ -44,12 +44,10 @@ const LabelText = styled(Text)`
   margin-bottom: 16px;
   margin-left: 8px;
   color: ${({ theme }) => theme.colors.fg.secondary};
-  letter-spacing: 0.0133em;
 `;
 
 const VisitSettingsText = styled(Text)`
   color: ${({ theme }) => theme.colors.fg.tertiary};
-  letter-spacing: 0.0133em;
 `;
 
 const NavLink = styled(Link)`

--- a/assets/src/design-system/components/banner/index.js
+++ b/assets/src/design-system/components/banner/index.js
@@ -31,7 +31,6 @@ import { Headline } from '../typography';
 
 const Title = styled(Headline)`
   grid-area: title;
-  font-weight: 700;
   padding-left: 8px;
 `;
 
@@ -76,7 +75,6 @@ const Container = styled.div`
       ${Title} {
         padding-left: 0;
         margin-top: -10px;
-        font-weight: ${({ theme }) => theme.typography.weight.bold};
       }
       ${Content} {
         margin: 8px auto 18px;

--- a/assets/src/design-system/components/banner/stories/index.js
+++ b/assets/src/design-system/components/banner/stories/index.js
@@ -24,7 +24,7 @@ import { boolean, text } from '@storybook/addon-knobs';
  * Internal dependencies
  */
 import { THEME_CONSTANTS } from '../../../theme';
-import { Text } from '../../typography';
+import { Text, Link } from '../../typography';
 import { Banner } from '../';
 
 const demoBgUrl = 'https://picsum.photos/id/240/1500/160';
@@ -80,13 +80,9 @@ export const DashboardBanner = () => {
         {
           'Check the box to help us improve the Web Stories plugin by allowing tracking of product usage stats. All data are treated in accordance with '
         }
-        <Text
-          size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-          href="#"
-          as="a"
-        >
+        <Link size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL} href="#">
           {'Google Privacy Policy'}
-        </Text>
+        </Link>
       </Text>
     </Banner>
   );

--- a/assets/src/design-system/components/typography/link/index.js
+++ b/assets/src/design-system/components/typography/link/index.js
@@ -27,15 +27,12 @@ import { THEME_CONSTANTS, themeHelpers } from '../../../theme';
 import { defaultTypographyStyle } from '../styles';
 
 export const Link = styled.a`
-  ${({ isBold, size, theme }) => css`
+  ${({ size, theme }) => css`
     ${defaultTypographyStyle};
     ${themeHelpers.expandPresetStyles({
-      preset: theme.typography.presets.paragraph[size],
+      preset: theme.typography.presets.link[size],
       theme,
     })};
-    font-weight: ${isBold
-      ? theme.typography.weight.bold
-      : theme.typography.presets.paragraph[size].weight};
 
     color: ${theme.colors.fg.linkNormal};
     text-decoration: none;
@@ -50,11 +47,8 @@ export const Link = styled.a`
 `;
 
 Link.propTypes = {
-  isBold: PropTypes.bool,
   size: PropTypes.oneOf(THEME_CONSTANTS.TYPOGRAPHY.TEXT_SIZES),
 };
 Link.defaultProps = {
-  as: 'a',
-  isBold: false,
   size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.MEDIUM,
 };

--- a/assets/src/design-system/components/typography/text/index.js
+++ b/assets/src/design-system/components/typography/text/index.js
@@ -37,6 +37,17 @@ const textCss = ({ isBold, size, theme }) => css`
     : theme.typography.presets.paragraph[size].weight};
 `;
 
+const labelTextCss = ({ isBold, size, theme }) => css`
+  ${defaultTypographyStyle};
+  ${themeHelpers.expandPresetStyles({
+    preset: theme.typography.presets.label[size],
+    theme,
+  })};
+  font-weight: ${isBold
+    ? theme.typography.weight.bold
+    : theme.typography.presets.label[size].weight};
+`;
+
 const Paragraph = styled.p`
   ${textCss};
 `;
@@ -46,7 +57,7 @@ const Span = styled.span`
 `;
 
 const Label = styled.label`
-  ${textCss};
+  ${labelTextCss};
 
   color: ${({ disabled, theme }) =>
     disabled ? theme.colors.fg.disable : 'auto'};

--- a/assets/src/design-system/components/typography/text/stories/index.js
+++ b/assets/src/design-system/components/typography/text/stories/index.js
@@ -24,7 +24,7 @@ import { select } from '@storybook/addon-knobs';
  */
 import { Text } from '../';
 import { Headline } from '../..';
-import { THEME_CONSTANTS } from '../../../../';
+import { THEME_CONSTANTS, theme } from '../../../../';
 
 export default {
   title: 'DesignSystem/Components/Typography/Text',
@@ -71,30 +71,38 @@ export const Bold = () => (
 export const Label = () => (
   <>
     <Headline as="h1">{'Label'}</Headline>
-    {textPresetSizes.map((presetSize) => (
-      <Text
-        key={`${presetSize}_text_link`}
-        size={presetSize}
-        as={select('label', textRenderAsOptions, 'label')}
-        isBold={select('isBold', booleanOptions, false)}
-      >
-        {`${presetSize} - Och glasen glittrar tyst på vårt bord`}
-        <br />
-      </Text>
-    ))}
+    {textPresetSizes.map((presetSize) => {
+      return (
+        theme.typography.presets.label[presetSize] && (
+          <Text
+            key={`${presetSize}_text_link`}
+            size={presetSize}
+            as={'label'}
+            isBold={select('isBold', booleanOptions, false)}
+          >
+            {`${presetSize} - Och glasen glittrar tyst på vårt bord`}
+            <br />
+          </Text>
+        )
+      );
+    })}
     <br />
     <Headline as="h1">{'Label - Disabled'}</Headline>
-    {textPresetSizes.map((presetSize) => (
-      <Text
-        key={`${presetSize}_text_link_disabled`}
-        size={presetSize}
-        as={select('label', textRenderAsOptions, 'label')}
-        isBold={select('isBold', booleanOptions, false)}
-        disabled
-      >
-        {`${presetSize} - Och glasen glittrar tyst på vårt bord`}
-        <br />
-      </Text>
-    ))}
+    {textPresetSizes.map((presetSize) => {
+      return (
+        theme.typography.presets.label[presetSize] && (
+          <Text
+            key={`${presetSize}_text_link_disabled`}
+            size={presetSize}
+            as={'label'}
+            isBold={select('isBold', booleanOptions, false)}
+            disabled
+          >
+            {`${presetSize} - Och glasen glittrar tyst på vårt bord`}
+            <br />
+          </Text>
+        )
+      );
+    })}
   </>
 );

--- a/assets/src/design-system/components/typography/text/stories/index.js
+++ b/assets/src/design-system/components/typography/text/stories/index.js
@@ -77,7 +77,7 @@ export const Label = () => (
           <Text
             key={`${presetSize}_text_link`}
             size={presetSize}
-            as={'label'}
+            as="label"
             isBold={select('isBold', booleanOptions, false)}
           >
             {`${presetSize} - Och glasen glittrar tyst på vårt bord`}
@@ -94,7 +94,7 @@ export const Label = () => (
           <Text
             key={`${presetSize}_text_link_disabled`}
             size={presetSize}
-            as={'label'}
+            as="label"
             isBold={select('isBold', booleanOptions, false)}
             disabled
           >

--- a/assets/src/design-system/theme/typography.js
+++ b/assets/src/design-system/theme/typography.js
@@ -29,7 +29,6 @@ export const typography = {
   weight: {
     bold: 500,
     regular: 400,
-    light: 300,
   },
   presets: {
     display: {
@@ -54,31 +53,31 @@ export const typography = {
     },
     headline: {
       [PRESET_SIZES.XX_LARGE]: {
-        weight: 500,
+        weight: 400,
         size: 42,
         lineHeight: 56,
         letterSpacing: 0,
       },
       [PRESET_SIZES.X_LARGE]: {
-        weight: 500,
+        weight: 400,
         size: 36,
         lineHeight: 44,
         letterSpacing: 0,
       },
       [PRESET_SIZES.LARGE]: {
-        weight: 500,
+        weight: 400,
         size: 32,
         lineHeight: 40,
         letterSpacing: 0,
       },
       [PRESET_SIZES.MEDIUM]: {
-        weight: 500,
+        weight: 400,
         size: 28,
         lineHeight: 36,
         letterSpacing: 0,
       },
       [PRESET_SIZES.SMALL]: {
-        weight: 500,
+        weight: 400,
         size: 24,
         lineHeight: 32,
         letterSpacing: 0,
@@ -90,7 +89,7 @@ export const typography = {
         letterSpacing: 0,
       },
       [PRESET_SIZES.XX_SMALL]: {
-        weight: 500,
+        weight: 700,
         size: 14,
         lineHeight: 20,
         letterSpacing: 0,
@@ -138,7 +137,7 @@ export const typography = {
       [PRESET_SIZES.MEDIUM]: {
         weight: 500,
         size: 16,
-        lineHeight: 24,
+        lineHeight: 20,
         letterSpacing: 0,
       },
       [PRESET_SIZES.SMALL]: {

--- a/assets/src/design-system/theme/typography.js
+++ b/assets/src/design-system/theme/typography.js
@@ -127,6 +127,38 @@ export const typography = {
         letterSpacing: 0.16,
       },
     },
+    link: {
+      [PRESET_SIZES.X_LARGE]: {
+        weight: 500,
+        size: 24,
+        lineHeight: 32,
+        letterSpacing: -0.02,
+      },
+      [PRESET_SIZES.LARGE]: {
+        weight: 700,
+        size: 18,
+        lineHeight: 24,
+        letterSpacing: 0,
+      },
+      [PRESET_SIZES.MEDIUM]: {
+        weight: 700,
+        size: 16,
+        lineHeight: 24,
+        letterSpacing: 0,
+      },
+      [PRESET_SIZES.SMALL]: {
+        weight: 700,
+        size: 14,
+        lineHeight: 20,
+        letterSpacing: 0,
+      },
+      [PRESET_SIZES.X_SMALL]: {
+        weight: 700,
+        size: 12,
+        lineHeight: 20,
+        letterSpacing: 0.16,
+      },
+    },
     label: {
       [PRESET_SIZES.LARGE]: {
         weight: 500,

--- a/assets/src/design-system/theme/typography.js
+++ b/assets/src/design-system/theme/typography.js
@@ -129,7 +129,7 @@ export const typography = {
     },
     link: {
       [PRESET_SIZES.X_LARGE]: {
-        weight: 500,
+        weight: 400,
         size: 24,
         lineHeight: 32,
         letterSpacing: -0.02,
@@ -161,25 +161,25 @@ export const typography = {
     },
     label: {
       [PRESET_SIZES.LARGE]: {
-        weight: 500,
+        weight: 400,
         size: 18,
         lineHeight: 24,
         letterSpacing: 0,
       },
       [PRESET_SIZES.MEDIUM]: {
-        weight: 500,
+        weight: 400,
         size: 16,
         lineHeight: 20,
         letterSpacing: 0,
       },
       [PRESET_SIZES.SMALL]: {
-        weight: 500,
+        weight: 400,
         size: 14,
-        lineHeight: 20,
+        lineHeight: 12,
         letterSpacing: 0,
       },
       [PRESET_SIZES.X_SMALL]: {
-        weight: 500,
+        weight: 400,
         size: 12,
         lineHeight: 20,
         letterSpacing: 0,


### PR DESCRIPTION
## Context

Typography settings were updated since implemented, this is to get our presets current. 

## Summary

Small tweak to the design system to get typography set in foundation of Figma for the design system current with what we have available to use. 

**From here, any time something isn't syncing with the typography set in the foundation we should be asking questions so we keep current with any updates and don't propagate accidental shifts!** 

## Relevant Technical Choices

- remove excess letter-spacing on telemetry banner
- use `<Link>` for storybook banner demo
- remove old bolded title area for banner to be current with typography for headlines
- separate link styles in `<Text>` since there is 1 less preset and the font weight is different 
- update headline font weight to 400 until xxxsmall, then it is 700
- update label medium to line height 20 (formerly 24)
- remove light font weight as that is not a weight available in font nor is it in use.
- give links their own preset, now that bold differs.


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Telemetry banner on dashboard should have letter-spacing of `0.16px` for the text to side of the checkbox now instead of `0.0133em`, links are bolded, and headline of banner is now font weight 400 not 500. 

New
![Screen Shot 2021-02-22 at 3 50 03 PM](https://user-images.githubusercontent.com/10720454/108780433-a9ec2f80-7525-11eb-842e-32a68a5c6a4b.png)

Old
![Screen Shot 2021-02-22 at 3 50 43 PM](https://user-images.githubusercontent.com/10720454/108780506-c8eac180-7525-11eb-80ac-adf8c3f5234b.png)


## Testing Instructions

- Verify the above user facing change. 
- Verify figma updates to typography presets using either storybook or theme typography object for presets.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6174 
