### PR TITLE
Video optimization: Change ffmpeg config to 720p@24fps

### DIFF
--- a/assets/src/edit-story/app/media/utils/useFFmpeg.js
+++ b/assets/src/edit-story/app/media/utils/useFFmpeg.js
@@ -120,11 +120,11 @@ function useFFmpeg() {
         // Stop writing to the stream after 1 frame.
         '-frames:v',
         '1',
-        // Resize videos if larger than 1080x1920, preserving aspect ratio.
+        // Scale down to 720p as recommended by Storytime.
         // See https://trac.ffmpeg.org/wiki/Scaling
         // Adds 1px pad to width/height if they're not divisible by 2, which FFmpeg will complain about.
         '-vf',
-        "scale='min(1080,iw)':'min(1920,ih)':'force_original_aspect_ratio=decrease',pad='width=ceil(iw/2)*2:height=ceil(ih/2)*2'",
+        "scale='min(720,iw)':'min(1280,ih)':'force_original_aspect_ratio=decrease',pad='width=ceil(iw/2)*2:height=ceil(ih/2)*2'",
         // Simpler color profile
         '-pix_fmt',
         'yuv420p',
@@ -174,11 +174,15 @@ function useFFmpeg() {
         // Use H.264 video codec.
         '-vcodec',
         'libx264',
-        // Resize videos if larger than 1080x1920, preserving aspect ratio.
+        // Scale down to 720p as recommended by Storytime.
         // See https://trac.ffmpeg.org/wiki/Scaling
         // Adds 1px pad to width/height if they're not divisible by 2, which FFmpeg will complain about.
         '-vf',
-        "scale='min(1080,iw)':'min(1920,ih)':'force_original_aspect_ratio=decrease',pad='width=ceil(iw/2)*2:height=ceil(ih/2)*2'",
+        "scale='min(720,iw)':'min(1280,ih)':'force_original_aspect_ratio=decrease',pad='width=ceil(iw/2)*2:height=ceil(ih/2)*2'",
+        // Reduce to 24fps as recommended by Storytime.
+        // See https://trac.ffmpeg.org/wiki/ChangingFrameRate
+        '-r',
+        '24',
         // move some information to the beginning of your file.
         '-movflags',
         '+faststart',


### PR DESCRIPTION
## Context

#7333 

## Summary

Changes ffmpeg config from 1080p@original to 720p@24fps to match Storytime rec.

Tested this locally with a 4K@60fps video shot on iPhone XS.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

N/A

## User-facing changes

N/A

## Testing Instructions

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a video with a large resolution and/or high frame rate and drag it onto the editor
2. Once video optimization completes, preview the story
3. Download the optimized video and compare it to the original video (binary size, resolution, and frame rate)
4. The optimized video should have a max resolution of 720x1280 and a max frame rate of 24fps, and generally a much smaller file size

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7333
