### PR TITLE
Redesign: Page attachment panel

### DIFF
--- a/assets/src/edit-story/components/canvas/pageAttachment/karma/pageAttachment.cuj.karma.js
+++ b/assets/src/edit-story/components/canvas/pageAttachment/karma/pageAttachment.cuj.karma.js
@@ -76,7 +76,9 @@ describe('Page Attachment', () => {
   };
 
   const setPageAttachmentLink = async (link) => {
-    const input = fixture.screen.getByLabelText('Page Attachment link');
+    const input = fixture.screen.getByLabelText(
+      'Type an address to add a page attachment link'
+    );
     await fixture.events.click(input, { clickCount: 3 });
     if ('' === link) {
       await fixture.events.keyboard.press('Del');

--- a/assets/src/edit-story/components/form/link.js
+++ b/assets/src/edit-story/components/form/link.js
@@ -35,9 +35,18 @@ const MIN_MAX = {
   },
 };
 
-function LinkInput({ onChange, onBlur, onFocus, value, description, ...rest }) {
+function LinkInput({
+  onChange,
+  onBlur,
+  onFocus,
+  value,
+  description,
+  hint,
+  hasError,
+  ...rest
+}) {
   const isValid = isValidUrl(withProtocol(value || ''));
-  const hasError = value.length > 0 && !isValid;
+  const isNotValid = value.length > 0 && !isValid;
   return (
     <>
       {description && <HelperText>{description}</HelperText>}
@@ -60,8 +69,8 @@ function LinkInput({ onChange, onBlur, onFocus, value, description, ...rest }) {
           value={value || ''}
           minLength={MIN_MAX.URL.MIN}
           maxLength={MIN_MAX.URL.MAX}
-          hasError={hasError}
-          hint={hasError ? __('Invalid web address.', 'web-stories') : null}
+          hasError={isNotValid || hasError}
+          hint={isNotValid ? __('Invalid web address.', 'web-stories') : hint}
           {...rest}
         />
       </Row>
@@ -75,6 +84,8 @@ LinkInput.propTypes = {
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
   description: PropTypes.string,
+  hint: PropTypes.string,
+  hasError: PropTypes.boolean,
 };
 
 export default LinkInput;

--- a/assets/src/edit-story/components/form/link.js
+++ b/assets/src/edit-story/components/form/link.js
@@ -45,8 +45,9 @@ function LinkInput({
   hasError,
   ...rest
 }) {
-  const isValid = isValidUrl(withProtocol(value || ''));
-  const isNotValid = value.length > 0 && !isValid;
+  const trimmedValue = (value || '').trim();
+  const isValid = isValidUrl(withProtocol(trimmedValue));
+  const isNotValid = trimmedValue.length > 0 && !isValid;
   return (
     <>
       {description && <HelperText>{description}</HelperText>}
@@ -55,9 +56,9 @@ function LinkInput({
           placeholder={__('Web address', 'web-stories')}
           onChange={(evt) => onChange(evt.target.value)}
           onBlur={() => {
-            if (value?.length) {
-              const urlWithProtocol = withProtocol(value);
-              if (urlWithProtocol !== value) {
+            if (trimmedValue?.length) {
+              const urlWithProtocol = withProtocol(trimmedValue);
+              if (urlWithProtocol !== trimmedValue) {
                 onChange(urlWithProtocol);
               }
             }

--- a/assets/src/edit-story/components/inspector/design/getDesignPanelsForSelection.js
+++ b/assets/src/edit-story/components/inspector/design/getDesignPanelsForSelection.js
@@ -59,9 +59,7 @@ function getDesignPanelsForSelection(elements) {
 
   // Only display background panel in case of background element.
   if (isBackground) {
-    const panels = [
-      { type: PanelTypes.PAGE_ATTACHMENT, Panel: PageAttachmentPanel },
-    ];
+    const panels = [];
 
     const isBackgroundMedia = !elements[0].isDefaultBackground;
     if (isBackgroundMedia) {
@@ -101,6 +99,12 @@ function getDesignPanelsForSelection(elements) {
         Panel: ColorPresetPanel,
       });
     }
+
+    panels.push({
+      type: PanelTypes.PAGE_ATTACHMENT,
+      Panel: PageAttachmentPanel,
+    });
+
     return panels;
   }
 

--- a/assets/src/edit-story/components/panels/design/link/karma/link.karma.js
+++ b/assets/src/edit-story/components/panels/design/link/karma/link.karma.js
@@ -48,7 +48,9 @@ describe('Link Panel', () => {
   };
 
   const setPageAttachmentLink = async (link) => {
-    const input = fixture.screen.getByLabelText('Page Attachment link');
+    const input = fixture.screen.getByLabelText(
+      'Type an address to add a page attachment link'
+    );
     await fixture.events.click(input, { clickCount: 3 });
     await fixture.events.keyboard.type(link);
     await input.dispatchEvent(new window.Event('blur'));

--- a/assets/src/edit-story/components/panels/design/pageAttachment/pageAttachment.js
+++ b/assets/src/edit-story/components/panels/design/pageAttachment/pageAttachment.js
@@ -30,7 +30,7 @@ import { isValidUrl, withProtocol } from '../../../../utils/url';
 import useElementsWithLinks from '../../../../utils/useElementsWithLinks';
 import { LinkInput, Row } from '../../../form';
 import { SimplePanel } from '../../panel';
-import { ExpandedTextInput } from '../../shared';
+import { Input } from '../../../../../design-system';
 
 const Error = styled.span`
   font-size: 12px;
@@ -108,16 +108,13 @@ function PageAttachmentPanel() {
   );
 
   const isDefault = _ctaText === defaultCTA;
+  const showTextInput = Boolean(url) && !isInvalidUrl;
   return (
     <SimplePanel
       name="pageAttachment"
       title={__('Page Attachment', 'web-stories')}
     >
       <LinkInput
-        description={__(
-          'Type an address to add a page attachment',
-          'web-stories'
-        )}
         onChange={(value) => updatePageAttachment({ url: value })}
         onFocus={onFocus}
         value={url || ''}
@@ -136,18 +133,19 @@ function PageAttachmentPanel() {
         </Row>
       )}
 
-      {Boolean(url) && !isInvalidUrl && (
+      {showTextInput && (
         <Row>
-          <ExpandedTextInput
-            onChange={(value) => {
+          <Input
+            onChange={({ target }) => {
+              const { value } = target;
               // This allows smooth input value change without any lag.
               _setCtaText(value);
               debouncedCTAUpdate(value);
             }}
-            onBlur={(atts = {}) => {
-              const { onClear } = atts;
-              if (onClear) {
+            onBlur={({ target }) => {
+              if (!target.value) {
                 updatePageAttachment({ ctaText: defaultCTA });
+                _setCtaText(defaultCTA);
               } else {
                 cancelCTAUpdate();
                 updatePageAttachment({
@@ -157,9 +155,7 @@ function PageAttachmentPanel() {
             }}
             value={_ctaText}
             aria-label={__('Page Attachment CTA text', 'web-stories')}
-            clear={Boolean(_ctaText) && !isDefault}
             suffix={isDefault ? __('default', 'web-stories') : null}
-            width={isDefault ? 85 : null}
           />
         </Row>
       )}

--- a/assets/src/edit-story/components/panels/design/pageAttachment/pageAttachment.js
+++ b/assets/src/edit-story/components/panels/design/pageAttachment/pageAttachment.js
@@ -73,8 +73,9 @@ function PageAttachmentPanel() {
 
   const updatePageAttachment = useCallback(
     (value) => {
+      const trimmedUrl = (value.url || '').trim();
       if (value.url) {
-        const urlWithProtocol = withProtocol(value.url);
+        const urlWithProtocol = withProtocol(trimmedUrl);
         const valid = isValidUrl(urlWithProtocol);
         setIsInvalidUrl(!valid);
       }
@@ -97,7 +98,7 @@ function PageAttachmentPanel() {
   );
 
   const [isInvalidUrl, setIsInvalidUrl] = useState(
-    !isValidUrl(withProtocol(url || ''))
+    !isValidUrl(withProtocol(url || '').trim())
   );
 
   const isDefault = _ctaText === defaultCTA;
@@ -135,8 +136,9 @@ function PageAttachmentPanel() {
     >
       <LinkInput
         onChange={(value) => updatePageAttachment({ url: value })}
+        onBlur={() => updatePageAttachment({ url: url?.trim() })}
         onFocus={onFocus}
-        value={url || ''}
+        value={url}
         clear
         aria-label={__(
           'Type an address to add a page attachment link',

--- a/assets/src/edit-story/components/panels/design/pageAttachment/pageAttachment.js
+++ b/assets/src/edit-story/components/panels/design/pageAttachment/pageAttachment.js
@@ -30,12 +30,11 @@ import { isValidUrl, withProtocol } from '../../../../utils/url';
 import useElementsWithLinks from '../../../../utils/useElementsWithLinks';
 import { LinkInput, Row } from '../../../form';
 import { SimplePanel } from '../../panel';
-import { Input } from '../../../../../design-system';
+import { Input, Text } from '../../../../../design-system';
+import { PRESET_SIZES } from '../../../../../design-system/theme/constants/typography';
 
-const Error = styled.span`
-  font-size: 12px;
-  line-height: 16px;
-  color: ${({ theme }) => theme.DEPRECATED_THEME.colors.warning};
+const Error = styled(Text)`
+  color: ${({ theme }) => theme.colors.status.negative};
 `;
 
 function PageAttachmentPanel() {
@@ -109,6 +108,32 @@ function PageAttachmentPanel() {
 
   const isDefault = _ctaText === defaultCTA;
   const showTextInput = Boolean(url) && !isInvalidUrl;
+
+  const handleChange = useCallback(
+    ({ target }) => {
+      const { value } = target;
+      // This allows smooth input value change without any lag.
+      _setCtaText(value);
+      debouncedCTAUpdate(value);
+    },
+    [debouncedCTAUpdate]
+  );
+
+  const handleBlur = useCallback(
+    ({ target }) => {
+      if (!target.value) {
+        updatePageAttachment({ ctaText: defaultCTA });
+        _setCtaText(defaultCTA);
+      } else {
+        cancelCTAUpdate();
+        updatePageAttachment({
+          ctaText: _ctaText ? _ctaText : defaultCTA,
+        });
+      }
+    },
+    [_ctaText, cancelCTAUpdate, defaultCTA, updatePageAttachment]
+  );
+
   return (
     <SimplePanel
       name="pageAttachment"
@@ -124,7 +149,7 @@ function PageAttachmentPanel() {
 
       {displayWarning && (
         <Row>
-          <Error>
+          <Error forwardedAs="span" size={PRESET_SIZES.X_SMALL}>
             {__(
               'Links cannot reside below the dashed line when a page attachment is present. If you add a page attachment, your viewers will not be able to click on the link.',
               'web-stories'
@@ -136,23 +161,8 @@ function PageAttachmentPanel() {
       {showTextInput && (
         <Row>
           <Input
-            onChange={({ target }) => {
-              const { value } = target;
-              // This allows smooth input value change without any lag.
-              _setCtaText(value);
-              debouncedCTAUpdate(value);
-            }}
-            onBlur={({ target }) => {
-              if (!target.value) {
-                updatePageAttachment({ ctaText: defaultCTA });
-                _setCtaText(defaultCTA);
-              } else {
-                cancelCTAUpdate();
-                updatePageAttachment({
-                  ctaText: _ctaText ? _ctaText : defaultCTA,
-                });
-              }
-            }}
+            onChange={handleChange}
+            onBlur={handleBlur}
             value={_ctaText}
             aria-label={__('Page Attachment CTA text', 'web-stories')}
             suffix={isDefault ? __('default', 'web-stories') : null}

--- a/assets/src/edit-story/components/panels/design/pageAttachment/pageAttachment.js
+++ b/assets/src/edit-story/components/panels/design/pageAttachment/pageAttachment.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import styled from 'styled-components';
 import { useCallback, useState, useEffect } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { __ } from '@web-stories-wp/i18n';
@@ -30,12 +29,7 @@ import { isValidUrl, withProtocol } from '../../../../utils/url';
 import useElementsWithLinks from '../../../../utils/useElementsWithLinks';
 import { LinkInput, Row } from '../../../form';
 import { SimplePanel } from '../../panel';
-import { Input, Text } from '../../../../../design-system';
-import { PRESET_SIZES } from '../../../../../design-system/theme/constants/typography';
-
-const Error = styled(Text)`
-  color: ${({ theme }) => theme.colors.status.negative};
-`;
+import { Input } from '../../../../../design-system';
 
 function PageAttachmentPanel() {
   const { currentPage, updateCurrentPageProperties } = useStory((state) => ({
@@ -144,20 +138,20 @@ function PageAttachmentPanel() {
         onFocus={onFocus}
         value={url || ''}
         clear
-        aria-label={__('Page Attachment link', 'web-stories')}
+        aria-label={__(
+          'Type an address to add a page attachment link',
+          'web-stories'
+        )}
+        hasError={displayWarning}
+        hint={
+          displayWarning
+            ? __(
+                'Links cannot reside below the dashed line when a page attachment is present. If you add a page attachment, your viewers will not be able to click on the link.',
+                'web-stories'
+              )
+            : undefined
+        }
       />
-
-      {displayWarning && (
-        <Row>
-          <Error forwardedAs="span" size={PRESET_SIZES.X_SMALL}>
-            {__(
-              'Links cannot reside below the dashed line when a page attachment is present. If you add a page attachment, your viewers will not be able to click on the link.',
-              'web-stories'
-            )}
-          </Error>
-        </Row>
-      )}
-
       {showTextInput && (
         <Row>
           <Input


### PR DESCRIPTION
## Context
- update the designs in the Page Attachment panel
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- Use the new design-system input instead of the ExpandedTextInput
- Update page attachment panel order

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- `LinkInput` was already implemented to use the design system but the ticket had a reference to `link text`. I'm not sure if that meant to change the `onBlur` to update the link so that it included `www` or some subdomain. I wrote this to change the validation to inject a default subdomain `www`:


```
const SUBDOMAIN_PATTERN = /^([a-z]+:\/{2})?([\w-]+\.[\w-]+\..*)$/;

/**
 * Prepends a subdomain (default www) to a URL that doesn't have one
 *
 * @param {string} url URL.
 * @param {string} [subdomain=www] default subdomain to prepend
 * @return {string} the url with the subdomain prepended to it
 */
export function withSubdomain(url, subdomain = 'www') {
  const hasSubdomain = SUBDOMAIN_PATTERN.test(url);
  if (hasSubdomain) {
    return url;
  }
  const [protocol] = url.match(PROTOCOL_PATTERN) ?? [];
  return protocol
    ? `${protocol}${subdomain}.${url.slice(protocol.length)}`
    : `${subdomain}.${url}`;
}
```
It has some weirdness if you type in something like `test` it will change it to `www.test` and then if you go in and blur again it will change it to `www.www.test` (because it's not passing the `hasSubdomain` test). The protocol was nice and simple because it just prepended it and there's a limited number of protocol strings to detect. the subdomain test is more complex. So I ultimately did not include it in the scope and left the functionality the same there.

- I did not include a `clear` button on this input--we don't have a visual reference for that, but I did update the panel to re-insert the default text if the value was empty.

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

https://user-images.githubusercontent.com/41136059/110009246-fd0a7300-7cd9-11eb-9312-3321aa8a2d83.mp4


<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. open a new story
2. add a background element to the page and select the background element
3. Assure the page attachment panel is last, except for layers
4. Add a link and a description to the inputs in the page attachment panel
5. Assure that inputs in the page attachment panel are to spec according to the [Figma](https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Design-System?node-id=3483%3A322) (Learn about page attachment should **not** be in the panel)

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6464 
