### PR TITLE
PPC: temporarily remove size check from video optimization

### DIFF
--- a/assets/src/edit-story/app/prepublish/guidance/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/media.js
@@ -17,7 +17,6 @@
 /**
  * Internal dependencies
  */
-import { VIDEO_SIZE_THRESHOLD } from '../../media/utils/useFFmpeg';
 import { MESSAGES, PRE_PUBLISH_MESSAGE_TYPES } from '../constants';
 import { VideoOptimization } from '../components/videoOptimization';
 
@@ -148,13 +147,8 @@ export function videoElementOptimized(element = {}) {
   const idResource = element.resource?.id;
   const idOrigin = idResource?.toString().split(':')?.[0];
   const isCoverrMedia = idOrigin === 'media/coverr';
-  const videoArea =
-    (element.resource?.sizes?.full?.height ?? element.resource?.height ?? 0) *
-    (element.resource?.sizes?.full?.width ?? element.resource?.width ?? 0);
-  const isLargeVideo =
-    videoArea >= VIDEO_SIZE_THRESHOLD.WIDTH * VIDEO_SIZE_THRESHOLD.HEIGHT;
 
-  if (!isCoverrMedia && isLargeVideo && !element.resource?.isOptimized) {
+  if (!isCoverrMedia && !element.resource?.isOptimized) {
     return {
       type: PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE,
       elementId: element.id,

--- a/assets/src/edit-story/app/prepublish/guidance/test/media.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/media.js
@@ -150,7 +150,7 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
     expect(result.elementId).toStrictEqual(tooLongVideo.id);
   });
 
-  it('should return a message if the video element is larger than 1080x1920 and not optimized', () => {
+  it('should return a message if the video element is not optimized', () => {
     const largeUnoptimizedVideo = {
       id: 202,
       type: 'video',
@@ -169,61 +169,6 @@ describe('Pre-publish checklist - media guidelines (guidance)', () => {
     expect(result.message).toBe('Video not optimized');
     expect(result.type).toStrictEqual('guidance');
     expect(result.elementId).toStrictEqual(largeUnoptimizedVideo.id);
-  });
-
-  it('should not return a message if the video element is larger than 1080x1920 and Optimized', () => {
-    const largeUnoptimizedVideo = {
-      id: 202,
-      type: 'video',
-      resource: {
-        isOptimized: true,
-        sizes: {
-          full: {
-            height: 2160,
-            width: 3840,
-          },
-        },
-      },
-    };
-
-    const result = mediaGuidance.videoElementOptimized(largeUnoptimizedVideo);
-    expect(result).toBeUndefined();
-  });
-
-  it('should not return a message if the video element is smaller than 1080x1920', () => {
-    const smallUnoptimizedVideo = {
-      id: 202,
-      type: 'video',
-      resource: {
-        isOptimized: false,
-        sizes: {
-          full: {
-            height: 300,
-            width: 400,
-          },
-        },
-      },
-    };
-    const smallOptimizedVideo = {
-      id: 203,
-      type: 'video',
-      resource: {
-        isOptimized: true,
-        sizes: {
-          full: {
-            height: 300,
-            width: 400,
-          },
-        },
-      },
-    };
-
-    expect(
-      mediaGuidance.videoElementOptimized(smallUnoptimizedVideo)
-    ).toBeUndefined();
-    expect(
-      mediaGuidance.videoElementOptimized(smallOptimizedVideo)
-    ).toBeUndefined();
   });
 
   it.todo('should return a message if the video element is less than 24fps');


### PR DESCRIPTION
## Context
ongoing work for recent PPC additions for video optimization that we squeezed in.

## Summary
This removes the check to look at size for videos to display `video not optimized` guidance. Just moving it temporarily because getting the actual video dimensions and other meta data requires more in depth changes with the existing setup.

## Relevant Technical Choices
To get the actual video dimensions, we'll need to get the response from the media endpoint into the PPC checks. This requires a little more work with the existing setup which currently only inspects the `story` state object.

I think this data will be inspected more as we add more fine tuned requirements for the `video not optimized` checks, so the expected changes should be useful in the near future.

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Enable the video optimization in PPC flag. add a video to your story that isn't optimized and isn't from coverr. see the check for the video not being optimized show up in guidance.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
