### PR TITLE
Use new data when changing Link value

### DIFF
--- a/assets/src/edit-story/components/panels/design/link/link.js
+++ b/assets/src/edit-story/components/panels/design/link/link.js
@@ -103,12 +103,12 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
     ({ url, title, icon }) =>
       pushUpdateForObject(
         'link',
-        (prev) =>
+        () =>
           url
             ? {
                 url,
-                desc: title ? title : prev.desc,
-                icon: icon ? toAbsoluteUrl(url, icon) : prev.icon,
+                desc: title ? title : '',
+                icon: icon ? toAbsoluteUrl(url, icon) : '',
               }
             : null,
         defaultLink,

--- a/assets/src/edit-story/components/panels/design/link/link.js
+++ b/assets/src/edit-story/components/panels/design/link/link.js
@@ -256,6 +256,7 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
               value={link.desc || ''}
               aria-label={__('Link description', 'web-stories')}
               isIndeterminate={isMultipleDesc}
+              disabled={fetchingMetadata}
             />
           </Row>
           <Row spaceBetween={false}>
@@ -268,6 +269,7 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
               buttonInsertText={__('Select as link icon', 'web-stories')}
               type={allowedImageMimeTypes}
               isLoading={fetchingMetadata}
+              disabled={fetchingMetadata}
               variant={MEDIA_VARIANTS.CIRCLE}
               menuOptions={link.icon ? ['edit', 'remove'] : []}
             />


### PR DESCRIPTION
## Context
When changing a link value, previously, new metadata was used only when the new metadata was not empty. This caused odd results, e.g. having a non-matching description or wrong icon.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
This PR always uses the new values even if empty.

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Disables the metadata fields while new are loading, to prevent allowing user to populate the fields and then those values to be overwritten.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add an element and open the link panel.
2. Type in a link, e.g. github.com, wait until the metadata populates.
3. Type in a new link now, e.g. bell.ca.
4. Verify that both Description and the Optional icon got overwritten (the icon was removed)

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6265 
