### PR TITLE
AMP: De-duplicate inline styles

### DIFF
--- a/includes/AMP/Integration/AMP_Story_Sanitizer.php
+++ b/includes/AMP/Integration/AMP_Story_Sanitizer.php
@@ -26,8 +26,8 @@
 
 namespace Google\Web_Stories\AMP\Integration;
 
+use AMP_Base_Sanitizer;
 use Google\Web_Stories\AMP\Traits\Sanitization_Utils;
-use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
 
 /**
  * AMP Story sanitizer.
@@ -38,7 +38,7 @@ use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
  *
  * @since 1.1.0
  */
-class AMP_Story_Sanitizer extends \AMP_Base_Sanitizer {
+class AMP_Story_Sanitizer extends AMP_Base_Sanitizer {
 	use Sanitization_Utils;
 
 	/**
@@ -54,5 +54,6 @@ class AMP_Story_Sanitizer extends \AMP_Base_Sanitizer {
 		$this->add_publisher_logo( $this->dom, $this->args['publisher_logo'], $this->args['publisher_logo_placeholder'] );
 		$this->add_publisher( $this->dom, $this->args['publisher'] );
 		$this->add_poster_images( $this->dom, $this->args['poster_images'] );
+		$this->deduplicate_inline_styles( $this->dom );
 	}
 }

--- a/includes/AMP/Story_Sanitizer.php
+++ b/includes/AMP/Story_Sanitizer.php
@@ -52,5 +52,6 @@ class Story_Sanitizer extends AMP_Base_Sanitizer {
 		$this->add_publisher_logo( $this->dom, $this->args['publisher_logo'], $this->args['publisher_logo_placeholder'] );
 		$this->add_publisher( $this->dom, $this->args['publisher'] );
 		$this->add_poster_images( $this->dom, $this->args['poster_images'] );
+		$this->deduplicate_inline_styles( $this->dom );
 	}
 }

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -204,7 +204,7 @@ trait Sanitization_Utils {
 	 * De-duplicate inline styles in the story.
 	 *
 	 * Greatly reduce the amount of `style[amp-custom]` CSS for stories by de-duplicating inline styles
-	 * and moving to simple class selector style rules,avoiding the specificity hac
+	 * and moving to simple class selector style rules, avoiding the specificity hack
 	 * that the AMP plugin's style sanitizer employs.
 	 *
 	 * @since 1.8.0

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -231,15 +231,24 @@ trait Sanitization_Utils {
 			}
 		}
 
+		if ( empty( $elements_by_inline_style ) ) {
+			return;
+		}
+
+		$style_element = $document->createElement( 'style' );
+
+		if ( ! $style_element ) {
+			return;
+		}
+
+		$document->head->appendChild( $style_element );
+
 		// Create style rule for each inline style and add class name to each element.
 		foreach ( $elements_by_inline_style as $inline_style => $styled_elements ) {
 			$inline_style_class_name = '_' . substr( md5( (string) $inline_style ), 0, 7 );
 
-			$style_element = $document->createElement( 'style' );
-			if ( $style_element ) {
-				$style_element->textContent = sprintf( '.%s{%s}', $inline_style_class_name, $inline_style );
-				$document->head->appendChild( $style_element );
-			}
+			$style_rule = $document->createTextNode( sprintf( '.%s{%s}', $inline_style_class_name, $inline_style ) );
+			$style_element->appendChild( $style_rule );
 
 			/**
 			 * The element with inline styles.

--- a/tests/phpunit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/tests/AMP/Story_Sanitizer.php
@@ -267,4 +267,22 @@ class Story_Sanitizer extends Test_Case {
 		$this->assertNotContains( 'data-tooltip-icon', $actual );
 		$this->assertNotContains( 'data-tooltip-text', $actual );
 	}
+
+	/**
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::deduplicate_inline_styles
+	 */
+	public function test_deduplicate_inline_styles() {
+		$source = '<html><head></head><body><amp-story><div style="color: blue;"></div><div style="color: blue;"></div><div style="color: blue; background: white;"></div><div style="color: red;"></div></amp-story></body></html>';
+
+		$args = [
+			'publisher_logo'             => '',
+			'publisher'                  => '',
+			'publisher_logo_placeholder' => '',
+			'poster_images'              => [],
+		];
+
+		$actual = $this->sanitize_and_get( $source, $args );
+
+		$this->assertContains( '<style>._a7988c6{color: blue;}._91f054f{color: blue; background: white;}._f479d19{color: red;}</style>', $actual );
+	}
 }

--- a/tests/phpunit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/tests/AMP/Story_Sanitizer.php
@@ -284,5 +284,6 @@ class Story_Sanitizer extends Test_Case {
 		$actual = $this->sanitize_and_get( $source, $args );
 
 		$this->assertContains( '<style>._a7988c6{color: blue;}._91f054f{color: blue; background: white;}._f479d19{color: red;}</style>', $actual );
+		$this->assertNotContains( 'style="', $actual );
 	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

While the AMP plugin's CSS sanitization helps a lot to de-duplicate inline styles, it also creates tons of selectors starting with `:root:not(#_):not(#_):not(#_):not(#_):not(#_)` and similar to ensure specificity when dealing with plugins/themes using `!important` in CSS.

See #6783 for detailed analysis.

## Summary

<!-- A brief description of what this PR does. -->

This PR changes the CSS sanitization to drastically increase the amount of CSS on a page.

When using a pre-existing template, CSS output is reduced by at least 1/3rd!

See https://github.com/google/web-stories-wp/issues/6783#issuecomment-846619292

## Relevant Technical Choices

<!-- Please describe your changes. -->

This new sanitizer addition bypasses the AMP plugin's style sanitizer specificity handling which is not needed in Web Stories. All inline styles are added to a `<style>` tag before the AMP library gets to parsing the CSS, avoiding these long selectors.


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

- ~Tests~

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6783
