### PR TITLE
Added lock toggle

### DIFF
--- a/assets/src/design-system/components/button/stories/index.js
+++ b/assets/src/design-system/components/button/stories/index.js
@@ -29,7 +29,7 @@ import { theme, THEME_CONSTANTS } from '../../../theme';
 import { Headline, Text } from '../../typography';
 import { Cross } from '../../../icons';
 import { Button, BUTTON_SIZES, BUTTON_TYPES, BUTTON_VARIANTS } from '../button';
-import { ToggleButton } from '../toggleButton';
+import { ToggleButton, LockToggle } from '../toggleButton';
 
 export default {
   title: 'DesignSystem/Components/Button',
@@ -210,6 +210,27 @@ export const ToggleButtons = () => {
           isToggled={isToggled}
           swapToggled={swapToggled}
         />
+      </ThemeProvider>
+    </>
+  );
+};
+
+export const PrebakedButtons = () => {
+  const [isLocked, setLocked] = useState(false);
+  const swapLocked = useCallback(() => setLocked((b) => !b), []);
+  return (
+    <>
+      <Container>
+        <Row>
+          <LockToggle isLocked={isLocked} onClick={swapLocked} />
+        </Row>
+      </Container>
+      <ThemeProvider theme={theme}>
+        <Container>
+          <Row>
+            <LockToggle isLocked={isLocked} onClick={swapLocked} />
+          </Row>
+        </Container>
       </ThemeProvider>
     </>
   );

--- a/assets/src/design-system/components/button/toggleButton.js
+++ b/assets/src/design-system/components/button/toggleButton.js
@@ -22,7 +22,8 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { BUTTON_TYPES } from './constants';
+import { LockOpen, LockClosed } from '../../icons';
+import { BUTTON_TYPES, BUTTON_SIZES, BUTTON_VARIANTS } from './constants';
 import { Button } from './button';
 
 function ToggleButton({ isToggled = false, ...rest }) {
@@ -39,4 +40,21 @@ ToggleButton.propTypes = {
   isToggled: PropTypes.bool,
 };
 
-export { ToggleButton };
+function LockToggle({ isLocked = false, ...rest }) {
+  return (
+    <Button
+      {...rest}
+      aria-pressed={isLocked}
+      type={BUTTON_TYPES.TERTIARY}
+      size={BUTTON_SIZES.SMALL}
+      variant={BUTTON_VARIANTS.SQUARE}
+    >
+      {isLocked ? <LockClosed /> : <LockOpen />}
+    </Button>
+  );
+}
+
+LockToggle.propTypes = {
+  isLocked: PropTypes.bool,
+};
+export { ToggleButton, LockToggle };


### PR DESCRIPTION
## Context

This implements a lock toggle button to be used through the design panels.

This is a "prebaked" button, as in it's a fixed usage of the existing general button component, that will be used through the application and thus for DRY reasons makes sense to create once-and-for-all.

As far as I am aware, this should not use the regular toggle button as the toggled state should be identical to the untoggled one except for the icon change (so no background color change).

## Testing Instructions

### QA

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1. Open storybook to Design System > Components > Buttons > Prebaked Buttons and observe the toggle.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6493
