### PR TITLE
Text display: check ref before trying to set style

### DIFF
--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -175,14 +175,17 @@ function TextDisplay({
   useTransformHandler(id, (transform) => {
     // Ref is set in case of high-light mode only, use the fgRef if that's missing.
     const target = ref?.current || fgRef.current;
-    const updatedFontSize = transform?.updates?.fontSize;
-    target.style.fontSize = updatedFontSize
-      ? `${dataToEditorY(updatedFontSize)}px`
-      : '';
-    const updatedMargin = transform?.updates?.marginOffset;
-    target.style.margin = updatedMargin
-      ? `${dataToEditorY(-updatedMargin) / 2}px 0`
-      : '';
+    if (target) {
+      const updatedFontSize = transform?.updates?.fontSize;
+      target.style.fontSize = updatedFontSize
+        ? `${dataToEditorY(updatedFontSize)}px`
+        : '';
+
+      const updatedMargin = transform?.updates?.marginOffset;
+      target.style.margin = updatedMargin
+        ? `${dataToEditorY(-updatedMargin) / 2}px 0`
+        : '';
+    }
 
     if (outerBorderRef.current || bgRef.current) {
       // Depending on the background mode, choose the element that has border assigned to it.


### PR DESCRIPTION
## Context

saw some console errors when resizing and moving text elements.

## Summary

This fixes some issues when resizing text elements and `target` is `null`, so trying to set `target.style` would cause errors.

## Relevant Technical Choices

Just checking if `target` is truthy.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

