### PR TITLE
Animation: Update Background Zoom Animation

### DIFF
--- a/assets/src/animation/effects/backgroundPan/animationProps.js
+++ b/assets/src/animation/effects/backgroundPan/animationProps.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@web-stories-wp/i18n';
+import { __, _x } from '@web-stories-wp/i18n';
 import PropTypes from 'prop-types';
 
 /**
@@ -28,6 +28,7 @@ import { AnimationInputPropTypes } from '../types';
 
 export const PanEffectInputPropTypes = {
   panDir: PropTypes.shape(AnimationInputPropTypes),
+  duration: PropTypes.shape(AnimationInputPropTypes),
 };
 
 export default {
@@ -41,5 +42,11 @@ export default {
       DIRECTION.RIGHT_TO_LEFT,
     ],
     defaultValue: DIRECTION.BOTTOM_TO_TOP,
+  },
+  duration: {
+    label: __('Duration', 'web-stories'),
+    type: FIELD_TYPES.NUMBER,
+    unit: _x('ms', 'Time in milliseconds', 'web-stories'),
+    defaultValue: 2000,
   },
 };

--- a/assets/src/animation/effects/backgroundPan/index.js
+++ b/assets/src/animation/effects/backgroundPan/index.js
@@ -17,11 +17,7 @@
 /**
  * Internal dependencies
  */
-import {
-  BACKGROUND_ANIMATION_EFFECTS,
-  DIRECTION,
-  BEZIER,
-} from '../../constants';
+import { BACKGROUND_ANIMATION_EFFECTS, DIRECTION } from '../../constants';
 import SimpleAnimation from '../../parts/simpleAnimation';
 import { getMediaBoundOffsets } from '../../utils';
 
@@ -29,7 +25,7 @@ export function EffectBackgroundPan({
   panDir = DIRECTION.RIGHT_TO_LEFT,
   duration = 2000,
   delay,
-  easing = BEZIER.inOut,
+  easing = 'cubic-bezier(.3,0,.55,1)',
   element,
 }) {
   const timings = {

--- a/assets/src/animation/effects/backgroundPan/index.js
+++ b/assets/src/animation/effects/backgroundPan/index.js
@@ -27,7 +27,7 @@ import { getMediaBoundOffsets } from '../../utils';
 
 export function EffectBackgroundPan({
   panDir = DIRECTION.RIGHT_TO_LEFT,
-  duration = 500,
+  duration = 2000,
   delay,
   easing = BEZIER.inOut,
   element,

--- a/assets/src/animation/effects/backgroundPanAndZoom/index.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/index.js
@@ -21,7 +21,6 @@ import {
   SCALE_DIRECTION,
   DIRECTION,
   BACKGROUND_ANIMATION_EFFECTS,
-  BEZIER,
 } from '../../constants';
 import SimpleAnimation from '../../parts/simpleAnimation';
 import { EffectBackgroundPan } from '../backgroundPan';
@@ -39,7 +38,7 @@ export function EffectBackgroundPanAndZoom({
   panDir = DIRECTION.RIGHT_TO_LEFT,
   duration = 1000,
   delay,
-  easing = BEZIER.inOut,
+  easing = 'cubic-bezier(.14,.34,.47,.9)',
 }) {
   const timings = {
     ...defaults,

--- a/assets/src/animation/effects/backgroundPanAndZoom/index.js
+++ b/assets/src/animation/effects/backgroundPanAndZoom/index.js
@@ -29,14 +29,14 @@ import { getMediaOrigin, getMediaBoundOffsets } from '../../utils';
 
 const defaults = {
   fill: 'forwards',
-  duration: 1000,
+  duration: 2000,
 };
 
 export function EffectBackgroundPanAndZoom({
   element,
   zoomDirection = SCALE_DIRECTION.SCALE_IN,
   panDir = DIRECTION.RIGHT_TO_LEFT,
-  duration = 1000,
+  duration = 2000,
   delay,
   easing = 'cubic-bezier(.14,.34,.47,.9)',
 }) {

--- a/assets/src/animation/effects/backgroundZoom/animationProps.js
+++ b/assets/src/animation/effects/backgroundZoom/animationProps.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@web-stories-wp/i18n';
+import { __, sprintf, _x } from '@web-stories-wp/i18n';
 import PropTypes from 'prop-types';
 
 /**
@@ -28,6 +28,7 @@ import { AnimationInputPropTypes } from '../types';
 
 export const ZoomEffectInputPropTypes = {
   zoomFrom: PropTypes.shape(AnimationInputPropTypes),
+  duration: PropTypes.shape(AnimationInputPropTypes),
 };
 
 export default {
@@ -42,5 +43,11 @@ export default {
     type: FIELD_TYPES.DIRECTION_PICKER,
     values: [SCALE_DIRECTION.SCALE_IN, SCALE_DIRECTION.SCALE_OUT],
     defaultValue: SCALE_DIRECTION.SCALE_OUT,
+  },
+  duration: {
+    label: __('Duration', 'web-stories'),
+    type: FIELD_TYPES.NUMBER,
+    unit: _x('ms', 'Time in milliseconds', 'web-stories'),
+    defaultValue: 2000,
   },
 };

--- a/assets/src/animation/effects/backgroundZoom/index.js
+++ b/assets/src/animation/effects/backgroundZoom/index.js
@@ -24,7 +24,7 @@ import { lerp, getMediaOrigin, getMediaBoundOffsets } from '../../utils';
 export function EffectBackgroundZoom({
   element,
   zoomDirection = SCALE_DIRECTION.SCALE_OUT,
-  duration = 1000,
+  duration = 2000,
   delay,
   easing = 'cubic-bezier(.3,0,.55,1)',
   transformOrigin,

--- a/assets/src/animation/effects/backgroundZoom/index.js
+++ b/assets/src/animation/effects/backgroundZoom/index.js
@@ -17,12 +17,7 @@
 /**
  * Internal dependencies
  */
-import {
-  BG_MIN_SCALE,
-  BG_MAX_SCALE,
-  SCALE_DIRECTION,
-  BEZIER,
-} from '../../constants';
+import { BG_MIN_SCALE, BG_MAX_SCALE, SCALE_DIRECTION } from '../../constants';
 import { AnimationZoom } from '../../parts/zoom';
 import { lerp, getMediaOrigin, getMediaBoundOffsets } from '../../utils';
 
@@ -31,7 +26,7 @@ export function EffectBackgroundZoom({
   zoomDirection = SCALE_DIRECTION.SCALE_OUT,
   duration = 1000,
   delay,
-  easing = BEZIER.inOut,
+  easing = 'cubic-bezier(.3,0,.55,1)',
   transformOrigin,
 }) {
   // Define the range based off the element scale


### PR DESCRIPTION
## Context
Design's has asked to update some of the animation defaults as of lately. This is part of that work.

## Summary
This ticket was to update the duration and easing defaults for `zoom` and `pan & zoom` based off of this slide:
https://docs.google.com/presentation/d/1Ny9o8qAiVmiQiJ4_wSIOhInBM_h2_O5p_IlfZT-xi0E/edit#slide=id.g79f2435400_0_817

## Relevant Technical Choices
NA

## To-do
- [x] See if design wanted `pan` to be updated to a duration of `2000` as well.
(Design asked to use the same ease and duration as zoom)

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
all background animations should now have a default duration of `2000` . Also `zoom` and `pan & zoom` should have smoother accelerations/easings now.

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Click through all the background animations and see that all the background animations have a duration of `2000` . Also all background animations should now have smoother accelerations.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
Follow testing instructions above
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7607 
