### PR TITLE
Pre-publish Checklist: remove 'Turn off Page Attachment or remove conflicting links' checks

### DIFF
--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -181,22 +181,6 @@ export const MESSAGES = {
         </ul>
       ),
     },
-    LINK_ATTACHMENT_CONFLICT: {
-      MAIN_TEXT: __(
-        'Turn off Page Attachment or remove conflicting links',
-        'web-stories'
-      ),
-      HELPER_TEXT: (
-        <ul>
-          <li>
-            {__(
-              'Remove the Page Attachment or any links at the bottom of the page, which conflict with the Page Attachment section',
-              'web-stories'
-            )}
-          </li>
-        </ul>
-      ),
-    },
     MISSING_VIDEO_POSTER: {
       MAIN_TEXT: __('Add a poster image for every video', 'web-stories'),
       HELPER_TEXT: (

--- a/assets/src/edit-story/app/prepublish/error/index.js
+++ b/assets/src/edit-story/app/prepublish/error/index.js
@@ -26,5 +26,5 @@ export default {
     metadataErrors.storyPosterAspectRatio,
     metadataErrors.publisherLogoSize,
   ],
-  page: [metadataErrors.linkInPageAttachmentRegion],
+  page: [],
 };

--- a/assets/src/edit-story/app/prepublish/error/index.js
+++ b/assets/src/edit-story/app/prepublish/error/index.js
@@ -26,5 +26,4 @@ export default {
     metadataErrors.storyPosterAspectRatio,
     metadataErrors.publisherLogoSize,
   ],
-  page: [],
 };

--- a/assets/src/edit-story/app/prepublish/error/metadata.js
+++ b/assets/src/edit-story/app/prepublish/error/metadata.js
@@ -17,7 +17,6 @@
 /**
  * Internal dependencies
  */
-import isElementBelowLimit from '../../../utils/isElementBelowLimit';
 import {
   PRE_PUBLISH_MESSAGE_TYPES,
   MESSAGES,
@@ -167,35 +166,6 @@ export function publisherLogoSize(story) {
       message: MESSAGES.CRITICAL_METADATA.LOGO_TOO_SMALL.MAIN_TEXT,
       help: MESSAGES.CRITICAL_METADATA.LOGO_TOO_SMALL.HELPER_TEXT,
       highlight: states.PUBLISHER_LOGO,
-    };
-  }
-  return undefined;
-}
-
-/**
- * Check for link and page attachment conflicts.
- * If there is an element with a link in the page attachment region, return an error message.
- * Otherwise, return undefined.
- *
- * @param {Page} page The story being checked for critical metadata
- * @return {Guidance|undefined} Guidance object for consumption
- */
-export function linkInPageAttachmentRegion(page) {
-  const { elements } = page;
-  const hasPageAttachment = Boolean(page.pageAttachment?.url?.length);
-  const linksInPageAttachmentArea =
-    hasPageAttachment &&
-    elements
-      .filter(({ link }) => Boolean(link?.url?.length))
-      .filter(isElementBelowLimit);
-
-  if (linksInPageAttachmentArea?.length) {
-    return {
-      type: PRE_PUBLISH_MESSAGE_TYPES.ERROR,
-      pageId: page.id,
-      elements: linksInPageAttachmentArea,
-      message: MESSAGES.CRITICAL_METADATA.LINK_ATTACHMENT_CONFLICT.MAIN_TEXT,
-      help: MESSAGES.CRITICAL_METADATA.LINK_ATTACHMENT_CONFLICT.HELPER_TEXT,
     };
   }
   return undefined;

--- a/assets/src/edit-story/app/prepublish/error/test/metadata.js
+++ b/assets/src/edit-story/app/prepublish/error/test/metadata.js
@@ -60,48 +60,6 @@ describe('Pre-publish checklist - missing critical metadata (errors)', () => {
     expect(testEmptyString.storyId).toStrictEqual(testEmptyStringStory.id);
   });
 
-  it('should return an error-type guidance message if there is a link in the page attachment region', () => {
-    const elementInRegion = {
-      x: 35,
-      y: 400,
-      width: 188,
-      height: 141,
-      rotationAngle: 0,
-      link: undefined,
-    };
-    const testPageAttachment = {
-      url: 'http://bomb.com',
-    };
-    const testNoLink = metadataGuidelines.linkInPageAttachmentRegion({
-      pageAttachment: testPageAttachment,
-      elements: [elementInRegion],
-    });
-    const testNoAttachment = metadataGuidelines.linkInPageAttachmentRegion({
-      pageAttachment: undefined,
-      elements: [{ ...elementInRegion, link: { url: 'bomb.com' } }],
-    });
-    const testLinkInPageAttachmentStory = {
-      id: 890,
-      pageAttachment: testPageAttachment,
-      elements: [{ ...elementInRegion, link: { url: 'bomb.com ' } }],
-    };
-    const testLinkInPageAttachment = metadataGuidelines.linkInPageAttachmentRegion(
-      testLinkInPageAttachmentStory
-    );
-    expect(testNoLink).toBeUndefined();
-    expect(testNoAttachment).toBeUndefined();
-    expect(testLinkInPageAttachment).not.toBeUndefined();
-    expect(testLinkInPageAttachment.message).toMatchInlineSnapshot(
-      `"Turn off Page Attachment or remove conflicting links"`
-    );
-    expect(testLinkInPageAttachment.pageId).toStrictEqual(
-      testLinkInPageAttachmentStory.id
-    );
-    expect(testLinkInPageAttachment.elements).toStrictEqual(
-      testLinkInPageAttachmentStory.elements
-    );
-  });
-
   // todo: The story's poster and publisher url are not yet returned by the api. See #5105.
   it("should return an error-type guidance message if the story's publisher logo is too small", () => {
     const testHeightStory = {


### PR DESCRIPTION
## Context

Per design discussion: `Currently, you're not allow to add link to the page attachment area. If you attempt to drag a link to the page attachment area, we message you and tell you that the link will not be clickable by your users. I think this might be enough to cover this use case. WDYT about eliminating this rule or at least making it non critical.` so we are removing it.

## Summary

Link attachment conflict is no longer displayed if 

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

1. Open a new story
2. Add anything to the editor and give it a link in the `design` panel
3. Move it to the bottom of the page outside the safe zone
4. Open the prepublish checklist
5. There should be no recommendation to "Turn off Page Attachment or remove conflicting links"

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open a new story
2. Add anything to the editor and give it a link in the `design` panel
3. Move it to the bottom of the page outside the safe zone
4. Open the prepublish checklist
5. There should be no recommendation to "Turn off Page Attachment or remove conflicting links"

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7149
