### PR TITLE
Masks: avoid passing flip prop down to div element

### DIFF
--- a/assets/src/edit-story/masks/frame.js
+++ b/assets/src/edit-story/masks/frame.js
@@ -163,11 +163,11 @@ export default function WithMask({
   style,
   children,
   eventHandlers = null,
+  flip,
   ...rest
 }) {
   const [hover, setHover] = useState(false);
   const { isBackground } = element;
-  const { flip } = rest;
 
   const mask = getElementMask(element);
   const flipStyle = flip ? { transform: getTransformFlip(flip) } : null;

--- a/assets/src/edit-story/masks/frame.js
+++ b/assets/src/edit-story/masks/frame.js
@@ -234,6 +234,10 @@ WithMask.propTypes = {
   element: StoryPropTypes.element.isRequired,
   style: PropTypes.object,
   fill: PropTypes.bool,
+  flip: PropTypes.shape({
+    vertical: PropTypes.bool,
+    horizontal: PropTypes.bool,
+  }),
   eventHandlers: PropTypes.object,
   children: PropTypes.node.isRequired,
 };


### PR DESCRIPTION
## Context

I spotted `flip="[object Object]"` in the DOM and thought I'd fix it.

<img width="682" alt="Screenshot 2021-03-01 at 17 50 52" src="https://user-images.githubusercontent.com/841956/109530221-c56fb100-7ab6-11eb-9fe0-36cb12527daf.png">

## Summary

Fixes a small bug by not passing down `flip`.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6564
