### PR TITLE
Fix loading when rearranging stories

### DIFF
--- a/assets/src/web-stories-block/block/block-types/selected-stories/storyPicker.js
+++ b/assets/src/web-stories-block/block/block-types/selected-stories/storyPicker.js
@@ -188,6 +188,7 @@ function StoryPicker({
 
   useEffect(() => {
     if (isSortingStories) {
+      setIsFetchingForTheFirstTime(false);
       return;
     }
 


### PR DESCRIPTION
## Context

Loading message stuck when rearranging stories

![image (1)](https://user-images.githubusercontent.com/841956/111700437-b3716a80-8839-11eb-95ea-1e1168704d33.png)

## Summary

Fixes an issue where the rearranging screen was stuck showing a loading message.
