### PR TITLE
Dashboard: Redirect users to templates on first load if they have no stories

### DIFF
--- a/assets/src/dashboard/app/api/test/apiProvider.js
+++ b/assets/src/dashboard/app/api/test/apiProvider.js
@@ -450,4 +450,34 @@ describe('ApiProvider', () => {
 
     expect(result.current.state.stories.stories).toStrictEqual({});
   });
+
+  it('should call initialFetch listeners once when first storystatuses returned', async () => {
+    const listenerMock = jest.fn();
+    const { result } = renderHook(() => useApi(), {
+      // eslint-disable-next-line react/display-name
+      wrapper: (props) => (
+        <ConfigProvider config={{ api: { stories: 'stories' } }}>
+          <ApiProvider {...props} />
+        </ConfigProvider>
+      ),
+    });
+
+    act(() => {
+      result.current.actions.storyApi.addInitialFetchListener(listenerMock);
+    });
+
+    await act(async () => {
+      await result.current.actions.storyApi.fetchStories({});
+    });
+
+    expect(listenerMock).toHaveBeenCalledTimes(1);
+    expect(listenerMock).toHaveBeenCalledWith({ all: 1, draft: 0, publish: 1 });
+
+    // Run again just to make sure it doesn't call the listeners more than once
+    await act(async () => {
+      await result.current.actions.storyApi.fetchStories({});
+    });
+
+    expect(listenerMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -65,17 +65,36 @@ const AppContent = () => {
       currentPath,
       queryParams: { id: templateId },
     },
+    actions: { push },
   } = useRouteHistory();
 
-  const { currentTemplate } = useApi(
+  const { currentTemplate, addInitialFetchListener } = useApi(
     ({
+      actions: {
+        storyApi: { addInitialFetchListener },
+      },
       state: {
+        stories: { stories },
         templates: { templates },
       },
     }) => ({
+      stories,
       currentTemplate:
         templateId !== undefined ? templates[templateId]?.title : undefined,
+      addInitialFetchListener,
     })
+  );
+
+  // Direct user to templates on first load if they
+  // have no stories created.
+  useEffect(
+    () =>
+      addInitialFetchListener((storyStatuses) => {
+        if (storyStatuses?.all <= 0) {
+          push(APP_ROUTES.TEMPLATES_GALLERY);
+        }
+      }),
+    [addInitialFetchListener, push]
   );
 
   const fullPath = useMemo(() => {

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -87,7 +87,7 @@ const AppContent = () => {
   // have no stories created.
   useEffect(
     () =>
-      addInitialFetchListener((storyStatuses) => {
+      addInitialFetchListener?.((storyStatuses) => {
         if (storyStatuses?.all <= 0) {
           push(APP_ROUTES.TEMPLATES_GALLERY);
         }

--- a/assets/src/dashboard/app/index.js
+++ b/assets/src/dashboard/app/index.js
@@ -74,11 +74,9 @@ const AppContent = () => {
         storyApi: { addInitialFetchListener },
       },
       state: {
-        stories: { stories },
         templates: { templates },
       },
     }) => ({
-      stories,
       currentTemplate:
         templateId !== undefined ? templates[templateId]?.title : undefined,
       addInitialFetchListener,


### PR DESCRIPTION
## Context
Enhancement requested by @samitron7 for templates to show up when user has no stories on initial load

## Summary
If you have no stories, when the plugin first loads you should see the templates page instead of the empty stories page.

## Relevant Technical Choices
Just added some functionality to listen to first load of story statuses to the api provider, then hooked into that in the app to redirect if no stories returned. Since the Application component & API Provider are around for the entirety of the user's experience in the dashboard, this approach works for firing something once on initial visit.

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Templates page is now the initial page you start on from a fresh page load if you have no stories created.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Either delete all of your stories or run `npm run env:reset` to delete all of your stories. Refresh the plugin from the base page or click into it from the wp-admin menu. The first page you should land on now is the explore `templates page` instead of the `my stories` page.

If you create a story (or have 1 or more stories created) the application behavior should be unaffected and allow you to arrive on the `my stories` page on initial load
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
Follow testing instructions above. (Not really sure how to test this on the staging environment because it involves deleting all stories.)
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testiing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #4997 
