### PR TITLE
Fix nested buttons issue for Swatch

### DIFF
--- a/assets/src/design-system/components/swatch/swatch.js
+++ b/assets/src/design-system/components/swatch/swatch.js
@@ -75,6 +75,8 @@ const SwatchButton = styled.button.attrs({ type: 'button' })`
   }
 `;
 
+const SwatchPreview = styled(SwatchButton).attrs({ as: 'div', type: '' })``;
+
 const presetCSS = css`
   display: block;
   width: 100%;
@@ -125,6 +127,7 @@ function Swatch({
   isDisabled = false,
   isSmall = false,
   children,
+  isPreview,
   ...props
 }) {
   if (!pattern) {
@@ -137,8 +140,9 @@ function Swatch({
     : pattern;
   // Small swatches and gradient swatches are never split.
   const displaySplit = !isSmall && !swatchIsGradient && swatchHasTransparency;
+  const SwatchDisplay = isPreview ? SwatchPreview : SwatchButton;
   return (
-    <SwatchButton disabled={isDisabled} isSmall={isSmall} {...props}>
+    <SwatchDisplay disabled={isDisabled} isSmall={isSmall} {...props}>
       {swatchHasTransparency && <Transparent />}
       <SwatchItem
         $pattern={pattern}
@@ -152,7 +156,7 @@ function Swatch({
         )}
         {children}
       </SwatchItem>
-    </SwatchButton>
+    </SwatchDisplay>
   );
 }
 
@@ -161,6 +165,7 @@ Swatch.propTypes = {
   pattern: PropTypes.object,
   isDisabled: PropTypes.bool,
   isSmall: PropTypes.bool,
+  isPreview: PropTypes.bool,
 };
 
 export { Swatch };

--- a/assets/src/edit-story/components/form/color/colorInput.js
+++ b/assets/src/edit-story/components/form/color/colorInput.js
@@ -179,6 +179,7 @@ function ColorInput({
             <ColorPreview>
               <Swatch
                 isSmall
+                isPreview
                 role="status"
                 tabIndex="-1"
                 pattern={previewPattern}


### PR DESCRIPTION
## Context
`Swatch` is a `button` by default but it's also used within buttons occasionally, causing nested buttons.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- Adds `isPreview` prop for the `Swatch`, allowing it to display as `div` instead of a button.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
- Add a Shape
- Change the background colour of the shape to Radial
- Verify that the color input has only one `button` in the source, and there are no warnings about nested buttons for the component.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
N/A 
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6889 
