### PR TITLE
Fix rotate handle position for non-zero rotation

### DIFF
--- a/assets/src/edit-story/components/moveable/moveStyle.js
+++ b/assets/src/edit-story/components/moveable/moveStyle.js
@@ -104,13 +104,8 @@ export const GlobalStyle = createGlobalStyle`
   .default-moveable.moveable-control-box .moveable-line.moveable-rotation-line {
     background: ${({ theme }) => theme.colors.border.selection} !important;
     width: 1px;
-    height: 13px;
-    top: 2px;
-  }
-
-  .default-moveable.moveable-control-box .moveable-rotation {
-    top: -15px;
-    bottom: initial;
+    height: 15px;
+    top: 25px;
   }
 
   .default-moveable.moveable-control-box .moveable-control.moveable-rotation-control {
@@ -118,6 +113,7 @@ export const GlobalStyle = createGlobalStyle`
     width: 10px;
     height: 10px;
     margin-left: -5px;
+    top: 25px;
   }
 
   .default-moveable.hide-handles .moveable-line.moveable-rotation-line,


### PR DESCRIPTION
## Summary

Fixes the issue introduced some time ago when react-moveable was updated.
Tested with zoom.

## Testing Instructions

1. Add an image to a page
2. Rotate it
3. Observe that the rotation handle is connected to the element/at the right angle.

### QA & UAT
^

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7616
