### PR TITLE
AMP: add `class_exists` check for AMP configuration class

### DIFF
--- a/includes/Integrations/AMP.php
+++ b/includes/Integrations/AMP.php
@@ -256,7 +256,12 @@ class AMP extends Service_Base {
 	 * @return array The modified configuration.
 	 */
 	public function filter_amp_optimizer_config( $configuration ) {
-		if ( is_singular( Story_Post_Type::POST_TYPE_SLUG ) ) {
+		// These classes were only added in AMP 2.1.
+		if (
+			is_singular( Story_Post_Type::POST_TYPE_SLUG ) &&
+			class_exists( '\AmpProject\Optimizer\Transformer\RewriteAmpUrls' ) &&
+			class_exists( '\AmpProject\Optimizer\Configuration\RewriteAmpUrlsConfiguration' )
+		) {
 			$configuration[ Optimizer\Transformer\RewriteAmpUrls::class ][ Optimizer\Configuration\RewriteAmpUrlsConfiguration::ESM_MODULES_ENABLED ] = false;
 		}
 		return $configuration;


### PR DESCRIPTION
See https://wordpress.org/support/topic/php-fatal-error-in-web-stories-includes-integrations-amp-php259/ for context.

This fixes a fatal error when using AMP v2.0.x where these classes don't exist yet.

Note: this code will be removed again with #7649 

