### PR TITLE
Editor: Text Sets Panel Keyboard Navigation

### DIFF
--- a/assets/src/design-system/components/index.js
+++ b/assets/src/design-system/components/index.js
@@ -35,5 +35,6 @@ export * from './tooltip';
 export * from './keyboard';
 export * from './keyboard/gridview';
 export * from './notificationBubble';
+export { Toggle } from './toggle';
 export { Display, Headline, Link, Text } from './typography';
 export { VisuallyHidden } from './visuallyHidden';

--- a/assets/src/edit-story/components/library/libraryLayout.js
+++ b/assets/src/edit-story/components/library/libraryLayout.js
@@ -38,7 +38,7 @@ const Layout = styled.section.attrs({
   display: flex;
   flex-direction: column;
   background-color: ${({ theme }) => theme.colors.bg.secondary};
-  color: ${({ theme }) => theme.DEPRECATED_THEME.colors.fg.white};
+  color: ${({ theme }) => theme.colors.fg.primary};
   max-height: 100%;
 `;
 

--- a/assets/src/edit-story/components/library/panes/pageLayouts/karma/pageLayoutsPane.karma.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/karma/pageLayoutsPane.karma.js
@@ -84,6 +84,45 @@ describe('CUJ: Page Layouts: Creator can Apply a Page Layout', () => {
     await fixture.snapshot('applied page layout');
   });
 
+  it('should apply page layout to an empty page using keyboard', async () => {
+    await fixture.editor.library.pageLayoutsTab.click();
+
+    await waitFor(() =>
+      expect(
+        fixture.editor.library.pageLayoutsPane.pageLayouts.length
+      ).toBeTruthy()
+    );
+
+    const { pageLayouts } = fixture.editor.library.pageLayoutsPane;
+    await fixture.events.focus(
+      fixture.editor.library.pageLayoutsPane.pageLayouts[0]
+    );
+
+    await fixture.events.keyboard.press('right');
+
+    await fixture.events.keyboard.press('down');
+
+    const activeTextSetId = pageLayouts[3].getAttribute('data-testid');
+    const documentTestId = document.activeElement.getAttribute('data-testid');
+
+    expect(activeTextSetId).toBe(documentTestId);
+    await fixture.events.keyboard.press('Enter');
+
+    // check that all elements have been applied
+    const currentPage = await fixture.renderHook(() =>
+      useStory(({ state }) => state.currentPage)
+    );
+    const cookingTemplate = formattedTemplatesArray.find(
+      (t) => t.title === 'Cooking'
+    );
+    const coverPage = cookingTemplate.pages.find(
+      (p) => p.pageLayoutType === 'cover'
+    );
+    expectPageLayoutEqual(currentPage, coverPage);
+
+    await fixture.snapshot('applied page layout');
+  });
+
   it('should confirm and apply layout to a page with changes', async () => {
     // Insert element to make the page have changes
     const insertElement = await fixture.renderHook(() => useInsertElement());

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
@@ -52,8 +52,7 @@ const PreviewPageWrapper = styled.div`
   height: ${({ pageSize }) => pageSize.containerHeight}px;
   width: ${({ pageSize }) => pageSize.width}px;
   z-index: -1;
-  background-color: ${({ theme }) =>
-    theme.DEPRECATED_THEME.colors.loading.primary};
+  background-color: ${({ theme }) => theme.colors.interactiveBg.secondary};
   border-radius: ${({ theme }) => theme.borders.radius.small};
   overflow: hidden;
 `;

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayout.js
@@ -98,7 +98,7 @@ function PageLayout(
   return (
     <PageLayoutWrapper
       pageSize={pageSize}
-      role="button"
+      role="listitem"
       ref={ref}
       tabIndex={0}
       onMouseEnter={handleSetHoverActive}

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayouts.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayouts.js
@@ -21,6 +21,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useVirtual } from 'react-virtual';
 import { trackEvent } from '@web-stories-wp/tracking';
+import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
@@ -166,6 +167,8 @@ function PageLayouts({ pages, parentRef }) {
           rowHeight={pageSize.containerHeight}
           paneLeft={PANE_PADDING}
           onFocus={handleGridFocus}
+          role="list"
+          aria-label={__('Page Layout Options', 'web-stories')}
         >
           {rowVirtualizer.virtualItems.map((virtualRow) =>
             columnVirtualizer.virtualItems.map((virtualColumn) => {

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayouts.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayouts.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useMemo, useRef, useEffect, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useVirtual } from 'react-virtual';
@@ -26,42 +26,28 @@ import { trackEvent } from '@web-stories-wp/tracking';
 /**
  * Internal dependencies
  */
-import { useFocusOut, useKeyDownEffect } from '../../../../../design-system';
 import { useStory } from '../../../../app';
 import { PAGE_RATIO, FULLBLEED_RATIO } from '../../../../constants';
 import { duplicatePage } from '../../../../elements';
-import useRovingTabIndex from '../../../../utils/useRovingTabIndex';
 
 import { UnitsProvider } from '../../../../units';
 import isDefaultPage from '../../../../utils/isDefaultPage';
-import useFocusCanvas from '../../../canvas/useFocusCanvas';
 import { PANE_PADDING } from '../shared';
+import {
+  getVirtualizedPageIndex,
+  useVirtualizedGridNavigation,
+  VirtualizedContainer,
+} from '../shared/virtualizedPanelGrid';
 import PageLayout from './pageLayout';
 import ConfirmPageLayoutDialog from './confirmPageLayoutDialog';
 
 const PAGE_LAYOUT_PANE_WIDTH = 158;
-const PAGE_LAYOUT_ROW_GAP = 12;
+export const PAGE_LAYOUT_ROW_GAP = 12;
 
 const PageLayoutsContainer = styled.div`
   height: ${({ height }) => `${height}px`};
   width: 100%;
   position: relative;
-`;
-
-const PageLayoutsVirtualizedContainer = styled.div`
-  position: absolute;
-  top: 0;
-  left: ${PANE_PADDING};
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-columns: ${({ pageSize }) => `
-    repeat(auto-fill, ${pageSize.width}px)`};
-  grid-template-rows: ${({ pageSize }) =>
-    `minmax(${pageSize.containerHeight}px, auto)`};
-  gap: ${PAGE_LAYOUT_ROW_GAP}px;
-  width: 100%;
-  height: 100%;
-  margin-top: 4px;
 `;
 
 function PageLayouts({ pages, parentRef }) {
@@ -76,9 +62,7 @@ function PageLayouts({ pages, parentRef }) {
   const pageRefs = useRef({});
 
   const [selectedPage, setSelectedPage] = useState();
-  const [activePageId, setActivePageId] = useState();
   const [isConfirming, setIsConfirming] = useState();
-  const [isPageLayoutsFocused, setIsPageLayoutsFocused] = useState(false);
 
   const pageIds = useMemo(() => pages.map((page) => page.id), [pages]);
 
@@ -120,17 +104,6 @@ function PageLayouts({ pages, parentRef }) {
     [requiresConfirmation, handleApplyPageLayout]
   );
 
-  const handleKeyboardPageClick = useCallback(
-    ({ key }, page) => {
-      if (key === 'Enter') {
-        if (isPageLayoutsFocused) {
-          handlePageClick(page);
-        }
-      }
-    },
-    [isPageLayoutsFocused, handlePageClick]
-  );
-
   const handleCloseDialog = useCallback(() => {
     setSelectedPage(null);
     setIsConfirming(false);
@@ -140,15 +113,6 @@ function PageLayouts({ pages, parentRef }) {
     handleApplyPageLayout(selectedPage);
     setIsConfirming(false);
   }, [selectedPage, handleApplyPageLayout]);
-
-  const handlePageFocus = useCallback(
-    (pageId) => {
-      if (activePageId !== pageId) {
-        setActivePageId(pageId);
-      }
-    },
-    [activePageId]
-  );
 
   const rowVirtualizer = useVirtual({
     size: Math.ceil((pages || []).length / 2),
@@ -170,62 +134,27 @@ function PageLayouts({ pages, parentRef }) {
     overscan: 0,
   });
 
-  /**
-   * useVirtual and useRovingTabIndex do not play well together but we need both!
-   * The Below useEffect is key to maintaining the proper focus for keyboard users.
-   * What happens is on "scroll" of the virtualized container useVirtual is grabbing more rows
-   * and these rows are fed through the rendered map to create page layouts that are visible to users.
-   * While it doesn't look like the DOM is updating, it is in fact updating.
-   * So the old refs get lost and the list gets new ones! By manually forcing focus and maintaining an object
-   * of pageRefs that are organized by page id (those don't update) we can make sure the focus stays where it's supposed to be.
-   * Checking for a difference in currentAvailableRows and assigning the matching ref to any change is just so that the effect hook will run when the virtualized list
-   * updates and reattach focus to the new instance of an already selected layout.
-   */
-  const currentAvailableRows = useMemo(() => rowVirtualizer.virtualItems, [
+  const {
+    activePageId,
+    handlePageLayoutFocus,
+    handlePageFocus,
+    isPageLayoutsFocused,
+  } = useVirtualizedGridNavigation({
     rowVirtualizer,
-  ]);
-  const currentAvailableRowsRef = useRef();
-
-  useEffect(() => {
-    if (currentAvailableRows !== currentAvailableRowsRef?.current) {
-      currentAvailableRowsRef.current = currentAvailableRows;
-    }
-
-    if (activePageId && isPageLayoutsFocused) {
-      pageRefs.current?.[activePageId]?.focus();
-    }
-  }, [activePageId, currentAvailableRows, isPageLayoutsFocused]);
-
-  const handlePageLayoutFocus = useCallback(() => {
-    if (!isPageLayoutsFocused) {
-      const newPageId = pageRefs.current?.[activePageId]
-        ? activePageId
-        : pageIds[0];
-
-      setActivePageId(newPageId);
-      setIsPageLayoutsFocused(true);
-      pageRefs.current?.[newPageId]?.focus();
-    }
-  }, [activePageId, isPageLayoutsFocused, pageIds]);
-
-  useRovingTabIndex({ ref: containerRef });
-
-  // Exit page layouts
-  const focusCanvas = useFocusCanvas();
-
-  const onTabKeyDown = useCallback(() => {
-    focusCanvas();
-    setIsPageLayoutsFocused(false);
-  }, [focusCanvas]);
-
-  useKeyDownEffect(containerRef, 'tab', onTabKeyDown, [onTabKeyDown]);
-
-  useFocusOut(
     containerRef,
-    () => {
-      setIsPageLayoutsFocused(false);
+    pageRefs,
+    pageIds,
+  });
+
+  const handleKeyboardPageClick = useCallback(
+    ({ key }, page) => {
+      if (key === 'Enter') {
+        if (isPageLayoutsFocused) {
+          handlePageClick(page);
+        }
+      }
     },
-    [isConfirming]
+    [isPageLayoutsFocused, handlePageClick]
   );
 
   return (
@@ -236,19 +165,22 @@ function PageLayouts({ pages, parentRef }) {
       }}
     >
       <PageLayoutsContainer height={rowVirtualizer.totalSize}>
-        <PageLayoutsVirtualizedContainer
+        <VirtualizedContainer
           height={rowVirtualizer.totalSize}
           ref={containerRef}
-          pageSize={pageSize}
+          columnWidth={pageSize.width}
+          rowHeight={pageSize.containerHeight}
           tab={0}
+          paneLeft={PANE_PADDING}
           onFocus={handlePageLayoutFocus}
         >
           {rowVirtualizer.virtualItems.map((virtualRow) =>
             columnVirtualizer.virtualItems.map((virtualColumn) => {
-              const pageIndex =
-                virtualColumn.index === 0
-                  ? virtualRow.index * 2
-                  : virtualRow.index * 2 + 1;
+              const pageIndex = getVirtualizedPageIndex({
+                virtualColumn,
+                virtualRow,
+              });
+
               const page = pages[pageIndex];
 
               if (!page) {
@@ -272,7 +204,7 @@ function PageLayouts({ pages, parentRef }) {
               );
             })
           )}
-        </PageLayoutsVirtualizedContainer>
+        </VirtualizedContainer>
         {isConfirming && (
           <ConfirmPageLayoutDialog
             onConfirm={handleConfirmDialog}

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
@@ -28,6 +28,7 @@ import { getTimeTracker, trackEvent } from '@web-stories-wp/tracking';
 import { useAPI } from '../../../../app/api';
 import { Pane } from '../shared';
 import PillGroup from '../shared/pillGroup';
+import { virtualPaneContainer } from '../shared/virtualizedPanelGrid';
 import paneId from './paneId';
 import PageLayouts from './pageLayouts';
 import { PAGE_LAYOUT_TYPES } from './constants';
@@ -44,13 +45,11 @@ export const PaneInner = styled.div`
   flex-direction: column;
 `;
 
-// padding-top is to help outlines on page layouts render
+// padding-top is to help outlines on page layouts
 export const PageLayoutsParentContainer = styled.div`
+  ${virtualPaneContainer}
   overflow-x: hidden;
   overflow-y: scroll;
-  margin-top: 26px;
-  padding-top: 2px;
-  width: 100%;
 `;
 
 function PageLayoutsPane(props) {

--- a/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
+++ b/assets/src/edit-story/components/library/panes/pageLayouts/pageLayoutsPane.js
@@ -45,7 +45,6 @@ export const PaneInner = styled.div`
   flex-direction: column;
 `;
 
-// padding-top is to help outlines on page layouts
 export const PageLayoutsParentContainer = styled.div`
   ${virtualPaneContainer}
   overflow-x: hidden;

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/components.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/components.js
@@ -17,19 +17,30 @@
 /**
  * External dependencies
  */
+import styled, { css } from 'styled-components';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
 
-// TODO params
-/**
- * VirtualizedContainer is the last accessible parent before virtualizedRows and columns are in play.
- *
- * @param root0
- * @param root0.paneLeft
- * @param root0.columnWidth
- * @param root0.rowHeight
- * @param root0.rowGap
- */
+export const PANEL_GRID_ROW_GAP = 12;
+
+// padding-top is to help outlines on text sets
+export const virtualPaneContainer = css`
+  margin-top: 38px;
+  padding-top: 2px;
+  width: 100%;
+  height: 100%;
+`;
+
+// Contains mapped over useVirtual rows
+export const VirtualizedWrapper = styled.div`
+  height: ${({ height }) => `${height}px`};
+  width: 100%;
+  position: relative;
+`;
+VirtualizedWrapper.propTypes = {
+  height: PropTypes.number.isRequired,
+};
+
+// VirtualizedContainer is the last accessible parent before virtualizedRows and columns are in play.
 export const VirtualizedContainer = styled.div`
   position: absolute;
   top: 0;

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/components.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/components.js
@@ -60,7 +60,7 @@ VirtualizedContainer.propTypes = {
   columnWidth: PropTypes.number.isRequired,
   rowHeight: PropTypes.number.isRequired,
   rowGap: PropTypes.number,
-  paneLeft: PropTypes.number,
+  paneLeft: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 VirtualizedContainer.defaultProps = {
   rowGap: 12,

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/getVirtualizedItemIndex.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/getVirtualizedItemIndex.js
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
-// TODO NOTES & TESTS
-export const getVirtualizedPageIndex = ({ virtualColumn, virtualRow }) =>
-  virtualColumn.index === 0 ? virtualRow.index * 2 : virtualRow.index * 2 + 1;
+/**
+ * @param {Object} props       All props.
+ * @param {number} props.rowIndex    Identifies the virtualized row index.
+ * @param {number} props.columnIndex Identifies the virtualized column index.
+ * @return {number} itemIndex  Returns the true index of an item in a virtualized grid
+ */
+export const getVirtualizedItemIndex = ({ columnIndex, rowIndex }) =>
+  columnIndex === 0 ? rowIndex * 2 : rowIndex * 2 + 1;

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/getVirtualizedItemIndex.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/getVirtualizedItemIndex.js
@@ -15,10 +15,10 @@
  */
 
 /**
- * @param {Object} props       All props.
+ * @param {Object} props             All props.
  * @param {number} props.rowIndex    Identifies the virtualized row index.
  * @param {number} props.columnIndex Identifies the virtualized column index.
- * @return {number} itemIndex  Returns the true index of an item in a virtualized grid
+ * @return {number} itemIndex        Returns the true index of an item in a virtualized grid
  */
 export const getVirtualizedItemIndex = ({ columnIndex, rowIndex }) =>
   columnIndex === 0 ? rowIndex * 2 : rowIndex * 2 + 1;

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/getVirtualizedPageIndex.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/getVirtualizedPageIndex.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO NOTES & TESTS
+export const getVirtualizedPageIndex = ({ virtualColumn, virtualRow }) =>
+  virtualColumn.index === 0 ? virtualRow.index * 2 : virtualRow.index * 2 + 1;

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/index.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/index.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { VirtualizedContainer } from './virtualizedContainer';
 export { default as useVirtualizedGridNavigation } from './useVirtualizedGridNavigation';
-export { getVirtualizedPageIndex } from './getVirtualizedPageIndex';
+export { getVirtualizedItemIndex } from './getVirtualizedItemIndex';
+export * from './components';

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/index.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/index.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { default as useVirtualizedGridNavigation } from './useVirtualizedGridNavigation';
-export { getVirtualizedItemIndex } from './getVirtualizedItemIndex';
 export * from './components';
+export { getVirtualizedItemIndex } from './getVirtualizedItemIndex';
+export { default as useVirtualizedGridNavigation } from './useVirtualizedGridNavigation';

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/index.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/index.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { VirtualizedContainer } from './virtualizedContainer';
+export { default as useVirtualizedGridNavigation } from './useVirtualizedGridNavigation';
+export { getVirtualizedPageIndex } from './getVirtualizedPageIndex';

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/test/getVirtualizedItemIndex.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/test/getVirtualizedItemIndex.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getVirtualizedItemIndex } from '../getVirtualizedItemIndex';
+
+describe('getVirtualizedItemIndex', () => {
+  it.each`
+    rowIndex | columnIndex | returnedGridIndex
+    ${0}     | ${0}        | ${0}
+    ${0}     | ${1}        | ${1}
+    ${1}     | ${0}        | ${2}
+    ${1}     | ${1}        | ${3}
+    ${2}     | ${0}        | ${4}
+    ${2}     | ${1}        | ${5}
+    ${3}     | ${0}        | ${6}
+    ${10}    | ${0}        | ${20}
+    ${10}    | ${1}        | ${21}
+    ${49}    | ${1}        | ${99}
+    ${101}   | ${0}        | ${202}
+  `(
+    'Should return `$returnedGridIndex` when columnIndex is `$columnIndex` and rowIndex is `$rowIndex`',
+    ({ rowIndex, columnIndex, returnedGridIndex }) => {
+      expect(getVirtualizedItemIndex({ rowIndex, columnIndex })).toStrictEqual(
+        returnedGridIndex
+      );
+    }
+  );
+});

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/test/useVirtualizedGridNavigation.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/test/useVirtualizedGridNavigation.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+import { createRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import useVirtualizedGridNavigation from '../useVirtualizedGridNavigation';
+
+describe('useVirtualizedGridNavigation()', function () {
+  it('should initially return focus booleans as false', function () {
+    const { result } = renderHook(
+      () =>
+        useVirtualizedGridNavigation({
+          containerRef: createRef(),
+          gridItemRefs: { current: [] },
+          gritItemIds: [],
+          rowVirtualizer: { virtualItems: [] },
+        }),
+      {}
+    );
+
+    expect(result.current.activeGridItemId).toBeUndefined();
+    expect(result.current.isGridFocused).toBe(false);
+  });
+
+  it('should update isGridFocused to true and set activeGridItemId to first index when handleGridFocus is called', function () {
+    const { result } = renderHook(
+      () =>
+        useVirtualizedGridNavigation({
+          containerRef: createRef(),
+          gridItemRefs: { current: [] },
+          gridItemIds: ['one', 'two', 'three'],
+          rowVirtualizer: { virtualItems: [] },
+        }),
+      {}
+    );
+
+    act(() => {
+      result.current.handleGridFocus();
+    });
+
+    expect(result.current.activeGridItemId).toBe('one');
+    expect(result.current.isGridFocused).toBe(true);
+  });
+
+  it('should update activeGridItemId when handleGridItemFocus is called', function () {
+    const { result } = renderHook(
+      () =>
+        useVirtualizedGridNavigation({
+          containerRef: createRef(),
+          gridItemRefs: { current: [] },
+          gridItemIds: ['one', 'two', 'three'],
+          rowVirtualizer: { virtualItems: [] },
+        }),
+      {}
+    );
+    expect(result.current.activeGridItemId).toBeUndefined();
+
+    act(() => {
+      result.current.handleGridItemFocus('two');
+    });
+
+    expect(result.current.activeGridItemId).toBe('two');
+  });
+});

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/useVirtualizedGridNavigation.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/useVirtualizedGridNavigation.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { useFocusOut, useKeyDownEffect } from '../../../../../../design-system';
+import useRovingTabIndex from '../../../../../utils/useRovingTabIndex';
+import useFocusCanvas from '../../../../canvas/useFocusCanvas';
+
+// todo add notes
+/**
+ * useVirtual and useRovingTabIndex do not play well together but we need both!
+ * The below useEffect is key to maintaining the proper focus for keyboard users.
+ * What happens is on "scroll" of the virtualized container useVirtual is grabbing more rows
+ * and these rows are fed through the rendered map to create page layouts that are visible to users.
+ * While it doesn't look like the DOM is updating, it is in fact updating.
+ * So the old refs get lost and the list gets new ones! By manually forcing focus and maintaining an object
+ * of pageRefs that are organized by page id (those don't update) we can make sure the focus stays where it's supposed to be.
+ * Checking for a difference in currentAvailableRows and assigning the matching ref to any change is just so that the effect hook will run when the virtualized list
+ * updates and reattach focus to the new instance of an already selected layout.
+ */
+
+export default function useVirtualizedGridNavigation({
+  containerRef,
+  pageRefs,
+  pageIds,
+  rowVirtualizer,
+}) {
+  const [activePageId, setActivePageId] = useState();
+
+  const [isPageLayoutsFocused, setIsPageLayoutsFocused] = useState(false);
+  const currentAvailableRows = useMemo(() => rowVirtualizer.virtualItems, [
+    rowVirtualizer,
+  ]);
+  const currentAvailableRowsRef = useRef();
+
+  useEffect(() => {
+    if (currentAvailableRows !== currentAvailableRowsRef?.current) {
+      currentAvailableRowsRef.current = currentAvailableRows;
+    }
+
+    if (activePageId && isPageLayoutsFocused) {
+      pageRefs.current?.[activePageId]?.focus();
+    }
+  }, [activePageId, currentAvailableRows, isPageLayoutsFocused, pageRefs]);
+
+  useRovingTabIndex({ ref: containerRef });
+
+  const handlePageLayoutFocus = useCallback(() => {
+    if (!isPageLayoutsFocused) {
+      const newPageId = pageRefs.current?.[activePageId]
+        ? activePageId
+        : pageIds[0];
+
+      setActivePageId(newPageId);
+      setIsPageLayoutsFocused(true);
+      pageRefs.current?.[newPageId]?.focus();
+    }
+  }, [activePageId, isPageLayoutsFocused, pageIds, pageRefs]);
+
+  const handlePageFocus = useCallback(
+    (pageId) => {
+      if (activePageId !== pageId) {
+        setActivePageId(pageId);
+      }
+    },
+    [activePageId]
+  );
+
+  // Exit page layouts
+  const focusCanvas = useFocusCanvas();
+
+  const onTabKeyDown = useCallback(() => {
+    focusCanvas();
+    setIsPageLayoutsFocused(false);
+  }, [focusCanvas]);
+
+  useKeyDownEffect(containerRef, 'tab', onTabKeyDown, [onTabKeyDown]);
+
+  useFocusOut(
+    containerRef,
+    () => {
+      setIsPageLayoutsFocused(false);
+    },
+    []
+  );
+
+  return useMemo(
+    () => ({
+      handlePageLayoutFocus,
+      handlePageFocus,
+      activePageId,
+      isPageLayoutsFocused,
+    }),
+    [activePageId, isPageLayoutsFocused, handlePageLayoutFocus, handlePageFocus]
+  );
+}

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/useVirtualizedGridNavigation.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/useVirtualizedGridNavigation.js
@@ -83,7 +83,7 @@ export default function useVirtualizedGridNavigation({
     if (!isGridFocused) {
       const newGridItemId = gridItemRefs.current?.[activeGridItemId]
         ? activeGridItemId
-        : gridItemIds[0];
+        : gridItemIds?.[0];
 
       setActiveGridItemId(newGridItemId);
       setIsGridFocused(true);

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/useVirtualizedGridNavigation.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/useVirtualizedGridNavigation.js
@@ -60,10 +60,10 @@ export default function useVirtualizedGridNavigation({
    * useVirtual and useRovingTabIndex do not play well together but we need both!
    * The below useEffect is key to maintaining the proper focus for keyboard users.
    * What happens is on "scroll" of the virtualized container useVirtual is grabbing more rows
-   * and these rows are fed through the rendered map to create page layouts that are visible to users.
+   * and these rows are fed through the rendered map to create grid that is visible to users.
    * While it doesn't look like the DOM is updating, it is in fact updating.
    * So the old refs get lost and the list gets new ones! By manually forcing focus and maintaining an object
-   * of gridItemRefs that are organized by page id (those don't update) we can make sure the focus stays where it's supposed to be.
+   * of gridItemRefs that are organized by gridItem id (those don't update) we can make sure the focus stays where it's supposed to be.
    * Checking for a difference in currentAvailableRows and assigning the matching ref to any change is just so that the effect hook will run when the virtualized list
    * updates and reattach focus to the new instance of an already selected layout.
    */
@@ -81,26 +81,26 @@ export default function useVirtualizedGridNavigation({
 
   const handleGridFocus = useCallback(() => {
     if (!isGridFocused) {
-      const newPageId = gridItemRefs.current?.[activeGridItemId]
+      const newGridItemId = gridItemRefs.current?.[activeGridItemId]
         ? activeGridItemId
         : gridItemIds[0];
 
-      setActiveGridItemId(newPageId);
+      setActiveGridItemId(newGridItemId);
       setIsGridFocused(true);
-      gridItemRefs.current?.[newPageId]?.focus();
+      gridItemRefs.current?.[newGridItemId]?.focus();
     }
   }, [activeGridItemId, isGridFocused, gridItemIds, gridItemRefs]);
 
   const handleGridItemFocus = useCallback(
-    (pageId) => {
-      if (activeGridItemId !== pageId) {
-        setActiveGridItemId(pageId);
+    (itemId) => {
+      if (activeGridItemId !== itemId) {
+        setActiveGridItemId(itemId);
       }
     },
     [activeGridItemId]
   );
 
-  // Exit page layouts
+  // Exit grid
   const focusCanvas = useFocusCanvas();
 
   const onTabKeyDown = useCallback(() => {

--- a/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/virtualizedContainer.js
+++ b/assets/src/edit-story/components/library/panes/shared/virtualizedPanelGrid/virtualizedContainer.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+// TODO params
+/**
+ * VirtualizedContainer is the last accessible parent before virtualizedRows and columns are in play.
+ *
+ * @param root0
+ * @param root0.paneLeft
+ * @param root0.columnWidth
+ * @param root0.rowHeight
+ * @param root0.rowGap
+ */
+export const VirtualizedContainer = styled.div`
+  position: absolute;
+  top: 0;
+  left: ${({ paneLeft }) => paneLeft};
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-columns: ${({ columnWidth }) => `
+    repeat(auto-fill, ${columnWidth}px)`};
+  grid-template-rows: ${({ rowHeight }) => `minmax(${rowHeight}px, auto)`};
+  gap: ${({ rowGap }) => rowGap}px;
+  width: 100%;
+  height: 100%;
+  margin-top: 4px;
+`;
+
+VirtualizedContainer.propTypes = {
+  columnWidth: PropTypes.number.isRequired,
+  rowHeight: PropTypes.number.isRequired,
+  rowGap: PropTypes.number,
+  paneLeft: PropTypes.number,
+};
+VirtualizedContainer.defaultProps = {
+  rowGap: 12,
+  paneLeft: 0,
+};

--- a/assets/src/edit-story/components/library/panes/text/karma/textSets.cuj.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/karma/textSets.cuj.karma.js
@@ -63,6 +63,29 @@ describe('CUJ: Text Sets (Text and Shape Combinations): Using Text Sets', () => 
     expect(selection.length).toBeGreaterThan(1);
   });
 
+  it('should allow inserting text set by keyboard', async () => {
+    await waitFor(
+      () => expect(fixture.editor.library.text.textSets.length).toBeTruthy(),
+      { timeout: 2000 }
+    );
+    const textSets = fixture.editor.library.text.textSets;
+
+    await fixture.events.focus(textSets[0]);
+
+    await fixture.events.keyboard.press('down');
+
+    const activeTextSetId = textSets[2].getAttribute('data-testid');
+    const documentTestId = document.activeElement.getAttribute('data-testid');
+
+    expect(activeTextSetId).toBe(documentTestId);
+    await fixture.events.keyboard.press('Enter');
+
+    const storyContext = await fixture.renderHook(() => useStory());
+    const selection = storyContext.state.selectedElements;
+    // Text sets contain at least 2 elements.
+    expect(selection.length).toBeGreaterThan(1);
+  });
+
   // Disable reason: flakey tests.
   // See https://github.com/google/web-stories-wp/pull/6162
   // eslint-disable-next-line jasmine/no-disabled-tests

--- a/assets/src/edit-story/components/library/panes/text/textPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textPane.js
@@ -33,7 +33,7 @@ import { Pane as SharedPane } from '../shared';
 import paneId from './paneId';
 import { PRESETS } from './textPresets';
 import useInsertPreset from './useInsertPreset';
-import TextSets from './textSets';
+import TextSetsPane from './textSets/textSetsPane';
 
 // Relative position needed for Moveable to update its position properly.
 const Pane = styled(SharedPane)`
@@ -96,7 +96,7 @@ function TextPane(props) {
           />
         ))}
       </Section>
