### PR TITLE
Animations: Background Pan and Zoom Effect

### DIFF
--- a/assets/src/animation/constants.js
+++ b/assets/src/animation/constants.js
@@ -81,6 +81,10 @@ export const BACKGROUND_ANIMATION_EFFECTS = {
     name: __('Zoom', 'web-stories'),
   },
   PAN: { value: 'effect-background-pan', name: ANIMATION_EFFECTS.PAN.name },
+  PAN_AND_ZOOM: {
+    value: 'effect-background-pan-and-zoom',
+    name: __('Pan and Zoom', 'web-stories'),
+  },
 };
 
 export const ANIMATION_PARTS = {

--- a/assets/src/animation/effects/backgroundPanAndZoom/animationProps.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/animationProps.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@web-stories-wp/i18n';
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { FIELD_TYPES, SCALE_DIRECTION } from '../../constants';
+import { AnimationInputPropTypes } from '../types';
+
+export const ZoomEffectInputPropTypes = {
+  zoomFrom: PropTypes.shape(AnimationInputPropTypes),
+};
+
+export default {
+  zoomDirection: {
+    label: __('Direction', 'web-stories'),
+    tooltip: sprintf(
+      /* translators: 1: scaleIn. 2: scaleOut */
+      __('Valid values are %1$s or %2$s', 'web-stories'),
+      'zoomIn',
+      'zoomOut'
+    ),
+    type: FIELD_TYPES.DIRECTION_PICKER,
+    values: [SCALE_DIRECTION.SCALE_IN, SCALE_DIRECTION.SCALE_OUT],
+    defaultValue: SCALE_DIRECTION.SCALE_OUT,
+  },
+};

--- a/assets/src/animation/effects/backgroundPanAndZoom/animationProps.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/animationProps.js
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES } from '../../constants';
+import { FIELD_TYPES, SCALE_DIRECTION } from '../../constants';
 import zoomAnimationProps, {
   ZoomEffectInputPropTypes,
 } from '../backgroundZoom/animationProps';
@@ -35,6 +39,10 @@ const zoomAnimationPropsWithDropdown = {
   zoomDirection: {
     ...zoomAnimationProps.zoomDirection,
     type: FIELD_TYPES.DROPDOWN,
+    values: [
+      { value: SCALE_DIRECTION.SCALE_IN, name: __('Zoom in', 'web-stories') },
+      { value: SCALE_DIRECTION.SCALE_OUT, name: __('Zoom out', 'web-stories') },
+    ],
   },
 };
 

--- a/assets/src/animation/effects/backgroundPanAndZoom/animationProps.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/animationProps.js
@@ -15,32 +15,30 @@
  */
 
 /**
- * External dependencies
- */
-import { __, sprintf } from '@web-stories-wp/i18n';
-import PropTypes from 'prop-types';
-
-/**
  * Internal dependencies
  */
-import { FIELD_TYPES, SCALE_DIRECTION } from '../../constants';
-import { AnimationInputPropTypes } from '../types';
+import { FIELD_TYPES } from '../../constants';
+import zoomAnimationProps, {
+  ZoomEffectInputPropTypes,
+} from '../backgroundZoom/animationProps';
+import panAnimationProps, {
+  PanEffectInputPropTypes,
+} from '../backgroundPan/animationProps';
 
