### PR TITLE
Use ratio to calculate shape dimensions correctly

### DIFF
--- a/assets/src/edit-story/elements/shape/icon.js
+++ b/assets/src/edit-story/elements/shape/icon.js
@@ -26,6 +26,8 @@ import { getMaskByType } from '../../masks';
 import { elementWithBackgroundColor } from '../shared';
 import StoryPropTypes from '../../types';
 
+const PREVIEW_SIZE = 16;
+
 const Container = styled.div`
   display: flex;
   flex-direction: row;
@@ -39,8 +41,8 @@ const Container = styled.div`
 
 const ShapePreview = styled.div`
   ${elementWithBackgroundColor}
-  width: ${({ width = 16 }) => width}px;
-  height: auto;
+  width: ${({ width }) => width}px;
+  height: ${({ height }) => height}px;
 `;
 
 function ShapeLayerIcon({ element: { id, mask, backgroundColor } }) {
@@ -54,7 +56,8 @@ function ShapeLayerIcon({ element: { id, mask, backgroundColor } }) {
         style={{
           clipPath: `url(#${maskId})`,
         }}
-        width={16 * maskDef.ratio}
+        width={PREVIEW_SIZE * maskDef.ratio}
+        height={PREVIEW_SIZE}
         backgroundColor={backgroundColor}
       >
         <svg width={0} height={0}>


### PR DESCRIPTION
## Summary

I've used the same logic as in the [Shapes Pane](https://github.com/google/web-stories-wp/blob/c9d2291dd2d45e01fdef2f9272558f37c9526923/assets/src/edit-story/components/library/panes/shapes/shapePreview.js#L146-L156) (fixed height, width*ratio).

## User-facing changes

The shapes preview in Layers looks correct now.

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/21036224/118660635-a8619900-b7ee-11eb-8305-fae6ec5e5d6b.png) | ![image](https://user-images.githubusercontent.com/21036224/118660717-badbd280-b7ee-11eb-9356-54bddb8e0f99.png) |





<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

Insert all types of shapes, check if the preview looks good (aspect ratio).

### QA

Can be tested by dev? (just a simple visual fix)

### UAT

^

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6746
