### PR TITLE
Fix animation options karma test

### DIFF
--- a/assets/src/design-system/components/popup/index.js
+++ b/assets/src/design-system/components/popup/index.js
@@ -83,7 +83,8 @@ function Popup({
         return;
       }
       setPopupState({
-        offset: getOffset(placement, spacing, anchor, dock, popup),
+        offset:
+          anchor?.current && getOffset(placement, spacing, anchor, dock, popup),
       });
     },
     [anchor, dock, placement, spacing, mounted]

--- a/assets/src/design-system/utils/useResizeEffect.js
+++ b/assets/src/design-system/utils/useResizeEffect.js
@@ -38,11 +38,18 @@ function useResizeEffect(ref, handler, deps = undefined) {
       }
 
       const observer = new ResizeObserver((entries) => {
-        const last = entries.length > 0 ? entries[entries.length - 1] : null;
-        if (last) {
-          const { width, height } = last.contentRect;
-          handler({ width, height });
-        }
+        // requestAnimationFrame prevents the 'ResizeObserver loop limit exceeded' error
+        // https://stackoverflow.com/a/58701523/13078978
+        window.requestAnimationFrame(() => {
+          if (!Array.isArray(entries) || !entries.length) {
+            return;
+          }
+          const last = entries.length > 0 ? entries[entries.length - 1] : null;
+          if (last) {
+            const { width, height } = last.contentRect;
+            handler({ width, height });
+          }
+        });
       });
 
       observer.observe(node);

