### PR TITLE
Design System: Decrease transition time

### DIFF
--- a/assets/src/design-system/components/button/constants.js
+++ b/assets/src/design-system/components/button/constants.js
@@ -34,4 +34,4 @@ export const BUTTON_VARIANTS = {
 };
 
 export const BUTTON_SIZE = 32;
-export const BUTTON_TRANSITION_TIMING = '0.6s ease 0s';
+export const BUTTON_TRANSITION_TIMING = '0.3s ease 0s';

--- a/assets/src/design-system/components/pill/pill.js
+++ b/assets/src/design-system/components/pill/pill.js
@@ -55,8 +55,8 @@ const StyledPill = styled.button(
       color: ${isActive ? theme.colors.bg.primary : theme.colors.fg.disable};
     }
 
-    transition: color 0.6s ease 0s;
-    transition: background-color 0.6s ease 0s;
+    transition: color 0.3s ease 0s;
+    transition: background-color 0.3s ease 0s;
   `
 );
 


### PR DESCRIPTION
…system

## Context

Briefly discussed this in #6590 

https://github.com/google/web-stories-wp/pull/6590#discussion_r588426020

## Summary

Decrease button and pill transition time from 0.6s to 0.3s in design system

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

None

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6635 
