### PR TITLE
Add custom icon to stories widget

### DIFF
--- a/includes/Customizer.php
+++ b/includes/Customizer.php
@@ -412,7 +412,7 @@ class Customizer {
 				[
 					'type'            => 'checkbox',
 					'section'         => self::SECTION_SLUG,
-					'label'           => __( 'Display Archives Link', 'web-stories' ),
+					'label'           => __( 'Display Archive Link', 'web-stories' ),
 					'active_callback' => $active_callback,
 				]
 			);

--- a/includes/Widgets/Stories.php
+++ b/includes/Widgets/Stories.php
@@ -93,25 +93,29 @@ class Stories extends WP_Widget {
 			echo $args['before_title'] . $title . $args['after_title'];
 		}
 
+		$instance['number_of_columns'] = ! empty( $instance['number_of_columns'] ) ? (int) $instance['number_of_columns'] : 1;
+		$instance['number_of_stories'] = ! empty( $instance['number_of_stories'] ) ? (int) $instance['number_of_stories'] : 5;
+		$instance['circle_size']       = ! empty( $instance['circle_size'] ) ? (int) $instance['circle_size'] : 100;
+
 		$story_attrs = [
-			'view_type'          => $instance['view_type'],
+			'view_type'          => isset( $instance['view_type'] ) ? $instance['view_type'] : 'circles',
 			'show_title'         => (bool) $instance['show_title'],
 			'show_excerpt'       => (bool) $instance['show_excerpt'],
 			'show_author'        => (bool) $instance['show_author'],
 			'show_date'          => (bool) $instance['show_date'],
 			'show_archive_link'  => (bool) $instance['show_archive_link'],
-			'archive_link_label' => (bool) $instance['archive_link_label'],
-			'circle_size'        => (int) $instance['circle_size'],
+			'archive_link_label' => (string) $instance['archive_link_label'],
+			'circle_size'        => min( absint( $instance['circle_size'] ), 150 ),
 			'sharp_corners'      => (bool) $instance['sharp_corners'],
 			'image_alignment'    => (string) $instance['image_alignment'],
-			'number_of_columns'  => ( (int) $instance['number_of_columns'] ),
+			'number_of_columns'  => min( absint( $instance['number_of_columns'] ), 4 ),
 			'class'              => 'web-stories-list--widget',
 		];
 
 		$story_args = [
-			'posts_per_page' => $instance['number_of_stories'],
-			'orderby'        => $instance['orderby'],
-			'order'          => $instance['order'],
+			'posts_per_page' => min( absint( $instance['number_of_stories'] ), 20 ),
+			'orderby'        => ( isset( $instance['orderby'] ) ) ? (string) $instance['orderby'] : 'post_date',
+			'order'          => ( isset( $instance['order'] ) ) ? (string) $instance['order'] : 'DESC',
 		];
 
 		$story_query = new Story_Query( $story_attrs, $story_args );
