### PR TITLE
Workspace: Add `useLiveRegion` hook to application where needed

### DIFF
--- a/assets/src/design-system/components/dropDown/useDropDown.js
+++ b/assets/src/design-system/components/dropDown/useDropDown.js
@@ -67,7 +67,6 @@ export default function useDropDown({ options = [], selectedValue }) {
 
   /* Announce changes to the length of the list */
   useEffect(() => {
-    //announce %d results found, use up and down arrow keys to navigate / ... / No results found
     if (isOpen.value) {
       const message = options.length
         ? sprintf(

--- a/assets/src/design-system/components/dropDown/useDropDown.js
+++ b/assets/src/design-system/components/dropDown/useDropDown.js
@@ -65,7 +65,7 @@ export default function useDropDown({ options = [], selectedValue }) {
       });
   }, [selectedValue, normalizedOptions]);
 
-  /* Announce changes to the length of the list */
+  /* Announce length on open and changes to the length of the list */
   useEffect(() => {
     if (isOpen.value) {
       const message = options.length

--- a/assets/src/design-system/components/dropDown/useDropDown.js
+++ b/assets/src/design-system/components/dropDown/useDropDown.js
@@ -16,16 +16,19 @@
 /**
  * External dependencies
  */
-import { useMemo, useState } from 'react';
+import { sprintf, _n, __ } from '@web-stories-wp/i18n';
+import { useEffect, useMemo, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 
 /**
  * Internal dependencies
  */
 import { getOptions } from '../menu/utils';
+import { useLiveRegion } from '../../utils';
 
 export default function useDropDown({ options = [], selectedValue }) {
   const [_isOpen, _setIsOpen] = useState(false);
+  const speak = useLiveRegion('assertive');
 
   const [setIsOpen] = useDebouncedCallback(_setIsOpen, 300, {
     leading: true,
@@ -61,6 +64,27 @@ export default function useDropDown({ options = [], selectedValue }) {
         );
       });
   }, [selectedValue, normalizedOptions]);
+
+  /* Announce changes to the length of the list */
+  useEffect(() => {
+    //announce %d results found, use up and down arrow keys to navigate / ... / No results found
+    if (isOpen.value) {
+      const message = options.length
+        ? sprintf(
+            /* translators: %d number of options in dropdown */
+            _n(
+              '%d result found, use left and right or up and down arrow keys to navigate.',
+              '%d results found, use left and right or up and down arrow keys to navigate.',
+              options.length,
+              'web-stories'
+            ),
+            options.length
+          )
+        : __('No results found.', 'web-stories');
+
+      speak(message);
+    }
+  }, [isOpen.value, options.length, speak]);
 
   return { activeOption, normalizedOptions, isOpen };
 }

--- a/assets/src/design-system/components/search/useSearch.js
+++ b/assets/src/design-system/components/search/useSearch.js
@@ -30,7 +30,7 @@ export default function useSearch({
   selectedValue,
   options,
 }) {
-  const speak = useLiveRegion();
+  const speak = useLiveRegion('assertive');
 
   /**
    *Control when associated menu of search should be visible.

--- a/assets/src/design-system/components/search/useSearch.js
+++ b/assets/src/design-system/components/search/useSearch.js
@@ -16,18 +16,22 @@
 /**
  * External dependencies
  */
+import { sprintf, _n, __ } from '@web-stories-wp/i18n';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 /**
  * Internal dependencies
  */
 import { getOptions } from '../menu/utils';
+import { useLiveRegion } from '../../utils';
 
 export default function useSearch({
   handleSearchValueChange,
   selectedValue,
   options,
 }) {
+  const speak = useLiveRegion();
+
   /**
    *Control when associated menu of search should be visible.
    */
@@ -124,6 +128,26 @@ export default function useSearch({
     handleSearchValueChange,
     inputState,
   ]);
+
+  /* Announce changes to the length of the list */
+  useEffect(() => {
+    if (isOpen.value) {
+      const message = options.length
+        ? sprintf(
+            /* translators: %d number of options in dropdown */
+            _n(
+              '%d result found.',
+              '%d results found.',
+              options.length,
+              'web-stories'
+            ),
+            options.length
+          )
+        : __('No results found.', 'web-stories');
+
+      speak(message);
+    }
+  }, [isOpen.value, options.length, speak]);
 
   return {
     activeOption,

--- a/assets/src/design-system/components/search/useSearch.js
+++ b/assets/src/design-system/components/search/useSearch.js
@@ -131,7 +131,7 @@ export default function useSearch({
 
   /* Announce changes to the length of the list */
   useEffect(() => {
-    if (isOpen.value) {
+    if (isOpen.value && inputState.value?.length) {
       const message = options.length
         ? sprintf(
             /* translators: %d number of options in dropdown */
@@ -147,7 +147,7 @@ export default function useSearch({
 
       speak(message);
     }
-  }, [isOpen.value, options.length, speak]);
+  }, [inputState.value, isOpen.value, options.length, speak]);
 
   return {
     activeOption,

--- a/assets/src/design-system/components/snackbar/snackbarMessage.js
+++ b/assets/src/design-system/components/snackbar/snackbarMessage.js
@@ -106,6 +106,7 @@ const CloseButton = styled(Button)`
 `;
 
 const SnackbarMessage = ({
+  'aria-label': ariaLabel,
   actionLabel,
   onAction = noop,
   onDismiss = noop,
@@ -156,6 +157,7 @@ const SnackbarMessage = ({
       {...props}
     >
       <Message
+        aria-label={ariaLabel}
         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
         hasAction={hasAction}
       >

--- a/assets/src/design-system/utils/useLiveRegion.js
+++ b/assets/src/design-system/utils/useLiveRegion.js
@@ -86,17 +86,26 @@ function useLiveRegion(politeness = 'polite') {
 
   useEffect(ensureContainerExists, [ensureContainerExists]);
 
-  const speak = (message) => {
-    ensureContainerExists();
+  /**
+   * Add message to aria live region so it can be announced by
+   * a screen reader.
+   */
+  const speak = useCallback(
+    (message) => {
+      ensureContainerExists();
 
-    // Clear any existing messages.
-    const regions = document.querySelectorAll('.web-stories-aria-live-region');
-    for (const region of regions) {
-      region.textContent = '';
-    }
+      // Clear any existing messages.
+      const regions = document.querySelectorAll(
+        '.web-stories-aria-live-region'
+      );
+      for (const region of regions) {
+        region.textContent = '';
+      }
 
-    elementRef.current.textContent = message;
-  };
+      elementRef.current.textContent = message;
+    },
+    [ensureContainerExists]
+  );
 
   return speak;
 }


### PR DESCRIPTION
## Context

ARIA live regions are being used to announce updates to screen readers

## Summary

Adds ARIA live regions in the following places:
- `Search` component
- `Dropdown` component

If there are any more needed I'm happy to add them there too

## Relevant Technical Choices

1. The ticket specifies that the `Snackbar` should be updated to use ARIA live regions, however it already announces itself because it has an aria-role of `status`. Happy to change it to use a live region instead, but it seemed unnecessary since the snackbar message already announces itself to the user
2. The ticket wanted a live region added to the 'style' panel to announce contrast problems. However, there's no contrast check on that panel yet. Added a different ticket for this: https://github.com/google/web-stories-wp/issues/7230

Looked through the design system to see if any other components needed this, but it seemed to me like none did. If y'all know of any content that changes suddenly that should be announced to the user, let me know!

## To-do

none

## User-facing changes

|Search|Dropdown
|--|--|
|![search-aria](https://user-images.githubusercontent.com/22185279/114941514-81373680-9e00-11eb-8f37-61981309f6a1.gif)|![dropdown-aria](https://user-images.githubusercontent.com/22185279/114941541-87c5ae00-9e00-11eb-9cd1-dc4a4723954c.gif)|

## Testing Instructions

Need to test live regions for the search and dropdown. Turn on voiceover. If on mac that can be done with `Cmd + Shift + F5`

**Search**
1. Go to dashboard
2. Click on search, should see nothing about results until you type
3. As you type and list gets shorter, you'll see announcements like `x results found`
4. If you type something that doesn't find any stories, you'll see `No results found`

**Dashboard**
1. Go to dashboard settings
2. Click on dropdown at the bottom of the page
3. You can't interact with any dropdowns by typing in the app at the moment, so this is as much as we need to test.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

Turn on voiceover. If on mac that can be done with `Cmd + Shift + F5`

**Search**
1. Go to dashboard
2. Click on search, should see nothing about results until you type
3. As you type and list gets shorter, you'll see announcements like `x results found`
4. If you type something that doesn't find any stories, you'll see `No results found`

**Dashboard**
1. Go to dashboard settings
2. Click on dropdown at the bottom of the page
3. You can't interact with any dropdowns by typing in the app at the moment, so this is as much as we need to test.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6059 
