### PR TITLE
Added a simplified dropdown as `Select`

### DIFF
--- a/assets/src/design-system/components/dropDown/select/components.js
+++ b/assets/src/design-system/components/dropDown/select/components.js
@@ -119,6 +119,7 @@ export const Value = styled(Text)`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  ${({ selectValueStylesOverride }) => selectValueStylesOverride};
 `;
 
 export const LabelText = styled(Text)`

--- a/assets/src/design-system/components/dropDown/select/index.js
+++ b/assets/src/design-system/components/dropDown/select/index.js
@@ -58,6 +58,7 @@ const DropDownSelect = (
     <Value
       forwardedAs="span"
       size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
+      selectValueStylesOverride={rest.selectValueStylesOverride}
     >
       {activeItemLabel || placeholder}
     </Value>

--- a/assets/src/edit-story/components/form/index.js
+++ b/assets/src/edit-story/components/form/index.js
@@ -26,3 +26,4 @@ export { default as AdvancedDropDown } from './advancedDropDown';
 export { default as DateTime } from './dateTime';
 export { default as Required } from './required';
 export { default as RadioGroup } from './radioGroup';
+export { default as Select } from './select';

--- a/assets/src/edit-story/components/form/select/index.js
+++ b/assets/src/edit-story/components/form/select/index.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default } from './select';

--- a/assets/src/edit-story/components/form/select/select.js
+++ b/assets/src/edit-story/components/form/select/select.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled, { css } from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { DropDown } from '../../../../design-system';
+
+const menuStylesOverride = css`
+  top: -14px;
+  right: unset;
+  width: auto;
+`;
+
+const Container = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const StyledDropDown = styled(DropDown)`
+  background-color: transparent;
+  border: 0;
+  width: auto;
+  button {
+    border: none;
+    width: auto;
+    margin-right: auto;
+    padding-left: 0;
+    > span:first-child {
+      margin-right: -12px;
+    }
+  }
+`;
+
+function Select(props) {
+  return (
+    <Container>
+      <StyledDropDown
+        isInline
+        hasSearch={false}
+        menuStylesOverride={menuStylesOverride}
+        {...props}
+      />
+    </Container>
+  );
+}
+
+export default Select;

--- a/assets/src/edit-story/components/form/select/select.js
+++ b/assets/src/edit-story/components/form/select/select.js
@@ -24,12 +24,6 @@ import styled, { css } from 'styled-components';
  */
 import { DropDown } from '../../../../design-system';
 
-const menuStylesOverride = css`
-  top: -14px;
-  right: unset;
-  width: auto;
-`;
-
 const Container = styled.div`
   position: relative;
   width: 100%;
