### PR TITLE
Design System: Update snackbar styling

### DIFF
--- a/assets/src/design-system/components/snackbar/snackbarContainer.js
+++ b/assets/src/design-system/components/snackbar/snackbarContainer.js
@@ -34,7 +34,8 @@ const StyledContainer = styled.div`
   top: ${({ placement }) => (placement.indexOf('top') === 0 ? 0 : 'inherit')};
   bottom: ${({ placement }) =>
     placement.indexOf('bottom') === 0 ? 0 : 'inherit'};
-  ${getSnackbarXPos}
+  ${getSnackbarXPos};
+  margin-bottom: 33px;
   display: flex;
   flex-direction: column;
   align-items: ${({ alignItems }) => alignItems};

--- a/assets/src/design-system/components/snackbar/snackbarMessage.js
+++ b/assets/src/design-system/components/snackbar/snackbarMessage.js
@@ -60,7 +60,7 @@ MessageContainer.propTypes = {
 
 const Message = styled(Text)`
   color: ${({ theme }) => theme.colors.inverted.fg.primary};
-  max-width: 206px;
+  max-width: 430px;
   padding-right: ${({ hasAction }) => (hasAction ? '52px' : '0px')};
 `;
 
@@ -76,6 +76,7 @@ const ActionButton = styled(Button)`
   height: 2em;
   padding: 0;
   color: ${({ theme }) => theme.colors.inverted.fg.linkNormal};
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
 
   ${({ theme }) =>
     focusableOutlineCSS(


### PR DESCRIPTION
## Context

Snackbar styling in figma showed new designs for the snackbar: https://www.figma.com/file/1YM3jA9h4QGc4xLdyaXIJS/Stories-Sprint-1.7?node-id=7347%3A56346.

Designs:
![image](https://user-images.githubusercontent.com/22185279/119404022-72179400-bc9c-11eb-9870-feb63191e23c.png)


## Summary

Updates snackbar styling
- Increase max width of snackbar
- Bold the action button text
- Increase spacing from bottom of screen

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/22185279/119403878-409ec880-bc9c-11eb-8a23-4058d8193064.png)|![image](https://user-images.githubusercontent.com/22185279/119403764-16e5a180-bc9c-11eb-9356-dd84a61c7d0a.png)|

## Testing Instructions

1. Enable quick actions experiment
2. Go to editor
3. Add image to canvas as foreground image
4. Add animation to image
5. Click `clear animations` quick action to show the snackbar
6. Repeat until satisfied

### QA

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

n/a

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7685 
