### PR TITLE
Quick Action Menu: Background Media

### DIFF
--- a/assets/src/edit-story/app/highlights/quickActions/constants.js
+++ b/assets/src/edit-story/app/highlights/quickActions/constants.js
@@ -39,23 +39,23 @@ export const ELEMENT_TYPE_COPY = {
 
 export const ACTION_TEXT = {
   ADD_ANIMATION: __('Add animation', 'web-stories'),
-  ADD_LINK: __('Add Link', 'web-stories'),
+  ADD_LINK: __('Add link', 'web-stories'),
   CHANGE_BACKGROUND_COLOR: __('Change background color', 'web-stories'),
   CHANGE_COLOR: __('Change color', 'web-stories'),
   CLEAR_ANIMATIONS: __('Clear animations', 'web-stories'),
   CLEAR_ANIMATION_AND_FILTERS: __('Clear filters and animation', 'web-stories'),
   INSERT_BACKGROUND_MEDIA: __('Insert background media', 'web-stories'),
   INSERT_TEXT: __('Insert text', 'web-stories'),
-  REPLACE_MEDIA: __('Replace media', 'web-stories'),
   REPLACE_BACKGROUND_MEDIA: __('Replace background', 'web-stories'),
+  REPLACE_MEDIA: __('Replace media', 'web-stories'),
 };
 
 export const RESET_PROPERTIES = {
-  BACKGROUND_OVERLAY: 'backgroundOverlay',
   ANIMATION: 'animation',
+  BACKGROUND_OVERLAY: 'backgroundOverlay',
 };
 
 export const RESET_LIST_COPY = {
-  [RESET_PROPERTIES.BACKGROUND_OVERLAY]: 'filters',
   [RESET_PROPERTIES.ANIMATION]: 'animations',
+  [RESET_PROPERTIES.BACKGROUND_OVERLAY]: 'filters',
 };

--- a/assets/src/edit-story/app/highlights/quickActions/constants.js
+++ b/assets/src/edit-story/app/highlights/quickActions/constants.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
+
+export const ELEMENT_TYPE = {
+  IMAGE: 'image',
+  SHAPE: 'shape',
+  TEXT: 'text',
+  VIDEO: 'video',
+  GIF: 'gif',
+  BACKGROUND: 'background',
+};
+
+export const ELEMENT_TYPE_COPY = {
+  [ELEMENT_TYPE.IMAGE]: __('image', 'web-stories'),
+  [ELEMENT_TYPE.SHAPE]: __('shape', 'web-stories'),
+  [ELEMENT_TYPE.TEXT]: __('text', 'web-stories'),
+  [ELEMENT_TYPE.VIDEO]: __('video', 'web-stories'),
+  [ELEMENT_TYPE.GIF]: __('gif', 'web-stories'),
+  [ELEMENT_TYPE.BACKGROUND]: __('background', 'web-stories'),
+};
+
+export const ACTION_TEXT = {
+  ADD_ANIMATION: __('Add animation', 'web-stories'),
+  ADD_LINK: __('Add Link', 'web-stories'),
+  CHANGE_BACKGROUND_COLOR: __('Change background color', 'web-stories'),
+  CHANGE_COLOR: __('Change color', 'web-stories'),
+  CLEAR_ANIMATIONS: __('Clear animations', 'web-stories'),
+  INSERT_BACKGROUND_MEDIA: __('Insert background media', 'web-stories'),
+  INSERT_TEXT: __('Insert text', 'web-stories'),
+  REPLACE_MEDIA: __('Replace media', 'web-stories'),
+  CHANGE_BACKGROUND_MEDIA: __('Replace background', 'web-stories'),
+  CLEAR_FILTERS_AND_ANIMATION: __('Clear filters and animation', 'web-stories'),
+};
+
+export const RESET_PROPERTIES = {
+  BACKGROUND_OVERLAY: 'backgroundOverlay',
+  ANIMATION: 'animation',
+};
+
+export const RESET_LIST_COPY = {
+  [RESET_PROPERTIES.BACKGROUND_OVERLAY]: 'filters',
+  [RESET_PROPERTIES.ANIMATION]: 'animations',
+};

--- a/assets/src/edit-story/app/highlights/quickActions/constants.js
+++ b/assets/src/edit-story/app/highlights/quickActions/constants.js
@@ -43,11 +43,11 @@ export const ACTION_TEXT = {
   CHANGE_BACKGROUND_COLOR: __('Change background color', 'web-stories'),
   CHANGE_COLOR: __('Change color', 'web-stories'),
   CLEAR_ANIMATIONS: __('Clear animations', 'web-stories'),
+  CLEAR_ANIMATION_AND_FILTERS: __('Clear filters and animation', 'web-stories'),
   INSERT_BACKGROUND_MEDIA: __('Insert background media', 'web-stories'),
   INSERT_TEXT: __('Insert text', 'web-stories'),
   REPLACE_MEDIA: __('Replace media', 'web-stories'),
-  CHANGE_BACKGROUND_MEDIA: __('Replace background', 'web-stories'),
-  CLEAR_FILTERS_AND_ANIMATION: __('Clear filters and animation', 'web-stories'),
+  REPLACE_BACKGROUND_MEDIA: __('Replace background', 'web-stories'),
 };
 
 export const RESET_PROPERTIES = {

--- a/assets/src/edit-story/app/highlights/quickActions/index.js
+++ b/assets/src/edit-story/app/highlights/quickActions/index.js
@@ -13,4 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { default as useQuickActions, ACTION_TEXT } from './useQuickActions';
+export { default as useQuickActions } from './useQuickActions';

--- a/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
@@ -33,7 +33,7 @@ import {
   Media,
   PictureSwap,
 } from '../../../../../design-system/icons';
-import { ACTION_TEXT } from '../useQuickActions';
+import { ACTION_TEXT } from '../constants';
 
 jest.mock('../../../story', () => ({
   useStory: jest.fn(),
@@ -58,6 +58,36 @@ const BACKGROUND_ELEMENT = {
   id: 'background-element-id',
   isBackground: true,
   type: 'shape',
+};
+const BACKGROUND_IMAGE_ELEMENT = {
+  id: 'background-image-element-id',
+  isBackground: true,
+  type: 'image',
+  resource: {
+    resource: {
+      id: 'mysite/1234',
+    },
+  },
+  backgroundOverlay: { type: 'linear' },
+};
+
+const BACKGROUND_IMAGE_MEDIA3P_ELEMENT = {
+  id: 'background-image-media3p-element-id',
+  isBackground: true,
+  type: 'image',
+  resource: {
+    id: 'media/unsplash:wsomemedia-123',
+  },
+  backgroundOverlay: { type: 'linear' },
+};
+
+const BACKGROUND_VIDEO_ELEMENT = {
+  id: 'background-video-element-id',
+  isBackground: true,
+  type: 'video',
+  resource: {
+    id: 'mysite/1234',
+  },
 };
 
 const IMAGE_ELEMENT = {
@@ -121,11 +151,11 @@ const foregroundImageQuickActions = [
   }),
 ];
 
-const shapeQuickActions = [
+const backgroundMediaQuickActions = [
   expect.objectContaining({
-    label: ACTION_TEXT.CHANGE_COLOR,
+    label: ACTION_TEXT.REPLACE_BACKGROUND_MEDIA,
     onClick: expect.any(Function),
-    Icon: Bucket,
+    Icon: PictureSwap,
   }),
   expect.objectContaining({
     label: ACTION_TEXT.ADD_ANIMATION,
@@ -133,12 +163,7 @@ const shapeQuickActions = [
     Icon: CircleSpeed,
   }),
   expect.objectContaining({
-    label: ACTION_TEXT.ADD_LINK,
-    onClick: expect.any(Function),
-    Icon: Link,
-  }),
-  expect.objectContaining({
-    label: ACTION_TEXT.CLEAR_ANIMATIONS,
+    label: ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS,
     onClick: expect.any(Function),
     Icon: Eraser,
   }),
@@ -230,7 +255,7 @@ describe('useQuickActions', () => {
     });
   });
 
-  describe('background element selected', () => {
+  describe('empty background element selected', () => {
     beforeEach(() => {
       mockUseStory.mockReturnValue({
         currentPage: {
@@ -271,6 +296,131 @@ describe('useQuickActions', () => {
     });
   });
 
+  describe('background image element is selected', () => {
+    beforeEach(() => {
+      mockUseStory.mockReturnValue({
+        currentPage: {
+          elements: [BACKGROUND_IMAGE_ELEMENT],
+        },
+        selectedElementAnimations: [],
+        selectedElements: [BACKGROUND_IMAGE_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
+      });
+    });
+
+    it('should return the quick actions', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      expect(result.current).toStrictEqual(backgroundMediaQuickActions);
+    });
+
+    it('should set the correct highlight', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      result.current[0].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: BACKGROUND_IMAGE_ELEMENT.id,
+        highlight: states.MEDIA,
+      });
+
+      result.current[1].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: BACKGROUND_IMAGE_ELEMENT.id,
+        highlight: states.ANIMATION,
+      });
+    });
+
+    describe('background third party image element is selected', () => {
+      beforeEach(() => {
+        mockUseStory.mockReturnValue({
+          currentPage: {
+            elements: [BACKGROUND_IMAGE_MEDIA3P_ELEMENT],
+          },
+          selectedElementAnimations: [],
+          selectedElements: [BACKGROUND_IMAGE_MEDIA3P_ELEMENT],
+          updateElementsById: mockUpdateElementsById,
+        });
+      });
+
+      it('should return the quick actions', () => {
+        const { result } = renderHook(() => useQuickActions());
+
+        expect(result.current).toStrictEqual(backgroundMediaQuickActions);
+      });
+
+      it('should set the correct highlight', () => {
+        const { result } = renderHook(() => useQuickActions());
+
+        result.current[0].onClick(mockClickEvent);
+        expect(highlight).toStrictEqual({
+          elementId: BACKGROUND_IMAGE_MEDIA3P_ELEMENT.id,
+          highlight: states.MEDIA3P,
+        });
+
+        result.current[1].onClick(mockClickEvent);
+        expect(highlight).toStrictEqual({
+          elementId: BACKGROUND_IMAGE_MEDIA3P_ELEMENT.id,
+          highlight: states.ANIMATION,
+        });
+      });
+    });
+
+    describe('background video element is selected', () => {
+      beforeEach(() => {
+        mockUseStory.mockReturnValue({
+          currentPage: {
+            elements: [BACKGROUND_VIDEO_ELEMENT],
+          },
+          selectedElementAnimations: [],
+          selectedElements: [BACKGROUND_VIDEO_ELEMENT],
+          updateElementsById: mockUpdateElementsById,
+        });
+      });
+
+      it('should return the quick actions', () => {
+        const { result } = renderHook(() => useQuickActions());
+
+        expect(result.current).toStrictEqual(backgroundMediaQuickActions);
+      });
+
+      it('should set the correct highlight', () => {
+        const { result } = renderHook(() => useQuickActions());
+
+        result.current[0].onClick(mockClickEvent);
+        expect(highlight).toStrictEqual({
+          elementId: BACKGROUND_VIDEO_ELEMENT.id,
+          highlight: states.MEDIA,
+        });
+
+        result.current[1].onClick(mockClickEvent);
+        expect(highlight).toStrictEqual({
+          elementId: BACKGROUND_VIDEO_ELEMENT.id,
+          highlight: states.ANIMATION,
+        });
+      });
+
+      it('clicking `clear filters and animations` should update the element', () => {
+        const { result } = renderHook(() => useQuickActions());
+
+        result.current[2].onClick(mockClickEvent);
+        expect(mockUpdateElementsById).toHaveBeenCalledWith({
+          elementIds: [BACKGROUND_VIDEO_ELEMENT.id],
+          properties: expect.any(Function),
+        });
+      });
+    });
+
+    it('clicking `clear filters and animations` should update the element', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      result.current[2].onClick(mockClickEvent);
+      expect(mockUpdateElementsById).toHaveBeenCalledWith({
+        elementIds: [BACKGROUND_IMAGE_ELEMENT.id],
+        properties: expect.any(Function),
+      });
+    });
+  });
+
   describe('foreground image element selected', () => {
     beforeEach(() => {
       mockUseStory.mockReturnValue({
@@ -299,7 +449,7 @@ describe('useQuickActions', () => {
       result.current[0].onClick(mockClickEvent);
       expect(highlight).toStrictEqual({
         elementId: IMAGE_ELEMENT.id,
-        highlight: states.MEDIA3P,
+        highlight: states.MEDIA,
       });
 
       result.current[1].onClick(mockClickEvent);
@@ -353,42 +503,8 @@ describe('useQuickActions', () => {
       });
     });
 
-    it('should return the quick actions', () => {
-      const { result } = renderHook(() => useQuickActions());
-      expect(result.current).toStrictEqual(shapeQuickActions);
-    });
-
-    it('should set the correct highlight', () => {
-      const { result } = renderHook(() => useQuickActions());
-
-      result.current[0].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: SHAPE_ELEMENT.id,
-        highlight: states.STYLE,
-      });
-
-      result.current[1].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: SHAPE_ELEMENT.id,
-        highlight: states.ANIMATION,
-      });
-
-      result.current[2].onClick(mockClickEvent);
-      expect(highlight).toStrictEqual({
-        elementId: SHAPE_ELEMENT.id,
-        highlight: states.LINK,
-      });
-    });
-
-    it('clicking `clear animations` should call `updateElementsById`', () => {
-      const { result } = renderHook(() => useQuickActions());
-
-      result.current[3].onClick(mockClickEvent);
-      expect(mockUpdateElementsById).toHaveBeenCalledWith({
-        elementIds: [SHAPE_ELEMENT.id],
-        properties: expect.any(Function),
-      });
-    });
+    it.todo('should return the quick actions');
+    it.todo('should set the correct highlight');
   });
 
   describe('text selected', () => {

--- a/assets/src/edit-story/app/highlights/quickActions/test/utils.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/utils.js
@@ -46,9 +46,9 @@ describe('quickAction utils', () => {
       ${[]}                                                                | ${ELEMENT_TYPE.IMAGE}      | ${''}
       ${['opacity']}                                                       | ${ELEMENT_TYPE.IMAGE}      | ${''}
       ${['daisy', 'sunflower', false, 0]}                                  | ${ELEMENT_TYPE.IMAGE}      | ${''}
-      ${[RESET_PROPERTIES.ANIMATION]}                                      | ${ELEMENT_TYPE.IMAGE}      | ${'All animations were removed from the image'}
-      ${[RESET_PROPERTIES.BACKGROUND_OVERLAY]}                             | ${ELEMENT_TYPE.BACKGROUND} | ${'All filters were removed from the background'}
-      ${[RESET_PROPERTIES.ANIMATION, RESET_PROPERTIES.BACKGROUND_OVERLAY]} | ${ELEMENT_TYPE.BACKGROUND} | ${'All animations and filters were removed from the background'}
+      ${[RESET_PROPERTIES.ANIMATION]}                                      | ${ELEMENT_TYPE.IMAGE}      | ${'All animations were removed from the image.'}
+      ${[RESET_PROPERTIES.BACKGROUND_OVERLAY]}                             | ${ELEMENT_TYPE.BACKGROUND} | ${'All filters were removed from the background.'}
+      ${[RESET_PROPERTIES.ANIMATION, RESET_PROPERTIES.BACKGROUND_OVERLAY]} | ${ELEMENT_TYPE.BACKGROUND} | ${'All animations and filters were removed from the background.'}
     `(
       'should return snackbar copy as expected',
       ({ properties, elementType, result }) => {

--- a/assets/src/edit-story/app/highlights/quickActions/test/utils.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/utils.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { ELEMENT_TYPE, RESET_PROPERTIES } from '../constants';
+import { getResetProperties, getSnackbarClearCopy } from '../utils';
+
+describe('quickAction utils', () => {
+  describe('getResetProperties', () => {
+    it.each`
+      selectedElement                                          | selectedElementAnimations       | result
+      ${{ backgroundOverlay: '', id: '1234' }}                 | ${[]}                           | ${[]}
+      ${{ backgroundOverlay: { type: 'linear' }, id: '1234' }} | ${[]}                           | ${[RESET_PROPERTIES.BACKGROUND_OVERLAY]}
+      ${{ backgroundOverlay: { type: 'linear' }, id: '1234' }} | ${[{ type: 'effect-fade-in' }]} | ${[RESET_PROPERTIES.BACKGROUND_OVERLAY, RESET_PROPERTIES.ANIMATION]}
+      ${{ backgroundOverlay: '', id: '1234' }}                 | ${[{ type: 'effect-fade-in' }]} | ${[RESET_PROPERTIES.ANIMATION]}
+    `(
+      'should return array with reset properties',
+      ({ selectedElement, selectedElementAnimations, result }) => {
+        const resetPropertiesArray = getResetProperties(
+          selectedElement,
+          selectedElementAnimations
+        );
+
+        expect(resetPropertiesArray).toStrictEqual(result);
+      }
+    );
+  });
+
+  describe('getSnackbarClearCopy', () => {
+    it.each`
+      properties                                                           | elementType                | result
+      ${[]}                                                                | ${ELEMENT_TYPE.IMAGE}      | ${''}
+      ${['opacity']}                                                       | ${ELEMENT_TYPE.IMAGE}      | ${''}
+      ${['daisy', 'sunflower', false, 0]}                                  | ${ELEMENT_TYPE.IMAGE}      | ${''}
+      ${[RESET_PROPERTIES.ANIMATION]}                                      | ${ELEMENT_TYPE.IMAGE}      | ${'All animations were removed from the image'}
+      ${[RESET_PROPERTIES.BACKGROUND_OVERLAY]}                             | ${ELEMENT_TYPE.BACKGROUND} | ${'All filters were removed from the background'}
+      ${[RESET_PROPERTIES.ANIMATION, RESET_PROPERTIES.BACKGROUND_OVERLAY]} | ${ELEMENT_TYPE.BACKGROUND} | ${'All animations and filters were removed from the background'}
+    `(
+      'should return snackbar copy as expected',
+      ({ properties, elementType, result }) => {
+        expect(getSnackbarClearCopy(properties, elementType)).toBe(result);
+      }
+    );
+  });
+});

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import { __ } from '@web-stories-wp/i18n';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 /**
  * Internal dependencies
  */
@@ -115,7 +115,7 @@ const useQuickActions = () => {
   const handleResetProperties = useCallback(
     (elementId, properties) => {
       const newProperties = {};
-
+      console.log({ properties });
       // Choose properties to clear
       if (properties.includes('backgroundOverlay')) {
         newProperties.backgroundOverlay = null;
@@ -191,7 +191,6 @@ const useQuickActions = () => {
 
   const {
     handleFocusAnimationPanel,
-    handleFocusMedia3pPanel,
     handleFocusLinkPanel,
     handleFocusPageBackground,
     handleFocusTextSetsPanel,
@@ -200,7 +199,6 @@ const useQuickActions = () => {
     () => ({
       handleFocusAnimationPanel: handleFocusPanel(states.ANIMATION),
       handleFocusLinkPanel: handleFocusPanel(states.LINK),
-      handleFocusMedia3pPanel: handleFocusPanel(states.MEDIA3P),
       handleFocusPageBackground: handleFocusPanel(states.PAGE_BACKGROUND),
       handleFocusTextSetsPanel: handleFocusPanel(states.TEXT),
       handleFocusStylePanel: handleFocusPanel(states.STYLE),
@@ -276,7 +274,10 @@ const useQuickActions = () => {
       },
     ],
     [
-      handleClearAnimations,
+      handleFocusMediaPanel,
+      selectedElement?.id,
+      actionMenuProps,
+      handleFocusAnimationPanel,
       handleFocusLinkPanel,
       handleFocusAnimationPanel,
       actionMenuProps,
@@ -352,6 +353,10 @@ const useQuickActions = () => {
     ]
   );
 
+  useEffect(() => {
+    console.log({ selectedElement });
+  }, [selectedElement]);
+
   // Hide menu if there are multiple elements selected
   if (selectedElements.length > 1) {
     return [];
@@ -379,7 +384,6 @@ const useQuickActions = () => {
       selectedElements?.[0]?.type
     ) > -1
   ) {
-    console.log('bg media found');
     return backgroundElementMediaActions;
   }
 

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -318,7 +318,7 @@ const useQuickActions = () => {
     return [
       {
         Icon: PictureSwap,
-        label: ACTION_TEXT.CHANGE_BACKGROUND_MEDIA,
+        label: ACTION_TEXT.REPLACE_BACKGROUND_MEDIA,
         onClick: handleFocusMediaPanel(selectedElement?.id),
         ...actionMenuProps,
       },
@@ -330,7 +330,7 @@ const useQuickActions = () => {
       },
       {
         Icon: Eraser,
-        label: ACTION_TEXT.CLEAR_FILTERS_AND_ANIMATION,
+        label: ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS,
         onClick: () =>
           handleClearAnimationsAndFilters({
             elementId: selectedElement?.id,

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -229,8 +229,13 @@ const useQuickActions = () => {
     handleMouseDown,
   ]);
 
-  const foregroundCommonActions = useMemo(
-    () => [
+  const foregroundCommonActions = useMemo(() => {
+    const resetProperties = getResetProperties(
+      selectedElement,
+      selectedElementAnimations
+    );
+
+    return [
       {
         Icon: CircleSpeed,
         label: ACTION_TEXT.ADD_ANIMATION,
@@ -246,44 +251,41 @@ const useQuickActions = () => {
       {
         Icon: Eraser,
         label: ACTION_TEXT.CLEAR_ANIMATIONS,
+
         onClick: () =>
           handleClearAnimationsAndFilters({
             elementId: selectedElement?.id,
             resetProperties,
-            elementType: ELEMENT_TYPE.IMAGE,
+            elementType: selectedElements?.[0]?.type,
           }),
         separator: 'top',
         disabled: resetProperties.length === 0,
         ...actionMenuProps,
       },
-    ],
-    [
-      handleFocusMediaPanel,
-      selectedElement?.id,
-      actionMenuProps,
-      handleFocusAnimationPanel,
-      handleFocusLinkPanel,
-      handleFocusAnimationPanel,
-      actionMenuProps,
-      selectedElement?.id,
-      selectedElementAnimations?.length,
-      handleClearAnimations,
-    ]
-  );
+    ];
+  }, [
+    selectedElement,
+    selectedElementAnimations,
+    handleFocusAnimationPanel,
+    actionMenuProps,
+    handleFocusLinkPanel,
+    handleClearAnimationsAndFilters,
+    selectedElements,
+  ]);
 
   const foregroundImageActions = useMemo(
     () => [
       {
         Icon: PictureSwap,
         label: ACTION_TEXT.REPLACE_MEDIA,
-        onClick: handleFocusMedia3pPanel(selectedElement?.id),
+        onClick: handleFocusMediaPanel(selectedElement?.id),
         ...actionMenuProps,
       },
       ...foregroundCommonActions,
     ],
     [
       actionMenuProps,
-      handleFocusMedia3pPanel,
+      handleFocusMediaPanel,
       foregroundCommonActions,
       selectedElement?.id,
     ]

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -364,10 +364,9 @@ const useQuickActions = () => {
   //  1. no element is selected
   //  2. the selected element is the background element and it's not media
   if (
-      !isBackgroundElementMedia &&
-      ((selectedElements.length === 0 &&
-       backgroundElement) ||
-       selectedElements[0]?.isBackground)
+    !isBackgroundElementMedia &&
+    ((selectedElements.length === 0 && backgroundElement) ||
+      selectedElements[0]?.isBackground)
   ) {
     return defaultActions;
   }

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -364,10 +364,10 @@ const useQuickActions = () => {
   //  1. no element is selected
   //  2. the selected element is the background element and it's not media
   if (
-    (selectedElements.length === 0 &&
-      backgroundElement &&
-      !isBackgroundElementMedia) ||
-    (selectedElements[0]?.isBackground && !isBackgroundElementMedia)
+      !isBackgroundElementMedia &&
+      ((selectedElements.length === 0 &&
+       backgroundElement) ||
+       selectedElements[0]?.isBackground)
   ) {
     return defaultActions;
   }

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -45,6 +45,7 @@ export const ELEMENT_TYPE = {
   SHAPE: 'shape',
   TEXT: 'text',
   VIDEO: 'video',
+  GIF: 'gif',
 };
 
 export const ACTION_TEXT = {
@@ -172,9 +173,24 @@ const useQuickActions = () => {
     [setHighlights]
   );
 
+  const handleFocusMediaPanel = useMemo(() => {
+    const idOrigin = selectedElements?.[0]?.resource?.id
+      ?.toString()
+      .split(':')?.[0];
+    const is3PGif =
+      !idOrigin &&
+      selectedElements?.[0]?.resource?.type?.toLowerCase() === 'gif';
+    const is3PVideo = idOrigin?.toLowerCase() === 'media/coverr';
+    const is3PImage = idOrigin?.toLowerCase() === 'media/unsplash';
+
+    const panelToFocus =
+      is3PImage || is3PVideo || is3PGif ? states.MEDIA3P : states.MEDIA;
+
+    return handleFocusPanel(panelToFocus);
+  }, [handleFocusPanel, selectedElements]);
+
   const {
     handleFocusAnimationPanel,
-    handleFocusMediaPanel,
     handleFocusMedia3pPanel,
     handleFocusLinkPanel,
     handleFocusPageBackground,
@@ -184,7 +200,6 @@ const useQuickActions = () => {
     () => ({
       handleFocusAnimationPanel: handleFocusPanel(states.ANIMATION),
       handleFocusLinkPanel: handleFocusPanel(states.LINK),
-      handleFocusMediaPanel: handleFocusPanel(states.MEDIA),
       handleFocusMedia3pPanel: handleFocusPanel(states.MEDIA3P),
       handleFocusPageBackground: handleFocusPanel(states.PAGE_BACKGROUND),
       handleFocusTextSetsPanel: handleFocusPanel(states.TEXT),
@@ -360,7 +375,7 @@ const useQuickActions = () => {
 
   if (
     isBackgroundElementMedia &&
-    [ELEMENT_TYPE.IMAGE, ELEMENT_TYPE.VIDEO].indexOf(
+    [ELEMENT_TYPE.IMAGE, ELEMENT_TYPE.VIDEO, ELEMENT_TYPE.GIF].indexOf(
       selectedElements?.[0]?.type
     ) > -1
   ) {

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -56,6 +56,9 @@ export const ACTION_TEXT = {
   INSERT_BACKGROUND_MEDIA: __('Insert background media', 'web-stories'),
   INSERT_TEXT: __('Insert text', 'web-stories'),
   REPLACE_MEDIA: __('Replace media', 'web-stories'),
+  CHANGE_BACKGROUND_MEDIA: __('Replace background', 'web-stories'),
+  ADD_ANIMATION: __('Add animation', 'web-stories'),
+  CLEAR_FILTERS_AND_ANIMATION: __('Clear filters and animation', 'web-stories'),
 };
 
 /**
@@ -303,19 +306,66 @@ const useQuickActions = () => {
     ]
   );
 
+  const backgroundElementMediaActions = useMemo(
+    () => [
+      {
+        Icon: PictureSwap,
+        label: ACTION_TEXT.CHANGE_BACKGROUND_MEDIA,
+        onClick: handleFocusMediaPanel(selectedElement?.id),
+        ...actionMenuProps,
+      },
+      {
+        Icon: CircleSpeed,
+        label: ACTION_TEXT.ADD_ANIMATION,
+        onClick: handleFocusAnimationPanel(selectedElement?.id),
+        ...actionMenuProps,
+      },
+      {
+        Icon: Eraser,
+        label: ACTION_TEXT.CLEAR_FILTERS_AND_ANIMATION,
+        onClick: () => handleClearAnimations(selectedElement?.id),
+        separator: 'top',
+        ...actionMenuProps,
+      },
+    ],
+    [
+      handleFocusMediaPanel,
+      selectedElement?.id,
+      actionMenuProps,
+      handleFocusAnimationPanel,
+      handleClearAnimations,
+    ]
+  );
+
   // Hide menu if there are multiple elements selected
   if (selectedElements.length > 1) {
     return [];
   }
 
+  const isBackgroundElementMedia = Boolean(
+    backgroundElement && backgroundElement?.resource
+  );
+
   // Return the base state if:
   //  1. no element is selected
-  //  2. the selected element is the background element
+  //  2. the selected element is the background element and it's not media
   if (
-    (selectedElements.length === 0 && backgroundElement) ||
-    selectedElements[0]?.isBackground
+    (selectedElements.length === 0 &&
+      backgroundElement &&
+      !isBackgroundElementMedia) ||
+    (selectedElements[0]?.isBackground && !isBackgroundElementMedia)
   ) {
     return defaultActions;
+  }
+
+  if (
+    isBackgroundElementMedia &&
+    [ELEMENT_TYPE.IMAGE, ELEMENT_TYPE.VIDEO].indexOf(
+      selectedElements?.[0]?.type
+    ) > -1
+  ) {
+    console.log('bg media found');
+    return backgroundElementMediaActions;
   }
 
   switch (selectedElements?.[0]?.type) {

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -283,6 +283,7 @@ const useQuickActions = () => {
       actionMenuProps,
       selectedElement?.id,
       selectedElementAnimations?.length,
+      handleClearAnimations,
     ]
   );
 
@@ -341,6 +342,7 @@ const useQuickActions = () => {
         label: ACTION_TEXT.CLEAR_FILTERS_AND_ANIMATION,
         onClick: () => handleClearAnimations(selectedElement?.id),
         separator: 'top',
+        disabled: !selectedElementAnimations?.length,
         ...actionMenuProps,
       },
     ],
@@ -349,13 +351,10 @@ const useQuickActions = () => {
       selectedElement?.id,
       actionMenuProps,
       handleFocusAnimationPanel,
+      selectedElementAnimations?.length,
       handleClearAnimations,
     ]
   );
-
-  useEffect(() => {
-    console.log({ selectedElement });
-  }, [selectedElement]);
 
   // Hide menu if there are multiple elements selected
   if (selectedElements.length > 1) {

--- a/assets/src/edit-story/app/highlights/quickActions/utils/getResetProperties.js
+++ b/assets/src/edit-story/app/highlights/quickActions/utils/getResetProperties.js
@@ -25,7 +25,7 @@ import { RESET_PROPERTIES } from '../constants';
  *
  * @param {Object} selectedElement element currently selected
  * @param {Array} selectedElementAnimations array of animations currently applied to the selected element
- * @return {Array}
+ * @return {Array} array of properties to reset on element
  */
 export const getResetProperties = (
   selectedElement,

--- a/assets/src/edit-story/app/highlights/quickActions/utils/getResetProperties.js
+++ b/assets/src/edit-story/app/highlights/quickActions/utils/getResetProperties.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { RESET_PROPERTIES } from '../constants';
+
+/**
+ * Determines which properties on an element are to be reset when
+ * "clear" is selected from a quick action menu
+ *
+ * @param {Object} selectedElement element currently selected
+ * @param {Array} selectedElementAnimations array of animations currently applied to the selected element
+ * @return {Array}
+ */
+export const getResetProperties = (
+  selectedElement,
+  selectedElementAnimations = []
+) => {
+  const resetProperties = [];
+
+  if (selectedElement?.backgroundOverlay) {
+    resetProperties.push(RESET_PROPERTIES.BACKGROUND_OVERLAY);
+  }
+  if (selectedElementAnimations?.length) {
+    resetProperties.push(RESET_PROPERTIES.ANIMATION);
+  }
+  return resetProperties;
+};

--- a/assets/src/edit-story/app/highlights/quickActions/utils/getResetProperties.js
+++ b/assets/src/edit-story/app/highlights/quickActions/utils/getResetProperties.js
@@ -24,8 +24,8 @@ import { RESET_PROPERTIES } from '../constants';
  * the "clear" action is selected from a quick action menu
  *
  * @param {Object} selectedElement element currently selected
- * @param {Array} selectedElementAnimations array of animations currently applied to the selected element
- * @return {Array} array of properties to reset on element
+ * @param {Array.<Object>} selectedElementAnimations array of animations currently applied to the selected element
+ * @return {Array.<string>} array of properties to reset on element
  */
 export const getResetProperties = (
   selectedElement,

--- a/assets/src/edit-story/app/highlights/quickActions/utils/getResetProperties.js
+++ b/assets/src/edit-story/app/highlights/quickActions/utils/getResetProperties.js
@@ -21,7 +21,7 @@ import { RESET_PROPERTIES } from '../constants';
 
 /**
  * Determines which properties on an element are to be reset when
- * "clear" is selected from a quick action menu
+ * the "clear" action is selected from a quick action menu
  *
  * @param {Object} selectedElement element currently selected
  * @param {Array} selectedElementAnimations array of animations currently applied to the selected element

--- a/assets/src/edit-story/app/highlights/quickActions/utils/getSnackbarClearCopy.js
+++ b/assets/src/edit-story/app/highlights/quickActions/utils/getSnackbarClearCopy.js
@@ -43,7 +43,7 @@ export const getSnackbarClearCopy = (resetProperties = [], elementType) => {
 
   return sprintf(
     /* translators: %1$s: list of element properties to be reset, %2$s is the element type */
-    __('All %1$s were removed from the %2$s', 'web-stories'),
+    __('All %1$s were removed from the %2$s.', 'web-stories'),
     translateToInclusiveList(resetPropertiesAsCopy),
     elementTypeAsCopy
   );

--- a/assets/src/edit-story/app/highlights/quickActions/utils/getSnackbarClearCopy.js
+++ b/assets/src/edit-story/app/highlights/quickActions/utils/getSnackbarClearCopy.js
@@ -30,7 +30,7 @@ import { ELEMENT_TYPE_COPY, RESET_LIST_COPY } from '../constants';
  *
  * @param {Array} resetProperties the element's properties to reset to default values
  * @param {string} elementType the type of element getting reset
- * @return {string}
+ * @return {string} string to display in snackbar
  */
 export const getSnackbarClearCopy = (resetProperties = [], elementType) => {
   const resetPropertiesAsCopy = resetProperties

--- a/assets/src/edit-story/app/highlights/quickActions/utils/getSnackbarClearCopy.js
+++ b/assets/src/edit-story/app/highlights/quickActions/utils/getSnackbarClearCopy.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { sprintf, translateToInclusiveList, __ } from '@web-stories-wp/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ELEMENT_TYPE_COPY, RESET_LIST_COPY } from '../constants';
+
+/**
+ * Sets up the copy to display on snackbar in editor
+ * when 'clear' is selected from a quick action menu
+ *
+ * @param {Array} resetProperties the element's properties to reset to default values
+ * @param {string} elementType the type of element getting reset
+ * @return {string}
+ */
+export const getSnackbarClearCopy = (resetProperties = [], elementType) => {
+  const resetPropertiesAsCopy = resetProperties
+    .map((property) => RESET_LIST_COPY[property])
+    .filter((propertyCopy) => propertyCopy);
+  const elementTypeAsCopy = ELEMENT_TYPE_COPY[elementType];
+  if (resetPropertiesAsCopy.length <= 0) {
+    return '';
+  }
+
+  return sprintf(
+    /* translators: %1$s: list of element properties to be reset, %2$s is the element type */
+    __('All %1$s were removed from the %2$s', 'web-stories'),
+    translateToInclusiveList(resetPropertiesAsCopy),
+    elementTypeAsCopy
+  );
+};

--- a/assets/src/edit-story/app/highlights/quickActions/utils/getSnackbarClearCopy.js
+++ b/assets/src/edit-story/app/highlights/quickActions/utils/getSnackbarClearCopy.js
@@ -26,7 +26,7 @@ import { ELEMENT_TYPE_COPY, RESET_LIST_COPY } from '../constants';
 
 /**
  * Sets up the copy to display on snackbar in editor
- * when 'clear' is selected from a quick action menu
+ * when the 'clear' action is selected from a quick action menu
  *
  * @param {Array} resetProperties the element's properties to reset to default values
  * @param {string} elementType the type of element getting reset

--- a/assets/src/edit-story/app/highlights/quickActions/utils/index.js
+++ b/assets/src/edit-story/app/highlights/quickActions/utils/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,19 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Internal dependencies
- */
-import { OUTLINE, FLASH } from './styles';
 
-export { default as useHighlights } from './useHighlights';
-export { default as useFocusHighlight } from './useFocusHighlight';
-export { default as HighlightsProvider } from './provider';
-export { default as states } from './states';
-export { ACTION_TEXT } from './quickActions/constants';
-export { useQuickActions } from './quickActions';
-
-export const styles = {
-  OUTLINE,
-  FLASH,
-};
+export { getResetProperties } from './getResetProperties';
+export { getSnackbarClearCopy } from './getSnackbarClearCopy';

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -482,8 +482,6 @@ fdescribe('Quick Actions integration', () => {
       await waitFor(() => {
         expect(animations.length).toBe(0);
         expect(selectedElement.backgroundOverlay).toBeNull();
-        expect(selectedElement).toBeFalsy();
-
         expect(
           fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
             .disabled

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -420,7 +420,7 @@ describe('Quick Actions integration', () => {
       );
     });
 
-    it(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERSS}\` button should remove all animations and filters. Clicking the undo button should reapply the animation and filter.`, async () => {
+    it(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS}\` button should remove all animations and filters. Clicking the undo button should reapply the animation and filter.`, async () => {
       // quick action should be disabled if there are no animations yet
       expect(
         fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { waitFor } from '@testing-library/dom';
 import { useStory } from '../../../app';
 import { ACTION_TEXT } from '../../../app/highlights';
 import { Fixture } from '../../../karma';
@@ -427,6 +428,11 @@ fdescribe('Quick Actions integration', () => {
           .disabled
       ).toBe(true);
 
+      // apply filter to background element
+      await fixture.events.click(
+        fixture.editor.inspector.designPanel.filters.linear
+      );
+
       // add animation to image
       const effectChooserToggle =
         fixture.editor.inspector.designPanel.animation.effectChooser;
@@ -440,11 +446,6 @@ fdescribe('Quick Actions integration', () => {
       // apply animation to element
       await fixture.events.click(animation, { clickCount: 1 });
 
-      // apply filter to background element
-      await fixture.events.click(
-        fixture.editor.inspector.designPanel.filters.linear
-      );
-
       // verify that element has animation and filter
       const {
         animations: originalAnimations,
@@ -455,19 +456,20 @@ fdescribe('Quick Actions integration', () => {
           selectedElement: state.selectedElements[0],
         }))
       );
-      expect(originalAnimations.length).toBe(1);
-      expect(originalSelectedElement.backgroundOverlay.type).toBe('linear');
+
+      await waitFor(() => {
+        expect(originalAnimations.length).toBe(1);
+        expect(originalSelectedElement.backgroundOverlay.type).toBe('linear');
+        expect(
+          fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
+            .disabled
+        ).toBe(false);
+      });
 
       // click quick menu button
-      expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
-          .disabled
-      ).toBe(false);
       await fixture.events.click(
         fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
       );
-
-      await fixture.events.sleep(500);
 
       // verify that element has no animations
       const { animations, selectedElement } = await fixture.renderHook(() =>
@@ -476,14 +478,17 @@ fdescribe('Quick Actions integration', () => {
           selectedElement: state.selectedElements[0],
         }))
       );
-      expect(animations.length).toBe(0);
-      expect(selectedElement.backgroundOverlay).toBeNull();
-      expect(selectedElement).toBeFalsy();
 
-      expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
-          .disabled
-      ).toBe(true);
+      await waitFor(() => {
+        expect(animations.length).toBe(0);
+        expect(selectedElement.backgroundOverlay).toBeNull();
+        expect(selectedElement).toBeFalsy();
+
+        expect(
+          fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
+            .disabled
+        ).toBe(true);
+      });
 
       // click `undo` button on snackbar
       await fixture.events.click(
@@ -500,16 +505,19 @@ fdescribe('Quick Actions integration', () => {
           selectedElement: state.selectedElements[0],
         }))
       );
-      expect(revertedAnimations.length).toBe(1);
-      expect(revertedAnimations[0]).toEqual(originalAnimations[0]);
-      expect(revertedSelectedElement.backgroundOverlay?.type).toEqual(
-        originalSelectedElement.backgroundOverlay?.type
-      );
 
-      expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
-          .disabled
-      ).toBe(false);
+      await waitFor(() => {
+        expect(revertedAnimations.length).toBe(1);
+        expect(revertedAnimations[0]).toEqual(originalAnimations[0]);
+        expect(revertedSelectedElement.backgroundOverlay?.type).toEqual(
+          originalSelectedElement.backgroundOverlay?.type
+        );
+
+        expect(
+          fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
+            .disabled
+        ).toBe(false);
+      });
     });
   });
 

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -121,7 +121,7 @@ describe('Quick Actions integration', () => {
       );
     });
 
-    it(`clicking the \`${ACTION_TEXT.REPLACE_MEDIA}\` button should select select the media 3p tab and focus the media 3p tab`, async () => {
+    it(`clicking the \`${ACTION_TEXT.REPLACE_MEDIA}\` button should select select the media tab and focus the media tab`, async () => {
       // hide 3p modal before we click the quick action
       await fixture.events.click(fixture.editor.library.media3pTab);
       // tab to dismiss button and press enter
@@ -129,17 +129,14 @@ describe('Quick Actions integration', () => {
       await fixture.events.keyboard.press('tab');
       await fixture.events.keyboard.press('Enter');
 
-      // change tab to make sure tab isn't selected before quick action
-      await fixture.events.click(fixture.editor.library.mediaTab);
-
       // click quick menu button
       await fixture.events.click(
         fixture.editor.canvas.quickActionMenu.replaceMediaButton
       );
 
-      expect(fixture.editor.library.media3p).not.toBeNull();
+      expect(fixture.editor.library.media).not.toBeNull();
 
-      expect(document.activeElement).toEqual(fixture.editor.library.media3pTab);
+      expect(document.activeElement).toEqual(fixture.editor.library.mediaTab);
     });
 
     it(`clicking the \`${ACTION_TEXT.ADD_ANIMATION}\` button should select the animation panel and focus the dropdown`, async () => {
@@ -369,4 +366,160 @@ describe('Quick Actions integration', () => {
       ).toBe(false);
     });
   });
+
+  describe('background image selected', () => {
+    beforeEach(async () => {
+      await addBackgroundImage(0);
+
+      const {
+        state: {
+          currentPage: {
+            elements: [{ id }],
+          },
+        },
+      } = await fixture.renderHook(() => useStory());
+
+      const canvasElementWrapperId = fixture.querySelector(
+        `[data-testid="safezone"] [data-element-id="${id}"]`
+      );
+
+      await fixture.events.click(canvasElementWrapperId);
+    });
+
+    it(`clicking the \`${ACTION_TEXT.REPLACE_BACKGROUND_MEDIA}\` button should select select the media tab and focus the media tab`, async () => {
+      // change tab to make sure tab isn't selected before quick action
+      // hide 3p modal before we click the quick action
+      await fixture.events.click(fixture.editor.library.mediaTab);
+      // tab to dismiss button and press enter
+      await fixture.events.keyboard.press('tab');
+      await fixture.events.keyboard.press('tab');
+      await fixture.events.keyboard.press('Enter');
+
+      const bgMediaButton =
+        fixture.editor.canvas.quickActionMenu.replaceBackgroundMediaButton;
+      expect(bgMediaButton).toBeDefined();
+
+      // click quick menu button
+      await fixture.events.click(bgMediaButton);
+
+      expect(fixture.editor.library.media).not.toBeNull();
+
+      expect(document.activeElement).toEqual(fixture.editor.library.mediaTab);
+    });
+
+    it(`clicking the \`${ACTION_TEXT.ADD_ANIMATION}\` button should select the animation panel and focus the dropdown`, async () => {
+      // click quick menu button
+      await fixture.events.click(
+        fixture.editor.canvas.quickActionMenu.addAnimationButton
+      );
+
+      expect(fixture.editor.inspector.designPanel.animation).not.toBeNull();
+
+      expect(document.activeElement).toEqual(
+        fixture.editor.inspector.designPanel.animation.effectChooser
+      );
+    });
+
+    it(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERSS}\` button should remove all animations and filters. Clicking the undo button should reapply the animation and filter.`, async () => {
+      // quick action should be disabled if there are no animations yet
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
+          .disabled
+      ).toBe(true);
+
+      // add animation to image
+      const effectChooserToggle =
+        fixture.editor.inspector.designPanel.animation.effectChooser;
+      await fixture.events.click(effectChooserToggle, { clickCount: 1 });
+
+      // animation
+      const animation = fixture.screen.getByRole('option', {
+        name: '"Pan and Zoom" Effect',
+      });
+
+      // apply animation to element
+      await fixture.events.click(animation, { clickCount: 1 });
+
+      // apply filter to background element
+      await fixture.events.click(
+        fixture.editor.inspector.designPanel.filters.linear
+      );
+
+      // verify that element has animation and filter
+      const {
+        animations: originalAnimations,
+        selectedElement: originalSelectedElement,
+      } = await fixture.renderHook(() =>
+        useStory(({ state }) => ({
+          animations: state.pages[0].animations,
+          selectedElement: state.selectedElements[0],
+        }))
+      );
+      expect(originalAnimations.length).toBe(1);
+      expect(originalSelectedElement.backgroundOverlay.type).toBe('linear');
+
+      // click quick menu button
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
+          .disabled
+      ).toBe(false);
+      await fixture.events.click(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
+      );
+
+      // verify that element has no animations
+      const { animations, selectedElement } = await fixture.renderHook(() =>
+        useStory(({ state }) => ({
+          animations: state.pages[0].animations,
+          selectedElement: state.selectedElements[0],
+        }))
+      );
+      expect(animations.length).toBe(0);
+      expect(selectedElement.backgroundOverlay).toBeNull();
+
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
+          .disabled
+      ).toBe(true);
+
+      // click `undo` button on snackbar
+      await fixture.events.click(
+        fixture.screen.getByRole('button', { name: /^Undo$/ })
+      );
+
+      // Verify that new animations match original animation
+      const {
+        animations: revertedAnimations,
+        selectedElement: revertedSelectedElement,
+      } = await fixture.renderHook(() =>
+        useStory(({ state }) => ({
+          animations: state.pages[0].animations,
+          selectedElement: state.selectedElements[0],
+        }))
+      );
+      expect(revertedAnimations.length).toBe(1);
+      expect(revertedAnimations[0]).toEqual(originalAnimations[0]);
+      expect(revertedSelectedElement.backgroundOverlay.type).toEqual(
+        originalSelectedElement.backgroundOverlay.type
+      );
+
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
+          .disabled
+      ).toBe(false);
+    });
+  });
+
+  async function addBackgroundImage(index) {
+    // Drag image to canvas corner to set as background
+    const image = fixture.editor.library.media.item(index);
+    const canvas = fixture.editor.canvas.framesLayer.fullbleed;
+
+    await fixture.events.mouse.seq(({ down, moveRel, up }) => [
+      moveRel(image, 20, 20),
+      down(),
+      moveRel(canvas, 10, 10),
+      up(),
+    ]);
+  }
 });

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/**
+ * External dependencies
+ */
+import { waitFor } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { waitFor } from '@testing-library/dom';
 import { useStory } from '../../../app';
 import { ACTION_TEXT } from '../../../app/highlights';
 import { Fixture } from '../../../karma';
 import useInsertElement from '../useInsertElement';
 
-fdescribe('Quick Actions integration', () => {
+describe('Quick Actions integration', () => {
   let fixture;
 
   async function clickOnTarget(target) {
@@ -421,7 +423,7 @@ fdescribe('Quick Actions integration', () => {
       );
     });
 
-    fit(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS}\` button should remove all animations and filters. Clicking the undo button should reapply the animation and filter.`, async () => {
+    it(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS}\` button should remove all animations and filters. Clicking the undo button should reapply the animation and filter.`, async () => {
       // quick action should be disabled if there are no animations yet
       expect(
         fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -22,7 +22,7 @@ import { ACTION_TEXT } from '../../../app/highlights';
 import { Fixture } from '../../../karma';
 import useInsertElement from '../useInsertElement';
 
-describe('Quick Actions integration', () => {
+fdescribe('Quick Actions integration', () => {
   let fixture;
 
   async function clickOnTarget(target) {
@@ -499,8 +499,8 @@ describe('Quick Actions integration', () => {
       );
       expect(revertedAnimations.length).toBe(1);
       expect(revertedAnimations[0]).toEqual(originalAnimations[0]);
-      expect(revertedSelectedElement.backgroundOverlay.type).toEqual(
-        originalSelectedElement.backgroundOverlay.type
+      expect(revertedSelectedElement.backgroundOverlay?.type).toEqual(
+        originalSelectedElement.backgroundOverlay?.type
       );
 
       expect(

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -420,7 +420,7 @@ fdescribe('Quick Actions integration', () => {
       );
     });
 
-    it(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS}\` button should remove all animations and filters. Clicking the undo button should reapply the animation and filter.`, async () => {
+    fit(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS}\` button should remove all animations and filters. Clicking the undo button should reapply the animation and filter.`, async () => {
       // quick action should be disabled if there are no animations yet
       expect(
         fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
@@ -467,6 +467,8 @@ fdescribe('Quick Actions integration', () => {
         fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
       );
 
+      await fixture.events.sleep(500);
+
       // verify that element has no animations
       const { animations, selectedElement } = await fixture.renderHook(() =>
         useStory(({ state }) => ({
@@ -476,6 +478,7 @@ fdescribe('Quick Actions integration', () => {
       );
       expect(animations.length).toBe(0);
       expect(selectedElement.backgroundOverlay).toBeNull();
+      expect(selectedElement).toBeFalsy();
 
       expect(
         fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton

--- a/assets/src/edit-story/karma/fixture/containers/quickActionMenu.js
+++ b/assets/src/edit-story/karma/fixture/containers/quickActionMenu.js
@@ -54,6 +54,12 @@ export class QuickActionMenu extends Container {
     });
   }
 
+  get replaceBackgroundMediaButton() {
+    return this.queryByRole('menuitem', {
+      name: ACTION_TEXT.REPLACE_BACKGROUND_MEDIA,
+    });
+  }
+
   get addAnimationButton() {
     return this.queryByRole('menuitem', {
       name: ACTION_TEXT.ADD_ANIMATION,
@@ -69,6 +75,12 @@ export class QuickActionMenu extends Container {
   get clearAnimationsButton() {
     return this.queryByRole('menuitem', {
       name: ACTION_TEXT.CLEAR_ANIMATIONS,
+    });
+  }
+
+  get clearAnimationsAndFiltersButton() {
+    return this.queryByRole('menuitem', {
+      name: ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS,
     });
   }
 }


### PR DESCRIPTION
## Context

Adds the quick menu specific to background images (also video), this is behind a feature flag.

## Summary

New quick menu for background media (applies to images, video, gifs, whatever media is your background element). 
Has the ability to:
- Navigate to media panel (which ever the existing media came from) 
- Navigate to animation panel 
- If there are animations or filters applied to the bg media element then the 'clear' button will reset those values (hitting undo will bring them back)

## Relevant Technical Choices

Most of the core functionality here was already done so I focused on some peripheral updates to make sharing code easier. 

- moved all the static text and constants to `./constants` to make `useQuickActions` a little less long. 
- update function that was formerly `clearAnimations` to be `handleClearAnimationsAndFilters` (though it doesn't need to be limited to that now) and wrote some helpers to figure out what values we want to reset dynamically. Those live in `../quickActions/utils`
- Updated `handleFocusMedia` so that it can dynamically pick whichever media tab the existing media came from, defaults to local media. Updated foreground image to use this. 
- Adjust checks for the empty bg menu (defualt) vs bg element with media for what menu to display.

## Notes to discuss next week when design is back!

- I feel like maybe some of the copy is out of sorts between the `clear ___` buttons and the snackbar messages. I just checked the figma files today and the snackbar messages say a blanket "styles have been removed" but we're only ever getting rid of either animations or filters so that's a bit misleading. I think that'll be easier to talk to design about next week. 
- On a similar note I think maybe only saying "clear animations" or "clear filters" or "clear animations and filters" on the clear tooltip would be helpful according to what the element has set. 

## To Do

- [ ]  Add in some axe karma tests 💪 

## User-facing changes

None, hidden behind a feature flag 

## Testing Instructions

1. Make sure that `Enable Quick Action Menus` experiment is on. 
2. Open a story or make a new one 
3. Add a background image/video/gif and see the quick menu update to have the options of 1) replace background 2) Add animation 3) clear filters and animation

By default `clear` should be disabled until you have filters or animations present

Clicking `replace background` takes you to the media panel from which the existing background media came from (this is new) 
Clicking `add animation` takes you to the animation panel 
Clicking `clear` (when enabled) will clear off any filter or animation applied to the element and show a snackbar saying what it updated (filter or animation or both). 


https://user-images.githubusercontent.com/10720454/119204990-cc6de600-ba4b-11eb-9f67-3f7483050463.mp4


### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6142 
