### PR TITLE
Pre-Publish Checklist: Fix TypeError: `backgroundColor` is not iterable

### DIFF
--- a/assets/src/edit-story/app/prepublish/getPrepublishErrors.js
+++ b/assets/src/edit-story/app/prepublish/getPrepublishErrors.js
@@ -64,21 +64,19 @@ async function getPrepublishErrors(story) {
         (prev, currentPage, currentIndex) => {
           const pageNum = currentIndex + 1;
           const { id: pageId, elements } = currentPage;
-
           function prepareResult(result) {
             if (typeof result !== 'undefined') {
-              if (Array.isArray(result)) {
-                return result.map((message) => ({
-                  ...message,
-                  page: pageNum,
-                  pageId,
-                }));
-              }
-              return {
-                ...result,
-                page: pageNum,
-                pageId,
-              };
+              return Array.isArray(result)
+                ? result.map((message) => ({
+                    ...message,
+                    page: pageNum,
+                    pageId,
+                  }))
+                : {
+                    ...result,
+                    page: pageNum,
+                    pageId,
+                  };
             }
             return result;
           }

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -107,10 +107,14 @@ export function videoElementSizeOnPage(page) {
   );
   if (videoElementsOnPage.length === 1) {
     const [videoElement] = videoElementsOnPage;
-    return {
-      pageId: page.id,
-      ...mediaElementSizeOnPage(videoElement),
-    };
+    const sizeOnPageMessage = mediaElementSizeOnPage(videoElement);
+
+    return (
+      sizeOnPageMessage && {
+        pageId: page.id,
+        ...sizeOnPageMessage,
+      }
+    );
   }
   return undefined;
 }

--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -249,6 +249,13 @@ function getOverlapBgColor({ elementId, pageId, bgImage, bgBox, overlapBox }) {
   });
 }
 
+/**
+ * @param {Object} arguments The arguments
+ * @param {Array} arguments.backgroundColor The r, g, b tuple representing a background color to compare to the text colors
+ * @param {Array} arguments.textColors The array of style colors of the text being checked
+ * @param {number} arguments.fontSize The font size (in editor pixels) of the text being checked
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
 function textBgColorsLowContrast({
   backgroundColor,
   textColors,
@@ -256,6 +263,9 @@ function textBgColorsLowContrast({
   ...elements
 }) {
   const someTextHasLowContrast = textColors.some((styleColor) => {
+    if (!backgroundColor || !styleColor) {
+      return false;
+    }
     const [r, g, b] = backgroundColor;
     const textLuminance = calculateLuminanceFromStyleColor(styleColor);
     const backgroundLuminance = calculateLuminanceFromRGB({ r, g, b });

--- a/assets/src/edit-story/app/prepublish/warning/accessibility.js
+++ b/assets/src/edit-story/app/prepublish/warning/accessibility.js
@@ -325,11 +325,7 @@ function getOverlapBgColor({ elementId, pageId, bgImage, bgBox, overlapBox }) {
     return setOrCreateImage({
       src: cropImage.src,
       id: elementId,
-    }).then((colorData) => ({
-      r: colorData[0],
-      g: colorData[1],
-      b: colorData[2],
-    }));
+    }).then(([r, g, b]) => ({ r, g, b }));
   });
 }
 


### PR DESCRIPTION
## Context
- Fix an uncaught type error: `TypeError: backgroundColor is not iterable`
- While searching for the cause of the bug I made some other improvements which should not impact functionality, which I included in the PR. I'll explain them for clarity.

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- added a type checking fix in the `accessibility` module 
- While in the `accessibility` file I noticed it was sometimes hard to read so I added some documentation for added clarity.
- I changed the "RGB" return type around in the `accessibility` module while I was trying to find the bug. I left those changes as improvements.

for changes to: `media`: I noticed a prop-type error while hunting for this error. this function should return `undefined` but was returning `{ pageId: <page-id> }`
for changes to `getPrepublishErrors`: just shortened up a return here while debugging, left it in
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
The problem code is here: 
```
        const getBackgroundColor = getBackgroundColorByType(backgroundElement);
        const backgroundColor = getBackgroundColor(args);

        let backgroundColorResult;

        if (backgroundColor instanceof Promise) {
          backgroundColorResult = backgroundColor.then((resolvedBgColor) => {
            cleanupDOM(ids);
            return {
              backgroundColor: resolvedBgColor,
              textColors,
              fontSize: element.fontSize,
              pageId: page.id,
              elements: [backgroundElement, element],
            };
          });
        } else if (backgroundColor !== undefined) {
          backgroundColorResult = {
            backgroundColor,
            textColors,
            fontSize: element.fontSize,
            pageId: page.id,
            elements: [backgroundElement, element],
          };
        }

        if (backgroundColorResult !== undefined) {
          backgroundColorPromises.push(backgroundColorResult);
        }
      }
    }
  });

  if (backgroundColorPromises.length > 0) {
    const results = await Promise.all(backgroundColorPromises).catch(() => {
      // ignore errors with finding colors
    });

    return results.map(textBgColorsLowContrast).filter(Boolean);
  }
```

There are many issues here which I attempted to improve on in this PR. 

- it's not very DRY so I tightened up some of the promise-array creation logic.
- The bug is caused by not checking the return type of the actual `backgroundColor` property that is sent on the arguments object to `textBgColorsLowContrast` (`textBackgroundLowContrast` after updates). I fixed that by adding the `prepare` step to decide how to shape the object based on the existence of background color that is sent there and only passed the object if it is defined. 
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
May be tested for regression
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

1. Open a new story in the editor
2. Add templates to pages and assure that the following `Uncaught Type Error` does not appear when adding templates to the story: `TypeError: backgroundColor is not iterable`
3. Visit the demo story at `wp-admin/post-new.php?post_type=web-story&web-stories-demo=1` and assure that the following `Uncaught Type Error` does not appear when loading the story: `TypeError: backgroundColor is not iterable`

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6176
