### PR TITLE
Redesign: Implemented size+position panel

### DIFF
--- a/assets/src/design-system/components/input/index.js
+++ b/assets/src/design-system/components/input/index.js
@@ -55,6 +55,13 @@ const Suffix = styled(Text)`
   background: transparent;
   color: ${({ theme }) => theme.colors.fg.tertiary};
   white-space: nowrap;
+
+  svg {
+    width: 32px;
+    height: 32px;
+    margin: 2px -10px;
+    display: block;
+  }
 `;
 
 const InputContainer = styled.div(

--- a/assets/src/edit-story/components/canvas/karma/backgroundCopyPaste.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/backgroundCopyPaste.karma.js
@@ -77,7 +77,7 @@ describe('Background Copy Paste integration', () => {
     await setBackgroundColor('FF0000');
     await gotoPage(2);
     await setBackgroundColor('00FF00');
-    await addBackgroundImage('blue-marble');
+    await addBackgroundImage(0);
 
     // Verify setup - 1 element on each page
     await gotoPage(1);
@@ -115,7 +115,7 @@ describe('Background Copy Paste integration', () => {
     // Arrange the backgrounds
     await gotoPage(1);
     await setBackgroundColor('FF0000');
-    await addBackgroundImage('blue-marble');
+    await addBackgroundImage(0);
     await gotoPage(2);
     await setBackgroundColor('00FF00');
 
@@ -160,12 +160,18 @@ describe('Background Copy Paste integration', () => {
     // Arrange the backgrounds
     await gotoPage(1);
     await setBackgroundColor('FF0000');
-    await addBackgroundImage('blue-marble');
-    await setFilter('linear');
+    await addBackgroundImage(0);
+    await fixture.events.sleep(100);
+    await fixture.events.click(
+      fixture.editor.inspector.designPanel.filters.linear.button
+    );
     await gotoPage(2);
     await setBackgroundColor('00FF00');
-    await addBackgroundImage('saturn');
-    await setFilter('vignette');
+    await addBackgroundImage(1);
+    await fixture.events.sleep(100);
+    await fixture.events.click(
+      fixture.editor.inspector.designPanel.filters.radial.button
+    );
 
     // Verify setup - 1 image on each page with correct overlay
     await gotoPage(1);
@@ -179,7 +185,7 @@ describe('Background Copy Paste integration', () => {
     );
     expect(await getNumElements()).toBe(1);
     await gotoPage(2);
-    expect(await getCanvasBackgroundImage()).toHaveProperty('src', /saturn/);
+    expect(await getCanvasBackgroundImage()).toHaveProperty('src', /curiosity/);
     expect(await getCanvasBackgroundOverlay()).toHaveStyle(
       'background-image',
       'radial-gradient(80% 50%, rgba(0, 0, 0, 0) 25%, rgba(0, 0, 0, 0.6) 100%)'
@@ -242,21 +248,17 @@ describe('Background Copy Paste integration', () => {
     await fixture.events.keyboard.type(hex);
     await fixture.events.keyboard.press('tab');
   }
-  function setFilter(filterName) {
-    const filterCheckbox = getInputByAriaLabel(
-      new RegExp(`set filter: ${filterName}`, 'i')
-    );
-    const filterLabel = filterCheckbox.parentNode;
-    filterLabel.click();
-  }
-  async function addBackgroundImage(imageAlt) {
-    // Click img in library to add it to page
-    const source = getMediaElement(imageAlt);
-    await fixture.events.click(source);
+  async function addBackgroundImage(index) {
+    // Drag image to canvas corner to set as background
+    const image = fixture.editor.library.media.item(index);
+    const canvas = fixture.editor.canvas.fullbleed.container;
 
-    // Click "set as background"
-    const setAsBackground = getButtonByText('Set as background');
-    await fixture.events.click(setAsBackground);
+    await fixture.events.mouse.seq(({ down, moveRel, up }) => [
+      moveRel(image, 5, 5),
+      down(),
+      moveRel(canvas, 5, 5),
+      up(),
+    ]);
   }
   async function getNumElements() {
     const {
@@ -293,22 +295,11 @@ describe('Background Copy Paste integration', () => {
     return Array.from(fixture.querySelectorAll(tagName)).find(matcher);
   }
 
-  function getByInnerText(text) {
-    return (el) =>
-      typeof text === 'string'
-        ? el.innerText === text
-        : text.test(el.innerText);
-  }
-
   function getByAttribute(attr, value) {
     return (el) =>
       typeof value === 'string'
         ? el.getAttribute(attr) === value
         : value.test(el.getAttribute(attr));
-  }
-
-  function getButtonByText(buttonText) {
-    return getElementByQueryAndMatcher('button', getByInnerText(buttonText));
   }
 
   function getButtonByAriaLabel(ariaLabel) {
@@ -322,13 +313,6 @@ describe('Background Copy Paste integration', () => {
     return getElementByQueryAndMatcher(
       'input',
       getByAttribute('aria-label', ariaLabel)
-    );
-  }
-
-  function getMediaElement(imageAlt) {
-    return getElementByQueryAndMatcher(
-      '[data-testid^="mediaElement"] img',
-      getByAttribute('alt', imageAlt)
     );
   }
 

--- a/assets/src/edit-story/components/dropTargets/karma/background.karma.js
+++ b/assets/src/edit-story/components/dropTargets/karma/background.karma.js
@@ -32,58 +32,70 @@ describe('Background Drop-Target integration', () => {
     fixture.restore();
   });
 
-  const getBackgroundElement = async () => {
+  const getElements = async () => {
     const storyContext = await fixture.renderHook(() => useStory());
-    return storyContext.state.currentPage.elements[0];
+    return storyContext.state.currentPage.elements;
   };
 
   describe('when there is nothing on the canvas', () => {
     it('should by default have transparent background', async () => {
-      const bgElement = await getCanvasBackgroundElement(fixture);
+      const backgroundId = (await getElements(fixture))[0].id;
+      const bgElement = fixture.editor.canvas.displayLayer.display(backgroundId)
+        .element;
+
       // Verify that it's empty
       expect(bgElement).toBeEmpty();
+
       // And that background color is transparent:
       expect(bgElement).toHaveStyle('backgroundColor', 'rgba(0, 0, 0, 0)');
     });
 
     it('should correctly handle image dragged from library straight to edge', async () => {
-      const backgroundId = await getBackgroundElementId(fixture);
+      const backgroundId = (await getElements(fixture))[0].id;
 
       // Verify that bg replacement is empty
-      let rep1 = await getCanvasBackgroundReplacement(fixture);
+      let rep1 = fixture.editor.canvas.displayLayer.display(backgroundId)
+        .replacement;
       expect(rep1).toBeEmpty();
 
       // Get library element reference
-      const libraryElement = getMediaLibraryElementByIndex(fixture, 0);
-      const libraryImage = libraryElement.querySelector('img');
+      const libraryElement = fixture.editor.library.media.item(0);
 
       // Drag the element to the background
       await dragToDropTarget(fixture, libraryElement, backgroundId);
 
       // Update to DOM mutations
-      rep1 = await getCanvasBackgroundReplacement(fixture);
+      rep1 = fixture.editor.canvas.displayLayer.display(backgroundId)
+        .replacement;
 
       // Verify that bg replacement is no longer empty
       expect(rep1).not.toBeEmpty();
 
       // Verify that replacement img has correct source
       const replaceImg = rep1.querySelector('img');
+      const libraryImage = libraryElement.querySelector('img');
       expect(replaceImg).toHaveProperty('src', libraryImage.src);
 
       // Now drop the element
       await fixture.events.mouse.up();
 
+      // And then wait a frame before invoking story hook
+      await fixture.events.sleep(100);
+
       // Verify new background element has the correct image
-      const bg = await getCanvasBackgroundElement(fixture);
+      const bgElement = (await getElements(fixture))[0];
+      expect(bgElement.type).toBe('image');
+      const bg = fixture.editor.canvas.displayLayer.display(bgElement.id)
+        .element;
       const bgImg = bg.querySelector('img');
       expect(bgImg).toHaveProperty('src', libraryImage.src);
 
       // And verify that we no longer have a replacement element
-      const rep2 = await getCanvasBackgroundReplacement(fixture);
+      const rep2 = fixture.editor.canvas.displayLayer.display(bgElement.id)
+        .replacement;
       expect(rep2).toBeEmpty();
 
       // Verify the background base color is handled as expected.
-      const bgElement = await getBackgroundElement();
       expect(bgElement.resource.baseColor).toEqual([201, 201, 219]);
     });
   });
@@ -92,27 +104,24 @@ describe('Background Drop-Target integration', () => {
     let imageData;
 
     beforeEach(async () => {
-      await addDummyImage(fixture, 0);
-      const {
-        state: {
-          currentPage: { elements },
-        },
-      } = await fixture.renderHook(() => useStory());
-      imageData = elements[1];
+      await fixture.events.click(fixture.editor.library.media.item(0));
+      imageData = (await getElements(fixture))[1];
     });
 
     it('should correctly handle image dropped on edge', async () => {
-      const backgroundId = await getBackgroundElementId(fixture);
+      const backgroundId = (await getElements(fixture))[0].id;
 
       // Verify that bg replacement is empty
-      let rep1 = await getCanvasBackgroundReplacement(fixture);
+      let rep1 = fixture.editor.canvas.displayLayer.display(backgroundId)
+        .replacement;
       expect(rep1).toBeEmpty();
 
       // Drag the image element to the background
       await dragCanvasElementToDropTarget(fixture, imageData.id, backgroundId);
 
       // Update to DOM mutations
-      rep1 = await getCanvasBackgroundReplacement(fixture);
+      rep1 = fixture.editor.canvas.displayLayer.display(backgroundId)
+        .replacement;
 
       // Verify that bg replacement is no longer empty
       expect(rep1).not.toBeEmpty();
@@ -125,34 +134,16 @@ describe('Background Drop-Target integration', () => {
       await fixture.events.mouse.up();
 
       // Verify new background element has the correct image
-      const bg = await getCanvasBackgroundElement(fixture);
+      const newBackgroundId = (await getElements(fixture))[0].id;
+      const bg = fixture.editor.canvas.displayLayer.display(newBackgroundId)
+        .element;
       const bgImg = bg.querySelector('img');
       expect(bgImg).toHaveProperty('src', imageData.resource.src);
 
       // And verify that we no longer have a replacement element
-      const rep2 = await getCanvasBackgroundReplacement(fixture);
+      const rep2 = fixture.editor.canvas.displayLayer.display(newBackgroundId)
+        .replacement;
       expect(rep2).toBeEmpty();
-    });
-
-    it('should correctly handle pressing "set as background"', async () => {
-      // Find element
-      const el = getCanvasElementWrapperById(fixture, imageData.id);
-      const rect = el.getBoundingClientRect();
-
-      // Click the element center
-      await fixture.events.mouse.click(
-        rect.x + rect.width / 2,
-        rect.y + rect.height / 2
-      );
-
-      // Click the "set as background" button
-      const setAsBackground = getButtonByText(fixture, 'Set as background');
-      await fixture.events.click(setAsBackground);
-
-      // Verify new background element has the correct image
-      const bg = await getCanvasBackgroundElement(fixture);
-      const bgImg = bg.querySelector('img');
-      expect(bgImg).toHaveProperty('src', imageData.resource.src);
     });
   });
 
@@ -160,38 +151,37 @@ describe('Background Drop-Target integration', () => {
     let bgImageData;
 
     beforeEach(async () => {
-      await addDummyImage(fixture, 0);
-      const setAsBackground = getButtonByText(fixture, 'Set as background');
-      await fixture.events.click(setAsBackground);
-      const {
-        state: {
-          currentPage: { elements },
-        },
-      } = await fixture.renderHook(() => useStory());
-      bgImageData = elements[0];
+      const libraryElement = fixture.editor.library.media.item(0);
+      const backgroundId = (await getElements(fixture))[0].id;
+      await dragToDropTarget(fixture, libraryElement, backgroundId);
+      await fixture.events.mouse.up();
+      await fixture.events.sleep(100);
+
+      bgImageData = (await getElements(fixture))[0];
     });
 
     it('should correctly handle image dragged from library straight to edge replacing old image', async () => {
-      const backgroundId = await getBackgroundElementId(fixture);
-
       // Verify that background element has the correct image before doing anything
-      const bg1 = await getCanvasBackgroundElement(fixture);
+      const bg1 = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+        .element;
       const bgImg1 = bg1.querySelector('img');
       expect(bgImg1).toHaveProperty('src', bgImageData.resource.src);
 
       // Verify that bg replacement is empty
-      let rep1 = await getCanvasBackgroundReplacement(fixture);
+      let rep1 = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+        .replacement;
       expect(rep1).toBeEmpty();
 
       // Get library element reference
-      const libraryElement = getMediaLibraryElementByIndex(fixture, 0);
+      const libraryElement = fixture.editor.library.media.item(1);
       const libraryImage = libraryElement.querySelector('img');
 
       // Drag the element to the background
-      await dragToDropTarget(fixture, libraryElement, backgroundId);
+      await dragToDropTarget(fixture, libraryElement, bgImageData.id);
 
       // make sure rep1 is up to date with latest DOM updates.
-      rep1 = await getCanvasBackgroundReplacement(fixture);
+      rep1 = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+        .replacement;
 
       // Verify that bg replacement is no longer empty
       expect(rep1).not.toBeEmpty();
@@ -204,12 +194,15 @@ describe('Background Drop-Target integration', () => {
       await fixture.events.mouse.up();
 
       // Verify new background element has the correct image
-      const bg2 = await getCanvasBackgroundElement(fixture);
+      const newBackgroundId = (await getElements(fixture))[0].id;
+      const bg2 = fixture.editor.canvas.displayLayer.display(newBackgroundId)
+        .element;
       const bgImg2 = bg2.querySelector('img');
       expect(bgImg2).toHaveProperty('src', libraryImage.src);
 
       // And verify that we no longer have a replacement element
-      const rep2 = await getCanvasBackgroundReplacement(fixture);
+      const rep2 = fixture.editor.canvas.displayLayer.display(newBackgroundId)
+        .replacement;
       expect(rep2).toBeEmpty();
     });
 
@@ -217,23 +210,20 @@ describe('Background Drop-Target integration', () => {
       let imageData;
 
       beforeEach(async () => {
-        await addDummyImage(fixture, 1);
-        const {
-          state: {
-            currentPage: { elements },
-          },
-        } = await fixture.renderHook(() => useStory());
-        imageData = elements[1];
+        await fixture.events.click(fixture.editor.library.media.item(1));
+        imageData = (await getElements(fixture))[1];
       });
 
       it('should correctly handle image dropped on edge replacing old image', async () => {
         // Verify that background element has the correct image before doing anything
-        const bg1 = await getCanvasBackgroundElement(fixture);
+        const bg1 = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+          .element;
         const bgImg1 = bg1.querySelector('img');
         expect(bgImg1).toHaveProperty('src', bgImageData.resource.src);
 
         // Verify that bg replacement is empty
-        let rep1 = await getCanvasBackgroundReplacement(fixture);
+        let rep1 = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+          .replacement;
         expect(rep1).toBeEmpty();
 
         // Drag the image element to the background
@@ -244,7 +234,8 @@ describe('Background Drop-Target integration', () => {
         );
 
         // Update to DOM mutations
-        rep1 = await getCanvasBackgroundReplacement(fixture);
+        rep1 = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+          .replacement;
 
         // Verify that bg replacement is no longer empty
         expect(rep1).not.toBeEmpty();
@@ -257,65 +248,38 @@ describe('Background Drop-Target integration', () => {
         await fixture.events.mouse.up();
 
         // Verify new background element has the correct image
-        const bg2 = await getCanvasBackgroundElement(fixture);
+        const newBackgroundId = (await getElements(fixture))[0].id;
+        const bg2 = fixture.editor.canvas.displayLayer.display(newBackgroundId)
+          .element;
         const bgImg2 = bg2.querySelector('img');
         expect(bgImg2).toHaveProperty('src', imageData.resource.src);
 
         // And verify that we no longer have a replacement element
-        const rep2 = await getCanvasBackgroundReplacement(fixture);
+        const rep2 = fixture.editor.canvas.displayLayer.display(newBackgroundId)
+          .replacement;
         expect(rep2).toBeEmpty();
-      });
-
-      it('should correctly handle pressing "set as background" replacing old image', async () => {
-        // Verify that background element has the correct image before doing anything
-        const bg1 = await getCanvasBackgroundElement(fixture);
-        const bgImg1 = bg1.querySelector('img');
-        expect(bgImg1).toHaveProperty('src', bgImageData.resource.src);
-
-        // Find element
-        const el = getCanvasElementWrapperById(fixture, imageData.id);
-        const rect = el.getBoundingClientRect();
-
-        // Click the element center
-        await fixture.events.mouse.click(
-          rect.x + rect.width / 2,
-          rect.y + rect.height / 2
-        );
-
-        // Click the "set as background" button
-        const setAsBackground = getButtonByText(fixture, 'Set as background');
-        await fixture.events.click(setAsBackground);
-
-        // Verify new background element has the correct image
-        const bg2 = await getCanvasBackgroundElement(fixture);
-        const bgImg2 = bg2.querySelector('img');
-        expect(bgImg2).toHaveProperty('src', imageData.resource.src);
-
-        // Verify the page average color is assigned as expected.
-        const bgElement = await getBackgroundElement();
-        expect(bgElement.resource.baseColor).toEqual([169, 132, 102]);
       });
 
       describe('when the background is flipped', () => {
         beforeEach(async () => {
           // Click the bg in the top left corner
-          const bgElement = getCanvasElementWrapperById(
-            fixture,
+          const bgElement = fixture.editor.canvas.framesLayer.frame(
             bgImageData.id
-          );
-          const bgRect = bgElement.getBoundingClientRect();
-          await fixture.events.mouse.click(bgRect.left + 1, bgRect.top + 1);
+          ).node;
+          await fixture.events.mouse.clickOn(bgElement, 5, 5);
+
           // And flip it
-          const flip = getButtonByLabel(fixture, 'Flip horizontally');
-          await fixture.events.click(flip);
+          await fixture.events.click(
+            fixture.editor.inspector.designPanel.pageBackground.flipHorizontal
+          );
         });
 
         it('should correctly handle image dropped on edge without flip', async () => {
           // Verify that background element has the correct transform (flip) before doing anything
-          const bg1 = await getCanvasBackgroundElementWrapper(fixture);
-          const rep = bg1.querySelector(
-            `[class^="displayElement__ReplacementContainer-"]`
-          );
+          const bg1 = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+            .node;
+          const rep = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+            .replacement;
           const bgImg1 = bg1.querySelector('img');
           const combinedBgTransform1 = getAllTransformsBetween(bgImg1, bg1);
           expect(combinedBgTransform1).toBe('matrix(-1, 0, 0, 1, 0, 0)');
@@ -336,35 +300,10 @@ describe('Background Drop-Target integration', () => {
           await fixture.events.mouse.up();
 
           // Verify that new background is not flipped
-          const bg2 = await getCanvasBackgroundElementWrapper(fixture);
-          const bgImg2 = bg2.querySelector('img');
-          const combinedBgTransform2 = getAllTransformsBetween(bgImg2, bg2);
-          expect(combinedBgTransform2).toBe('');
-        });
-
-        it('should correctly handle pressing "set as background" without flip', async () => {
-          // Verify that background element has the correct transform (flip) before doing anything
-          const bg1 = await getCanvasBackgroundElementWrapper(fixture);
-          const bgImg1 = bg1.querySelector('img');
-          const combinedBgTransform1 = getAllTransformsBetween(bgImg1, bg1);
-          expect(combinedBgTransform1).toBe('matrix(-1, 0, 0, 1, 0, 0)');
-
-          // Find element
-          const el = getCanvasElementWrapperById(fixture, imageData.id);
-          const rect = el.getBoundingClientRect();
-
-          // Click the element center
-          await fixture.events.mouse.click(
-            rect.x + rect.width / 2,
-            rect.y + rect.height / 2
-          );
-
-          // Click the "set as background" button
-          const setAsBackground = getButtonByText(fixture, 'Set as background');
-          await fixture.events.click(setAsBackground);
-
-          // Verify that new background is not flipped
-          const bg2 = await getCanvasBackgroundElementWrapper(fixture);
+          const newBackgroundId = (await getElements(fixture))[0].id;
+          const bg2 = fixture.editor.canvas.displayLayer.display(
+            newBackgroundId
+          ).node;
           const bgImg2 = bg2.querySelector('img');
           const combinedBgTransform2 = getAllTransformsBetween(bgImg2, bg2);
           expect(combinedBgTransform2).toBe('');
@@ -374,20 +313,26 @@ describe('Background Drop-Target integration', () => {
       describe('when the canvas element is flipped', () => {
         beforeEach(async () => {
           // Click the corner of the on-canvas element
-          const element = getCanvasElementWrapperById(fixture, imageData.id);
-          const rect = element.getBoundingClientRect();
-          await fixture.events.mouse.click(rect.left + 1, rect.top + 1);
+          const element = fixture.editor.canvas.framesLayer.frame(imageData.id)
+            .node;
+          await fixture.events.mouse.clickOn(element, 1, 1);
+
           // And flip it
-          const flip = getButtonByLabel(fixture, 'Flip horizontally');
-          flip.click();
+          await fixture.events.click(
+            fixture.editor.inspector.designPanel.sizePosition.flipHorizontal
+          );
         });
 
-        it('should correctly handle image dropped on edge with flip', async () => {
-          // Verify that background element has the correct transform (none) before doing anything
-          let bg1 = await getCanvasBackgroundElementWrapper(fixture);
-          let rep = (
-            await getCanvasBackgroundElementWrapper(fixture)
-          ).querySelector(`[class^="displayElement__ReplacementContainer-"]`);
+        // Disable reason: There's actually a bug here - replacement image appears flipped in flipped bg
+        // but dropped image is unflipped once dropped.
+        // Filed in: https://github.com/google/web-stories-wp/issues/6643
+        // eslint-disable-next-line jasmine/no-disabled-tests
+        xit('should correctly handle image dropped on edge with flip', async () => {
+          // Verify that background element has the correct transform (flip) before doing anything
+          let bg1 = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+            .node;
+          let rep = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+            .replacement;
           const bgImg1 = bg1.querySelector('img');
           const combinedBgTransform1 = getAllTransformsBetween(bgImg1, bg1);
           expect(combinedBgTransform1).toBe('');
@@ -400,49 +345,23 @@ describe('Background Drop-Target integration', () => {
           );
 
           // Make sure rep is up to date with DOM mutations
-          rep = (
-            await getCanvasBackgroundElementWrapper(fixture)
-          ).querySelector(`[class^="displayElement__ReplacementContainer-"]`);
-          bg1 = await getCanvasBackgroundElementWrapper(fixture);
+          bg1 = fixture.editor.canvas.displayLayer.display(bgImageData.id).node;
+          rep = fixture.editor.canvas.displayLayer.display(bgImageData.id)
+            .replacement;
 
-          // Verify that replacement img is flipped
+          // Verify that replacement img has correct transform
           const replaceImg = rep.querySelector('img');
           const combinedRepTransform = getAllTransformsBetween(replaceImg, bg1);
-          expect(combinedRepTransform).toBe('matrix(-1, 0, 0, 1, 0, 0)');
+          expect(combinedRepTransform).toBe('');
 
           // Now drop the element
           await fixture.events.mouse.up();
 
           // Verify that new background is flipped
-          const bg2 = await getCanvasBackgroundElementWrapper(fixture);
-          const bgImg2 = bg2.querySelector('img');
-          const combinedBgTransform2 = getAllTransformsBetween(bgImg2, bg2);
-          expect(combinedBgTransform2).toBe('matrix(-1, 0, 0, 1, 0, 0)');
-        });
-
-        it('should correctly handle pressing "set as background" with flip', async () => {
-          // Verify that background element has the correct transform (none) before doing anything
-          const bg1 = await getCanvasBackgroundElementWrapper(fixture);
-          const bgImg1 = bg1.querySelector('img');
-          const combinedBgTransform1 = getAllTransformsBetween(bgImg1, bg1);
-          expect(combinedBgTransform1).toBe('');
-
-          // Find element
-          const el = getCanvasElementWrapperById(fixture, imageData.id);
-          const rect = el.getBoundingClientRect();
-
-          // Click the element center
-          await fixture.events.mouse.click(
-            rect.x + rect.width / 2,
-            rect.y + rect.height / 2
-          );
-
-          // Click the "set as background" button
-          const setAsBackground = getButtonByText(fixture, 'Set as background');
-          await fixture.events.click(setAsBackground);
-
-          // Verify that new background is flipped
-          const bg2 = await getCanvasBackgroundElementWrapper(fixture);
+          const newBackgroundId = (await getElements(fixture))[0].id;
+          const bg2 = fixture.editor.canvas.displayLayer.display(
+            newBackgroundId
+          ).node;
           const bgImg2 = bg2.querySelector('img');
           const combinedBgTransform2 = getAllTransformsBetween(bgImg2, bg2);
           expect(combinedBgTransform2).toBe('matrix(-1, 0, 0, 1, 0, 0)');
@@ -452,81 +371,21 @@ describe('Background Drop-Target integration', () => {
   });
 });
 
-function getMediaLibraryElementByIndex(fixture, index) {
-  return fixture.querySelectorAll('[data-testid^=mediaElement]')[index];
-}
-
-export async function addDummyImage(fixture, index) {
-  await fixture.events.click(getMediaLibraryElementByIndex(fixture, index));
-}
-
-export async function dragCanvasElementToDropTarget(
-  fixture,
-  canvasElementId,
-  targetId
-) {
-  // Find from element
-  const from = await getCanvasElementWrapperById(fixture, canvasElementId);
-  return dragToDropTarget(fixture, from, targetId);
+function dragCanvasElementToDropTarget(fixture, fromId, toId) {
+  const from = fixture.editor.canvas.framesLayer.frame(fromId).node;
+  return dragToDropTarget(fixture, from, toId);
 }
 
 async function dragToDropTarget(fixture, from, toId) {
-  const to = getCanvasElementWrapperById(fixture, toId);
+  const to = fixture.editor.canvas.framesLayer.frame(toId).node;
 
-  // Find element dimensions
-  const fromRect = from.getBoundingClientRect();
-  const toRect = to.getBoundingClientRect();
-
-  // Schedule a sequence of events by dragging from center of image to edge of bg
-  await fixture.events.mouse.seq(({ move, down }) => [
-    move(fromRect.x + fromRect.width / 2, fromRect.y + fromRect.height / 2),
+  // Schedule a sequence of events by dragging from center of image
+  // to corner of target
+  await fixture.events.mouse.seq(({ moveRel, down }) => [
+    moveRel(from, '50%', '50%'),
     down(),
-    move(toRect.x + 3, toRect.y + 103, { steps: 5 }),
+    moveRel(to, 5, 5, { steps: 5 }),
   ]);
-}
-
-function getButtonByText(fixture, buttonText) {
-  return Array.from(fixture.querySelectorAll('button')).find(
-    (el) => el.innerText === buttonText
-  );
-}
-
-function getButtonByLabel(fixture, ariaLabel) {
-  return fixture.screen.getByRole('button', { name: ariaLabel });
-}
-
-function getCanvasElementWrapperById(fixture, id) {
-  return fixture.querySelector(`[data-element-id="${id}"]`);
-}
-
-export async function getBackgroundElementId(fixture) {
-  const {
-    state: {
-      currentPage: {
-        elements: [{ id }],
-      },
-    },
-  } = await fixture.renderHook(() => useStory());
-  return id;
-}
-
-async function getCanvasBackgroundElementWrapper(fixture) {
-  const id = await getBackgroundElementId(fixture);
-  return getCanvasElementWrapperById(fixture, id);
-}
-
-async function getCanvasBackgroundElement(fixture) {
-  const wrapper = await getCanvasBackgroundElementWrapper(fixture);
-  // TODO fix this selector
-  return wrapper.querySelector(`[class^="display__Element-"]`);
-}
-
-async function getCanvasBackgroundReplacement(fixture) {
-  const wrapper = await getCanvasBackgroundElementWrapper(fixture);
-  // TODO fix this selector
-  return wrapper.querySelector(
-    `[class^="displayElement__ReplacementContainer-"]`
-  );
 }
 
 function getAllTransformsBetween(startElement, endElement) {
@@ -538,27 +397,4 @@ function getAllTransformsBetween(startElement, endElement) {
   }
 
   return transforms.filter((t) => t !== 'none').join(' ');
-}
-
-function getComputedStyle(element) {
-  return window.getComputedStyle(element);
-}
-
-export async function addBackgroundImage(fixture, options) {
-  await addDummyImage(fixture, 1);
-  const {
-    actions: { updateElementById },
-    state: {
-      currentPage: { elements },
-    },
-  } = await fixture.renderHook(() => useStory());
-  if (options?.properties) {
-    updateElementById({
-      elementId: elements[1].id,
-      properties: options?.properties,
-    });
-  }
-  const backgroundId = await getBackgroundElementId(fixture);
-  await dragCanvasElementToDropTarget(fixture, elements[1].id, backgroundId);
-  await fixture.events.mouse.up();
 }

--- a/assets/src/edit-story/components/dropTargets/karma/order.karma.js
+++ b/assets/src/edit-story/components/dropTargets/karma/order.karma.js
@@ -24,7 +24,6 @@ import { waitFor } from '@testing-library/react';
  */
 import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
-import { getBackgroundElementId } from './background.karma';
 
 describe('Drop-Target order', () => {
   let fixture;
@@ -87,7 +86,7 @@ describe('Drop-Target order', () => {
     // Expect old element to have been removed
     expect(fixture.editor.canvas.framesLayer.frame(otherImage.id)).toBeFalsy();
 
-    const backgroundId = await getBackgroundElementId(fixture);
+    const backgroundId = (await getElements(fixture))[0].id;
     // TODO: refactor after #2386?
     const topImageImg = fixture.editor.canvas.displayLayer
       .display(topImage.id)

--- a/assets/src/edit-story/components/panels/design/filter/karma/filter.karma.js
+++ b/assets/src/edit-story/components/panels/design/filter/karma/filter.karma.js
@@ -35,13 +35,16 @@ describe('Filter Panel', () => {
     fixture = new Fixture();
     await fixture.render();
 
-    await fixture.events.click(fixture.editor.library.media.item(0));
+    // Drag first media element straight to canvas edge to set as background
+    const media = fixture.editor.library.media.item(0);
+    const canvas = fixture.editor.canvas.fullbleed.container;
+    await fixture.events.mouse.seq(({ down, moveRel, up }) => [
+      moveRel(media, 5, 5),
+      down(),
+      moveRel(canvas, 5, 5),
+      up(),
+    ]);
 
-    // TODO: replace with correctly addressing this button through fixture container
-    const setAsBackground = fixture.screen.getByRole('button', {
-      name: 'Set as background',
-    });
-    await fixture.events.click(setAsBackground);
     const {
       state: {
         currentPage: { elements },

--- a/assets/src/edit-story/components/panels/design/pageBackground/pageBackground.js
+++ b/assets/src/edit-story/components/panels/design/pageBackground/pageBackground.js
@@ -91,8 +91,8 @@ function PageBackgroundPanel({ selectedElements, pushUpdate }) {
     [updateCurrentPageProperties]
   );
 
-  const { setBackgroundElement } = useStory((state) => ({
-    setBackgroundElement: state.actions.setBackgroundElement,
+  const { clearBackgroundElement } = useStory((state) => ({
+    clearBackgroundElement: state.actions.clearBackgroundElement,
   }));
 
   const removeAsBackground = useCallback(() => {
@@ -104,8 +104,8 @@ function PageBackgroundPanel({ selectedElements, pushUpdate }) {
       },
       true
     );
-    setBackgroundElement({ elementId: null });
-  }, [pushUpdate, setBackgroundElement]);
+    clearBackgroundElement();
+  }, [pushUpdate, clearBackgroundElement]);
 
   const backgroundEl = selectedElements[0];
   if (!backgroundEl || !backgroundEl.isBackground) {

--- a/assets/src/edit-story/components/panels/design/sizePosition/karma/sizePosition.karma.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/karma/sizePosition.karma.js
@@ -65,7 +65,7 @@ describe('Size & Position Panel', () => {
       expect(Math.round(newHeight)).toBe(Math.round(300 / ratio));
 
       // Take off lock ratio by clicking on the visible part of the lock aspect ratio checkbox.
-      await fixture.events.click(panel.lockAspectRatio.button);
+      await fixture.events.click(panel.lockAspectRatio);
       expect(panel.height.placeholder).toBe('AUTO');
       expect(panel.height.disabled).toBeTrue();
 
@@ -93,7 +93,7 @@ describe('Size & Position Panel', () => {
       const oHeight2 = elements[1].height;
 
       // Take off lock ratio by clicking on the visible part of the lock aspect ratio checkbox.
-      await fixture.events.click(panel.lockAspectRatio.button);
+      await fixture.events.click(panel.lockAspectRatio);
       expect(panel.height.placeholder).toBe('AUTO');
 
       await fixture.snapshot('Unlocked multi-selection with height disabled');

--- a/assets/src/edit-story/components/panels/design/sizePosition/karma/sizePosition.karma.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/karma/sizePosition.karma.js
@@ -66,7 +66,7 @@ describe('Size & Position Panel', () => {
 
       // Take off lock ratio by clicking on the visible part of the lock aspect ratio checkbox.
       await fixture.events.click(panel.lockAspectRatio);
-      expect(panel.height.placeholder).toBe('AUTO');
+      expect(panel.height.placeholder).toBe('Auto');
       expect(panel.height.disabled).toBeTrue();
 
       await fixture.snapshot('Unlocked element with height disabled');
@@ -94,12 +94,12 @@ describe('Size & Position Panel', () => {
 
       // Take off lock ratio by clicking on the visible part of the lock aspect ratio checkbox.
       await fixture.events.click(panel.lockAspectRatio);
-      expect(panel.height.placeholder).toBe('AUTO');
+      expect(panel.height.placeholder).toBe('Auto');
 
       await fixture.snapshot('Unlocked multi-selection with height disabled');
 
       expect(panel.height.value).toBe('');
-      expect(panel.height.placeholder).toBe('AUTO');
+      expect(panel.height.placeholder).toBe('Auto');
       expect(panel.height.disabled).toBeTrue();
       await fixture.events.click(panel.width);
       await fixture.events.keyboard.type('300');

--- a/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
@@ -140,6 +140,12 @@ function SizePositionPanel({
 
   usePresubmitHandlers(lockAspectRatio, height, width);
 
+  const enabledHeightPlaceholder =
+    MULTIPLE_VALUE === height ? MULTIPLE_DISPLAY_VALUE : null;
+  const heightPlaceholder = disableHeight
+    ? __('Auto', 'web-stories')
+    : enabledHeightPlaceholder;
+
   const getMixedValueProps = useCallback((value) => {
     return {
       isIndeterminate: MULTIPLE_VALUE === value,
@@ -228,13 +234,7 @@ function SizePositionPanel({
             }}
             aria-label={__('Height', 'web-stories')}
             isIndeterminate={MULTIPLE_VALUE === height}
-            placeholder={
-              disableHeight
-                ? __('Auto', 'web-stories')
-                : MULTIPLE_VALUE === height
-                ? MULTIPLE_DISPLAY_VALUE
-                : null
-            }
+            placeholder={heightPlaceholder}
           />
         </Area>
         <Area area="l">

--- a/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
@@ -49,7 +49,7 @@ const Grid = styled.div`
     'x . . . y . .'
     'w . d . h . l'
     'r . . . f . .';
-  grid-template-columns: 112px 1fr 8px 1fr 112px 1fr 32px;
+  grid-template-columns: 1fr 4px 8px 4px 1fr 4px 32px;
   grid-template-rows: repeat(3, 36px);
   row-gap: 16px;
   align-items: center;

--- a/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
@@ -140,6 +140,7 @@ function SizePositionPanel({
 
   usePresubmitHandlers(lockAspectRatio, height, width);
 
+  const disableHeight = !lockAspectRatio && hasText;
   const enabledHeightPlaceholder =
     MULTIPLE_VALUE === height ? MULTIPLE_DISPLAY_VALUE : null;
   const heightPlaceholder = disableHeight
@@ -152,8 +153,6 @@ function SizePositionPanel({
       placeholder: MULTIPLE_VALUE === value ? MULTIPLE_DISPLAY_VALUE : null,
     };
   }, []);
-
-  const disableHeight = !lockAspectRatio && hasText;
   return (
     <SimplePanel name="size" title={__('Size & position', 'web-stories')}>
       <Grid>

--- a/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
@@ -211,7 +211,6 @@ function SizePositionPanel({
           <NumericInput
             suffix={_x('H', 'The Height dimension', 'web-stories')}
             value={disableHeight ? '' : height}
-            placeholder={disableHeight ? __('AUTO', 'web-stories') : ''}
             disabled={disableHeight}
             min={MIN_MAX.HEIGHT.MIN}
             max={MIN_MAX.HEIGHT.MAX}
@@ -228,7 +227,14 @@ function SizePositionPanel({
               pushUpdate(getUpdateObject(newWidth, newHeight), true);
             }}
             aria-label={__('Height', 'web-stories')}
-            {...getMixedValueProps(height)}
+            isIndeterminate={MULTIPLE_VALUE === height}
+            placeholder={
+              disableHeight
+                ? __('Auto', 'web-stories')
+                : MULTIPLE_VALUE === height
+                ? MULTIPLE_DISPLAY_VALUE
+                : null
+            }
           />
         </Area>
         <Area area="l">

--- a/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
@@ -240,11 +240,11 @@ function SizePositionPanel({
         <Area area="l">
           <Tooltip
             placement={PLACEMENT.BOTTOM}
-            title={__('Constrain proportions', 'web-stories')}
+            title={__('Lock aspect ratio', 'web-stories')}
           >
             <LockToggle
-              aria-label={__('Aspect ratio lock', 'web-stories')}
-              title={__('Constrain proportions', 'web-stories')}
+              aria-label={__('Lock aspect ratio', 'web-stories')}
+              title={__('Lock aspect ratio', 'web-stories')}
               isLocked={lockAspectRatio}
               onClick={() =>
                 pushUpdate({ lockAspectRatio: !lockAspectRatio }, true)

--- a/assets/src/edit-story/components/panels/design/sizePosition/test/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/test/sizePosition.js
@@ -98,12 +98,6 @@ describe('Panels/SizePosition', () => {
     expect(element).toBeInTheDocument();
   });
 
-  it('should render Background button for Image', () => {
-    const { getByRole } = renderSizePosition([defaultImage]);
-    const element = getByRole('button', { name: 'Set as background' });
-    expect(element).toBeInTheDocument();
-  });
-
   describe('single selection', () => {
     it('should not render flip controls when not allowed', () => {
       const { queryByTitle } = renderSizePosition([defaultText]);

--- a/assets/src/edit-story/components/panels/design/sizePosition/test/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/test/sizePosition.js
@@ -37,7 +37,7 @@ jest.mock('../../../../../elements');
 describe('Panels/SizePosition', () => {
   let defaultElement, defaultImage, defaultText, unlockAspectRatioElement;
   let defaultFlip;
-  const aspectRatioLockButtonLabel = 'Aspect ratio lock';
+  const aspectRatioLockButtonLabel = 'Lock aspect ratio';
 
   beforeEach(() => {
     defaultFlip = { horizontal: false, vertical: false };

--- a/assets/src/edit-story/components/panels/design/sizePosition/test/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/test/sizePosition.js
@@ -161,10 +161,13 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith({
-        width: 150,
-        height: 150 / (100 / 80),
-      });
+      expect(pushUpdate).toHaveBeenCalledWith(
+        {
+          width: 150,
+          height: 150 / (100 / 80),
+        },
+        true
+      );
     });
 
     it('should update height with lock ratio', () => {
@@ -172,10 +175,13 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '160' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith({
-        height: 160,
-        width: 160 * (100 / 80),
-      });
+      expect(pushUpdate).toHaveBeenCalledWith(
+        {
+          height: 160,
+          width: 160 * (100 / 80),
+        },
+        true
+      );
     });
 
     it('should update width without lock ratio', () => {
@@ -186,7 +192,7 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith({ width: 150, height: 80 });
+      expect(pushUpdate).toHaveBeenCalledWith({ width: 150, height: 80 }, true);
     });
 
     it('should disable height without lock ratio for text element', () => {
@@ -199,7 +205,7 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Height' });
       expect(input).toBeDisabled();
       expect(input).toHaveValue('');
-      expect(input.placeholder).toStrictEqual('AUTO');
+      expect(input.placeholder).toStrictEqual('Auto');
     });
 
     it('should disable height without lock ratio for multi-selection with text', () => {
@@ -217,43 +223,31 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Height' });
       expect(input).toBeDisabled();
       expect(input).toHaveValue('');
-      expect(input.placeholder).toStrictEqual('AUTO');
+      expect(input.placeholder).toStrictEqual('Auto');
     });
 
     it('should not update width if empty value is submitted', () => {
       const { getByRole, pushUpdate } = renderSizePosition([defaultImage]);
       const inputWidth = getByRole('textbox', { name: 'Width' });
-      const inputHeight = getByRole('textbox', { name: 'Height' });
-      const originalWidth = parseInt(inputWidth.value);
-      const originalHeight = parseInt(inputHeight.value);
       fireEvent.change(inputWidth, { target: { value: '' } });
       fireEvent.keyDown(inputWidth, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith({
-        width: originalWidth,
-        height: originalHeight,
-      });
+      expect(pushUpdate).not.toHaveBeenCalled();
     });
 
     it('should not update height if empty value is submitted', () => {
       const { getByRole, pushUpdate } = renderSizePosition([defaultImage]);
-      const inputWidth = getByRole('textbox', { name: 'Width' });
       const inputHeight = getByRole('textbox', { name: 'Height' });
-      const originalWidth = parseInt(inputWidth.value);
-      const originalHeight = parseInt(inputHeight.value);
       fireEvent.change(inputHeight, { target: { value: '' } });
       fireEvent.keyDown(inputHeight, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith({
-        width: originalWidth,
-        height: originalHeight,
-      });
+      expect(pushUpdate).not.toHaveBeenCalled();
     });
 
     it('should update lock ratio to false for element', () => {
       const { getByRole, pushUpdate } = renderSizePosition([defaultImage]);
       fireEvent.click(
-        getByRole('checkbox', { name: aspectRatioLockButtonLabel })
+        getByRole('button', { name: aspectRatioLockButtonLabel })
       );
-      expect(pushUpdate).toHaveBeenCalledWith({ lockAspectRatio: false });
+      expect(pushUpdate).toHaveBeenCalledWith({ lockAspectRatio: false }, true);
     });
 
     it('should update lock ratio to true for unlock aspect ratio element', () => {
@@ -261,9 +255,9 @@ describe('Panels/SizePosition', () => {
         unlockAspectRatioElement,
       ]);
       fireEvent.click(
-        getByRole('checkbox', { name: aspectRatioLockButtonLabel })
+        getByRole('button', { name: aspectRatioLockButtonLabel })
       );
-      expect(pushUpdate).toHaveBeenCalledWith({ lockAspectRatio: true });
+      expect(pushUpdate).toHaveBeenCalledWith({ lockAspectRatio: true }, true);
     });
   });
 
@@ -319,10 +313,13 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith({
-        width: 150,
-        height: dataPixels(150 / (100 / 80)),
-      });
+      expect(pushUpdate).toHaveBeenCalledWith(
+        {
+          width: 150,
+          height: dataPixels(150 / (100 / 80)),
+        },
+        true
+      );
 
       const submits = submit({ width: 150, height: MULTIPLE_VALUE });
       expect(submits[image.id]).toStrictEqual(
@@ -347,10 +344,13 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith({
-        width: 150,
-        height: MULTIPLE_VALUE,
-      });
+      expect(pushUpdate).toHaveBeenCalledWith(
+        {
+          width: 150,
+          height: MULTIPLE_VALUE,
+        },
+        true
+      );
 
       const submits = submit({ width: 150, height: MULTIPLE_VALUE });
       expect(submits[image.id]).toStrictEqual(
@@ -375,10 +375,13 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '160' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith({
-        height: 160,
-        width: MULTIPLE_VALUE,
-      });
+      expect(pushUpdate).toHaveBeenCalledWith(
+        {
+          height: 160,
+          width: MULTIPLE_VALUE,
+        },
+        true
+      );
 
       const submits = submit({ height: 160, width: MULTIPLE_VALUE });
       expect(submits[image.id]).toStrictEqual(
@@ -401,9 +404,9 @@ describe('Panels/SizePosition', () => {
         imageWithSameSize,
       ]);
       fireEvent.click(
-        getByRole('checkbox', { name: aspectRatioLockButtonLabel })
+        getByRole('button', { name: aspectRatioLockButtonLabel })
       );
-      expect(pushUpdate).toHaveBeenCalledWith({ lockAspectRatio: false });
+      expect(pushUpdate).toHaveBeenCalledWith({ lockAspectRatio: false }, true);
     });
 
     it('should disable aspect ratio lock if elements had different settings for aspect ratio lock', () => {
@@ -412,9 +415,9 @@ describe('Panels/SizePosition', () => {
         imageWithSameSize,
       ]);
       fireEvent.click(
-        getByRole('checkbox', { name: aspectRatioLockButtonLabel })
+        getByRole('button', { name: aspectRatioLockButtonLabel })
       );
-      expect(pushUpdate).toHaveBeenCalledWith({ lockAspectRatio: false });
+      expect(pushUpdate).toHaveBeenCalledWith({ lockAspectRatio: false }, true);
     });
 
     it('should enable aspect ratio lock only if all elements had lock disabled', () => {
@@ -423,9 +426,9 @@ describe('Panels/SizePosition', () => {
         unlockImage,
       ]);
       fireEvent.click(
-        getByRole('checkbox', { name: aspectRatioLockButtonLabel })
+        getByRole('button', { name: aspectRatioLockButtonLabel })
       );
-      expect(pushUpdate).toHaveBeenCalledWith({ lockAspectRatio: true });
+      expect(pushUpdate).toHaveBeenCalledWith({ lockAspectRatio: true }, true);
     });
 
     it('should update height with lock ratio and extrapolated size and reset to max allowed', () => {
@@ -433,10 +436,13 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '2000' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith({
-        height: 2000,
-        width: 2000 * (100 / 80),
-      });
+      expect(pushUpdate).toHaveBeenCalledWith(
+        {
+          height: 2000,
+          width: 2000 * (100 / 80),
+        },
+        true
+      );
 
       const submits = submit({ height: 2000, width: 2000 * (100 / 80) });
       expect(submits[image.id]).toStrictEqual(

--- a/assets/src/edit-story/elements/video/karma/autoplay.karma.js
+++ b/assets/src/edit-story/elements/video/karma/autoplay.karma.js
@@ -23,7 +23,7 @@ import { waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import { Fixture } from '../../../karma';
-import { getBackgroundElementId } from '../../../components/dropTargets/karma/background.karma';
+import { useStory } from '../../../app/story';
 
 describe('Autoplay video', () => {
   let fixture;
@@ -81,7 +81,7 @@ describe('Autoplay video', () => {
     // Should not play during the drag
     expect(video1El.paused).toBe(true);
     await fixture.events.mouse.up();
-    const backgroundId = await getBackgroundElementId(fixture);
+    const backgroundId = (await getElements(fixture))[0].id;
     const backgroundElVideo = fixture.editor.canvas.displayLayer
       .display(backgroundId)
       .node.querySelector('video');
@@ -104,3 +104,12 @@ describe('Autoplay video', () => {
     expect(backgroundElVideo.paused).toBe(false);
   });
 });
+
+async function getElements(fixture) {
+  const {
+    state: {
+      currentPage: { elements },
+    },
+  } = await fixture.renderHook(() => useStory());
+  return elements;
+}

--- a/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
+++ b/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
@@ -18,7 +18,6 @@
  * Internal dependencies
  */
 import useInsertElement from '../components/canvas/useInsertElement';
-import { addBackgroundImage } from '../components/dropTargets/karma/background.karma';
 import { useStory } from '../app/story';
 import { Fixture } from './fixture';
 
@@ -228,12 +227,38 @@ describe('Background Copy & Paste', () => {
     });
     await fixture.events.click(addNewPageButton, { clickCount: 1 });
 
-    // Navigate back to previous page and aff Background image
+    // Navigate back to previous page and add Background image
     await goToPreviousPage();
+    const bgMedia = fixture.editor.library.media.item(0);
+    const canvas = fixture.editor.canvas.fullbleed.container;
+    await fixture.events.mouse.seq(({ down, moveRel, up }) => [
+      moveRel(bgMedia, 5, 5),
+      down(),
+      moveRel(canvas, 5, 5),
+      up(),
+    ]);
+
     // we want to zoom in a little bit so background
     // is big enough for all background animations.
     // scale is between 100 -> 400
-    await addBackgroundImage(fixture, { properties: { scale: 200 } });
+    const backgroundElement = await fixture.renderHook(() =>
+      useStory(({ state }) => state.currentPage.elements[0])
+    );
+    const bgFrame = fixture.editor.canvas.framesLayer.frame(
+      backgroundElement.id
+    ).node;
+    // Click twice to enter edit mode
+    await fixture.events.click(bgFrame);
+    await fixture.events.click(bgFrame);
+    const slider = fixture.editor.canvas.editLayer.sizeSlider;
+    await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
+      moveRel(slider, 5, 5),
+      down(),
+      moveBy(50, 0, { steps: 4 }),
+      up(),
+    ]);
+    // Click just below the slider to exit edit mode
+    await fixture.events.mouse.clickOn(slider, 0, 20);
   });
 
   afterEach(() => {

--- a/assets/src/edit-story/karma/fixture/containers/canvas.js
+++ b/assets/src/edit-story/karma/fixture/containers/canvas.js
@@ -109,6 +109,16 @@ class Display extends Container {
       '[class^="displayElement__BackgroundOverlay-sc-"]'
     );
   }
+
+  get element() {
+    return this.node.querySelector('[class^="display__Element-sc-"]');
+  }
+
+  get replacement() {
+    return this.node.querySelector(
+      '[class^="displayElement__ReplacementContainer-sc-"]'
+    );
+  }
 }
 
 /**

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/index.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/index.js
@@ -31,6 +31,7 @@ import { BorderRadius } from './borderRadius';
 import { ColorPreset } from './colorPreset';
 import { Layers } from './layers';
 import { Link } from './link';
+import { PageBackground } from './pageBackground';
 import { SizePosition } from './sizePosition';
 import { TextStyle } from './textStyle';
 import { TextStylePreset } from './textStylePreset';
@@ -154,6 +155,14 @@ export class DesignPanel extends Container {
       this.getByRole('region', { name: /Animation/ }),
       'animation',
       Animation
+    );
+  }
+
+  get pageBackground() {
+    return this._get(
+      this.getByRole('region', { name: /Page background/ }),
+      'pageBackground',
+      PageBackground
     );
   }
 

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/pageBackground.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/pageBackground.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { AbstractPanel } from './abstractPanel';
+
+/**
+ * The page background panel containing inputs flipping and detaching images as well as setting bg color.
+ */
+export class PageBackground extends AbstractPanel {
+  constructor(node, path) {
+    super(node, path);
+  }
+
+  get flipVertical() {
+    return this.getByRole('button', { name: /Flip vertically/i });
+  }
+
+  get flipHorizontal() {
+    return this.getByRole('button', { name: /Flip horizontally/i });
+  }
+}

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/sizePosition.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/sizePosition.js
@@ -17,7 +17,6 @@
 /**
  * Internal dependencies
  */
-import { Toggle } from '../common';
 import { AbstractPanel } from './abstractPanel';
 
 /**
@@ -37,15 +36,19 @@ export class SizePosition extends AbstractPanel {
   }
 
   get lockAspectRatio() {
-    return this._get(
-      this.getByRole('checkbox', { name: /Aspect ratio lock/ }),
-      'italic',
-      Toggle
-    );
+    return this.getByRole('button', { name: /Aspect ratio lock/ });
   }
 
   get rotate() {
     // @todo Implement.
     return null;
+  }
+
+  get flipVertical() {
+    return this.getByRole('button', { name: /Flip vertically/i });
+  }
+
+  get flipHorizontal() {
+    return this.getByRole('button', { name: /Flip horizontally/i });
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/sizePosition.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/sizePosition.js
@@ -36,7 +36,7 @@ export class SizePosition extends AbstractPanel {
   }
 
   get lockAspectRatio() {
-    return this.getByRole('button', { name: /Aspect ratio lock/ });
+    return this.getByRole('button', { name: /Lock aspect ratio/ });
   }
 
   get rotate() {


### PR DESCRIPTION
## Context

Implements size&position panel as per #6468.

## User-facing changes

| Before | After |
|-|-|
| ![Screen Shot 2021-03-07 at 14 44 25](https://user-images.githubusercontent.com/637548/110252553-0141c500-7f54-11eb-8a09-fc52ec51b330.png) | ![Screen Shot 2021-03-07 at 14 43 40](https://user-images.githubusercontent.com/637548/110252558-03a41f00-7f54-11eb-9b94-358de822fedc.png) |
| ![Screen Shot 2021-03-07 at 14 44 39](https://user-images.githubusercontent.com/637548/110252570-0d2d8700-7f54-11eb-8f39-55b8d4071758.png) | ![Screen Shot 2021-03-07 at 14 43 46](https://user-images.githubusercontent.com/637548/110252573-0f8fe100-7f54-11eb-8c21-c2766fc2b13b.png) |
| ![Screen Shot 2021-03-07 at 23 32 33](https://user-images.githubusercontent.com/637548/110298146-3edd3700-7fc2-11eb-927d-b2bacab9be78.png) | ![Screen Shot 2021-03-07 at 23 32 12](https://user-images.githubusercontent.com/637548/110298149-400e6400-7fc2-11eb-8964-abc49c4142a5.png) |

## Testing Instructions

### QA

This PR can be tested by following these steps:

1. Select a shape element
2. Manipulate it using the size+position panel
3. Observe that all functions still work, including flip toggles
4. Select another shape element as well at a different position and angle
5. Observe all text fields correctly displaying _"Mixed"_
6. Enter values in the mixed input fields to align the two shapes in position and/or size

### UAT

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6468
