### PR TITLE
Set up infrastructure to trigger help center tips

### DIFF
--- a/assets/src/edit-story/app/helpCenter/context.js
+++ b/assets/src/edit-story/app/helpCenter/context.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { createContext } from '../../../design-system/utils/context';
+
+export default createContext({ state: {}, actions: {} });

--- a/assets/src/edit-story/app/helpCenter/index.js
+++ b/assets/src/edit-story/app/helpCenter/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as HelpCenterProvider } from './provider';
+export { useHelpCenter } from './useHelpCenter';

--- a/assets/src/edit-story/app/helpCenter/provider.js
+++ b/assets/src/edit-story/app/helpCenter/provider.js
@@ -17,16 +17,21 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import { useReducer, useEffect, useState, useMemo, useRef } from 'react';
 import { trackEvent } from '@web-stories-wp/tracking';
 
 /**
  * Internal dependencies
  */
-import { clamp } from '../../../../animation';
-import { useCurrentUser } from '../../../app';
-import localStore, { LOCAL_STORAGE_PREFIX } from '../../../utils/localStore';
-import { BASE_NAVIGATION_FLOW, TRANSITION_DURATION } from '../constants';
+import { clamp } from '../../../animation';
+import { useCurrentUser } from '..';
+import localStore, { LOCAL_STORAGE_PREFIX } from '../../utils/localStore';
+import {
+  BASE_NAVIGATION_FLOW,
+  TRANSITION_DURATION,
+} from '../../components/helpCenter/constants';
+import Context from './context';
 import {
   composeEffects,
   createDynamicNavigationFlow,
@@ -39,7 +44,7 @@ import {
   deriveAutoOpen,
   deriveInitialOpen,
   deriveInitialUnreadTipsCount,
-} from './effects';
+} from './useHelpCenter/effects';
 
 /**
  * Performs any state updates that result from
@@ -171,7 +176,7 @@ const createBooleanMapFromKey = (key) =>
       {}
     );
 
-export function useHelpCenter() {
+function HelpCenterProvider({ children }) {
   const [store, dispatch] = useReducer(reducer, initial);
   const { currentUser, updateCurrentUser } = useCurrentUser(
     ({ state, actions }) => ({
@@ -294,7 +299,7 @@ export function useHelpCenter() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [navigationIndex]);
 
-  return useMemo(
+  const contextValue = useMemo(
     () => ({
       state: {
         ...store.state,
@@ -304,4 +309,12 @@ export function useHelpCenter() {
     }),
     [actions, store.state, navigationIndex]
   );
+
+  return <Context.Provider value={contextValue}>{children}</Context.Provider>;
 }
+
+HelpCenterProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default HelpCenterProvider;

--- a/assets/src/edit-story/app/helpCenter/provider.js
+++ b/assets/src/edit-story/app/helpCenter/provider.js
@@ -44,6 +44,7 @@ import {
   deriveAutoOpen,
   deriveInitialOpen,
   deriveInitialUnreadTipsCount,
+  resetIsOpeningToTip,
 } from './useHelpCenter/effects';
 
 /**
@@ -67,6 +68,7 @@ export const deriveState = composeEffects(
     deriveReadTip,
     deriveUnreadTipsCount,
     deriveAutoOpen,
+    resetIsOpeningToTip,
   ]
 );
 
@@ -87,6 +89,7 @@ const persisted = localStore.getItemByKey(LOCAL_STORAGE_PREFIX.HELP_CENTER);
 
 export const initialState = {
   isOpen: false,
+  isOpeningToTip: false,
   navigationIndex: -1,
   navigationFlow: BASE_NAVIGATION_FLOW,
   isLeftToRightTransition: true,
@@ -123,6 +126,14 @@ export const initial = {
     goToTip: (key) => ({ navigationFlow }) => ({
       navigationIndex: navigationFlow.findIndex((v) => v === key),
     }),
+    openToUnreadTip: (key) => ({ navigationFlow, readTips }) =>
+      !readTips[key]
+        ? {
+            isOpen: true,
+            isOpeningToTip: true,
+            navigationIndex: navigationFlow.findIndex((v) => v === key),
+          }
+        : {},
     toggle: () => ({ isOpen }) => {
       trackEvent('help_center_toggled', {
         status: isOpen ? 'closed' : 'open',

--- a/assets/src/edit-story/app/helpCenter/useHelpCenter/effects.js
+++ b/assets/src/edit-story/app/helpCenter/useHelpCenter/effects.js
@@ -35,9 +35,12 @@ const isInitialHydrate = (previous, next) =>
 
 export const resetNavigationIndexOnOpen = (previous, next) => {
   const isOpening = !previous.isOpen && next.isOpen;
-  return {
-    navigationIndex: isOpening ? -1 : next.navigationIndex,
+  const isOpeningToTip = !previous.isOpeningToTip && next.isOpeningToTip;
+  const result = {
+    navigationIndex: isOpening && !isOpeningToTip ? -1 : next.navigationIndex,
   };
+
+  return result;
 };
 
 export const deriveBottomNavigation = (previous, next) => ({
@@ -121,6 +124,12 @@ export function deriveInitialUnreadTipsCount(persisted) {
         unreadTipsCount: persisted?.unreadTipsCount,
       }
     : {};
+}
+
+export function resetIsOpeningToTip(previous, next) {
+  return {
+    isOpeningToTip: next.isOpeningToTip && !previous.isOpeningToTip,
+  };
 }
 
 /**

--- a/assets/src/edit-story/app/helpCenter/useHelpCenter/effects.js
+++ b/assets/src/edit-story/app/helpCenter/useHelpCenter/effects.js
@@ -20,7 +20,7 @@ import {
   DONE_TIP_ENTRY,
   BASE_NAVIGATION_FLOW,
   TIP_KEYS_MAP,
-} from '../constants';
+} from '../../../components/helpCenter/constants';
 
 const isMenuIndex = (previous, next) => next.navigationIndex < 0;
 

--- a/assets/src/edit-story/app/helpCenter/useHelpCenter/index.js
+++ b/assets/src/edit-story/app/helpCenter/useHelpCenter/index.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { useContextSelector, identity } from '../../../../design-system';
+import Context from '../context';
+
+export function useHelpCenter(selector) {
+  const context = useContextSelector(Context, selector ?? identity);
+  if (!context) {
+    throw new Error('Must use `useHelpCenter` within <helpCenter.Provider />');
+  }
+  return context;
+}

--- a/assets/src/edit-story/app/helpCenter/useHelpCenter/test/effects.js
+++ b/assets/src/edit-story/app/helpCenter/useHelpCenter/test/effects.js
@@ -16,13 +16,13 @@
 /**
  * Internal dependencies
  */
