### PR TITLE
Stickers: Respect Aspect Ratio on Input Size Update

### DIFF
--- a/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
@@ -35,6 +35,7 @@ import {
 import { MULTIPLE_DISPLAY_VALUE, MULTIPLE_VALUE } from '../../../../constants';
 import { dataPixels } from '../../../../units';
 import { getDefinitionForType } from '../../../../elements';
+import stickers from '../../../../stickers';
 import { calcRotatedObjectPositionAndSize } from '../../../../utils/getBoundRect';
 import { SimplePanel } from '../../panel';
 import FlipControls from '../../shared/flipControls';
@@ -42,6 +43,10 @@ import { getCommonValue, useCommonObjectValue } from '../../shared';
 import usePresubmitHandlers from './usePresubmitHandlers';
 import { getMultiSelectionMinMaxXY, isNum } from './utils';
 import { MIN_MAX, DEFAULT_FLIP } from './constants';
+
+function getStickerAspectRatio(element) {
+  return stickers?.[element?.sticker?.type].aspectRatio || 1;
+}
 
 const Grid = styled.div`
   display: grid;
@@ -207,7 +212,18 @@ function SizePositionPanel({
                   newHeight = dataPixels(newWidth / origRatio);
                 }
               }
-              pushUpdate(getUpdateObject(newWidth, newHeight), true);
+              pushUpdate((element) => {
+                // For stickers, we maintain aspect ratio of the sticker
+                // regardless of input and selected elements.
+                if (element?.type === 'sticker') {
+                  const aspectRatio = getStickerAspectRatio(element);
+                  return getUpdateObject(
+                    newWidth,
+                    Math.floor(newWidth / aspectRatio)
+                  );
+                }
+                return getUpdateObject(newWidth, newHeight);
+              }, true);
             }}
             aria-label={__('Width', 'web-stories')}
             {...getMixedValueProps(width)}
@@ -233,7 +249,18 @@ function SizePositionPanel({
                   newWidth = dataPixels(newHeight * origRatio);
                 }
               }
-              pushUpdate(getUpdateObject(newWidth, newHeight), true);
+              pushUpdate((element) => {
+                // For stickers, we maintain aspect ratio of the sticker
+                // regardless of input and selected elements.
+                if (element?.type === 'sticker') {
+                  const aspectRatio = getStickerAspectRatio(element);
+                  return getUpdateObject(
+                    Math.floor(newHeight * aspectRatio),
+                    newHeight
+                  );
+                }
+                return getUpdateObject(newWidth, newHeight);
+              }, true);
             }}
             aria-label={__('Height', 'web-stories')}
             isIndeterminate={MULTIPLE_VALUE === height}

--- a/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
@@ -100,6 +100,10 @@ function SizePositionPanel({
     ({ type }) => getDefinitionForType(type).canFlip
   );
 
+  const isAspectAlwaysLocked = selectedElements.some(
+    ({ type }) => getDefinitionForType(type).isAspectAlwaysLocked
+  );
+
   const hasText = selectedElements.some(({ type }) => 'text' === type);
 
   const actualDimensions = useMemo(() => {
@@ -244,8 +248,10 @@ function SizePositionPanel({
             <LockToggle
               aria-label={__('Lock aspect ratio', 'web-stories')}
               title={__('Lock aspect ratio', 'web-stories')}
-              isLocked={lockAspectRatio}
+              isLocked={lockAspectRatio || isAspectAlwaysLocked}
+              disabled={isAspectAlwaysLocked}
               onClick={() =>
+                !isAspectAlwaysLocked &&
                 pushUpdate({ lockAspectRatio: !lockAspectRatio }, true)
               }
             />

--- a/assets/src/edit-story/components/panels/design/sizePosition/test/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/test/sizePosition.js
@@ -34,7 +34,7 @@ import SizePosition from '../sizePosition';
 
 jest.mock('../../../../../elements');
 
-describe('Panels/SizePosition', () => {
+describe('panels/SizePosition', () => {
   let defaultElement, defaultImage, defaultText, unlockAspectRatioElement;
   let defaultFlip;
   const aspectRatioLockButtonLabel = 'Lock aspect ratio';
@@ -161,13 +161,12 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith(
-        {
-          width: 150,
-          height: 150 / (100 / 80),
-        },
-        true
-      );
+      const [updateArg, submitArg] = pushUpdate.mock.calls[0];
+      expect(updateArg()).toStrictEqual({
+        width: 150,
+        height: 150 / (100 / 80),
+      });
+      expect(submitArg).toBeTrue();
     });
 
     it('should update height with lock ratio', () => {
@@ -175,13 +174,12 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '160' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith(
-        {
-          height: 160,
-          width: 160 * (100 / 80),
-        },
-        true
-      );
+      const [updateArg, submitArg] = pushUpdate.mock.calls[0];
+      expect(updateArg()).toStrictEqual({
+        height: 160,
+        width: 160 * (100 / 80),
+      });
+      expect(submitArg).toBeTrue();
     });
 
     it('should update width without lock ratio', () => {
@@ -192,7 +190,9 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith({ width: 150, height: 80 }, true);
+      const [updateArg, submitArg] = pushUpdate.mock.calls[0];
+      expect(updateArg()).toStrictEqual({ width: 150, height: 80 });
+      expect(submitArg).toBeTrue();
     });
 
     it('should disable height without lock ratio for text element', () => {
@@ -313,13 +313,12 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith(
-        {
-          width: 150,
-          height: dataPixels(150 / (100 / 80)),
-        },
-        true
-      );
+      const [updateArg, submitArg] = pushUpdate.mock.calls[0];
+      expect(updateArg()).toStrictEqual({
+        width: 150,
+        height: dataPixels(150 / (100 / 80)),
+      });
+      expect(submitArg).toBeTrue();
 
       const submits = submit({ width: 150, height: MULTIPLE_VALUE });
       expect(submits[image.id]).toStrictEqual(
@@ -344,13 +343,12 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Width' });
       fireEvent.change(input, { target: { value: '150' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith(
-        {
-          width: 150,
-          height: MULTIPLE_VALUE,
-        },
-        true
-      );
+      const [updateArg, submitArg] = pushUpdate.mock.calls[0];
+      expect(updateArg()).toStrictEqual({
+        width: 150,
+        height: MULTIPLE_VALUE,
+      });
+      expect(submitArg).toBeTrue();
 
       const submits = submit({ width: 150, height: MULTIPLE_VALUE });
       expect(submits[image.id]).toStrictEqual(
@@ -375,13 +373,12 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '160' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith(
-        {
-          height: 160,
-          width: MULTIPLE_VALUE,
-        },
-        true
-      );
+      const [updateArg, submitArg] = pushUpdate.mock.calls[0];
+      expect(updateArg()).toStrictEqual({
+        height: 160,
+        width: MULTIPLE_VALUE,
+      });
+      expect(submitArg).toBeTrue();
 
       const submits = submit({ height: 160, width: MULTIPLE_VALUE });
       expect(submits[image.id]).toStrictEqual(
@@ -436,13 +433,12 @@ describe('Panels/SizePosition', () => {
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '2000' } });
       fireEvent.keyDown(input, { key: 'Enter', which: 13 });
-      expect(pushUpdate).toHaveBeenCalledWith(
-        {
-          height: 2000,
-          width: 2000 * (100 / 80),
-        },
-        true
-      );
+      const [updateArg, submitArg] = pushUpdate.mock.calls[0];
+      expect(updateArg()).toStrictEqual({
+        height: 2000,
+        width: 2000 * (100 / 80),
+      });
+      expect(submitArg).toBeTrue();
 
       const submits = submit({ height: 2000, width: 2000 * (100 / 80) });
       expect(submits[image.id]).toStrictEqual(

--- a/assets/src/edit-story/elements/sticker/display.js
+++ b/assets/src/edit-story/elements/sticker/display.js
@@ -31,7 +31,7 @@ const Noop = () => null;
 
 function StickerDisplay({ element }) {
   const { sticker } = element;
-  const Sticker = stickers[sticker?.type] || Noop;
+  const Sticker = stickers[sticker?.type]?.svg || Noop;
   return <Sticker style={style} />;
 }
 

--- a/assets/src/edit-story/elements/sticker/layer.js
+++ b/assets/src/edit-story/elements/sticker/layer.js
@@ -30,7 +30,7 @@ const Noop = () => null;
 
 function StickerLayerContent({ element }) {
   const { sticker } = element;
-  const Sticker = stickers[sticker.type] || Noop;
+  const Sticker = stickers[sticker.type]?.svg || Noop;
   return <Sticker style={style} />;
 }
 

--- a/assets/src/edit-story/elements/sticker/output.js
+++ b/assets/src/edit-story/elements/sticker/output.js
@@ -32,7 +32,7 @@ const Noop = () => null;
 
 function StickerOutput({ element }) {
   const { sticker } = element;
-  const Sticker = stickers[sticker.type] || Noop;
+  const Sticker = stickers[sticker.type]?.svg || Noop;
   return <Sticker className="fill" style={style} />;
 }
 

--- a/assets/src/edit-story/stickers/index.js
+++ b/assets/src/edit-story/stickers/index.js
@@ -16,7 +16,7 @@
 /**
  * Internal dependencies
  */
-import { default as SampleSticker } from './sampleSticker';
+import { default as sample } from './sampleSticker';
 export default {
-  SampleSticker,
+  sample,
 };

--- a/assets/src/edit-story/stickers/sampleSticker.js
+++ b/assets/src/edit-story/stickers/sampleSticker.js
@@ -60,4 +60,7 @@ SampleSticker.propTypes = {
   style: PropTypes.object,
 };
 
-export default SampleSticker;
+export default {
+  aspectRatio: 78 / 76,
+  svg: SampleSticker,
+};


### PR DESCRIPTION
## Context
Some inspector edits for the sticker so regardless of user input, stickers maintain aspect ratio.

## Summary
Updates the input so no matter what you input in height or width, the aspect ratio is respected for a sticker. Also disables the ability to unlock aspect ratio.

Takes care of both of these tickets:
https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/6585
https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/6584

## Relevant Technical Choices
Updated the stickers to hold both `aspectRatio` as well as the react component to render the svg markup. Almost put the aspectRatio in the story schema for the sticker, but figured just adding it to the sticker itself allowed for the least duplication and opportunity for aspect ratios and viewboxes to get out of sync.

## To-do
NA

## User-facing changes
Not really user facing since the only way to add stickers is by manually editing the story schema.

Now if you have a sticker in your story, whenever you update either height or width, the other updates accordingly to respect the stickers aspect ratio. Also the ability to unlock aspect ratio gets disabled.

(have to manually add stickers though the schema by giving an element these properties):
```
{
  "type": "sticker",
  "sticker": {
    "type": "sample"
  }
}
```
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Add a sticker to your schema and load it in by giving an element the properties listed above.

See that aspect ratio lock is disabled in the locked position. Update either height or width and see that the aspect ratio of the sticker is respected. Try it out with multi-select and see that the behavior remains consistent with the sticker element.

**Note:** the sticker will have whatever dimensions of the element you replaced it with on first load, so aspect ratio will not be respected until you alter height or width through the design panel. This won't be an issue out in the wild cus when we add functionality to add the sticker to the story, it will start off with the proper aspect ratio.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
NA
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6584 
Fixes #6585 
