### PR TITLE
Karma: Add Test for Duplicating Page with animations

### DIFF
--- a/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
+++ b/assets/src/edit-story/karma/copyAndPaste.cuj.karma.js
@@ -164,7 +164,7 @@ function sequencedForEach(htmlCollection, op) {
           );
           expect(pasted.elementAnimations.length).toEqual(1);
 
-          // Coppied and Pasted anims should share all attributes
+          // Copied and Pasted animations should share all attributes
           // Except `id` & `targets`
           const {
             id: cId,

--- a/assets/src/edit-story/karma/duplicate.cuj.karma.js
+++ b/assets/src/edit-story/karma/duplicate.cuj.karma.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import useInsertElement from '../components/canvas/useInsertElement';
+import { useStory } from '../app/story';
+import { Fixture } from './fixture';
+
+describe('Duplicate page', () => {
+  let fixture;
+  let duplicatePageButton;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    await fixture.render();
+
+    // Insert selected element to perform operations on.
+    const insertElement = await fixture.renderHook(() => useInsertElement());
+    await fixture.act(() =>
+      insertElement('text', {
+        x: 10,
+        y: 10,
+        width: 100,
+        height: 50,
+        content: 'Hello, Stories!',
+      })
+    );
+
+    duplicatePageButton = fixture.screen.getByRole('button', {
+      name: /Duplicate Page/,
+    });
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  it('should duplicate an animation', async () => {
+    // open effect chooser
+    const effectChooserToggle =
+      fixture.editor.inspector.designPanel.animation.effectChooser;
+    await fixture.events.click(effectChooserToggle, { clickCount: 1 });
+
+    // animation
+    const animation = fixture.screen.getByRole('option', {
+      name: 'Pulse Effect',
+    });
+
+    // apply animation to element
+    await fixture.events.click(animation, { clickCount: 1 });
+
+    // get original element
+    const {
+      animations: originalAnimations,
+      elements: originalElements,
+    } = await fixture.renderHook(() =>
+      useStory(({ state }) => ({
+        animations: state.pages[0].animations,
+        elements: state.currentPage.elements,
+      }))
+    );
+    expect(originalAnimations.length).toBe(1);
+
+    const {
+      delay: originalDelay,
+      duration: originalDuration,
+      type: originalType,
+      targets: originalTargets,
+    } = originalAnimations[0];
+
+    // Verify that animation is assigned to correct element
+    expect(originalTargets.length).toEqual(1);
+    expect(
+      originalElements.find((element) => element.id === originalTargets[0])
+    ).not.toBeUndefined();
+
+    // duplicate page
+    await fixture.events.click(duplicatePageButton, { clickCount: 1 });
+
+    // get the duplicated element
+    const { animations, elements } = await fixture.renderHook(() =>
+      useStory(({ state }) => ({
+        animations: state.pages[1].animations,
+        elements: state.pages[1].elements,
+      }))
+    );
+    expect(animations.length).toBe(1);
+
+    const { delay, duration, type, targets } = animations[0];
+
+    // Verify that animation values are identical
+    expect(delay).toBe(originalDelay);
+    expect(duration).toBe(originalDuration);
+    expect(type).toBe(originalType);
+
+    // Verify that animation is assigned to correct element
+    expect(targets.length).toEqual(1);
+    expect(
+      elements.find((element) => element.id === targets[0])
+    ).not.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Context

FIXIT week

## Summary

Adds a karma test to make sure that duplicating a page with animations works as intended.

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

none

## Testing Instructions

Tests should pass

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

n/a

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5737 
