### PR TITLE
Pre-Publish Checklist: Video Optimization displays thumbnail for missing poster

### DIFF
--- a/assets/src/edit-story/app/prepublish/components/videoOptimization.js
+++ b/assets/src/edit-story/app/prepublish/components/videoOptimization.js
@@ -68,11 +68,13 @@ export function VideoOptimization({ element, caption }) {
   return (
     <Container>
       <Caption>{caption}</Caption>
-      <Thumbnail
-        src={resource?.poster}
-        alt={resource?.alt || __('Video thumbnail', 'web-stories')}
-        crossOrigin="anonymous"
-      />
+      {resource?.poster && (
+        <Thumbnail
+          src={resource.poster}
+          alt={resource?.alt || __('Video thumbnail', 'web-stories')}
+          crossOrigin="anonymous"
+        />
+      )}
       <OptimizeButton
         type={BUTTON_TYPES.TERTIARY}
         size={BUTTON_SIZES.SMALL}


### PR DESCRIPTION
## Context
Part of video optimization in PPC work

## Summary
Conditionally renders video thumbnail depending on if there's a poster image.

Before, it would display the alt and not look good
![119059308-5710ff80-b9d0-11eb-8fe0-ad0b7a3f8757](https://user-images.githubusercontent.com/35983235/119167390-0a074a80-ba1d-11eb-90f5-d57504a37bd0.png)


## Relevant Technical Choices
NA
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
In the pre-publish checklist check for unoptimized videos:
If a user uploads a video without a poster image, the poster image thumbnail should not display anymore.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
-> Open Settings
-> Turn off auto optimize videos
-> Navigate to the editor
-> Drag a large video onto the canvas without a poster image
-> Navigate to the pre-publish checklist
-> If the check should never show the alt text in the thumbnail. Just either the video thumbnail with an image or no thumbnail
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
Follow testing instructions above.
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7635 
