### PR TITLE
Fix: focusing on media input buttons when highlighted from checklist

### DIFF
--- a/assets/src/design-system/components/mediaInput/index.js
+++ b/assets/src/design-system/components/mediaInput/index.js
@@ -43,9 +43,6 @@ const MediaRectangle = styled.section`
   width: 100%;
   height: 100%;
   background-color: ${({ theme }) => theme.colors.bg.primary};
-  :focus {
-    outline: -webkit-focus-ring-color auto 1px;
-  }
   border-radius: 4px;
   position: relative;
 `;
@@ -172,16 +169,17 @@ export const MediaInput = forwardRef(function Media(
   const hasMenu = menuOptions?.length > 0;
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-  const buttonRef = useRef(null);
-
   const listId = useMemo(() => `list-${uuidv4()}`, []);
   const buttonId = useMemo(() => `button-${uuidv4()}`, []);
+
+  const defaultRef = useRef(null);
+  const buttonRef = ref ?? defaultRef;
 
   const StyledMedia = MediaOptions[variant];
   // Media input only allows simplified dropdown with one group.
   const options = [{ group: menuOptions }];
   return (
-    <StyledMedia ref={ref} className={className} {...rest}>
+    <StyledMedia className={className} {...rest}>
       <ImageWrapper variant={variant}>
         {value ? (
           <Img src={value} alt={alt} crossOrigin="anonymous" />

--- a/assets/src/edit-story/components/form/media.js
+++ b/assets/src/edit-story/components/form/media.js
@@ -26,13 +26,16 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { useMediaPicker } from '../mediaPicker';
-import { MediaInput as Input } from '../../../design-system/components/mediaInput';
+import { MediaInput as Input, themeHelpers } from '../../../design-system';
 import { MULTIPLE_VALUE } from '../../constants';
-import { focusStyle } from '../panels/shared';
 
 const StyledInput = styled(Input)`
-  button {
-    ${focusStyle};
+  button:focus {
+    ${({ theme }) =>
+      themeHelpers.focusCSS(
+        theme.colors.border.focus,
+        theme.colors.bg.secondary
+      )}
   }
 `;
 

--- a/assets/src/edit-story/components/inspector/karma/prepublishSelect.karma.js
+++ b/assets/src/edit-story/components/inspector/karma/prepublishSelect.karma.js
@@ -351,7 +351,7 @@ describe('Pre-publish checklist select offending elements onClick', () => {
       );
     });
 
-    it('should open the document inspector panel', async () => {
+    it('should open the document inspector panel and focus the media button', async () => {
       await enableHighPriorityMessagesWith5Pages();
       await fixture.events.click(fixture.editor.library.media.item(0));
 
@@ -377,6 +377,8 @@ describe('Pre-publish checklist select offending elements onClick', () => {
           )
         ).not.toBeNull();
       });
+      const mediaButton = fixture.screen.getByLabelText('Poster image');
+      expect(mediaButton.contains(document.activeElement)).toBeTrue();
       await fixture.snapshot('document tab opened by checklist panel');
     });
   });

--- a/assets/src/edit-story/components/inspector/prepublish/components/checklistTab.js
+++ b/assets/src/edit-story/components/inspector/prepublish/components/checklistTab.js
@@ -154,9 +154,10 @@ const ChecklistTab = ({
 
       return {
         onClick: () => setHighlights(args),
-        onKeyUp: (event) => {
+        onKeyDown: (event) => {
           if (event.key === 'Enter') {
             event.preventDefault();
+            event.stopPropagation();
             setHighlights(args);
           }
         },

--- a/assets/src/edit-story/components/panels/document/publish/publish.js
+++ b/assets/src/edit-story/components/panels/document/publish/publish.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { useCallback, useRef, useMemo } from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { __, sprintf, translateToExclusiveList } from '@web-stories-wp/i18n';
 
 /**
@@ -58,11 +58,6 @@ const MediaWrapper = styled.div`
 const StyledMedia = styled(Media)`
   width: ${({ width }) => width}px;
   height: ${({ height }) => height}px;
-  ${({ isHighlighted }) =>
-    isHighlighted &&
-    css`
-      ${styles.OUTLINE}
-    `}
 `;
 
 const HighlightRow = styled(Row)`
@@ -198,7 +193,6 @@ function PublishPanel() {
           <MediaInputWrapper>
             <MediaWrapper>
               <StyledMedia
-                isHighlighted={highlightPoster?.showEffect}
                 ref={posterButtonRef}
                 width={54}
                 height={96}
@@ -219,7 +213,6 @@ function PublishPanel() {
           <MediaInputWrapper>
             <MediaWrapper>
               <StyledMedia
-                isHighlighted={highlightLogo?.showEffect}
                 width={72}
                 height={72}
                 ref={publisherLogoRef}


### PR DESCRIPTION
## Context
- When selecting the prepublish item from the checklist, it should focus the relevant input for best accessibility. 
- The poster image button was not being focused or styled when selecting the "Add poster image" item from the checklist.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- This PR adds the correct focus behavior and styles to the selection of the Add poster image item from the checklist
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- `focusStyle` was not working for the media input button due to the way highlights work, where it gets a ref and calls `.focus()` in order to focus a button from context. The styles are not applied to `:focus` items but to some other selector. If there's a better way to apply this style, please let me know. This is what got it to work in any focus case (tabbing + selecting from ppc)
- added a `stopPropagation` to the set highlight event to prevent selected items on the canvas from also getting the `onKeyDown` event.
- Changed `onKeyUp` back to `onKeyDown`. Didn't work otherwise.
- The placeholder image to show the selected media for the media input doesn't need to be focused, so I removed those styles.
- The button ref is the only ref that matters in terms of the `MediaInput`'s API, it's the only `ref` that needs to be used externally so I got rid of the ref which was being forwarded onto the containing div and swapped out the button ref for the provided ref, if it was provided. The component's internals also need a default ref, that's the meaning behind the `defaultRef` changes in the display component.
- Removed some unneeded styles.
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
**After**
https://user-images.githubusercontent.com/41136059/117869652-e7707700-b24f-11eb-9823-92e3d2f6677a.mp4

**Before**
https://user-images.githubusercontent.com/41136059/117869658-e93a3a80-b24f-11eb-90b1-3c03827accc7.mp4


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Edit/choose a template (the important part is to make sure you don't have a poster image for the story but have enough pages so that the prepublish checklist will be active -- any template should have enough pages to activate the prepublish checklist)
2. Open the checklist
3. Click "Add poster image"
4. The tab should change to the Document tab and the button should be focused (you can press enter and it should open the media picker)
5. Repeat the same experience but click on the checklist tab, press "tab" until the Add poster image title is focused, then press "enter"
6. The tab should change to the Document tab and the button should be focused (you can press enter and it should open the media picker)

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
