### PR TITLE
Code Quality: Remove duplicate focus selector in typography Link

### DIFF
--- a/assets/src/design-system/components/typography/link/index.js
+++ b/assets/src/design-system/components/typography/link/index.js
@@ -46,10 +46,6 @@ export const Link = styled.a`
       color: ${theme.colors.fg.linkNormal} !important;
     }
 
-    :focus {
-      color: ${theme.colors.fg.linkNormal};
-    }
-
     ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)}
   `};
 `;

--- a/assets/src/edit-story/components/library/test/__snapshots__/termsDialog.js.snap
+++ b/assets/src/edit-story/components/library/test/__snapshots__/termsDialog.js.snap
@@ -34,10 +34,6 @@ exports[`TermsDialog should render 1`] = `
   color: #4F7ED9 !important;
 }
 
-.c0:focus {
-  color: #4F7ED9;
-}
-
 .c0.focus-visible,
 .c0[data-focus-visible-added] {
   outline: none;


### PR DESCRIPTION
## Context

style lint was (rightfully) complaining about a duplicated `:focus` selector, seems there was an unnoticed rebase where this duplication snuck through. 

## Summary

Removed duplicative line of code. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

none

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7051 