### PR TITLE
PPC: Add check for unoptimized video

### DIFF
--- a/assets/src/edit-story/app/media/utils/useFFmpeg.js
+++ b/assets/src/edit-story/app/media/utils/useFFmpeg.js
@@ -32,6 +32,11 @@ import {
 } from '../../../constants';
 import getFileName from './getFileName';
 
+export const VIDEO_SIZE_THRESHOLD = {
+  HEIGHT: 1080,
+  WIDTH: 1920,
+};
+
 const isDevelopment = process.env.NODE_ENV === 'development';
 
 /**
@@ -124,7 +129,7 @@ function useFFmpeg() {
         // See https://trac.ffmpeg.org/wiki/Scaling
         // Adds 1px pad to width/height if they're not divisible by 2, which FFmpeg will complain about.
         '-vf',
-        "scale='min(1080,iw)':'min(1920,ih)':'force_original_aspect_ratio=decrease',pad='width=ceil(iw/2)*2:height=ceil(ih/2)*2'",
+        `scale='min(${VIDEO_SIZE_THRESHOLD.HEIGHT},iw)':'min(${VIDEO_SIZE_THRESHOLD.WIDTH},ih)':'force_original_aspect_ratio=decrease',pad='width=ceil(iw/2)*2:height=ceil(ih/2)*2'`,
         // Simpler color profile
         '-pix_fmt',
         'yuv420p',
@@ -178,7 +183,7 @@ function useFFmpeg() {
         // See https://trac.ffmpeg.org/wiki/Scaling
         // Adds 1px pad to width/height if they're not divisible by 2, which FFmpeg will complain about.
         '-vf',
-        "scale='min(1080,iw)':'min(1920,ih)':'force_original_aspect_ratio=decrease',pad='width=ceil(iw/2)*2:height=ceil(ih/2)*2'",
+        `scale='min(${VIDEO_SIZE_THRESHOLD.HEIGHT},iw)':'min(${VIDEO_SIZE_THRESHOLD.WIDTH},ih)':'force_original_aspect_ratio=decrease',pad='width=ceil(iw/2)*2:height=ceil(ih/2)*2'`,
         // move some information to the beginning of your file.
         '-movflags',
         '+faststart',

--- a/assets/src/edit-story/app/media/utils/useProcessVideo.js
+++ b/assets/src/edit-story/app/media/utils/useProcessVideo.js
@@ -123,7 +123,7 @@ function useProcessVideo({
           additionalData: { alt: oldResource.alt, title: oldResource.title },
         });
       };
-      process();
+      return process();
     },
     [
       copyResourceData,

--- a/assets/src/edit-story/app/prepublish/components/videoOptimization.js
+++ b/assets/src/edit-story/app/prepublish/components/videoOptimization.js
@@ -16,12 +16,20 @@
 /**
  * External dependencies
  */
