### PR TITLE
Redesign: Page header button updates

### DIFF
--- a/assets/src/edit-story/components/header/buttons/buttonWithChecklistWarning.js
+++ b/assets/src/edit-story/components/header/buttons/buttonWithChecklistWarning.js
@@ -44,8 +44,9 @@ import {
 } from '../../../../design-system';
 
 const Button = styled(DefaultButton)`
+  padding: 4px 8px;
   svg {
-    margin-right: -10px;
+    margin-right: -2px;
     margin-left: 2px;
   }
 `;

--- a/assets/src/edit-story/components/header/buttons/preview.js
+++ b/assets/src/edit-story/components/header/buttons/preview.js
@@ -151,7 +151,7 @@ function Preview() {
       <Tooltip title={label} placement={TOOLTIP_PLACEMENT.BOTTOM} hasTail>
         <Button
           variant={BUTTON_VARIANTS.SQUARE}
-          type={BUTTON_TYPES.TERTIARY}
+          type={BUTTON_TYPES.QUATERNARY}
           size={BUTTON_SIZES.SMALL}
           onClick={openPreviewLink}
           disabled={isSaving || isUploading}

--- a/assets/src/edit-story/components/header/buttons/switchToDraft.js
+++ b/assets/src/edit-story/components/header/buttons/switchToDraft.js
@@ -56,7 +56,7 @@ function SwitchToDraft() {
     <Tooltip title={label} placement={TOOLTIP_PLACEMENT.BOTTOM} hasTail>
       <Button
         variant={BUTTON_VARIANTS.SQUARE}
-        type={BUTTON_TYPES.TERTIARY}
+        type={BUTTON_TYPES.QUATERNARY}
         size={BUTTON_SIZES.SMALL}
         onClick={handleUnPublish}
         disabled={isSaving || isUploading}

--- a/assets/src/edit-story/components/header/buttons/update.js
+++ b/assets/src/edit-story/components/header/buttons/update.js
@@ -88,7 +88,7 @@ function Update() {
         <Tooltip title={text} placement={TOOLTIP_PLACEMENT.BOTTOM} hasTail>
           <Button
             variant={BUTTON_VARIANTS.SQUARE}
-            type={BUTTON_TYPES.TERTIARY}
+            type={BUTTON_TYPES.QUATERNARY}
             size={BUTTON_SIZES.SMALL}
             onClick={() => saveStory({ status: 'draft' })}
             disabled={!isEnabled}


### PR DESCRIPTION
## Summary
The style for the buttons in the header has the following changes:
- The type of the icon buttons is now `quaternary`
- The height of the Publish button is now 32px
- The padding on the left and right is now 8px instead of the 16px default.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
| Before | After |
|--------|------|
| <img width="378" alt="Screenshot 2021-03-23 at 10 42 33" src="https://user-images.githubusercontent.com/3294597/112117886-1f4a2f00-8bbc-11eb-9bca-fecc48b42559.png"> | <img width="364" alt="Screenshot 2021-03-23 at 10 41 07" src="https://user-images.githubusercontent.com/3294597/112117706-ea3ddc80-8bbb-11eb-83d4-4458ba6470dc.png"> |
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->


### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Verify the Header buttons look as in Figma

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6714 
Fixes #6716 
