### PR TITLE
Call `setup_new_site()` upon plugin activation

### DIFF
--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -83,6 +83,7 @@ function rewrite_flush() {
  * @return void
  */
 function activate( $network_wide = false ) {
+	setup_new_site();
 	get_plugin_instance()->activate( $network_wide );
 
 	do_action( 'web_stories_activation', $network_wide );

--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -55,7 +55,6 @@ function setup_new_site() {
 	$database_upgrader->register();
 }
 
-
 /**
  * Flush rewrites.
  *
@@ -83,7 +82,10 @@ function rewrite_flush() {
  * @return void
  */
 function activate( $network_wide = false ) {
+	// Ensures capabilities are properly set up as that class is not a service.
 	setup_new_site();
+
+	// Runs all activateable services.
 	get_plugin_instance()->activate( $network_wide );
 
 	do_action( 'web_stories_activation', $network_wide );
@@ -111,8 +113,8 @@ function new_site( $site ) {
 	setup_new_site();
 	restore_current_blog();
 }
-add_action( 'wp_initialize_site', __NAMESPACE__ . '\new_site', PHP_INT_MAX );
 
+add_action( 'wp_initialize_site', __NAMESPACE__ . '\new_site', PHP_INT_MAX );
 
 /**
  * Hook into delete site.
@@ -178,6 +180,7 @@ register_deactivation_hook( WEBSTORIES_PLUGIN_FILE, __NAMESPACE__ . '\deactivate
 function load_amp_plugin_compat() {
 	require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/compat/amp.php';
 }
+
 add_action( 'wp', __NAMESPACE__ . '\load_amp_plugin_compat' );
 
 
@@ -189,8 +192,8 @@ add_action( 'wp', __NAMESPACE__ . '\load_amp_plugin_compat' );
 function includes() {
 	require_once WEBSTORIES_PLUGIN_DIR_PATH . 'includes/functions.php';
 }
-add_action( 'init', __NAMESPACE__ . '\includes' );
 
+add_action( 'init', __NAMESPACE__ . '\includes' );
 
 /**
  * Append result of internal request to REST API for purpose of preloading data to be attached to a page.
@@ -268,8 +271,6 @@ function rest_preload_api_request( $memo, $path ) {
 	return $memo;
 }
 
-get_plugin_instance()->register();
-
 /**
  * Web stories Plugin Instance
  *
@@ -284,3 +285,6 @@ function get_plugin_instance() {
 
 	return $web_stories;
 }
+
+// Initialize plugin by registering all services.
+get_plugin_instance()->register();


### PR DESCRIPTION
## Context

Site setup logic was not being run during plugin activation

## Summary

Adds back the `setup_new_site()` call we had here previously.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

* Investigate why e2e tests didn't catch this.

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Install plugin on a fresh site (locally, or Jurassic Ninja or similar)
2. Activate plugin
3. Verify the "Stories" admin menu item is visible
4. Verify the DB upgrader did run by checking the DB version in `wp_options` / `wp-admin/options.php`

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7488
