### PR TITLE
Animations:  Pan + Zoom Updates

### DIFF
--- a/assets/src/animation/effects/backgroundPanAndZoom/animationProps.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/animationProps.js
@@ -13,40 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * External dependencies
- */
-import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
  */
-import { FIELD_TYPES, SCALE_DIRECTION } from '../../constants';
-import zoomAnimationProps, {
-  ZoomEffectInputPropTypes,
-} from '../backgroundZoom/animationProps';
-import panAnimationProps, {
-  PanEffectInputPropTypes,
+export {
+  default,
+  PanEffectInputPropTypes as PanAndZoomEffectInputPropTypes,
 } from '../backgroundPan/animationProps';
-
-export const PanAndZoomEffectInputPropTypes = {
-  ...PanEffectInputPropTypes,
-  ...ZoomEffectInputPropTypes,
-};
-
-const zoomAnimationPropsWithDropdown = {
-  ...zoomAnimationProps,
-  zoomDirection: {
-    ...zoomAnimationProps.zoomDirection,
-    type: FIELD_TYPES.DROPDOWN,
-    values: [
-      { value: SCALE_DIRECTION.SCALE_IN, name: __('Zoom in', 'web-stories') },
-      { value: SCALE_DIRECTION.SCALE_OUT, name: __('Zoom out', 'web-stories') },
-    ],
-  },
-};
-
-export default {
-  ...panAnimationProps,
-  ...zoomAnimationPropsWithDropdown,
-};

--- a/assets/src/animation/effects/backgroundPanAndZoom/index.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/index.js
@@ -34,7 +34,7 @@ const defaults = {
 
 export function EffectBackgroundPanAndZoom({
   element,
-  zoomDirection = SCALE_DIRECTION.SCALE_OUT,
+  zoomDirection = SCALE_DIRECTION.SCALE_IN,
   panDir = DIRECTION.RIGHT_TO_LEFT,
   duration = 1000,
   delay,

--- a/assets/src/animation/utils/getMediaOrigin.js
+++ b/assets/src/animation/utils/getMediaOrigin.js
@@ -35,13 +35,28 @@ export function getMediaOrigin(
     left: 0,
   }
 ) {
+  // If both offsets are 0, we want the origin to be in the middle.
+  // Otherwise we want the percentage of one offset relative to the
+  // other
+  let vertical = 0.5;
+  const absOffsets = Object.entries(offsets).reduce(
+    (accum, [key, val]) => ({
+      ...accum,
+      [key]: Math.abs(val),
+    }),
+    {}
+  );
+  if (!(absOffsets.top < 0.01 && absOffsets.bottom < 0.01)) {
+    vertical = absOffsets.top / (absOffsets.top + absOffsets.bottom);
+  }
+  let horizontal = 0.5;
+  if (!(absOffsets.left < 0.01 && absOffsets.right < 0.01)) {
+    horizontal = absOffsets.left / (absOffsets.left + absOffsets.right);
+  }
+
   const progress = {
-    vertical:
-      Math.abs(offsets.top) /
-      (Math.abs(offsets.top) + Math.abs(offsets.bottom)),
-    horizontal:
-      Math.abs(offsets.left) /
-      (Math.abs(offsets.left) + Math.abs(offsets.right)),
+    vertical,
+    horizontal,
   };
 
   return {

--- a/assets/src/animation/utils/test/getMediaOrigin.js
+++ b/assets/src/animation/utils/test/getMediaOrigin.js
@@ -80,6 +80,18 @@ describe('getMediaOrigin', () => {
         vertical: 50,
       },
     ],
+    [
+      {
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      },
+      {
+        horizontal: 50,
+        vertical: 50,
+      },
+    ],
   ])('given %p returns %p', (offset, origin) => {
     expect(getMediaOrigin(offset)).toStrictEqual(origin);
   });

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/dropdownConstants.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/dropdownConstants.js
@@ -53,6 +53,8 @@ import { getDirectionalEffect } from './utils';
 
 export const NO_ANIMATION = 'none';
 
+export const DYNAMIC_PROPERTY_VALUE = 'dynamicPropertyValue';
+
 /**
  * GRID_SIZING is used for how to present effect options visually in dropDown
  */
@@ -211,7 +213,7 @@ export const backgroundEffectOptions = {
     animation: {
       ariaLabel: __('Pan and Zoom Effect', 'web-stories'),
       value: BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value,
-      zoomDirection: 'extremely specific, look at effect chooser',
+      zoomDirection: DYNAMIC_PROPERTY_VALUE,
       Effect: PanAndZoomAnimation,
       size: 26,
     },

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
@@ -34,7 +34,11 @@ import {
   experimentalEffects,
 } from './dropdownConstants';
 import { ANIMATION_DIRECTION_PROP_TYPE } from './types';
-import { getDirectionalEffect, getDisabledBackgroundEffects } from './utils';
+import {
+  getDirectionalEffect,
+  getDisabledBackgroundEffects,
+  generateDynamicProps,
+} from './utils';
 import {
   styleOverrideForSelectButton,
   styleOverrideForAnimationEffectMenu,
@@ -116,17 +120,26 @@ export default function EffectChooserDropdown({
       }
 
       const selectedAnimation = animationOptionsObject[value]?.animation;
+      const animationWithDynamicProps = generateDynamicProps({
+        animation: selectedAnimation,
+        disabledTypeOptionsMap,
+      });
       onAnimationSelected({
-        animation: selectedAnimation.value,
-        panDir: selectedAnimation?.panDirection,
-        zoomDirection: selectedAnimation?.zoomDirection,
-        flyInDir: selectedAnimation?.flyInDirection,
-        rotateInDir: selectedAnimation?.rotateInDirection,
-        whooshInDir: selectedAnimation?.whooshInDirection,
-        scaleDirection: selectedAnimation?.scaleDirection,
+        animation: animationWithDynamicProps.value,
+        panDir: animationWithDynamicProps?.panDirection,
+        zoomDirection: animationWithDynamicProps?.zoomDirection,
+        flyInDir: animationWithDynamicProps?.flyInDirection,
+        rotateInDir: animationWithDynamicProps?.rotateInDirection,
+        whooshInDir: animationWithDynamicProps?.whooshInDirection,
+        scaleDirection: animationWithDynamicProps?.scaleDirection,
       });
     },
-    [animationOptionsObject, onAnimationSelected, onNoEffectSelected]
+    [
+      animationOptionsObject,
+      onAnimationSelected,
+      onNoEffectSelected,
+      disabledTypeOptionsMap,
+    ]
   );
 
   return (

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/types.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/types.js
@@ -32,10 +32,7 @@ const ANIMATION_OPTION_PROP_TYPE = {
   size: PropTypes.number,
   scaleDirection: PropTypes.oneOf(Object.values(SCALE_DIRECTION)),
   panDirection: PropTypes.oneOf(Object.values(DIRECTION)),
-  zoomDirection: PropTypes.oneOf([
-    ...Object.values(SCALE_DIRECTION),
-    'extremely specific, look at effect chooser', // specific for current iteration of pan and zoom
-  ]),
+  zoomDirection: PropTypes.oneOf(Object.values(SCALE_DIRECTION)),
   flyInDirection: PropTypes.oneOf(Object.values(DIRECTION)),
   rotateInDirection: PropTypes.oneOf(Object.values(DIRECTION)),
   whooshInDirection: PropTypes.oneOf(Object.values(DIRECTION)),

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/utils.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/utils.js
@@ -20,6 +20,7 @@
 import {
   BACKGROUND_ANIMATION_EFFECTS,
   SCALE_DIRECTION,
+  DIRECTION,
 } from '../../../../../../animation';
 import {
   effectValueExceptions,
@@ -59,6 +60,14 @@ export const hasDynamicProperty = (animation) => {
 };
 
 export const updateDynamicProps = ({ animation, disabledOptions = [] }) => {
+  // we don't want to have a disbaled direction initially selected either.
+  const panDirection =
+    animation.panDirection && !disabledOptions.includes(animation.panDirection)
+      ? animation.panDirection
+      : Object.values(DIRECTION).filter(
+          (direction) => !disabledOptions.includes(direction)
+        )?.[0] || undefined;
+
   switch (animation.value) {
     case BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value:
       return {
@@ -67,6 +76,7 @@ export const updateDynamicProps = ({ animation, disabledOptions = [] }) => {
         zoomDirection: disabledOptions.includes(SCALE_DIRECTION.SCALE_IN)
           ? SCALE_DIRECTION.SCALE_OUT
           : SCALE_DIRECTION.SCALE_IN,
+        panDirection,
       };
     default:
       return animation;

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/utils.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/utils.js
@@ -17,13 +17,17 @@
 /**
  * Internal dependencies
  */
-import { effectValueExceptions } from './dropdownConstants';
+import {
+  BACKGROUND_ANIMATION_EFFECTS,
+  SCALE_DIRECTION,
+} from '../../../../../../animation';
+import {
+  effectValueExceptions,
+  DYNAMIC_PROPERTY_VALUE,
+} from './dropdownConstants';
 
 // Because some animations have the same effect name we have to specify based on direction
 export const getDirectionalEffect = (effect, direction) => {
-  if (effectValueExceptions.indexOf(effect) > -1) {
-    return effect;
-  }
   return direction ? `${effect} ${direction}`.trim() : effect;
 };
 
@@ -32,6 +36,8 @@ export const getDisabledBackgroundEffects = (
   disabledTypeOptionsMap
 ) => {
   const disabledDirectionalEffects = Object.entries(disabledTypeOptionsMap)
+    // rn we don't ever disable the exceptions, but do dynamic props instead.
+    .filter(([effect]) => effectValueExceptions.indexOf(effect) === -1)
     .map(([effect, val]) => [effect, val.options])
     .reduce(
       (directionalEffects, [effect, directions]) => [
@@ -43,4 +49,32 @@ export const getDisabledBackgroundEffects = (
   return Object.keys(backgroundEffectOptions).filter((directionalEffect) =>
     disabledDirectionalEffects.includes(directionalEffect)
   );
+};
+
+export const hasDynamicProperty = (animation) => {
+  return Object.values(animation).includes(DYNAMIC_PROPERTY_VALUE);
+};
+
+export const updateDynamicProps = ({ animation, disabledOptions = [] }) => {
+  switch (animation.value) {
+    case BACKGROUND_ANIMATION_EFFECTS.PAN_AND_ZOOM.value:
+      return {
+        ...animation,
+        // Defautl zoomDirection to scale in unless disabled
+        zoomDirection: disabledOptions.includes(SCALE_DIRECTION.SCALE_IN)
+          ? SCALE_DIRECTION.SCALE_OUT
+          : SCALE_DIRECTION.SCALE_IN,
+      };
+    default:
+      return animation;
+  }
+};
+
+export const generateDynamicProps = ({ animation, disabledTypeOptionsMap }) => {
+  return hasDynamicProperty(animation)
+    ? updateDynamicProps({
+        animation,
+        disabledOptions: disabledTypeOptionsMap[animation.value]?.options,
+      })
+    : animation;
 };

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/utils.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/utils.js
@@ -28,6 +28,9 @@ import {
 
 // Because some animations have the same effect name we have to specify based on direction
 export const getDirectionalEffect = (effect, direction) => {
+  if (effectValueExceptions.includes(effect)) {
+    return effect;
+  }
   return direction ? `${effect} ${direction}`.trim() : effect;
 };
 


### PR DESCRIPTION
## Context
We pushed out an initial pan + zoom into staging behind a feature flag to get Sams feedback, and this is her implemented feedback.

## Summary
- Removes zoomIn/Out dropdown input from pan + zoom
- Dynamically chooses initial zoom direction and pan value based on disabled options at the moment
- Found a small edge case bug in our transform origin calculations and added an update.

## Relevant Technical Choices
Followed existing setup. Thank you @BrittanyIRL for the cleanup. it is much nicer in here now 🎉 

## To-do
NA

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Enable expiramental animations and select a bg image in the story editor. See that pan + zoom now auto selects zoom out if your image is too far zoomed in, but selects zoom in otherwise.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6882 
Fixes #6883  
