### PR TITLE
Quick Actions: Disable `Clear animation` action when no animations are applied

### DIFF
--- a/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
@@ -292,7 +292,22 @@ describe('useQuickActions', () => {
       });
     });
 
-    it('clicking `clear animations` should call `updateElementsById`', () => {
+    it(`\`${ACTION_TEXT.CLEAR_ANIMATIONS}\` action should be disabled if element has no animations`, () => {
+      mockUseStory.mockReturnValue({
+        currentPage: {
+          elements: [BACKGROUND_ELEMENT, IMAGE_ELEMENT],
+        },
+        selectedElementAnimations: [],
+        selectedElements: [IMAGE_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
+      });
+
+      const { result } = renderHook(() => useQuickActions());
+
+      expect(result.current[3].disabled).toBe(true);
+    });
+
+    it('clicking `clear animations` should update the element', () => {
       const { result } = renderHook(() => useQuickActions());
 
       result.current[3].onClick(mockClickEvent);

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -256,6 +256,7 @@ const useQuickActions = () => {
         label: ACTION_TEXT.CLEAR_ANIMATIONS,
         onClick: () => handleClearAnimations(selectedElement?.id),
         separator: 'top',
+        disabled: !selectedElementAnimations?.length,
         ...actionMenuProps,
       },
     ],
@@ -263,9 +264,10 @@ const useQuickActions = () => {
       actionMenuProps,
       handleClearAnimations,
       handleFocusAnimationPanel,
-      handleFocusMedia3pPanel,
       handleFocusLinkPanel,
+      handleFocusMedia3pPanel,
       selectedElement?.id,
+      selectedElementAnimations?.length,
     ]
   );
 

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -17,9 +17,6 @@
 /**
  * Internal dependencies
  */
-/**
- * External dependencies
- */
 import { useStory } from '../../../app';
 import { ACTION_TEXT } from '../../../app/highlights';
 import { Fixture } from '../../../karma';

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -17,6 +17,9 @@
 /**
  * Internal dependencies
  */
+/**
+ * External dependencies
+ */
 import { useStory } from '../../../app';
 import { ACTION_TEXT } from '../../../app/highlights';
 import { Fixture } from '../../../karma';
@@ -169,6 +172,11 @@ describe('Quick Actions integration', () => {
     });
 
     it(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATIONS}\` button should remove all animations. Clicking the undo button should reapply the animation.`, async () => {
+      // quick action should be disabled if there are no animations yet
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
+      ).toBe(true);
+
       // add animation to image
       const effectChooserToggle =
         fixture.editor.inspector.designPanel.animation.effectChooser;
@@ -191,6 +199,9 @@ describe('Quick Actions integration', () => {
       expect(originalAnimations.length).toBe(1);
 
       // click quick menu button
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
+      ).toBe(false);
       await fixture.events.click(
         fixture.editor.canvas.quickActionMenu.clearAnimationsButton
       );
@@ -202,6 +213,9 @@ describe('Quick Actions integration', () => {
         }))
       );
       expect(animations.length).toBe(0);
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
+      ).toBe(true);
 
       // click `undo` button on snackbar
       await fixture.events.click(
@@ -216,6 +230,9 @@ describe('Quick Actions integration', () => {
       );
       expect(revertedAnimations.length).toBe(1);
       expect(revertedAnimations[0]).toEqual(originalAnimations[0]);
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
+      ).toBe(false);
     });
   });
 });

--- a/assets/src/edit-story/karma/fixture/containers/quickActionMenu.js
+++ b/assets/src/edit-story/karma/fixture/containers/quickActionMenu.js
@@ -25,43 +25,43 @@ export class QuickActionMenu extends Container {
   }
 
   get changeBackgroundColorButton() {
-    return this.queryByRole('button', {
+    return this.queryByRole('menuitem', {
       name: ACTION_TEXT.CHANGE_BACKGROUND_COLOR,
     });
   }
 
   get insertBackgroundMediaButton() {
-    return this.queryByRole('button', {
+    return this.queryByRole('menuitem', {
       name: ACTION_TEXT.INSERT_BACKGROUND_MEDIA,
     });
   }
 
   get insertTextButton() {
-    return this.queryByRole('button', {
+    return this.queryByRole('menuitem', {
       name: ACTION_TEXT.INSERT_TEXT,
     });
   }
 
   get replaceMediaButton() {
-    return this.queryByRole('button', {
+    return this.queryByRole('menuitem', {
       name: ACTION_TEXT.REPLACE_MEDIA,
     });
   }
 
   get addAnimationButton() {
-    return this.queryByRole('button', {
+    return this.queryByRole('menuitem', {
       name: ACTION_TEXT.ADD_ANIMATION,
     });
   }
 
   get addLinkButton() {
-    return this.queryByRole('button', {
+    return this.queryByRole('menuitem', {
       name: ACTION_TEXT.ADD_LINK,
     });
   }
 
   get clearAnimationsButton() {
-    return this.queryByRole('button', {
+    return this.queryByRole('menuitem', {
       name: ACTION_TEXT.CLEAR_ANIMATIONS,
     });
   }


### PR DESCRIPTION
## Context

quick actions

## Summary

Disable `Clear animation` action when no animations are applied. Update tests too.

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![no-disable](https://user-images.githubusercontent.com/22185279/119032597-9a845300-b969-11eb-91e1-a3c8dc15c289.gif)|![disable](https://user-images.githubusercontent.com/22185279/119032613-9d7f4380-b969-11eb-87c1-159c3dfea446.gif)|

## Testing Instructions

1. Enable quick actions experiment
2. Add image to canvas in editor
3. Focus image
4. Last quick action should be disabled
5. Add an animation - should enable that button
6. Click the last quick action or remove the animation from the panel. Button should be disabled again.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7602
