### PR TITLE
Limit disabling ESM to the singular web-story template

### DIFF
--- a/includes/Integrations/AMP.php
+++ b/includes/Integrations/AMP.php
@@ -256,7 +256,9 @@ class AMP extends Service_Base {
 	 * @return array The modified configuration.
 	 */
 	public function filter_amp_optimizer_config( $configuration ) {
-		$configuration[ Optimizer\Transformer\RewriteAmpUrls::class ][ Optimizer\Configuration\RewriteAmpUrlsConfiguration::ESM_MODULES_ENABLED ] = false;
+		if ( is_singular( Story_Post_Type::POST_TYPE_SLUG ) ) {
+			$configuration[ Optimizer\Transformer\RewriteAmpUrls::class ][ Optimizer\Configuration\RewriteAmpUrlsConfiguration::ESM_MODULES_ENABLED ] = false;
+		}
 		return $configuration;
 	}
 


### PR DESCRIPTION
## Context

With Web Stories active, I was surprised to see ES modules not showing up anymore on (non-story) AMP pages. When ESM is disabled in #7521, it seems it just needs to do an additional check to see if it's a singular story being served.

## Summary

Check if the template is for a single `web-story` post before turning off ES modules for AMP.

## Testing Instructions

With the AMP plugin active, `v0.mjs` should be present on non-story AMP pages but absent on story pages.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
