### PR TITLE
Bug:  useRovingKeyIndex RTL direction odd

### DIFF
--- a/assets/src/edit-story/utils/test/useRovingTabIndex.js
+++ b/assets/src/edit-story/utils/test/useRovingTabIndex.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { getSiblingDirection } from '../useRovingTabIndex';
+
+describe('getSiblingDirection', () => {
+  describe('RTL', () => {
+    it.each(['ArrowRight', 'ArrowUp', 'PageUp'])(
+      'given key: %s returns "previousSibling"',
+      (key) => {
+        const isRTL = true;
+        expect(getSiblingDirection(isRTL, key)).toBe('previousSibling');
+      }
+    );
+
+    it.each(['ArrowLeft', 'ArrowDown', 'PageDown'])(
+      'given key: %s returns "nextSibling"',
+      (key) => {
+        const isRTL = true;
+        expect(getSiblingDirection(isRTL, key)).toBe('nextSibling');
+      }
+    );
+  });
+
+  describe('LTR', () => {
+    it.each(['ArrowLeft', 'ArrowUp', 'PageUp'])(
+      'given key: %s returns "previousSibling"',
+      (key) => {
+        const isRTL = false;
+        expect(getSiblingDirection(isRTL, key)).toBe('previousSibling');
+      }
+    );
+
+    it.each(['ArrowRight', 'ArrowDown', 'PageDown'])(
+      'given key: %s returns "nextSibling"',
+      (key) => {
+        const isRTL = false;
+        expect(getSiblingDirection(isRTL, key)).toBe('nextSibling');
+      }
+    );
+  });
+});

--- a/assets/src/edit-story/utils/useRovingTabIndex.js
+++ b/assets/src/edit-story/utils/useRovingTabIndex.js
@@ -67,11 +67,11 @@ function getDistanceSq(p1, p2) {
  * @param {string} key The key pressed.
  * @return {string} Either `previousSibling` or `nextSibling`.
  */
-function getSiblingDirection(isRTL, key) {
-  return !isRTL &&
-    (key === 'ArrowLeft' || key === 'ArrowUp' || key === 'PageUp')
-    ? ['previousSibling']
-    : 'nextSibling';
+export function getSiblingDirection(isRTL, key) {
+  const isPreviousDirection = isRTL
+    ? key === 'ArrowRight' || key === 'ArrowUp' || key === 'PageUp'
+    : key === 'ArrowLeft' || key === 'ArrowUp' || key === 'PageUp';
+  return isPreviousDirection ? 'previousSibling' : 'nextSibling';
 }
 
 /**


### PR DESCRIPTION
## Context
When WP was in RTL, all arrow keys were navigating to the next sibling in the page layouts tab regardless of direction.

## Summary
This PR just fixes the boolean logic there of determining sibling direction based off of key and RTL. This PR also adds a small unit/regression test for the lil' util used to infer this.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
If you're in RTL mode, and navigate to the page layouts in the editor, now using key navigation should work properly.

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Open editor and focus into page layouts library pane. Use arrow keys (up, down, left, right) and see that they navigate properly between page layouts. Switch to RTL and see that the keys still navigate properly (with left & right having reversed functionality from before)
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
Follow testing instructions above.
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6108 
