### PR TITLE
Font Size: check for negative values and clamp to previous value

### DIFF
--- a/assets/src/edit-story/components/panels/design/textStyle/font.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/font.js
@@ -102,6 +102,8 @@ function FontControls({ selectedElements, pushUpdate }) {
     [fontStyle, handleSelectFontWeight, maybeEnqueueFontStyle, selectedElements]
   );
 
+  // https://github.com/google/web-stories-wp/pull/7451
+  // Bug report introduced new state, return to previous value when entering negative numbers
   const previousFontSize = usePrevious(fontSize);
   useEffect(() => {
     if (fontSize < 0) {

--- a/assets/src/edit-story/components/panels/design/textStyle/font.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/font.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useEffect } from 'react';
 import styled from 'styled-components';
 import { __ } from '@web-stories-wp/i18n';
 
@@ -32,6 +32,7 @@ import clamp from '../../../../utils/clamp';
 import { MULTIPLE_VALUE, MULTIPLE_DISPLAY_VALUE } from '../../../../constants';
 import { Row, usePresubmitHandler } from '../../../form';
 import { getCommonValue } from '../../shared';
+import usePrevious from '../../../../../design-system/utils/usePrevious';
 import useRichTextFormatting from './useRichTextFormatting';
 import getFontWeights from './getFontWeights';
 import FontPicker from './fontPicker';
@@ -100,6 +101,13 @@ function FontControls({ selectedElements, pushUpdate }) {
     },
     [fontStyle, handleSelectFontWeight, maybeEnqueueFontStyle, selectedElements]
   );
+
+  const previousFontSize = usePrevious(fontSize);
+  useEffect(() => {
+    if (fontSize < 0) {
+      pushUpdate({ fontSize: previousFontSize }, true);
+    }
+  }, [fontSize, previousFontSize, pushUpdate]);
 
   usePresubmitHandler(
     ({ fontSize: newFontSize }) => ({


### PR DESCRIPTION
## Context
![image](https://user-images.githubusercontent.com/41136059/117500267-3ad18500-af31-11eb-93ac-cbad238318f1.png)
- In the Text style panel if a user enters a negative value into the font size field and focusing away changed the value from 32 to 8. 
- it shouldn’t allow negatives but then should reset to the original value
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- I have a question out to Matt to check if we want to clamp to the original value or if we want to actually stick with the current behavior, since it is just clamping to the minimum value. 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- For now storing the previous value so we can specifically change negative values back to their previous values.
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

https://user-images.githubusercontent.com/41136059/117500497-9439b400-af31-11eb-8d89-4be5bdf0ac5f.mp4


<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a story and add some text with a font size > 8
2. When entering a negative value in the font size input it should change back to the value entered in step 1

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6792 
