### PR TITLE
Fix AMP plugin version comparison

### DIFF
--- a/includes/Integrations/AMP.php
+++ b/includes/Integrations/AMP.php
@@ -228,12 +228,13 @@ class AMP extends Service_Base {
 	 * @return bool Whether post should be skipped from AMP.
 	 */
 	public function filter_amp_skip_post( $skipped, $post ) {
+		// This is the opposite to the `AMP__VERSION >= WEBSTORIES_AMP_VERSION` check in the HTML renderer.
 		if (
 			'web-story' === get_post_type( $post )
 			&&
 			defined( '\AMP__VERSION' )
 			&&
-			version_compare( WEBSTORIES_AMP_VERSION, AMP__VERSION, '>=' )
+			version_compare( WEBSTORIES_AMP_VERSION, AMP__VERSION, '>' )
 		) {
 			return true;
 		}


### PR DESCRIPTION
## Context

There was a reported incompatibility with the AMP plugin 2.1.1.

## Summary

This fixes an incorrect version comparison introduced in #7187 so it correctly matches the intended behavior (skip AMP if plugin is older, _but not equal_).

**The behavior we want:**

* In `HTML`, skip AMP logic if the AMP plugin version >= our bundled version
* In `AMP` integration class, skip logic if the AMP plugin version < our bundled version

Before this PR, if both versions were equal (==), both logic was skipped, so neither plugin did anything.

**Why wasn't this caught before**

Until very recently, we bundled 2.1.1-alpha, a pre-release version. So this wasn't caught in any real life scenarios on production sites.

**How this can be prevented in the future**

There could be some automated tests (see to-do below).

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

- Catch this in automated tests (e2e tests, or release-specific tests). See #7209

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

1. Activate AMP 2.1.1
2. View a web story
3. Verify that there are no AMP validation errors.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7506
