### PR TITLE
Prepublish Checklist: Add ability to disable panel toggle, prep for conditionally rendering checklist items

### DIFF
--- a/assets/src/edit-story/components/header/buttons/buttonWithChecklistWarning.js
+++ b/assets/src/edit-story/components/header/buttons/buttonWithChecklistWarning.js
@@ -31,15 +31,18 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { usePrepublishChecklist } from '../../inspector/prepublish';
-import { PRE_PUBLISH_MESSAGE_TYPES } from '../../../app/prepublish';
 import {
-  Icons,
   Button as DefaultButton,
   BUTTON_SIZES,
   BUTTON_TYPES,
   BUTTON_VARIANTS,
 } from '../../../../design-system';
+import {
+  ChecklistIcon,
+  usePrepublishChecklist,
+  PPC_CHECKPOINT_STATE,
+} from '../../inspector/prepublish';
+
 import Tooltip from '../../tooltip';
 
 const Button = styled(DefaultButton)`
@@ -51,10 +54,8 @@ const Button = styled(DefaultButton)`
 `;
 
 function ButtonWithChecklistWarning({ text, ...buttonProps }) {
-  const { checklist, refreshChecklist } = usePrepublishChecklist();
-  const hasErrors = checklist.some(
-    ({ type }) => PRE_PUBLISH_MESSAGE_TYPES.ERROR === type
-  );
+  const { refreshChecklist, currentCheckpoint } = usePrepublishChecklist();
+
   const button = (
     <Button
       variant={BUTTON_VARIANTS.RECTANGLE}
@@ -64,19 +65,26 @@ function ButtonWithChecklistWarning({ text, ...buttonProps }) {
       {...buttonProps}
     >
       {text}
-      {hasErrors && <Icons.ExclamationOutline height={24} width={24} />}
+      <ChecklistIcon checkpoint={currentCheckpoint} height={24} width={24} />
     </Button>
   );
 
-  return hasErrors ? (
-    <Tooltip
-      title={__('There are items in the checklist to resolve', 'web-stories')}
-      hasTail
-    >
+  const TOOLTIP_TEXT = {
+    [PPC_CHECKPOINT_STATE.ALL]: __(
+      'Make updates before publishing to improve discoverability and performance on search engines',
+      'web-stories'
+    ),
+    [PPC_CHECKPOINT_STATE.ONLY_RECOMMENDED]: __(
+      'Review checklist to improve performance before publishing',
+      'web-stories'
+    ),
+    [PPC_CHECKPOINT_STATE.UNAVAILABLE]: null,
+  };
+
+  return (
+    <Tooltip title={TOOLTIP_TEXT[currentCheckpoint]} hasTail>
       {button}
     </Tooltip>
-  ) : (
-    button
   );
 }
 

--- a/assets/src/edit-story/components/header/buttons/buttonWithChecklistWarning.js
+++ b/assets/src/edit-story/components/header/buttons/buttonWithChecklistWarning.js
@@ -46,10 +46,11 @@ import {
 import Tooltip from '../../tooltip';
 
 const Button = styled(DefaultButton)`
