### PR TITLE
Don't set resource width/height to inserted element size

### DIFF
--- a/assets/src/edit-story/components/canvas/test/getElementProperties.js
+++ b/assets/src/edit-story/components/canvas/test/getElementProperties.js
@@ -19,8 +19,7 @@
  */
 import { getElementProperties } from '../useInsertElement';
 
-const BASIC_SHAPE = {
-  id: '8e06a649-ad1f-455d-a76b-ad012aff08ad',
+const COMMON_PROPERTIES = {
   opacity: 100,
   flip: {
     vertical: false,
@@ -35,7 +34,6 @@ const BASIC_SHAPE = {
       b: 196,
     },
   },
-  type: 'shape',
   x: 94,
   y: 77,
   width: 137,
@@ -43,23 +41,74 @@ const BASIC_SHAPE = {
   scale: 100,
   focalX: 50,
   focalY: 50,
+};
+
+const BASIC_SHAPE = {
+  ...COMMON_PROPERTIES,
+  id: 'fake-shape-id',
+  backgroundColor: {
+    color: {
+      r: 196,
+      g: 196,
+      b: 196,
+    },
+  },
+  type: 'shape',
   mask: {
     type: 'triangle',
   },
 };
 
-describe('getElementProperties', () => {
-  it('should keep x,y unmodified', () => {
-    const inboundsX = 50;
-    const inboundsY = 25;
+const VIDEO_RESOURCE = {
+  type: 'video',
+  mimeType: 'video/webm',
+  creationDate: '2021-05-11T21:55:24',
+  src: 'http://test.example/video.mp4',
+  width: 720,
+  height: 1280,
+  poster: 'http://test.example/video-poster.jpg',
+  posterId: 92,
+  id: 91,
+  length: 6,
+  lengthFormatted: '0:06',
+  title: 'small-video',
+  alt: 'small-video',
+  sizes: {},
+  local: false,
+  isOptimized: false,
+  baseColor: [115, 71, 39],
+};
 
-    const result = getElementProperties(BASIC_SHAPE.type, {
+describe('getElementProperties', () => {
+  it('should default x/y to (48, 0) if not provided', () => {
+    const properties = getElementProperties('shape', {
       ...BASIC_SHAPE,
-      x: inboundsX,
-      y: inboundsY,
+      x: undefined,
+      y: undefined,
     });
 
-    expect(result.x).toBe(inboundsX);
-    expect(result.y).toBe(inboundsY);
+    expect(properties.x).toBe(48);
+    expect(properties.y).toBe(0);
+  });
+
+  it('should keep x/y unmodified', () => {
+    const properties = getElementProperties('shape', {
+      ...BASIC_SHAPE,
+      x: 50,
+      y: 25,
+    });
+
+    expect(properties.x).toBe(50);
+    expect(properties.y).toBe(25);
+  });
+
+  it('should keep resource width/height unmodified', () => {
+    const properties = getElementProperties('video', {
+      ...COMMON_PROPERTIES,
+      resource: VIDEO_RESOURCE,
+    });
+
+    expect(properties.resource.width).toBe(720);
+    expect(properties.resource.height).toBe(1280);
   });
 });

--- a/assets/src/edit-story/components/canvas/test/getElementProperties.js
+++ b/assets/src/edit-story/components/canvas/test/getElementProperties.js
@@ -102,13 +102,12 @@ describe('getElementProperties', () => {
     expect(properties.y).toBe(25);
   });
 
-  it('should keep resource width/height unmodified', () => {
+  it('should keep resource unmodified', () => {
     const properties = getElementProperties('video', {
       ...COMMON_PROPERTIES,
       resource: VIDEO_RESOURCE,
     });
 
-    expect(properties.resource.width).toBe(720);
-    expect(properties.resource.height).toBe(1280);
+    expect(properties.resource).toStrictEqual(VIDEO_RESOURCE);
   });
 });

--- a/assets/src/edit-story/components/canvas/useInsertElement.js
+++ b/assets/src/edit-story/components/canvas/useInsertElement.js
@@ -183,14 +183,7 @@ function getElementProperties(
 
   return {
     ...attrs,
-    ...(Boolean(resource) && {
-      resource: {
-        ...resource,
-        width,
-        height,
-        alt: resource.alt || '',
-      },
-    }),
+    resource,
     x,
     y,
     width,

--- a/assets/src/edit-story/components/inspector/karma/prepublishSelect.karma.js
+++ b/assets/src/edit-story/components/inspector/karma/prepublishSelect.karma.js
@@ -324,6 +324,8 @@ describe('Pre-publish checklist select offending elements onClick', () => {
           width: 640 / 2,
           height: 529 / 2,
           resource: {
+            width: 640,
+            height: 529,
             type: 'image',
             mimeType: 'image/jpg',
             src: 'http://localhost:9876/__static__/earth.jpg',


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

The new video optimization pre-publish check unexpectedly doesn't trigger when videos are inserted by (a) clicking on a video in the media panel or (b) opening the WP media popup and inserting a video from the "Media Library" tab.

Looks like the root cause is that we confusingly set `resource` width/height to the inserted element size in `useInsertElement`.

The incorrect size gets overridden to the correct size in some upload flows due to `getResourceFromAttachment`, which is why the video optimization pre-publish check only works sometimes.

AFAICT setting the resource size as such is incorrect, though I couldn't quite figure out the original rationale added in #566.

## Summary

This simple change fixes the issue for me locally.

## Relevant Technical Choices

I originally considered adding new "natural" or "native" size properties to the resource, but I think fixing the semantics of existing width/height properties is better if possible.

## To-do

N/A

## User-facing changes

The video optimization pre-publish check should reliably work (in the various ways of uploading and inserting elements). 

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

This PR can be tested by following these steps:

Upload a large video (resolution greater than 720x1280) and confirm that it triggers the video optimization check in the following ways:
1. Click "Upload" button, select the video in the popup, and click "Insert into page" once the upload completes
2. Click the "Upload" button, click the "Media Library" tab in the popup, select the already uploaded video, and click "Insert into page" to add it to the current page
3. Click the video in the editor's media panel to add it to the current page

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7476. Unblocks #7257.