@@ -39,15 +33,23 @@ const StyledDropDown = styled(DropDown)`
   background-color: transparent;
   border: 0;
   width: auto;
-  button {
-    border: none;
-    width: auto;
-    margin-right: auto;
-    padding-left: 0;
-    > span:first-child {
-      margin-right: -12px;
-    }
-  }
+`;
+
+const menuStylesOverride = css`
+  top: -14px;
+  right: unset;
+  width: auto;
+`;
+
+const selectButtonStylesOverride = css`
+  border: none;
+  width: auto;
+  margin-right: auto;
+  padding-left: 0;
+`;
+
+const selectValueStylesOverride = css`
+  margin-right: -12px;
 `;
 
 function Select(props) {
@@ -57,6 +59,8 @@ function Select(props) {
         isInline
         hasSearch={false}
         menuStylesOverride={menuStylesOverride}
+        selectButtonStylesOverride={selectButtonStylesOverride}
+        selectValueStylesOverride={selectValueStylesOverride}
         {...props}
       />
     </Container>

--- a/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
@@ -33,7 +33,6 @@ import {
   BUTTON_VARIANTS,
   Text,
   THEME_CONSTANTS,
-  DropDown,
   useSnackbar,
 } from '../../../../../../design-system';
 import { useConfig } from '../../../../../app/config';
@@ -41,6 +40,7 @@ import { useLocalMedia } from '../../../../../app/media';
 import { useMediaPicker } from '../../../../mediaPicker';
 import { SearchInput } from '../../../common';
 import useLibrary from '../../../useLibrary';
+import { Select } from '../../../../form';
 import { getResourceFromMediaPicker } from '../../../../../app/media/utils';
 import {
   MediaGalleryMessage,
@@ -74,11 +74,6 @@ const SearchCount = styled(Text).attrs({
   display: flex;
   align-items: center;
   justify-content: center;
-`;
-
-const StyledDropDown = styled(DropDown)`
-  background-color: transparent;
-  width: 132px;
 `;
 
 const FILTER_NONE = LOCAL_MEDIA_TYPE_ALL;
@@ -268,12 +263,11 @@ function MediaPane(props) {
             />
           </SearchInputContainer>
           <FilterArea>
-            <StyledDropDown
+            <Select
               selectedValue={mediaType?.toString() || FILTER_NONE}
               onMenuItemClick={onFilter}
               options={FILTERS}
               placement={Placement.BOTTOM_START}
-              fitContentWidth
             />
             {isSearching && media.length > 0 && (
               <SearchCount>

--- a/assets/src/edit-story/components/library/panes/pageTemplates/pageTemplatesPane.js
+++ b/assets/src/edit-story/components/library/panes/pageTemplates/pageTemplatesPane.js
@@ -26,7 +26,7 @@ import { __ } from '@web-stories-wp/i18n';
  * Internal dependencies
  */
 import { Pane } from '../shared';
-import { DropDown } from '../../../../../design-system';
+import { Select } from '../../../form';
 import { FULLBLEED_RATIO, PAGE_RATIO } from '../../../../constants';
 import paneId from './paneId';
 import DefaultTemplates from './defaultTemplates';
@@ -45,19 +45,9 @@ export const PaneInner = styled.div`
 `;
 
 const DropDownWrapper = styled.div`
-  width: 170px;
   text-align: left;
   height: 36px;
-  margin: 28px 0 17px 1em;
-`;
-
-// @todo Replace this when SimpleDropdown gets ready.
-const StyledDropDown = styled(DropDown)`
-  background-color: transparent;
-  border: 0;
-  button {
-    border: none;
-  }
+  margin: 28px 16px 17px;
 `;
 
 const DEFAULT = 'default';
@@ -91,14 +81,12 @@ function PageTemplatesPane(props) {
       <PaneInner>
         {customPageTemplates && (
           <DropDownWrapper>
-            <StyledDropDown
+            <Select
               options={options}
               selectedValue={showDefaultTemplates ? DEFAULT : SAVED}
               onMenuItemClick={(evt, value) =>
                 setShowDefaultTemplates(value === DEFAULT)
               }
-              isInline
-              hasSearch={false}
               aria-label={__('Select templates type', 'web-stories')}
             />
           </DropDownWrapper>

--- a/assets/src/edit-story/components/panels/design/preset/colorPreset/colorPresetActions.js
+++ b/assets/src/edit-story/components/panels/design/preset/colorPreset/colorPresetActions.js
@@ -18,16 +18,17 @@
  * External dependencies
  */
 import { useCallback, useState } from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { __, TranslateWithMarkup } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
  */
-import { Icons, DropDown } from '../../../../../../design-system';
+import { Icons } from '../../../../../../design-system';
 import { useStory } from '../../../../../app/story';
 import { PatternPropType } from '../../../../../types';
+import { Select } from '../../../../form';
 import { findMatchingColor } from '../utils';
 import { SAVED_COLOR_SIZE } from '../../../../../constants';
 import ColorGroup from './colorGroup';
@@ -78,18 +79,9 @@ const ColorsWrapper = styled.div`
 `;
 
 const DropDownWrapper = styled.div`
-  width: 145px;
   text-align: left;
   position: relative;
-`;
-
-const StyledDropDown = styled(DropDown)`
-  background-color: transparent;
-  border: 0;
-`;
-
-const menuStylesOverride = css`
-  top: -12px;
+  flex: 1 1 100%;
 `;
 
 const HeaderRow = styled.div`
@@ -202,17 +194,14 @@ function ColorPresetActions({ color, pushUpdate, onAction }) {
     <ActionsWrapper>
       <HeaderRow>
         <DropDownWrapper>
-          <StyledDropDown
+          <Select
             options={options}
             selectedValue={showLocalColors ? LOCAL : GLOBAL}
             onMenuItemClick={(evt, value) => {
               setShowLocalColors(value === LOCAL);
               onAction?.();
             }}
-            isInline
-            hasSearch={false}
             aria-label={__('Select color type', 'web-stories')}
-            menuStylesOverride={menuStylesOverride}
           />
         </DropDownWrapper>
         <ButtonWrapper>


### PR DESCRIPTION
## Context

This creates a simplified dropdown just named `<Select />`, which is merely a custom-styled and slightly opinionated dropdown.

This dropdown is then utilized in three places to unify the design and behavior in those places - compare the pretty big differences in before and after below.

## User-facing changes

| Before | After |
|-|-|
| ![Screen Shot 2021-04-22 at 21 46 45](https://user-images.githubusercontent.com/637548/115807034-d43b5b80-a3b5-11eb-9e1c-ae94f72c8a9b.png) | ![Screen Shot 2021-04-22 at 21 45 35](https://user-images.githubusercontent.com/637548/115807048-d8677900-a3b5-11eb-831c-e5c72cc76df5.png) |
| ![Screen Shot 2021-04-22 at 21 46 50](https://user-images.githubusercontent.com/637548/115807051-da313c80-a3b5-11eb-8a50-a43fa0237dce.png) | ![Screen Shot 2021-04-22 at 21 45 40](https://user-images.githubusercontent.com/637548/115807055-dbfb0000-a3b5-11eb-8d51-ee81248a61e0.png) |
| ![Screen Shot 2021-04-22 at 21 47 19](https://user-images.githubusercontent.com/637548/115807060-def5f080-a3b5-11eb-8859-eb7a821aab61.png) | ![Screen Shot 2021-04-22 at 21 47 55](https://user-images.githubusercontent.com/637548/115807067-e1584a80-a3b5-11eb-8af1-eb69cdbd3538.png) |
| ![Screen Shot 2021-04-22 at 21 47 24](https://user-images.githubusercontent.com/637548/115807069-e3220e00-a3b5-11eb-89f5-6c6c8b9a18a4.png) | ![Screen Shot 2021-04-22 at 21 48 00](https://user-images.githubusercontent.com/637548/115807072-e4ebd180-a3b5-11eb-9872-cd1834a8fd45.png) |
| ![Screen Shot 2021-04-22 at 21 47 29](https://user-images.githubusercontent.com/637548/115807088-ecab7600-a3b5-11eb-83b5-9283b8206503.png) | ![Screen Shot 2021-04-22 at 21 48 05](https://user-images.githubusercontent.com/637548/115807099-f03efd00-a3b5-11eb-92f3-0e4c0c4d0a49.png) |
| ![Screen Shot 2021-04-22 at 21 47 33](https://user-images.githubusercontent.com/637548/115807104-f2a15700-a3b5-11eb-815b-c5727b0f5261.png) | ![Screen Shot 2021-04-22 at 21 48 09](https://user-images.githubusercontent.com/637548/115807105-f3d28400-a3b5-11eb-9927-c307a215c0da.png) |

## Testing Instructions

### QA

This PR can be tested by following these steps:

1. Use the dropdown in the local media element library and observe design and behavior
1. Use the dropdown in the page template element library and observe design and behavior
1. Use the dropdown in the color picker for page background and observe design and behavior

### UAT

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #7056
