### PR TITLE
Added new toggle button

### DIFF
--- a/assets/src/design-system/components/button/button.js
+++ b/assets/src/design-system/components/button/button.js
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { forwardRef } from 'react';
+import styled, { css } from 'styled-components';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { THEME_CONSTANTS, themeHelpers } from '../../theme';
+import {
+  BUTTON_SIZES,
+  BUTTON_TYPES,
+  BUTTON_VARIANTS,
+  BUTTON_TRANSITION_TIMING,
+} from './constants';
+
+const Base = styled.button(
+  ({ size, theme }) => css`
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    border: none;
+    color: ${theme.colors.fg.primary};
+    cursor: pointer;
+    ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)};
+    ${themeHelpers.expandPresetStyles({
+      preset: {
+        ...theme.typography.presets.label[
+          size === BUTTON_SIZES.SMALL
+            ? THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL
+            : THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.MEDIUM
+        ],
+      },
+      theme,
+    })};
+
+    &:active {
+      background-color: ${theme.colors.interactiveBg.active};
+      color: ${theme.colors.interactiveFg.active};
+    }
+
+    &:disabled {
+      pointer-events: none;
+      background-color: ${theme.colors.interactiveBg.disable};
+      color: ${theme.colors.fg.disable};
+    }
+
+    transition: background-color ${BUTTON_TRANSITION_TIMING},
+      color ${BUTTON_TRANSITION_TIMING};
+  `
+);
+
+const primaryColors = ({ theme }) => css`
+  background-color: ${theme.colors.interactiveBg.brandNormal};
+  color: ${theme.colors.interactiveFg.brandNormal};
+  &:active {
+    background-color: ${theme.colors.interactiveBg.active};
+    color: ${theme.colors.interactiveFg.active};
+  }
+  &:hover:enabled,
+  &:focus:enabled {
+    background-color: ${theme.colors.interactiveBg.brandHover};
+    color: ${theme.colors.interactiveFg.brandHover};
+  }
+`;
+
+const secondaryColors = ({ theme }) => css`
+  background-color: ${theme.colors.interactiveBg.secondaryNormal};
+
+  &:hover:enabled,
+  &:focus:enabled {
+    background-color: ${theme.colors.interactiveBg.secondaryHover};
+  }
+`;
+
+const tertiaryColors = ({ theme }) => css`
+  background-color: ${theme.colors.interactiveBg.tertiaryNormal};
+
+  &:disabled {
+    background-color: ${theme.colors.interactiveBg.tertiaryNormal};
+  }
+
+  &:hover:enabled,
+  &:focus:enabled {
+    background-color: ${theme.colors.interactiveBg.tertiaryHover};
+  }
+`;
+
+const buttonColors = {
+  [BUTTON_TYPES.PRIMARY]: primaryColors,
+  [BUTTON_TYPES.SECONDARY]: secondaryColors,
+  [BUTTON_TYPES.TERTIARY]: tertiaryColors,
+};
+
+const ButtonRectangle = styled(Base)`
+  ${({ type }) => type && buttonColors?.[type]};
+  min-width: 1px;
+  min-height: 1em;
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+
+  padding: ${({ size }) =>
+    size === BUTTON_SIZES.SMALL ? '8px 16px' : '18px 32px'};
+`;
+
+const ButtonSquare = styled(Base)`
+  ${({ type }) => type && buttonColors?.[type]};
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+
+  ${({ size }) => css`
+    width: ${size === BUTTON_SIZES.SMALL
+      ? THEME_CONSTANTS.ICON_SIZE
+      : THEME_CONSTANTS.LARGE_BUTTON_SIZE}px;
+    height: ${size === BUTTON_SIZES.SMALL
+      ? THEME_CONSTANTS.ICON_SIZE
+      : THEME_CONSTANTS.LARGE_BUTTON_SIZE}px;
+  `}
+
+  svg {
+    width: ${THEME_CONSTANTS.ICON_SIZE}px;
+    height: ${THEME_CONSTANTS.ICON_SIZE}px;
+  }
+`;
+
+const ButtonCircle = styled(ButtonSquare)`
+  border-radius: ${({ theme }) => theme.borders.radius.round};
+`;
+
+const ButtonIcon = styled(Base)`
+  width: ${THEME_CONSTANTS.ICON_SIZE}px;
+  height: ${THEME_CONSTANTS.ICON_SIZE}px;
+  svg {
+    width: 100%;
+    height: 100%;
+  }
+`;
+
+const ButtonOptions = {
+  [BUTTON_VARIANTS.RECTANGLE]: ButtonRectangle,
+  [BUTTON_VARIANTS.CIRCLE]: ButtonCircle,
+  [BUTTON_VARIANTS.SQUARE]: ButtonSquare,
+  [BUTTON_VARIANTS.ICON]: ButtonIcon,
+};
+
+const Button = forwardRef(function Button(
+  {
+    size = BUTTON_SIZES.MEDIUM,
+    type = BUTTON_TYPES.PLAIN,
+    variant = BUTTON_VARIANTS.RECTANGLE,
+    children,
+    ...rest
+  },
+  ref
+) {
+  const isLink = rest.href !== undefined;
+  const StyledButton = ButtonOptions[variant];
+
+  return (
+    <StyledButton
+      ref={ref}
+      as={isLink ? 'a' : 'button'}
+      size={size}
+      type={type}
+      {...rest}
+    >
+      {children}
+    </StyledButton>
+  );
+});
+
+Button.propTypes = {
+  size: PropTypes.oneOf(Object.values(BUTTON_SIZES)),
+  type: PropTypes.oneOf(Object.values(BUTTON_TYPES)),
+  variant: PropTypes.oneOf(Object.values(BUTTON_VARIANTS)),
+  children: PropTypes.node.isRequired,
+  activeLabelText: PropTypes.string,
+};
+
+export { Button, BUTTON_SIZES, BUTTON_TYPES, BUTTON_VARIANTS };

