### PR TITLE
FFmpeg: avoid errors when dimension is not divisible by 2

### DIFF
--- a/assets/src/edit-story/app/media/utils/useFFmpeg.js
+++ b/assets/src/edit-story/app/media/utils/useFFmpeg.js
@@ -122,8 +122,9 @@ function useFFmpeg() {
         '1',
         // Resize videos if larger than 1080x1920, preserving aspect ratio.
         // See https://trac.ffmpeg.org/wiki/Scaling
+        // Adds 1px pad to width/height if they're not divisible by 2, which FFmpeg will complain about.
         '-vf',
-        "scale='min(1080,iw)':'min(1920,ih)':'force_original_aspect_ratio=decrease'",
+        "scale='min(1080,iw)':'min(1920,ih)':'force_original_aspect_ratio=decrease',pad='width=ceil(iw/2)*2:height=ceil(ih/2)*2'",
         // Simpler color profile
         '-pix_fmt',
         'yuv420p',
@@ -175,8 +176,9 @@ function useFFmpeg() {
         'libx264',
         // Resize videos if larger than 1080x1920, preserving aspect ratio.
         // See https://trac.ffmpeg.org/wiki/Scaling
+        // Adds 1px pad to width/height if they're not divisible by 2, which FFmpeg will complain about.
         '-vf',
-        "scale='min(1080,iw)':'min(1920,ih)':'force_original_aspect_ratio=decrease'",
+        "scale='min(1080,iw)':'min(1920,ih)':'force_original_aspect_ratio=decrease',pad='width=ceil(iw/2)*2:height=ceil(ih/2)*2'",
         // move some information to the beginning of your file.
         '-movflags',
         '+faststart',


### PR DESCRIPTION
## Context

FFmpeg doesn't like it when a video's height or width isn't divisible by 2.

## Summary

Adds 1px padding to odd dimension to avoid issues.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