-export const ZoomEffectInputPropTypes = {
-  zoomFrom: PropTypes.shape(AnimationInputPropTypes),
+export const PanAndZoomEffectInputPropTypes = {
+  ...PanEffectInputPropTypes,
+  ...ZoomEffectInputPropTypes,
+};
+
+const zoomAnimationPropsWithDropdown = {
+  ...zoomAnimationProps,
+  zoomDirection: {
+    ...zoomAnimationProps.zoomDirection,
+    type: FIELD_TYPES.DROPDOWN,
+  },
 };
 
 export default {
-  zoomDirection: {
-    label: __('Direction', 'web-stories'),
-    tooltip: sprintf(
-      /* translators: 1: scaleIn. 2: scaleOut */
-      __('Valid values are %1$s or %2$s', 'web-stories'),
-      'zoomIn',
-      'zoomOut'
-    ),
-    type: FIELD_TYPES.DIRECTION_PICKER,
-    values: [SCALE_DIRECTION.SCALE_IN, SCALE_DIRECTION.SCALE_OUT],
-    defaultValue: SCALE_DIRECTION.SCALE_OUT,
-  },
+  ...panAnimationProps,
+  ...zoomAnimationPropsWithDropdown,
 };

--- a/assets/src/animation/effects/backgroundPanAndZoom/index.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/index.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { BG_MIN_SCALE, BG_MAX_SCALE, SCALE_DIRECTION } from '../../constants';
+import { AnimationZoom } from '../../parts/zoom';
+import { lerp } from '../../utils';
+
+export function EffectBackgroundZoom({
+  element,
+  zoomDirection = SCALE_DIRECTION.SCALE_OUT,
+  duration = 1000,
+  delay,
+  easing,
+}) {
+  // Define the range based off the element scale
+  // at element scale 400, the range should be [1/4, 1]
+  // at element scale 100, the range should be [1, 4]
+  const range = [BG_MIN_SCALE / element.scale, BG_MAX_SCALE / element.scale];
+
+  return AnimationZoom({
+    zoomFrom: lerp(zoomDirection === SCALE_DIRECTION.SCALE_OUT ? 1 : 0, range),
+    zoomTo: 1,
+    duration,
+    delay,
+    easing,
+    targetLeafElement: true,
+  });
+}

--- a/assets/src/animation/effects/backgroundPanAndZoom/index.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/index.js
@@ -25,7 +25,7 @@ import {
 import SimpleAnimation from '../../parts/simpleAnimation';
 import { EffectBackgroundPan } from '../backgroundPan';
 import { EffectBackgroundZoom } from '../backgroundZoom';
-import { getMediaOrigin } from '../../utils';
+import { getMediaOrigin, getMediaBoundOffsets } from '../../utils';
 
 const defaults = {
   fill: 'forwards',
@@ -77,7 +77,7 @@ export function EffectBackgroundPanAndZoom({
   // direction and the current media position relative to
   // the frame. This prevents area from ever being shown
   // where the media does't fill the frame during scaling
-  const origin = getMediaOrigin(element);
+  const origin = getMediaOrigin(getMediaBoundOffsets(element));
   const transformOrigin =
     {
       [DIRECTION.RIGHT_TO_LEFT]: [

--- a/assets/src/animation/effects/backgroundPanAndZoom/index.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/index.js
@@ -48,11 +48,13 @@ export function EffectBackgroundPanAndZoom({
 
   const animationName = `direction-${panDir}-${zoomDirection}-${BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value}`;
 
+  // Background animations aren't really composable through element nesting
+  // because they all target the same dom node. To accomomdate for this we
+  // manually compose the keyframes and use those to generate a new animation.
   const { generatedKeyframes: zoomGeneratedKeyframes } = EffectBackgroundZoom({
     element,
     zoomDirection,
   });
-
   const { generatedKeyframes: panGeneratedKeyframes } = EffectBackgroundPan({
     element,
     panDir,
@@ -61,13 +63,21 @@ export function EffectBackgroundPanAndZoom({
   const zoomKeyframes = Object.values(zoomGeneratedKeyframes)?.[0] || [];
   const panKeyframes = Object.values(panGeneratedKeyframes)?.[0] || [];
 
-  const startTransform = `${zoomKeyframes?.transform[0]} ${panKeyframes?.transform[0]}`;
+  const startTransform = `${panKeyframes?.transform[0]} ${zoomKeyframes?.transform[0]}`;
   const zoomLastTransformIndex = (zoomKeyframes?.transform?.length || 1) - 1;
   const panLastTransformIndex = (panKeyframes?.transform?.length || 1) - 1;
-  const endTransform = `${zoomKeyframes?.transform[zoomLastTransformIndex]} ${panKeyframes?.transform[panLastTransformIndex]}`;
+  const endTransform = `${panKeyframes?.transform[zoomLastTransformIndex]} ${zoomKeyframes?.transform[panLastTransformIndex]}`;
 
+  const transformOrigin =
+    {
+      [DIRECTION.RIGHT_TO_LEFT]: ['0% 50%', '0% 50%'],
+      [DIRECTION.LEFT_TO_RIGHT]: ['100% 50%', '100% 50%'],
+      [DIRECTION.BOTTOM_TO_TOP]: ['50% 0%', '50% 0%'],
+      [DIRECTION.TOP_TO_BOTTOM]: ['50% 100%', '50% 100%'],
+    }[panDir] || [];
   const keyframes = {
     transform: [startTransform, endTransform],
+    transformOrigin,
   };
 
   const { id, WAAPIAnimation, AMPTarget, AMPAnimation } = SimpleAnimation(

--- a/assets/src/animation/effects/backgroundPanAndZoom/index.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/index.js
@@ -77,7 +77,7 @@ export function EffectBackgroundPanAndZoom({
   // direction and the current media position relative to
   // the frame. This prevents area from ever being shown
   // where the media does't fill the frame during scaling
-  const origin = getMediaOrigin(getMediaBoundOffsets(element));
+  const origin = getMediaOrigin(element && getMediaBoundOffsets({ element }));
   const transformOrigin =
     {
       [DIRECTION.RIGHT_TO_LEFT]: [

--- a/assets/src/animation/effects/backgroundPanAndZoom/index.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/index.js
@@ -25,6 +25,7 @@ import {
 import SimpleAnimation from '../../parts/simpleAnimation';
 import { EffectBackgroundPan } from '../backgroundPan';
 import { EffectBackgroundZoom } from '../backgroundZoom';
+import { getMediaBoundOffsets, lerp } from '../../utils';
 
 const defaults = {
   fill: 'forwards',
@@ -68,12 +69,48 @@ export function EffectBackgroundPanAndZoom({
   const panLastTransformIndex = (panKeyframes?.transform?.length || 1) - 1;
   const endTransform = `${panKeyframes?.transform[zoomLastTransformIndex]} ${zoomKeyframes?.transform[panLastTransformIndex]}`;
 
+  const offsets = element
+    ? getMediaBoundOffsets({ element })
+    : {
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      };
+
+  const progress = {
+    vertical:
+      Math.abs(offsets.top) /
+      (Math.abs(offsets.top) + Math.abs(offsets.bottom)),
+    horizontal:
+      Math.abs(offsets.left) /
+      (Math.abs(offsets.left) + Math.abs(offsets.right)),
+  };
+  const origin = {
+    vertical: lerp(progress.vertical, [0, 100]),
+    horizontal: lerp(progress.horizontal, [0, 100]),
+  };
+
+  // console.log(`${origin.horizontal}% ${origin.vertical}%`);
+
   const transformOrigin =
     {
-      [DIRECTION.RIGHT_TO_LEFT]: ['0% 50%', '0% 50%'],
-      [DIRECTION.LEFT_TO_RIGHT]: ['100% 50%', '100% 50%'],
-      [DIRECTION.BOTTOM_TO_TOP]: ['50% 0%', '50% 0%'],
-      [DIRECTION.TOP_TO_BOTTOM]: ['50% 100%', '50% 100%'],
+      [DIRECTION.RIGHT_TO_LEFT]: [
+        `0% ${origin.vertical}%`,
+        `0% ${origin.vertical}%`,
+      ],
+      [DIRECTION.LEFT_TO_RIGHT]: [
+        `100% ${origin.vertical}%`,
+        `100% ${origin.vertical}%`,
+      ],
+      [DIRECTION.BOTTOM_TO_TOP]: [
+        `${origin.horizontal}% 0%`,
+        `${origin.horizontal}% 0%`,
+      ],
+      [DIRECTION.TOP_TO_BOTTOM]: [
+        `${origin.horizontal}% 100%`,
+        `${origin.horizontal}% 100%`,
+      ],
     }[panDir] || [];
   const keyframes = {
     transform: [startTransform, endTransform],

--- a/assets/src/animation/effects/backgroundPanAndZoom/index.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/index.js
@@ -121,14 +121,3 @@ export function EffectBackgroundPanAndZoom({
     },
   };
 }
-
-// const translate = 100;
-// const scale = 2;
-// const origin = {
-//   x: (p) => 50 - p,
-//   y: (p) => 50 - p,
-// };
-// const counterScaleTransform = {
-//   x: deltaScale.x * origin.x(0),
-//   y: deltaScale.x * origin.y(0),
-// };

--- a/assets/src/animation/effects/backgroundPanAndZoom/index.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/index.js
@@ -75,7 +75,7 @@ export function EffectBackgroundPanAndZoom({
     }[panDir] || [];
 
   // Background animations aren't really composable through element nesting
-  // because they all target the same dom node. To accomomdate for this we
+  // because they all target the same dom node. To accommomdate for this we
   // manually compose the keyframes and use those to generate a new animation.
   const { generatedKeyframes: zoomGeneratedKeyframes } = EffectBackgroundZoom({
     element,
@@ -89,7 +89,7 @@ export function EffectBackgroundPanAndZoom({
 
   // The key to access the keyframes in the generated keyframes object returned
   // is internal to the effect. Both BgPan & BgZoom only generate one set of
-  // keyframes tho, so although this feels gross, it's fine for now to avoid
+  // keyframes though, so although this feels gross, it's fine for now to avoid
   // an alteration to the exisitng structure.
   const zoomKeyframes = Object.values(zoomGeneratedKeyframes)?.[0] || [];
   const panKeyframes = Object.values(panGeneratedKeyframes)?.[0] || [];

--- a/assets/src/animation/effects/backgroundZoom/index.js
+++ b/assets/src/animation/effects/backgroundZoom/index.js
@@ -34,7 +34,7 @@ export function EffectBackgroundZoom({
   const range = [BG_MIN_SCALE / element.scale, BG_MAX_SCALE / element.scale];
 
   // Account for moving bg media relative to frame
-  const origin = getMediaOrigin(getMediaBoundOffsets(element));
+  const origin = getMediaOrigin(element && getMediaBoundOffsets({ element }));
 
   return AnimationZoom({
     zoomFrom: lerp(zoomDirection === SCALE_DIRECTION.SCALE_OUT ? 1 : 0, range),

--- a/assets/src/animation/effects/backgroundZoom/index.js
+++ b/assets/src/animation/effects/backgroundZoom/index.js
@@ -19,7 +19,7 @@
  */
 import { BG_MIN_SCALE, BG_MAX_SCALE, SCALE_DIRECTION } from '../../constants';
 import { AnimationZoom } from '../../parts/zoom';
-import { lerp, getMediaOrigin } from '../../utils';
+import { lerp, getMediaOrigin, getMediaBoundOffsets } from '../../utils';
 
 export function EffectBackgroundZoom({
   element,
@@ -34,7 +34,7 @@ export function EffectBackgroundZoom({
   const range = [BG_MIN_SCALE / element.scale, BG_MAX_SCALE / element.scale];
 
   // Account for moving bg media relative to frame
-  const origin = getMediaOrigin(element);
+  const origin = getMediaOrigin(getMediaBoundOffsets(element));
 
   return AnimationZoom({
     zoomFrom: lerp(zoomDirection === SCALE_DIRECTION.SCALE_OUT ? 1 : 0, range),

--- a/assets/src/animation/effects/backgroundZoom/index.js
+++ b/assets/src/animation/effects/backgroundZoom/index.js
@@ -19,7 +19,7 @@
  */
 import { BG_MIN_SCALE, BG_MAX_SCALE, SCALE_DIRECTION } from '../../constants';
 import { AnimationZoom } from '../../parts/zoom';
-import { lerp } from '../../utils';
+import { lerp, getMediaOrigin } from '../../utils';
 
 export function EffectBackgroundZoom({
   element,
@@ -33,6 +33,9 @@ export function EffectBackgroundZoom({
   // at element scale 100, the range should be [1, 4]
   const range = [BG_MIN_SCALE / element.scale, BG_MAX_SCALE / element.scale];
 
+  // Account for moving bg media relative to frame
+  const origin = getMediaOrigin(element);
+
   return AnimationZoom({
     zoomFrom: lerp(zoomDirection === SCALE_DIRECTION.SCALE_OUT ? 1 : 0, range),
     zoomTo: 1,
@@ -40,5 +43,6 @@ export function EffectBackgroundZoom({
     delay,
     easing,
     targetLeafElement: true,
+    transformOrigin: `${origin.horizontal}% ${origin.vertical}%`,
   });
 }

--- a/assets/src/animation/effects/backgroundZoom/index.js
+++ b/assets/src/animation/effects/backgroundZoom/index.js
@@ -27,14 +27,12 @@ export function EffectBackgroundZoom({
   duration = 1000,
   delay,
   easing,
+  transformOrigin,
 }) {
   // Define the range based off the element scale
   // at element scale 400, the range should be [1/4, 1]
   // at element scale 100, the range should be [1, 4]
   const range = [BG_MIN_SCALE / element.scale, BG_MAX_SCALE / element.scale];
-
-  // Account for moving bg media relative to frame
-  const origin = getMediaOrigin(element && getMediaBoundOffsets({ element }));
 
   return AnimationZoom({
     zoomFrom: lerp(zoomDirection === SCALE_DIRECTION.SCALE_OUT ? 1 : 0, range),
@@ -43,6 +41,9 @@ export function EffectBackgroundZoom({
     delay,
     easing,
     targetLeafElement: true,
-    transformOrigin: `${origin.horizontal}% ${origin.vertical}%`,
+    // Account for moving bg media relative to frame
+    transformOrigin:
+      transformOrigin ||
+      getMediaOrigin(element && getMediaBoundOffsets({ element })),
   });
 }

--- a/assets/src/animation/parts/index.js
+++ b/assets/src/animation/parts/index.js
@@ -173,6 +173,25 @@ export function getAnimationEffectProps(type) {
       .value]: backgroundPanAndZoomEffectProps,
   };
 
+  let keyOrder = Object.keys({
+    ...(customProps[type] || {}),
+    ...basicAnimationProps,
+  });
+
+  // PAN_AND_ZOOM design deviates from the normal input order by putting
+  // a custom prop (zoom direction) at the end. This accomodates for that.
+  if (type === BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value) {
+    const zoomDirectionKey = 'zoomDirection';
+    const zoomDirectionIndex = keyOrder.indexOf(zoomDirectionKey);
+    if (zoomDirectionIndex > -1) {
+      keyOrder = [
+        ...keyOrder.slice(0, zoomDirectionIndex),
+        ...keyOrder.slice(zoomDirectionIndex + 1),
+        zoomDirectionKey,
+      ];
+    }
+  }
+
   return {
     type,
     // This order is important.
@@ -182,10 +201,7 @@ export function getAnimationEffectProps(type) {
         ...basicAnimationProps,
         ...(customProps[type] || {}),
       },
-      keys: Object.keys({
-        ...(customProps[type] || {}),
-        ...basicAnimationProps,
-      }),
+      keys: keyOrder,
     }),
   };
 }

--- a/assets/src/animation/parts/index.js
+++ b/assets/src/animation/parts/index.js
@@ -40,6 +40,7 @@ import { EffectZoom } from '../effects/zoom';
 import { EffectRotateIn } from '../effects/rotateIn';
 import { EffectBackgroundZoom } from '../effects/backgroundZoom';
 import { EffectBackgroundPan } from '../effects/backgroundPan';
+import { EffectBackgroundPanAndZoom } from '../effects/backgroundPanAndZoom';
 import fadeInProps from '../effects/fadeIn/animationProps';
 import flyInProps from '../effects/flyIn/animationProps';
 import panProps from '../effects/pan/animationProps';
@@ -50,6 +51,7 @@ import zoomEffectProps from '../effects/zoom/animationProps';
 import dropEffectProps from '../effects/drop/animationProps';
 import backgroundZoomEffectProps from '../effects/backgroundZoom/animationProps';
 import backgroundPanEffectProps from '../effects/backgroundPan/animationProps';
+import backgroundPanAndZoomEffectProps from '../effects/backgroundPanAndZoom/animationProps';
 
 import { orderByKeys } from '../utils';
 import { AnimationBounce } from './bounce';
@@ -114,6 +116,8 @@ export function AnimationPart(type, args) {
       [ANIMATION_EFFECTS.ROTATE_IN.value]: EffectRotateIn,
       [BACKGROUND_ANIMATION_EFFECTS.ZOOM.value]: EffectBackgroundZoom,
       [BACKGROUND_ANIMATION_EFFECTS.PAN.value]: EffectBackgroundPan,
+      [BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM
+        .value]: EffectBackgroundPanAndZoom,
     }[type?.value || type] || throughput;
 
   args.easing = args.easing || BEZIER[args.easingPreset];
@@ -165,6 +169,8 @@ export function getAnimationEffectProps(type) {
     [ANIMATION_EFFECTS.DROP.value]: dropEffectProps,
     [BACKGROUND_ANIMATION_EFFECTS.ZOOM.value]: backgroundZoomEffectProps,
     [BACKGROUND_ANIMATION_EFFECTS.PAN.value]: backgroundPanEffectProps,
+    [BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM
+      .value]: backgroundPanAndZoomEffectProps,
   };
 
   return {

--- a/assets/src/animation/parts/zoom/index.js
+++ b/assets/src/animation/parts/zoom/index.js
@@ -29,6 +29,7 @@ export function AnimationZoom({
   zoomFrom = 0,
   zoomTo = 1,
   targetLeafElement = false,
+  transformOrigin,
   ...args
 }) {
   const timings = {
@@ -40,6 +41,10 @@ export function AnimationZoom({
   const keyframes = {
     transform: [`scale(${zoomFrom})`, `scale(${zoomTo})`],
   };
+
+  if (transformOrigin) {
+    keyframes.transformOrigin = [transformOrigin, transformOrigin];
+  }
 
   const { id, WAAPIAnimation, AMPTarget, AMPAnimation } = SimpleAnimation(
     animationName,

--- a/assets/src/animation/parts/zoom/index.js
+++ b/assets/src/animation/parts/zoom/index.js
@@ -42,8 +42,26 @@ export function AnimationZoom({
     transform: [`scale(${zoomFrom})`, `scale(${zoomTo})`],
   };
 
+  // If supplied a transformOrigin, AMP doesn't allow us to set
+  // the transformOrigin property from the keyframes since it is
+  // an unanimatable property. To account for this we calculate a
+  // counter translate based off the scale change that mimicks the
+  // element scaling from a particular origin.
   if (transformOrigin) {
-    keyframes.transformOrigin = [transformOrigin, transformOrigin];
+    // transformOrigin default is `50% 50%` so we account for
+    // that here in our calculations.
+    const originRelativeToCenter = {
+      x: 50 - transformOrigin.horizontal,
+      y: 50 - transformOrigin.vertical,
+    };
+    const counterScaleTranslate = {
+      x: (zoomFrom - 1) * originRelativeToCenter.x,
+      y: (zoomFrom - 1) * originRelativeToCenter.y,
+    };
+    keyframes.transform = [
+      `translate(${counterScaleTranslate.x}%, ${counterScaleTranslate.y}%) ${keyframes.transform[0]}`,
+      `translate(0%, 0%) ${keyframes.transform[1]}`,
+    ];
   }
 
   const { id, WAAPIAnimation, AMPTarget, AMPAnimation } = SimpleAnimation(

--- a/assets/src/animation/utils/getMediaOrigin.js
+++ b/assets/src/animation/utils/getMediaOrigin.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { getMediaBoundOffsets, lerp } from '../utils';
+
+/**
+ * Given a media element, calculates where the origin is on the media
+ * relative to it's frame, such that scaling the media up or down
+ * (with the given transform-origin) most optimistically tries to
+ * fill the frame
+ *
+ * @param {*} element - story media element
+ * @return {Object} object containing horizontal and vertical transform origin percentages
+ */
+export function getMediaOrigin(element) {
+  const offsets = element
+    ? getMediaBoundOffsets({ element })
+    : {
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      };
+
+  const progress = {
+    vertical:
+      Math.abs(offsets.top) /
+      (Math.abs(offsets.top) + Math.abs(offsets.bottom)),
+    horizontal:
+      Math.abs(offsets.left) /
+      (Math.abs(offsets.left) + Math.abs(offsets.right)),
+  };
+
+  return {
+    horizontal: lerp(isNaN(progress.horizontal) ? 0.5 : progress.horizontal, [
+      0,
+      100,
+    ]),
+    vertical: lerp(isNaN(progress.vertical) ? 0.5 : progress.vertical, [
+      0,
+      100,
+    ]),
+  };
+}

--- a/assets/src/animation/utils/getMediaOrigin.js
+++ b/assets/src/animation/utils/getMediaOrigin.js
@@ -16,7 +16,7 @@
 /**
  * Internal dependencies
  */
-import { getMediaBoundOffsets, lerp } from '../utils';
+import { lerp } from '../utils';
 
 /**
  * Given a media element, calculates where the origin is on the media
@@ -24,19 +24,18 @@ import { getMediaBoundOffsets, lerp } from '../utils';
  * (with the given transform-origin) most optimistically tries to
  * fill the frame
  *
- * @param {*} element - story media element
+ * @param {Object} offsets - story media element offsets
+ * @param offsets
  * @return {Object} object containing horizontal and vertical transform origin percentages
  */
-export function getMediaOrigin(element) {
-  const offsets = element
-    ? getMediaBoundOffsets({ element })
-    : {
-        top: 0,
-        right: 0,
-        bottom: 0,
-        left: 0,
-      };
-
+export function getMediaOrigin(
+  offsets = {
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  }
+) {
   const progress = {
     vertical:
       Math.abs(offsets.top) /

--- a/assets/src/animation/utils/getMediaOrigin.js
+++ b/assets/src/animation/utils/getMediaOrigin.js
@@ -25,7 +25,6 @@ import { lerp } from '../utils';
  * fill the frame
  *
  * @param {Object} offsets - story media element offsets
- * @param offsets
  * @return {Object} object containing horizontal and vertical transform origin percentages
  */
 export function getMediaOrigin(

--- a/assets/src/animation/utils/index.js
+++ b/assets/src/animation/utils/index.js
@@ -20,3 +20,4 @@ export { getTotalDuration } from './getTotalDuration';
 export { getMediaBoundOffsets, hasOffsets } from './mediaPositions';
 export { getExclusion, orderByKeys } from './objectOperations';
 export { clamp, lerp, progress } from './range';
+export { getMediaOrigin } from './getMediaOrigin';

--- a/assets/src/animation/utils/test/getMediaOrigin.js
+++ b/assets/src/animation/utils/test/getMediaOrigin.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { getMediaOrigin } from '../';
+
+describe('getMediaOrigin', () => {
+  it.each([
+    [
+      {
+        top: 1,
+        right: 0,
+        bottom: -1,
+        left: -1,
+      },
+      {
+        horizontal: 100,
+        vertical: 50,
+      },
+    ],
+    [
+      {
+        top: 1,
+        right: 1,
+        bottom: -1,
+        left: 0,
+      },
+      {
+        horizontal: 0,
+        vertical: 50,
+      },
+    ],
+    [
+      {
+        top: 1,
+        right: 1,
+        bottom: 0,
+        left: -1,
+      },
+      {
+        horizontal: 50,
+        vertical: 100,
+      },
+    ],
+    [
+      {
+        top: 0,
+        right: 1,
+        bottom: -1,
+        left: -1,
+      },
+      {
+        horizontal: 50,
+        vertical: 0,
+      },
+    ],
+    [
+      {
+        top: 1,
+        right: 1,
+        bottom: -1,
+        left: -1,
+      },
+      {
+        horizontal: 50,
+        vertical: 50,
+      },
+    ],
+  ])('given %p returns %p', (offset, origin) => {
+    expect(getMediaOrigin(offset)).toStrictEqual(origin);
+  });
+});

--- a/assets/src/edit-story/components/form/dropDown/index.js
+++ b/assets/src/edit-story/components/form/dropDown/index.js
@@ -100,6 +100,7 @@ function DropDown({
   lightMode = false,
   placement = Placement.BOTTOM_END,
   placeholder = __('Select an option', 'web-stories'),
+  disabledOptions = [],
   ...rest
 }) {
   const selectRef = useRef();
@@ -164,6 +165,7 @@ function DropDown({
           handleCurrentValue={handleCurrentValue}
           value={activeItem && activeItem.value}
           options={options}
+          disabledOptions={disabledOptions}
           toggleOptions={toggleOptions}
           {...rest}
         />
@@ -181,6 +183,7 @@ DropDown.propTypes = {
   placeholder: PropTypes.string,
   labelledBy: PropTypes.string,
   placement: PropTypes.string,
+  disabledOptions: PropTypes.array,
 };
 
 export default DropDown;

--- a/assets/src/edit-story/components/form/dropDown/index.js
+++ b/assets/src/edit-story/components/form/dropDown/index.js
@@ -100,7 +100,6 @@ function DropDown({
   lightMode = false,
   placement = Placement.BOTTOM_END,
   placeholder = __('Select an option', 'web-stories'),
-  disabledOptions = [],
   ...rest
 }) {
   const selectRef = useRef();
@@ -165,7 +164,6 @@ function DropDown({
           handleCurrentValue={handleCurrentValue}
           value={activeItem && activeItem.value}
           options={options}
-          disabledOptions={disabledOptions}
           toggleOptions={toggleOptions}
           {...rest}
         />
@@ -183,7 +181,6 @@ DropDown.propTypes = {
   placeholder: PropTypes.string,
   labelledBy: PropTypes.string,
   placement: PropTypes.string,
-  disabledOptions: PropTypes.array,
 };
 
 export default DropDown;

--- a/assets/src/edit-story/components/form/dropDown/list.js
+++ b/assets/src/edit-story/components/form/dropDown/list.js
@@ -66,8 +66,13 @@ const Item = styled.li.attrs({ tabIndex: '0' })`
   line-height: 1;
   color: ${({ theme }) => theme.DEPRECATED_THEME.colors.fg.white};
 
-  &:hover,
-  &:focus {
+  &:disabled,
+  &[aria-disabled='true'] {
+    opacity: 0.75;
+  }
+
+  &:hover:not([aria-disabled='true']),
+  &:focus:not([aria-disabled='true']) {
     background-color: ${({ theme }) =>
       rgba(theme.DEPRECATED_THEME.colors.bg.white, 0.1)};
     outline: none;
@@ -82,6 +87,7 @@ function DropDownList({
   options,
   toggleOptions,
   hasMenuRole = false,
+  disabledOptions = [],
   ...rest
 }) {
   const listContainerRef = useRef();
@@ -207,16 +213,21 @@ function DropDownList({
         ref={listRef}
         role={hasMenuRole ? 'menu' : 'listbox'}
       >
-        {options.map(({ name, value: optValue }) => (
-          <Item
-            id={`dropDown-${optValue}`}
-            key={optValue}
-            onClick={(evt) => handleItemClick(optValue, evt)}
-            role={hasMenuRole ? 'menuitem' : 'option'}
-          >
-            {name}
-          </Item>
-        ))}
+        {options.map(({ name, value: optValue }) => {
+          const isDisabled = disabledOptions.includes(optValue);
+          return (
+            <Item
+              id={`dropDown-${optValue}`}
+              key={optValue}
+              disabled={isDisabled}
+              aria-disabled={isDisabled}
+              onClick={(evt) => !isDisabled && handleItemClick(optValue, evt)}
+              role={hasMenuRole ? 'menuitem' : 'option'}
+            >
+              {name}
+            </Item>
+          );
+        })}
       </List>
     </ListContainer>
   );
@@ -228,6 +239,7 @@ DropDownList.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   options: PropTypes.array.isRequired,
   hasMenuRole: PropTypes.bool,
+  disabledOptions: PropTypes.array,
 };
 
 export default DropDownList;

--- a/assets/src/edit-story/components/form/dropDown/list.js
+++ b/assets/src/edit-story/components/form/dropDown/list.js
@@ -87,7 +87,6 @@ function DropDownList({
   options,
   toggleOptions,
   hasMenuRole = false,
-  disabledOptions = [],
   ...rest
 }) {
   const listContainerRef = useRef();
@@ -213,15 +212,14 @@ function DropDownList({
         ref={listRef}
         role={hasMenuRole ? 'menu' : 'listbox'}
       >
-        {options.map(({ name, value: optValue }) => {
-          const isDisabled = disabledOptions.includes(optValue);
+        {options.map(({ name, value: optValue, disabled = false }) => {
           return (
             <Item
               id={`dropDown-${optValue}`}
               key={optValue}
-              disabled={isDisabled}
-              aria-disabled={isDisabled}
-              onClick={(evt) => !isDisabled && handleItemClick(optValue, evt)}
+              disabled={disabled}
+              aria-disabled={disabled}
+              onClick={(evt) => !disabled && handleItemClick(optValue, evt)}
               role={hasMenuRole ? 'menuitem' : 'option'}
             >
               {name}
@@ -239,7 +237,6 @@ DropDownList.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   options: PropTypes.array.isRequired,
   hasMenuRole: PropTypes.bool,
-  disabledOptions: PropTypes.array,
 };
 
 export default DropDownList;

--- a/assets/src/edit-story/components/panels/design/animation/animation.js
+++ b/assets/src/edit-story/components/panels/design/animation/animation.js
@@ -183,6 +183,17 @@ function AnimationPanel({
             normalizedScale >= 0.99 && SCALE_DIRECTION.SCALE_OUT,
           ].filter(Boolean),
         },
+        [BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value]: {
+          tooltip: backgroundAnimationTooltip,
+          options: [
+            !hasOffset.bottom && DIRECTION.TOP_TO_BOTTOM,
+            !hasOffset.left && DIRECTION.RIGHT_TO_LEFT,
+            !hasOffset.top && DIRECTION.BOTTOM_TO_TOP,
+            !hasOffset.right && DIRECTION.LEFT_TO_RIGHT,
+            normalizedScale <= 0.01 && SCALE_DIRECTION.SCALE_IN,
+            normalizedScale >= 0.99 && SCALE_DIRECTION.SCALE_OUT,
+          ].filter(Boolean),
+        },
       };
     }
     return {};

--- a/assets/src/edit-story/components/panels/design/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooser.js
@@ -27,6 +27,7 @@ import React, {
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { __ } from '@web-stories-wp/i18n';
+import { useFeatures } from 'flagged';
 
 /**
  * Internal dependencies
@@ -216,6 +217,7 @@ export default function EffectChooser({
   const { isRTL } = useConfig();
   const [focusedValue, setFocusedValue] = useState(null);
   const ref = useRef();
+  const { enableExperimentalAnimationEffects } = useFeatures();
 
   useEffect(() => {
     loadStylesheet(`${GOOGLE_MENU_FONT_URL}?family=Teko`).catch(function () {});
@@ -567,49 +569,52 @@ export default function EffectChooser({
                 </ZoomOutAnimation>
               </WithTooltip>
             </GridItemHalfRow>
-            <GridItemFullRow
-              aria-label={__('Pan and Zoom Effect', 'web-stories')}
-              onClick={(event) => {
-                handleOnSelect(
-                  event,
-                  BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
-                  {
-                    animation: BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
-                    zoomDirection: (
-                      disabledTypeOptionsMap[
-                        BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
-                      ]?.options || []
-                    ).includes(SCALE_DIRECTION.SCALE_OUT)
-                      ? SCALE_DIRECTION.SCALE_IN
-                      : SCALE_DIRECTION.SCALE_OUT,
-                  }
-                );
-              }}
-              aria-disabled={disabledBackgroundEffects.includes(
-                BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
-              )}
-              active={activeEffectListIndex === 7}
-            >
-              <WithTooltip
-                title={
-                  disabledBackgroundEffects.includes(
-                    BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
-                  )
-                    ? disabledTypeOptionsMap[
-                        BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
-                      ]?.tooltip
-                    : ''
-                }
-                placement="left"
+            {enableExperimentalAnimationEffects && (
+              <GridItemFullRow
+                aria-label={__('Pan and Zoom Effect', 'web-stories')}
+                onClick={(event) => {
+                  handleOnSelect(
+                    event,
+                    BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
+                    {
+                      animation:
+                        BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
+                      zoomDirection: (
+                        disabledTypeOptionsMap[
+                          BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
+                        ]?.options || []
+                      ).includes(SCALE_DIRECTION.SCALE_OUT)
+                        ? SCALE_DIRECTION.SCALE_IN
+                        : SCALE_DIRECTION.SCALE_OUT,
+                    }
+                  );
+                }}
+                aria-disabled={disabledBackgroundEffects.includes(
+                  BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
+                )}
+                active={activeEffectListIndex === 7}
               >
-                <ContentWrapper>
-                  {__('Pan and Zoom', 'web-stories')}
-                </ContentWrapper>
-                <PanAndZoomAnimation>
-                  {__('Pan and Zoom', 'web-stories')}
-                </PanAndZoomAnimation>
-              </WithTooltip>
-            </GridItemFullRow>
+                <WithTooltip
+                  title={
+                    disabledBackgroundEffects.includes(
+                      BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
+                    )
+                      ? disabledTypeOptionsMap[
+                          BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
+                        ]?.tooltip
+                      : ''
+                  }
+                  placement="left"
+                >
+                  <ContentWrapper>
+                    {__('Pan and Zoom', 'web-stories')}
+                  </ContentWrapper>
+                  <PanAndZoomAnimation>
+                    {__('Pan and Zoom', 'web-stories')}
+                  </PanAndZoomAnimation>
+                </WithTooltip>
+              </GridItemFullRow>
+            )}
           </>
         ) : (
           <>

--- a/assets/src/edit-story/components/panels/design/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooser.js
@@ -68,6 +68,7 @@ import {
   PanRightAnimation,
   PanBottomAnimation,
   PanLeftAnimation,
+  PanAndZoomAnimation,
 } from './effectChooserElements';
 
 const Container = styled.div`
@@ -200,6 +201,7 @@ const BACKGROUND_EFFECTS_LIST = [
   PAN_MAPPING[DIRECTION.TOP_TO_BOTTOM],
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_IN}`,
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_OUT}`,
+  `${BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.name}`,
 ];
 
 export default function EffectChooser({
@@ -565,6 +567,45 @@ export default function EffectChooser({
                 </ZoomOutAnimation>
               </WithTooltip>
             </GridItemHalfRow>
+            <GridItemFullRow
+              aria-label={__('Pan and Zoom Effect', 'web-stories')}
+              onClick={(event) =>
+                handleOnSelect(
+                  event,
+                  BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
+                  {
+                    animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                  }
+                )
+              }
+              aria-disabled={disabledBackgroundEffects.includes(
+                BACKGROUND_ANIMATION_EFFECTS.ZOOM.value
+              )}
+              active={activeEffectListIndex === 7}
+            >
+              <WithTooltip
+                title={
+                  disabledBackgroundEffects.includes(
+                    getDirectionalEffect(
+                      BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                      SCALE_DIRECTION.SCALE_OUT
+                    )
+                  )
+                    ? disabledTypeOptionsMap[
+                        BACKGROUND_ANIMATION_EFFECTS.ZOOM.value
+                      ]?.tooltip
+                    : ''
+                }
+                placement="left"
+              >
+                <ContentWrapper>
+                  {__('Pan and Zoom', 'web-stories')}
+                </ContentWrapper>
+                <PanAndZoomAnimation>
+                  {__('Pan and Zoom', 'web-stories')}
+                </PanAndZoomAnimation>
+              </WithTooltip>
+            </GridItemFullRow>
           </>
         ) : (
           <>

--- a/assets/src/edit-story/components/panels/design/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooser.js
@@ -201,7 +201,7 @@ const BACKGROUND_EFFECTS_LIST = [
   PAN_MAPPING[DIRECTION.TOP_TO_BOTTOM],
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_IN}`,
   `${BACKGROUND_ANIMATION_EFFECTS.ZOOM.value} ${SCALE_DIRECTION.SCALE_OUT}`,
-  `${BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.name}`,
+  BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
 ];
 
 export default function EffectChooser({
@@ -574,25 +574,22 @@ export default function EffectChooser({
                   event,
                   BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
                   {
-                    animation: BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
+                    animation: BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
                   }
                 )
               }
               aria-disabled={disabledBackgroundEffects.includes(
-                BACKGROUND_ANIMATION_EFFECTS.ZOOM.value
+                BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
               )}
               active={activeEffectListIndex === 7}
             >
               <WithTooltip
                 title={
                   disabledBackgroundEffects.includes(
-                    getDirectionalEffect(
-                      BACKGROUND_ANIMATION_EFFECTS.ZOOM.value,
-                      SCALE_DIRECTION.SCALE_OUT
-                    )
+                    BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
                   )
                     ? disabledTypeOptionsMap[
-                        BACKGROUND_ANIMATION_EFFECTS.ZOOM.value
+                        BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
                       ]?.tooltip
                     : ''
                 }

--- a/assets/src/edit-story/components/panels/design/animation/effectChooser.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooser.js
@@ -569,15 +569,22 @@ export default function EffectChooser({
             </GridItemHalfRow>
             <GridItemFullRow
               aria-label={__('Pan and Zoom Effect', 'web-stories')}
-              onClick={(event) =>
+              onClick={(event) => {
                 handleOnSelect(
                   event,
                   BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
                   {
                     animation: BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
+                    zoomDirection: (
+                      disabledTypeOptionsMap[
+                        BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
+                      ]?.options || []
+                    ).includes(SCALE_DIRECTION.SCALE_OUT)
+                      ? SCALE_DIRECTION.SCALE_IN
+                      : SCALE_DIRECTION.SCALE_OUT,
                   }
-                )
-              }
+                );
+              }}
               aria-disabled={disabledBackgroundEffects.includes(
                 BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value
               )}

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserElements.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserElements.js
@@ -24,6 +24,7 @@ export const PANEL_WIDTH = 276;
 
 export const BaseAnimationCell = styled.div`
   display: none;
+  transform-origin: 50% 50%;
 `;
 
 const dropKeyframes = keyframes`
@@ -292,4 +293,19 @@ const zoomOutKeyframes = keyframes`
 
 export const ZoomOutAnimation = styled(BaseAnimationCell)`
   animation: ${zoomOutKeyframes} 2s linear infinite;
+`;
+
+const panAndZoomKeyframes = keyframes`
+  0% {
+    opacity: 0;
+    transform: translate3d(-50%, 0, 0) scale(2);
+  }
+  50%, 100% {
+    opacity: 1;
+    transform: none;
+  }
+`;
+
+export const PanAndZoomAnimation = styled(BaseAnimationCell)`
+  animation: ${panAndZoomKeyframes} 2s linear infinite;
 `;

--- a/assets/src/edit-story/components/panels/design/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectInput.js
@@ -70,6 +70,7 @@ function EffectInput({
           value={valueForField}
           onChange={(value) => onChange(value, true)}
           options={effectProps[field].values}
+          disabledOptions={disabledOptions}
         />
       );
     case FIELD_TYPES.RANGE:

--- a/assets/src/edit-story/components/panels/design/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectInput.js
@@ -69,10 +69,7 @@ function EffectInput({
         <DropDown
           value={valueForField}
           onChange={(value) => onChange(value, true)}
-          options={effectProps[field].values.map((v) => ({
-            value: v,
-            name: v,
-          }))}
+          options={effectProps[field].values}
         />
       );
     case FIELD_TYPES.RANGE:

--- a/assets/src/edit-story/components/panels/design/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectInput.js
@@ -69,8 +69,10 @@ function EffectInput({
         <DropDown
           value={valueForField}
           onChange={(value) => onChange(value, true)}
-          options={effectProps[field].values}
-          disabledOptions={disabledOptions}
+          options={(effectProps[field].values || []).map((option) => ({
+            ...option,
+            disabled: disabledOptions.includes(option.value),
+          }))}
         />
       );
     case FIELD_TYPES.RANGE:

--- a/assets/src/edit-story/components/panels/design/animation/effectPanel.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectPanel.js
@@ -47,7 +47,9 @@ export function getEffectName(type) {
 }
 
 export function getEffectDirection(effect = {}) {
-  if (effect.zoomDirection) {
+  if (effect.zoomDirection && effect.panDir) {
+    return false;
+  } else if (effect.zoomDirection) {
     return effect.zoomDirection;
   } else if (effect.scaleDirection) {
     return effect.scaleDirection;

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -210,6 +210,17 @@ class Experiments {
 		return [
 			/**
 			 * Author: @littlemilkstudio
+			 * Issue: 6379
+			 * Creation date: 2021-03-09
+			 */
+			[
+				'name'        => 'enableExperimentalAnimationEffects',
+				'label'       => __( 'Experimental Animation Effects', 'web-stories' ),
+				'description' => __( 'Enables any animation effects that are currently experimental', 'web-stories' ),
+				'group'       => 'editor',
+			],
+			/**
+			 * Author: @littlemilkstudio
 			 * Issue: 5880
 			 * Creation date: 2021-01-19
 			 */


### PR DESCRIPTION
## Context
As part of the upcoming new template creation we wanted to create a ken burns effect which was both the pan and the zoom combined. These were the mockups for it:
![Group 5899 (1)](https://user-images.githubusercontent.com/35983235/110546447-b5c21f00-80eb-11eb-85e0-6e3be1da83b8.png)


## Summary
Adds Pan and zoom background animation effect behind `Experimental Animation Effects` feature flag.

## Relevant Technical Choices
both zoom and pan target the leaf media node so they can animate it within the canvas frame. Because of this I had to pull the keyframes off both the pan and zoom and combine to compose this animation vs just nesting top level animation elements.

Had to add some fancy `transform-origin` calculations to accommodate the user moving the bg image and it scaling from the proper origin on the image (while the pan was going on) to keep the image always filling the canvas.

Found the same bug in our normal bg zoom did a quick fix there too while I was at it.

## To-do
Take out from behind feature flag in a following PR. Wanted to get this in experiments so that UX wasn't a blocker and we could review it with the design team together on staging to further define UX. (This follows the requested UX, but want to get it in front of everyone)

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Go to experiments -> enable `Experimental Animation Effects` & save -> go to editor
Add or alter bg media to use new `PAN AND ZOOM` animation effect. mess around with it and see that it both Pans... and Zooms 🎉  at the same time 🙀 
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT
Follow testing instructions above. Hoping to go over this in a quick meeting/call after it's in staging behind a flag, so will discuss enhancement tickets that need to come out of this after that.
<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6379 