-  padding: 4px 8px;
+  padding: 4px 6px;
+  height: 32px;
   svg {
-    margin-right: -2px;
-    margin-left: 2px;
+    width: 24px;
+    height: auto;
   }
 `;
 
@@ -61,11 +62,12 @@ function ButtonWithChecklistWarning({ text, ...buttonProps }) {
       variant={BUTTON_VARIANTS.RECTANGLE}
       type={BUTTON_TYPES.PRIMARY}
       size={BUTTON_SIZES.SMALL}
+      isBold
       onPointerEnter={refreshChecklist}
       {...buttonProps}
     >
       {text}
-      <ChecklistIcon checkpoint={currentCheckpoint} height={24} width={24} />
+      <ChecklistIcon checkpoint={currentCheckpoint} />
     </Button>
   );
 

--- a/assets/src/edit-story/components/header/buttons/buttonWithChecklistWarning.js
+++ b/assets/src/edit-story/components/header/buttons/buttonWithChecklistWarning.js
@@ -62,7 +62,6 @@ function ButtonWithChecklistWarning({ text, ...buttonProps }) {
       variant={BUTTON_VARIANTS.RECTANGLE}
       type={BUTTON_TYPES.PRIMARY}
       size={BUTTON_SIZES.SMALL}
-      isBold
       onPointerEnter={refreshChecklist}
       {...buttonProps}
     >

--- a/assets/src/edit-story/components/inspector/inspectorProvider.js
+++ b/assets/src/edit-story/components/inspector/inspectorProvider.js
@@ -18,24 +18,26 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useCallback, useState, useRef, useEffect, useMemo } from 'react';
+import { useCallback, useState, useRef, useEffect } from 'react';
 import { useDebouncedCallback } from 'use-debounce/lib';
 import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
  */
-import { Icons, useResizeEffect } from '../../../design-system';
+import { useResizeEffect } from '../../../design-system';
 import { useAPI } from '../../app/api';
 import { useStory } from '../../app/story';
 
 import { useHighlights } from '../../app/highlights';
 import { DOCUMENT, DESIGN, PREPUBLISH } from './constants';
-import PrepublishInspector, { usePrepublishChecklist } from './prepublish';
+import PrepublishInspector, {
+  usePrepublishChecklist,
+  ChecklistIcon,
+} from './prepublish';
 import Context from './context';
 import DesignInspector from './design';
 import DocumentInspector from './document';
-import { PPC_CHECKPOINT_STATE } from './prepublish/prepublishCheckpointState';
 
 function InspectorProvider({ children }) {
   const {
@@ -59,16 +61,6 @@ function InspectorProvider({ children }) {
       setTab(highlightedTab);
     }
   }, [highlightedTab]);
-
-  const prepublishAlert = useMemo(() => {
-    switch (currentCheckpoint) {
-      case PPC_CHECKPOINT_STATE.ALL:
-        return <Icons.ExclamationOutline className="alert" />;
-
-      default:
-        return undefined;
-    }
-  }, [currentCheckpoint]);
 
   const inspectorRef = useRef(null);
 
@@ -157,7 +149,13 @@ function InspectorProvider({ children }) {
         },
 
         {
-          icon: prepublishAlert,
+          icon: (
+            <ChecklistIcon
+              checkpoint={currentCheckpoint}
+              height={24}
+              width={24}
+            />
+          ),
           id: PREPUBLISH,
           title: __('Checklist', 'web-stories'),
           Pane: PrepublishInspector,

--- a/assets/src/edit-story/components/inspector/inspectorProvider.js
+++ b/assets/src/edit-story/components/inspector/inspectorProvider.js
@@ -102,11 +102,10 @@ function InspectorProvider({ children }) {
     }
   }, [currentPage]);
 
-  const ChecklistTabIcon = useCallback(() => {
-    return (
-      <ChecklistIcon checkpoint={currentCheckpoint} height={28} width={28} />
-    );
-  }, [currentCheckpoint]);
+  const ChecklistTabIcon = useCallback(
+    () => <ChecklistIcon checkpoint={currentCheckpoint} className="alert" />,
+    [currentCheckpoint]
+  );
 
   const loadUsers = useCallback(() => {
     if (!isUsersLoading && users.length === 0) {

--- a/assets/src/edit-story/components/inspector/inspectorProvider.js
+++ b/assets/src/edit-story/components/inspector/inspectorProvider.js
@@ -102,6 +102,12 @@ function InspectorProvider({ children }) {
     }
   }, [currentPage]);
 
+  const ChecklistTabIcon = useCallback(() => {
+    return (
+      <ChecklistIcon checkpoint={currentCheckpoint} height={28} width={28} />
+    );
+  }, [currentCheckpoint]);
+
   const loadUsers = useCallback(() => {
     if (!isUsersLoading && users.length === 0) {
       setIsUsersLoading(true);
@@ -149,13 +155,7 @@ function InspectorProvider({ children }) {
         },
 
         {
-          icon: (
-            <ChecklistIcon
-              checkpoint={currentCheckpoint}
-              height={24}
-              width={24}
-            />
-          ),
+          icon: ChecklistTabIcon,
           id: PREPUBLISH,
           title: __('Checklist', 'web-stories'),
           Pane: PrepublishInspector,

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -19,6 +19,7 @@
 import { useCallback, useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { __, sprintf } from '@web-stories-wp/i18n';
+import PropTypes from 'prop-types';
 
 /**
  * Internal dependencies
@@ -28,7 +29,11 @@ import { useConfig } from '../../../app';
 import { PRE_PUBLISH_MESSAGE_TYPES, types } from '../../../app/prepublish';
 import { useHighlights } from '../../../app/highlights';
 import { SimplePanel } from '../../panels/panel';
-import { TEXT } from './constants';
+import {
+  DISABLED_HIGH_PRIORITY_CHECKPOINTS,
+  DISABLED_RECOMMENDED_CHECKPOINTS,
+  TEXT,
+} from './constants';
 import EmptyChecklist from './emptyChecklist';
 import {
   GoToIssue,
@@ -40,13 +45,23 @@ import {
   PanelTitle,
   Row,
 } from './styles';
+import { PPC_CHECKPOINT_STATE } from './prepublishCheckpointState';
 
-const ChecklistTab = (props) => {
-  const { checklist } = props;
+const ChecklistTab = ({ checklist, currentCheckpoint }) => {
   const { isRTL } = useConfig();
   const { setHighlights } = useHighlights(({ setHighlights }) => ({
     setHighlights,
   }));
+
+  const { isHighPriorityDisabled, isRecommendedDisabled } = useMemo(
+    () => ({
+      isRecommendedDisabled:
+        DISABLED_RECOMMENDED_CHECKPOINTS.indexOf(currentCheckpoint) > -1,
+      isHighPriorityDisabled:
+        DISABLED_HIGH_PRIORITY_CHECKPOINTS.indexOf(currentCheckpoint) > -1,
+    }),
+    [currentCheckpoint]
+  );
 
   const { highPriority, recommended, pages } = useMemo(
     () =>
@@ -186,13 +201,18 @@ const ChecklistTab = (props) => {
     <>
       {showHighPriorityItems && (
         <SimplePanel
-          collapsedByDefault={false}
+          collapsedByDefault={isHighPriorityDisabled}
+          isDisabledToggle={isHighPriorityDisabled}
           name="checklist"
           hasBadge
           title={
             <>
-              <PanelTitle>{TEXT.HIGH_PRIORITY_TITLE}</PanelTitle>
-              <NumberBadge number={highPriorityLength} />
+              <PanelTitle isDisabled={isHighPriorityDisabled}>
+                {TEXT.HIGH_PRIORITY_TITLE}
+              </PanelTitle>
+              {!isHighPriorityDisabled && (
+                <NumberBadge number={highPriorityLength} />
+              )}
             </>
           }
           ariaLabel={TEXT.HIGH_PRIORITY_TITLE}
@@ -203,12 +223,18 @@ const ChecklistTab = (props) => {
       )}
       {showRecommendedItems && (
         <SimplePanel
+          collapsedByDefault={isRecommendedDisabled}
+          isDisabledToggle={isRecommendedDisabled}
           name="checklist"
           hasBadge
           title={
             <>
-              <PanelTitle isRecommended>{TEXT.RECOMMENDED_TITLE}</PanelTitle>
-              <NumberBadge isRecommended number={recommendedLength} />
+              <PanelTitle isRecommended isDisabled={isRecommendedDisabled}>
+                {TEXT.RECOMMENDED_TITLE}
+              </PanelTitle>
+              {!isRecommendedDisabled && (
+                <NumberBadge isRecommended number={recommendedLength} />
+              )}
             </>
           }
           ariaLabel={TEXT.RECOMMENDED_TITLE}
@@ -223,6 +249,7 @@ const ChecklistTab = (props) => {
 
 ChecklistTab.propTypes = {
   checklist: types.GuidanceChecklist,
+  currentCheckpoint: PropTypes.oneOf(Object.values(PPC_CHECKPOINT_STATE)),
 };
 
 export default ChecklistTab;

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -223,7 +223,6 @@ const ChecklistTab = ({ checklist, currentCheckpoint }) => {
       )}
       {showRecommendedItems && (
         <SimplePanel
-          collapsedByDefault={isRecommendedDisabled}
           isDisabledToggle={isRecommendedDisabled}
           name="checklist"
           hasBadge

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -202,7 +202,7 @@ const ChecklistTab = ({ checklist, currentCheckpoint }) => {
       {showHighPriorityItems && (
         <SimplePanel
           collapsedByDefault={isHighPriorityDisabled}
-          isDisabledToggle={isHighPriorityDisabled}
+          isToggleDisabled={isHighPriorityDisabled}
           name="checklist"
           hasBadge
           title={
@@ -223,7 +223,7 @@ const ChecklistTab = ({ checklist, currentCheckpoint }) => {
       )}
       {showRecommendedItems && (
         <SimplePanel
-          isDisabledToggle={isRecommendedDisabled}
+          isToggleDisabled={isRecommendedDisabled}
           name="checklist"
           hasBadge
           title={

--- a/assets/src/edit-story/components/inspector/prepublish/constants.js
+++ b/assets/src/edit-story/components/inspector/prepublish/constants.js
@@ -18,6 +18,11 @@
  */
 import { __ } from '@web-stories-wp/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { PPC_CHECKPOINT_STATE } from './prepublishCheckpointState';
+
 export const MAX_NUMBER_FOR_BADGE = 99;
 
 export const TEXT = {
@@ -28,3 +33,12 @@ export const TEXT = {
   EMPTY_TITLE: __('Awesome work!', 'web-stories'),
   EMPTY_BODY: __('No Issues Found', 'web-stories'),
 };
+
+export const DISABLED_HIGH_PRIORITY_CHECKPOINTS = [
+  PPC_CHECKPOINT_STATE.UNAVAILABLE,
+  PPC_CHECKPOINT_STATE.ONLY_RECOMMENDED,
+];
+
+export const DISABLED_RECOMMENDED_CHECKPOINTS = [
+  PPC_CHECKPOINT_STATE.UNAVAILABLE,
+];

--- a/assets/src/edit-story/components/inspector/prepublish/prepublishChecklistProvider.js
+++ b/assets/src/edit-story/components/inspector/prepublish/prepublishChecklistProvider.js
@@ -68,7 +68,7 @@ function PrepublishChecklistProvider({ children }) {
 
   const [checkpointState, dispatch] = useReducer(
     checkpointReducer,
-    PPC_CHECKPOINT_STATE.UNAVAILABLE
+    PPC_CHECKPOINT_STATE.ALL
   );
 
   // Check for different qualifications to be met to update current PPC checkpoint

--- a/assets/src/edit-story/components/inspector/prepublish/prepublishInspector.js
+++ b/assets/src/edit-story/components/inspector/prepublish/prepublishInspector.js
@@ -20,9 +20,11 @@
 import { usePrepublishChecklist, ChecklistTab } from '.';
 
 function PrepublishInspector() {
-  const { checklist } = usePrepublishChecklist();
+  const { checklist, currentCheckpoint } = usePrepublishChecklist();
 
-  return <ChecklistTab checklist={checklist} />;
+  return (
+    <ChecklistTab checklist={checklist} currentCheckpoint={currentCheckpoint} />
+  );
 }
 
 export default PrepublishInspector;

--- a/assets/src/edit-story/components/inspector/prepublish/styles.js
+++ b/assets/src/edit-story/components/inspector/prepublish/styles.js
@@ -60,12 +60,20 @@ NumberBadge.propTypes = {
   number: PropTypes.number,
 };
 
+const getPanelTitleColor = (isRecommended, isDisabled) => {
+  if (isDisabled) {
+    return 'disable';
+  } else if (isRecommended) {
+    return 'linkNormal';
+  }
+  return 'negative';
+};
 export const PanelTitle = styled(Headline).attrs({
   size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.XX_SMALL,
   as: 'span',
 })`
