### PR TITLE
Embeds: Use placeholder when poster image is missing

### DIFF
--- a/assets/src/web-stories-block/block/components/storyCard.js
+++ b/assets/src/web-stories-block/block/components/storyCard.js
@@ -50,7 +50,13 @@ function StoryCard({
   return (
     <div className={singleStoryClasses}>
       <div className="web-stories-list__story-poster">
-        <img src={poster} alt={title} />
+        {poster ? (
+          <img src={poster} alt={title} />
+        ) : (
+          <div className="web-stories-list__story-poster-placeholder">
+            <span>{title}</span>
+          </div>
+        )}
       </div>
       {hasContentOverlay && (
         <div className="story-content-overlay web-stories-list__story-content-overlay">

--- a/assets/src/web-stories-block/block/test/storyCard.js
+++ b/assets/src/web-stories-block/block/test/storyCard.js
@@ -54,7 +54,11 @@ describe('StoryCard', () => {
         <div
           class="web-stories-list__story-poster"
         >
-          <img />
+          <div
+            class="web-stories-list__story-poster-placeholder"
+          >
+            <span />
+          </div>
         </div>
       </div>
     `);

--- a/assets/src/web-stories-block/css/common.css
+++ b/assets/src/web-stories-block/css/common.css
@@ -37,6 +37,24 @@
   position: relative;
 }
 
+/* Screen reader text */
+.web-stories-list__story-poster
+  .web-stories-list__story-poster-placeholder
+  span {
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute !important;
+  width: 1px;
+  word-wrap: normal !important;
+  word-break: normal;
+}
+
 .web-stories-list__story-poster img {
   position: absolute;
   width: 100%;

--- a/assets/src/web-stories-block/css/views/circles.css
+++ b/assets/src/web-stories-block/css/views/circles.css
@@ -26,8 +26,13 @@
   display: inline-block;
 }
 
+.web-stories-list.is-view-type-circles
+  .web-stories-list__story-poster
+  .web-stories-list__story-poster-placeholder,
 .web-stories-list.is-view-type-circles .web-stories-list__story-poster img {
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
   height: var(--ws-circle-size);
   width: var(--ws-circle-size);
   max-width: initial;
@@ -37,7 +42,10 @@
   padding: 2px;
 }
 
-.web-stories-list.is-view-type-circles .web-stories-list__story-poster::after,
+.web-stories-list.is-view-type-circles .web-stories-list__story-poster::after {
+  padding-bottom: var(--ws-circle-size);
+}
+
 .web-stories-list.is-view-type-circles .web-stories-list__story-poster::before {
   display: none;
 }

--- a/includes/Model/Story.php
+++ b/includes/Model/Story.php
@@ -41,7 +41,7 @@ class Story {
 	 *
 	 * @var int
 	 */
-	protected $id;
+	protected $id = 0;
 
 	/**
 	 * Title.
@@ -133,6 +133,7 @@ class Story {
 			return false;
 		}
 
+		$this->id      = $post->ID;
 		$this->title   = get_the_title( $post );
 		$this->excerpt = $post->post_excerpt;
 		$this->markup  = $post->post_content;

--- a/includes/Stories_Renderer/Carousel_Renderer.php
+++ b/includes/Stories_Renderer/Carousel_Renderer.php
@@ -64,7 +64,6 @@ class Carousel_Renderer extends Renderer {
 	 * @return void
 	 */
 	public function assets() {
-
 		parent::assets();
 
 		$this->register_script( self::SCRIPT_HANDLE );
@@ -75,7 +74,6 @@ class Carousel_Renderer extends Renderer {
 			'webStoriesCarouselSettings',
 			$this->get_carousel_settings()
 		);
-
 	}
 
 	/**
@@ -105,7 +103,6 @@ class Carousel_Renderer extends Renderer {
 	 * @return string Rendered stories output.
 	 */
 	public function render( array $args = [] ) {
-
 		if ( ! $this->valid() ) {
 			return '';
 		}
@@ -125,7 +122,7 @@ class Carousel_Renderer extends Renderer {
 					?>
 					<div class="web-stories-list__carousel <?php echo esc_attr( $this->get_view_type() ); ?>" data-id="<?php echo esc_attr( 'carousel-' . $this->instance_id ); ?>">
 						<?php
-						foreach ( $this->story_posts as $story ) {
+						foreach ( $this->stories as $story ) {
 							$this->render_single_story_content();
 							$this->next();
 						}
@@ -145,7 +142,7 @@ class Carousel_Renderer extends Renderer {
 						aria-label="<?php esc_attr_e( 'Web Stories', 'web-stories' ); ?>"
 					>
 						<?php
-						foreach ( $this->story_posts as $story ) {
+						foreach ( $this->stories as $story ) {
 							$this->render_single_story_content();
 							$this->next();
 						}

--- a/includes/Stories_Renderer/Generic_Renderer.php
+++ b/includes/Stories_Renderer/Generic_Renderer.php
@@ -67,7 +67,6 @@ class Generic_Renderer extends Renderer {
 	 * @return string Rendered stories output.
 	 */
 	public function render( array $args = [] ) {
-
 		if ( ! $this->valid() ) {
 			return '';
 		}
@@ -81,7 +80,7 @@ class Generic_Renderer extends Renderer {
 		<div class="<?php echo esc_attr( $container_classes ); ?>" data-id="<?php echo esc_attr( (string) $this->instance_id ); ?>">
 			<div class="web-stories-list__inner-wrapper" style="<?php echo esc_attr( $container_styles ); ?>">
 				<?php
-				foreach ( $this->story_posts as $story ) {
+				foreach ( $this->stories as $story ) {
 					$this->render_single_story_content();
 					$this->next();
 				}

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -516,37 +516,52 @@ abstract class Renderer implements RenderingInterface, Iterator {
 		 *
 		 * @var Story $story
 		 */
-		$story      = $this->current();
+		$story = $this->current();
+
+		// TODO: Only rely on portrait poster image going forward.
 		$poster_url = ( 'circles' === $this->get_view_type() ) ? $story->get_poster_square() : $story->get_poster_portrait();
 
-		?>
-		<div class="web-stories-list__story-poster">
+		if ( ! $poster_url ) {
+
+			?>
+			<div class="web-stories-list__story-poster">
+				<div class="web-stories-list__story-poster-placeholder">
+					<span>
+						<?php echo esc_html( $story->get_title() ); ?>
+					</span>
+				</div>
+			</div>
 			<?php
-			if ( $this->is_amp() ) {
-				// Set the dimensions to '0' so that we can handle image ratio/size by CSS per view type.
-				?>
-				<amp-img
-					src="<?php echo esc_url( $poster_url ); ?>"
-					layout="responsive"
-					width="0"
-					height="0"
-					alt="<?php echo esc_attr( $story->get_title() ); ?>"
-				>
-				</amp-img>
-			<?php } else { ?>
-				<img
-					src="<?php echo esc_url( $poster_url ); ?>"
-					alt="<?php echo esc_attr( $story->get_title() ); ?>"
-					width="<?php echo absint( $this->width ); ?>"
-					height="<?php echo absint( $this->height ); ?>"
-				>
-			<?php } ?>
-		</div>
-		<?php
+		} else {
+			?>
+			<div class="web-stories-list__story-poster">
+				<?php
+				if ( $this->is_amp() ) {
+					// Set the dimensions to '0' so that we can handle image ratio/size by CSS per view type.
+					?>
+					<amp-img
+						src="<?php echo esc_url( $poster_url ); ?>"
+						layout="responsive"
+						width="0"
+						height="0"
+						alt="<?php echo esc_attr( $story->get_title() ); ?>"
+					>
+					</amp-img>
+				<?php } else { ?>
+					<img
+						src="<?php echo esc_url( $poster_url ); ?>"
+						alt="<?php echo esc_attr( $story->get_title() ); ?>"
+						width="<?php echo absint( $this->width ); ?>"
+						height="<?php echo absint( $this->height ); ?>"
+					>
+				<?php } ?>
+			</div>
+			<?php
+		}
 		$this->get_content_overlay();
 
 		if ( ! $this->is_amp() ) {
-			$this->generate_lightbox_html_noamp( $story );
+			$this->generate_lightbox_html( $story );
 		} else {
 			$this->generate_amp_lightbox_html_amp( $story );
 		}

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -248,13 +248,11 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 * @return void
 	 */
 	public function assets() {
-
-		// Web Stories Styles for AMP and non-AMP pages.
+		// Web Stories styles for AMP and non-AMP pages.
 		$this->register_style( self::STYLE_HANDLE );
 
-		// Web Stories Lightbox script.
+		// Web Stories lightbox script.
 		$this->register_script( self::LIGHTBOX_SCRIPT_HANDLE, [ Embed_Base::STORY_PLAYER_HANDLE ] );
-
 	}
 
 	/**

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -275,13 +275,13 @@ abstract class Renderer implements RenderingInterface, Iterator {
 
 		// TODO: get from field state instead.
 		if ( ! $this->is_view_type( 'circles' ) ) {
-			if ( true === $this->attributes['show_author'] ) {
+			if ( isset( $this->attributes['show_author'] ) && true === $this->attributes['show_author'] ) {
 				$author_id = absint( get_post_field( 'post_author', $post->ID ) );
 
 				$story_data['author'] = get_the_author_meta( 'display_name', $author_id );
 			}
 
-			if ( true === $this->attributes['show_date'] ) {
+			if ( isset( $this->attributes['show_date'] ) && true === $this->attributes['show_date'] ) {
 				$story_data['date'] = get_the_date( __( 'M j, Y', 'web-stories' ), $post->ID );
 			}
 		}

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -86,7 +86,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 *
 	 * @var Story_Query Story_Query instance.
 	 */
-	protected $stories;
+	protected $query;
 
 	/**
 	 * Story attributes
@@ -100,7 +100,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 *
 	 * @var array An array of story posts.
 	 */
-	protected $story_posts = [];
+	protected $stories = [];
 
 	/**
 	 * Holds required html for the lightbox.
@@ -142,11 +142,11 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @param Story_Query $stories Story_Query instance.
+	 * @param Story_Query $query Story_Query instance.
 	 */
-	public function __construct( Story_Query $stories ) {
-		$this->stories         = $stories;
-		$this->attributes      = $this->stories->get_story_attributes();
+	public function __construct( Story_Query $query ) {
+		$this->query           = $query;
+		$this->attributes      = $this->query->get_story_attributes();
 		$this->content_overlay = $this->attributes['show_title'] || $this->attributes['show_date'] || $this->attributes['show_author'] || $this->attributes['show_excerpt'];
 	}
 
@@ -180,7 +180,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 * @return mixed|void
 	 */
 	public function current() {
-		return $this->story_posts[ $this->position ];
+		return $this->stories[ $this->position ];
 	}
 
 	/**
@@ -213,7 +213,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 * @return bool|void
 	 */
 	public function valid() {
-		return isset( $this->story_posts[ $this->position ] );
+		return isset( $this->stories[ $this->position ] );
 	}
 
 	/**
@@ -235,7 +235,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 * @return void
 	 */
 	public function init() {
-		$this->story_posts = array_map( [ $this, 'prepare_story_modal' ], $this->stories->get_stories() );
+		$this->stories = array_filter( array_map( [ $this, 'prepare_stories' ], $this->query->get_stories() ) );
 
 		add_action( 'wp_footer', [ $this, 'render_stories_lightbox' ] );
 	}
@@ -264,36 +264,36 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 *
 	 * @SuppressWarnings(PHPMD.NPathComplexity)
 	 *
-	 * @param object $post Array of stories.
+	 * @param object $post Array of post objects.
 	 *
-	 * @return object Returns single story item data.
+	 * @return Story|null Story object or null if given post
 	 */
-	public function prepare_story_modal( $post ) {
-		if ( ! ( $post instanceof WP_Post ) ) {
-			return $post;
+	public function prepare_stories( $post ) {
+		if ( ! $post instanceof WP_Post ) {
+			return null;
 		}
 
-		$is_circles_view = $this->is_view_type( 'circles' );
-		$a_post          = $post;
-		$author_name     = '';
-		$story_date      = '';
-		$story_data      = [];
-		$story_id        = $a_post->ID;
-		$author_id       = absint( get_post_field( 'post_author', $story_id ) );
+		$story_data = [];
 
-		if ( ! $is_circles_view ) {
-			$author_name = ( true === $this->attributes['show_author'] ) ? get_the_author_meta( 'display_name', $author_id ) : $author_name;
-			$story_date  = ( true === $this->attributes['show_date'] ) ? get_the_date( 'M j, Y', $story_id ) : $story_date;
+		// TODO: get from field state instead.
+		if ( ! $this->is_view_type( 'circles' ) ) {
+			if ( true === $this->attributes['show_author'] ) {
+				$author_id = absint( get_post_field( 'post_author', $post->ID ) );
+
+				$story_data['author'] = get_the_author_meta( 'display_name', $author_id );
+			}
+
+			if ( true === $this->attributes['show_date'] ) {
+				$story_data['date'] = get_the_date( __( 'M j, Y', 'web-stories' ), $post->ID );
+			}
 		}
 
-		$story_data['id']      = $story_id;
-		$story_data['author']  = $author_name;
-		$story_data['date']    = $story_date;
 		$story_data['classes'] = $this->get_single_story_classes();
-		$transformed_post      = new Story( $story_data );
-		$transformed_post->load_from_post( $story_id );
 
-		return $transformed_post;
+		$story = new Story( $story_data );
+		$story->load_from_post( $post );
+
+		return $story;
 	}
 
 	/**
@@ -488,9 +488,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 				class="<?php echo esc_attr( $single_story_classes ); ?>"
 				on="<?php echo esc_attr( sprintf( 'tap:AMP.setState({%1$s: ! %1$s})', $lightbox_state ) ); ?>"
 			>
-				<?php
-				$this->render_story_with_poster();
-				?>
+				<?php $this->render_story_with_poster(); ?>
 			</div>
 			<?php
 		} else {
@@ -499,9 +497,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 			wp_enqueue_script( self::LIGHTBOX_SCRIPT_HANDLE );
 			?>
 			<div class="<?php echo esc_attr( $single_story_classes ); ?>" data-story-url="<?php echo esc_url( $story->get_url() ); ?>">
-				<?php
-					$this->render_story_with_poster();
-				?>
+				<?php $this->render_story_with_poster(); ?>
 			</div>
 			<?php
 		}
@@ -579,26 +575,21 @@ abstract class Renderer implements RenderingInterface, Iterator {
 		<div class="web-stories-list__story-content-overlay">
 			<?php if ( $this->attributes['show_title'] ) { ?>
 				<div class="story-content-overlay__title">
-					<?php
-					echo esc_html( $story->get_title() );
-					?>
+					<?php echo esc_html( $story->get_title() ); ?>
 				</div>
 			<?php } ?>
 
 			<?php if ( $this->attributes['show_excerpt'] ) { ?>
 				<div class="story-content-overlay__excerpt">
-					<?php
-					echo esc_html( $story->get_excerpt() );
-					?>
+					<?php echo esc_html( $story->get_excerpt() ); ?>
 				</div>
 			<?php } ?>
 
 			<?php if ( ! empty( $story->get_author() ) ) { ?>
 				<div class="story-content-overlay__author">
 					<?php
-
-					/* translators: %s: author name. */
-					echo esc_html( sprintf( __( 'By %s', 'web-stories' ), $story->get_author() ) );
+						/* translators: %s: author name. */
+						echo esc_html( sprintf( __( 'By %s', 'web-stories' ), $story->get_author() ) );
 					?>
 				</div>
 			<?php } ?>
@@ -606,32 +597,30 @@ abstract class Renderer implements RenderingInterface, Iterator {
 			<?php if ( ! empty( $story->get_date() ) ) { ?>
 				<time class="story-content-overlay__date">
 					<?php
-
-					/* translators: %s: publish date. */
-					echo esc_html( sprintf( __( 'On %s', 'web-stories' ), $story->get_date() ) );
+						/* translators: %s: publish date. */
+						echo esc_html( sprintf( __( 'On %s', 'web-stories' ), $story->get_date() ) );
 					?>
 				</time>
 			<?php } ?>
 		</div>
 		<?php
-
 	}
 
 	/**
 	 * Generate HTML for the non-AMP page request.
 	 *
-	 * @since 1.5.0
-	 * @param Story $story_data Current Story.
+	 * @param Story $story Current Story.
 	 *
 	 * @return void
+	 * @since 1.5.0
 	 */
-	protected function generate_lightbox_html_noamp( $story_data ) {
+	protected function generate_lightbox_html( $story ) {
 		// Start collecting markup for the lightbox stories. This way we don't have to re-run the loop.
 		ob_start();
 
 		// Collect story links to fill-in non-AMP lightbox 'amp-story-player'.
 		?>
-			<a href="<?php echo esc_url( $story_data->get_url() ); ?>"><?php echo esc_html( $story_data->get_title() ); ?></a>
+			<a href="<?php echo esc_url( $story->get_url() ); ?>"><?php echo esc_html( $story->get_title() ); ?></a>
 		<?php
 
 		$this->lightbox_html .= ob_get_clean();
@@ -640,16 +629,16 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	/**
 	 * Markup for the lightbox used on AMP pages.
 	 *
-	 * @since 1.5.0
-	 * @param Story $story_data Current Story.
+	 * @param Story $story Current Story.
 	 *
 	 * @return void
+	 * @since 1.5.0
 	 */
-	protected function generate_amp_lightbox_html_amp( $story_data ) {
+	protected function generate_amp_lightbox_html_amp( $story ) {
 		// Start collecting markup for the lightbox stories. This way we don't have to re-run the loop.
 		ob_start();
-		$lightbox_state = 'lightbox' . $story_data->get_id() . $this->instance_id;
-		$lightbox_id    = 'lightbox-' . $story_data->get_id() . $this->instance_id;
+		$lightbox_state = 'lightbox' . $story->get_id() . $this->instance_id;
+		$lightbox_id    = 'lightbox-' . $story->get_id() . $this->instance_id;
 		?>
 		<amp-lightbox
 			id="<?php echo esc_attr( $lightbox_id ); ?>"
@@ -670,7 +659,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 					height="6"
 					layout="responsive"
 				>
-					<a href="<?php echo( esc_url( $story_data->get_url() ) ); ?>"><?php echo esc_html( $story_data->get_title() ); ?></a>
+					<a href="<?php echo( esc_url( $story->get_url() ) ); ?>"><?php echo esc_html( $story->get_title() ); ?></a>
 				</amp-story-player>
 			</div>
 		</amp-lightbox>
@@ -685,7 +674,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 *
 	 * @return void
 	 */
-	public function render_stories_with_lightbox_noamp() {
+	public function render_stories_with_lightbox() {
 		$data = [
 			'controls'  => [
 				[
@@ -744,7 +733,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 			if ( $this->is_amp() ) {
 				$this->render_stories_with_lightbox_amp();
 			} else {
-				$this->render_stories_with_lightbox_noamp();
+				$this->render_stories_with_lightbox();
 			}
 			?>
 		</div>

--- a/includes/Story_Query.php
+++ b/includes/Story_Query.php
@@ -103,11 +103,19 @@ class Story_Query {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @return WP_Post[] An array of Story posts.
+	 * @return WP_Post[] List of Story posts.
 	 */
 	public function get_stories() {
 		$stories_query = new WP_Query();
-		return $stories_query->query( $this->query_args );
+
+		/**
+		 * List of story posts.
+		 *
+		 * @var WP_Post[] $result
+		 */
+		$result = $stories_query->query( $this->query_args );
+
+		return $result;
 	}
 
 	/**

--- a/includes/Story_Query.php
+++ b/includes/Story_Query.php
@@ -29,6 +29,7 @@ namespace Google\Web_Stories;
 use Google\Web_Stories\Stories_Renderer\Carousel_Renderer;
 use Google\Web_Stories\Stories_Renderer\Generic_Renderer;
 use Google\Web_Stories\Stories_Renderer\Renderer;
+use WP_Post;
 use WP_Query;
 
 /**
@@ -102,7 +103,7 @@ class Story_Query {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @return array An array of Story posts.
+	 * @return WP_Post[] An array of Story posts.
 	 */
 	public function get_stories() {
 		$stories_query = new WP_Query();

--- a/tests/phpunit/tests/Stories_Renderer/Carousel_Renderer.php
+++ b/tests/phpunit/tests/Stories_Renderer/Carousel_Renderer.php
@@ -18,7 +18,7 @@
 namespace Google\Web_Stories\Tests\Stories_Renderer;
 
 use Google\Web_Stories\Model\Story;
-use Google\Web_Stories\Story_Query as Stories;
+use Google\Web_Stories\Story_Query;
 
 /**
  * @coversDefaultClass \Google\Web_Stories\Stories_Renderer\Carousel_Renderer
@@ -28,9 +28,9 @@ class Carousel_Renderer extends \WP_UnitTestCase_Base {
 	/**
 	 * Stories mock object.
 	 *
-	 * @var Stories
+	 * @var Story_Query
 	 */
-	private $stories;
+	private $story_query;
 
 	/**
 	 * Story post ID.
@@ -40,11 +40,16 @@ class Carousel_Renderer extends \WP_UnitTestCase_Base {
 	private static $story_id;
 
 	/**
-	 * Story Modal.
+	 * Story model.
 	 *
 	 * @var Story
 	 */
 	private $story_model;
+
+	/**
+	 * @var \WP_Post[]
+	 */
+	private $stories;
 
 	/**
 	 * Runs once before any test in the class run.
@@ -52,7 +57,6 @@ class Carousel_Renderer extends \WP_UnitTestCase_Base {
 	 * @param \WP_UnitTest_Factory $factory Factory class object.
 	 */
 	public static function wpSetUpBeforeClass( $factory ) {
-
 		self::$story_id = $factory->post->create(
 			[
 				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
@@ -71,9 +75,9 @@ class Carousel_Renderer extends \WP_UnitTestCase_Base {
 		parent::setUp();
 
 		$this->story_model = $this->createMock( Story::class );
-		$this->stories     = $this->createMock( Stories::class );
-		$this->stories->method( 'get_stories' )->willReturn( [ $this->story_model ] );
-		$this->story_posts = [ get_post( self::$story_id ) ];
+		$this->story_query = $this->createMock( Story_Query::class );
+		$this->story_query->method( 'get_stories' )->willReturn( [ get_post( self::$story_id ) ] );
+		$this->stories = [ get_post( self::$story_id ) ];
 	}
 
 	/**
@@ -82,14 +86,14 @@ class Carousel_Renderer extends \WP_UnitTestCase_Base {
 	 */
 	public function test_init() {
 
-		$this->stories->method( 'get_story_attributes' )->willReturn(
+		$this->story_query->method( 'get_story_attributes' )->willReturn(
 			[
 				'view_type'  => 'carousel',
 				'show_title' => true,
 			]
 		);
 
-		$renderer = new \Google\Web_Stories\Stories_Renderer\Carousel_Renderer( $this->stories );
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Carousel_Renderer( $this->story_query );
 		$renderer->init();
 
 		$this->assertTrue( wp_script_is( $renderer::SCRIPT_HANDLE, 'registered' ) );
@@ -101,7 +105,7 @@ class Carousel_Renderer extends \WP_UnitTestCase_Base {
 	 */
 	public function test_render() {
 
-		$this->stories->method( 'get_story_attributes' )->willReturn(
+		$this->story_query->method( 'get_story_attributes' )->willReturn(
 			[
 				'view_type'          => 'carousel',
 				'archive_link_label' => 'View all stories',
@@ -118,7 +122,7 @@ class Carousel_Renderer extends \WP_UnitTestCase_Base {
 			]
 		);
 
-		$renderer = new \Google\Web_Stories\Stories_Renderer\Carousel_Renderer( $this->stories );
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Carousel_Renderer( $this->story_query );
 
 		$renderer->init();
 

--- a/tests/phpunit/tests/Stories_Renderer/Carousel_Renderer.php
+++ b/tests/phpunit/tests/Stories_Renderer/Carousel_Renderer.php
@@ -77,7 +77,6 @@ class Carousel_Renderer extends \WP_UnitTestCase_Base {
 		$this->story_model = $this->createMock( Story::class );
 		$this->story_query = $this->createMock( Story_Query::class );
 		$this->story_query->method( 'get_stories' )->willReturn( [ get_post( self::$story_id ) ] );
-		$this->stories = [ get_post( self::$story_id ) ];
 	}
 
 	/**

--- a/tests/phpunit/tests/Stories_Renderer/Generic_Renderer.php
+++ b/tests/phpunit/tests/Stories_Renderer/Generic_Renderer.php
@@ -18,7 +18,7 @@
 namespace Google\Web_Stories\Tests\Stories_Renderer;
 
 use Google\Web_Stories\Model\Story;
-use Google\Web_Stories\Story_Query as Stories;
+use Google\Web_Stories\Story_Query;
 
 /**
  * @coversDefaultClass \Google\Web_Stories\Stories_Renderer\Generic_Renderer
@@ -28,9 +28,9 @@ class Generic_Renderer extends \WP_UnitTestCase_Base {
 	/**
 	 * Stories mock object.
 	 *
-	 * @var Stories
+	 * @var Story_Query
 	 */
-	private $stories;
+	private $story_query;
 
 	/**
 	 * Story post ID.
@@ -71,8 +71,8 @@ class Generic_Renderer extends \WP_UnitTestCase_Base {
 		parent::setUp();
 
 		$this->story_model = $this->createMock( Story::class );
-		$this->stories     = $this->createMock( Stories::class );
-		$this->stories->method( 'get_stories' )->willReturn( [ $this->story_model ] );
+		$this->story_query = $this->createMock( Story_Query::class );
+		$this->story_query->method( 'get_stories' )->willReturn( [ $this->story_model ] );
 	}
 
 	/**
@@ -80,7 +80,7 @@ class Generic_Renderer extends \WP_UnitTestCase_Base {
 	 */
 	public function test_assets() {
 
-		$this->stories->method( 'get_story_attributes' )->willReturn(
+		$this->story_query->method( 'get_story_attributes' )->willReturn(
 			[
 				'class'      => '',
 				'view_type'  => 'grid',
@@ -88,7 +88,7 @@ class Generic_Renderer extends \WP_UnitTestCase_Base {
 			]
 		);
 
-		$renderer = new \Google\Web_Stories\Stories_Renderer\Generic_Renderer( $this->stories );
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Generic_Renderer( $this->story_query );
 		$renderer->init();
 
 		$this->assertTrue( wp_style_is( \Google\Web_Stories\Embed_Base::STORY_PLAYER_HANDLE ) );
@@ -99,7 +99,7 @@ class Generic_Renderer extends \WP_UnitTestCase_Base {
 	 */
 	public function test_render() {
 
-		$this->stories->method( 'get_story_attributes' )->willReturn(
+		$this->story_query->method( 'get_story_attributes' )->willReturn(
 			[
 				'view_type'          => 'grid',
 				'number_of_columns'  => 2,
@@ -116,7 +116,7 @@ class Generic_Renderer extends \WP_UnitTestCase_Base {
 			]
 		);
 
-		$renderer = new \Google\Web_Stories\Stories_Renderer\Generic_Renderer( $this->stories );
+		$renderer = new \Google\Web_Stories\Stories_Renderer\Generic_Renderer( $this->story_query );
 		$renderer->init();
 
 		$output = $renderer->render();

--- a/tests/phpunit/tests/Stories_Renderer/Generic_Renderer.php
+++ b/tests/phpunit/tests/Stories_Renderer/Generic_Renderer.php
@@ -72,7 +72,7 @@ class Generic_Renderer extends \WP_UnitTestCase_Base {
 
 		$this->story_model = $this->createMock( Story::class );
 		$this->story_query = $this->createMock( Story_Query::class );
-		$this->story_query->method( 'get_stories' )->willReturn( [ $this->story_model ] );
+		$this->story_query->method( 'get_stories' )->willReturn( [ get_post( self::$story_id ) ] );
 	}
 
 	/**


### PR DESCRIPTION
## Context

Layouts look a bit broken when a story doesn't have a poster.

## Summary

With this PR we display a placeholder div with the same dimensions (and some text for screen readers) to maintain same layout.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Same visual change as #6618, but by using a placeholder instead of a transparent png.