-import { initialState } from '../';
+import { initialState } from '../../provider';
 import {
   BASE_NAVIGATION_FLOW,
   DONE_TIP_ENTRY,
   TIPS,
   TIP_KEYS_MAP,
-} from '../../constants';
+} from '../../../../components/helpCenter/constants';
 import {
   composeEffects,
   createDynamicNavigationFlow,

--- a/assets/src/edit-story/app/helpCenter/useHelpCenter/test/effects.js
+++ b/assets/src/edit-story/app/helpCenter/useHelpCenter/test/effects.js
@@ -34,6 +34,7 @@ import {
   deriveTransitionDirection,
   deriveUnreadTipsCount,
   resetNavigationIndexOnOpen,
+  resetIsOpeningToTip,
 } from '../effects';
 
 const mockState = (overrides = {}) => ({
@@ -415,5 +416,23 @@ describe('createDynamicNavigationFlow', () => {
         ],
       });
     });
+  });
+});
+
+describe('resetIsOpeningToTip', () => {
+  it('only sets the flag to true if the state is being toggled', () => {
+    let previousState = mockState({ isOpeningToTip: false });
+    let nextState = mockState({ isOpeningToTip: true });
+    const testTrue = resetIsOpeningToTip(previousState, nextState);
+    expect(testTrue.isOpeningToTip).toBe(true);
+
+    previousState = mockState({ isOpeningToTip: true });
+    const testBothTrue = resetIsOpeningToTip(previousState, nextState);
+    expect(testBothTrue.isOpeningToTip).toBe(false);
+
+    previousState = mockState({ isOpeningToTip: false });
+    nextState = mockState({ isOpeningToTip: false });
+    const testBothFalse = resetIsOpeningToTip(previousState, nextState);
+    expect(testBothFalse.isOpeningToTip).toBe(false);
   });
 });

