### PR TITLE
Design panel: Video Captions Panel Redesign

### DIFF
--- a/assets/src/edit-story/components/panels/design/captions/captions.js
+++ b/assets/src/edit-story/components/panels/design/captions/captions.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 import { useCallback, useRef } from 'react';
 import { __ } from '@web-stories-wp/i18n';
@@ -50,6 +50,17 @@ const InputRow = styled.div`
   flex-grow: 1;
   margin-right: 8px;
 `;
+
+const StyledFileInput = styled(Input)(
+  ({ hasMixedValue, theme }) => css`
+    ${!hasMixedValue &&
+    css`
+      * > input:disabled {
+        color: ${theme.colors.fg.primary};
+      }
+    `};
+  `
+);
 
 const UploadButton = styled(Button)`
   padding: 12px 8px;
@@ -138,11 +149,12 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
     >
       {isMixedValue && (
         <Row>
-          <Input
+          <StyledFileInput
             value={MULTIPLE_DISPLAY_VALUE}
             disabled
             aria-label={__('Filename', 'web-stories')}
             onChange={() => handleRemoveTrack()}
+            hasMixedValue={isMixedValue}
           />
         </Row>
       )}
@@ -151,10 +163,11 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
         tracks.map(({ id, trackName }) => (
           <Row key={`row-filename-${id}`}>
             <InputRow>
-              <Input
+              <StyledFileInput
                 value={trackName}
                 aria-label={__('Filename', 'web-stories')}
                 onChange={() => handleRemoveTrack(id)}
+                hasMixedValue={isMixedValue}
                 disabled
               />
             </InputRow>

--- a/assets/src/edit-story/components/panels/design/captions/captions.js
+++ b/assets/src/edit-story/components/panels/design/captions/captions.js
@@ -73,7 +73,8 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
   const isMixedValue = tracks === MULTIPLE_VALUE;
   const captionText = __('Upload a file', 'web-stories');
   const clearFileText = __('Remove file', 'web-stories');
-  // don't have a way to tell if there was an error on upload yet
+  /* @TODO: Implement error handling after removing modal and 
+  using native browser upload. */
   const uploadError = false;
 
   usePresubmitHandler(

--- a/assets/src/edit-story/components/panels/design/captions/captions.js
+++ b/assets/src/edit-story/components/panels/design/captions/captions.js
@@ -27,17 +27,39 @@ import { __ } from '@web-stories-wp/i18n';
  * Internal dependencies
  */
 import { MULTIPLE_VALUE, MULTIPLE_DISPLAY_VALUE } from '../../../../constants';
-import { Button, TextInput, Row, usePresubmitHandler } from '../../../form';
+import { Row, usePresubmitHandler } from '../../../form';
 import { useMediaPicker } from '../../../mediaPicker';
 import { SimplePanel } from '../../panel';
 import { getCommonValue } from '../../shared';
 import { states, styles, useFocusHighlight } from '../../../../app/highlights';
+import {
+  Button,
+  BUTTON_SIZES,
+  BUTTON_TYPES,
+  BUTTON_VARIANTS,
+  Icons,
+  Input,
+  Text,
+  THEME_CONSTANTS,
+  Tooltip,
+  TOOLTIP_PLACEMENT,
+} from '../../../../../design-system';
 
-const BoxedTextInput = styled(TextInput)`
-  padding: 6px 6px;
-  border-radius: 4px;
+const InputRow = styled.div`
+  display: flex;
   flex-grow: 1;
-  opacity: 1;
+  margin-right: 8px;
+`;
+
+const UploadButton = styled(Button)`
+  padding: 12px 8px;
+`;
+
+const ErrorText = styled(Text).attrs({
+  as: 'span',
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
+})`
+  color: ${({ theme }) => theme.colors.fg.negative};
 `;
 
 export const MIN_MAX = {
@@ -49,7 +71,10 @@ export const MIN_MAX = {
 function CaptionsPanel({ selectedElements, pushUpdate }) {
   const tracks = getCommonValue(selectedElements, 'tracks', []);
   const isMixedValue = tracks === MULTIPLE_VALUE;
-  const captionText = __('Upload captions', 'web-stories');
+  const captionText = __('Upload a file', 'web-stories');
+  const clearFileText = __('Remove file', 'web-stories');
+  // don't have a way to tell if there was an error on upload yet
+  const uploadError = false;
 
   usePresubmitHandler(
     ({ resource: newResource }) => ({
@@ -107,16 +132,15 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
     <SimplePanel
       css={highlight?.showEffect && styles.FLASH}
       name="caption"
-      title={__('Captions', 'web-stories')}
+      title={__('Caption and subtitles', 'web-stories')}
       isPersistable={!highlight}
     >
       {isMixedValue && (
         <Row>
-          <BoxedTextInput
+          <Input
             value={MULTIPLE_DISPLAY_VALUE}
             disabled
             aria-label={__('Filename', 'web-stories')}
-            clear
             onChange={() => handleRemoveTrack()}
           />
         </Row>
@@ -125,27 +149,53 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
         !isMixedValue &&
         tracks.map(({ id, trackName }) => (
           <Row key={`row-filename-${id}`}>
-            <BoxedTextInput
-              value={trackName}
-              disabled
-              aria-label={__('Filename', 'web-stories')}
-              clear
-              onChange={() => handleRemoveTrack(id)}
-              key={`filename-${id}`}
-            />
+            <InputRow>
+              <Input
+                value={trackName}
+                aria-label={__('Filename', 'web-stories')}
+                onChange={() => handleRemoveTrack(id)}
+                disabled
+              />
+            </InputRow>
+            <Tooltip
+              hasTail
+              placement={TOOLTIP_PLACEMENT.BOTTOM}
+              title={clearFileText}
+            >
+              <Button
+                aria-label={clearFileText}
+                type={BUTTON_TYPES.TERTIARY}
+                size={BUTTON_SIZES.SMALL}
+                variant={BUTTON_VARIANTS.SQUARE}
+                onClick={() => handleRemoveTrack(id)}
+              >
+                <Icons.Trash />
+              </Button>
+            </Tooltip>
           </Row>
         ))}
       {!tracks.length && (
-        <Row expand>
-          <Button
-            css={highlight?.showEffect && styles.OUTLINE}
-            ref={buttonRef}
-            onClick={UploadCaption}
-            fullWidth
-          >
-            {captionText}
-          </Button>
-        </Row>
+        <>
+          <Row expand>
+            <UploadButton
+              css={highlight?.showEffect && styles.OUTLINE}
+              ref={buttonRef}
+              onClick={UploadCaption}
+              type={BUTTON_TYPES.SECONDARY}
+              size={BUTTON_SIZES.SMALL}
+              variant={BUTTON_VARIANTS.RECTANGLE}
+            >
+              {captionText}
+            </UploadButton>
+          </Row>
+          {uploadError && (
+            <Row expand>
+              <ErrorText role="alert">
+                {__('Upload error. Please try again', 'web-stories')}
+              </ErrorText>
+            </Row>
+          )}
+        </>
       )}
     </SimplePanel>
   );

--- a/assets/src/edit-story/components/panels/design/captions/test/captions.js
+++ b/assets/src/edit-story/components/panels/design/captions/test/captions.js
@@ -57,7 +57,9 @@ describe('Panels/Captions', () => {
 
   it('should render <Captions /> panel', () => {
     const { getByRole } = renderCaptions([defaultElement]);
-    const captionRegion = getByRole('region', { name: /Captions/i });
+    const captionRegion = getByRole('region', {
+      name: /Caption and subtitles/i,
+    });
     expect(captionRegion).toBeInTheDocument();
   });
 

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -88,7 +88,7 @@ const Collapse = styled.button`
   }
   margin-left: -12px;
 
-  ${themeHelpers.focusableOutlineCSS};
+  ${({ theme }) => themeHelpers.focusableOutlineCSS(theme.colors.border.focus, theme.colors.bg.secondary)};
 `;
 
 function Toggle({ children, toggle, ...rest }) {

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -88,7 +88,11 @@ const Collapse = styled.button`
   }
   margin-left: -12px;
 
-  ${({ theme }) => themeHelpers.focusableOutlineCSS(theme.colors.border.focus, theme.colors.bg.secondary)};
+  ${({ theme }) =>
+    themeHelpers.focusableOutlineCSS(
+      theme.colors.border.focus,
+      theme.colors.bg.secondary
+    )};
 `;
 
 function Toggle({ children, toggle, ...rest }) {

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -32,8 +32,8 @@ import {
   Icons,
   THEME_CONSTANTS,
   Headline,
+  themeHelpers,
 } from '../../../../../design-system';
-import { KEYBOARD_USER_SELECTOR } from '../../../../utils/keyboardOnlyOutline';
 import DragHandle from './handle';
 
 // If the header is collapsed, we're leaving 8px less padding to apply that from the content.
@@ -79,6 +79,7 @@ const Collapse = styled.button`
   color: inherit;
   height: 32px;
   display: flex; /* removes implicit line-height padding from child element */
+  align-items: center;
   padding: 0 4px 0 0;
   cursor: pointer;
   svg {
@@ -86,9 +87,8 @@ const Collapse = styled.button`
     height: 32px;
   }
   margin-left: -12px;
-  ${KEYBOARD_USER_SELECTOR} &:focus {
-    outline: ${({ theme }) => theme.colors.border.focus} auto 2px;
-  }
+
+  ${themeHelpers.focusableOutlineCSS};
 `;
 
 function Toggle({ children, toggle, ...rest }) {

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -32,8 +32,8 @@ import {
   Icons,
   THEME_CONSTANTS,
   Headline,
-  themeHelpers,
 } from '../../../../../design-system';
+import { KEYBOARD_USER_SELECTOR } from '../../../../utils/keyboardOnlyOutline';
 import DragHandle from './handle';
 
 // If the header is collapsed, we're leaving 8px less padding to apply that from the content.
@@ -79,7 +79,6 @@ const Collapse = styled.button`
   color: inherit;
   height: 32px;
   display: flex; /* removes implicit line-height padding from child element */
-  align-items: center;
   padding: 0 4px 0 0;
   cursor: pointer;
   svg {
@@ -87,12 +86,9 @@ const Collapse = styled.button`
     height: 32px;
   }
   margin-left: -12px;
-
-  ${({ theme }) =>
-    themeHelpers.focusableOutlineCSS(
-      theme.colors.border.focus,
-      theme.colors.bg.secondary
-    )};
+  ${KEYBOARD_USER_SELECTOR} &:focus {
+    outline: ${({ theme }) => theme.colors.border.focus} auto 2px;
+  }
 `;
 
 function Toggle({ children, toggle, ...rest }) {


### PR DESCRIPTION
## Context

Implementing the redesign for the editor.
[Designs](https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories-Post-Stable?node-id=1069%3A230220)

**Designs**
|File uploaded|File upload Error
|--|--|
|<img src="https://user-images.githubusercontent.com/22185279/110863002-42e8ad80-827d-11eb-8fd1-843b403b2d21.png" width="500px" />|<img src="https://user-images.githubusercontent.com/22185279/110863085-5f84e580-827d-11eb-9681-39b0801c2313.png" width="100%" />|

**Note**: The language dropdown has not been implemented yet, so I didn't add that for now. When that is added, we'll need to fix the bottom border radiuses on the input.

## Summary

- Swaps out input for input in design system
- Add trash Icon button
- Add error text (isn't visible atm)

## Relevant Technical Choices

- added a tooltip to the icon button. It has an aria label, but figured the tooltip is helpful (and consistent with other textless buttons in this panel)

## To-do

- Language dropdown needs to be added (not a part of this ticket)

## User-facing changes

|Type|Before|After|
|--|--|--|
|Single video selected|<img src="https://user-images.githubusercontent.com/22185279/110862746-f604d700-827c-11eb-96d7-917cd17cc400.gif" width="100%" />|<img src="https://user-images.githubusercontent.com/22185279/110862241-7d057f80-827c-11eb-8a2d-c69f7edbffd3.gif" width="100%" />|
|Multiple videos selected|![image](https://user-images.githubusercontent.com/22185279/110863269-ad99e900-827d-11eb-8bf6-c0ebffaff210.png)|![image](https://user-images.githubusercontent.com/22185279/110863241-a1ae2700-827d-11eb-9c0c-a7b0804d0f77.png)|


Note: the error text isn't visible except in this gif. There is currently no way to tell if a file failed to upload.

## Testing Instructions

- create a story
- add a couple videos
- click on one, scroll the design panel to captions. Open and play around with it. Should be able to upload files and delete files.
- select multiple videos. Currently you can't upload a caption for multiple videos.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

- create a story
- add a couple videos
- click on one, scroll the design panel to captions. Open and play around with it. Should be able to upload files and delete files.
- select multiple videos. Currently you can't upload a caption for multiple videos.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6504