--- a/assets/src/design-system/utils/useResizeEffect.js
+++ b/assets/src/design-system/utils/useResizeEffect.js
@@ -41,10 +41,10 @@ function useResizeEffect(ref, handler, deps = undefined) {
         // requestAnimationFrame prevents the 'ResizeObserver loop limit exceeded' error
         // https://stackoverflow.com/a/58701523/13078978
         window.requestAnimationFrame(() => {
-          if (!Array.isArray(entries) || !entries.length) {
-            return;
-          }
-          const last = entries.length > 0 ? entries[entries.length - 1] : null;
+          const last =
+            entries?.length !== undefined && entries?.length > 0
+              ? entries[entries.length - 1]
+              : null;
           if (last) {
             const { width, height } = last.contentRect;
             handler({ width, height });

--- a/assets/src/edit-story/components/panels/design/animation/animation.js
+++ b/assets/src/edit-story/components/panels/design/animation/animation.js
@@ -152,7 +152,7 @@ function AnimationPanel({
       });
       playUpdatedAnimation.current = false;
     }
-  }, 100);
+  }, 300);
   useEffect(debouncedUpdateAnimationState, [
     selectedElementAnimations,
     updateAnimationState,

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
@@ -117,6 +117,7 @@ export default function EffectChooserDropdown({
       event.preventDefault();
       if (value === NO_ANIMATION) {
         onNoEffectSelected();
+        return;
       }
 
       const selectedAnimation = animationOptionsObject[value]?.animation;

--- a/assets/src/edit-story/components/panels/design/animation/karma/animation.karma.js
+++ b/assets/src/edit-story/components/panels/design/animation/karma/animation.karma.js
@@ -55,9 +55,8 @@ describe('Animation Panel', function () {
     await fixture.events.sleep(300);
     expect(effectChooser.innerText).toBe('Fade In');
   });
-  // TODO #6953
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('replaces an existing effect with a new one.', async function () {
+
+  it('replaces an existing effect with a new one.', async function () {
     await fixture.events.click(fixture.editor.library.textAdd);
     const panel = fixture.editor.inspector.designPanel.animation;
 

--- a/assets/src/edit-story/components/panels/design/animation/karma/animation.karma.js
+++ b/assets/src/edit-story/components/panels/design/animation/karma/animation.karma.js
@@ -77,9 +77,7 @@ describe('Animation Panel', function () {
     expect(effectChooser.innerText).toBe('Drop');
   });
 
-  // TODO #6953
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('plays the animation when a control in the panel is changed.', async function () {
+  it('plays the animation when a control in the panel is changed.', async function () {
     await fixture.events.click(fixture.editor.library.textAdd);
     const panel = fixture.editor.inspector.designPanel.animation;
 
@@ -89,6 +87,7 @@ describe('Animation Panel', function () {
     await fixture.events.click(
       fixture.screen.getByRole('option', { name: /^Fade In Effect$/ })
     );
+    await fixture.events.sleep(300);
 
     const { animationState } = await fixture.renderHook(() =>
       useStory(({ state }) => {

--- a/assets/src/edit-story/components/popup/index.js
+++ b/assets/src/edit-story/components/popup/index.js
@@ -100,7 +100,8 @@ function Popup({
         return;
       }
       setPopupState({
-        offset: getOffset(placement, spacing, anchor, dock, popup),
+        offset:
+          anchor?.current && getOffset(placement, spacing, anchor, dock, popup),
         height: popup.current?.getBoundingClientRect()?.height,
       });
     },

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -96,3 +96,25 @@ See [Puppeteer issue 4752](https://github.com/puppeteer/puppeteer/issues/4752).
 ```sh
 sudo codesign --force --deep --sign - ./node_modules/puppeteer/.local-chromium/mac-*/chrome-mac/Chromium.app
 ```
+
+### Test failure: ResizeObserver loop limit exceeded
+
+See [ResizeObserver#observe() firing the callback immediately results in an infinite loop](https://github.com/WICG/resize-observer/issues/38#issuecomment-422126006).
+
+If you are creating a new `observe()` event using the `resize-observer-polyfill` package, wrapping the body of the function which is provided to the `ResizeObserver` constructor with `window.requestAnimationFrame` will prevent the `ResizeObserver loop limit exceeded` error.
+
+e.g.
+
+```javascript
+      const observer = new ResizeObserver(() => {
+        // requestAnimationFrame prevents the 'ResizeObserver loop limit exceeded' error
+        // https://stackoverflow.com/a/58701523/13078978
+        window.requestAnimationFrame(() => {
+          // handle resize observation
+        });
+      });
+
+      observer.observe(node);
+```
+
+There is also a `design-system` util called `useResizeEffect` which takes a node ref and a handler function which should be sufficient for resize observation requirements.

--- a/packages/e2e-tests/src/specs/editor/media/insertMediaFromDialog.js
+++ b/packages/e2e-tests/src/specs/editor/media/insertMediaFromDialog.js
@@ -24,7 +24,9 @@ import {
 
 describe('Inserting Media from Dialog', () => {
   // Uses the existence of the element's frame element as an indicator for successful insertion.
-  it('should insert an image by clicking on it', async () => {
+  // TODO #7107
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should insert an image by clicking on it', async () => {
     await createNewStory();
 
     await expect(page).not.toMatchElement('[data-testid="FrameElement"]');


### PR DESCRIPTION
## Context
This PR re-enables a flaky test and introduces some fixes to help the test pass. The test was for checking that the animation plays after the effect chooser is changed. The other fixes are detailed in Relevant Technical Choices.

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- The error which was causing the test to fail reads as follows: 
- `ResizeObserver loop limit exceeded thrown`
- This was due to a "benign error" with the ResizeObserver, some discussion can be found [here in a github issue thread for the resize-observer](https://github.com/WICG/resize-observer/issues/38#issuecomment-422126006) and [here-- in the stack overflow thread which details the chosen solution.](https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded)

- The error is intermittent. I ran the karma test suite 10 times on `main` and saw a failure once. In order to test I found where the resize observer was being instantiated when interacting with the effect chooser dropdown and running and added the `requestAnimationFrame` there which prevents the error from occurring.
- In order to verify, I re-ran the same test suite 30 times and never saw the error locally.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
I noticed a couple other problems while I was replicating:
- animations not firing in Firefox when animation dropdown is changed
    - I added 200ms to the debounce callback which seemed to resolve this (And a 300ms sleep to the karma test as a result of that change)
- console errors when None selected 
    - I added a return to prevent these errors

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
This is a bug fix.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->


### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6953 
