### PR TITLE
Design System: Slightly hide anti aliasing on `Pill`

### DIFF
--- a/assets/src/design-system/components/pill/pill.js
+++ b/assets/src/design-system/components/pill/pill.js
@@ -36,7 +36,10 @@ const StyledPill = styled.button(
     background-color: ${isActive
       ? theme.colors.interactiveBg.primaryNormal
       : theme.colors.opacity.footprint};
-    border: none;
+    border: 1px solid
+      ${isActive
+        ? theme.colors.interactiveBg.primaryNormal
+        : theme.colors.bg.primary};
     border-radius: ${theme.borders.radius.x_large};
     ${themeHelpers.focusableOutlineCSS(theme.colors.border.focus)};
 


### PR DESCRIPTION
## Context

It seems like the browser is trying to smooth out the curved border (anti-aliasing). 
- The pixels on the edges of the white box shadow are blurred slightly to make the white box shadow seem more curved

From the blurring of the white box shadow we see a little bit of blue come up from underneath it. This disappears when we remove the border radius because there is no curving that needs to be 'anti aliased':

![border-radius-3](https://user-images.githubusercontent.com/22185279/116753249-08210d00-a9c4-11eb-8f8a-8857046640b8.gif)

## Summary

It seems like the browser is trying to smooth out the curved border (anti-aliasing). Added a border to slightly cover the blurred pixels. It doesn't solve the problem all the way, but I think it's a good try.

If there's a way to disable anti aliasing for a box shadow - let me know!

## Relevant Technical Choices

Trying to hide the anti aliasing using a border to cover the pixels that are slightly transparent.

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/22185279/116753374-3b639c00-a9c4-11eb-94bc-11cc5872321d.png)|![image](https://user-images.githubusercontent.com/22185279/116753405-46b6c780-a9c4-11eb-8c49-d312b07dba26.png)|


## Testing Instructions

1. Go to dashboard/storybook
2. Tab with keyboard until you find a pill
3. See that there is less of those lines on the border of the pill.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6537 
