### PR TITLE
Design System: Popup positioning tweaks

### DIFF
--- a/assets/src/design-system/components/popup/index.js
+++ b/assets/src/design-system/components/popup/index.js
@@ -105,10 +105,10 @@ function Popup({
   );
 
   useLayoutEffect(() => {
-    setMounted(true);
     if (!isOpen) {
       return () => {};
     }
+    setMounted(true);
     positionPopup();
     // Adjust the position when scrolling.
     document.addEventListener('scroll', positionPopup, true);

--- a/assets/src/design-system/components/popup/utils/getOffset.js
+++ b/assets/src/design-system/components/popup/utils/getOffset.js
@@ -18,40 +18,25 @@
  * Internal dependencies
  */
 import { PLACEMENT } from '../constants';
-import { getXTransforms, getYTransforms } from './getTransforms';
+import { getXTransforms } from './getTransforms';
 
-export function getXOffset(
-  placement,
-  spacing = 0,
-  anchorRect,
-  dockRect,
-  bodyRect
-) {
+export function getXOffset(placement, spacing = 0, anchorRect, dockRect) {
   switch (placement) {
     case PLACEMENT.BOTTOM_START:
     case PLACEMENT.TOP_START:
     case PLACEMENT.LEFT:
     case PLACEMENT.LEFT_END:
     case PLACEMENT.LEFT_START:
-      return bodyRect.left + (dockRect?.left || anchorRect.left) - spacing;
+      return (dockRect?.left || anchorRect.left) - spacing;
     case PLACEMENT.BOTTOM_END:
     case PLACEMENT.TOP_END:
     case PLACEMENT.RIGHT:
     case PLACEMENT.RIGHT_END:
     case PLACEMENT.RIGHT_START:
-      return (
-        bodyRect.left +
-        (dockRect?.left || anchorRect.left) +
-        anchorRect.width +
-        spacing
-      );
+      return (dockRect?.left || anchorRect.left) + anchorRect.width + spacing;
     case PLACEMENT.BOTTOM:
     case PLACEMENT.TOP:
-      return (
-        bodyRect.left +
-        (dockRect?.left || anchorRect.left) +
-        anchorRect.width / 2
-      );
+      return (dockRect?.left || anchorRect.left) + anchorRect.width / 2;
     default:
       return 0;
   }
@@ -90,33 +75,22 @@ export function getOffset(placement, spacing, anchor, dock, popup) {
     popupRect.width = Math.max(popupRect.width, popup.current?.scrollWidth);
   }
 
-  const { height = 0, width = 0 } = popupRect || {};
+  const { width = 0 } = popupRect || {};
   const { x: spacingH = 0, y: spacingV = 0 } = spacing || {};
 
   // Horizontal
-  const offsetX = getXOffset(
-    placement,
-    spacingH,
-    anchorRect,
-    dockRect,
-    bodyRect
-  );
+  const offsetX = getXOffset(placement, spacingH, anchorRect, dockRect);
   const maxOffsetX = bodyRect.width - width - getXTransforms(placement) * width;
 
   // Vertical
+  // We always want just the pure offset of Y because if anything scrolls (panels or the window) we want that position to stay true to the anchor.
+  // This prevents any overlap of labels on scroll with an open popup.
   const offsetY = getYOffset(placement, spacingV, anchorRect);
 
-  const maxOffsetY =
-    bodyRect.height + bodyRect.y - height - getYTransforms(placement) * height;
-
-  // In cases where the window has scrolled we want to make sure that the sum of maxOffsetY is more than 0
-  // If it's not we should fallback to the true offsetY to respect viewports that have scroll.
-  const trueMaxOffsetY = maxOffsetY > 0 ? maxOffsetY : offsetY;
-
-  // Clamp values
+  // Clamp X value
   return {
     x: Math.max(0, Math.min(offsetX, maxOffsetX)),
-    y: Math.max(0, Math.min(offsetY, trueMaxOffsetY)),
+    y: offsetY,
     width: anchorRect.width,
     height: anchorRect.height,
   };


### PR DESCRIPTION
## Context

Now that we have more use cases for the tooltip in the editor which uses the popup that I edited (as opposed to storybook and dashboard which treat page space differently) trying to tie together some of the positioning that can be a little out of whack. 

## Summary

Makes popup stay in place on window scroll so that it doesn't overlap with anchor.

## Relevant Technical Choices

1. Remove bodyRect.left from sum to get X offset because the anchor will always have the true value of x in its bodyRect. This extra left causes spacing issues when there is horizontal scroll (edge case but still). 
2. Vertical (offsetY) should always be set to the true YOffset, not the maxYOffset because we always want the popup to be  next to the anchor, this makes sure that on scroll the popup never overlaps with the anchor.
3. Moved `setMounted(true)` below the check for `!isOpen` so that we don't mount popups everywhere that might never be needed. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Editor Horizontal Scroll: 
| Old | New |
| :---        |  :---  |
| ![sad tooltip](https://user-images.githubusercontent.com/10720454/109200158-80b5e400-775d-11eb-935e-1debc36f0e1c.gif) | ![better horizontal scroll](https://user-images.githubusercontent.com/10720454/109200093-6bd95080-775d-11eb-8f78-577dd14dfd70.gif) |

Old dropdown below initial fold of page:
| Old | New |
| :---        |  :---  |
| ![updated popup results on dashboard](https://user-images.githubusercontent.com/10720454/109200099-6da31400-775d-11eb-91c2-0c55da8707f1.gif) | ![better dropdown](https://user-images.githubusercontent.com/10720454/109200247-9b885880-775d-11eb-9685-767276d55784.gif) |



## Testing Instructions

- Trigger new tooltips in editor (they are white) and see that they are accurately positioned.
- Open the dropdown on dashboard settings and see that it is positioned right below the associated dropdown button.

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #6496 
