### PR TITLE
Dashboard: Fix conflicting min-width

### DIFF
--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -51,7 +51,7 @@ const HeadlineFilters = styled.div`
 const HeaderSearch = styled.div`
   width: 208px;
   max-width: 208px;
-  min-width: 208px;
+
   margin: auto 0;
 `;
 

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -28,31 +28,34 @@ import { NavMenuButton, StandardViewContentGutter } from '../../../components';
 const HeadingContainer = styled(StandardViewContentGutter)`
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   justify-content: space-between;
   margin-bottom: 16px;
   padding-top: 48px;
-  padding-bottom: 24px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.divider.secondary};
 `;
 
 const StyledHeadline = styled(Display)`
   display: flex;
   align-items: center;
-  margin-right: 8px;
+  margin-right: 28px;
+  padding-bottom: 24px;
   white-space: nowrap;
 `;
 
 const HeadlineFilters = styled.div`
   display: flex;
   align-items: center;
-  margin: 0 auto;
+  margin: auto 0 auto 0;
+  padding-bottom: 24px;
 `;
 
 const HeaderSearch = styled.div`
   width: 208px;
   max-width: 208px;
-
+  min-width: 208px;
   margin: auto 0;
+  padding-bottom: 24px;
 `;
 
 const PageHeading = ({

--- a/assets/src/dashboard/app/views/shared/pageHeading.js
+++ b/assets/src/dashboard/app/views/shared/pageHeading.js
@@ -51,6 +51,7 @@ const HeadlineFilters = styled.div`
 const HeaderSearch = styled.div`
   width: 208px;
   max-width: 208px;
+  min-width: 208px;
   margin: auto 0;
 `;
 

--- a/assets/src/dashboard/components/contentGutter/index.js
+++ b/assets/src/dashboard/components/contentGutter/index.js
@@ -27,26 +27,3 @@ import { PAGE_WRAPPER } from '../../constants';
 export const StandardViewContentGutter = styled.div`
   margin: 0 ${PAGE_WRAPPER.GUTTER}px;
 `;
-
-export const DetailViewContentGutter = styled.div(
-  ({ theme }) => `
-    padding-top: ${
-      theme.DEPRECATED_THEME.navBar.height +
-      theme.DEPRECATED_THEME.detailViewContentGutter.desktop / 2
-    }px;
-    margin: 0 ${theme.DEPRECATED_THEME.detailViewContentGutter.desktop}px;
-
-
-    @media ${theme.DEPRECATED_THEME.breakpoint.tablet} {
-      padding-top: ${
-        theme.DEPRECATED_THEME.navBar.height +
-        theme.DEPRECATED_THEME.detailViewContentGutter.tablet / 2
-      }px;
-      margin: 0 ${theme.DEPRECATED_THEME.detailViewContentGutter.tablet}px;
-    }
-
-    @media ${theme.DEPRECATED_THEME.breakpoint.smallDisplayPhone} {
-      margin: 0 ${theme.DEPRECATED_THEME.detailViewContentGutter.min}px;
-    }
-  `
-);

--- a/assets/src/dashboard/components/pageStructure/index.js
+++ b/assets/src/dashboard/components/pageStructure/index.js
@@ -55,8 +55,10 @@ import {
 } from './navigationComponents';
 
 export const AppFrame = styled.div`
-  overflow-x: scroll;
-  min-width: 100%;
+  width: 100%;
+  @media screen and (max-width: ${MIN_DASHBOARD_WIDTH}px) {
+    width: ${MIN_DASHBOARD_WIDTH}px;
+  }
 `;
 
 export const PageContent = styled.div`
@@ -70,7 +72,6 @@ export const PageContent = styled.div`
   @media screen and (max-width: ${MIN_DASHBOARD_WIDTH}px) {
     left: 0;
     width: 100%;
-    min-width: ${MIN_DASHBOARD_WIDTH}px;
   }
 `;
 

--- a/assets/src/dashboard/components/pageStructure/menuButton.js
+++ b/assets/src/dashboard/components/pageStructure/menuButton.js
@@ -24,6 +24,7 @@ import { __ } from '@web-stories-wp/i18n';
 /**
  * Internal dependencies
  */
+import { MIN_DASHBOARD_WIDTH } from '../../constants';
 import { Menu as MenuSvg } from '../../icons';
 import { useNavContext } from '../navProvider';
 
@@ -51,7 +52,7 @@ const TransparentButton = styled.button`
     showOnlyOnSmallViewport &&
     css`
       display: none;
-      @media ${({ theme }) => theme.DEPRECATED_THEME.breakpoint.tablet} {
+      @media screen and (max-width: ${MIN_DASHBOARD_WIDTH}px) {
         display: inline-block;
       }
     `}

