### PR TITLE
Skip post from AMP if plugin is older than bundled version

### DIFF
--- a/includes/Integrations/AMP.php
+++ b/includes/Integrations/AMP.php
@@ -226,7 +226,7 @@ class AMP extends Service_Base {
 		if (
 			'web-story' === get_post_type( $post )
 			&&
-			defined( 'AMP__VERSION' )
+			defined( '\AMP__VERSION' )
 			&&
 			version_compare( WEBSTORIES_AMP_VERSION, AMP__VERSION, '>=' )
 		) {

--- a/includes/Integrations/AMP.php
+++ b/includes/Integrations/AMP.php
@@ -217,6 +217,8 @@ class AMP extends Service_Base {
 	 *
 	 * @link https://github.com/google/web-stories-wp/issues/7131
 	 *
+	 * @since 1.6.0
+	 *
 	 * @param bool $skipped Whether the post should be skipped from AMP.
 	 * @param int  $post    Post ID.
 	 *


### PR DESCRIPTION
## Context

If the AMP plugin version is lower than what's included in this plugin, there can be false positives in the AMP validation.

## Summary

Skips post from AMP if plugin is older than bundled version

## Relevant Technical Choices

Uses `amp_skip_post` filter as suggested on the ticket.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

When using AMP 2.0.11, now there shouldn't be any reported validation errors because the post is skipped entirely.

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7131