-  color: ${({ isRecommended, theme }) =>
-    isRecommended ? theme.colors.fg.linkNormal : theme.colors.fg.negative};
+  color: ${({ isRecommended, theme, isDisabled }) =>
+    theme.colors.fg[getPanelTitleColor(isRecommended, isDisabled)]};
 `;
 PanelTitle.propTypes = {
   isRecommended: PropTypes.bool,

--- a/assets/src/edit-story/components/inspector/prepublish/test/prepublishChecklistProvider.js
+++ b/assets/src/edit-story/components/inspector/prepublish/test/prepublishChecklistProvider.js
@@ -93,7 +93,7 @@ function setup({ pageCount = 1 }) {
 
 describe('prepublishChecklistProvider', () => {
   // TODO this should be set to UNAVAILABLE once blank story trigger is ready
-  it(`should begin a story at ${PPC_CHECKPOINT_STATE.ALL}`, async () => {
+  it(`should begin a story at '${PPC_CHECKPOINT_STATE.ALL}'`, async () => {
     const { result } = setup({ pageCount: 1 });
 
     await act(async () => {

--- a/assets/src/edit-story/components/inspector/prepublish/test/prepublishChecklistProvider.js
+++ b/assets/src/edit-story/components/inspector/prepublish/test/prepublishChecklistProvider.js
@@ -92,15 +92,14 @@ function setup({ pageCount = 1 }) {
 }
 
 describe('prepublishChecklistProvider', () => {
-  it(`should begin a story at ${PPC_CHECKPOINT_STATE.UNAVAILABLE}`, async () => {
+  // TODO this should be set to UNAVAILABLE once blank story trigger is ready
+  it(`should begin a story at ${PPC_CHECKPOINT_STATE.ALL}`, async () => {
     const { result } = setup({ pageCount: 1 });
 
     await act(async () => {
       await result.current.refreshChecklist();
     });
 
-    expect(result.current.currentCheckpoint).toBe(
-      PPC_CHECKPOINT_STATE.UNAVAILABLE
-    );
+    expect(result.current.currentCheckpoint).toBe(PPC_CHECKPOINT_STATE.ALL);
   });
 });

--- a/assets/src/edit-story/components/inspector/prepublish/utils/getChecklistIcon.js
+++ b/assets/src/edit-story/components/inspector/prepublish/utils/getChecklistIcon.js
@@ -14,9 +14,20 @@
  * limitations under the License.
  */
 
-export { default } from './prepublishInspector';
-export { default as ChecklistTab } from './checklistTab';
-export { default as PrepublishChecklistProvider } from './prepublishChecklistProvider';
-export { default as usePrepublishChecklist } from './usePrepublishChecklist';
-export { ChecklistIcon } from './utils';
-export { PPC_CHECKPOINT_STATE } from './prepublishCheckpointState';
+/**
+ * Internal dependencies
+ */
+import { Icons } from '../../../../../design-system';
+import { PPC_CHECKPOINT_STATE } from '../prepublishCheckpointState';
+
+const ChecklistIcon = ({ checkpoint, ...rest }) => {
+  switch (checkpoint) {
+    case PPC_CHECKPOINT_STATE.ALL:
+      return <Icons.ExclamationOutline className="alert" {...rest} />;
+
+    default:
+      return undefined;
+  }
+};
+
+export default ChecklistIcon;

--- a/assets/src/edit-story/components/inspector/prepublish/utils/getChecklistIcon.js
+++ b/assets/src/edit-story/components/inspector/prepublish/utils/getChecklistIcon.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
@@ -26,8 +29,11 @@ const ChecklistIcon = ({ checkpoint, ...rest }) => {
       return <Icons.ExclamationOutline className="alert" {...rest} />;
 
     default:
-      return undefined;
+      return null;
   }
+};
+ChecklistIcon.propTypes = {
+  checkpoint: PropTypes.oneOf(Object.values(PPC_CHECKPOINT_STATE)),
 };
 
 export default ChecklistIcon;

--- a/assets/src/edit-story/components/inspector/prepublish/utils/getChecklistIcon.js
+++ b/assets/src/edit-story/components/inspector/prepublish/utils/getChecklistIcon.js
@@ -24,13 +24,10 @@ import { Icons } from '../../../../../design-system';
 import { PPC_CHECKPOINT_STATE } from '../prepublishCheckpointState';
 
 const ChecklistIcon = ({ checkpoint, ...rest }) => {
-  switch (checkpoint) {
-    case PPC_CHECKPOINT_STATE.ALL:
-      return <Icons.ExclamationOutline className="alert" {...rest} />;
-
-    default:
-      return null;
+  if (checkpoint === PPC_CHECKPOINT_STATE.ALL) {
+    return <Icons.ExclamationOutline className="alert" {...rest} />;
   }
+  return null;
 };
 ChecklistIcon.propTypes = {
   checkpoint: PropTypes.oneOf(Object.values(PPC_CHECKPOINT_STATE)),

--- a/assets/src/edit-story/components/inspector/prepublish/utils/getChecklistIcon.js
+++ b/assets/src/edit-story/components/inspector/prepublish/utils/getChecklistIcon.js
@@ -25,7 +25,7 @@ import { PPC_CHECKPOINT_STATE } from '../prepublishCheckpointState';
 
 const ChecklistIcon = ({ checkpoint, ...rest }) => {
   if (checkpoint === PPC_CHECKPOINT_STATE.ALL) {
-    return <Icons.ExclamationOutline className="alert" {...rest} />;
+    return <Icons.ExclamationOutline {...rest} />;
   }
   return null;
 };

--- a/assets/src/edit-story/components/inspector/prepublish/utils/index.js
+++ b/assets/src/edit-story/components/inspector/prepublish/utils/index.js
@@ -14,9 +14,4 @@
  * limitations under the License.
  */
 
-export { default } from './prepublishInspector';
-export { default as ChecklistTab } from './checklistTab';
-export { default as PrepublishChecklistProvider } from './prepublishChecklistProvider';
-export { default as usePrepublishChecklist } from './usePrepublishChecklist';
-export { ChecklistIcon } from './utils';
-export { PPC_CHECKPOINT_STATE } from './prepublishCheckpointState';
+export { default as ChecklistIcon } from './getChecklistIcon';

--- a/assets/src/edit-story/components/inspector/stories/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/stories/checklistTab.js
@@ -17,10 +17,12 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import { select } from '@storybook/addon-knobs';
 /**
  * Internal dependencies
  */
 import ChecklistTab from '../prepublish/checklistTab';
+import { PPC_CHECKPOINT_STATE } from '../prepublish/prepublishCheckpointState';
 
 const Container = styled.div`
   background: ${({ theme }) => theme.colors.bg.primary};
