### PR TITLE
Bugfix: Fix failing text preset karma test

### DIFF
--- a/assets/src/edit-story/components/library/panes/text/karma/textPane.karma.js
+++ b/assets/src/edit-story/components/library/panes/text/karma/textPane.karma.js
@@ -28,13 +28,15 @@ import { dataFontEm, dataPixels } from '../../../../../units';
 import stripHTML from '../../../../../utils/stripHTML';
 import { PRESETS } from '../textPresets';
 
+const TIMEOUT_INTERVAL = 300000;
+
 describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => {
   let fixture;
   let originalTimeout;
 
   beforeEach(async () => {
     originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
-    jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT_INTERVAL;
     fixture = new Fixture();
     await fixture.render();
   });
@@ -44,13 +46,12 @@ describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => 
     fixture.restore();
   });
 
-  // TODO #6956
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should add text presets below each other if added consecutively', async () => {
+  it('should add text presets below each other if added consecutively', async () => {
     await fixture.editor.library.textTab.click();
 
-    await waitFor(() =>
-      expect(fixture.editor.library.text.textSets.length).toBeTruthy()
+    await waitFor(
+      () => expect(fixture.editor.library.text.textSets.length).toBeTruthy(),
+      { timeout: TIMEOUT_INTERVAL / 3 }
     );
 
     await fixture.events.click(fixture.editor.library.text.preset('Title 1'));
@@ -60,9 +61,7 @@ describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => 
     await fixture.snapshot('consecutively added different text presets');
   });
 
-  // TODO #6956
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should ensure staggered presets fit on the page', async () => {
+  it('should ensure staggered presets fit on the page', async () => {
     const POSITION_MARGIN = dataFontEm(1);
     const PARAGRAPH_TEXT =
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
@@ -102,8 +101,11 @@ describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => 
 
     await fixture.editor.library.textTab.click();
 
-    await waitFor(() =>
-      expect(fixture.editor.library.text.textSets.length).toBeTruthy()
+    await waitFor(
+      () => expect(fixture.editor.library.text.textSets.length).toBeTruthy(),
+      {
+        timeout: TIMEOUT_INTERVAL / 3,
+      }
     );
 
     // Stagger all different text presets.


### PR DESCRIPTION
## Context

Fixes two karma tests that were commented out. 

## Summary

Tests were failing due to a timeout issue. Increasing the timeout while waiting for the text sets to be loaded makes the tests pass.

## Relevant Technical Choices

n/a

## To-do

none

## User-facing changes

none

## Testing Instructions

run karma tests for edit-story, should pass!

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

Not necessary to test.

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6956 
