### PR TITLE
Design System: Firefox bugfix for context menus

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/karma/editorSettings.karma.js
+++ b/assets/src/dashboard/app/views/editorSettings/karma/editorSettings.karma.js
@@ -337,21 +337,22 @@ describe('Settings View', () => {
 
     await focusOnPublisherLogos();
 
-    const page1 = fixture.screen.getByTestId(/^uploaded-publisher-logo-0/);
+    const logo1 = fixture.screen.getByTestId(/^uploaded-publisher-logo-0/);
     await fixture.events.keyboard.press('right');
-    expect(page1).toEqual(document.activeElement);
+    expect(logo1).toEqual(document.activeElement);
 
-    // // go right by 1
+    // go to second logo
     await fixture.events.keyboard.press('right');
 
-    await fixture.events.keyboard.press('Enter');
-
-    const page2 = fixture.screen.getByTestId(/^uploaded-publisher-logo-1/);
-    expect(page2).toEqual(document.activeElement);
+    const logo2 = fixture.screen.getByTestId(/^uploaded-publisher-logo-1/);
+    expect(logo2).toEqual(document.activeElement);
 
     await fixture.events.keyboard.press('Tab');
 
     await fixture.events.keyboard.press('Enter');
+
+    // Tab into second menu
+    await fixture.events.keyboard.press('Tab');
 
     // we want to select the second list item
     await fixture.events.keyboard.press('ArrowDown');
@@ -435,21 +436,22 @@ describe('Settings View', () => {
 
     await focusOnPublisherLogos();
 
-    const page1 = fixture.screen.getByTestId(/^uploaded-publisher-logo-0/);
+    const logo1 = fixture.screen.getByTestId(/^uploaded-publisher-logo-0/);
     await fixture.events.keyboard.press('right');
-    expect(page1).toEqual(document.activeElement);
+    expect(logo1).toEqual(document.activeElement);
 
     // go right by 1
     await fixture.events.keyboard.press('right');
 
+    const logo2 = fixture.screen.getByTestId(/^uploaded-publisher-logo-1/);
+    expect(logo2).toEqual(document.activeElement);
+
+    // set focus within logo2
+    await fixture.events.keyboard.press('tab');
+    // activate menu
     await fixture.events.keyboard.press('Enter');
-
-    const page2 = fixture.screen.getByTestId(/^uploaded-publisher-logo-1/);
-    expect(page2).toEqual(document.activeElement);
-
-    await fixture.events.keyboard.press('Tab');
-
-    await fixture.events.keyboard.press('Enter');
+    //tab into menu
+    await fixture.events.keyboard.press('tab');
 
     // we want to select the first list item
     await fixture.events.keyboard.press('Enter');

--- a/assets/src/design-system/components/contextMenu/animatedContextMenu.js
+++ b/assets/src/design-system/components/contextMenu/animatedContextMenu.js
@@ -201,9 +201,14 @@ ButtonInner.propTypes = {
   isReady: PropTypes.bool,
 };
 
-function AnimationContainer({ children, isOpen, ...props }) {
+function AnimationContainer({
+  children,
+  isOpen,
+  isReady,
+  onAnimationComplete,
+  ...props
+}) {
   const [align, setAlign] = useState(null);
-  const [isReady, setIsReady] = useState(false);
   const menuPositionRef = useRef(null);
   const menuTogglePositionRef = useRef(null);
 
@@ -244,10 +249,12 @@ function AnimationContainer({ children, isOpen, ...props }) {
    * from batching those renders and animating from wrong alignment.
    */
   useEffect(() => {
-    const frameId = requestAnimationFrame(() => setIsReady(Boolean(align)));
+    const frameId = requestAnimationFrame(() =>
+      onAnimationComplete(Boolean(align))
+    );
 
     return () => cancelAnimationFrame(frameId);
-  }, [align]);
+  }, [align, onAnimationComplete]);
 
   return (
     <ButtonInner
@@ -270,14 +277,24 @@ function AnimationContainer({ children, isOpen, ...props }) {
 }
 AnimationContainer.propTypes = {
   isOpen: PropTypes.bool,
+  isReady: PropTypes.bool,
+  onAnimationComplete: PropTypes.func.isRequired,
   children: PropTypes.node,
 };
 
-const AnimatedContextMenu = ({ isOpen, items, ...props }) => (
-  <AnimationContainer isOpen={isOpen}>
-    <Menu items={items} isOpen={isOpen} {...props} />
-  </AnimationContainer>
-);
+const AnimatedContextMenu = ({ isOpen, items, ...props }) => {
+  const [isReady, setIsReady] = useState(false);
+
+  return (
+    <AnimationContainer
+      isReady={isReady}
+      onAnimationComplete={setIsReady}
+      isOpen={isOpen}
+    >
+      <Menu items={items} isOpen={isOpen && isReady} {...props} />
+    </AnimationContainer>
+  );
+};
 AnimatedContextMenu.propTypes = {
   ...MenuPropTypes,
   isOpen: PropTypes.bool,

--- a/assets/src/design-system/components/contextMenu/animatedContextMenu.js
+++ b/assets/src/design-system/components/contextMenu/animatedContextMenu.js
@@ -201,14 +201,9 @@ ButtonInner.propTypes = {
   isReady: PropTypes.bool,
 };
 
-function AnimationContainer({
-  children,
-  isOpen,
-  isReady,
-  onAnimationComplete,
-  ...props
-}) {
+function AnimationContainer({ children, isOpen, ...props }) {
   const [align, setAlign] = useState(null);
+  const [isReady, setIsReady] = useState(false);
   const menuPositionRef = useRef(null);
   const menuTogglePositionRef = useRef(null);
 
@@ -249,12 +244,10 @@ function AnimationContainer({
    * from batching those renders and animating from wrong alignment.
    */
   useEffect(() => {
-    const frameId = requestAnimationFrame(() =>
-      onAnimationComplete(Boolean(align))
-    );
+    const frameId = requestAnimationFrame(() => setIsReady(Boolean(align)));
 
     return () => cancelAnimationFrame(frameId);
-  }, [align, onAnimationComplete]);
+  }, [align]);
 
   return (
     <ButtonInner
@@ -277,24 +270,14 @@ function AnimationContainer({
 }
 AnimationContainer.propTypes = {
   isOpen: PropTypes.bool,
-  isReady: PropTypes.bool,
-  onAnimationComplete: PropTypes.func.isRequired,
   children: PropTypes.node,
 };
 
-const AnimatedContextMenu = ({ isOpen, items, ...props }) => {
-  const [isReady, setIsReady] = useState(false);
-
-  return (
-    <AnimationContainer
-      isReady={isReady}
-      onAnimationComplete={setIsReady}
-      isOpen={isOpen}
-    >
-      <Menu items={items} isOpen={isOpen && isReady} {...props} />
-    </AnimationContainer>
-  );
-};
+const AnimatedContextMenu = ({ isOpen, items, ...props }) => (
+  <AnimationContainer isOpen={isOpen}>
+    <Menu items={items} isOpen={isOpen} {...props} />
+  </AnimationContainer>
+);
 AnimatedContextMenu.propTypes = {
   ...MenuPropTypes,
   isOpen: PropTypes.bool,

--- a/assets/src/design-system/components/contextMenu/menu.js
+++ b/assets/src/design-system/components/contextMenu/menu.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 /**
@@ -124,7 +124,6 @@ const MenuList = styled.ul(
 const Menu = ({ isOpen, items, ...props }) => {
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const listRef = useRef(null);
-  const menuWasAlreadyOpen = useRef(isOpen);
   const ids = useMemo(() => items.map(() => uuidv4()), [items]);
 
   const totalIndex = useMemo(() => items.length - 1, [items]);
@@ -162,34 +161,6 @@ const Menu = ({ isOpen, items, ...props }) => {
   useKeyDownEffect(listRef, { key: ['down', 'up'] }, handleKeyboardNav, [
     handleKeyboardNav,
   ]);
-
-  useEffect(() => {
-    // focus first 'focusable' element if menu is opened and no element is focused
-    if (
-      isOpen &&
-      !menuWasAlreadyOpen.current &&
-      listRef?.current &&
-      focusedIndex === -1
-    ) {
-      let index = 0;
-
-      while (index <= totalIndex) {
-        const element = listRef.current?.children?.[index]?.children?.[0];
-
-        if (
-          FOCUSABLE_ELEMENTS.includes(element?.tagName) &&
-          !element?.disabled
-        ) {
-          setFocusedIndex(index);
-          return;
-        }
-
-        index++;
-      }
-
-      menuWasAlreadyOpen.current = true;
-    }
-  }, [focusedIndex, isOpen, totalIndex]);
 
   return (
     <MenuWrapper>

--- a/assets/src/design-system/components/contextMenu/menu.js
+++ b/assets/src/design-system/components/contextMenu/menu.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 /**
@@ -124,6 +124,7 @@ const MenuList = styled.ul(
 const Menu = ({ isOpen, items, ...props }) => {
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const listRef = useRef(null);
+  const menuWasAlreadyOpen = useRef(isOpen);
   const ids = useMemo(() => items.map(() => uuidv4()), [items]);
 
   const totalIndex = useMemo(() => items.length - 1, [items]);
@@ -161,6 +162,34 @@ const Menu = ({ isOpen, items, ...props }) => {
   useKeyDownEffect(listRef, { key: ['down', 'up'] }, handleKeyboardNav, [
     handleKeyboardNav,
   ]);
+
+  useEffect(() => {
+    // focus first 'focusable' element if menu is opened and no element is focused
+    if (
+      isOpen &&
+      !menuWasAlreadyOpen.current &&
+      listRef?.current &&
+      focusedIndex === -1
+    ) {
+      let index = 0;
+
+      while (index <= totalIndex) {
+        const element = listRef.current?.children?.[index]?.children?.[0];
+
+        if (
+          FOCUSABLE_ELEMENTS.includes(element?.tagName) &&
+          !element?.disabled
+        ) {
+          setFocusedIndex(index);
+          return;
+        }
+
+        index++;
+      }
+
+      menuWasAlreadyOpen.current = true;
+    }
+  }, [focusedIndex, isOpen, totalIndex]);
 
   return (
     <MenuWrapper>


### PR DESCRIPTION
## Context

Noticed that in firefox specifically, context menu `button` type options were not firing. Figured we should fix it.

## Summary

The animated context menu need to render before it's able to be interacted with, so we have an `isOpen` as well as an `isReady` prop that control functionality. The menu itself is unaware of this because the animated version is just a wrapper. There was an improvement to keyboard functionality made with the updated version that was added to the design system that automatically focuses the first menu item if it's the first time a user is in that specific instance of a menu. 


## Relevant Technical Choices

This `useEffect` is firing before the animated context menu is usable (`isReady`) state. The isReady state is not available at this level of the menu. Chrome is able to figure this out and works fine, however firefox doesn't - so menu items that are buttons don't ever trigger an `onClick`. 

It seems like this was just a nice enhancement from the existing functionality, not something that is key to the menu working. As such, I opted to remove the useEffect hook ahead of release since I couldn't figure out an alternative in a timely manner.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

context menus in dashboard on firefox should work better.

## Testing Instructions

Open context menus in chrome and firefox, click _every_ action - see that they work. (menus are in 'my stories' and settings for logos)

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
