### PR TITLE
Fix colour picker inputs' design

### DIFF
--- a/assets/src/edit-story/components/colorPicker/editablePreview.js
+++ b/assets/src/edit-story/components/colorPicker/editablePreview.js
@@ -29,6 +29,7 @@ import {
   Text,
   THEME_CONSTANTS,
   useKeyDownEffect,
+  themeHelpers,
 } from '../../../design-system';
 
 const Preview = styled.button`
@@ -39,6 +40,23 @@ const Preview = styled.button`
   background: transparent;
   color: ${({ theme }) => theme.colors.fg.primary};
   width: 100%;
+  padding: 7px 12px;
+
+  ${({ theme }) =>
+    themeHelpers.focusableOutlineCSS(
+      theme.colors.border.focus,
+      theme.colors.bg.secondary
+    )};
+`;
+
+const Wrapper = styled.div`
+  input {
+    ${({ theme }) =>
+      themeHelpers.focusableOutlineCSS(
+        theme.colors.border.focus,
+        theme.colors.bg.secondary
+      )};
+  }
 `;
 
 function EditablePreview({ label, value, width, format, onChange }) {
@@ -92,7 +110,11 @@ function EditablePreview({ label, value, width, format, onChange }) {
 
   if (!isEditing) {
     return (
-      <Preview aria-label={label} onClick={enableEditing}>
+      <Preview
+        aria-label={label}
+        onClick={enableEditing}
+        onFocus={enableEditing}
+      >
         <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
           {format(value)}
         </Text>
@@ -101,7 +123,7 @@ function EditablePreview({ label, value, width, format, onChange }) {
   }
 
   return (
-    <div ref={wrapperRef} tabIndex={-1} onBlur={handleOnBlur}>
+    <Wrapper ref={wrapperRef} tabIndex={-1} onBlur={handleOnBlur}>
       <EditableInput
         value={value}
         ref={editableRef}
@@ -109,7 +131,7 @@ function EditablePreview({ label, value, width, format, onChange }) {
         onChangeComplete={disableEditing}
         style={inputStyles}
       />
-    </div>
+    </Wrapper>
   );
 }
 

--- a/assets/src/edit-story/components/colorPicker/editablePreview.js
+++ b/assets/src/edit-story/components/colorPicker/editablePreview.js
@@ -40,7 +40,7 @@ const Preview = styled.button`
   background: transparent;
   color: ${({ theme }) => theme.colors.fg.primary};
   width: 100%;
-  padding: 7px 12px;
+  padding: 7px;
 
   ${({ theme }) =>
     themeHelpers.focusableOutlineCSS(


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->
## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
|Before|After|
|-------|-----|
| ![Screenshot 2021-05-05 at 11 48 05](https://user-images.githubusercontent.com/3294597/117117074-6583d800-ad8f-11eb-929e-b0cb367be301.png) | ![Screenshot 2021-05-05 at 11 45 49](https://user-images.githubusercontent.com/3294597/117116918-366d6680-ad8f-11eb-8c46-2afa57eea381.png) |
| ![Screenshot 2021-05-05 at 11 47 42](https://user-images.githubusercontent.com/3294597/117117090-6caae600-ad8f-11eb-98b6-1ac651cc954b.png) | ![Screenshot 2021-05-05 at 11 45 40](https://user-images.githubusercontent.com/3294597/117116945-3f5e3800-ad8f-11eb-87d0-424fc83fc3b6.png) |


<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open colour picker for a shape.
2. Verify the opacity and hex input don't look broken and maintain a similar size when active/not.
3. Verify that when tabbing into the hex/opacity input, it displays the focus outline.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6797 
