### PR TITLE
Text Sets A11Y

### DIFF
--- a/assets/src/edit-story/components/library/panes/shared/chipGroup/index.js
+++ b/assets/src/edit-story/components/library/panes/shared/chipGroup/index.js
@@ -95,7 +95,13 @@ const ExpandButton = styled(Button).attrs({
   align-items: center;
 `;
 
-const ChipGroup = ({ items, selectedItemId, selectItem, deselectItem }) => {
+const ChipGroup = ({
+  items,
+  selectedItemId,
+  selectItem,
+  deselectItem,
+  ariaLabel,
+}) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const sectionRef = useRef();
@@ -159,7 +165,9 @@ const ChipGroup = ({ items, selectedItemId, selectItem, deselectItem }) => {
             id={containerId}
             isExpanded={isExpanded}
             role="listbox"
-            aria-label={__('List of filtering options', 'web-stories')}
+            aria-label={
+              ariaLabel || __('List of filtering options', 'web-stories')
+            }
           >
             <InnerContainer
               role="presentation"
@@ -210,6 +218,7 @@ ChipGroup.propTypes = {
   selectedItemId: PropTypes.string,
   selectItem: PropTypes.func,
   deselectItem: PropTypes.func,
+  ariaLabel: PropTypes.string,
 };
 
 export default ChipGroup;

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
@@ -140,17 +140,17 @@ function TextSetsPane({ paneRef }) {
     [textSets]
   );
 
-  const speak = useLiveRegion('polite');
+  const speak = useLiveRegion();
 
   const handleSelectedCategory = useCallback(
     (selectedCategory) => {
       setSelectedCat(selectedCategory);
       speak(
         selectedCategory === null
-          ? __(`Deselected text set filter`, 'web-stories')
+          ? __('Show all text sets', 'web-stories')
           : sprintf(
               /* translators: %s: filter category name */
-              __(`Selected text set filter %s`, 'web-stories'),
+              __('Selected text set filter %s', 'web-stories'),
               CATEGORIES[selectedCategory]
             )
       );

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSetsPane.js
@@ -32,6 +32,7 @@ import {
   Text,
   Toggle,
   Headline,
+  useLiveRegion,
 } from '../../../../../../design-system';
 import { FullWidthWrapper } from '../../common/styles';
 import { ChipGroup } from '../../shared';
@@ -139,12 +140,26 @@ function TextSetsPane({ paneRef }) {
     [textSets]
   );
 
-  const handleSelectedCategory = useCallback((selectedCategory) => {
-    setSelectedCat(selectedCategory);
-    localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS}`, {
-      selectedCategory,
-    });
-  }, []);
+  const speak = useLiveRegion('polite');
+
+  const handleSelectedCategory = useCallback(
+    (selectedCategory) => {
+      setSelectedCat(selectedCategory);
+      speak(
+        selectedCategory === null
+          ? __(`Deselected text set filter`, 'web-stories')
+          : sprintf(
+              /* translators: %s: filter category name */
+              __(`Selected text set filter %s`, 'web-stories'),
+              CATEGORIES[selectedCategory]
+            )
+      );
+      localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TEXT_SET_SETTINGS}`, {
+        selectedCategory,
+      });
+    },
+    [speak]
+  );
 
   const onChangeShowInUse = useCallback(
     () => requestAnimationFrame(() => setShowInUse((prevVal) => !prevVal)),
@@ -194,6 +209,7 @@ function TextSetsPane({ paneRef }) {
           selectedItemId={selectedCat}
           selectItem={handleSelectedCategory}
           deselectItem={() => handleSelectedCategory(null)}
+          ariaLabel={__('Select filter for text sets list', 'web-stories')}
         />
       </FullWidthWrapper>
       <TextSetsWrapper>


### PR DESCRIPTION
## Context
From the ticket:
- Category selection/deselection doesn't seem to get announced to screen readers
- To screen readers it's not clear what the list of categories does. 

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- add more descriptive aria-label to text set chip group 
- add an announcement when the filter is selected/deselected
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- added `ariaLabel` prop to `chipGroup` to make the announcement of the filter list more descriptive
- used `useLiveRegion` to speak the deselection/selection of a filter
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
For users using a screen reader, focusing the filter chips on the text sets list now reads "Select filter for text sets list". Selecting a filter is now announced like "Selected text set filter `<filter name>`".

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Turn on your screen reader
2. Focus the the filter chips on the text sets (All, Cover, etc) list now reads "Select filter for text sets list" before announcing the name on the chip which is focused. 
3. Press enter or space to select a chip 
4. Screen readers should now announce "Selected text set filter `<filter name>`". Selecting all will read "Show all text sets"

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?
NA
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
NA
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
NA
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6295 
