### PR TITLE
Fix: Border radius not respected while animating

### DIFF
--- a/assets/src/edit-story/elements/shape/output.js
+++ b/assets/src/edit-story/elements/shape/output.js
@@ -30,7 +30,9 @@ function ShapeOutput({ element: { backgroundColor, isDefaultBackground } }) {
   const style = isDefaultBackground
     ? null
     : generatePatternStyles(backgroundColor);
-  return <div className="fill" style={style} />;
+  return (
+    <div className="fill" style={{ ...style, 'willChange': 'transform' }} />
+  );
 }
 
 ShapeOutput.propTypes = {

--- a/assets/src/edit-story/elements/shape/output.js
+++ b/assets/src/edit-story/elements/shape/output.js
@@ -30,9 +30,7 @@ function ShapeOutput({ element: { backgroundColor, isDefaultBackground } }) {
   const style = isDefaultBackground
     ? null
     : generatePatternStyles(backgroundColor);
-  return (
-    <div className="fill" style={{ ...style, 'willChange': 'transform' }} />
-  );
+  return <div className="fill" style={{ ...style, willChange: 'transform' }} />;
 }
 
 ShapeOutput.propTypes = {

--- a/assets/src/edit-story/elements/shape/output.js
+++ b/assets/src/edit-story/elements/shape/output.js
@@ -30,6 +30,8 @@ function ShapeOutput({ element: { backgroundColor, isDefaultBackground } }) {
   const style = isDefaultBackground
     ? null
     : generatePatternStyles(backgroundColor);
+  // willChange added by #7380 https://github.com/google/web-stories-wp/pull/7380
+  // to prevent issues with the border radius on shapes not being respected when animated
   return <div className="fill" style={{ ...style, willChange: 'transform' }} />;
 }
 

--- a/assets/src/edit-story/output/utils/styles.js
+++ b/assets/src/edit-story/output/utils/styles.js
@@ -92,6 +92,7 @@ function CustomStyles() {
               .mask {
                 position: absolute;
                 overflow: hidden;
+                will-change: transform;
               }
 
               .fill {

--- a/assets/src/edit-story/output/utils/styles.js
+++ b/assets/src/edit-story/output/utils/styles.js
@@ -92,7 +92,6 @@ function CustomStyles() {
               .mask {
                 position: absolute;
                 overflow: hidden;
-                will-change: transform;
               }
 
               .fill {


### PR DESCRIPTION
## Context
Adding a border radius to shapes was not being respected on the output.

https://user-images.githubusercontent.com/41136059/117073438-be4b6600-ace6-11eb-8df0-c0d5f6c69b21.mp4

This PR should fix this issue.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- Added `will-change: transform` to the mask's CSS.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
From the MDN Docs
https://developer.mozilla.org/en-US/docs/Web/CSS/will-change
> will-change is intended to be used as a last resort, in order to try to deal with existing performance problems. It should not be used to anticipate performance problems.

Originally I had `will-change: transform` on the `.mask` style, but I didn't want it applied to every mask, just shapes, which were the only elements I could find which had this issue. So I went with the change to `shape/output` to minimize the usage of `will-change` per recommendations.
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
Now adding a border radius and animation to any element should retain its border radius.

https://user-images.githubusercontent.com/41136059/117075408-9c9fae00-ace9-11eb-8962-87df9cf6183a.mp4


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a square shape element to the canvas
2. Add a border radius > 1, either all the same or different
3. Add any animation to the shape.
3. Click `Preview` or update a published story and view the updated story
4. The animated element should retain the border radius.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7356 
