### PR TITLE
Disable ESM modules in AMP optimizer

### DIFF
--- a/includes/AMP/Optimization.php
+++ b/includes/AMP/Optimization.php
@@ -149,6 +149,12 @@ class Optimization {
 
 		$configuration = [
 			Configuration::KEY_TRANSFORMERS => $transformers,
+			// Temporarily disable ESM transformation since STAMP preview mode (#development=1)
+			// is unavailable in amp-story-1.0.mjs. 
+			// https://github.com/ampproject/amphtml/issues/34364
+			RewriteAmpUrls::class => [
+				Configuration\RewriteAmpUrlsConfiguration::ESM_MODULES_ENABLED => false,
+			],
 		];
 
 		/**

--- a/includes/AMP/Optimization.php
+++ b/includes/AMP/Optimization.php
@@ -150,9 +150,8 @@ class Optimization {
 		$configuration = [
 			Configuration::KEY_TRANSFORMERS => $transformers,
 			// Temporarily disable ESM transformation since STAMP preview mode (#development=1)
-			// is unavailable in amp-story-1.0.mjs. 
-			// https://github.com/ampproject/amphtml/issues/34364
-			RewriteAmpUrls::class => [
+			// is unavailable in amp-story-1.0.mjs (https://github.com/ampproject/amphtml/issues/34364).
+			RewriteAmpUrls::class           => [
 				Configuration\RewriteAmpUrlsConfiguration::ESM_MODULES_ENABLED => false,
 			],
 		];

--- a/includes/Integrations/AMP.php
+++ b/includes/Integrations/AMP.php
@@ -26,6 +26,7 @@
 
 namespace Google\Web_Stories\Integrations;
 
+use AmpProject\Optimizer;
 use DOMElement;
 use Google\Web_Stories\AMP\Integration\AMP_Story_Sanitizer;
 use Google\Web_Stories\Model\Story;
@@ -66,6 +67,7 @@ class AMP extends Service_Base {
 		add_filter( 'amp_content_sanitizers', [ $this, 'add_amp_content_sanitizers' ] );
 		add_filter( 'amp_validation_error_sanitized', [ $this, 'filter_amp_validation_error_sanitized' ], 10, 2 );
 		add_filter( 'amp_skip_post', [ $this, 'filter_amp_skip_post' ], 10, 2 );
+		add_filter( 'amp_optimizer_config', [ $this, 'filter_amp_optimizer_config' ] );
 
 		// This filter is actually used in this plugin's `Sanitization` class.
 		add_filter( 'web_stories_amp_validation_error_sanitized', [ $this, 'filter_amp_validation_error_sanitized' ], 10, 2 );
@@ -240,6 +242,22 @@ class AMP extends Service_Base {
 		}
 
 		return $skipped;
+	}
+
+	/**
+	 * Temporarily disable ESM transformation since STAMP preview mode (#development=1) is unavailable in amp-story-1.0.mjs.
+	 *
+	 * @since 1.7.2
+	 *
+	 * @link https://github.com/ampproject/amphtml/issues/34364
+	 *
+	 * @param array $configuration The AMP Optimizer configuration.
+	 *
+	 * @return array The modified configuration.
+	 */
+	public function filter_amp_optimizer_config( $configuration ) {
+		$configuration[ Optimizer\Transformer\RewriteAmpUrls::class ][ Optimizer\Configuration\RewriteAmpUrlsConfiguration::ESM_MODULES_ENABLED ] = false;
+		return $configuration;
 	}
 
 	/**

--- a/tests/phpunit/tests/AMP/Optimization.php
+++ b/tests/phpunit/tests/AMP/Optimization.php
@@ -82,8 +82,9 @@ class Optimization extends Test_Case {
 
 		$transformers = Configuration::DEFAULT_TRANSFORMERS;
 
-		$this->assertCount( 1, $config_array );
+		$this->assertCount( 2, $config_array );
 		$this->assertArrayHasKey( 'transformers', $config_array );
+		$this->assertArrayHasKey( RewriteAmpUrls::class, $config_array );
 		$this->assertEqualSets( $transformers, $config_array['transformers'] );
 	}
 
@@ -104,8 +105,9 @@ class Optimization extends Test_Case {
 			ReorderHead::class,
 		];
 
-		$this->assertCount( 1, $config_array );
+		$this->assertCount( 2, $config_array );
 		$this->assertArrayHasKey( 'transformers', $config_array );
+		$this->assertArrayHasKey( RewriteAmpUrls::class, $config_array );
 		$this->assertEqualSets( $transformers, $config_array['transformers'] );
 	}
 }


### PR DESCRIPTION
## Context

#7516. 

STAMP preview mode (`#development=1`) doesn't work in AMP's ESM modules output, which I believe was enabled in the latest version of AMP WP plugin bundled with v1.7.

## Summary

Disable ESM module rewriting in the AMP optimizer.

## Relevant Technical Choices

- We could consider keeping ESM module rewriting in the published story (and non-ESM in preview).

## To-do

N/A

## User-facing changes

The STAMP preview mode should work again if the WP AMP plugin is not also installed.

## Testing Instructions

### QA

<!--
Not all changes require manual QA.
-->

This PR can be tested by following these steps:

1. Open a story and click the preview button.
2. The multiple device emulation preview mode should be displayed (not just the story itself).

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7516.
