### PR TITLE
Bring over alt attribute when combining elements

### DIFF
--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
@@ -86,6 +86,7 @@ function combineElements(
     : {};
 
   const propsFromFirst = [
+    'alt',
     'type',
     'resource',
     'scale',

--- a/assets/src/edit-story/app/story/useStoryReducer/test/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/combineElements.js
@@ -229,6 +229,7 @@ describe('combineElements', () => {
       {
         id: '123',
         resource: { type: 'image', src: '1' },
+        alt: 'Hello',
         type: 'image',
         focalX: 50,
         focalY: 50,
@@ -278,6 +279,7 @@ describe('combineElements', () => {
         id: '456',
         type: 'image',
         resource: { type: 'image', src: '1' },
+        alt: 'Hello',
         x: 10,
         y: 10,
         width: 10,
@@ -691,6 +693,7 @@ function getDefaultState2() {
             y: 10,
             width: 10,
             height: 10,
+            alt: 'Hello',
           },
         ],
       },


### PR DESCRIPTION
## Summary
Previously, only `resource` was brought over from the first element while merging, however, custom set `alt` was not, always resetting the alt when combining elements.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
1. Add an image and change the Assistive text.
2. Add a shape.
3. Drag the image into the shape
4. Verify the custom alt text is still there.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
See the testing instructions above.
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5653 
