### PR TITLE
Dashboard: Update CTA border width

### DIFF
--- a/assets/src/dashboard/components/pageStructure/navigationComponents.js
+++ b/assets/src/dashboard/components/pageStructure/navigationComponents.js
@@ -46,7 +46,7 @@ export const NewStoryButton = styled(Button)(
   ({ theme }) => css`
     margin-bottom: 0;
     margin-top: 0;
-    border: 2px solid ${theme.colors.border.defaultActive};
+    border: 1px solid ${theme.colors.border.defaultActive};
     border-radius: ${theme.borders.radius.medium};
     transition: background-color 0.25s linear, color 0.25s linear;
 


### PR DESCRIPTION
## Context

Dashboard 'Create New Story'  CTA on left nav is a custom button. Forgot to fix the border to 1px. 

## Summary

Drops 'Create New Story' button border (outline) to 1px instead of 2px. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Left is the update, right is the one that is too thick. 
![Screen Shot 2021-03-09 at 3 41 44 PM](https://user-images.githubusercontent.com/10720454/110548740-439f0980-80ee-11eb-9658-5b922bf7af04.png)


## Testing Instructions

See that the button has a 1px outline

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6687 
