### PR TITLE
Settings: revert support for GA4 measurement IDs

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/googleAnalytics/index.js
@@ -51,14 +51,8 @@ export const TEXT = {
   CONTEXT_LINK:
     'https://blog.amp.dev/2019/08/28/analytics-for-your-amp-stories/',
   SECTION_HEADING: __('Google Analytics', 'web-stories'),
-  PLACEHOLDER: __(
-    'Enter your Google Analytics Tracking ID or Measurement ID',
-    'web-stories'
-  ),
-  ARIA_LABEL: __(
-    'Enter your Google Analytics Tracking ID or Measurement ID',
-    'web-stories'
-  ),
+  PLACEHOLDER: __('Enter your Google Analytics Tracking ID', 'web-stories'),
+  ARIA_LABEL: __('Enter your Google Analytics Tracking ID', 'web-stories'),
   INPUT_ERROR: __('Invalid ID format', 'web-stories'),
   SUBMIT_BUTTON: __('Save', 'web-stories'),
   SITE_KIT_NOT_INSTALLED: __(

--- a/assets/src/dashboard/utils/test/validateGoogleAnalyticsIdFormat.js
+++ b/assets/src/dashboard/utils/test/validateGoogleAnalyticsIdFormat.js
@@ -19,19 +19,21 @@
  */
 import { validateGoogleAnalyticsIdFormat } from '../';
 
+// GA4 measurement ID format is not yet supported in AMP.
+// See https://github.com/google/web-stories-wp/issues/6479
 const idsToValidate = [
   ['UA-000000-56', true],
   ['ua-098765432-9875', true],
   ['78787878', false],
   ['ua--123448-0', false],
   ['clearly wrong', false],
-  ['G-9878987', true],
-  ['g-9878987', true],
-  ['G-1A2BCD345E', true],
+  ['G-9878987', false],
+  ['g-9878987', false],
+  ['G-1A2BCD345E', false],
   ['X-8888888', false],
-  ['G-123456', true],
-  ['G-12345678', true],
-  ['G-abcdefg8910', true],
+  ['G-123456', false],
+  ['G-12345678', false],
+  ['G-abcdefg8910', false],
 ];
 
 describe('validateGoogleAnalyticsIdFormat', () => {

--- a/assets/src/dashboard/utils/validateGoogleAnalyticsIdFormat.js
+++ b/assets/src/dashboard/utils/validateGoogleAnalyticsIdFormat.js
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-const propertyIdOrMeasurementIdFormatRegex = /^ua-\d+-\d+|g-[\w]+$/;
+// GA4 measurement ID format is not yet supported in AMP.
+// See https://github.com/google/web-stories-wp/issues/6479
+const idFormatRegex = /^ua-\d+-\d+$/;
 
 export default function validateGoogleAnalyticsIdFormat(value = '') {
-  return Boolean(
-    value.toLowerCase().match(propertyIdOrMeasurementIdFormatRegex)
-  );
+  return Boolean(value.toLowerCase().match(idFormatRegex));
 }


### PR DESCRIPTION
GA4 measurement ID format is not yet supported in AMP.

## Context

In #5808 (#5856) I wrongly assumed that AMP + GA4 work well together, but it turns out that it is not yet supported at all. See https://github.com/ampproject/amphtml/issues/24621.

That's why #6479 was opened.

## Summary

This PR removes any UI references for support of GA4 measurement IDs from the settings screen, marking such IDs as invalid in the input validation.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Slightly changed wording

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to dashboard settings
2. try changing the analytics ID to `UA-000000-2` and `G-XXXXXXX`
3. Verify that only the former is deemed valid

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6479
Essentially reverts #5856