### PR TITLE
Dashboard: Checkbox cursor updated to pointer

### DIFF
--- a/assets/src/dashboard/app/views/editorSettings/components.js
+++ b/assets/src/dashboard/app/views/editorSettings/components.js
@@ -97,6 +97,7 @@ export const CheckboxLabel = styled(Text)`
   display: flex;
   justify-content: flex-start;
   margin-top: 8px;
+  cursor: pointer;
 `;
 
 export const CheckboxLabelText = styled(HelperText)`

--- a/assets/src/dashboard/app/views/shared/telemetryBanner.js
+++ b/assets/src/dashboard/app/views/shared/telemetryBanner.js
@@ -38,6 +38,7 @@ import useTelemetryOptIn from './useTelemetryOptIn';
 
 const Label = styled.label.attrs({ htmlFor: 'telemetry-banner-opt-in' })`
   display: flex;
+  cursor: pointer;
 `;
 
 const LabelText = styled(Text)`

--- a/assets/src/design-system/components/checkbox/index.js
+++ b/assets/src/design-system/components/checkbox/index.js
@@ -37,7 +37,6 @@ const Border = styled.div(
     width: ${CONTAINER_WIDTH}px;
     border-radius: ${theme.borders.radius.small};
     border: ${BORDER_WIDTH}px solid ${theme.colors.border.defaultNormal};
-    pointer-events: none;
   `
 );
 
@@ -57,6 +56,7 @@ const CheckboxContainer = styled.div(
     width: ${CONTAINER_WIDTH}px;
     min-height: ${CONTAINER_WIDTH}px;
     min-width: ${CONTAINER_WIDTH}px;
+    cursor: pointer;
 
     /* Hide Checkbox */
     input[type='checkbox'] {


### PR DESCRIPTION
## Context

Checkbox cursor was default when hovering over a checkbox. 

## Summary

Updates checkbox in design system to allow cursor to be pointer on hover. Updates telemetry banner and dashboard settings to have cursor pointer on checkbox labels as well. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Cursor should be pointer on hover of checkbox and checkbox labels (the areas you can click to change the value of the checkbox) 
![pointer](https://user-images.githubusercontent.com/10720454/110549947-0f2c4d00-80f0-11eb-9c71-0f4e11ab7e13.gif)


## Testing Instructions

Hover over a checkbox and see a pointer cursor.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6688 
