### PR TITLE
Fixed replacement flip

### DIFF
--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -41,7 +41,6 @@ import {
   getResponsiveBorder,
   shouldDisplayBorder,
 } from '../../utils/elementBorder';
-import getTransformFlip from '../../elements/shared/getTransformFlip';
 
 const Wrapper = styled.div`
   ${elementWithPosition}
@@ -70,7 +69,6 @@ const ReplacementContainer = styled.div`
   transition: opacity 0.25s cubic-bezier(0, 0, 0.54, 1);
   pointer-events: none;
   opacity: ${({ hasReplacement }) => (hasReplacement ? 1 : 0)};
-  transform: ${({ flip }) => (flip ? getTransformFlip(flip) : null)};
   height: 100%;
 `;
 
@@ -99,18 +97,6 @@ function DisplayElement({ element, previewMode, isAnimatable = false }) {
 
   const hasReplacement = Boolean(replacement);
 
-  const replacementElement = hasReplacement
-    ? {
-        ...element,
-        type: replacement.resource.type,
-        resource: replacement.resource,
-        scale: replacement.scale,
-        focalX: replacement.focalX,
-        focalY: replacement.focalY,
-        flip: replacement.flip,
-      }
-    : null;
-
   const {
     id,
     opacity,
@@ -120,6 +106,21 @@ function DisplayElement({ element, previewMode, isAnimatable = false }) {
     border = {},
     flip,
   } = element;
+
+  const replacementElement = hasReplacement
+    ? {
+        ...element,
+        type: replacement.resource.type,
+        resource: replacement.resource,
+        scale: replacement.scale,
+        focalX: replacement.focalX,
+        focalY: replacement.focalY,
+        // Okay, this is a bit weird, but... the flip property is taken from the drop-image if
+        // target is background, but from the original image if target is non-background
+        flip: isBackground ? replacement.flip : flip,
+      }
+    : null;
+
   const { Display } = getDefinitionForType(type);
   const { Display: Replacement } =
     getDefinitionForType(replacement?.resource.type) || {};
@@ -184,10 +185,7 @@ function DisplayElement({ element, previewMode, isAnimatable = false }) {
           <Display element={element} previewMode={previewMode} box={box} />
         </WithMask>
         {!previewMode && (
-          <ReplacementContainer
-            flip={flip}
-            hasReplacement={Boolean(replacementElement)}
-          >
+          <ReplacementContainer hasReplacement={hasReplacement}>
             {replacementElement && (
               <WithMask
                 element={replacementElement}

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -115,8 +115,11 @@ function DisplayElement({ element, previewMode, isAnimatable = false }) {
         scale: replacement.scale,
         focalX: replacement.focalX,
         focalY: replacement.focalY,
-        // Okay, this is a bit weird, but... the flip property is taken from the drop-image if
-        // target is background, but from the original image if target is non-background
+        // Okay, this is a bit weird, but... the flip property is taken from the dragged image
+        // if the drop-target is the background element, but from the original drop-target image
+        // itself if the drop-target is a regular element.
+        //
+        // @see compare with similar logic in `combineElements`
         flip: isBackground ? replacement.flip : flip,
       }
     : null;

--- a/assets/src/edit-story/components/dropTargets/karma/background.karma.js
+++ b/assets/src/edit-story/components/dropTargets/karma/background.karma.js
@@ -323,11 +323,7 @@ describe('Background Drop-Target integration', () => {
           );
         });
 
-        // Disable reason: There's actually a bug here - replacement image appears flipped in flipped bg
-        // but dropped image is unflipped once dropped.
-        // Filed in: https://github.com/google/web-stories-wp/issues/6643
-        // eslint-disable-next-line jasmine/no-disabled-tests
-        xit('should correctly handle image dropped on edge with flip', async () => {
+        it('should correctly handle image dropped on edge with flip', async () => {
           // Verify that background element has the correct transform (flip) before doing anything
           let bg1 = fixture.editor.canvas.displayLayer.display(bgImageData.id)
             .node;
@@ -352,7 +348,7 @@ describe('Background Drop-Target integration', () => {
           // Verify that replacement img has correct transform
           const replaceImg = rep.querySelector('img');
           const combinedRepTransform = getAllTransformsBetween(replaceImg, bg1);
-          expect(combinedRepTransform).toBe('');
+          expect(combinedRepTransform).toBe('matrix(-1, 0, 0, 1, 0, 0)');
 
           // Now drop the element
           await fixture.events.mouse.up();
@@ -365,6 +361,121 @@ describe('Background Drop-Target integration', () => {
           const bgImg2 = bg2.querySelector('img');
           const combinedBgTransform2 = getAllTransformsBetween(bgImg2, bg2);
           expect(combinedBgTransform2).toBe('matrix(-1, 0, 0, 1, 0, 0)');
+        });
+      });
+
+      describe('when there is a third flipped image on the canvas', () => {
+        let flippedImageData;
+
+        beforeEach(async () => {
+          await fixture.events.click(fixture.editor.library.media.item(2));
+          flippedImageData = (await getElements(fixture))[2];
+
+          await fixture.events.click(
+            fixture.editor.inspector.designPanel.sizePosition.flipHorizontal
+          );
+
+          const element = fixture.editor.canvas.displayLayer.display(
+            flippedImageData.id
+          ).node;
+
+          await fixture.events.mouse.seq(({ moveRel, down, up }) => [
+            moveRel(element, '50%', '50%'),
+            down(),
+            moveRel(element, '50%', '200%'),
+            up(),
+          ]);
+        });
+
+        it('should correctly handle flipped image dropped into non-flipped image', async () => {
+          // Verify that non-flipped element has the correct transform (flip) before doing anything
+          let target = fixture.editor.canvas.displayLayer.display(imageData.id)
+            .node;
+          let rep = fixture.editor.canvas.displayLayer.display(imageData.id)
+            .replacement;
+          const targetImg = target.querySelector('img');
+          const transformBefore = getAllTransformsBetween(targetImg, target);
+          expect(transformBefore).toBe('');
+
+          // Drag the image element to the background
+          await dragCanvasElementToDropTarget(
+            fixture,
+            flippedImageData.id,
+            imageData.id
+          );
+
+          // Make sure rep is up to date with DOM mutations
+          target = fixture.editor.canvas.displayLayer.display(imageData.id)
+            .node;
+          rep = fixture.editor.canvas.displayLayer.display(imageData.id)
+            .replacement;
+
+          // Verify that replacement img has correct transform
+          const replaceImg = rep.querySelector('img');
+          const replTransform = getAllTransformsBetween(replaceImg, target);
+          expect(replTransform).toBe('');
+
+          // Now drop the element
+          await fixture.events.mouse.up();
+
+          // Verify that new combined element is still not flipped
+          const newElementId = (await getElements(fixture))[1].id;
+          const newTarget = fixture.editor.canvas.displayLayer.display(
+            newElementId
+          ).node;
+          const newTargetImg = newTarget.querySelector('img');
+          const transformAfter = getAllTransformsBetween(
+            newTargetImg,
+            newTarget
+          );
+          expect(transformAfter).toBe('');
+        });
+
+        it('should correctly handle non-flipped image dropped into flipped image', async () => {
+          // Verify that non-flipped element has the correct transform (flip) before doing anything
+          let target = fixture.editor.canvas.displayLayer.display(
+            flippedImageData.id
+          ).node;
+          let rep = fixture.editor.canvas.displayLayer.display(
+            flippedImageData.id
+          ).replacement;
+          const targetImg = target.querySelector('img');
+          const transformBefore = getAllTransformsBetween(targetImg, target);
+          expect(transformBefore).toBe('matrix(-1, 0, 0, 1, 0, 0)');
+
+          // Drag the image element to the background
+          await dragCanvasElementToDropTarget(
+            fixture,
+            imageData.id,
+            flippedImageData.id
+          );
+
+          // Make sure rep is up to date with DOM mutations
+          target = fixture.editor.canvas.displayLayer.display(
+            flippedImageData.id
+          ).node;
+          rep = fixture.editor.canvas.displayLayer.display(flippedImageData.id)
+            .replacement;
+
+          // Verify that replacement img has correct transform
+          const replaceImg = rep.querySelector('img');
+          const replTransform = getAllTransformsBetween(replaceImg, target);
+          expect(replTransform).toBe('matrix(-1, 0, 0, 1, 0, 0)');
+
+          // Now drop the element
+          await fixture.events.mouse.up();
+
+          // Verify that new combined element is still flipped
+          const newElementId = (await getElements(fixture))[1].id;
+          const newTarget = fixture.editor.canvas.displayLayer.display(
+            newElementId
+          ).node;
+          const newTargetImg = newTarget.querySelector('img');
+          const transformAfter = getAllTransformsBetween(
+            newTargetImg,
+            newTarget
+          );
+          expect(transformAfter).toBe('matrix(-1, 0, 0, 1, 0, 0)');
         });
       });
     });

--- a/assets/src/edit-story/components/dropTargets/karma/dropTarget.karma.js
+++ b/assets/src/edit-story/components/dropTargets/karma/dropTarget.karma.js
@@ -20,7 +20,7 @@
 import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
 
-describe('Background Drop-Target integration', () => {
+describe('Drop-Target integration', () => {
   let fixture;
 
   beforeEach(async () => {
@@ -397,7 +397,7 @@ describe('Background Drop-Target integration', () => {
           const transformBefore = getAllTransformsBetween(targetImg, target);
           expect(transformBefore).toBe('');
 
-          // Drag the image element to the background
+          // Drag the flipped image element to the non-flipped target
           await dragCanvasElementToDropTarget(
             fixture,
             flippedImageData.id,

--- a/assets/src/edit-story/elements/shared/getTransformFlip.js
+++ b/assets/src/edit-story/elements/shared/getTransformFlip.js
@@ -21,7 +21,8 @@
  * @return {string} CSS transform scale value.
  */
 function getTransformFlip(flip) {
-  if (!flip) {
+  // If no flip
+  if (!flip || (!flip.horizontal && !flip.vertical)) {
     return null;
   }
 

--- a/assets/src/edit-story/elements/shared/getTransformFlip.js
+++ b/assets/src/edit-story/elements/shared/getTransformFlip.js
@@ -21,18 +21,13 @@
  * @return {string} CSS transform scale value.
  */
 function getTransformFlip(flip) {
-  let transformFlip = null;
   if (!flip) {
-    return transformFlip;
+    return null;
   }
-  if (flip.vertical && flip.horizontal) {
-    transformFlip = 'scale3d(-1, -1, 1)';
-  } else if (flip.horizontal) {
-    transformFlip = 'scale3d(-1, 1, 1)';
-  } else if (flip.vertical) {
-    transformFlip = 'scale3d(1, -1, 1)';
-  }
-  return transformFlip;
+
+  const xSign = flip.horizontal ? '-' : '';
+  const ySign = flip.vertical ? '-' : '';
+  return `scale3d(${xSign}1, ${ySign}1, 1)`;
 }
 
 export default getTransformFlip;

--- a/assets/src/edit-story/masks/display.js
+++ b/assets/src/edit-story/masks/display.js
@@ -39,7 +39,7 @@ const FILL_STYLE = {
 export default function WithMask({
   element,
   fill,
-  style,
+  style = {},
   children,
   box,
   applyFlip = true,
@@ -49,12 +49,15 @@ export default function WithMask({
   const mask = getElementMask(element);
   const { flip, isBackground } = element;
 
-  const transformFlip = getTransformFlip(flip);
-  if (transformFlip && applyFlip) {
-    style.transform = style.transform
-      ? `${style.transform} ${transformFlip}`
-      : transformFlip;
-  }
+  const flipTransform = (applyFlip && getTransformFlip(flip)) || '';
+
+  const actualTransform = `${style.transform || ''} ${flipTransform}`.trim();
+
+  const fullStyle = {
+    ...(fill ? FILL_STYLE : {}),
+    ...style,
+    transform: actualTransform,
+  };
 
   // Don't display mask if we have a border, not to cut it off while resizing.
   // Note that border can be applied to a rectangle only anyway.
@@ -64,13 +67,7 @@ export default function WithMask({
     shouldDisplayBorder(element)
   ) {
     return (
-      <div
-        style={{
-          ...(fill ? FILL_STYLE : {}),
-          ...style,
-        }}
-        {...rest}
-      >
+      <div style={fullStyle} {...rest}>
         {children}
       </div>
     );
@@ -85,10 +82,10 @@ export default function WithMask({
 
   return (
     <div
+      className="this-is-foo"
       style={{
         pointerEvents: 'initial',
-        ...(fill ? FILL_STYLE : {}),
-        ...style,
+        ...fullStyle,
         ...(!isBackground ? { clipPath: `url(#${maskId})` } : {}),
       }}
       {...rest}

