### PR TITLE
Animation: Update Rotate In Defaults

### DIFF
--- a/assets/src/animation/effects/rotateIn/index.js
+++ b/assets/src/animation/effects/rotateIn/index.js
@@ -32,7 +32,7 @@ const stopAngle = 0;
 export function EffectRotateIn({
   duration = 1000,
   rotateInDir = DIRECTION.LEFT_TO_RIGHT,
-  easing = 'cubic-bezier(0.4, 0.4, 0.0, 1)',
+  easing = 'cubic-bezier(.2, 0, .8, 1)',
   delay,
   element,
 }) {
@@ -52,7 +52,7 @@ export function EffectRotateIn({
     generatedKeyframes: moveKeyframes,
   } = AnimationMove({
     offsetX,
-    duration,
+    duration: duration * 0.87,
     delay,
     easing,
     element,
@@ -66,13 +66,13 @@ export function EffectRotateIn({
   } = AnimationSpin({
     rotation: `${
       (rotateInDir === DIRECTION.LEFT_TO_RIGHT ? -1 : 1) *
-      360 *
+      180 *
       numberOfRotations
     }`,
     stopAngle,
     duration,
     delay,
-    easing,
+    easing: 'cubic-bezier(.2, 0, .5, 1)',
     element,
   });
 

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserElements.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserElements.js
@@ -144,7 +144,7 @@ export const PulseAnimation = styled(BaseAnimationCell)`
 
 const rotateInLeftKeyframes = keyframes`
   0% {
-    transform: translateX(-100%) rotate(360deg);
+    transform: translateX(-100%) rotate(-360deg);
   }
   50%, 100% {
     transform: translateX(0%);
@@ -157,7 +157,7 @@ export const RotateInLeftAnimation = styled(BaseAnimationCell)`
 
 const rotateInRightKeyframes = keyframes`
   0% {
-    transform: translateX(100%) rotate(-360deg);
+    transform: translateX(100%) rotate(360deg);
   }
   50%, 100% {
     transform: translateX(0%);


### PR DESCRIPTION
## Context
Design requested to update the defaults for animations in this doc here:
https://docs.google.com/presentation/d/1Ny9o8qAiVmiQiJ4_wSIOhInBM_h2_O5p_IlfZT-xi0E/edit#slide=id.gdb3242d678_0_21

This is part of that work

## Summary
Updated the `rotate-in` animation to resemble the timings and curves as much as possible in design specification deck above.

## Relevant Technical Choices
Modeled the curves specified in the slides as much as possible with custom cubic-beziers

## To-do
- [x] verify with Marian that it's to her liking: 
https://xwp.slack.com/archives/C0144TS0EFJ/p1621959638019300

## User-facing changes
Rotate-in animation now has some new eases and internal durations although the total duration of the animation remains the same as it was before.

https://user-images.githubusercontent.com/35983235/119534502-3afcbd80-bd44-11eb-8868-f8c4746991f9.mp4


<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
-> Open the editor
-> Add a foreground element
-> Apply the `Rotate` animation to it
-> This should be updated to have slightly different internal timings/accelerations from before
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
Follow testing instructions above
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7610 