-import { __ } from '@web-stories-wp/i18n';
+import { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { __ } from '@web-stories-wp/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Button, BUTTON_TYPES, BUTTON_SIZES } from '../../../../design-system';
+import { useLocalMedia } from '../../media';
 
 const Container = styled.div`
   margin-top: 10px;
+  display: flex;
 `;
 
 const Thumbnail = styled.img`
@@ -32,14 +40,43 @@ const Thumbnail = styled.img`
   object-position: 50% 50%;
 `;
 
+const OptimizeButton = styled(Button)`
+  margin: auto 16px;
+  border: ${({ theme }) => `1px solid ${theme.colors.border.defaultNormal}`};
+`;
 export function VideoOptimization({ element }) {
+  const { resource = {} } = element;
+  const { optimizeVideo } = useLocalMedia((state) => ({
+    optimizeVideo: state.actions.optimizeVideo,
+  }));
+
+  const [isOptimizing, setIsOptimizing] = useState(false);
+
+  const handleUpdateVideo = useCallback(async () => {
+    setIsOptimizing(true);
+    await optimizeVideo({ resource }).finally(() => {
+      // TODO add in an error state #7315
+      setIsOptimizing(false);
+    });
+  }, [resource, optimizeVideo]);
+
   return (
     <Container>
       <Thumbnail
-        src={element.resource?.poster}
-        alt={element.resource?.alt || __('video thumbnail', 'web-stories')}
+        src={resource?.poster}
+        alt={resource?.alt || __('video thumbnail', 'web-stories')}
         crossOrigin="anonymous"
       />
+      <OptimizeButton
+        type={BUTTON_TYPES.TERTIARY}
+        size={BUTTON_SIZES.SMALL}
+        onClick={handleUpdateVideo}
+        disabled={isOptimizing}
+      >
+        {isOptimizing
+          ? __('Optimizing video', 'web-stories')
+          : __('Optimize video', 'web-stories')}
+      </OptimizeButton>
     </Container>
   );
 }

--- a/assets/src/edit-story/app/prepublish/components/videoOptimization.js
+++ b/assets/src/edit-story/app/prepublish/components/videoOptimization.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  margin-top: 10px;
+`;
+
+const Thumbnail = styled.img`
+  height: 66px;
+  width: 44px;
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+  object-fit: cover;
+  object-position: 50% 50%;
+`;
+
+export function VideoOptimization({ element }) {
+  return (
+    <Container>
+      <Thumbnail
+        src={element.resource?.poster}
+        alt={element.resource?.alt}
+        crossOrigin="anonymous"
+      />
+    </Container>
+  );
+}
+
+VideoOptimization.propTypes = {
+  element: PropTypes.object,
+};

--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -19,7 +19,7 @@
  */
 import { __, sprintf, _n, TranslateWithMarkup } from '@web-stories-wp/i18n';
 import { trackClick } from '@web-stories-wp/tracking';
-import PropTypes from 'prop-types';
+
 /**
  * Internal dependencies
  */
@@ -59,24 +59,6 @@ const VIDEO_DOCUMENTATION_URL = __(
   'https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/#visual-treat',
   'web-stories'
 );
-
-const SomeComponent = ({ src, alt }) => (
-  <ul>
-    <button onClick={() => {}}>{`test button`}</button>
-    <li>{__('farts', 'web-stories')}</li>
-    <img
-      src={src}
-      alt={alt}
-      crossOrigin="anonymous"
-      height="100px"
-      width="100px"
-    />
-  </ul>
-);
-SomeComponent.propTypes = {
-  src: PropTypes.string,
-  alt: PropTypes.string,
-};
 
 export const MESSAGES = {
   CRITICAL_METADATA: {
@@ -657,7 +639,6 @@ export const MESSAGES = {
     },
     VIDEO_NOT_OPTIMIZED: {
       MAIN_TEXT: __('Video not optimized', 'web-stories'),
-      HELPER_TEXT: SomeComponent,
     },
   },
 };

--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -19,6 +19,7 @@
  */
 import { __, sprintf, _n, TranslateWithMarkup } from '@web-stories-wp/i18n';
 import { trackClick } from '@web-stories-wp/tracking';
+import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
@@ -58,6 +59,24 @@ const VIDEO_DOCUMENTATION_URL = __(
   'https://amp.dev/documentation/guides-and-tutorials/start/create_successful_stories/#visual-treat',
   'web-stories'
 );
+
+const SomeComponent = ({ src, alt }) => (
+  <ul>
+    <button onClick={() => {}}>{`test button`}</button>
+    <li>{__('farts', 'web-stories')}</li>
+    <img
+      src={src}
+      alt={alt}
+      crossOrigin="anonymous"
+      height="100px"
+      width="100px"
+    />
+  </ul>
+);
+SomeComponent.propTypes = {
+  src: PropTypes.string,
+  alt: PropTypes.string,
+};
 
 export const MESSAGES = {
   CRITICAL_METADATA: {
@@ -635,6 +654,10 @@ export const MESSAGES = {
           </li>
         </ul>
       ),
+    },
+    VIDEO_NOT_OPTIMIZED: {
+      MAIN_TEXT: __('Video not optimized', 'web-stories'),
+      HELPER_TEXT: SomeComponent,
     },
   },
 };