--- a/assets/src/edit-story/app/helpCenter/useHelpCenter/test/useHelpCenter.js
+++ b/assets/src/edit-story/app/helpCenter/useHelpCenter/test/useHelpCenter.js
@@ -196,4 +196,34 @@ describe('useHelpCenter', () => {
       }
     });
   });
+
+  describe('openToUnreadTip', () => {
+    it('should only open the tip if it is not already read', async () => {
+      const { result } = setup();
+      await act(async () => {
+        await result.current.actions.goToTip('cropSelectedElements');
+        await result.current.actions.goToMenu();
+        await result.current.actions.close();
+      });
+
+      expect(result.current.state.navigationIndex).toBe(-1);
+      expect(result.current.state.isOpen).toBe(false);
+
+      await act(async () => {
+        await result.current.actions.openToUnreadTip('cropSelectedElements');
+      });
+      expect(result.current.state.navigationIndex).toBe(-1);
+      expect(result.current.state.isOpen).toBe(false);
+
+      await act(async () => {
+        await result.current.actions.openToUnreadTip('addBackgroundMedia');
+      });
+      expect(result.current.state.navigationIndex).toBe(
+        result.current.state.navigationFlow.findIndex(
+          (v) => v === 'addBackgroundMedia'
+        )
+      );
+      expect(result.current.state.isOpen).toBe(true);
+    });
+  });
 });

--- a/assets/src/edit-story/app/helpCenter/useHelpCenter/test/useHelpCenter.js
+++ b/assets/src/edit-story/app/helpCenter/useHelpCenter/test/useHelpCenter.js
@@ -22,8 +22,9 @@ import { renderHook, act } from '@testing-library/react-hooks';
  */
 import APIContext from '../../../../app/api/context';
 import { CurrentUserProvider } from '../../../../app/currentUser';
-import { DONE_TIP_ENTRY } from '../../constants';
+import { DONE_TIP_ENTRY } from '../../../../components/helpCenter/constants';
 import { useHelpCenter } from '../';
+import HelpCenterProvider from '../../provider';
 
 function setup() {
   const currentUser = { meta: {} };
@@ -41,7 +42,9 @@ function setup() {
   };
   const wrapper = ({ children }) => (
     <APIContext.Provider value={apiContextValue}>
-      <CurrentUserProvider>{children}</CurrentUserProvider>
+      <CurrentUserProvider>
+        <HelpCenterProvider>{children}</HelpCenterProvider>
+      </CurrentUserProvider>
     </APIContext.Provider>
   );
 

--- a/assets/src/edit-story/app/index.js
+++ b/assets/src/edit-story/app/index.js
@@ -29,6 +29,8 @@ import { useStory } from './story';
 import { useCanvas } from './canvas';
 import { useLayout } from './layout';
 import { useCurrentUser } from './currentUser';
+import { useHelpCenter } from './helpCenter';
+import { useUserOnboarding } from './userOnboarding';
 
 export {
   useHistory,
@@ -43,4 +45,6 @@ export {
   useCanvas,
   useLayout,
   useCurrentUser,
+  useHelpCenter,
+  useUserOnboarding,
 };

--- a/assets/src/edit-story/app/userOnboarding/index.js
+++ b/assets/src/edit-story/app/userOnboarding/index.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { useUserOnboarding } from './useUserOnboarding';

--- a/assets/src/edit-story/app/userOnboarding/test/useUserOnboarding.js
+++ b/assets/src/edit-story/app/userOnboarding/test/useUserOnboarding.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+import { useUserOnboarding } from '../..';
+import { KEYS } from '../../../components/helpCenter/constants';
+import { useHelpCenter } from '../../helpCenter';
+jest.mock('../../helpCenter');
+
+describe('useUserOnboarding', () => {
+  jest.useFakeTimers();
+  beforeEach(jest.clearAllMocks);
+
+  it('should open the help center to the Safe Zone tip if it is triggered', async () => {
+    const openToUnreadTip = jest.fn();
+    useHelpCenter.mockImplementationOnce(() => ({ openToUnreadTip }));
+
+    const { result: trigger } = renderHook(() =>
+      useUserOnboarding(({ SAFE_ZONE }) => SAFE_ZONE)
+    );
+
+    await act(async () => {
+      await trigger.current();
+    });
+
+    jest.runOnlyPendingTimers();
+    expect(openToUnreadTip).toHaveBeenCalledWith(KEYS.SAFE_ZONE);
+  });
+});

--- a/assets/src/edit-story/app/userOnboarding/useUserOnboarding.js
+++ b/assets/src/edit-story/app/userOnboarding/useUserOnboarding.js
@@ -17,40 +17,35 @@
  * External dependencies
  */
 import { useCallback } from 'react';
+import { useDebouncedCallback } from 'use-debounce/lib';
 /**
  * Internal dependencies
  */
-// import { useCurrentUser } from '../currentUser';
+import { KEYS } from '../../components/helpCenter/constants';
 import { useHelpCenter } from '../helpCenter';
 
 const TRIGGER_CONTEXTS = {
   SAFE_ZONE: 'safeZone',
-  // todo [@embarks]: other onboarding triggers
 };
 
 export function useUserOnboarding(selector) {
   const triggerType = selector(TRIGGER_CONTEXTS);
 
-  // const { updateCurrentUser, currentUser } = useCurrentUser(
-  //   ({ state, actions }) => ({
-  //     currentUser: state.currentUser,
-  //     updateCurrentUser: actions.updateCurrentUser,
-  //   })
-  // );
-
   const { openToUnreadTip } = useHelpCenter(({ actions }) => ({
     openToUnreadTip: actions.openToUnreadTip,
   }));
 
+  const [openToUnreadTipDebounced] = useDebouncedCallback(openToUnreadTip, 300);
+
   const trigger = useCallback(() => {
     switch (triggerType) {
       case TRIGGER_CONTEXTS.SAFE_ZONE:
-        openToUnreadTip('safeZone');
+        openToUnreadTipDebounced(KEYS.SAFE_ZONE);
         break;
       default:
         return;
     }
-  }, [triggerType, openToUnreadTip]);
+  }, [triggerType, openToUnreadTipDebounced]);
 
   return trigger;
 }

