### PR TITLE
Blocks: fix infinite loop in select stories dialog

### DIFF
--- a/assets/src/web-stories-block/block/block-types/selected-stories/storyPicker.js
+++ b/assets/src/web-stories-block/block/block-types/selected-stories/storyPicker.js
@@ -97,7 +97,9 @@ function StoryPicker({
   isSortingStories,
   setIsSortingStories,
 }) {
-  const [fetchingForTheFirstTime, setFetchingForTheFirstTime] = useState(true);
+  const [isFetchingForTheFirstTime, setIsFetchingForTheFirstTime] = useState(
+    true
+  );
   const [currentAuthor, setCurrentAuthor] = useState([]);
   const [authorKeyword, setAuthorKeyword] = useState('');
   const { maxNumOfStories } = useConfig();
@@ -157,7 +159,7 @@ function StoryPicker({
     }
 
     await fetchStories(query);
-    setFetchingForTheFirstTime(false);
+    setIsFetchingForTheFirstTime(false);
   }, [
     page.value,
     search.keyword,
@@ -165,7 +167,7 @@ function StoryPicker({
     sort,
     currentAuthor,
     fetchStories,
-    setFetchingForTheFirstTime,
+    setIsFetchingForTheFirstTime,
   ]);
 
   const fetchStoryAuthors = useCallback(async () => {
@@ -186,10 +188,7 @@ function StoryPicker({
 
   useEffect(() => {
     if (isSortingStories) {
-      setFetchingForTheFirstTime(false);
       return;
-    } else if (!orderedStories.length) {
-      setFetchingForTheFirstTime(true);
     }
 
     fetchWebStories();
@@ -239,7 +238,7 @@ function StoryPicker({
       shouldCloseOnClickOutside={false}
     >
       <ModalContent>
-        {fetchingForTheFirstTime ? (
+        {isFetchingForTheFirstTime ? (
           <LoaderContainer>
             {__('Fetching stories', 'web-stories')}
           </LoaderContainer>
@@ -291,7 +290,7 @@ function StoryPicker({
       </ModalContent>
       <ModalFooter>
         <ModalFooterLeft>
-          {!isSortingStories && !fetchingForTheFirstTime && (
+          {!isSortingStories && !isFetchingForTheFirstTime && (
             <LimitIndicator
               reachedMaximum={selectedStories.length >= maxNumOfStories}
             >


### PR DESCRIPTION
## Context

There's an edge case when there are no existing stories.

## Summary

Fixes an infinite loop in the select stories dialog when no stories exist yet.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6819