--- a/assets/src/edit-story/app/prepublish/guidance/index.js
+++ b/assets/src/edit-story/app/prepublish/guidance/index.js
@@ -30,6 +30,7 @@ export default {
   video: [
     mediaGuidance.mediaElementResolution,
     mediaGuidance.videoElementLength,
+    mediaGuidance.videoElementOptimized,
   ],
   gif: [mediaGuidance.mediaElementResolution],
   image: [mediaGuidance.mediaElementResolution],

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -144,12 +144,13 @@ export function videoElementLength(element) {
  * @param {Element} element The element being checked
  * @return {Guidance|undefined} The guidance object for consumption
  */
-export function videoElementOptimized(element) {
-  const idOrigin = element?.resource?.id?.split(':')?.[0];
+export function videoElementOptimized(element = {}) {
+  const idResource = element.resource?.id;
+  const idOrigin = idResource?.toString().split(':')?.[0];
   const isCoverrMedia = idOrigin === 'media/coverr';
   const videoArea =
-    (element.resource.sizes.full?.height || 0) *
-    (element.resource.sizes.full?.width || 0);
+    (element.resource?.sizes?.full?.height || 0) *
+    (element.resource?.sizes?.full?.width || 0);
   const isLargeVideo =
     videoArea >= VIDEO_SIZE_THRESHOLD.WIDTH * VIDEO_SIZE_THRESHOLD.HEIGHT;
   if (!isCoverrMedia && isLargeVideo && !element.resource?.isOptimized) {
@@ -158,6 +159,7 @@ export function videoElementOptimized(element) {
       elementId: element.id,
       message: MESSAGES.MEDIA.VIDEO_NOT_OPTIMIZED.MAIN_TEXT,
       help: <VideoOptimization element={element} />,
+      noHighlight: true,
     };
   }
   return undefined;

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { VIDEO_SIZE_THRESHOLD } from '../../media/utils/useFFmpeg';
 import { MESSAGES, PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
 import { VideoOptimization } from '../components/videoOptimization';
 
@@ -144,11 +145,14 @@ export function videoElementLength(element) {
  * @return {Guidance|undefined} The guidance object for consumption
  */
 export function videoElementOptimized(element) {
+  const idOrigin = element?.resource?.id?.split(':')?.[0];
+  const isCoverrMedia = idOrigin === 'media/coverr';
   const videoArea =
     (element.resource.sizes.full?.height || 0) *
     (element.resource.sizes.full?.width || 0);
-  const isLargeVideo = videoArea >= 1080 * 1920;
-  if (isLargeVideo && !element.resource?.isOptimized) {
+  const isLargeVideo =
+    videoArea >= VIDEO_SIZE_THRESHOLD.WIDTH * VIDEO_SIZE_THRESHOLD.HEIGHT;
+  if (!isCoverrMedia && isLargeVideo && !element.resource?.isOptimized) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       elementId: element.id,

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -18,6 +18,7 @@
  * Internal dependencies
  */
 import { MESSAGES, PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
+import { VideoOptimization } from '../components/videoOptimization';
 
 const MAX_VIDEO_WIDTH = 3840;
 const MAX_VIDEO_HEIGHT = 2160;
@@ -152,10 +153,7 @@ export function videoElementOptimized(element) {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       elementId: element.id,
       message: MESSAGES.MEDIA.VIDEO_NOT_OPTIMIZED.MAIN_TEXT,
-      help: MESSAGES.MEDIA.VIDEO_NOT_OPTIMIZED.HELPER_TEXT({
-        src: element.resource.poster,
-        alt: element.alt || element.resource.alt,
-      }),
+      help: <VideoOptimization element={element} />,
     };
   }
   return undefined;

--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -134,3 +134,29 @@ export function videoElementLength(element) {
   }
   return undefined;
 }
+
+/**
+ * Check a if a video element's been optimized.
+ * If is not optimized, return guidance. Otherwise return undefined.
+ *
+ * @param {Element} element The element being checked
+ * @return {Guidance|undefined} The guidance object for consumption
+ */
+export function videoElementOptimized(element) {
+  const videoArea =
+    (element.resource.sizes.full?.height || 0) *
+    (element.resource.sizes.full?.width || 0);
+  const isLargeVideo = videoArea >= 1080 * 1920;
+  if (isLargeVideo && !element.resource?.isOptimized) {
+    return {
+      type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
+      elementId: element.id,
+      message: MESSAGES.MEDIA.VIDEO_NOT_OPTIMIZED.MAIN_TEXT,
+      help: MESSAGES.MEDIA.VIDEO_NOT_OPTIMIZED.HELPER_TEXT({
+        src: element.resource.poster,
+        alt: element.alt || element.resource.alt,
+      }),
+    };
+  }
+  return undefined;
+}

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -166,7 +166,6 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
     };
 
     const result = mediaGuidance.videoElementOptimized(largeUnoptimizedVideo);
-    expect(result).not.toBeUndefined();
     expect(result.message).toBe('Video not optimized');
     expect(result.type).toStrictEqual('guidance');
     expect(result.elementId).toStrictEqual(largeUnoptimizedVideo.id);

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -150,5 +150,82 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
     expect(result.elementId).toStrictEqual(tooLongVideo.id);
   });
 
+  it('should return a message if the video element is larger than 1080x1920 and not optimized', () => {
+    const largeUnoptimizedVideo = {
+      id: 202,
+      type: 'video',
+      resource: {
+        isOptimized: false,
+        sizes: {
+          full: {
+            height: 2160,
+            width: 3840,
+          },
+        },
+      },
+    };
+
+    const result = mediaGuidance.videoElementOptimized(largeUnoptimizedVideo);
+    expect(result).not.toBeUndefined();
+    expect(result.message).toBe('Video not optimized');
+    expect(result.type).toStrictEqual('guidance');
+    expect(result.elementId).toStrictEqual(largeUnoptimizedVideo.id);
+  });
+
+  it('should not return a message if the video element is larger than 1080x1920 and Optimized', () => {
+    const largeUnoptimizedVideo = {
+      id: 202,
+      type: 'video',
+      resource: {
+        isOptimized: true,
+        sizes: {
+          full: {
+            height: 2160,
+            width: 3840,
+          },
+        },
+      },
+    };
+
+    const result = mediaGuidance.videoElementOptimized(largeUnoptimizedVideo);
+    expect(result).toBeUndefined();
+  });
+
+  it('should not return a message if the video element is smaller than 1080x1920', () => {
+    const smallUnoptimizedVideo = {
+      id: 202,
+      type: 'video',
+      resource: {
+        isOptimized: false,
+        sizes: {
+          full: {
+            height: 300,
+            width: 400,
+          },
+        },
+      },
+    };
+    const smallOptimizedVideo = {
+      id: 203,
+      type: 'video',
+      resource: {
+        isOptimized: true,
+        sizes: {
+          full: {
+            height: 300,
+            width: 400,
+          },
+        },
+      },
+    };
+
+    expect(
+      mediaGuidance.videoElementOptimized(smallUnoptimizedVideo)
+    ).toBeUndefined();
+    expect(
+      mediaGuidance.videoElementOptimized(smallOptimizedVideo)
+    ).toBeUndefined();
+  });
+
   it.todo('should return a message if the video element is less than 24fps');
 });

--- a/assets/src/edit-story/app/prepublish/index.js
+++ b/assets/src/edit-story/app/prepublish/index.js
@@ -19,5 +19,5 @@
 import * as types from './types';
 
 export { default as getPrepublishErrors } from './getPrepublishErrors';
-export { PRE_PUBLISH_MESSAGE_TYPES } from './constants';
+export { PRE_PUBLISH_MESSAGE_TYPES, MESSAGES } from './constants';
 export { types };

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -297,7 +297,7 @@ const ChecklistTab = ({
         }
         ariaLabel={TEXT.RECOMMENDED_TITLE}
       >
-        {isVideoOptimizationEnabled && (
+        {enablePrePublishVideoOptimization && (
           <AutoVideoOptimization
             areVideosAutoOptimized={areVideosAutoOptimized}
             onAutoOptimizeVideoClick={onAutoVideoOptimizationClick}

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -90,11 +90,17 @@ const ChecklistTab = ({
   currentCheckpoint,
   onAutoVideoOptimizationClick,
 }) => {
-  const { isRTL } = useConfig();
+  const {
+    isRTL,
+    capabilities: { hasUploadMediaAction },
+  } = useConfig();
   const { enablePrePublishVideoOptimization } = useFeatures();
   const { setHighlights } = useHighlights(({ setHighlights }) => ({
     setHighlights,
   }));
+
+  const canOptimizeVideo =
+    hasUploadMediaAction && enablePrePublishVideoOptimization;
 
   const { isHighPriorityDisabledState, isRecommendedDisabledState } = useMemo(
     () => ({
@@ -114,7 +120,7 @@ const ChecklistTab = ({
         // look at it.
         .filter((item) =>
           item.message === MESSAGES.MEDIA.VIDEO_NOT_OPTIMIZED.MAIN_TEXT
-            ? enablePrePublishVideoOptimization
+            ? canOptimizeVideo
             : true
         )
         .reduce(
@@ -166,13 +172,13 @@ const ChecklistTab = ({
             pages: {},
           }
         ),
-    [checklist, enablePrePublishVideoOptimization]
+    [checklist, canOptimizeVideo]
   );
 
   const getOnPrepublishSelect = useCallback(
     (args) => {
-      const { elements, elementId, pageId, highlight } = args;
-      if (!elements && !elementId && !pageId && !highlight) {
+      const { elements, elementId, pageId, highlight, noHighlight } = args;
+      if (noHighlight || (!elements && !elementId && !pageId && !highlight)) {
         return {};
       }
 
@@ -297,7 +303,7 @@ const ChecklistTab = ({
         }
         ariaLabel={TEXT.RECOMMENDED_TITLE}
       >
-        {enablePrePublishVideoOptimization && (
+        {canOptimizeVideo && (
           <AutoVideoOptimization
             areVideosAutoOptimized={areVideosAutoOptimized}
             onAutoOptimizeVideoClick={onAutoVideoOptimizationClick}

--- a/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/checklistTab.js
@@ -20,14 +20,18 @@ import { useCallback, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
 import { __, sprintf } from '@web-stories-wp/i18n';
-import { useFeature } from 'flagged';
+import { useFeatures } from 'flagged';
 
 /**
  * Internal dependencies
  */
 import { Icons, useContextSelector } from '../../../../design-system';
 import { useConfig } from '../../../app';
-import { PRE_PUBLISH_MESSAGE_TYPES, types } from '../../../app/prepublish';
+import {
+  PRE_PUBLISH_MESSAGE_TYPES,
+  MESSAGES,
+  types,
+} from '../../../app/prepublish';
 import { useHighlights } from '../../../app/highlights';
 import { SimplePanel, panelContext } from '../../panels/panel';
 import AutoVideoOptimization from './autoVideoOptimization';
@@ -87,10 +91,7 @@ const ChecklistTab = ({
   onAutoVideoOptimizationClick,
 }) => {
   const { isRTL } = useConfig();
-  const isVideoOptimizationEnabled = useFeature(
-    'enablePrePublishVideoOptimization'
-  );
-
+  const { enablePrePublishVideoOptimization } = useFeatures();
   const { setHighlights } = useHighlights(({ setHighlights }) => ({
     setHighlights,
   }));
@@ -107,56 +108,65 @@ const ChecklistTab = ({
 
   const { highPriority, recommended, pages } = useMemo(
     () =>
-      checklist.reduce(
-        (prevMessages, current) => {
-          const id = uuidv4();
-          const currentMessage = { ...current, id };
-          const isHighPriority =
-            currentMessage.type === PRE_PUBLISH_MESSAGE_TYPES.ERROR;
+      checklist
+        // TODO remove filtering out video optimization check
+        // based on feature flag after design has a chance to
+        // look at it.
+        .filter((item) =>
+          item.message === MESSAGES.MEDIA.VIDEO_NOT_OPTIMIZED.MAIN_TEXT
+            ? enablePrePublishVideoOptimization
+            : true
+        )
+        .reduce(
+          (prevMessages, current) => {
+            const id = uuidv4();
+            const currentMessage = { ...current, id };
+            const isHighPriority =
+              currentMessage.type === PRE_PUBLISH_MESSAGE_TYPES.ERROR;
 
-          const [typeKey, copyKey] = isHighPriority
-            ? ['highPriority', 'recommended']
-            : ['recommended', 'highPriority'];
+            const [typeKey, copyKey] = isHighPriority
+              ? ['highPriority', 'recommended']
+              : ['recommended', 'highPriority'];
 
-          if (currentMessage.page !== undefined) {
-            const prevTypeGroup = prevMessages.pages[typeKey] || {};
-            const prevPageGroup = prevTypeGroup[currentMessage.page] || [];
+            if (currentMessage.page !== undefined) {
+              const prevTypeGroup = prevMessages.pages[typeKey] || {};
+              const prevPageGroup = prevTypeGroup[currentMessage.page] || [];
 
-            let prevLengths = { highPriority: 0, recommended: 0 };
-            if (prevMessages.pages?.lengths) {
-              ({ lengths: prevLengths } = prevMessages.pages);
+              let prevLengths = { highPriority: 0, recommended: 0 };
+              if (prevMessages.pages?.lengths) {
+                ({ lengths: prevLengths } = prevMessages.pages);
+              }
+
+              return {
+                recommended: prevMessages.recommended,
+                highPriority: prevMessages.highPriority,
+                pages: {
+                  ...prevMessages.pages,
+                  [typeKey]: {
+                    ...prevTypeGroup,
+                    [currentMessage.page]: [...prevPageGroup, currentMessage],
+                  },
+                  lengths: {
+                    ...prevLengths,
+                    [typeKey]: prevLengths[typeKey] + 1,
+                  },
+                },
+              };
             }
 
-            return {
-              recommended: prevMessages.recommended,
-              highPriority: prevMessages.highPriority,
-              pages: {
-                ...prevMessages.pages,
-                [typeKey]: {
-                  ...prevTypeGroup,
-                  [currentMessage.page]: [...prevPageGroup, currentMessage],
-                },
-                lengths: {
-                  ...prevLengths,
-                  [typeKey]: prevLengths[typeKey] + 1,
-                },
-              },
+            const groupedMessages = {
+              [copyKey]: prevMessages[copyKey],
+              [typeKey]: [...prevMessages[typeKey], currentMessage],
             };
+            return { pages: prevMessages.pages, ...groupedMessages };
+          },
+          {
+            highPriority: [],
+            recommended: [],
+            pages: {},
           }
-
-          const groupedMessages = {
-            [copyKey]: prevMessages[copyKey],
-            [typeKey]: [...prevMessages[typeKey], currentMessage],
-          };
-          return { pages: prevMessages.pages, ...groupedMessages };
-        },
-        {
-          highPriority: [],
-          recommended: [],
-          pages: {},
-        }
-      ),
-    [checklist]
+        ),
+    [checklist, enablePrePublishVideoOptimization]
   );
 
   const getOnPrepublishSelect = useCallback(

--- a/assets/src/edit-story/components/inspector/prepublish/test/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/test/checklistTab.js
@@ -18,6 +18,7 @@
  */
 import { noop } from '../../../../../design-system';
 import { renderWithProviders } from '../../../../../design-system/testUtils/renderWithProviders';
+import { ConfigProvider } from '../../../../app/config';
 import { PRE_PUBLISH_MESSAGE_TYPES } from '../../../../app/prepublish';
 import ChecklistTab from '../checklistTab';
 
@@ -37,15 +38,28 @@ const GUIDANCE_ERROR = {
   help: 'Test help',
 };
 
-describe('<ChecklistTab />', () => {
-  it("should render a toggle if the user's web_stories_media_optimization setting is initially false", () => {
-    const { getByRole } = renderWithProviders(
+const renderChecklistTab = ({
+  areVideosAutoOptimized = false,
+  hasUploadMediaAction = true,
+}) => {
+  return renderWithProviders(
+    <ConfigProvider
+      config={{
+        isRTL: false,
+        capabilities: { hasUploadMediaAction },
+      }}
+    >
       <ChecklistTab
-        areVideosAutoOptimized={false}
+        areVideosAutoOptimized={areVideosAutoOptimized}
         checklist={[GUIDANCE_ERROR]}
         onAutoVideoOptimizationClick={noop}
       />
-    );
+    </ConfigProvider>
+  );
+};
+describe('<ChecklistTab />', () => {
+  it("should render a toggle if the user's web_stories_media_optimization setting is initially false", () => {
+    const { getByRole } = renderChecklistTab({ areVideosAutoOptimized: false });
 
     const toggle = getByRole('checkbox', { hidden: true });
 
@@ -53,13 +67,19 @@ describe('<ChecklistTab />', () => {
   });
 
   it("should not render toggle if the user's web_stories_media_optimization setting is initially true", () => {
-    const { queryByRole } = renderWithProviders(
-      <ChecklistTab
-        areVideosAutoOptimized
-        checklist={[GUIDANCE_ERROR]}
-        onAutoVideoOptimizationClick={noop}
-      />
-    );
+    const { queryByRole } = renderChecklistTab({
+      areVideosAutoOptimized: true,
+    });
+
+    const toggle = queryByRole('checkbox', { hidden: true });
+
+    expect(toggle).not.toBeInTheDocument();
+  });
+
+  it("should not render toggle if the user doesn't have proper permissions", () => {
+    const { queryByRole } = renderChecklistTab({
+      areVideosAutoOptimized: true,
+    });
 
     const toggle = queryByRole('checkbox', { hidden: true });
 

--- a/assets/src/edit-story/components/inspector/prepublish/test/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/test/checklistTab.js
@@ -23,6 +23,9 @@ import ChecklistTab from '../checklistTab';
 
 jest.mock('flagged', () => ({
   useFeature: () => true,
+  useFeatures: () => ({
+    enablePrePublishVideoOptimization: true,
+  }),
 }));
 
 const GUIDANCE_ERROR = {


### PR DESCRIPTION
## Context
Part of incorporating video optimization into the PPC.

## Summary
Just adds the check for video optimization into the checklist. Functionality where we can trigger the video optimization from the checklist is to follow in another ticket: https://github.com/google/web-stories-wp/issues/7258

We put this behind a the `enablePrePublishVideoOptimization` feature flag so we can test out and see if it's too annoying before we incorporate into the codebase.

## Relevant Technical Choices
Added a small `/components` directory to the `app/prepublish` directory so we didn't have to store react components in the constants and deviate away from how the message constant is handled currently.

## To-do
- Assess how annoying this check is in UAT

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
go to experiments and enable `Video optimization pre-publish checklist` , go back to your story and add a video element. you should then see the `Video not optimized` check show up on the checklist.

go to experiments and disable `Video optimization pre-publish checklist` , go back to your story and add a video element. you should **not** see the `Video not optimized` check show up on the checklist.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
Follow testing instructions above
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7257 