--- a/assets/src/edit-story/app/userOnboarding/useUserOnboarding.js
+++ b/assets/src/edit-story/app/userOnboarding/useUserOnboarding.js
@@ -21,7 +21,7 @@ import { useCallback } from 'react';
  * Internal dependencies
  */
 // import { useCurrentUser } from '../currentUser';
-// import { useHelpCenter } from '../helpCenter';
+import { useHelpCenter } from '../helpCenter';
 
 const TRIGGER_CONTEXTS = {
   SAFE_ZONE: 'safeZone',
@@ -38,19 +38,19 @@ export function useUserOnboarding(selector) {
   //   })
   // );
 
-  // const { goToTip } = useHelpCenter(({ actions }) => ({
-  //   goToTip: actions.goToTip,
-  // }));
+  const { openToUnreadTip } = useHelpCenter(({ actions }) => ({
+    openToUnreadTip: actions.openToUnreadTip,
+  }));
 
   const trigger = useCallback(() => {
     switch (triggerType) {
       case TRIGGER_CONTEXTS.SAFE_ZONE:
-        // console.log('TRIGGERED SAFE_ZONE');
+        openToUnreadTip('safeZone');
         break;
       default:
         return;
     }
-  }, [triggerType]);
+  }, [triggerType, openToUnreadTip]);
 
   return trigger;
 }

--- a/assets/src/edit-story/app/userOnboarding/useUserOnboarding.js
+++ b/assets/src/edit-story/app/userOnboarding/useUserOnboarding.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+/**
+ * Internal dependencies
+ */
+// import { useCurrentUser } from '../currentUser';
+// import { useHelpCenter } from '../helpCenter';
+
+const TRIGGER_CONTEXTS = {
+  SAFE_ZONE: 'safeZone',
+  // todo [@embarks]: other onboarding triggers
+};
+
+export function useUserOnboarding(selector) {
+  const triggerType = selector(TRIGGER_CONTEXTS);
+
+  // const { updateCurrentUser, currentUser } = useCurrentUser(
+  //   ({ state, actions }) => ({
+  //     currentUser: state.currentUser,
+  //     updateCurrentUser: actions.updateCurrentUser,
+  //   })
+  // );
+
+  // const { goToTip } = useHelpCenter(({ actions }) => ({
+  //   goToTip: actions.goToTip,
+  // }));
+
+  const trigger = useCallback(() => {
+    switch (triggerType) {
+      case TRIGGER_CONTEXTS.SAFE_ZONE:
+        // console.log('TRIGGERED SAFE_ZONE');
+        break;
+      default:
+        return;
+    }
+  }, [triggerType]);
+
+  return trigger;
+}

