### PR TITLE
Redesign: fix page bg panel media icon

### DIFF
--- a/assets/src/edit-story/components/panels/design/pageBackground/pageBackground.js
+++ b/assets/src/edit-story/components/panels/design/pageBackground/pageBackground.js
@@ -61,10 +61,11 @@ const MediaWrapper = styled.div`
   width: 24px;
   border-radius: 4px;
   overflow: hidden;
-  margin: 6px;
+  margin: 5px;
   img {
     object-fit: cover;
-    min-height: 24px;
+    max-height: 100%;
+    max-width: 100%;
   }
 `;
 
@@ -115,7 +116,7 @@ function PageBackgroundPanel({ selectedElements, pushUpdate }) {
   const isMedia = backgroundEl.isBackground && !isDefaultBackground;
 
   const { backgroundColor } = currentPage;
-  const { LayerContent } = getDefinitionForType(backgroundEl.type);
+  const { LayerIcon } = getDefinitionForType(backgroundEl.type);
 
   // Background can only have one selected element.
   const flip = selectedElements[0]?.flip || DEFAULT_FLIP;
@@ -142,7 +143,7 @@ function PageBackgroundPanel({ selectedElements, pushUpdate }) {
         <Row expand={false}>
           <SelectedMedia>
             <MediaWrapper>
-              <LayerContent element={backgroundEl} height={'100%'} />
+              <LayerIcon element={backgroundEl} />
             </MediaWrapper>
             <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
               {__('Media', 'web-stories')}


### PR DESCRIPTION
## Context
Fixes Page Background panel regression from layer panel adjustments.

## Testing Instructions

### QA

1. Add media and set it as background
2. Open the Page background panel, verify the media icon is displayed correctly.

### UAT

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6461
