### PR TITLE
Bugfix: Dashboard Grid Focus Trap

### DIFF
--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -135,6 +135,7 @@ function StoriesView({
       setContextMenuId(-1);
       trackEvent('duplicate_story');
       storyActions.duplicateStory(story);
+      setFocusedStory({ id: story.id });
     },
     [storyActions]
   );
@@ -172,6 +173,7 @@ function StoriesView({
               ),
         dismissable: true,
       });
+      setFocusedStory({ id: story.id });
     },
     [showSnackbar]
   );

--- a/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
+++ b/assets/src/dashboard/app/views/myStories/content/storiesView/index.js
@@ -79,11 +79,13 @@ function StoriesView({
     // then we use storiesById to find the proper index of the interacted with item and use that to decide where to move focus
     if (focusedStory.id && !returnStoryFocusId) {
       const storyArrayIndex = storiesById.indexOf(focusedStory.id);
-      const adjustedIndex = focusedStory.isDeleted ? -1 : 0;
+      const isDeletedAdjustmentDirection = storyArrayIndex > 0 ? -1 : +1;
+      const adjustedIndex = focusedStory.isDeleted
+        ? isDeletedAdjustmentDirection
+        : 0;
       const focusIndex = storyArrayIndex + adjustedIndex;
       const storyIdToFocus = storiesById[focusIndex];
-
-      setReturnStoryFocusId(storyIdToFocus);
+      storyIdToFocus && setReturnStoryFocusId(storyIdToFocus);
     }
   }, [focusedStory, returnStoryFocusId, storiesById]);
 
@@ -252,7 +254,10 @@ function StoriesView({
           renameStory={renameStory}
           storyMenu={storyMenu}
           stories={stories}
-          returnStoryFocusId={returnStoryFocusId}
+          returnStoryFocusId={{
+            value: returnStoryFocusId,
+            set: setReturnStoryFocusId,
+          }}
         />
       );
     }

--- a/assets/src/dashboard/app/views/shared/storyGridView.js
+++ b/assets/src/dashboard/app/views/shared/storyGridView.js
@@ -253,7 +253,10 @@ StoryGridView.propTypes = {
   pageSize: PageSizePropType.isRequired,
   storyMenu: StoryMenuPropType,
   renameStory: RenameStoryPropType,
-  returnStoryFocusId: PropTypes.number,
+  returnStoryFocusId: PropTypes.shape({
+    value: PropTypes.number,
+    set: PropTypes.func,
+  }),
 };
 
 export default StoryGridView;

--- a/assets/src/dashboard/components/scrollToTop/index.js
+++ b/assets/src/dashboard/components/scrollToTop/index.js
@@ -46,6 +46,10 @@ const StyledButton = styled(Button)(
     box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
     opacity: ${Number(isVisible)};
     transition: opacity 300ms ease-in-out;
+    &:focus {
+      opacity: 1;
+      pointer-events: 'auto';
+    }
   `
 );
 


### PR DESCRIPTION
## Context

Fix it week

## Summary

Fixes an issue where if you're using the keyboard to navigate through the dashboard story grid view and you open the delete dialog, regardless of if you cancel or delete in the dialog, you would lose focus of the grid and end up at the top of the entire browser window - just super jarring.  

## Relevant Technical Choices

The grid here is using a shared util to navigate the grid with arrow keys. It's also using the shared `useFocusOut` util that fires whenever you _click_ out of the ref that is getting watched. That's all fine and well if you are using a mouse. What I've learned is that this just isn't firing right for keyboards and it's causing the focus to get real weird and never return to the proper grid item (thus the jarring focus to the browser on dialog close). 


- Update to how the adjusted index to focus when returning to the grid to account for deleting the first item in the grid 
- Only apply the 'new' (it might be returning to the existing id but it's new to what `document.activeElement` thinks, when it's not null to prevent `returnStoryFocusId` from becoming `null` just because focusedStory.id exists (this otherwise causes a bummer of a little loop otherwise where if you tab out of a card and expect to move forward you just repeat that same card). 
- Pass in `setReturnStoryFocusId` to the `storyGridView` so that we can set it there and account for what the focus out hook is missing by not knowing the keyboard. 
- Track the activeGridItemId with a ref so that we avoid needlessly returning the focus to the dashboard when we haven't fired any action that would demand it (delete, duplicate, copy) - that ref's getting tracked in the standard effect hook that's setting the preview element as the focus in the grid and then it's getting set to null in our new `manuallySetFocusOut` that fires when delete, duplicate or copy is selected from context menu. 
- Hijacking the `storyMenu` and giving it a little extra functionality for delete, duplicate and copy that's only available in the grid, not the storyView. 
- Duplicating stories and Copying Story Links also benefit from having the focus restored on those actions, so they got the same treatment as delete. The others seem ok to me, focus isn't getting hijacked for those. 
- Little update to `ScrollToTop` so that if you're using the keyboard from the get go and haven't scrolled but you've tabbed past the grid container you don't lose what's focused. 


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

- Focus should not get lost on the dashboard grid anymore on delete. Nothing visual should have changed. 
- Original reported issue that stemmed this where if you tried to delete a story with the keyboard on the grid and then click to the search bar you can't get in it, that's fixed here.


## Testing Instructions

Use the keyboard to navigate the dashboard story grid, do actions in the context menu, see that you never get booted out of the grid. 
If you exit the grid and go back to it you'll start from the top.
Try deleting a story (just opening the dialog is plenty, cancel works fine too) and then click into the search on dashboard, should be able to search. 


https://user-images.githubusercontent.com/10720454/117368240-19609280-ae78-11eb-9fb0-9363c276826e.mp4


### QA

Use the keyboard to navigate the dashboard story grid, do actions in the context menu, see that you never get booted out of the grid. 
If you exit the grid and go back to it you'll start from the top.
Try deleting a story (just opening the dialog is plenty, cancel works fine too) and then click into the search on dashboard, should be able to search. 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6996