@@ -138,11 +142,11 @@ class Stories extends WP_Widget {
 		$title              = ! empty( $instance['title'] ) ? $instance['title'] : esc_html__( 'Web Stories', 'web-stories' );
 		$view_types         = $this->get_layouts();
 		$current_view_type  = ! empty( $instance['view_type'] ) ? (string) $instance['view_type'] : 'circles';
-		$show_title         = ! empty( $instance['show_title'] ) ? (int) $instance['show_title'] : '';
-		$show_author        = ! empty( $instance['show_author'] ) ? (int) $instance['show_author'] : '';
-		$show_date          = ! empty( $instance['show_date'] ) ? (int) $instance['show_date'] : '';
-		$show_excerpt       = ! empty( $instance['show_excerpt'] ) ? (int) $instance['show_excerpt'] : '';
-		$show_archive_link  = ! empty( $instance['show_archive_link'] ) ? (int) $instance['show_archive_link'] : '';
+		$show_title         = ! empty( $instance['show_title'] ) ? (bool) $instance['show_title'] : '';
+		$show_author        = ! empty( $instance['show_author'] ) ? (bool) $instance['show_author'] : '';
+		$show_date          = ! empty( $instance['show_date'] ) ? (bool) $instance['show_date'] : '';
+		$show_excerpt       = ! empty( $instance['show_excerpt'] ) ? (bool) $instance['show_excerpt'] : '';
+		$show_archive_link  = ! empty( $instance['show_archive_link'] ) ? (bool) $instance['show_archive_link'] : '';
 		$archive_link_label = ! empty( $instance['archive_link_label'] ) ? $instance['archive_link_label'] : __( 'View all stories', 'web-stories' );
 		$circle_size        = ! empty( $instance['circle_size'] ) ? (int) $instance['circle_size'] : 100;
 		$sharp_corners      = ! empty( $instance['sharp_corners'] ) ? (int) $instance['sharp_corners'] : '';
@@ -333,11 +337,11 @@ class Stories extends WP_Widget {
 
 		$this->input(
 			[
-				'id'            => 'archive_link',
-				'name'          => 'archive_link',
-				'label'         => __( 'Display Archives Link', 'web-stories' ),
+				'id'            => 'show_archive_link',
+				'name'          => 'show_archive_link',
+				'label'         => __( 'Display Archive Link', 'web-stories' ),
 				'type'          => 'checkbox',
-				'classname'     => 'widefat archive_link stories-widget-field',
+				'classname'     => 'widefat show_archive_link stories-widget-field',
 				'wrapper_class' => 'archive_link_wrapper',
 				'value'         => $show_archive_link,
 			]

--- a/includes/Widgets/Stories.php
+++ b/includes/Widgets/Stories.php
@@ -404,6 +404,8 @@ class Stories extends WP_Widget {
 			return;
 		}
 
+		$this->enqueue_style( self::SCRIPT_HANDLE );
+
 		$this->enqueue_script( self::SCRIPT_HANDLE, [ 'jquery' ] );
 
 		wp_localize_script(

--- a/includes/Widgets/Stories.php
+++ b/includes/Widgets/Stories.php
@@ -31,7 +31,7 @@ use Google\Web_Stories\Traits\Stories_Script_Data;
 /**
  * Class Stories
  *
- * @package Google\Web_Stories\Widgets
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 class Stories extends WP_Widget {
 	use Stories_Script_Data;

--- a/packages/widget/src/index.js
+++ b/packages/widget/src/index.js
@@ -19,6 +19,11 @@
 import domReady from '@wordpress/dom-ready';
 
 /**
+ * Internal dependencies
+ */
+import './style.css';
+
+/**
  * Store field states in local variable.
  *
  * @type {Object}

--- a/packages/widget/src/style.css
+++ b/packages/widget/src/style.css
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#available-widgets [class*='web_stories'] .widget-title:before {
+  content: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHZpZXdCb3g9IjAgMCAyMDggMjA4IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8Y2lyY2xlIGN4PSIxMDAiIGN5PSIxMDAiIHI9IjEwMCIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEzNS4yIDYyLjQwMDVDMTQwLjk0NCA2Mi40MDA1IDE0NS42IDY3LjA1NjcgMTQ1LjYgNzIuODAwNVYxMzUuMkMxNDUuNiAxNDAuOTQ0IDE0MC45NDQgMTQ1LjYgMTM1LjIgMTQ1LjZWNjIuNDAwNVoiIGZpbGw9IndoaXRlIi8+CjxwYXRoIGQ9Ik01Ny4yIDYyLjQwMDVDNTcuMiA1Ni42NTY3IDYxLjg1NjIgNTIuMDAwNSA2Ny42IDUyLjAwMDVIMTE0LjRDMTIwLjE0NCA1Mi4wMDA1IDEyNC44IDU2LjY1NjcgMTI0LjggNjIuNDAwNVYxNDUuNkMxMjQuOCAxNTEuMzQ0IDEyMC4xNDQgMTU2IDExNC40IDE1Nkg2Ny42QzYxLjg1NjIgMTU2IDU3LjIgMTUxLjM0NCA1Ny4yIDE0NS42VjYyLjQwMDVaIiBmaWxsPSJ3aGl0ZSIvPgo8cGF0aCBkPSJNMTU2IDcyLjgwMDVDMTYwLjMwOCA3Mi44MDA1IDE2My44IDc2LjI5MjcgMTYzLjggODAuNjAwNVYxMjcuNEMxNjMuOCAxMzEuNzA4IDE2MC4zMDggMTM1LjIgMTU2IDEzNS4yVjcyLjgwMDVaIiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4=');
+}

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -344,6 +344,9 @@ const widgetScript = {
   },
   plugins: [
     new DependencyExtractionWebpackPlugin({}),
+    new MiniCssExtractPlugin({
+      filename: '../css/[name].css',
+    }),
     new WebpackBar({
       name: 'WP Widget Script',
       color: '#F757A5',


### PR DESCRIPTION
1. Add custom icon to stories widget
2. Fix widget sanitization for newly inserted instances. `$instance` for newly inserted widgets is usually completely empty.


<img width="563" alt="Screenshot 2021-03-05 at 14 28 15" src="https://user-images.githubusercontent.com/841956/110122157-89429600-7dbf-11eb-957d-d1107bb4e853.png">
