### PR TITLE
Stop scrolling when lightbox is open

### DIFF
--- a/assets/src/web-stories-block/css/lightbox.css
+++ b/assets/src/web-stories-block/css/lightbox.css
@@ -1,5 +1,5 @@
 /* Lightbox styles */
-.ws-lightbox-open {
+.web-stories-lightbox-open {
   /* Stop page scroll when lightbox is visible. */
   overflow-y: hidden;
 }

--- a/assets/src/web-stories-block/css/lightbox.css
+++ b/assets/src/web-stories-block/css/lightbox.css
@@ -1,18 +1,20 @@
 /* Lightbox styles */
+.ws-lightbox-open {
+  /* Stop page scroll when lightbox is visible. */
+  overflow-y: hidden;
+}
+
 .web-stories-list__lightbox {
   justify-content: center;
   align-items: center;
   position: fixed;
   background: black;
-  left: -100%;
+  left: 0;
   top: 0;
   width: 100%;
   height: 100%;
   opacity: 0;
-}
-
-.admin-bar .web-stories-list__lightbox {
-  top: 46px;
+  transform: translate(0, -100vh);
 }
 
 /* amp-lightbox needs to have z-index to render on top of other elements in the page. */
@@ -22,7 +24,7 @@
 }
 
 .web-stories-list__lightbox.show {
-  left: 0;
+  transform: translate(0, 0);
   opacity: 1;
 }
 
@@ -71,6 +73,10 @@ html:not([amp])
 }
 
 @media all and (min-width: 676px) {
+  .admin-bar .web-stories-list__lightbox {
+    top: 46px;
+  }
+
   .story-lightbox__close-button {
     left: 10px;
   }

--- a/includes/Stories_Renderer/Renderer.php
+++ b/includes/Stories_Renderer/Renderer.php
@@ -689,7 +689,7 @@ abstract class Renderer implements RenderingInterface, Iterator {
 	 */
 	public function render_stories_with_lightbox() {
 		$data = [
-			'controls'  => [
+			'controls' => [
 				[
 					'name'     => 'close',
 					'position' => 'start',
@@ -698,10 +698,8 @@ abstract class Renderer implements RenderingInterface, Iterator {
 					'name' => 'skip-next',
 				],
 			],
-			'behaviour' => [
+			'behavior' => [
 				'autoplay' => false,
-				'on'       => 'end',
-				'action'   => 'circular-wrapping',
 			],
 		];
 		?>

--- a/packages/stories-lightbox/src/web-stories-lightbox.js
+++ b/packages/stories-lightbox/src/web-stories-lightbox.js
@@ -54,7 +54,7 @@ class Lightbox {
     this.player.addEventListener('amp-story-player-close', () => {
       this.player.pause();
       this.lightboxElement.classList.toggle('show');
-      document.body.classList.toggle('ws-lightbox-open');
+      document.body.classList.toggle('web-stories-lightbox-open');
     });
   }
 
@@ -76,7 +76,7 @@ class Lightbox {
         this.player.show(storyObject.href);
         this.player.play();
         this.lightboxElement.classList.toggle('show');
-        document.body.classList.toggle('ws-lightbox-open');
+        document.body.classList.toggle('web-stories-lightbox-open');
       });
     });
   }

--- a/packages/stories-lightbox/src/web-stories-lightbox.js
+++ b/packages/stories-lightbox/src/web-stories-lightbox.js
@@ -54,6 +54,7 @@ class Lightbox {
     this.player.addEventListener('amp-story-player-close', () => {
       this.player.pause();
       this.lightboxElement.classList.toggle('show');
+      document.body.classList.toggle('ws-lightbox-open');
     });
   }
 
@@ -75,6 +76,7 @@ class Lightbox {
         this.player.show(storyObject.href);
         this.player.play();
         this.lightboxElement.classList.toggle('show');
+        document.body.classList.toggle('ws-lightbox-open');
       });
     });
   }


### PR DESCRIPTION
## Context
User were able to scroll the page when lightbox is open. On page load all stories were loading even though they are not in the viewport.

## This PR
- Fix: stop page scroll when lightbox is open.
- Fix: typo for 'amp-story-player' behavior data to stop auto play.
- Fix: stop stories not in viewport from loading.
