### PR TITLE
Bugfix: Animation direction tooltips showing for enabled direction

### DIFF
--- a/assets/src/edit-story/components/panels/design/animation/directionRadioInput.js
+++ b/assets/src/edit-story/components/panels/design/animation/directionRadioInput.js
@@ -119,7 +119,7 @@ const Figure = styled.div`
 const SPACE_FROM_EDGE = 3;
 const Label = styled.label`
   position: absolute;
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
 
   ${({ direction }) => {
     switch (direction) {
@@ -318,9 +318,10 @@ export const DirectionRadioInput = ({
               aria-label={translations[direction]}
               htmlFor={direction}
               direction={direction}
+              disabled={isDisabled}
             >
               <Tooltip
-                title={disabled ? tooltip : ''}
+                title={isDisabled ? tooltip : ''}
                 placement={
                   isInternalScaleDirection(direction)
                     ? getPostfixFromCamelCase(direction)


### PR DESCRIPTION
## Context

Found while prepping for bug bash. 

## Summary

Tooltips were showing up for enabled direction.

## Relevant Technical Choices

A prop was getting the wrong name - needed isDisabled not disabled. Also turning cursor to default when direction is disabled.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Tooltips on animation direction should now only show up for disabled directions. 

## Testing Instructions

See that only disabled directions in animation panel show tooltips.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
