### PR TITLE
Animation: Update Scale Animation Defaults

### DIFF
--- a/assets/src/animation/effects/zoom/animationProps.js
+++ b/assets/src/animation/effects/zoom/animationProps.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { __, sprintf } from '@web-stories-wp/i18n';
+import { __, sprintf, _x } from '@web-stories-wp/i18n';
 
 /**
  * External dependencies
@@ -46,5 +46,11 @@ export default {
     type: FIELD_TYPES.DIRECTION_PICKER,
     values: [SCALE_DIRECTION.SCALE_IN, SCALE_DIRECTION.SCALE_OUT],
     defaultValue: SCALE_DIRECTION.SCALE_IN,
+  },
+  duration: {
+    label: __('Duration', 'web-stories'),
+    type: FIELD_TYPES.NUMBER,
+    unit: _x('ms', 'Time in milliseconds', 'web-stories'),
+    defaultValue: 2000,
   },
 };

--- a/assets/src/animation/effects/zoom/index.js
+++ b/assets/src/animation/effects/zoom/index.js
@@ -24,7 +24,7 @@ export function EffectZoom({
   scaleDirection = SCALE_DIRECTION.SCALE_IN,
   duration = 1000,
   delay,
-  easing,
+  easing = 'cubic-bezier(.3,0,.55,1)',
 }) {
   return AnimationZoom({
     zoomFrom: scaleDirection === SCALE_DIRECTION.SCALE_OUT ? 1 / 3 : 3,


### PR DESCRIPTION
## Context
Part of updates to animations.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Updates duration and ease for foreground `scale in/out` animations
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
NA
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
The foreground scale animation should now have a default of 2000ms and an updated ease.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Open a story in the editor. Make sure theres a foreground object like text, media or a shape. Select the foreground object and apply a `scale in` animation to it. see that it has a default duration of `2000` and an updated ease.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
Follow testing instructions above.
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7608 