--- a/assets/src/dashboard/style.css
+++ b/assets/src/dashboard/style.css
@@ -32,8 +32,7 @@ body.js {
 
 body.web-story_page_stories-dashboard {
   position: relative;
-  overflow-x: hidden;
-  overflow-y: scroll;
+  overflow: scroll;
 }
 
 #adminmenuback {

--- a/assets/src/dashboard/theme.js
+++ b/assets/src/dashboard/theme.js
@@ -192,11 +192,6 @@ const theme = {
       },
     },
   },
-  detailViewContentGutter: {
-    desktop: 80,
-    tablet: 40,
-    min: 10,
-  },
   breakpoint: {
     desktop: 'screen and (max-width: 1280px)',
     tablet: 'screen and (max-width: 1120px)',

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -101,7 +101,12 @@ const sizeFromWidth = (
 };
 
 const getContainerWidth = (windowWidth) => {
-  return windowWidth > MIN_DASHBOARD_WIDTH ? windowWidth : MIN_DASHBOARD_WIDTH;
+  // Because the dashboard has a min width (MIN_DASHBOARD_WIDTH) check to see if that min should be used or the actual space of the dashboard
+  const isWindowSmallerThanMinDashboardWidth =
+    window.innerWidth < MIN_DASHBOARD_WIDTH;
+  return isWindowSmallerThanMinDashboardWidth
+    ? MIN_DASHBOARD_WIDTH
+    : windowWidth;
 };
 
 export default function usePagePreviewSize(options = {}) {
@@ -109,15 +114,14 @@ export default function usePagePreviewSize(options = {}) {
   // When the dashboard is pulled out of wordpress this id will need to be updated.
   // For now, we need to grab wordpress instead because of how the app's rendered
   const dashboardContainerRef = useRef(document.getElementById(WPBODY_ID));
+
   // BP is contingent on the actual window size
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
 
   const [bp, setBp] = useState(getCurrentBp(viewportWidth));
 
   const [availableContainerSpace, setAvailableContainerSpace] = useState(
-    getContainerWidth(
-      dashboardContainerRef.current?.offsetWidth || window.innerWidth
-    )
+    getContainerWidth(dashboardContainerRef.current?.offsetWidth)
   );
 
   const [debounceSetViewportWidth] = useDebouncedCallback((width) => {

--- a/assets/src/dashboard/utils/usePagePreviewSize.js
+++ b/assets/src/dashboard/utils/usePagePreviewSize.js
@@ -121,7 +121,9 @@ export default function usePagePreviewSize(options = {}) {
   const [bp, setBp] = useState(getCurrentBp(viewportWidth));
 
   const [availableContainerSpace, setAvailableContainerSpace] = useState(
-    getContainerWidth(dashboardContainerRef.current?.offsetWidth)
+    getContainerWidth(
+      dashboardContainerRef.current?.offsetWidth || window.innerWidth
+    )
   );
 
   const [debounceSetViewportWidth] = useDebouncedCallback((width) => {


### PR DESCRIPTION
## Context

The issue identified in bug bash on Tuesday was that between 1020 and 1000 or so, a 20px ish difference in viewport width, the dashboard `bodyViewOptions` wasn't in sync with the rest of the page. Turns out that that container wasn't really the problem. This PR is to fix the inconsistency in the min width that was causing this difference in justification. 

## Summary
Consolidates where width is getting forced to 1098px in the dashboard. Small improvement to util for grid to let calculation be aware of the actual grid space regardless of window space.


## Relevant Technical Choices

- Gut old detail view gutter component, that isn't in use and I was cleaning up to make sense of the issue. 
- Move forced width minimum to the highest level of the dashboard possible so that everything inside the dashboard is aware of it. When the dashboard hits 1098px it will not shrink past this. This width is based on the entire viewport, so it's inclusive of whatever the wordPress menu is doing.  
- The hamburger button that controls the toggle of the dashboard side nav was using deprecated media queries that was getting it out of sync with the new min width stuff
- Tweak to how the current "breakpoint" in the util to figure out responsive grid size. If our min width is 1098px and our ref that tells us how much of that space belongs to the dashboard and is available for the grid, but our min width is getting locked in at 1098px  and our window.innerWidth is actually larger than that, the grid gets all weird. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

The right edge of content of the dashboard should now always be aligned. 

This is how it is on staging, as reported during bugbash: 

https://user-images.githubusercontent.com/10720454/110826150-05baf600-8252-11eb-947c-c5b1bbfb7b29.mp4


This is the update - focus on the right edge, where the filtering dropdown is and the line of stories in the grid. 

https://user-images.githubusercontent.com/10720454/110823836-b5db2f80-824f-11eb-8e08-0149b4396456.mp4


https://user-images.githubusercontent.com/10720454/110823840-b70c5c80-824f-11eb-9a8e-c2de803c8bbf.mp4



## Testing Instructions

Resize the dashboard and see the page respond. The story previews sometimes have a little delay because they are recalculating but they should adjust and the right line should be consistent. This is only an issue on 'my stories' since it's the only view currently with a sort.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6689 