--- a/assets/src/edit-story/components/canvas/utils/useSnapping.js
+++ b/assets/src/edit-story/components/canvas/utils/useSnapping.js
@@ -25,7 +25,7 @@ import { useCallback, useEffect } from 'react';
 import { FULLBLEED_RATIO } from '../../../constants';
 import { useGlobalIsKeyPressed } from '../../../../design-system';
 import { useDropTargets } from '../../dropTargets';
-import { useCanvas, useLayout } from '../../../app';
+import { useCanvas, useLayout, useUserOnboarding } from '../../../app';
 
 function useSnapping({
   isDragging,
@@ -50,6 +50,8 @@ function useSnapping({
     activeDropTargetId: state.state.activeDropTargetId,
   }));
 
+  const triggerOnboarding = useUserOnboarding(({ SAFE_ZONE }) => SAFE_ZONE);
+
   // ⌘ key disables snapping
   const snapDisabled = useGlobalIsKeyPressed('meta');
   canSnap = canSnap && !snapDisabled && !activeDropTargetId;
@@ -58,10 +60,12 @@ function useSnapping({
     (visible) => {
       if (designSpaceGuideline) {
         designSpaceGuideline.style.visibility = visible ? 'visible' : 'hidden';
+        visible && triggerOnboarding();
       }
     },
-    [designSpaceGuideline]
+    [designSpaceGuideline, triggerOnboarding]
   );
+
   const handleSnap = useCallback(
     ({ elements }) =>
       // Show design space if we're snapping to any of its edges

--- a/assets/src/edit-story/components/helpCenter/constants.js
+++ b/assets/src/edit-story/components/helpCenter/constants.js
@@ -19,8 +19,19 @@
 import PropTypes from 'prop-types';
 import { __ } from '@web-stories-wp/i18n';
 
+export const KEYS = {
+  ADD_BACKGROUND_MEDIA: 'addBackgroundMedia',
+  CROP_SELECTED_ELEMENTS: 'cropSelectedElements',
+  CROP_ELEMENTS_WITH_SHAPES: 'cropElementsWithShapes',
+  SAFE_ZONE: 'safeZone',
+  PREVIEW_STORY: 'previewStory',
+  ADD_LINKS: 'addLinks',
+  ENABLE_SWIPE: 'enableSwipe',
+  DONE: 'done',
+};
+
 export const TIPS = {
-  addBackgroundMedia: {
+  [KEYS.ADD_BACKGROUND_MEDIA]: {
     title: __('Add background media', 'web-stories'),
     figureSrc: 'images/help-center/add_bg_module_1',
     description: [
@@ -30,7 +41,7 @@ export const TIPS = {
       ),
     ],
   },
-  cropSelectedElements: {
+  [KEYS.CROP_SELECTED_ELEMENTS]: {
     title: __('Crop selected element', 'web-stories'),
     figureSrc: 'images/help-center/media_edit_mode_module_2',
     description: [
@@ -40,7 +51,7 @@ export const TIPS = {
       ),
     ],
   },
-  cropElementsWithShapes: {
+  [KEYS.CROP_ELEMENTS_WITH_SHAPES]: {
     title: __('Crop elements using shapes', 'web-stories'),
     figureSrc: 'images/help-center/media_bg_shape_module_3',
     description: [
@@ -50,7 +61,7 @@ export const TIPS = {
       ),
     ],
   },
-  safeZone: {
+  [KEYS.SAFE_ZONE]: {
     title: __('Stay within the safe zone', 'web-stories'),
     figureSrc: 'images/help-center/safe_zone_module_4',
     description: [
@@ -60,7 +71,7 @@ export const TIPS = {
       ),
     ],
   },
-  previewStory: {
+  [KEYS.PREVIEW_STORY]: {
     title: __('Preview your Web Story', 'web-stories'),
     figureSrc: 'images/help-center/preview_module_5',
     description: [
@@ -74,7 +85,7 @@ export const TIPS = {
       ),
     ],
   },
-  addLinks: {
+  [KEYS.ADD_LINKS]: {
     title: __('Add links to Story elements', 'web-stories'),
     figureSrc: 'images/help-center/add_link_module_6',
     description: [
@@ -84,7 +95,7 @@ export const TIPS = {
       ),
     ],
   },
-  enableSwipe: {
+  [KEYS.ENABLE_SWIPE]: {
     title: __('Enable swipe-up option', 'web-stories'),
     figureSrc: 'images/help-center/page_attachment_module_7',
     description: [
@@ -97,7 +108,7 @@ export const TIPS = {
 };
 
 export const DONE_TIP_ENTRY = [
-  'done',
+  KEYS.DONE,
   {
     title: __('Done!', 'web-stories'),
     description: [

--- a/assets/src/edit-story/components/helpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/index.js
@@ -26,11 +26,11 @@ import styled from 'styled-components';
 import { ThemeGlobals } from '../../../design-system';
 import { Z_INDEX } from '../canvas/layout';
 import DirectionAware from '../directionAware';
+import { useHelpCenter } from '../../app/helpCenter';
 import { Navigator } from './navigator';
 import { Companion } from './companion';
 import { POPUP_ID } from './constants';
 import { Toggle } from './toggle';
-import { useHelpCenter } from './useHelpCenter';
 import { Popup } from './popup';
 import { forceFocusCompanion } from './utils';
 

--- a/assets/src/edit-story/editorApp.js
+++ b/assets/src/edit-story/editorApp.js
@@ -39,6 +39,7 @@ import { CurrentUserProvider } from './app/currentUser';
 import AutoSaveHandler from './components/autoSaveHandler';
 import { TransformProvider } from './components/transform';
 import { DropTargetsProvider } from './components/dropTargets';
+import { HelpCenterProvider } from './app/helpCenter';
 import StatusCheck from './components/statusCheck';
 import PostLock from './components/postLock';
 import Layout from './components/layout';
@@ -72,14 +73,16 @@ function App({ config }) {
                                 <AutoSaveHandler />
                                 <TransformProvider>
                                   <DropTargetsProvider>
-                                    <GlobalStyle />
-                                    <DevTools />
-                                    <DefaultMoveableGlobalStyle />
-                                    <CropMoveableGlobalStyle />
-                                    <ModalGlobalStyle />
-                                    <CalendarStyle />
-                                    <KeyboardOnlyOutlines />
-                                    <Layout />
+                                    <HelpCenterProvider>
+                                      <GlobalStyle />
+                                      <DevTools />
+                                      <DefaultMoveableGlobalStyle />
+                                      <CropMoveableGlobalStyle />
+                                      <ModalGlobalStyle />
+                                      <CalendarStyle />
+                                      <KeyboardOnlyOutlines />
+                                      <Layout />
+                                    </HelpCenterProvider>
                                   </DropTargetsProvider>
                                 </TransformProvider>
                               </MediaProvider>


### PR DESCRIPTION
## Context
We have a help center which shows users tips on how to use the editor. The help center should open and show tips relevant to the user's context.
The in-context experience is described in [the figma](https://www.figma.com/file/NHHMwIfxMnz39NxqkrFb7R/Stories---Post-Stable?node-id=6515%3A522898).

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Create a new module `useUserOnboarding` to handle the following:
1. only show the relevant tip if it is the user's first time in the context
2. Create a map of triggers to help center actions and perform the help center actions

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- Moved some help center logic and use providers to share the actions which can open and control the help center from another context
- Created a new module `useUserOnboarding` to contain common onboarding events that components and hooks can easily access with a key/selector
- ~[todo] Persist new keys to the `web_stories_onboarding.meta` property for the `currentUser` to determine if they have been onboarded or not (similar to persisting which help center tips a user has read)~
- Since we only show the tip if it's not read, we can use that persistence for this first FTUE feature.
<!-- Please describe your changes. -->

## To-do
- [x] polish and publish this pull request
- [x] when the safe zone/design guideline is visible to the user for the first time, open the help center and show the relevant quick tip
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- Now when a user moves an element outside the safe zone for the first time and the relevant quick tip is not read, open the help center menu and show the user that tip
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Clear your read tips in your console by typing `await wp.apiFetch({ path: '/web-stories/v1/users/me', method: 'POST', data: { meta: { web_stories_onboarding: {} }}})` when in the editor
2. Create a new story and add an element or template
3. Move an element so that the safe zone appears
4. The help center menu should open to the Safe Zone tip
5. Close the menu
6. Move another element so the safe zone appears
7. The menu should remain closed

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6633 and #6368
