### PR TITLE
Quick Actions: Foreground image actions

### DIFF
--- a/assets/src/design-system/components/contextMenu/menuItem.js
+++ b/assets/src/design-system/components/contextMenu/menuItem.js
@@ -68,6 +68,7 @@ export const MenuItem = ({
   onFocus,
   shortcut,
   Icon,
+  ...menuItemProps
 }) => {
   const itemRef = useRef(null);
   /**
@@ -127,6 +128,7 @@ export const MenuItem = ({
         onClick={handleClick}
         onFocus={onFocus}
         {...newTabProps}
+        {...menuItemProps}
       >
         {textContent}
       </StyledLink>
@@ -141,13 +143,14 @@ export const MenuItem = ({
         disabled={disabled}
         onClick={handleClick}
         onFocus={onFocus}
+        {...menuItemProps}
       >
         {textContent}
       </StyledButton>
     );
   }
 
-  return <div>{textContent}</div>;
+  return <div {...menuItemProps}>{textContent}</div>;
 };
 
 /**

--- a/assets/src/design-system/components/tooltip/index.js
+++ b/assets/src/design-system/components/tooltip/index.js
@@ -48,7 +48,7 @@ const TooltipContainer = styled.div`
   align-items: center;
   text-align: center;
   flex-direction: row;
-  max-width: 13em;
+  max-width: 14em;
   transition: 0.4s opacity;
   opacity: ${({ shown }) => (shown ? 1 : 0)};
   pointer-events: ${({ shown }) => (shown ? 'all' : 'none')};

--- a/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
@@ -24,7 +24,16 @@ import { useQuickActions } from '..';
 import { states } from '../..';
 import useHighlights from '../../useHighlights';
 import { useStory } from '../../../story';
-import { Bucket, LetterTPlus, Media } from '../../../../../design-system/icons';
+import {
+  Bucket,
+  CircleSpeed,
+  Eraser,
+  LetterTPlus,
+  Link,
+  Media,
+  PictureSwap,
+} from '../../../../../design-system/icons';
+import { ACTION_TEXT } from '../useQuickActions';
 
 jest.mock('../../../story', () => ({
   useStory: jest.fn(),
@@ -34,6 +43,10 @@ jest.mock('../../useHighlights', () => ({
   __esModule: true,
   default: jest.fn(),
 }));
+
+const mockClickEvent = {
+  preventDefault: jest.fn(),
+};
 
 const BACKGROUND_ELEMENT = {
   id: 'background-element-id',
@@ -63,19 +76,42 @@ const VIDEO_ELEMENT = {
 
 const defaultQuickActions = [
   expect.objectContaining({
-    label: 'Change background color',
+    label: ACTION_TEXT.CHANGE_BACKGROUND_COLOR,
     onClick: expect.any(Function),
     Icon: Bucket,
   }),
   expect.objectContaining({
-    label: 'Insert background media',
+    label: ACTION_TEXT.INSERT_BACKGROUND_MEDIA,
     onClick: expect.any(Function),
     Icon: Media,
   }),
   expect.objectContaining({
-    label: 'Insert text',
+    label: ACTION_TEXT.INSERT_TEXT,
     onClick: expect.any(Function),
     Icon: LetterTPlus,
+  }),
+];
+
+const foregroundImageQuickActions = [
+  expect.objectContaining({
+    label: ACTION_TEXT.REPLACE_MEDIA,
+    onClick: expect.any(Function),
+    Icon: PictureSwap,
+  }),
+  expect.objectContaining({
+    label: ACTION_TEXT.ADD_ANIMATION,
+    onClick: expect.any(Function),
+    Icon: CircleSpeed,
+  }),
+  expect.objectContaining({
+    label: ACTION_TEXT.ADD_LINK,
+    onClick: expect.any(Function),
+    Icon: Link,
+  }),
+  expect.objectContaining({
+    label: ACTION_TEXT.CLEAR_FILTERS_AND_ANIMATIONS,
+    onClick: expect.any(Function),
+    Icon: Eraser,
   }),
 ];
 
@@ -138,19 +174,19 @@ describe('useQuickActions', () => {
     it('should set the correct highlight', () => {
       const { result } = renderHook(() => useQuickActions());
 
-      result.current[0].onClick();
+      result.current[0].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
-        elementId: 'background-element-id',
+        elementId: BACKGROUND_ELEMENT.id,
         highlight: states.PAGE_BACKGROUND,
       });
 
-      result.current[1].onClick();
+      result.current[1].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: undefined,
         highlight: states.MEDIA,
       });
 
-      result.current[2].onClick();
+      result.current[2].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: undefined,
         highlight: states.TEXT,
@@ -177,19 +213,19 @@ describe('useQuickActions', () => {
     it('should set the correct highlight', () => {
       const { result } = renderHook(() => useQuickActions());
 
-      result.current[0].onClick();
+      result.current[0].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
-        elementId: 'background-element-id',
+        elementId: BACKGROUND_ELEMENT.id,
         highlight: states.PAGE_BACKGROUND,
       });
 
-      result.current[1].onClick();
+      result.current[1].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: undefined,
         highlight: states.MEDIA,
       });
 
-      result.current[2].onClick();
+      result.current[2].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: undefined,
         highlight: states.TEXT,
@@ -207,8 +243,38 @@ describe('useQuickActions', () => {
       });
     });
 
-    it.todo('should return the quick actions');
-    it.todo('should set the correct highlight');
+    it('should return the quick actions', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      expect(result.current).toStrictEqual(foregroundImageQuickActions);
+    });
+
+    it('should set the correct highlight', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      result.current[0].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: IMAGE_ELEMENT.id,
+        highlight: states.MEDIA,
+      });
+
+      result.current[1].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: IMAGE_ELEMENT.id,
+        highlight: states.ANIMATION,
+      });
+
+      result.current[2].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: IMAGE_ELEMENT.id,
+        highlight: states.LINK,
+      });
+
+      result.current[3].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: IMAGE_ELEMENT.id,
+      });
+    });
   });
 
   describe('shape element selected', () => {

--- a/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
@@ -40,11 +40,13 @@ jest.mock('../../../story', () => ({
 }));
 
 jest.mock('../../useHighlights', () => ({
+  ...jest.requireActual('../../useHighlights'),
   __esModule: true,
   default: jest.fn(),
 }));
 
 jest.mock('../../../../../design-system', () => ({
+  ...jest.requireActual('../../../../../design-system'),
   useSnackbar: () => ({ showSnackbar: jest.fn() }),
 }));
 
@@ -123,6 +125,7 @@ describe('useQuickActions', () => {
   let highlight;
   const mockUseHighlights = useHighlights;
   const mockUseStory = useStory;
+  const mockUpdateElementsById = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -138,7 +141,9 @@ describe('useQuickActions', () => {
       currentPage: {
         elements: [BACKGROUND_ELEMENT],
       },
+      selectedElementAnimations: [],
       selectedElements: [],
+      updateElementsById: mockUpdateElementsById,
     });
   });
 
@@ -148,7 +153,9 @@ describe('useQuickActions', () => {
         currentPage: {
           elements: [BACKGROUND_ELEMENT, IMAGE_ELEMENT, VIDEO_ELEMENT],
         },
+        selectedElementAnimations: [],
         selectedElements: [IMAGE_ELEMENT, VIDEO_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
       });
     });
 
@@ -165,7 +172,9 @@ describe('useQuickActions', () => {
         currentPage: {
           elements: [BACKGROUND_ELEMENT],
         },
+        selectedElementAnimations: [],
         selectedElements: [],
+        updateElementsById: mockUpdateElementsById,
       });
     });
 
@@ -204,7 +213,9 @@ describe('useQuickActions', () => {
         currentPage: {
           elements: [BACKGROUND_ELEMENT],
         },
+        selectedElementAnimations: [],
         selectedElements: [BACKGROUND_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
       });
     });
 
@@ -243,7 +254,13 @@ describe('useQuickActions', () => {
         currentPage: {
           elements: [BACKGROUND_ELEMENT, IMAGE_ELEMENT],
         },
+        selectedElementAnimations: [
+          {
+            target: [IMAGE_ELEMENT.id],
+          },
+        ],
         selectedElements: [IMAGE_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
       });
     });
 
@@ -273,10 +290,15 @@ describe('useQuickActions', () => {
         elementId: IMAGE_ELEMENT.id,
         highlight: states.LINK,
       });
+    });
+
+    it('clicking `clear animations` should call `updateElementsById`', () => {
+      const { result } = renderHook(() => useQuickActions());
 
       result.current[3].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: IMAGE_ELEMENT.id,
+      expect(mockUpdateElementsById).toHaveBeenCalledWith({
+        elementIds: [IMAGE_ELEMENT.id],
+        properties: expect.any(Function),
       });
     });
   });
@@ -287,7 +309,9 @@ describe('useQuickActions', () => {
         currentPage: {
           elements: [BACKGROUND_ELEMENT, SHAPE_ELEMENT],
         },
+        selectedElementAnimations: [],
         selectedElements: [SHAPE_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
       });
     });
 
@@ -301,7 +325,9 @@ describe('useQuickActions', () => {
         currentPage: {
           elements: [BACKGROUND_ELEMENT, VIDEO_ELEMENT],
         },
+        selectedElementAnimations: [],
         selectedElements: [VIDEO_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
       });
     });
     it.todo('should return the quick actions');
@@ -314,7 +340,9 @@ describe('useQuickActions', () => {
         currentPage: {
           elements: [BACKGROUND_ELEMENT, TEXT_ELEMENT],
         },
+        selectedElementAnimations: [],
         selectedElements: [TEXT_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
       });
     });
 

--- a/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
@@ -44,6 +44,10 @@ jest.mock('../../useHighlights', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('../../../../../design-system', () => ({
+  useSnackbar: () => ({ showSnackbar: jest.fn() }),
+}));
+
 const mockClickEvent = {
   preventDefault: jest.fn(),
 };
@@ -255,7 +259,7 @@ describe('useQuickActions', () => {
       result.current[0].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: IMAGE_ELEMENT.id,
-        highlight: states.MEDIA,
+        highlight: states.MEDIA3P,
       });
 
       result.current[1].onClick(mockClickEvent);

--- a/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
@@ -115,7 +115,7 @@ const foregroundImageQuickActions = [
     Icon: Link,
   }),
   expect.objectContaining({
-    label: ACTION_TEXT.CLEAR_FILTERS_AND_ANIMATIONS,
+    label: ACTION_TEXT.CLEAR_ANIMATIONS,
     onClick: expect.any(Function),
     Icon: Eraser,
   }),

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -23,7 +23,16 @@ import { useCallback, useMemo } from 'react';
  * Internal dependencies
  */
 import { states, useHighlights } from '..';
-import { Bucket, LetterTPlus, Media } from '../../../../design-system/icons';
+import { noop } from '../../../../design-system';
+import {
+  Bucket,
+  CircleSpeed,
+  Eraser,
+  LetterTPlus,
+  Link,
+  Media,
+  PictureSwap,
+} from '../../../../design-system/icons';
 import { useStory } from '../../story';
 
 /** @typedef {import('../../../../design-system/components').MenuItemProps} MenuItemProps */
@@ -36,9 +45,16 @@ export const ELEMENT_TYPE = {
 };
 
 export const ACTION_TEXT = {
+  ADD_ANIMATION: __('Add animation', 'web-stories'),
+  ADD_LINK: __('Add Link', 'web-stories'),
   CHANGE_BACKGROUND_COLOR: __('Change background color', 'web-stories'),
+  CLEAR_FILTERS_AND_ANIMATIONS: __(
+    'Clear filters and animations',
+    'web-stories'
+  ),
   INSERT_BACKGROUND_MEDIA: __('Insert background media', 'web-stories'),
   INSERT_TEXT: __('Insert text', 'web-stories'),
+  REPLACE_MEDIA: __('Replace media', 'web-stories'),
 };
 
 /**
@@ -63,7 +79,8 @@ const useQuickActions = () => {
   }));
 
   const handleFocusPanel = useCallback(
-    (highlight) => (elementId) => () => {
+    (highlight) => (elementId) => (ev) => {
+      ev.stopPropagation();
       setHighlights({ elementId, highlight });
     },
     [setHighlights]
@@ -113,6 +130,33 @@ const useQuickActions = () => {
     ]
   );
 
+  const foregroundImageActions = useMemo(
+    () => [
+      {
+        Icon: PictureSwap,
+        label: ACTION_TEXT.REPLACE_MEDIA,
+        onClick: noop,
+      },
+      {
+        Icon: CircleSpeed,
+        label: ACTION_TEXT.ADD_ANIMATION,
+        onClick: noop,
+      },
+      {
+        Icon: Link,
+        label: ACTION_TEXT.ADD_LINK,
+        onClick: noop,
+      },
+      {
+        Icon: Eraser,
+        label: ACTION_TEXT.CLEAR_FILTERS_AND_ANIMATIONS,
+        onClick: noop,
+        separator: 'top',
+      },
+    ],
+    []
+  );
+
   // Hide menu if there are multiple elements selected
   if (selectedElements.length > 1) {
     return [];
@@ -130,6 +174,7 @@ const useQuickActions = () => {
 
   switch (selectedElements?.[0]?.type) {
     case ELEMENT_TYPE.IMAGE:
+      return foregroundImageActions;
     case ELEMENT_TYPE.SHAPE:
     case ELEMENT_TYPE.TEXT:
     case ELEMENT_TYPE.VIDEO:

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -23,7 +23,6 @@ import { useCallback, useMemo } from 'react';
  * Internal dependencies
  */
 import { states, useHighlights } from '..';
-import { noop } from '../../../../design-system';
 import {
   Bucket,
   CircleSpeed,
@@ -77,6 +76,13 @@ const useQuickActions = () => {
   const { setHighlights } = useHighlights(({ setHighlights }) => ({
     setHighlights,
   }));
+
+  const handleClearFiltersAndAnimations = useCallback(
+    (elementId) => {
+      setHighlights({ elementId });
+    },
+    [setHighlights]
+  );
 
   const handleFocusPanel = useCallback(
     (highlight) => (elementId) => (ev) => {
@@ -155,11 +161,12 @@ const useQuickActions = () => {
       {
         Icon: Eraser,
         label: ACTION_TEXT.CLEAR_FILTERS_AND_ANIMATIONS,
-        onClick: noop,
+        onClick: () => handleClearFiltersAndAnimations(selectedElement?.id),
         separator: 'top',
       },
     ],
     [
+      handleClearFiltersAndAnimations,
       handleFocusAnimationPanel,
       handleFocusMediaPanel,
       handleFocusLinkPanel,

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -112,7 +112,9 @@ const useQuickActions = () => {
       // Choose properties to clear
       if (properties.includes('backgroundOverlay')) {
         newProperties.backgroundOverlay = null;
-      } else if (properties.includes('animation')) {
+      }
+
+      if (properties.includes('animation')) {
         newProperties.animation = {
           ...selectedElementAnimations?.[0],
           delete: true,
@@ -133,16 +135,15 @@ const useQuickActions = () => {
   );
 
   /**
-   * Clear animations and show a snackbar. Clicking the action
-   * in the snackbar adds the animations back to the element.
+   * Clear animations and show a confirmation snackbar. Clicking
+   * the action in the snackbar adds the animations back to the element.
    *
    * @param {string} elementId the id of the element
-   * @param {Array.<string>} properties The properties of the element to update
    * @return {void}
    */
   const handleClearAnimations = useCallback(
-    (elementId, properties) => {
-      handleResetProperties(elementId, properties);
+    (elementId) => {
+      handleResetProperties(elementId, ['animation']);
 
       showSnackbar({
         actionLabel: __('Undo', 'web-stories'),
@@ -243,8 +244,7 @@ const useQuickActions = () => {
       {
         Icon: Eraser,
         label: ACTION_TEXT.CLEAR_ANIMATIONS,
-        onClick: () =>
-          handleClearAnimations(selectedElement?.id, ['animation']),
+        onClick: () => handleClearAnimations(selectedElement?.id),
         onMouseDown: handleMouseDown,
         separator: 'top',
       },

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -80,20 +80,24 @@ const useQuickActions = () => {
 
   const handleFocusPanel = useCallback(
     (highlight) => (elementId) => (ev) => {
-      ev.stopPropagation();
+      ev.preventDefault();
       setHighlights({ elementId, highlight });
     },
     [setHighlights]
   );
 
   const {
-    handleFocusPageBackground,
+    handleFocusAnimationPanel,
     handleFocusMediaPanel,
+    handleFocusLinkPanel,
+    handleFocusPageBackground,
     handleFocusTextSetsPanel,
   } = useMemo(
     () => ({
-      handleFocusPageBackground: handleFocusPanel(states.PAGE_BACKGROUND),
+      handleFocusAnimationPanel: handleFocusPanel(states.ANIMATION),
+      handleFocusLinkPanel: handleFocusPanel(states.LINK),
       handleFocusMediaPanel: handleFocusPanel(states.MEDIA),
+      handleFocusPageBackground: handleFocusPanel(states.PAGE_BACKGROUND),
       handleFocusTextSetsPanel: handleFocusPanel(states.TEXT),
     }),
     [handleFocusPanel]
@@ -102,6 +106,7 @@ const useQuickActions = () => {
   const backgroundElement =
     currentPage?.elements.find((element) => element.isBackground) ||
     selectedElements?.[0]?.isBackground;
+  const selectedElement = selectedElements?.[0];
 
   const defaultActions = useMemo(
     () => [
@@ -135,17 +140,17 @@ const useQuickActions = () => {
       {
         Icon: PictureSwap,
         label: ACTION_TEXT.REPLACE_MEDIA,
-        onClick: noop,
+        onClick: handleFocusMediaPanel(selectedElement?.id),
       },
       {
         Icon: CircleSpeed,
         label: ACTION_TEXT.ADD_ANIMATION,
-        onClick: noop,
+        onClick: handleFocusAnimationPanel(selectedElement?.id),
       },
       {
         Icon: Link,
         label: ACTION_TEXT.ADD_LINK,
-        onClick: noop,
+        onClick: handleFocusLinkPanel(selectedElement?.id),
       },
       {
         Icon: Eraser,
@@ -154,7 +159,12 @@ const useQuickActions = () => {
         separator: 'top',
       },
     ],
-    []
+    [
+      handleFocusAnimationPanel,
+      handleFocusMediaPanel,
+      handleFocusLinkPanel,
+      selectedElement?.id,
+    ]
   );
 
   // Hide menu if there are multiple elements selected

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -23,6 +23,7 @@ import { useCallback, useMemo } from 'react';
  * Internal dependencies
  */
 import { states, useHighlights } from '..';
+import { useSnackbar } from '../../../../design-system';
 import {
   Bucket,
   CircleSpeed,
@@ -73,15 +74,27 @@ const useQuickActions = () => {
     })
   );
 
+  const { showSnackbar } = useSnackbar();
+
   const { setHighlights } = useHighlights(({ setHighlights }) => ({
     setHighlights,
   }));
 
+  const handleMouseDown = useCallback((ev) => {
+    ev.stopPropagation();
+  }, []);
+
   const handleClearFiltersAndAnimations = useCallback(
     (elementId) => {
       setHighlights({ elementId });
+      showSnackbar({
+        actionLabel: __('Undo', 'web-stories'),
+        dismissable: false,
+        message: __('All styles were removed from the image', 'web-stories'),
+        onAction: () => console.log('UNDID'),
+      });
     },
-    [setHighlights]
+    [setHighlights, showSnackbar]
   );
 
   const handleFocusPanel = useCallback(
@@ -95,6 +108,7 @@ const useQuickActions = () => {
   const {
     handleFocusAnimationPanel,
     handleFocusMediaPanel,
+    handleFocusMedia3pPanel,
     handleFocusLinkPanel,
     handleFocusPageBackground,
     handleFocusTextSetsPanel,
@@ -103,6 +117,7 @@ const useQuickActions = () => {
       handleFocusAnimationPanel: handleFocusPanel(states.ANIMATION),
       handleFocusLinkPanel: handleFocusPanel(states.LINK),
       handleFocusMediaPanel: handleFocusPanel(states.MEDIA),
+      handleFocusMedia3pPanel: handleFocusPanel(states.MEDIA3P),
       handleFocusPageBackground: handleFocusPanel(states.PAGE_BACKGROUND),
       handleFocusTextSetsPanel: handleFocusPanel(states.TEXT),
     }),
@@ -120,17 +135,20 @@ const useQuickActions = () => {
         Icon: Bucket,
         label: ACTION_TEXT.CHANGE_BACKGROUND_COLOR,
         onClick: handleFocusPageBackground(backgroundElement?.id),
+        onMouseDown: handleMouseDown,
       },
       {
         Icon: Media,
         label: ACTION_TEXT.INSERT_BACKGROUND_MEDIA,
         onClick: handleFocusMediaPanel(),
+        onMouseDown: handleMouseDown,
         separator: 'top',
       },
       {
         Icon: LetterTPlus,
         label: ACTION_TEXT.INSERT_TEXT,
         onClick: handleFocusTextSetsPanel(),
+        onMouseDown: handleMouseDown,
       },
     ],
     [
@@ -138,6 +156,7 @@ const useQuickActions = () => {
       handleFocusMediaPanel,
       handleFocusPageBackground,
       handleFocusTextSetsPanel,
+      handleMouseDown,
     ]
   );
 
@@ -146,30 +165,35 @@ const useQuickActions = () => {
       {
         Icon: PictureSwap,
         label: ACTION_TEXT.REPLACE_MEDIA,
-        onClick: handleFocusMediaPanel(selectedElement?.id),
+        onClick: handleFocusMedia3pPanel(selectedElement?.id),
+        onMouseDown: handleMouseDown,
       },
       {
         Icon: CircleSpeed,
         label: ACTION_TEXT.ADD_ANIMATION,
         onClick: handleFocusAnimationPanel(selectedElement?.id),
+        onMouseDown: handleMouseDown,
       },
       {
         Icon: Link,
         label: ACTION_TEXT.ADD_LINK,
         onClick: handleFocusLinkPanel(selectedElement?.id),
+        onMouseDown: handleMouseDown,
       },
       {
         Icon: Eraser,
         label: ACTION_TEXT.CLEAR_FILTERS_AND_ANIMATIONS,
         onClick: () => handleClearFiltersAndAnimations(selectedElement?.id),
+        onMouseDown: handleMouseDown,
         separator: 'top',
       },
     ],
     [
       handleClearFiltersAndAnimations,
       handleFocusAnimationPanel,
-      handleFocusMediaPanel,
+      handleFocusMedia3pPanel,
       handleFocusLinkPanel,
+      handleMouseDown,
       selectedElement?.id,
     ]
   );

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -50,10 +50,7 @@ export const ACTION_TEXT = {
   ADD_ANIMATION: __('Add animation', 'web-stories'),
   ADD_LINK: __('Add Link', 'web-stories'),
   CHANGE_BACKGROUND_COLOR: __('Change background color', 'web-stories'),
-  CLEAR_FILTERS_AND_ANIMATIONS: __(
-    'Clear filters and animations',
-    'web-stories'
-  ),
+  CLEAR_ANIMATIONS: __('Clear animations', 'web-stories'),
   INSERT_BACKGROUND_MEDIA: __('Insert background media', 'web-stories'),
   INSERT_TEXT: __('Insert text', 'web-stories'),
   REPLACE_MEDIA: __('Replace media', 'web-stories'),
@@ -150,7 +147,10 @@ const useQuickActions = () => {
       showSnackbar({
         actionLabel: __('Undo', 'web-stories'),
         dismissable: false,
-        message: __('All styles were removed from the image', 'web-stories'),
+        message: __(
+          'All animations were removed from the image',
+          'web-stories'
+        ),
         onAction: undo,
       });
     },
@@ -242,7 +242,7 @@ const useQuickActions = () => {
       },
       {
         Icon: Eraser,
-        label: ACTION_TEXT.CLEAR_FILTERS_AND_ANIMATIONS,
+        label: ACTION_TEXT.CLEAR_ANIMATIONS,
         onClick: () =>
           handleClearAnimations(selectedElement?.id, ['animation']),
         onMouseDown: handleMouseDown,

--- a/assets/src/edit-story/app/highlights/states.js
+++ b/assets/src/edit-story/app/highlights/states.js
@@ -17,7 +17,7 @@
  * Internal dependencies
  */
 import { DOCUMENT, DESIGN } from '../../components/inspector';
-import { MEDIA, TEXT } from '../../components/library/constants';
+import { MEDIA, MEDIA3P, TEXT } from '../../components/library/constants';
 
 /**
  * Highlight state object
@@ -43,6 +43,7 @@ const keys = {
 
   // LIBRARY
   MEDIA: 'MEDIA',
+  MEDIA3P: 'MEDIA3P',
   TEXT: 'TEXT',
 };
 
@@ -89,6 +90,10 @@ export const STATES = {
   [keys.MEDIA]: {
     focus: true,
     tab: MEDIA.id,
+  },
+  [keys.MEDIA3P]: {
+    focus: true,
+    tab: MEDIA3P.id,
   },
   [keys.TEXT]: {
     focus: true,

--- a/assets/src/edit-story/app/highlights/states.js
+++ b/assets/src/edit-story/app/highlights/states.js
@@ -32,9 +32,11 @@ const keys = {
   STORY_TITLE: 'STORY_TITLE',
 
   // INSPECTOR
+  ANIMATION: 'ANIMATION',
   ASSISTIVE_TEXT: 'ASSISTIVE_TEXT',
   CAPTIONS: 'CAPTIONS',
   EXCERPT: 'EXCERPT',
+  LINK: 'LINK',
   PAGE_BACKGROUND: 'PAGE_BACKGROUND',
   POSTER: 'POSTER',
   PUBLISHER_LOGO: 'PUBLISHER_LOGO',
@@ -71,6 +73,14 @@ export const STATES = {
     tab: DESIGN,
   },
   [keys.PAGE_BACKGROUND]: {
+    focus: true,
+    tab: DESIGN,
+  },
+  [keys.ANIMATION]: {
+    focus: true,
+    tab: DESIGN,
+  },
+  [keys.LINK]: {
     focus: true,
     tab: DESIGN,
   },

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -139,8 +139,7 @@ describe('Quick Actions integration', () => {
 
       expect(fixture.editor.library.media3p).not.toBeNull();
 
-      // TODO: once #7522 is merged, we can uncomment this line
-      // expect(document.activeElement).toEqual(fixture.editor.library.media3pTab);
+      expect(document.activeElement).toEqual(fixture.editor.library.media3pTab);
     });
 
     it(`clicking the \`${ACTION_TEXT.ADD_ANIMATION}\` button should select the animation panel and focus the dropdown`, async () => {

--- a/assets/src/edit-story/components/form/link.js
+++ b/assets/src/edit-story/components/form/link.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import { forwardRef } from 'react';
 import { __ } from '@web-stories-wp/i18n';
 
 /**
@@ -35,21 +36,17 @@ const MIN_MAX = {
   },
 };
 
-function LinkInput({
-  onChange,
-  onBlur,
-  onFocus,
-  value = '',
-  hint,
-  hasError,
-  ...rest
-}) {
+function LinkInput(
+  { onChange, onBlur, onFocus, value = '', hint, hasError, ...rest },
+  ref
+) {
   const trimmedValue = (value || '').trim();
   const isValid = isValidUrl(withProtocol(trimmedValue));
   const isNotValid = trimmedValue.length > 0 && !isValid;
   return (
     <Row>
       <Input
+        ref={ref}
         placeholder={__('Web address', 'web-stories')}
         onChange={(evt) => onChange(evt.target.value)}
         onBlur={() => {
@@ -85,4 +82,4 @@ LinkInput.propTypes = {
   hasError: PropTypes.bool,
 };
 
-export default LinkInput;
+export default forwardRef(LinkInput);

--- a/assets/src/edit-story/components/form/link.js
+++ b/assets/src/edit-story/components/form/link.js
@@ -36,7 +36,7 @@ const MIN_MAX = {
   },
 };
 
-function LinkInput(
+const LinkInput = forwardRef(function LinkInput(
   { onChange, onBlur, onFocus, value = '', hint, hasError, ...rest },
   ref
 ) {
@@ -71,7 +71,7 @@ function LinkInput(
       />
     </Row>
   );
-}
+});
 
 LinkInput.propTypes = {
   value: PropTypes.string,
@@ -82,4 +82,4 @@ LinkInput.propTypes = {
   hasError: PropTypes.bool,
 };
 
-export default forwardRef(LinkInput);
+export default LinkInput;

--- a/assets/src/edit-story/components/library/libraryLayout.js
+++ b/assets/src/edit-story/components/library/libraryLayout.js
@@ -30,7 +30,7 @@ import { states, useFocusHighlight } from '../../app/highlights';
 import LibraryPanes from './libraryPanes';
 import useLibrary from './useLibrary';
 import { getTabId, getPaneId } from './panes/shared';
-import { MEDIA, TEXT } from './constants';
+import { MEDIA, MEDIA3P, TEXT } from './constants';
 
 const Layout = styled.section.attrs({
   'aria-label': __('Library', 'web-stories'),
@@ -65,6 +65,7 @@ function LibraryLayout() {
   }));
 
   useFocusHighlight(states.MEDIA, tabRefs[MEDIA.id]);
+  useFocusHighlight(states.MEDIA3P, tabRefs[MEDIA3P.id]);
   useFocusHighlight(states.TEXT, tabRefs[TEXT.id]);
 
   const onTabChange = useCallback(

--- a/assets/src/edit-story/components/library/libraryPanes.js
+++ b/assets/src/edit-story/components/library/libraryPanes.js
@@ -42,6 +42,7 @@ function LibraryPanes() {
   }));
 
   const mediaHighlight = useFocusHighlight(states.MEDIA);
+  const media3pHighlight = useFocusHighlight(states.MEDIA3P);
   const textHighlight = useFocusHighlight(states.TEXT);
 
   return tabs.map(({ id }) => {
@@ -60,7 +61,12 @@ function LibraryPanes() {
           />
         );
       case MEDIA3P.id:
-        return <Media3pPane {...paneProps} />;
+        return (
+          <Media3pPane
+            {...paneProps}
+            css={media3pHighlight?.showEffect && styles.FLASH}
+          />
+        );
       case SHAPES.id:
         return <ShapesPane {...paneProps} />;
       case TEXT.id:

--- a/assets/src/edit-story/components/panels/design/animation/animation.js
+++ b/assets/src/edit-story/components/panels/design/animation/animation.js
@@ -79,7 +79,8 @@ function AnimationPanel({
   updateAnimationState,
 }) {
   const playUpdatedAnimation = useRef(false);
-  const highlight = useFocusHighlight(states.ANIMATION);
+  const dropdownRef = useRef(null);
+  const highlight = useFocusHighlight(states.ANIMATION, dropdownRef);
 
   const isBackground =
     selectedElements.length === 1 && selectedElements[0].isBackground;
@@ -243,6 +244,7 @@ function AnimationPanel({
       <GroupWrapper hasAnimation={selectedEffectTitle}>
         <StyledRow>
           <EffectChooserDropdown
+            ref={dropdownRef}
             onAnimationSelected={handleAddOrUpdateElementEffect}
             onNoEffectSelected={handleRemoveEffect}
             isBackgroundEffects={isBackground}

--- a/assets/src/edit-story/components/panels/design/animation/animation.js
+++ b/assets/src/edit-story/components/panels/design/animation/animation.js
@@ -43,6 +43,7 @@ import StoryPropTypes, { AnimationPropType } from '../../../../types';
 import { Row } from '../../../form';
 import { SimplePanel } from '../../panel';
 import { Text, THEME_CONSTANTS } from '../../../../../design-system';
+import { states, styles, useFocusHighlight } from '../../../../app/highlights';
 import EffectPanel, { getEffectName, getEffectDirection } from './effectPanel';
 import { EffectChooserDropdown } from './effectChooserDropdown';
 
@@ -78,6 +79,7 @@ function AnimationPanel({
   updateAnimationState,
 }) {
   const playUpdatedAnimation = useRef(false);
+  const highlight = useFocusHighlight(states.ANIMATION);
 
   const isBackground =
     selectedElements.length === 1 && selectedElements[0].isBackground;
@@ -222,7 +224,11 @@ function AnimationPanel({
 
   const selectedEffectTitle = getEffectName(updatedAnimations[0]?.type);
   return selectedElements.length > 1 ? (
-    <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
+    <SimplePanel
+      name="animation"
+      title={__('Animation', 'web-stories')}
+      css={highlight?.showEffect && styles.FLASH}
+    >
       <Row>
         <Note
           forwardedAs="span"

--- a/assets/src/edit-story/components/panels/design/animation/animation.js
+++ b/assets/src/edit-story/components/panels/design/animation/animation.js
@@ -224,11 +224,7 @@ function AnimationPanel({
 
   const selectedEffectTitle = getEffectName(updatedAnimations[0]?.type);
   return selectedElements.length > 1 ? (
-    <SimplePanel
-      name="animation"
-      title={__('Animation', 'web-stories')}
-      css={highlight?.showEffect && styles.FLASH}
-    >
+    <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
       <Row>
         <Note
           forwardedAs="span"
@@ -239,7 +235,11 @@ function AnimationPanel({
       </Row>
     </SimplePanel>
   ) : (
-    <SimplePanel name="animation" title={__('Animation', 'web-stories')}>
+    <SimplePanel
+      name="animation"
+      title={__('Animation', 'web-stories')}
+      css={highlight?.showEffect && styles.FLASH}
+    >
       <GroupWrapper hasAnimation={selectedEffectTitle}>
         <StyledRow>
           <EffectChooserDropdown

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useMemo } from 'react';
+import { forwardRef, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { __ } from '@web-stories-wp/i18n';
 
@@ -44,14 +44,17 @@ import {
 } from './styles';
 import DropDownItem from './dropdownItem';
 
-export default function EffectChooserDropdown({
-  onAnimationSelected,
-  onNoEffectSelected,
-  isBackgroundEffects = false,
-  selectedEffectType,
-  disabledTypeOptionsMap,
-  direction,
-}) {
+const EffectChooserDropdown = forwardRef(function EffectChooserDropdown(
+  {
+    onAnimationSelected,
+    onNoEffectSelected,
+    isBackgroundEffects = false,
+    selectedEffectType,
+    disabledTypeOptionsMap,
+    direction,
+  },
+  ref
+) {
   const { enableExperimentalAnimationEffects } = useFeatures();
 
   const selectedValue = useMemo(
@@ -144,6 +147,7 @@ export default function EffectChooserDropdown({
 
   return (
     <DropDown
+      ref={ref}
       options={assembledOptions}
       placeholder={__('None', 'web-stories')}
       selectedValue={selectedValue}
@@ -160,7 +164,7 @@ export default function EffectChooserDropdown({
       }
     />
   );
-}
+});
 
 EffectChooserDropdown.propTypes = {
   onAnimationSelected: PropTypes.func.isRequired,
@@ -175,3 +179,5 @@ EffectChooserDropdown.propTypes = {
     })
   ),
 };
+
+export default EffectChooserDropdown;

--- a/assets/src/edit-story/components/panels/design/link/link.js
+++ b/assets/src/edit-story/components/panels/design/link/link.js
@@ -44,6 +44,7 @@ import {
   useCommonObjectValue,
 } from '../../shared';
 import { MEDIA_VARIANTS } from '../../../../../design-system/components/mediaInput/constants';
+import { states, styles, useFocusHighlight } from '../../../../app/highlights';
 
 const IconInfo = styled.div`
   display: flex;
@@ -80,6 +81,8 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
   const { currentPage } = useStory((state) => ({
     currentPage: state.state.currentPage,
   }));
+
+  const highlight = useFocusHighlight(states.LINK);
 
   const { getElementsInAttachmentArea } = useElementsWithLinks();
   const hasElementsInAttachmentArea =
@@ -216,7 +219,11 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
   const isMultipleUrl = MULTIPLE_VALUE === link.url;
   const isMultipleDesc = MULTIPLE_VALUE === link.desc;
   return (
-    <SimplePanel name="link" title={__('Link', 'web-stories')}>
+    <SimplePanel
+      name="link"
+      title={__('Link', 'web-stories')}
+      css={highlight?.showEffect && styles.FLASH}
+    >
       <LinkInput
         onChange={(value) =>
           !displayLinkGuidelines &&

--- a/assets/src/edit-story/components/panels/design/link/link.js
+++ b/assets/src/edit-story/components/panels/design/link/link.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { useDebouncedCallback } from 'use-debounce';
@@ -82,7 +82,8 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
     currentPage: state.state.currentPage,
   }));
 
-  const highlight = useFocusHighlight(states.LINK);
+  const linkRef = useRef(null);
+  const highlight = useFocusHighlight(states.LINK, linkRef);
 
   const { getElementsInAttachmentArea } = useElementsWithLinks();
   const hasElementsInAttachmentArea =
@@ -225,6 +226,7 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
       css={highlight?.showEffect && styles.FLASH}
     >
       <LinkInput
+        ref={linkRef}
         onChange={(value) =>
           !displayLinkGuidelines &&
           handleChange({ url: value }, !value /* submit */)

--- a/assets/src/edit-story/karma/fixture/containers/canvas.js
+++ b/assets/src/edit-story/karma/fixture/containers/canvas.js
@@ -17,8 +17,8 @@
 /**
  * Internal dependencies
  */
-import { ACTION_TEXT } from '../../../app/highlights';
 import { Container } from './container';
+import { QuickActionMenu } from './quickActionMenu';
 
 /**
  * The editor's canvas. Includes: display, frames, editor layers,
@@ -273,29 +273,5 @@ class Header extends Container {
 
   get schedule() {
     return this.getByRole('button', { name: 'Schedule' });
-  }
-}
-
-class QuickActionMenu extends Container {
-  constructor(node, path) {
-    super(node, path);
-  }
-
-  get changeBackgroundColorButton() {
-    return this.getByRole('button', {
-      name: ACTION_TEXT.CHANGE_BACKGROUND_COLOR,
-    });
-  }
-
-  get insertBackgroundMediaButton() {
-    return this.getByRole('button', {
-      name: ACTION_TEXT.INSERT_BACKGROUND_MEDIA,
-    });
-  }
-
-  get insertTextButton() {
-    return this.getByRole('button', {
-      name: ACTION_TEXT.INSERT_TEXT,
-    });
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/library/index.js
+++ b/assets/src/edit-story/karma/fixture/containers/library/index.js
@@ -45,6 +45,14 @@ export class Library extends Container {
     return this.getByRole('tab', { name: /Explore Media/ });
   }
 
+  get media3p() {
+    return this._get(
+      this.getByRole('tabpanel', { name: /Explore Media/ }),
+      'media3p',
+      Media3P
+    );
+  }
+
   get textTab() {
     return this.getByRole('tab', { name: /Text library/ });
   }
@@ -103,5 +111,11 @@ export class Media extends Container {
 
   item(index) {
     return this.node.querySelectorAll('[data-testid^=mediaElement]')[index];
+  }
+}
+
+export class Media3P extends Container {
+  constructor(node, path) {
+    super(node, path);
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/quickActionMenu.js
+++ b/assets/src/edit-story/karma/fixture/containers/quickActionMenu.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { ACTION_TEXT } from '../../../app/highlights';
+import { Container } from './container';
+
+export class QuickActionMenu extends Container {
+  constructor(node, path) {
+    super(node, path);
+  }
+
+  get changeBackgroundColorButton() {
+    return this.getByRole('button', {
+      name: ACTION_TEXT.CHANGE_BACKGROUND_COLOR,
+    });
+  }
+
+  get insertBackgroundMediaButton() {
+    return this.getByRole('button', {
+      name: ACTION_TEXT.INSERT_BACKGROUND_MEDIA,
+    });
+  }
+
+  get insertTextButton() {
+    return this.getByRole('button', {
+      name: ACTION_TEXT.INSERT_TEXT,
+    });
+  }
+
+  get replaceMediaButton() {
+    return this.getByRole('button', {
+      name: ACTION_TEXT.REPLACE_MEDIA,
+    });
+  }
+
+  get addAnimationButton() {
+    return this.getByRole('button', {
+      name: ACTION_TEXT.ADD_ANIMATION,
+    });
+  }
+
+  get addLinkButton() {
+    return this.getByRole('button', {
+      name: ACTION_TEXT.ADD_LINK,
+    });
+  }
+
+  get clearAnimationsButton() {
+    return this.getByRole('button', {
+      name: ACTION_TEXT.CLEAR_ANIMATIONS,
+    });
+  }
+}

--- a/assets/src/edit-story/karma/fixture/containers/quickActionMenu.js
+++ b/assets/src/edit-story/karma/fixture/containers/quickActionMenu.js
@@ -25,43 +25,43 @@ export class QuickActionMenu extends Container {
   }
 
   get changeBackgroundColorButton() {
-    return this.getByRole('button', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.CHANGE_BACKGROUND_COLOR,
     });
   }
 
   get insertBackgroundMediaButton() {
-    return this.getByRole('button', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.INSERT_BACKGROUND_MEDIA,
     });
   }
 
   get insertTextButton() {
-    return this.getByRole('button', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.INSERT_TEXT,
     });
   }
 
   get replaceMediaButton() {
-    return this.getByRole('button', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.REPLACE_MEDIA,
     });
   }
 
   get addAnimationButton() {
-    return this.getByRole('button', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.ADD_ANIMATION,
     });
   }
 
   get addLinkButton() {
-    return this.getByRole('button', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.ADD_LINK,
     });
   }
 
   get clearAnimationsButton() {
-    return this.getByRole('button', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.CLEAR_ANIMATIONS,
     });
   }


### PR DESCRIPTION
## Context

Setting up more of the quick actions

## Summary

Adds the quick actions when selecting a 'foreground image'.

## Relevant Technical Choices

n/a

## To-do

<!-- ignore-task-list-start -->
- [ ] hide snackbar when the user clicks undo. maybe show a snackbar stating that the animations were re-applied (doing in a separate pr)
- [x] finish karma tests for 'clear animations' action
- [x] update karma tests once #7522 is merged. Allows us to focus the tabs in the library when clicking a quick action.
<!-- ignore-task-list-end -->

## User-facing changes

<details>
<summary>Gifs are here but very large</summary>

|Action|Gif|
|--|--|
|Replace Media|![first-action](https://user-images.githubusercontent.com/22185279/118729372-08f2d500-b7f3-11eb-98c4-6e6fab54a18b.gif)|
|Add Animation|![second-action](https://user-images.githubusercontent.com/22185279/118729384-0ee8b600-b7f3-11eb-865b-768303e8ab9e.gif)|
|Add Link|![third-action](https://user-images.githubusercontent.com/22185279/118729389-127c3d00-b7f3-11eb-9e14-3453352fcc05.gif)|
|Clear Animations|![fourth-action](https://user-images.githubusercontent.com/22185279/118729393-14de9700-b7f3-11eb-84dd-dce46e16236a.gif)|
</details>

## Testing Instructions

1. Make sure quick actions experiment is enabled
2. Go to editor
3. Add image to the canvas (not as a background image)
4. Mess with actions - clicking and keyboard. Actions should do the following:
    - Replace media: should show the user the media3p panel in the library. Should focus the media3p tab.
    - Add animation: should focus the animation panel in the design panel. Should focus the dropdown.
    - Add link: should focus the link panel in the design panel. Should focus the input.
    - Clear animations: should remove the animations from the element. If there are no animations nothing should happen. Clicking `undo` in the snackbar that's shown should add the previously removed animation back to the element

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6143
