### PR TITLE
Media: Add `crossorigin` attribute in WordPress media modal

### DIFF
--- a/includes/Admin/Cross_Origin_Isolation.php
+++ b/includes/Admin/Cross_Origin_Isolation.php
@@ -271,7 +271,7 @@ class Cross_Origin_Isolation extends Service_Base {
 		$tags = [
 			'audio',
 			'img',
-			'video'
+			'video',
 		];
 		foreach ( $tags as $tag ) {
 			$html = (string) str_replace( '<' . $tag, '<' . $tag . ' crossorigin="anonymous"', $html );

--- a/includes/Admin/Cross_Origin_Isolation.php
+++ b/includes/Admin/Cross_Origin_Isolation.php
@@ -32,7 +32,6 @@ use Google\Web_Stories\Service_Base;
 use Google\Web_Stories\Traits\Screen;
 use Google\Web_Stories\User\Preferences;
 use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
-use Google\Web_Stories\Experiments;
 
 
 /**
@@ -60,6 +59,7 @@ class Cross_Origin_Isolation extends Service_Base {
 		add_filter( 'style_loader_tag', [ $this, 'style_loader_tag' ], 10, 3 );
 		add_filter( 'script_loader_tag', [ $this, 'script_loader_tag' ], 10, 3 );
 		add_filter( 'get_avatar', [ $this, 'get_avatar' ], 10, 6 );
+		add_action( 'wp_enqueue_media', [ $this, 'override_media_templates' ] );
 	}
 
 	/**
@@ -242,6 +242,42 @@ class Cross_Origin_Isolation extends Service_Base {
 		$new_html = (string) str_replace( "{$attribute}='{$url}'", "crossorigin='anonymous' {$attribute}='{$url}'", $new_html );
 
 		return $new_html;
+	}
+
+	/**
+	 * Unhook wp_print_media_templates and replace with custom media templates.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return void
+	 */
+	public function override_media_templates() {
+		remove_action( 'admin_footer', 'wp_print_media_templates' );
+		add_action( 'admin_footer', [ $this, 'custom_print_media_templates' ] );
+	}
+
+	/**
+	 * Add crossorigin attribute to all tags that could have assets loaded from a different domain.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @return void
+	 */
+	public function custom_print_media_templates() {
+		ob_start();
+		wp_print_media_templates();
+		$html = (string) ob_get_clean();
+
+		$tags = [
+			'audio',
+			'img',
+			'video'
+		];
+		foreach ( $tags as $tag ) {
+			$html = (string) str_replace( '<' . $tag, '<' . $tag . ' crossorigin="anonymous"', $html );
+		}
+
+		echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/tests/phpunit/tests/Admin/Cross_Origin_Isolation.php
+++ b/tests/phpunit/tests/Admin/Cross_Origin_Isolation.php
@@ -217,6 +217,20 @@ class Cross_Origin_Isolation extends Test_Case {
 		$this->assertContains( '<img crossorigin="anonymous" src="http://www.example.com/test1.jpg" />', $result );
 	}
 
+
+	/**
+	 * @covers ::custom_print_media_templates
+	 */
+	public function test_custom_print_media_templates() {
+		require_once ABSPATH . WPINC . '/media-template.php';
+		$object = $this->get_coi_object();
+		$output = get_echo( [ $object, 'custom_print_media_templates' ] );
+		$this->assertContains( '<audio crossorigin="anonymous"', $output );
+		$this->assertContains( '<img crossorigin="anonymous"', $output );
+		$this->assertContains( '<video crossorigin="anonymous"', $output );
+	}
+
+
 	/**
 	 * @return \Google\Web_Stories\Admin\Cross_Origin_Isolation
 	 */


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Override custom underscore templates and repalce, audio, video and image tags with one with crossorigin attribute. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7560 
