### PR TITLE
Redesign: Mixed value handling for panels with new design

### DIFF
--- a/assets/src/design-system/components/hex/getPreviewText.js
+++ b/assets/src/design-system/components/hex/getPreviewText.js
@@ -19,18 +19,13 @@
  */
 import { __ } from '@web-stories-wp/i18n';
 
-/**
- * Internal dependencies
- */
-import { MULTIPLE_VALUE } from '../../utils';
-
 function printRGB(r, g, b) {
   const hex = (v) => v.toString(16).padStart(2, '0');
   return `${hex(r)}${hex(g)}${hex(b)}`.toUpperCase();
 }
 
 function getPreviewText(pattern) {
-  if (!pattern || pattern === MULTIPLE_VALUE) {
+  if (!pattern) {
     return null;
   }
   switch (pattern.type) {

--- a/assets/src/design-system/components/hex/index.js
+++ b/assets/src/design-system/components/hex/index.js
@@ -25,8 +25,6 @@ import PropTypes from 'prop-types';
  */
 import { parseToRgb } from 'polished';
 import { Input, useKeyDownEffect } from '../';
-// @todo Should the multiple value come from the editor / input usage instead?
-import { MULTIPLE_VALUE } from '../../utils';
 import { InputPropTypes } from '../input';
 import getHexFromValue from './getHexFromValue';
 import getPreviewText from './getPreviewText';
@@ -35,9 +33,6 @@ export const HexInput = forwardRef(function Hex(
   { value, placeholder, onChange, ...rest },
   ref
 ) {
-  const isMixed = value === MULTIPLE_VALUE;
-  value = isMixed ? '' : value;
-
   const [inputValue, setInputValue] = useState('');
 
   const inputRef = useRef(null);
@@ -62,10 +57,10 @@ export const HexInput = forwardRef(function Hex(
       const { red: r, green: g, blue: b } = parseToRgb(`#${hex}`);
 
       // Keep same opacity as before though. In case of mixed values, set to default (1).
-      const a = isMixed ? 1 : value.color.a;
+      const a = value.color.a;
       onChange({ color: { r, g, b, a } });
     }
-  }, [inputValue, previewText, onChange, value, isMixed]);
+  }, [inputValue, previewText, onChange, value]);
 
   const handleEnter = useCallback(() => {
     validateAndSubmitInput();

--- a/assets/src/design-system/components/mediaInput/index.js
+++ b/assets/src/design-system/components/mediaInput/index.js
@@ -35,7 +35,6 @@ import {
 import { Pencil } from '../../icons';
 import { Menu } from '../menu';
 import { Tooltip } from '../tooltip';
-import { MULTIPLE_VALUE } from '../../utils';
 import { PLACEMENT, Popup } from '../popup';
 import { ReactComponent as Landscape } from './landscape.svg';
 import { MEDIA_VARIANTS } from './constants';
@@ -172,7 +171,6 @@ export const MediaInput = forwardRef(function Media(
   ref
 ) {
   const hasMenu = menuOptions?.length > 0;
-  const isMultiple = value === MULTIPLE_VALUE;
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const buttonRef = useRef(null);
@@ -186,7 +184,7 @@ export const MediaInput = forwardRef(function Media(
   return (
     <StyledMedia ref={ref} className={className} {...rest}>
       <ImageWrapper variant={variant}>
-        {value && !isMultiple ? (
+        {value ? (
           <Img src={value} alt={alt} />
         ) : (
           <DefaultImageWrapper>

--- a/assets/src/design-system/utils/constants.js
+++ b/assets/src/design-system/utils/constants.js
@@ -20,5 +20,3 @@ export const KEYS = {
   RIGHT: 'ArrowRight',
   UP: 'ArrowUp',
 };
-
-export const MULTIPLE_VALUE = '((MULTIPLE))';

--- a/assets/src/edit-story/components/form/color/colorInput.js
+++ b/assets/src/edit-story/components/form/color/colorInput.js
@@ -162,6 +162,7 @@ function ColorInput({
             aria-label={label}
             value={value}
             onChange={onChange}
+            isIndeterminate={isMixed}
             placeholder={isMixed ? MULTIPLE_DISPLAY_VALUE : ''}
           />
           <ColorPreview>

--- a/assets/src/edit-story/components/form/media.js
+++ b/assets/src/edit-story/components/form/media.js
@@ -26,6 +26,7 @@ import { __ } from '@web-stories-wp/i18n';
  */
 import { useMediaPicker } from '../mediaPicker';
 import { MediaInput as Input } from '../../../design-system/components/mediaInput';
+import { MULTIPLE_VALUE } from '../../constants';
 
 const MediaInput = forwardRef(
   (
@@ -35,6 +36,7 @@ const MediaInput = forwardRef(
       onChange,
       title = __('Choose an image', 'web-stories'),
       type = 'image',
+      value,
       ...rest
     },
     forwardedRef
@@ -53,10 +55,14 @@ const MediaInput = forwardRef(
       { label: __('Reset', 'web-stories'), value: 'reset' },
     ];
 
+    // No menu for mixed value.
     // Match the options from props, if none are matched, menu is not displayed.
-    const dropdownOptions = availableMenuOptions.filter(({ value }) =>
-      menuOptions.includes(value)
-    );
+    const dropdownOptions =
+      value === MULTIPLE_VALUE
+        ? []
+        : availableMenuOptions.filter(({ value: option }) =>
+            menuOptions.includes(option)
+          );
 
     const onOption = useCallback(
       (evt, opt) => {
@@ -81,6 +87,7 @@ const MediaInput = forwardRef(
         menuOptions={dropdownOptions}
         openMediaPicker={openMediaPicker}
         ref={forwardedRef}
+        value={value === MULTIPLE_VALUE ? null : value}
         {...rest}
       />
     );
@@ -93,6 +100,7 @@ MediaInput.propTypes = {
   onChange: PropTypes.func.isRequired,
   type: PropTypes.string,
   title: PropTypes.string,
+  value: PropTypes.string,
 };
 
 export default MediaInput;

--- a/assets/src/edit-story/components/panels/design/layerStyle/layerStyle.js
+++ b/assets/src/edit-story/components/panels/design/layerStyle/layerStyle.js
@@ -29,6 +29,7 @@ import { NumericInput } from '../../../../../design-system';
 import { Row } from '../../../form';
 import { SimplePanel } from '../../panel';
 import { getCommonValue } from '../../shared';
+import { MULTIPLE_DISPLAY_VALUE, MULTIPLE_VALUE } from '../../../../constants';
 
 const MIN_MAX = {
   OPACITY: {
@@ -64,6 +65,8 @@ function LayerStylePanel({ selectedElements, pushUpdate }) {
           min={MIN_MAX.OPACITY.MIN}
           max={MIN_MAX.OPACITY.MAX}
           aria-label={__('Opacity in percent', 'web-stories')}
+          placeholder={opacity === MULTIPLE_VALUE ? MULTIPLE_DISPLAY_VALUE : ''}
+          isIndeterminate={opacity === MULTIPLE_VALUE}
         />
       </ShortRow>
     </SimplePanel>

--- a/assets/src/edit-story/components/panels/design/layerStyle/test/layerStyle.js
+++ b/assets/src/edit-story/components/panels/design/layerStyle/test/layerStyle.js
@@ -82,9 +82,7 @@ describe('Panels/LayerStyle', () => {
     expect(pushUpdate).toHaveBeenCalledWith({ opacity: 23 }, true);
   });
 
-  // Disable reason: Will be implemented once #6574 is merged
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should display mixed in case of multi-selection with different values', () => {
+  it('should display mixed in case of multi-selection with different values', () => {
     const { getByRole } = renderLayerStyle([
       { ...defaultElement, opacity: 50 },
       { id: 2, opacity: 80 },


### PR DESCRIPTION
## Context

Uses `isIndeterminate` as the indicator for mixed value.

## User-facing changes


### QA

This PR can be tested by following these steps:

1. Add two shapes
2. Assing layer opacity 50% to one of the shapes
3. Select both shapes now
4. Verify the input shows "Mixed" as placeholder

### UAT


<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6640 
