### PR TITLE
Page Templates: Add envelope support to REST API endpoint

### DIFF
--- a/includes/Page_Template_Post_Type.php
+++ b/includes/Page_Template_Post_Type.php
@@ -26,7 +26,7 @@
 
 namespace Google\Web_Stories;
 
-use Google\Web_Stories\REST_API\Stories_Base_Controller;
+use Google\Web_Stories\REST_API\Page_Template_Controller;
 use Google\Web_Stories\Traits\Post_Type;
 
 /**
@@ -116,7 +116,7 @@ class Page_Template_Post_Type extends Service_Base {
 				'public'                => false,
 				'show_ui'               => false,
 				'show_in_rest'          => true,
-				'rest_controller_class' => Stories_Base_Controller::class,
+				'rest_controller_class' => Page_Template_Controller::class,
 			]
 		);
 	}

--- a/includes/REST_API/Page_Template_Controller.php
+++ b/includes/REST_API/Page_Template_Controller.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Class Page_Template_Controller
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2021 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\REST_API;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Page_Template_Controller class.
+ */
+class Page_Template_Controller extends Stories_Base_Controller {
+	/**
+	 * Retrieves a collection of page templates.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+	 */
+	public function get_items( $request ) {
+		$response = parent::get_items( $request );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( $request['_web_stories_envelope'] ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$response = rest_get_server()->envelope_response( $response, isset( $request['_embed'] ) ? $request['_embed'] : false );
+		}
+		return $response;
+	}
+
+	/**
+	 * Retrieves the query params for the posts collection.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		$query_params = parent::get_collection_params();
+
+		$query_params['_web_stories_envelope'] = [
+			'description' => __( 'Envelope request for preloading.', 'web-stories' ),
+			'type'        => 'boolean',
+			'default'     => false,
+		];
+
+		return $query_params;
+	}
+}

--- a/tests/phpunit/tests/REST_API/Page_Template_Controller.php
+++ b/tests/phpunit/tests/REST_API/Page_Template_Controller.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests\REST_API;
+
+use Google\Web_Stories\Settings;
+use Google\Web_Stories\Tests\Test_REST_TestCase;
+use Spy_REST_Server;
+use WP_REST_Request;
+
+/**
+ * Class Page_Template_Controller
+ *
+ * @package Google\Web_Stories\Tests\REST_API
+ *
+ * @coversDefaultClass \Google\Web_Stories\REST_API\Page_Template_Controller
+ */
+class Page_Template_Controller extends Test_REST_TestCase {
+
+	protected $server;
+
+	protected static $user_id;
+	protected static $user2_id;
+	protected static $user3_id;
+
+	protected static $author_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$user_id = $factory->user->create(
+			[
+				'role'         => 'administrator',
+				'display_name' => 'Andrea Adams',
+			]
+		);
+
+		self::$user2_id = $factory->user->create(
+			[
+				'role'         => 'administrator',
+				'display_name' => 'Jane Doe',
+			]
+		);
+
+		self::$user3_id = $factory->user->create(
+			[
+				'role'         => 'administrator',
+				'display_name' => 'Zane Doe',
+			]
+		);
+
+		self::$author_id = $factory->user->create(
+			[
+				'role' => 'author',
+			]
+		);
+
+		$post_type = \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG;
+
+		$factory->post->create_many(
+			3,
+			[
+				'post_status' => 'publish',
+				'post_author' => self::$user_id,
+				'post_type'   => $post_type,
+			]
+		);
+
+		$future_date = strtotime( '+1 day' );
+
+		$factory->post->create_many(
+			3,
+			[
+				'post_status' => 'future',
+				'post_date'   => strftime( '%Y-%m-%d %H:%M:%S', $future_date ),
+				'post_author' => self::$user_id,
+				'post_type'   => $post_type,
+			]
+		);
+
+		$factory->post->create_many(
+			2,
+			[
+				'post_status' => 'publish',
+				'post_author' => self::$user2_id,
+				'post_type'   => $post_type,
+			]
+		);
+
+		$factory->post->create_many(
+			2,
+			[
+				'post_status' => 'publish',
+				'post_author' => self::$user3_id,
+				'post_type'   => $post_type,
+			]
+		);
+
+		$factory->post->create_many(
+			3,
+			[
+				'post_status' => 'draft',
+				'post_author' => self::$user_id,
+				'post_type'   => $post_type,
+			]
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$user_id );
+		self::delete_user( self::$user2_id );
+		self::delete_user( self::$user3_id );
+		self::delete_user( self::$author_id );
+	}
+
+	public function setUp() {
+		parent::setUp();
+
+		/** @var \WP_REST_Server $wp_rest_server */
+		global $wp_rest_server;
+		$wp_rest_server = new Spy_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+
+		$this->add_caps_to_roles();
+
+		$this->set_permalink_structure( '/%postname%/' );
+	}
+
+	public function tearDown() {
+		/** @var \WP_REST_Server $wp_rest_server */
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		$this->remove_caps_from_roles();
+
+		$this->set_permalink_structure( '' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers ::register_routes
+	 */
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/web-stories/v1/web-story', $routes );
+		$this->assertCount( 2, $routes['/web-stories/v1/web-story'] );
+	}
+
+	/**
+	 * @covers ::get_items
+	 */
+	public function test_get_items_format() {
+		wp_set_current_user( self::$user_id );
+		$request = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/web-story' );
+		$request->set_param( 'status', [ 'draft' ] );
+		$request->set_param( 'context', 'edit' );
+		$request->set_param( '_web_stories_envelope', true );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Body of request.
+		$this->assertArrayHasKey( 'headers', $data );
+		$this->assertArrayHasKey( 'body', $data );
+		$this->assertArrayHasKey( 'status', $data );
+
+		$this->assertEquals( 3, $data['headers']['X-WP-Total'] );
+	}
+}


### PR DESCRIPTION
## Context
From https://github.com/google/web-stories-wp/pull/7477

## Summary

Add pagination for saved page templates to rest api

## Relevant Technical Choices

Simply move logic to base class. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
