### PR TITLE
Fix using arrow keys for all numeric inputs in the design panel

### DIFF
--- a/assets/src/edit-story/components/form/color/opacityInput.js
+++ b/assets/src/edit-story/components/form/color/opacityInput.js
@@ -41,11 +41,10 @@ function OpacityInput({ value, onChange }) {
 
   // Allow any input, but only persist non-NaN values up-chain
   const handleChange = useCallback(
-    (evt) => {
-      setInputValue(evt.target.value);
-      const val = parseInt(evt.target.value) / 100;
+    (evt, val) => {
+      setInputValue(val);
       if (!isNaN(val)) {
-        onChange(val);
+        onChange(val / 100);
       }
     },
     [onChange]

--- a/assets/src/edit-story/components/panels/design/border/borderWidth.js
+++ b/assets/src/edit-story/components/panels/design/border/borderWidth.js
@@ -105,21 +105,18 @@ function WidthControls({ selectedElements, pushUpdateForObject }) {
   const lockBorder = border.lockedWidth === true;
 
   const handleChange = useCallback(
-    (name) => (evt) => {
-      const value = Number(evt?.target?.value);
-      if (value) {
-        const newBorder = !lockBorder
-          ? {
-              [name]: value,
-            }
-          : {
-              left: value,
-              top: value,
-              right: value,
-              bottom: value,
-            };
-        pushUpdateForObject('border', newBorder, DEFAULT_BORDER, true);
-      }
+    (name) => (evt, value) => {
+      const newBorder = !lockBorder
+        ? {
+            [name]: value,
+          }
+        : {
+            left: value,
+            top: value,
+            right: value,
+            bottom: value,
+          };
+      pushUpdateForObject('border', newBorder, DEFAULT_BORDER, true);
     },
     [pushUpdateForObject, lockBorder]
   );

--- a/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/sizePosition.js
@@ -171,10 +171,7 @@ function SizePositionPanel({
             value={x}
             min={minMaxXY.minX}
             max={minMaxXY.maxX}
-            onChange={(evt) => {
-              const value = Number(evt.target.value);
-              pushUpdate({ x: value }, true);
-            }}
+            onChange={(evt, value) => pushUpdate({ x: value }, true)}
             aria-label={__('X position', 'web-stories')}
             canBeNegative
             {...getMixedValueProps(x)}
@@ -186,10 +183,7 @@ function SizePositionPanel({
             value={y}
             min={minMaxXY.minY}
             max={minMaxXY.maxY}
-            onChange={(evt) => {
-              const value = Number(evt.target.value);
-              pushUpdate({ y: value }, true);
-            }}
+            onChange={(evt, value) => pushUpdate({ y: value }, true)}
             aria-label={__('Y position', 'web-stories')}
             canBeNegative
             {...getMixedValueProps(y)}
@@ -202,8 +196,8 @@ function SizePositionPanel({
             value={width}
             min={MIN_MAX.WIDTH.MIN}
             max={MIN_MAX.WIDTH.MAX}
-            onChange={(evt) => {
-              const newWidth = Number(evt.target.value);
+            onChange={(evt, value) => {
+              const newWidth = value;
               let newHeight = height;
               if (lockAspectRatio) {
                 if (newWidth === '') {
@@ -239,8 +233,8 @@ function SizePositionPanel({
             disabled={disableHeight}
             min={MIN_MAX.HEIGHT.MIN}
             max={MIN_MAX.HEIGHT.MAX}
-            onChange={(evt) => {
-              const newHeight = Number(evt.target.value);
+            onChange={(evt, value) => {
+              const newHeight = value;
               let newWidth = width;
               if (lockAspectRatio) {
                 if (newHeight === '') {
@@ -291,10 +285,9 @@ function SizePositionPanel({
             value={rotationAngle}
             min={MIN_MAX.ROTATION.MIN}
             max={MIN_MAX.ROTATION.MAX}
-            onChange={(evt) => {
-              const value = Number(evt.target.value);
-              pushUpdate({ rotationAngle: value }, true);
-            }}
+            onChange={(evt, value) =>
+              pushUpdate({ rotationAngle: value }, true)
+            }
             aria-label={__('Rotation', 'web-stories')}
             canBeNegative
             {...getMixedValueProps(rotationAngle)}

--- a/assets/src/edit-story/components/panels/design/sizePosition/test/sizePosition.js
+++ b/assets/src/edit-story/components/panels/design/sizePosition/test/sizePosition.js
@@ -432,11 +432,11 @@ describe('panels/SizePosition', () => {
       const { getByRole, pushUpdate, submit } = renderSizePosition([image]);
       const input = getByRole('textbox', { name: 'Height' });
       fireEvent.change(input, { target: { value: '2000' } });
-      fireEvent.keyDown(input, { key: 'Enter', which: 13 });
+      fireEvent.blur(input);
       const [updateArg, submitArg] = pushUpdate.mock.calls[0];
       expect(updateArg()).toStrictEqual({
-        height: 2000,
-        width: 2000 * (100 / 80),
+        height: 1000,
+        width: 1000 * (100 / 80),
       });
       expect(submitArg).toBeTrue();
 

--- a/assets/src/edit-story/components/panels/design/textBox/padding.js
+++ b/assets/src/edit-story/components/panels/design/textBox/padding.js
@@ -139,8 +139,7 @@ function PaddingControls({
     ? {
         suffix: __('Padding', 'web-stories'),
         'aria-label': __('Padding', 'web-stories'),
-        onChange: (evt) => {
-          const value = Number(evt?.target?.value);
+        onChange: (evt, value) => {
           handleChange((el) => {
             return {
               horizontal: value + getHiddenPadding(el, 'horizontal'),
@@ -153,8 +152,7 @@ function PaddingControls({
     : {
         suffix: __('Horizontal padding', 'web-stories'),
         'aria-label': __('Horizontal padding', 'web-stories'),
-        onChange: (evt) => {
-          const value = Number(evt?.target?.value);
+        onChange: (evt, value) => {
           handleChange((el) => ({
             horizontal: value + getHiddenPadding(el, 'horizontal'),
           }));
@@ -213,13 +211,10 @@ function PaddingControls({
             }
             suffix={__('Vertical padding', 'web-stories')}
             value={displayedPadding.vertical}
-            onChange={(evt) => {
-              const value = evt?.target?.value;
-              if (value) {
-                handleChange((el) => ({
-                  vertical: Number(value) + getHiddenPadding(el, 'vertical'),
-                }));
-              }
+            onChange={(evt, value) => {
+              handleChange((el) => ({
+                vertical: Number(value) + getHiddenPadding(el, 'vertical'),
+              }));
             }}
             aria-label={__('Vertical padding', 'web-stories')}
           />

--- a/assets/src/edit-story/components/panels/design/textStyle/font.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/font.js
@@ -135,9 +135,7 @@ function FontControls({ selectedElements, pushUpdate }) {
           aria-label={__('Font size', 'web-stories')}
           isFloat
           value={fontSize}
-          onChange={(evt) =>
-            pushUpdate({ fontSize: Number(evt.target.value) }, true)
-          }
+          onChange={(evt, value) => pushUpdate({ fontSize: value }, true)}
           min={MIN_MAX.FONT_SIZE.MIN}
           max={MIN_MAX.FONT_SIZE.MAX}
           isIndeterminate={MULTIPLE_VALUE === fontSize}


### PR DESCRIPTION

## Summary
The numeric input in case of many of the panels was using the `evt` for getting the value, however, it needed to use the already processed second param `value`.
<!-- A brief description of what this PR does. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Verify that all numeric inputs allow changing the value using Up and Down arrow keys.
2. Verify this for the Opacity input, Border, Border radius, Text Style, Text Box, Size & Position panels.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6724 
Fixes #6793 
Fixes #6803 
Fixes #6828 