--- a/assets/src/edit-story/masks/display.js
+++ b/assets/src/edit-story/masks/display.js
@@ -82,7 +82,6 @@ export default function WithMask({
 
   return (
     <div
-      className="this-is-foo"
       style={{
         pointerEvents: 'initial',
         ...fullStyle,


### PR DESCRIPTION
## Context

This fixes the replacement image on drop hover on both background elements and regular elements.

When dropping into a background element, the flip of the dropped image is preserved, so the replacement image also reflects this.

When dropping into a regular element (masked or not), the flipped of the existing element is preserved, so the replace image also reflects this.

## Testing Instructions

### QA

This PR can be tested by following these steps:

#### Dragging flipped image to background
1. Drag an image into the background
2. Drag another image onto the canvas
3. Flip the second image
4. Drag it into the background
5. Observe that both the preview image before dropping and the background after drop is **flipped**

#### Dragging non-flipped image into flipped image
1. Drag two images onto the canvas
2. Flip image A
3. Drag (non-flipped) image B into (flipped) image A
5. Observe that both the preview image before dropping and the image after drop is **flipped**

#### Dragging flipped image into non-flipped image
1. Drag two images onto the canvas
2. Flip image A
3. Drag (flipped) image A into (non-flipped) image B
5. Observe that both the preview image before dropping and the image after drop is **not flipped**

### UAT

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6643
