### PR TITLE
Code Quality: use injector instead of service container for now

### DIFF
--- a/includes/Database_Upgrader.php
+++ b/includes/Database_Upgrader.php
@@ -297,7 +297,11 @@ class Database_Upgrader extends Service_Base implements Activateable {
 	 * @return void
 	 */
 	protected function add_stories_caps() {
-		$story_post_type = Services::get( 'story_post_type' );
+		$injector = Services::get_injector();
+		if ( ! method_exists( $injector, 'make' ) ) {
+			return;
+		}
+		$story_post_type = $injector->make( Story_Post_Type::class );
 		$story_post_type->add_caps_to_roles();
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -63,7 +63,12 @@ function get_stories( array $attrs = [], array $query_args = [] ) {
  * @return void
  */
 function render_theme_stories() {
-	$customizer = Services::get( 'customizer' );
+	$injector = Services::get_injector();
+	if ( ! method_exists( $injector, 'make' ) ) {
+		return;
+	}
+
+	$customizer = $injector->make( Customizer::class );
 	//phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo $customizer->render_stories();
 }

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -38,7 +38,11 @@ use WP_Site;
  * @return void
  */
 function setup_new_site() {
-	$story = Services::get( 'story_post_type' );
+	$injector = Services::get_injector();
+	if ( ! method_exists( $injector, 'make' ) ) {
+		return;
+	}
+	$story = $injector->make( Story_Post_Type::class );
 	$story->register();
 	// TODO Register cap to roles within class itself.
 	$story->add_caps_to_roles();
@@ -48,11 +52,8 @@ function setup_new_site() {
 
 	// Not using Services::get(...) because the class is only registered on 'admin_init', which we might not be in here.
 	// TODO move this logic to Database_Upgrader class.
-	$injector = Services::get_injector();
-	if ( method_exists( $injector, 'make' ) ) {
-		$database_upgrader = $injector->make( Database_Upgrader::class );
-		$database_upgrader->register();
-	}
+	$database_upgrader = $injector->make( Database_Upgrader::class );
+	$database_upgrader->register();
 }
 
 /**
@@ -118,13 +119,18 @@ function remove_site( $error, $site ) {
 		return;
 	}
 
-	$story = Services::get( 'story_post_type' );
+	$injector = Services::get_injector();
+	if ( ! method_exists( $injector, 'make' ) ) {
+		return;
+	}
+	$story = $injector->make( Story_Post_Type::class );
 
 	$site_id = (int) $site->blog_id;
 	switch_to_blog( $site_id );
 	$story->remove_caps_from_roles();
 	restore_current_blog();
 }
+
 add_action( 'wp_validate_site_deletion', __NAMESPACE__ . '\remove_site', PHP_INT_MAX, 2 );
 
 /**


### PR DESCRIPTION
## Context

See https://github.com/google/web-stories-wp/pull/7088#issuecomment-818916558 for a very good explanation.

DB upgrades where not working on older installs due to required classes not being instantiated yet.

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Fixes an issue where the db upgrader was trying to get the classes from the service container which haven't been initialized yet.

## Relevant Technical Choices

Partially reverts #7088.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Deactivate the Web Stories plugin
1. Go to `wp-admin/options.php`
2. Set `web_stories_db_version` to `2.0.4`
3. Set `web_stories_previous_db_version` to 2.0.0
4. Save changes
5. Activate plugin
6. Plugin should activate normally

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

N/A

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
