### PR TITLE
Fix Animations: 0ms duration not persisted

### DIFF
--- a/assets/src/edit-story/components/panels/design/animation/effectInput.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectInput.js
@@ -79,7 +79,7 @@ function EffectInput({
     [onChange]
   );
 
-  const valueForField = effectConfig[field] || effectProps[field].defaultValue;
+  const valueForField = effectConfig[field] ?? effectProps[field].defaultValue;
   const isFloat = effectProps[field].type === FIELD_TYPES.FLOAT;
   switch (effectProps[field].type) {
     case FIELD_TYPES.DROPDOWN:

--- a/assets/src/edit-story/components/panels/design/animation/test/effectInput.js
+++ b/assets/src/edit-story/components/panels/design/animation/test/effectInput.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import { renderWithTheme } from '../../../../../testUtils';
+import EffectInput from '../effectInput';
+import { FIELD_TYPES } from '../../../../../../animation';
+
+describe('<EffectInput />', () => {
+  const testFieldKey = 'testField';
+  const testValue = 500;
+  const defaultProps = {
+    effectProps: {
+      [testFieldKey]: {
+        type: FIELD_TYPES.NUMBER,
+        label: testFieldKey,
+      },
+    },
+    effectConfig: {
+      [testFieldKey]: testValue,
+    },
+    onChange: jest.fn(),
+    field: testFieldKey,
+  };
+  it('should render', () => {
+    const { getByLabelText } = renderWithTheme(
+      <EffectInput {...defaultProps} />
+    );
+    const input = getByLabelText(testFieldKey);
+    expect(input).toBeInTheDocument();
+  });
+  it('should render falsey defined values', () => {
+    renderWithTheme(
+      <EffectInput {...defaultProps} effectConfig={{ [testFieldKey]: 0 }} />
+    );
+    const testInput = screen.getByDisplayValue(0);
+    expect(testInput).toBeInTheDocument();
+    expect(testInput).toHaveAttribute('aria-label', testFieldKey);
+  });
+});

--- a/assets/src/edit-story/components/panels/design/animation/test/effectInput.js
+++ b/assets/src/edit-story/components/panels/design/animation/test/effectInput.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,6 @@
  */
 import { screen } from '@testing-library/react';
 
-/**
- * Internal dependencies
- */
 /**
  * Internal dependencies
  */


### PR DESCRIPTION
## Context
- 0ms durations in the inputs in the animations design panel were not being persisted. This PR is to persist a 0ms durations.
### Steps to Reproduce
Add animation to element
Set duration to 0ms
Preview story, verify that change has been saved successfully
De-select element, select it again
See that 0ms is gone, and 1000ms is displayed (or whatever the animation default is)

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- The 0ms duration was actually was persisted, the animation would have a 0ms duration, but the default value was being shown due to a logical check in the `EffectInput`
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- I changed the OR operator to NULLISH COALESCING. OR was evaluation `0` as `false` and so using the default value to display in the input. We only want the default value if the config's value for the field is `undefined` or `null`.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add animation to element
2. Set duration to 0ms
3. Preview story, verify that change has been saved successfully
4. De-select element, select it again
5. See that the duration of 0ms is shown in the effect input in the animation design panel.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
