### PR TITLE
E2E Tests: Pin docker image at previous version to fix CI

### DIFF
--- a/bin/local-env/docker-compose.yml
+++ b/bin/local-env/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   wordpress:
-    image: wordpress:php${PHP_VERSION:-7.4}
+    image: wordpress:5.6-php${PHP_VERSION:-7.4}
     ports:
       - '127.0.0.1:8899:80'
     environment:

--- a/bin/local-env/docker-compose.yml
+++ b/bin/local-env/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.1'
 
 services:
   wordpress:
+    # See https://github.com/docker-library/wordpress/pull/575
     image: wordpress:5.6-php${PHP_VERSION:-7.4}
     ports:
       - '127.0.0.1:8899:80'

--- a/bin/local-env/install-wordpress.sh
+++ b/bin/local-env/install-wordpress.sh
@@ -35,6 +35,12 @@ if [ "$1" == '--reset-site' ]; then
 	wp db reset --yes --quiet
 fi
 
+if [ "$WP_VERSION" == "latest" ]; then
+  # Potentially update WordPress
+	echo -e $(status_message "Updating WordPress")
+	wp core update --force --quiet
+fi
+
 if [ ! -z "$WP_VERSION" ] && [ "$WP_VERSION" != "latest" ]; then
 	# Potentially downgrade WordPress
 	echo -e $(status_message "Downloading WordPress version $WP_VERSION...")

--- a/bin/local-env/install-wordpress.sh
+++ b/bin/local-env/install-wordpress.sh
@@ -35,12 +35,6 @@ if [ "$1" == '--reset-site' ]; then
 	wp db reset --yes --quiet
 fi
 
-if [ "$WP_VERSION" == "latest" ]; then
-	# Potentially update WordPress
-	echo -e $(status_message "Updating WordPress")
-	wp core update --force --quiet
-fi
-
 if [ ! -z "$WP_VERSION" ] && [ "$WP_VERSION" != "latest" ]; then
 	# Potentially downgrade WordPress
 	echo -e $(status_message "Downloading WordPress version $WP_VERSION...")
@@ -50,6 +44,12 @@ fi
 # Install WordPress.
 echo -e $(status_message "Installing WordPress...")
 wp core install --title="$SITE_TITLE" --admin_user=admin --admin_password=password --admin_email=test@test.com --skip-email --url=http://localhost:$HOST_PORT --quiet
+
+if [ "$WP_VERSION" == "latest" ]; then
+	# Potentially update WordPress
+	echo -e $(status_message "Updating WordPress")
+	wp core update --force --quiet
+fi
 
 # Create additional users.
 echo -e $(status_message "Creating additional users...")

--- a/bin/local-env/install-wordpress.sh
+++ b/bin/local-env/install-wordpress.sh
@@ -36,7 +36,7 @@ if [ "$1" == '--reset-site' ]; then
 fi
 
 if [ "$WP_VERSION" == "latest" ]; then
-  # Potentially update WordPress
+	# Potentially update WordPress
 	echo -e $(status_message "Updating WordPress")
 	wp core update --force --quiet
 fi


### PR DESCRIPTION
## Context

E2E tests have started to fail this week due to a change to the Docker image.

## Summary

This fixes the CI issues where the Docker environment fails to start because of WordPress not being able to be installed, due to the database `wordpress` not being created. It turns out the Docker image `wordpress` has been creating this default database all this time, until [recently](https://github.com/docker-library/wordpress/pull/572/files?file-filters%5B%5D=.php&file-filters%5B%5D=.sh&file-filters%5B%5D=.template&file-filters%5B%5D=No+extension&hide-deleted-files=true#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038aL263).

This PR downgrades the WP image to 5.6 for now until there is a better way of using the latest image.  Otherwise we would have to to build our own WP image to wait on the `mysql` container to fully start and create the needed DB.

**Note**: we're still running the tests against WordPress 5.7. This just downgrades to Docker image, **not** WordPress.