-      {paneRef.current && <TextSets paneRef={paneRef} />}
+      {paneRef.current && <TextSetsPane paneRef={paneRef} />}
     </Pane>
   );
 }

--- a/assets/src/edit-story/components/library/panes/text/textSets/constants.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/constants.js
@@ -18,6 +18,10 @@
  * External dependencies
  */
 import { __ } from '@web-stories-wp/i18n';
+/**
+ * Internal dependencies
+ */
+import { PAGE_RATIO, TEXT_SET_SIZE } from '../../../../../constants';
 
 export const CATEGORIES = {
   contact: __('Contact', 'web-stories'),
@@ -34,3 +38,10 @@ export const PANE_TEXT = {
   TITLE: __('Text Sets', 'web-stories'),
   SWITCH_LABEL: __('Match fonts from story', 'web-stories'),
 };
+
+export const TEXT_SET_PAGE_SIZE = {
+  width: TEXT_SET_SIZE,
+  height: TEXT_SET_SIZE / PAGE_RATIO,
+};
+
+export { TEXT_SET_SIZE };

--- a/assets/src/edit-story/components/library/panes/text/textSets/constants.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/constants.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
+
+export const CATEGORIES = {
+  contact: __('Contact', 'web-stories'),
+  editorial: __('Editorial', 'web-stories'),
+  list: __('List', 'web-stories'),
+  cover: __('Cover', 'web-stories'),
+  section_header: __('Header', 'web-stories'),
+  step: __('Steps', 'web-stories'),
+  table: __('Table', 'web-stories'),
+  quote: __('Quote', 'web-stories'),
+};
+
+export const PANE_TEXT = {
+  TITLE: __('Text Sets', 'web-stories'),
+  SWITCH_LABEL: __('Match fonts from story', 'web-stories'),
+};
+
+export const TEXT_SET_ROW_GAP = 12;

--- a/assets/src/edit-story/components/library/panes/text/textSets/constants.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/constants.js
@@ -34,5 +34,3 @@ export const PANE_TEXT = {
   TITLE: __('Text Sets', 'web-stories'),
   SWITCH_LABEL: __('Match fonts from story', 'web-stories'),
 };
-
-export const TEXT_SET_ROW_GAP = 12;

--- a/assets/src/edit-story/components/library/panes/text/textSets/test/textSetsPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/test/textSetsPane.js
@@ -28,7 +28,7 @@ import APIContext from '../../../../../../app/api/context';
 import ConfigContext from '../../../../../../app/config/context';
 import { renderWithTheme } from '../../../../../../testUtils';
 import StoryContext from '../../../../../../app/story/context';
-import TextSets from '../textSets';
+import TextSetsPane from '../textSetsPane';
 
 function setup() {
   const libraryValue = {
@@ -73,7 +73,7 @@ function setup() {
             <FontContext.Provider value={fontsValue}>
               <LibraryContext.Provider value={libraryValue}>
                 <MockPane>
-                  {(paneRef) => <TextSets paneRef={paneRef} />}
+                  {(paneRef) => <TextSetsPane paneRef={paneRef} />}
                 </MockPane>
               </LibraryContext.Provider>
             </FontContext.Provider>

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
@@ -98,7 +98,7 @@ function TextSet({ elements, translateY, translateX, ...rest }, ref) {
   const dragHeight = dataToEditorY(textSetHeight, pageHeight);
   return (
     <TextSetItem
-      role="button"
+      role="listitem"
       tabIndex={0}
       aria-label={__('Insert Text Set', 'web-stories')}
       translateX={translateX}

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
@@ -41,7 +41,6 @@ const TextSetItem = styled.div`
   width: ${TEXT_SET_SIZE}px;
   display: flex;
   flex-direction: column;
-  cursor: pointer;
   transform: ${({ translateX, translateY }) =>
     `translateX(${translateX}px) translateY(${translateY}px)`};
 
@@ -50,6 +49,7 @@ const TextSetItem = styled.div`
   background-color: ${({ theme }) =>
     theme.colors.interactiveBg.secondaryNormal};
   border-radius: ${({ theme }) => theme.borders.radius.small};
+  cursor: default;
 
   &:hover {
     background-color: ${({ theme }) =>

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
@@ -17,34 +17,47 @@
 /**
  * External dependencies
  */
-import { rgba } from 'polished';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { __ } from '@web-stories-wp/i18n';
 import { trackEvent } from '@web-stories-wp/tracking';
-import { useCallback } from 'react';
+import { useCallback, forwardRef } from 'react';
 
 /**
  * Internal dependencies
  */
+import { themeHelpers } from '../../../../../../design-system';
 import { useLayout } from '../../../../../app/layout';
 import { TEXT_SET_SIZE } from '../../../../../constants';
-import { KEYBOARD_USER_SELECTOR } from '../../../../../utils/keyboardOnlyOutline';
 import useLibrary from '../../../useLibrary';
 import { dataToEditorX, dataToEditorY } from '../../../../../units';
 import LibraryMoveable from '../../shared/libraryMoveable';
 import TextSetElements from './textSetElements';
 
 const TextSetItem = styled.div`
-  position: relative;
-  width: ${TEXT_SET_SIZE}px;
+  position: absolute;
+  top: 0;
   height: ${TEXT_SET_SIZE}px;
-  background-color: ${({ theme }) =>
-    rgba(theme.DEPRECATED_THEME.colors.bg.white, 0.07)};
-  border-radius: 4px;
+  width: ${TEXT_SET_SIZE}px;
+  display: flex;
+  flex-direction: column;
   cursor: pointer;
-  ${KEYBOARD_USER_SELECTOR} &:focus {
-    outline: -webkit-focus-ring-color auto 2px;
+  transform: ${({ translateX, translateY }) =>
+    `translateX(${translateX}px) translateY(${translateY}px)`};
+
+  ${themeHelpers.focusableOutlineCSS};
+
+  background-color: ${({ theme }) =>
+    theme.colors.interactiveBg.secondaryNormal};
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+
+  &:hover {
+    background-color: ${({ theme }) =>
+      theme.colors.interactiveBg.secondaryHover};
+  }
+  &:active {
+    background-color: ${({ theme }) =>
+      theme.colors.interactiveBg.secondaryPress};
   }
 `;
 
@@ -53,11 +66,10 @@ const DragContainer = styled.div`
   opacity: 0;
   width: ${({ width }) => width}px;
   height: ${({ height }) => height}px;
-  background-color: ${({ theme }) =>
-    rgba(theme.DEPRECATED_THEME.colors.bg.white, 0.2)};
+  background-color: ${({ theme }) => theme.colors.opacity.white24};
 `;
 
-function TextSet({ elements }) {
+function TextSet({ elements, translateY, translateX, ...rest }, ref) {
   const { insertTextSet } = useLibrary((state) => ({
     insertTextSet: state.actions.insertTextSet,
   }));
@@ -71,14 +83,29 @@ function TextSet({ elements }) {
     trackEvent('insert_textset');
   }, [elements, insertTextSet]);
 
+  const handleKeyboardPageClick = useCallback(
+    ({ key }) => {
+      if (key === 'Enter') {
+        onClick();
+      }
+    },
+    [onClick]
+  );
+
   const { textSetHeight, textSetWidth } = elements[0];
   const { width: pageWidth, height: pageHeight } = canvasPageSize;
   const dragWidth = dataToEditorX(textSetWidth, pageWidth);
   const dragHeight = dataToEditorY(textSetHeight, pageHeight);
   return (
     <TextSetItem
-      role="listitem"
+      role="button"
+      tabIndex={0}
       aria-label={__('Insert Text Set', 'web-stories')}
+      translateX={translateX}
+      translateY={translateY}
+      ref={ref}
+      onKeyUp={handleKeyboardPageClick}
+      {...rest}
     >
       <TextSetElements isForDisplay elements={elements} />
       <LibraryMoveable
@@ -111,6 +138,10 @@ function TextSet({ elements }) {
 
 TextSet.propTypes = {
   elements: PropTypes.array.isRequired,
+  translateY: PropTypes.number.isRequired,
+  translateX: PropTypes.number.isRequired,
 };
 
-export default TextSet;
+TextSet.displayName = 'TextSet';
+
+export default forwardRef(TextSet);

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -20,6 +20,7 @@
 import { useMemo, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useVirtual } from 'react-virtual';
+import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
@@ -85,6 +86,8 @@ function TextSets({ paneRef, filteredTextSets }) {
           columnWidth={TEXT_SET_SIZE}
           rowHeight={TEXT_SET_SIZE}
           onFocus={handleGridFocus}
+          role="list"
+          aria-label={__('Text Set Options', 'web-stories')}
         >
           {rowVirtualizer.virtualItems.map((virtualRow) =>
             columnVirtualizer.virtualItems.map((virtualColumn) => {
@@ -123,12 +126,12 @@ function TextSets({ paneRef, filteredTextSets }) {
 
 TextSets.propTypes = {
   paneRef: PropTypes.object,
-  filteredTextSets: PropTypes.shape([
-    {
+  filteredTextSets: PropTypes.arrayOf(
+    PropTypes.shape({
       id: PropTypes.string,
       elements: PropTypes.array,
-    },
-  ]),
+    })
+  ),
 };
 
 export default TextSets;

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSets.js
@@ -26,7 +26,6 @@ import { __ } from '@web-stories-wp/i18n';
  * Internal dependencies
  */
 import { UnitsProvider } from '../../../../../units';
-import { PAGE_RATIO, TEXT_SET_SIZE } from '../../../../../constants';
 import {
   getVirtualizedItemIndex,
   useVirtualizedGridNavigation,
@@ -35,6 +34,7 @@ import {
   VirtualizedWrapper,
 } from '../../shared/virtualizedPanelGrid';
 import TextSet from './textSet';
+import { TEXT_SET_PAGE_SIZE, TEXT_SET_SIZE } from './constants';
 
 function TextSets({ paneRef, filteredTextSets }) {
   const containerRef = useRef();
@@ -73,12 +73,7 @@ function TextSets({ paneRef, filteredTextSets }) {
   });
 
   return (
-    <UnitsProvider
-      pageSize={{
-        width: TEXT_SET_SIZE,
-        height: TEXT_SET_SIZE / PAGE_RATIO,
-      }}
-    >
+    <UnitsProvider pageSize={TEXT_SET_PAGE_SIZE}>
       <VirtualizedWrapper height={rowVirtualizer.totalSize}>
         <VirtualizedContainer
           height={rowVirtualizer.totalSize}

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
@@ -44,6 +44,7 @@ import {
   getTextSetsForFonts,
 } from '../../../../../utils/getInUseFonts';
 import { Container as SectionContainer } from '../../../common/section';
+import { virtualPaneContainer } from '../../shared/virtualizedPanelGrid';
 import TextSets from './textSets';
 import { CATEGORIES, PANE_TEXT } from './constants';
 
@@ -61,10 +62,7 @@ const TextSetsToggle = styled.div`
 `;
 
 const TextSetsWrapper = styled.div`
-  margin-top: 26px;
-  padding-top: 2px;
-  width: 100%;
-  height: 100%;
+  ${virtualPaneContainer};
 `;
 
 function TextSetsPane({ paneRef }) {

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useState, useMemo, useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { v4 as uuidv4 } from 'uuid';
+import { trackEvent } from '@web-stories-wp/tracking';
+
+/**
+ * Internal dependencies
+ */
+import {
+  THEME_CONSTANTS,
+  Text,
+  Toggle,
+  Headline,
+} from '../../../../../../design-system';
+import { FullWidthWrapper } from '../../common/styles';
+import PillGroup from '../../shared/pillGroup';
+import localStore, {
+  LOCAL_STORAGE_PREFIX,
+} from '../../../../../utils/localStore';
+import useLibrary from '../../../useLibrary';
+import useStory from '../../../../../app/story/useStory';
+import {
+  getInUseFontsForPages,
+  getTextSetsForFonts,
+} from '../../../../../utils/getInUseFonts';
+import { Container as SectionContainer } from '../../../common/section';
+import TextSets from './textSets';
+import { CATEGORIES, PANE_TEXT } from './constants';
+
+const TitleBar = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 20px 0;
+`;
+
+const TextSetsToggle = styled.div`
+  display: flex;
+  p {
+    margin: auto 12px;
+  }
+`;
+
+const TextSetsWrapper = styled.div`
+  margin-top: 26px;
+  padding-top: 2px;
+  width: 100%;
+  height: 100%;
+`;
+
+function TextSetsPane({ paneRef }) {
+  const { textSets } = useLibrary(({ state: { textSets } }) => ({ textSets }));
+  const [showInUse, setShowInUse] = useState(false);
+
+  const allTextSets = useMemo(() => Object.values(textSets).flat(), [textSets]);
+  const storyPages = useStory(({ state: { pages } }) => pages);
+
+  const [selectedCat, setSelectedCat] = useState(
+    localStore.getItemByKey(`${LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS}`)
+      ?.selectedCategory
+  );
+
+  const getTextSetsForInUseFonts = useCallback(
+    () =>
+      getTextSetsForFonts({
+        fonts: getInUseFontsForPages(storyPages),
+        textSets: selectedCat ? textSets[selectedCat] : allTextSets,
+      }),
+    [allTextSets, storyPages, selectedCat, textSets]
+  );
+
+  const addIdToTextSets = useCallback(
+    (sets) =>
+      sets.map((elements) => {
+        return {
+          id: `text_set_${uuidv4()}`,
+          elements,
+        };
+      }),
+    []
+  );
+  const filteredTextSets = useMemo(() => {
+    if (showInUse) {
+      return addIdToTextSets(getTextSetsForInUseFonts());
+    }
+    return addIdToTextSets(selectedCat ? textSets[selectedCat] : allTextSets);
+  }, [
+    selectedCat,
+    textSets,
+    allTextSets,
+    addIdToTextSets,
+    getTextSetsForInUseFonts,
+    showInUse,
+  ]);
+
+  const categories = useMemo(
+    () => [
+      ...Object.keys(textSets).map((cat) => ({
+        id: cat,
+        label: CATEGORIES[cat] ?? cat,
+      })),
+    ],
+    [textSets]
+  );
+
+  const handleSelectedCategory = useCallback((selectedCategory) => {
+    setSelectedCat(selectedCategory);
+    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS}`, {
+      selectedCategory,
+    });
+  }, []);
+
+  const onChangeShowInUse = useCallback(
+    () => requestAnimationFrame(() => setShowInUse((prevVal) => !prevVal)),
+    [setShowInUse]
+  );
+
+  useEffect(() => {
+    trackEvent('search', {
+      search_type: 'textsets',
+      search_term: '',
+      search_category: selectedCat,
+      search_filter: showInUse ? 'show_in_use' : undefined,
+    });
+  }, [selectedCat, showInUse]);
+
+  const sectionId = useMemo(() => `section-${uuidv4()}`, []);
+  const toggleId = useMemo(() => `toggle_text_sets_${uuidv4()}`, []);
+  return (
+    <SectionContainer id={sectionId}>
+      <TitleBar>
+        <Headline size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.XX_SMALL}>
+          {PANE_TEXT.TITLE}
+        </Headline>
+        <TextSetsToggle>
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
+            {PANE_TEXT.SWITCH_LABEL}
+          </Text>
+          <Toggle
+            id={toggleId}
+            aria-label={PANE_TEXT.SWITCH_LABEL}
+            name={toggleId}
+            checked={showInUse}
+            onChange={onChangeShowInUse}
+            label={PANE_TEXT.SWITCH_LABEL}
+          />
+        </TextSetsToggle>
+      </TitleBar>
+      <FullWidthWrapper>
+        <PillGroup
+          items={categories}
+          selectedItemId={selectedCat}
+          selectItem={handleSelectedCategory}
+          deselectItem={() => handleSelectedCategory(null)}
+        />
+      </FullWidthWrapper>
+      <TextSetsWrapper>
+        <TextSets paneRef={paneRef} filteredTextSets={filteredTextSets} />
+      </TextSetsWrapper>
+    </SectionContainer>
+  );
+}
+
+TextSetsPane.propTypes = {
+  paneRef: PropTypes.object,
+};
+
+export default TextSetsPane;

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
@@ -87,8 +87,8 @@ function TextSetsPane({ paneRef }) {
   );
 
   const addIdToTextSets = useCallback(
-    (sets) =>
-      sets.map((elements) => {
+    (textSetsArray) =>
+      textSetsArray.map((elements) => {
         return {
           id: `text_set_${uuidv4()}`,
           elements,
@@ -112,9 +112,9 @@ function TextSetsPane({ paneRef }) {
 
   const categories = useMemo(
     () => [
-      ...Object.keys(textSets).map((cat) => ({
-        id: cat,
-        label: CATEGORIES[cat] ?? cat,
+      ...Object.keys(textSets).map((category) => ({
+        id: category,
+        label: CATEGORIES[category] ?? category,
       })),
     ],
     [textSets]
@@ -146,7 +146,10 @@ function TextSetsPane({ paneRef }) {
   return (
     <SectionContainer id={sectionId}>
       <TitleBar>
-        <Headline size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.XX_SMALL}>
+        <Headline
+          as="h3"
+          size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.XX_SMALL}
+        >
           {PANE_TEXT.TITLE}
         </Headline>
         <TextSetsToggle>

--- a/assets/src/edit-story/karma/fixture/containers/library/pageLayouts.js
+++ b/assets/src/edit-story/karma/fixture/containers/library/pageLayouts.js
@@ -25,10 +25,10 @@ export default class PageLayouts extends Container {
   }
 
   get pageLayouts() {
-    return this.getAllByRole('button');
+    return this.getAllByRole('listitem');
   }
 
   pageLayout(name) {
-    return this.getByRole('button', { name });
+    return this.getByRole('listitem', { name });
   }
 }


### PR DESCRIPTION
## Context

Previously the text sets were a tab trap, now you can use arrows to navigate through them.

## Summary

Enables users to tab to text sets and then use arrow keys (up, down, left, right) to go through options. Tab again to focus out of text sets onto the canvas (just like page layouts).

## Relevant Technical Choices

- Pulled the original solution for this out of pageLayouts and into a shared `virtualizedGridPanel` directory since they needed the same code. Figure we might have more virtualized lists in the future. 
- Cleaned code up to be more generic instead of for 'pageLayouts'.
- Updated a _few_ styles to the new design system but not everything. The ticket for that update is: #6214 - I wanted this a11y fix to go through without getting caught up in design. 


## To-do

- Came across a bug on the new toggle button for RTL, made a separate ticket:  #6548
- Unsure of proper aria labeling for text sets, ticket here: #6517 

## User-facing changes

Text Sets are now navigable by keyboard arrows 🎉  

![text set keyboard nav](https://user-images.githubusercontent.com/10720454/109366329-66106780-7850-11eb-8e89-22daf416e1b9.gif)
![minor style updates](https://user-images.githubusercontent.com/10720454/109366333-67da2b00-7850-11eb-9cd3-5178b673a02b.gif)


## Testing Instructions

- Go to editor and then the text panel. 
- Navigate to text sets with keyboard (`tab`), now use arrow keys to go through text sets. 
- Press `enter` to select a text set. 
- When you select a text set your focus will shift to the canvas with your new text set elements in focus. 

Regression tests: 
- Toggle text sets to 'match fonts from story'
- text set selection using cursor 
- page layout selection using keyboard 
- page layout selection using cursor

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #6295
See #789
-->

Fixes #5878 
Partially addresses #6295 (TextSetItem uses role=listitem, but there's no parent with role=list, rest of that will follow naturally with pill group update)