@@ -77,7 +79,16 @@ export const _default = () => {
         'The entire story should have a minimum of 100 characters of text in total.',
     },
   ];
-  return <ChecklistTab checklist={defaultChecklist} />;
+  return (
+    <ChecklistTab
+      checklist={defaultChecklist}
+      currentCheckpoint={select(
+        'currentCheckpoint',
+        Object.values(PPC_CHECKPOINT_STATE),
+        PPC_CHECKPOINT_STATE.UNAVAILABLE
+      )}
+    />
+  );
 };
 
 export const withPages = () => {
@@ -147,7 +158,16 @@ export const withPages = () => {
       pageId: 456,
     },
   ];
-  return <ChecklistTab checklist={checklist} />;
+  return (
+    <ChecklistTab
+      checklist={checklist}
+      currentCheckpoint={select(
+        'currentCheckpoint',
+        Object.values(PPC_CHECKPOINT_STATE),
+        PPC_CHECKPOINT_STATE.UNAVAILABLE
+      )}
+    />
+  );
 };
 
 export const recommendedOnly = () => {
@@ -173,9 +193,27 @@ export const recommendedOnly = () => {
       page: 2,
     },
   ];
-  return <ChecklistTab checklist={checklist} />;
+  return (
+    <ChecklistTab
+      checklist={checklist}
+      currentCheckpoint={select(
+        'currentCheckpoint',
+        Object.values(PPC_CHECKPOINT_STATE),
+        PPC_CHECKPOINT_STATE.UNAVAILABLE
+      )}
+    />
+  );
 };
 
 export const emptyChecklist = () => {
-  return <ChecklistTab checklist={[]} />;
+  return (
+    <ChecklistTab
+      checklist={[]}
+      currentCheckpoint={select(
+        'currentCheckpoint',
+        Object.values(PPC_CHECKPOINT_STATE),
+        PPC_CHECKPOINT_STATE.UNAVAILABLE
+      )}
+    />
+  );
 };

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -50,6 +50,7 @@ function Panel({
   ariaLabel = null,
   ariaHidden = false,
   isPersistable = true,
+  isDisabledToggle,
   ...rest
 }) {
   const { selectedElementIds } = useStory(
@@ -68,6 +69,10 @@ function Panel({
     [name, isPersistable]
   );
   const [isCollapsed, setIsCollapsed] = useState(() => {
+    // If toggle is disabled, always default to collapsed
+    if (isDisabledToggle) {
+      return true;
+    }
     // If not persisted, always default to expanded.
     if (!isPersistable) {
       return false;
@@ -224,6 +229,7 @@ Panel.propTypes = {
   name: PropTypes.string.isRequired,
   children: PropTypes.node,
   initialHeight: PropTypes.number,
+  isDisabledToggle: PropTypes.bool,
   resizeable: PropTypes.bool,
   canCollapse: PropTypes.bool,
   collapsedByDefault: PropTypes.bool,

--- a/assets/src/edit-story/components/panels/panel/panel.js
+++ b/assets/src/edit-story/components/panels/panel/panel.js
@@ -50,7 +50,7 @@ function Panel({
   ariaLabel = null,
   ariaHidden = false,
   isPersistable = true,
-  isDisabledToggle,
+  isToggleDisabled,
   ...rest
 }) {
   const { selectedElementIds } = useStory(
@@ -70,7 +70,7 @@ function Panel({
   );
   const [isCollapsed, setIsCollapsed] = useState(() => {
     // If toggle is disabled, always default to collapsed
-    if (isDisabledToggle) {
+    if (isToggleDisabled) {
       return true;
     }
     // If not persisted, always default to expanded.
@@ -229,7 +229,7 @@ Panel.propTypes = {
   name: PropTypes.string.isRequired,
   children: PropTypes.node,
   initialHeight: PropTypes.number,
-  isDisabledToggle: PropTypes.bool,
+  isToggleDisabled: PropTypes.bool,
   resizeable: PropTypes.bool,
   canCollapse: PropTypes.bool,
   collapsedByDefault: PropTypes.bool,

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -102,7 +102,7 @@ const Collapse = styled.button`
   display: flex; /* removes implicit line-height padding from child element */
   padding: 0 4px 0 0;
   align-items: center;
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
   margin-left: -12px;
   transition: ${BUTTON_TRANSITION_TIMING};
 
@@ -150,6 +150,7 @@ function Title({
   secondaryAction,
   isResizable,
   canCollapse,
+  isDisabledToggle,
   ...props
 }) {
   const {
@@ -223,7 +224,8 @@ function Title({
       )}
       <Toggle
         toggle={toggle}
-        disabled={!canCollapse}
+        disabled={!canCollapse || isDisabledToggle}
+        isDisabledToggle={isDisabledToggle}
         tabIndex={ariaHidden ? -1 : 0}
         aria-label={ariaLabel}
         aria-expanded={!isCollapsed}
@@ -231,7 +233,9 @@ function Title({
         isCollapsed={isCollapsed}
         hasBadge={hasBadge}
       >
-        <IconWrapper>{canCollapse && toggleIcon}</IconWrapper>
+        <IconWrapper>
+          {!isDisabledToggle && canCollapse && toggleIcon}
+        </IconWrapper>
         <Heading
           isCollapsed={isCollapsed}
           id={panelTitleId}
@@ -249,6 +253,7 @@ Title.propTypes = {
   ariaLabel: PropTypes.string,
   children: PropTypes.node,
   hasBadge: PropTypes.bool,
+  isDisabledToggle: PropTypes.bool,
   isPrimary: PropTypes.bool,
   isSecondary: PropTypes.bool,
   isResizable: PropTypes.bool,

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -203,6 +203,13 @@ function Title({
   ) : (
     <Icons.ChevronDownSmall />
   );
+
+  // There are 2 props that could affect the panel being able to toggle.
+  // canCollapse enforces a toggle panel that is always expanded.
+  // isToggleDisabled leaves the panel in whatever state it currently is.
+  const preserveToggleCollapseState = !canCollapse || isToggleDisabled;
+  const showToggleIcon = canCollapse && !isToggleDisabled;
+
   return (
     <Header
       isPrimary={isPrimary}
@@ -224,7 +231,7 @@ function Title({
       )}
       <Toggle
         toggle={toggle}
-        disabled={!canCollapse || isToggleDisabled}
+        disabled={preserveToggleCollapseState}
         isToggleDisabled={isToggleDisabled}
         tabIndex={ariaHidden ? -1 : 0}
         aria-label={ariaLabel}
@@ -233,9 +240,7 @@ function Title({
         isCollapsed={isCollapsed}
         hasBadge={hasBadge}
       >
-        <IconWrapper>
-          {!isToggleDisabled && canCollapse && toggleIcon}
-        </IconWrapper>
+        <IconWrapper>{showToggleIcon && toggleIcon}</IconWrapper>
         <Heading
           isCollapsed={isCollapsed}
           id={panelTitleId}

--- a/assets/src/edit-story/components/panels/panel/shared/title.js
+++ b/assets/src/edit-story/components/panels/panel/shared/title.js
@@ -150,7 +150,7 @@ function Title({
   secondaryAction,
   isResizable,
   canCollapse,
-  isDisabledToggle,
+  isToggleDisabled,
   ...props
 }) {
   const {
@@ -224,8 +224,8 @@ function Title({
       )}
       <Toggle
         toggle={toggle}
-        disabled={!canCollapse || isDisabledToggle}
-        isDisabledToggle={isDisabledToggle}
+        disabled={!canCollapse || isToggleDisabled}
+        isToggleDisabled={isToggleDisabled}
         tabIndex={ariaHidden ? -1 : 0}
         aria-label={ariaLabel}
         aria-expanded={!isCollapsed}
@@ -234,7 +234,7 @@ function Title({
         hasBadge={hasBadge}
       >
         <IconWrapper>
-          {!isDisabledToggle && canCollapse && toggleIcon}
+          {!isToggleDisabled && canCollapse && toggleIcon}
         </IconWrapper>
         <Heading
           isCollapsed={isCollapsed}
@@ -253,7 +253,7 @@ Title.propTypes = {
   ariaLabel: PropTypes.string,
   children: PropTypes.node,
   hasBadge: PropTypes.bool,
-  isDisabledToggle: PropTypes.bool,
+  isToggleDisabled: PropTypes.bool,
   isPrimary: PropTypes.bool,
   isSecondary: PropTypes.bool,
   isResizable: PropTypes.bool,

--- a/assets/src/edit-story/components/panels/panel/simplePanel.js
+++ b/assets/src/edit-story/components/panels/panel/simplePanel.js
@@ -26,12 +26,21 @@ import Panel from './panel';
 import PanelTitle from './shared/title';
 import PanelContent from './shared/content';
 
-function SimplePanel({ children, name, ariaLabel, hasBadge, title, ...rest }) {
+function SimplePanel({
+  children,
+  name,
+  ariaLabel,
+  hasBadge,
+  title,
+  isDisabledToggle,
+  ...rest
+}) {
   return (
-    <Panel name={name} {...rest}>
+    <Panel name={name} isDisabledToggle={isDisabledToggle} {...rest}>
       <PanelTitle
         hasBadge={hasBadge}
         ariaLabel={ariaLabel ?? (typeof title === 'string' ? title : '')}
+        isDisabledToggle={isDisabledToggle}
       >
         {title}
       </PanelTitle>
@@ -44,6 +53,7 @@ SimplePanel.propTypes = {
   children: PropTypes.node,
   name: PropTypes.string.isRequired,
   hasBadge: PropTypes.bool,
+  isDisabledToggle: PropTypes.bool,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   ariaLabel: PropTypes.string,
 };

--- a/assets/src/edit-story/components/panels/panel/simplePanel.js
+++ b/assets/src/edit-story/components/panels/panel/simplePanel.js
@@ -32,15 +32,15 @@ function SimplePanel({
   ariaLabel,
   hasBadge,
   title,
-  isDisabledToggle,
+  isToggleDisabled,
   ...rest
 }) {
   return (
-    <Panel name={name} isDisabledToggle={isDisabledToggle} {...rest}>
+    <Panel name={name} isToggleDisabled={isToggleDisabled} {...rest}>
       <PanelTitle
         hasBadge={hasBadge}
         ariaLabel={ariaLabel ?? (typeof title === 'string' ? title : '')}
-        isDisabledToggle={isDisabledToggle}
+        isToggleDisabled={isToggleDisabled}
       >
         {title}
       </PanelTitle>
@@ -53,7 +53,7 @@ SimplePanel.propTypes = {
   children: PropTypes.node,
   name: PropTypes.string.isRequired,
   hasBadge: PropTypes.bool,
-  isDisabledToggle: PropTypes.bool,
+  isToggleDisabled: PropTypes.bool,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   ariaLabel: PropTypes.string,
 };

--- a/assets/src/edit-story/components/tabview/index.js
+++ b/assets/src/edit-story/components/tabview/index.js
@@ -111,13 +111,7 @@ const Tab = styled.li.attrs(({ isActive }) => ({
   svg.alert {
     width: ${ALERT_ICON_SIZE}px;
     margin-left: 4px;
-
-    &.warning {
-      color: ${({ theme }) => theme.colors.fg.linkNormal};
-    }
-    &.error {
-      color: ${({ theme }) => theme.colors.fg.negative};
-    }
+    color: ${({ theme }) => theme.colors.fg.primary};
   }
 
   span,


### PR DESCRIPTION
## Context

Updates UI for PPC design that involves triggers

## Summary

New designs for Prepublish Checklist have new "trigger" or "checkpoints" that reveal checklist gradually. While #7259 is getting reviewed this just preps for the UI changes. 

Thought these would be helpful changes to do ahead of the logic behind the new triggers in the checklist to avoid conflicts as we work on those and need the same or similar base.

## Relevant Technical Choices

- `SimplePanel` now needs a disabled state that is _collapsed_ instead of permanently open. I added in a new prop called `isDisabledToggle` that tells the panel to stay collapsed and disables the toggle. Defaults to false, doesn't affect any code outside of prepublish checklist and for now it's always false anyways.  
- New shared source for deciding what icon to show for checklist acknowledgement. Kinda seems like overkill right now since it's only ever the one icon if anything but the shared source makes sense. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

For now, the only 2 things that changed are the tooltip text on the publish button: `Make updates before publishing to improve discoverability and performance on search engines` (instead of `There are items in the checklist to resolve`) and the color of the icon is now whiteish.

This PR preps us for the following: 
- Only show badge counts of checklist items when checkpoints are met 
- Only show exclamation icon when the ALL checkpoint is met 
- Disable the checklist toggles on fresh stories 

<img width="315" alt="Screen Shot 2021-04-21 at 12 54 01 PM" src="https://user-images.githubusercontent.com/10720454/115614211-4589ea00-a2a2-11eb-83c6-99178261c952.png">
<img width="222" alt="Screen Shot 2021-04-21 at 12 53 46 PM" src="https://user-images.githubusercontent.com/10720454/115614212-46228080-a2a2-11eb-8f42-ff0ddd9ef36d.png">


## Testing Instructions

See that the editor loads as expected. Note the updated tooltip text on publish button and new icon color. 
Go to storybook `Stories Editor/Components/Checklist Tab/` and play with the `currentCheckpoint` knob to see different toggle states. 

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7137 
