### PR TITLE
Cherry-pick changes for 1.7.0

### DIFF
--- a/includes/Integrations/AMP.php
+++ b/includes/Integrations/AMP.php
@@ -228,12 +228,13 @@ class AMP extends Service_Base {
 	 * @return bool Whether post should be skipped from AMP.
 	 */
 	public function filter_amp_skip_post( $skipped, $post ) {
+		// This is the opposite to the `AMP__VERSION >= WEBSTORIES_AMP_VERSION` check in the HTML renderer.
 		if (
 			'web-story' === get_post_type( $post )
 			&&
 			defined( '\AMP__VERSION' )
 			&&
-			version_compare( WEBSTORIES_AMP_VERSION, AMP__VERSION, '>=' )
+			version_compare( WEBSTORIES_AMP_VERSION, AMP__VERSION, '>' )
 		) {
 			return true;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,12 @@ Web Stories are powered by [AMP](https://amp.dev/), which adds some restrictions
 
 For the plugin's full changelog, please see [the Releases page on GitHub](https://github.com/google/web-stories-wp/releases).
 
+= 1.7.1 =
+
+**Release Date:** May 13, 2021.
+
+* Fixes an incompatibility with the AMP plugin.
+
 = 1.7.0 =
 
 **Release Date:** May 11, 2021.
@@ -193,6 +199,10 @@ For the plugin's full changelog, please see [the Releases page on GitHub](https:
 * Initial stable release.
 
 == Upgrade Notice ==
+
+= 1.7.1 =
+
+Custom page templates, improved pre-publish checklist, bug fixes and performance improvements.
 
 = 1.7.0 =
 


### PR DESCRIPTION
Copies upgrade notice so users will see all the features from the “skipped” 1.7.0 release

See #7484 