### PR TITLE
Reverted to older popup logic

### DIFF
--- a/assets/src/design-system/components/popup/index.js
+++ b/assets/src/design-system/components/popup/index.js
@@ -105,10 +105,10 @@ function Popup({
   );
 
   useLayoutEffect(() => {
-    setMounted(true);
     if (!isOpen) {
       return () => {};
     }
+    setMounted(true);
     positionPopup();
     // Adjust the position when scrolling.
     document.addEventListener('scroll', positionPopup, true);

--- a/assets/src/design-system/components/popup/utils/getOffset.js
+++ b/assets/src/design-system/components/popup/utils/getOffset.js
@@ -18,40 +18,25 @@
  * Internal dependencies
  */
 import { PLACEMENT } from '../constants';
-import { getXTransforms, getYTransforms } from './getTransforms';
+import { getXTransforms } from './getTransforms';
 
-export function getXOffset(
-  placement,
-  spacing = 0,
-  anchorRect,
-  dockRect,
-  bodyRect
-) {
+export function getXOffset(placement, spacing = 0, anchorRect, dockRect) {
   switch (placement) {
     case PLACEMENT.BOTTOM_START:
     case PLACEMENT.TOP_START:
     case PLACEMENT.LEFT:
     case PLACEMENT.LEFT_END:
     case PLACEMENT.LEFT_START:
-      return bodyRect.left + (dockRect?.left || anchorRect.left) - spacing;
+      return (dockRect?.left || anchorRect.left) - spacing;
     case PLACEMENT.BOTTOM_END:
     case PLACEMENT.TOP_END:
     case PLACEMENT.RIGHT:
     case PLACEMENT.RIGHT_END:
     case PLACEMENT.RIGHT_START:
-      return (
-        bodyRect.left +
-        (dockRect?.left || anchorRect.left) +
-        anchorRect.width +
-        spacing
-      );
+      return (dockRect?.left || anchorRect.left) + anchorRect.width + spacing;
     case PLACEMENT.BOTTOM:
     case PLACEMENT.TOP:
-      return (
-        bodyRect.left +
-        (dockRect?.left || anchorRect.left) +
-        anchorRect.width / 2
-      );
+      return (dockRect?.left || anchorRect.left) + anchorRect.width / 2;
     default:
       return 0;
   }
@@ -90,33 +75,22 @@ export function getOffset(placement, spacing, anchor, dock, popup) {
     popupRect.width = Math.max(popupRect.width, popup.current?.scrollWidth);
   }
 
-  const { height = 0, width = 0 } = popupRect || {};
+  const { width = 0 } = popupRect || {};
   const { x: spacingH = 0, y: spacingV = 0 } = spacing || {};
 
   // Horizontal
-  const offsetX = getXOffset(
-    placement,
-    spacingH,
-    anchorRect,
-    dockRect,
-    bodyRect
-  );
+  const offsetX = getXOffset(placement, spacingH, anchorRect, dockRect);
   const maxOffsetX = bodyRect.width - width - getXTransforms(placement) * width;
 
   // Vertical
+  // We always want just the pure offset of Y because if anything scrolls (panels or the window) we want that position to stay true to the anchor.
+  // This prevents any overlap of labels on scroll with an open popup.
   const offsetY = getYOffset(placement, spacingV, anchorRect);
 
-  const maxOffsetY =
-    bodyRect.height + bodyRect.y - height - getYTransforms(placement) * height;
-
-  // In cases where the window has scrolled we want to make sure that the sum of maxOffsetY is more than 0
-  // If it's not we should fallback to the true offsetY to respect viewports that have scroll.
-  const trueMaxOffsetY = maxOffsetY > 0 ? maxOffsetY : offsetY;
-
-  // Clamp values
+  // Clamp X value
   return {
     x: Math.max(0, Math.min(offsetX, maxOffsetX)),
-    y: Math.max(0, Math.min(offsetY, trueMaxOffsetY)),
+    y: offsetY,
     width: anchorRect.width,
     height: anchorRect.height,
   };

--- a/assets/src/design-system/components/popup/utils/getOffset.js
+++ b/assets/src/design-system/components/popup/utils/getOffset.js
@@ -92,6 +92,7 @@ export function getOffset(placement, spacing, anchor, dock, popup) {
 
   const { height = 0, width = 0 } = popupRect || {};
   const { x: spacingH = 0, y: spacingV = 0 } = spacing || {};
+
   // Horizontal
   const offsetX = getXOffset(
     placement,

--- a/assets/src/design-system/components/popup/utils/getOffset.js
+++ b/assets/src/design-system/components/popup/utils/getOffset.js
@@ -92,7 +92,6 @@ export function getOffset(placement, spacing, anchor, dock, popup) {
 
   const { height = 0, width = 0 } = popupRect || {};
   const { x: spacingH = 0, y: spacingV = 0 } = spacing || {};
-
   // Horizontal
   const offsetX = getXOffset(
     placement,
@@ -106,12 +105,8 @@ export function getOffset(placement, spacing, anchor, dock, popup) {
   // Vertical
   const offsetY = getYOffset(placement, spacingV, anchorRect);
 
-  // use window.pageYOffset instead of bodyRect.height to account for scroll
   const maxOffsetY =
-    window.pageYOffset +
-    bodyRect.y -
-    height -
-    getYTransforms(placement) * height;
+    bodyRect.height + bodyRect.y - height - getYTransforms(placement) * height;
 
   // In cases where the window has scrolled we want to make sure that the sum of maxOffsetY is more than 0
   // If it's not we should fallback to the true offsetY to respect viewports that have scroll.

--- a/assets/src/edit-story/components/carousel/karma/carouselMenu.karma.js
+++ b/assets/src/edit-story/components/carousel/karma/carouselMenu.karma.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+
+describe('Carousel menu', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  it('should show correct tooltip on hover', async () => {
+    const { gridViewToggle } = fixture.editor.carousel;
+    await fixture.events.mouse.moveRel(gridViewToggle, '50%', '50%', {
+      steps: 2,
+    });
+
+    await fixture.snapshot('Grid view tooltip visible');
+  });
+});

--- a/assets/src/edit-story/karma/fixture/containers/carousel.js
+++ b/assets/src/edit-story/karma/fixture/containers/carousel.js
@@ -45,6 +45,10 @@ export class Carousel extends Container {
       (page) => page.node.getAttribute('data-page-id') === pageId
     );
   }
+
+  get gridViewToggle() {
+    return this.getByRole('button', { name: 'Grid View' });
+  }
 }
 
 /**

--- a/assets/src/karma-fixture/init.js
+++ b/assets/src/karma-fixture/init.js
@@ -369,6 +369,11 @@ beforeEach(async () => {
     margin: 0;
   `;
   document.body.appendChild(rootEl);
+  document.body.cssText = `
+    height: 100vh;
+    width: 100vw;
+    margin: 0;
+  `;
 
   // Each test should start with the pointer in the same location ([-1,-1]) to
   // avoid pointerover/mouseover/hover flakes.

--- a/assets/src/karma-fixture/init.js
+++ b/assets/src/karma-fixture/init.js
@@ -369,6 +369,9 @@ beforeEach(async () => {
     margin: 0;
   `;
   document.body.appendChild(rootEl);
+  // The below is added to make the body element cover the entire window, as
+  // the app above is fixed-positioned. This ensures proper placement of
+  // popups in karma test runs.
   document.body.cssText = `
     height: 100vh;
     width: 100vw;


### PR DESCRIPTION
## Context

Reverting to (maybe?) older popup logic, as the previous logic was broken in the editor.

## Testing Instructions

### QA

This PR can be tested by following these steps:

1. Hover the grid view icon in the carousel menu
2. Observe tooltip appearing just over button and not at the top of the browser

### UAT

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6496 
