### PR TITLE
Fix: Editor crash on text sets

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
@@ -87,7 +87,7 @@ function TextSetsPane({ paneRef }) {
   );
 
   const addIdToTextSets = useCallback(
-    (textSetsArray) =>
+    (textSetsArray = []) =>
       textSetsArray.map((elements) => {
         return {
           id: `text_set_${uuidv4()}`,
@@ -100,7 +100,7 @@ function TextSetsPane({ paneRef }) {
     if (showInUse) {
       return addIdToTextSets(getTextSetsForInUseFonts());
     }
-    return addIdToTextSets(selectedCat ? textSets[selectedCat] : allTextSets);
+    return addIdToTextSets(selectedCat ? textSets?.[selectedCat] : allTextSets);
   }, [
     selectedCat,
     textSets,


### PR DESCRIPTION
## Context

Text Sets was crashing on initial panel activating 

## Summary

Fixes the text sets panel to not crash when its initially rendered. 

## Relevant Technical Choices

- default prop to array to avoid crashing editor. 
- checking for key to exist in addIdToTextSets before allowing it to map


## To-do

N/A

## User-facing changes

Text Sets will no longer crash

## Testing Instructions

Load the editor, quickly navigate to the text sets panel. See that it does not crash.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Load the editor, quickly navigate to the text sets panel. See that it does not crash.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6807 
