### PR TITLE
Quick Action Menu: Keep element selected when clicking in between the buttons

### DIFF
--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -122,7 +122,11 @@ function DisplayLayer() {
 
   const quickActions = useQuickActions();
 
-  const { editingElement, setPageContainer, setFullbleedContainer } = useCanvas(
+  const {
+    editingElement,
+    setPageContainer,
+    setFullbleedContainer,
+  } = useCanvas(
     ({
       state: { editingElement },
       actions: { setPageContainer, setFullbleedContainer },
@@ -136,10 +140,18 @@ function DisplayLayer() {
     updateAnimationState({ animationState: STORY_ANIMATION_STATE.RESET });
   }, [updateAnimationState]);
 
-  const animatedElements = useMemo(
-    () => selectedElements.map((el) => el.id),
-    [selectedElements]
-  );
+  /**
+   * Stop the event from bubbling if the user clicks in between buttons.
+   *
+   * This prevents the selected element from losing focus.
+   */
+  const handleMenuBackgroundClick = useCallback((ev) => {
+    ev.stopPropagation();
+  }, []);
+
+  const animatedElements = useMemo(() => selectedElements.map((el) => el.id), [
+    selectedElements,
+  ]);
 
   return (
     <StoryAnimation.Provider
@@ -179,7 +191,12 @@ function DisplayLayer() {
         {enableQuickActionMenu && quickActions.length && (
           <DirectionAware>
             <QuickActionsArea>
-              <ContextMenu isAlwaysVisible isIconMenu items={quickActions} />
+              <ContextMenu
+                isAlwaysVisible
+                isIconMenu
+                items={quickActions}
+                onMouseDown={handleMenuBackgroundClick}
+              />
             </QuickActionsArea>
           </DirectionAware>
         )}

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -143,7 +143,7 @@ function DisplayLayer() {
   /**
    * Stop the event from bubbling if the user clicks in between buttons.
    *
-   * This prevents the selected element from losing focus.
+   * This prevents the selected element in the canvas from losing focus.
    */
   const handleMenuBackgroundClick = useCallback((ev) => {
     ev.stopPropagation();

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -122,11 +122,7 @@ function DisplayLayer() {
 
   const quickActions = useQuickActions();
 
-  const {
-    editingElement,
-    setPageContainer,
-    setFullbleedContainer,
-  } = useCanvas(
+  const { editingElement, setPageContainer, setFullbleedContainer } = useCanvas(
     ({
       state: { editingElement },
       actions: { setPageContainer, setFullbleedContainer },
@@ -149,9 +145,10 @@ function DisplayLayer() {
     ev.stopPropagation();
   }, []);
 
-  const animatedElements = useMemo(() => selectedElements.map((el) => el.id), [
-    selectedElements,
-  ]);
+  const animatedElements = useMemo(
+    () => selectedElements.map((el) => el.id),
+    [selectedElements]
+  );
 
   return (
     <StoryAnimation.Provider


### PR DESCRIPTION
## Context

Quick Actions

## Summary

Keeps the selected element focused when clicking the menu but missing the button.

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![clicky-sucks](https://user-images.githubusercontent.com/22185279/119177089-0e396500-ba29-11eb-9eab-a5646a425536.gif)|![clicky-works](https://user-images.githubusercontent.com/22185279/119177009-f9f56800-ba28-11eb-8341-cd8d6f53878b.gif)|

## Testing Instructions

1. Enable quick actions experiment
2. Go to editor
3. Add image
4. Click menu *in between the buttons*. Element should stay focused.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7625
