### PR TITLE
Rewind story in the lightbox

### DIFF
--- a/includes/Traits/Theme_Support.php
+++ b/includes/Traits/Theme_Support.php
@@ -90,6 +90,7 @@ trait Theme_Support {
 				],
 				'date'              => [
 					'enabled' => false,
+					'default' => false,
 				],
 				'archive_link'      => [
 					'enabled' => true,

--- a/packages/stories-lightbox/src/web-stories-lightbox.js
+++ b/packages/stories-lightbox/src/web-stories-lightbox.js
@@ -52,6 +52,8 @@ class Lightbox {
 
     // Event triggered when user clicks on close (X) button.
     this.player.addEventListener('amp-story-player-close', () => {
+      // Rewind the story and pause there upon closing the lightbox.
+      this.player.rewind();
       this.player.pause();
       this.lightboxElement.classList.toggle('show');
       document.body.classList.toggle('web-stories-lightbox-open');

--- a/tests/phpunit/tests/Customizer.php
+++ b/tests/phpunit/tests/Customizer.php
@@ -345,6 +345,7 @@ class Customizer extends \WP_UnitTestCase {
 				],
 				'date'              => [
 					'enabled' => false,
+					'default' => false,
 				],
 				'archive_link'      => [
 					'enabled' => true,


### PR DESCRIPTION
## Context

- Story opened in lightbox were paused upon closing the lightbox, if user re-opens the same story s/he will find the story mid-way ( paused at previous state ).

## Summary

- This PR uses recently introduced 'player.rewind()' to rewind the stories when user closes the lightbox.
- Also fixes a php notice for customizer theme support array.
