### PR TITLE
Fix Copy & Paste Background Animation Karma Tests

### DIFF
--- a/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
+++ b/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -250,6 +254,7 @@ describe('Background Copy & Paste', () => {
     // Click twice to enter edit mode
     await fixture.events.click(bgFrame);
     await fixture.events.click(bgFrame);
+    await waitFor(() => fixture.editor.canvas.editLayer.sizeSlider);
     const slider = fixture.editor.canvas.editLayer.sizeSlider;
     await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
       moveRel(slider, 5, 5),
@@ -267,22 +272,21 @@ describe('Background Copy & Paste', () => {
 
   // Disable reason: flakey tests.
   // See https://github.com/google/web-stories-wp/issues/6936
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('works for all background animations', async () => {
+  it('works for all background animations', async () => {
     // open effect chooser
     await openEffectChooser();
 
     // see that effect chooser is open
-    const effectChooser = fixture.screen.getByRole('list', {
-      name: /Available Animations To Select/,
+    const effectChooser = fixture.screen.getByRole('listbox', {
+      name: /Animation: Effect Chooser Option List Selector/,
     });
 
     // iterate through children with process
     await sequencedForEach(effectChooser.children, async (_, i) => {
       // need to regrab the button because we're openeing
       // and closing effect chooser causing karma ids to change
-      const effectButton = fixture.screen.getByRole('list', {
-        name: /Available Animations To Select/,
+      const effectButton = fixture.screen.getByRole('listbox', {
+        name: /Animation: Effect Chooser Option List Selector/,
       }).children[i];
 
       // first button is `none` and doesn't apply animation
@@ -321,6 +325,17 @@ describe('Background Copy & Paste', () => {
         copied.elementAnimations[0] || {};
       const { id: pId, targets: pTargets, ...pPersisted } =
         pasted.elementAnimations[0] || {};
+
+      // animation properties are explicitly passed as of #6888
+      // https://github.com/google/web-stories-wp/pull/6888/files#diff-e2509f6271734915fc6fb3d6b0fd1a78d6d34df81e215f0a79f2fce50586bb86R119
+      // so undefined properties are removed to check for object equality
+      Object.keys(cPersisted).forEach((key) =>
+        cPersisted[key] === undefined ? delete cPersisted[key] : {}
+      );
+      Object.keys(pPersisted).forEach((key) =>
+        pPersisted[key] === undefined ? delete pPersisted[key] : {}
+      );
+
       expect(cPersisted).toEqual(pPersisted);
 
       // pasted animations should contain the newly pasted

--- a/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
+++ b/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
@@ -270,8 +270,6 @@ describe('Background Copy & Paste', () => {
     fixture.restore();
   });
 
-  // Disable reason: flakey tests.
-  // See https://github.com/google/web-stories-wp/issues/6936
   it('works for all background animations', async () => {
     // open effect chooser
     await openEffectChooser();


### PR DESCRIPTION
## Context
Karma tests for background animations in `edit-story/karma/copyAndPaste.cuj.karma.js` are failing because of the following:
`Unable to find an accessible element with the role "region" and name "Edit layer".`

This PR fixes and reenables the background animation test in `copyAndPaste.cuj.karma.js`
 
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- re-enables a skipped test (`Background Copy and Paste 'works for all background animations'`)
- introduces a fix the original problem (waiting for the edit layer), and updated since the test was disabled
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- Added a `await waitFor` for the Edit layer (the original test failure). This role is only rendered after entering edit mode.
- The name of the effect chooser has changed since this test was disabled, so I updated that.
- Finally the effect chooser passes all the animation keys explicitly now (the change is documented in the comment above the change). Because of this the equality check fails, so I delete the undefined keys to deal with equality discrepancies.
- Ran this test several times to make reasonably sure it wasn't flaky anymore. It passed 30 times locally.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6936 
