### PR TITLE
Quick Action Menus: Hide Clear Button When Irrelevant 

### DIFF
--- a/assets/src/edit-story/app/highlights/quickActions/constants.js
+++ b/assets/src/edit-story/app/highlights/quickActions/constants.js
@@ -56,6 +56,6 @@ export const RESET_PROPERTIES = {
 };
 
 export const RESET_LIST_COPY = {
-  [RESET_PROPERTIES.ANIMATION]: 'animations',
-  [RESET_PROPERTIES.BACKGROUND_OVERLAY]: 'filters',
+  [RESET_PROPERTIES.ANIMATION]: __('animations', 'web-stories'),
+  [RESET_PROPERTIES.BACKGROUND_OVERLAY]: __('filters', 'web-stories'),
 };

--- a/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
@@ -68,7 +68,6 @@ const BACKGROUND_IMAGE_ELEMENT = {
       id: 'mysite/1234',
     },
   },
-  backgroundOverlay: { type: 'linear' },
 };
 
 const BACKGROUND_IMAGE_MEDIA3P_ELEMENT = {
@@ -78,7 +77,6 @@ const BACKGROUND_IMAGE_MEDIA3P_ELEMENT = {
   resource: {
     id: 'media/unsplash:wsomemedia-123',
   },
-  backgroundOverlay: { type: 'linear' },
 };
 
 const BACKGROUND_VIDEO_ELEMENT = {
@@ -109,6 +107,18 @@ const VIDEO_ELEMENT = {
   id: 'image-element-id',
   type: 'image',
 };
+
+const clearAnimationAction = expect.objectContaining({
+  label: ACTION_TEXT.CLEAR_ANIMATIONS,
+  onClick: expect.any(Function),
+  Icon: Eraser,
+});
+
+const clearAnimationAndFiltersAction = expect.objectContaining({
+  label: ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS,
+  onClick: expect.any(Function),
+  Icon: Eraser,
+});
 
 const defaultQuickActions = [
   expect.objectContaining({
@@ -144,13 +154,12 @@ const foregroundImageQuickActions = [
     onClick: expect.any(Function),
     Icon: Link,
   }),
-  expect.objectContaining({
-    label: ACTION_TEXT.CLEAR_ANIMATIONS,
-    onClick: expect.any(Function),
-    Icon: Eraser,
-  }),
 ];
 
+const foregroundImageQuickActionsWithClear = [
+  ...foregroundImageQuickActions,
+  clearAnimationAction,
+];
 const backgroundMediaQuickActions = [
   expect.objectContaining({
     label: ACTION_TEXT.REPLACE_BACKGROUND_MEDIA,
@@ -162,11 +171,10 @@ const backgroundMediaQuickActions = [
     onClick: expect.any(Function),
     Icon: CircleSpeed,
   }),
-  expect.objectContaining({
-    label: ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS,
-    onClick: expect.any(Function),
-    Icon: Eraser,
-  }),
+];
+const backgroundMediaQuickActionsWithClear = [
+  ...backgroundMediaQuickActions,
+  clearAnimationAndFiltersAction,
 ];
 
 describe('useQuickActions', () => {
@@ -329,84 +337,80 @@ describe('useQuickActions', () => {
         highlight: states.ANIMATION,
       });
     });
+  });
 
-    describe('background third party image element is selected', () => {
-      beforeEach(() => {
-        mockUseStory.mockReturnValue({
-          currentPage: {
-            elements: [BACKGROUND_IMAGE_MEDIA3P_ELEMENT],
-          },
-          selectedElementAnimations: [],
-          selectedElements: [BACKGROUND_IMAGE_MEDIA3P_ELEMENT],
-          updateElementsById: mockUpdateElementsById,
-        });
-      });
-
-      it('should return the quick actions', () => {
-        const { result } = renderHook(() => useQuickActions());
-
-        expect(result.current).toStrictEqual(backgroundMediaQuickActions);
-      });
-
-      it('should set the correct highlight', () => {
-        const { result } = renderHook(() => useQuickActions());
-
-        result.current[0].onClick(mockClickEvent);
-        expect(highlight).toStrictEqual({
-          elementId: BACKGROUND_IMAGE_MEDIA3P_ELEMENT.id,
-          highlight: states.MEDIA3P,
-        });
-
-        result.current[1].onClick(mockClickEvent);
-        expect(highlight).toStrictEqual({
-          elementId: BACKGROUND_IMAGE_MEDIA3P_ELEMENT.id,
-          highlight: states.ANIMATION,
-        });
+  describe('background third party image element is selected with animation', () => {
+    beforeEach(() => {
+      mockUseStory.mockReturnValue({
+        currentPage: {
+          elements: [BACKGROUND_IMAGE_MEDIA3P_ELEMENT],
+        },
+        selectedElementAnimations: [],
+        selectedElements: [BACKGROUND_IMAGE_MEDIA3P_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
       });
     });
 
-    describe('background video element is selected', () => {
-      beforeEach(() => {
-        mockUseStory.mockReturnValue({
-          currentPage: {
-            elements: [BACKGROUND_VIDEO_ELEMENT],
+    it('should return the quick actions', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      expect(result.current).toStrictEqual(backgroundMediaQuickActions);
+    });
+
+    it('should set the correct highlight', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      result.current[0].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: BACKGROUND_IMAGE_MEDIA3P_ELEMENT.id,
+        highlight: states.MEDIA3P,
+      });
+
+      result.current[1].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: BACKGROUND_IMAGE_MEDIA3P_ELEMENT.id,
+        highlight: states.ANIMATION,
+      });
+    });
+  });
+
+  describe('background video element is selected', () => {
+    beforeEach(() => {
+      mockUseStory.mockReturnValue({
+        currentPage: {
+          elements: [BACKGROUND_VIDEO_ELEMENT],
+        },
+        selectedElementAnimations: [
+          {
+            target: [BACKGROUND_VIDEO_ELEMENT.id],
           },
-          selectedElementAnimations: [],
-          selectedElements: [BACKGROUND_VIDEO_ELEMENT],
-          updateElementsById: mockUpdateElementsById,
-        });
+        ],
+        selectedElements: [BACKGROUND_VIDEO_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
+      });
+    });
+
+    it('should return the quick actions', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      expect(result.current).toStrictEqual(
+        backgroundMediaQuickActionsWithClear
+      );
+    });
+
+    it('should set the correct highlight', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      result.current[0].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: BACKGROUND_VIDEO_ELEMENT.id,
+        highlight: states.MEDIA,
       });
 
-      it('should return the quick actions', () => {
-        const { result } = renderHook(() => useQuickActions());
-
-        expect(result.current).toStrictEqual(backgroundMediaQuickActions);
-      });
-
-      it('should set the correct highlight', () => {
-        const { result } = renderHook(() => useQuickActions());
-
-        result.current[0].onClick(mockClickEvent);
-        expect(highlight).toStrictEqual({
-          elementId: BACKGROUND_VIDEO_ELEMENT.id,
-          highlight: states.MEDIA,
-        });
-
-        result.current[1].onClick(mockClickEvent);
-        expect(highlight).toStrictEqual({
-          elementId: BACKGROUND_VIDEO_ELEMENT.id,
-          highlight: states.ANIMATION,
-        });
-      });
-
-      it('clicking `clear filters and animations` should update the element', () => {
-        const { result } = renderHook(() => useQuickActions());
-
-        result.current[2].onClick(mockClickEvent);
-        expect(mockUpdateElementsById).toHaveBeenCalledWith({
-          elementIds: [BACKGROUND_VIDEO_ELEMENT.id],
-          properties: expect.any(Function),
-        });
+      result.current[1].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: BACKGROUND_VIDEO_ELEMENT.id,
+        highlight: states.ANIMATION,
       });
     });
 
@@ -415,7 +419,7 @@ describe('useQuickActions', () => {
 
       result.current[2].onClick(mockClickEvent);
       expect(mockUpdateElementsById).toHaveBeenCalledWith({
-        elementIds: [BACKGROUND_IMAGE_ELEMENT.id],
+        elementIds: [BACKGROUND_VIDEO_ELEMENT.id],
         properties: expect.any(Function),
       });
     });
@@ -440,7 +444,9 @@ describe('useQuickActions', () => {
     it('should return the quick actions', () => {
       const { result } = renderHook(() => useQuickActions());
 
-      expect(result.current).toStrictEqual(foregroundImageQuickActions);
+      expect(result.current).toStrictEqual(
+        foregroundImageQuickActionsWithClear
+      );
     });
 
     it('should set the correct highlight', () => {

--- a/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
@@ -465,7 +465,7 @@ describe('useQuickActions', () => {
       });
     });
 
-    it(`\`${ACTION_TEXT.CLEAR_ANIMATIONS}\` action should be disabled if element has no animations`, () => {
+    it(`\`${ACTION_TEXT.CLEAR_ANIMATIONS}\` action should not be present if element has no animations`, () => {
       mockUseStory.mockReturnValue({
         currentPage: {
           elements: [BACKGROUND_ELEMENT, IMAGE_ELEMENT],
@@ -477,7 +477,7 @@ describe('useQuickActions', () => {
 
       const { result } = renderHook(() => useQuickActions());
 
-      expect(result.current[3].disabled).toBe(true);
+      expect(result.current[3]).toBeFalsy();
     });
 
     it('clicking `clear animations` should update the element', () => {
@@ -497,7 +497,11 @@ describe('useQuickActions', () => {
         currentPage: {
           elements: [BACKGROUND_ELEMENT, SHAPE_ELEMENT],
         },
-        selectedElementAnimations: [],
+        selectedElementAnimations: [
+          {
+            target: [IMAGE_ELEMENT.id],
+          },
+        ],
         selectedElements: [SHAPE_ELEMENT],
         updateElementsById: mockUpdateElementsById,
       });

--- a/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/test/useQuickActions.js
@@ -477,7 +477,7 @@ describe('useQuickActions', () => {
 
       const { result } = renderHook(() => useQuickActions());
 
-      expect(result.current[3]).toBeFalsy();
+      expect(result.current[3]).toBeUndefined();
     });
 
     it('clicking `clear animations` should update the element', () => {

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -248,7 +248,7 @@ const useQuickActions = () => {
         onClick: handleFocusLinkPanel(selectedElement?.id),
         ...actionMenuProps,
       },
-      {
+      selectedElementAnimations?.length && {
         Icon: Eraser,
         label: ACTION_TEXT.CLEAR_ANIMATIONS,
 

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -234,8 +234,7 @@ const useQuickActions = () => {
       selectedElement,
       selectedElementAnimations
     );
-
-    return [
+    const baseActions = [
       {
         Icon: CircleSpeed,
         label: ACTION_TEXT.ADD_ANIMATION,
@@ -248,29 +247,31 @@ const useQuickActions = () => {
         onClick: handleFocusLinkPanel(selectedElement?.id),
         ...actionMenuProps,
       },
-      selectedElementAnimations?.length && {
-        Icon: Eraser,
-        label: ACTION_TEXT.CLEAR_ANIMATIONS,
-
-        onClick: () =>
-          handleClearAnimationsAndFilters({
-            elementId: selectedElement?.id,
-            resetProperties,
-            elementType: selectedElements?.[0]?.type,
-          }),
-        separator: 'top',
-        disabled: resetProperties.length === 0,
-        ...actionMenuProps,
-      },
     ];
+
+    const clearAction = {
+      Icon: Eraser,
+      label: ACTION_TEXT.CLEAR_ANIMATIONS,
+      onClick: () =>
+        handleClearAnimationsAndFilters({
+          elementId: selectedElement?.id,
+          resetProperties,
+          elementType: selectedElements?.[0]?.type,
+        }),
+      separator: 'top',
+      ...actionMenuProps,
+    };
+
+    return resetProperties.length === 0
+      ? [...baseActions, clearAction]
+      : baseActions;
   }, [
-    selectedElement,
-    selectedElementAnimations,
+    handleClearAnimations,
+    handleFocusLinkPanel,
     handleFocusAnimationPanel,
     actionMenuProps,
-    handleFocusLinkPanel,
-    handleClearAnimationsAndFilters,
-    selectedElements,
+    selectedElement?.id,
+    selectedElementAnimations?.length,
   ]);
 
   const foregroundImageActions = useMemo(

--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -256,22 +256,22 @@ const useQuickActions = () => {
         handleClearAnimationsAndFilters({
           elementId: selectedElement?.id,
           resetProperties,
-          elementType: selectedElements?.[0]?.type,
+          elementType: selectedElement?.type,
         }),
       separator: 'top',
       ...actionMenuProps,
     };
 
-    return resetProperties.length === 0
+    return resetProperties.length > 0
       ? [...baseActions, clearAction]
       : baseActions;
   }, [
-    handleClearAnimations,
+    handleClearAnimationsAndFilters,
     handleFocusLinkPanel,
     handleFocusAnimationPanel,
     actionMenuProps,
-    selectedElement?.id,
-    selectedElementAnimations?.length,
+    selectedElement,
+    selectedElementAnimations,
   ]);
 
   const foregroundImageActions = useMemo(
@@ -316,7 +316,7 @@ const useQuickActions = () => {
       selectedElementAnimations
     );
 
-    return [
+    const baseActions = [
       {
         Icon: PictureSwap,
         label: ACTION_TEXT.REPLACE_BACKGROUND_MEDIA,
@@ -329,20 +329,24 @@ const useQuickActions = () => {
         onClick: handleFocusAnimationPanel(selectedElement?.id),
         ...actionMenuProps,
       },
-      {
-        Icon: Eraser,
-        label: ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS,
-        onClick: () =>
-          handleClearAnimationsAndFilters({
-            elementId: selectedElement?.id,
-            resetProperties,
-            elementType: ELEMENT_TYPE.BACKGROUND,
-          }),
-        separator: 'top',
-        disabled: resetProperties.length === 0,
-        ...actionMenuProps,
-      },
     ];
+
+    const clearAction = {
+      Icon: Eraser,
+      label: ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS,
+      onClick: () =>
+        handleClearAnimationsAndFilters({
+          elementId: selectedElement?.id,
+          resetProperties,
+          elementType: ELEMENT_TYPE.BACKGROUND,
+        }),
+      separator: 'top',
+      ...actionMenuProps,
+    };
+
+    return resetProperties.length > 0
+      ? [...baseActions, clearAction]
+      : baseActions;
   }, [
     selectedElement,
     selectedElementAnimations,

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -170,9 +170,9 @@ describe('Quick Actions integration', () => {
 
     it(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATIONS}\` button should remove all animations. Clicking the undo button should reapply the animation.`, async () => {
       // quick action should be disabled if there are no animations yet
-      expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
-      ).toBe(true);
+      expect(fixture.editor.canvas.quickActionMenu.clearAnimationsButton).toBe(
+        null
+      );
 
       // add animation to image
       const effectChooserToggle =
@@ -197,8 +197,8 @@ describe('Quick Actions integration', () => {
 
       // click quick menu button
       expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
-      ).toBe(false);
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton
+      ).toBeDefined();
       await fixture.events.click(
         fixture.editor.canvas.quickActionMenu.clearAnimationsButton
       );
@@ -210,9 +210,9 @@ describe('Quick Actions integration', () => {
         }))
       );
       expect(animations.length).toBe(0);
-      expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
-      ).toBe(true);
+      expect(fixture.editor.canvas.quickActionMenu.clearAnimationsButton).toBe(
+        null
+      );
 
       // click `undo` button on snackbar
       await fixture.events.click(
@@ -228,8 +228,8 @@ describe('Quick Actions integration', () => {
       expect(revertedAnimations.length).toBe(1);
       expect(revertedAnimations[0]).toEqual(originalAnimations[0]);
       expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
-      ).toBe(false);
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton
+      ).toBeDefined();
     });
   });
 
@@ -307,9 +307,9 @@ describe('Quick Actions integration', () => {
 
     it(`should click the \`${ACTION_TEXT.CLEAR_ANIMATIONS}\` button and remove all animations, then click the undo button and reapply the animation.`, async () => {
       // quick action should be disabled if there are no animations yet
-      expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
-      ).toBe(true);
+      expect(fixture.editor.canvas.quickActionMenu.clearAnimationsButton).toBe(
+        null
+      );
 
       // add animation to image
       const effectChooserToggle =
@@ -334,8 +334,8 @@ describe('Quick Actions integration', () => {
 
       // click quick menu button
       expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
-      ).toBe(false);
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton
+      ).toBeDefined();
       await fixture.events.click(
         fixture.editor.canvas.quickActionMenu.clearAnimationsButton
       );
@@ -347,9 +347,9 @@ describe('Quick Actions integration', () => {
         }))
       );
       expect(animations.length).toBe(0);
-      expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
-      ).toBe(true);
+      expect(fixture.editor.canvas.quickActionMenu.clearAnimationsButton).toBe(
+        null
+      );
 
       // click `undo` button on snackbar
       await fixture.events.click(
@@ -365,8 +365,8 @@ describe('Quick Actions integration', () => {
       expect(revertedAnimations.length).toBe(1);
       expect(revertedAnimations[0]).toEqual(originalAnimations[0]);
       expect(
-        fixture.editor.canvas.quickActionMenu.clearAnimationsButton.disabled
-      ).toBe(false);
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton
+      ).toBeDefined();
     });
   });
 

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -169,10 +169,10 @@ describe('Quick Actions integration', () => {
     });
 
     it(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATIONS}\` button should remove all animations. Clicking the undo button should reapply the animation.`, async () => {
-      // quick action should be disabled if there are no animations yet
-      expect(fixture.editor.canvas.quickActionMenu.clearAnimationsButton).toBe(
-        null
-      );
+      // quick action should not be present if there are no animations yet
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton
+      ).toBeNull();
 
       // add animation to image
       const effectChooserToggle =
@@ -210,9 +210,9 @@ describe('Quick Actions integration', () => {
         }))
       );
       expect(animations.length).toBe(0);
-      expect(fixture.editor.canvas.quickActionMenu.clearAnimationsButton).toBe(
-        null
-      );
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton
+      ).toBeNull();
 
       // click `undo` button on snackbar
       await fixture.events.click(
@@ -306,10 +306,10 @@ describe('Quick Actions integration', () => {
     });
 
     it(`should click the \`${ACTION_TEXT.CLEAR_ANIMATIONS}\` button and remove all animations, then click the undo button and reapply the animation.`, async () => {
-      // quick action should be disabled if there are no animations yet
-      expect(fixture.editor.canvas.quickActionMenu.clearAnimationsButton).toBe(
-        null
-      );
+      // quick action should not be present if there are no animations yet
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton
+      ).toBeNull();
 
       // add animation to image
       const effectChooserToggle =
@@ -347,9 +347,9 @@ describe('Quick Actions integration', () => {
         }))
       );
       expect(animations.length).toBe(0);
-      expect(fixture.editor.canvas.quickActionMenu.clearAnimationsButton).toBe(
-        null
-      );
+      expect(
+        fixture.editor.canvas.quickActionMenu.clearAnimationsButton
+      ).toBeNull();
 
       // click `undo` button on snackbar
       await fixture.events.click(
@@ -424,11 +424,10 @@ describe('Quick Actions integration', () => {
     });
 
     it(`clicking the \`${ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS}\` button should remove all animations and filters. Clicking the undo button should reapply the animation and filter.`, async () => {
-      // quick action should be disabled if there are no animations yet
+      // quick action should not be present if there are no animations yet
       expect(
         fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
-          .disabled
-      ).toBe(true);
+      ).toBeNull();
 
       // apply filter to background element
       await fixture.events.click(
@@ -464,8 +463,7 @@ describe('Quick Actions integration', () => {
         expect(originalSelectedElement.backgroundOverlay.type).toBe('linear');
         expect(
           fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
-            .disabled
-        ).toBe(false);
+        ).toBeDefined();
       });
 
       // click quick menu button
@@ -486,8 +484,7 @@ describe('Quick Actions integration', () => {
         expect(selectedElement.backgroundOverlay).toBeNull();
         expect(
           fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
-            .disabled
-        ).toBe(true);
+        ).toBeNull();
       });
 
       // click `undo` button on snackbar
@@ -515,8 +512,7 @@ describe('Quick Actions integration', () => {
 
         expect(
           fixture.editor.canvas.quickActionMenu.clearAnimationsAndFiltersButton
-            .disabled
-        ).toBe(false);
+        ).toBeDefined();
       });
     });
   });


### PR DESCRIPTION
## Context

Minor update to quick action menu feature for 1.8 release


## Summary

This is follow up to #7602 to instead of disabling clear button in quick action menus when there's nothing to clear we're hiding it. 

From Figma: https://www.figma.com/file/1YM3jA9h4QGc4xLdyaXIJS/Stories-Sprint-1.7?node-id=7347%3A60816 
<img width="577" alt="Screen Shot 2021-05-24 at 1 25 45 PM" src="https://user-images.githubusercontent.com/10720454/119403662-8d31d600-bc93-11eb-8e18-f942df787eaa.png">


https://user-images.githubusercontent.com/10720454/119403823-ca966380-bc93-11eb-84a0-dc9af6d9d0e4.mp4


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

## User-facing changes

Clear button not part of menus if there's nothing to clear. 

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7682 
