### PR TITLE
Bug: Stickers Scrollable Quick Fix

### DIFF
--- a/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
+++ b/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
@@ -59,7 +59,7 @@ function ShapesPane(props) {
   const ref = useRef();
   useRovingTabIndex({ ref });
   return (
-    <Pane id={paneId} {...props}>
+    <Pane id={paneId} {...props} isOverflowScrollable={enableStickers}>
       {showTextAndShapesSearchInput && (
         <SearchInput
           initialValue={''}

--- a/assets/src/edit-story/components/library/panes/shared/index.js
+++ b/assets/src/edit-story/components/library/panes/shared/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const PANE_PADDING = '1em';
 
@@ -27,6 +27,12 @@ const Pane = styled.section.attrs(({ isActive }) => ({
   hidden: !isActive,
 }))`
   padding: 1.5em ${PANE_PADDING};
+  ${({ isOverflowScrollable = false }) =>
+    isOverflowScrollable &&
+    css`
+      overflow-y: scroll;
+      height: 100%;
+    `}
 `;
 
 function getPaneId(tab) {


### PR DESCRIPTION
## Context
We have enough stickers now that the pane needs to be scrollable to access them all

## Summary
Adds the non-user facing scrolling behavior to the shapes pane when stickers enabled

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Enable stickers, go to shapes pane, see that you can scroll the pane and all the stickers are selectable
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7281 