--- a/assets/src/design-system/components/button/stories/index.js
+++ b/assets/src/design-system/components/button/stories/index.js
@@ -17,15 +17,19 @@
 /**
  * External dependencies
  */
+import { useState, useCallback } from 'react';
 import styled, { ThemeProvider } from 'styled-components';
 import { select } from '@storybook/addon-knobs';
+import PropTypes from 'prop-types';
+
 /**
  * Internal dependencies
  */
 import { theme, THEME_CONSTANTS } from '../../../theme';
 import { Headline, Text } from '../../typography';
 import { Cross } from '../../../icons';
-import { Button, BUTTON_SIZES, BUTTON_TYPES, BUTTON_VARIANTS } from '..';
+import { Button, BUTTON_SIZES, BUTTON_TYPES, BUTTON_VARIANTS } from '../button';
+import { ToggleButton } from '../toggleButton';
 
 export default {
   title: 'DesignSystem/Components/Button',
@@ -33,10 +37,12 @@ export default {
 
 const Container = styled.div`
   background-color: ${(props) => props.theme.colors.bg.primary};
+  border: 1px solid ${(props) => props.theme.colors.fg.black};
 
   display: flex;
   align-items: space-evenly;
   flex-direction: column;
+  padding: 20px;
 `;
 
 const Row = styled.div`
@@ -52,17 +58,18 @@ const Row = styled.div`
   }
 `;
 
+function ButtonContent({ variant }) {
+  return variant === BUTTON_VARIANTS.RECTANGLE ? 'Standard Button' : <Cross />;
+}
+
+ButtonContent.propTypes = {
+  variant: PropTypes.oneOf(Object.values(BUTTON_VARIANTS)),
+};
+
 const ButtonCombosToDisplay = () => (
   <Container>
     <Headline as="h2">{'Buttons by Variant, Size, and Type'}</Headline>
     {Object.values(BUTTON_VARIANTS).map((buttonVariant) => {
-      const buttonContent =
-        buttonVariant === BUTTON_VARIANTS.RECTANGLE ? (
-          'Standard Button'
-        ) : (
-          <Cross />
-        );
-
       return Object.values(BUTTON_SIZES).map((buttonSize) => (
         <Row key={`${buttonVariant}_${buttonSize}_row_storybook`}>
           {Object.values(BUTTON_TYPES).map((buttonType) => (
@@ -73,7 +80,7 @@ const ButtonCombosToDisplay = () => (
                 type={buttonType}
                 size={buttonSize}
               >
-                {buttonContent}
+                <ButtonContent variant={buttonVariant} />
               </Button>
               <Text>
                 {`variant: ${buttonVariant}`} <br />
@@ -149,7 +156,7 @@ const ButtonCombosToDisplay = () => (
   </Container>
 );
 
-export const _default = () => {
+export const DarkTheme = () => {
   return (
     <ThemeProvider theme={theme}>
       <ButtonCombosToDisplay />
@@ -157,4 +164,53 @@ export const _default = () => {
   );
 };
 
-export const LightThemeButtons = () => <ButtonCombosToDisplay />;
+export const LightTheme = () => <ButtonCombosToDisplay />;
+
+const TOGGLE_VARIANTS = [BUTTON_VARIANTS.CIRCLE, BUTTON_VARIANTS.SQUARE];
+const ToggleButtonContainer = ({ isToggled, swapToggled }) => (
+  <Container>
+    {Object.values(BUTTON_SIZES).map((buttonSize) => (
+      <Row key={`${buttonSize}_row_storybook`}>
+        {TOGGLE_VARIANTS.map((buttonVariant) => (
+          <div key={`${buttonVariant}_${buttonSize}_storybook`}>
+            <ToggleButton
+              key={`${buttonVariant}_storybook`}
+              variant={buttonVariant}
+              size={buttonSize}
+              isToggled={isToggled}
+              onClick={swapToggled}
+            >
+              <ButtonContent variant={buttonVariant} />
+            </ToggleButton>
+            <Text>
+              {`variant: ${buttonVariant}`} <br />
+              {`size: ${buttonSize}`} <br />
+              {`is on: ${isToggled}`}
+            </Text>
+          </div>
+        ))}
+      </Row>
+    ))}
+  </Container>
+);
+
+ToggleButtonContainer.propTypes = {
+  isToggled: PropTypes.bool.isRequired,
+  swapToggled: PropTypes.func.isRequired,
+};
+
+export const ToggleButtons = () => {
+  const [isToggled, setToggled] = useState(false);
+  const swapToggled = useCallback(() => setToggled((b) => !b), []);
+  return (
+    <>
+      <ToggleButtonContainer isToggled={isToggled} swapToggled={swapToggled} />
+      <ThemeProvider theme={theme}>
+        <ToggleButtonContainer
+          isToggled={isToggled}
+          swapToggled={swapToggled}
+        />
+      </ThemeProvider>
+    </>
+  );
+};

--- a/assets/src/design-system/components/button/toggleButton.js
+++ b/assets/src/design-system/components/button/toggleButton.js
@@ -14,5 +14,29 @@
  * limitations under the License.
  */
 
-export * from './button';
-export * from './toggleButton';
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { BUTTON_TYPES } from './constants';
+import { Button } from './button';
+
+function ToggleButton({ isToggled = false, ...rest }) {
+  return (
+    <Button
+      {...rest}
+      type={isToggled ? BUTTON_TYPES.SECONDARY : BUTTON_TYPES.TERTIARY}
+      aria-pressed={isToggled}
+    />
+  );
+}
+
+ToggleButton.propTypes = {
+  isToggled: PropTypes.bool,
+};
+
+export { ToggleButton };


### PR DESCRIPTION
## Context

This implements a toggle button necessary (probably only for small square icon buttons) in the design panels for states that can be turned on and off like mirroring, bold, etc as well as for some radio-like functionality such as text orientation.

## Testing Instructions

### QA

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1. Open storybook and observe Design System > Components > Button > Toggle Buttons

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6490
