### PR TITLE
Keep poster when combining elements

### DIFF
--- a/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/reducers/combineElements.js
@@ -92,6 +92,7 @@ function combineElements(
     'focalX',
     'focalY',
     'tracks',
+    'poster',
   ];
 
   // If the element we're dropping into is not background, maintain link, too.

--- a/assets/src/edit-story/app/story/useStoryReducer/test/combineElements.js
+++ b/assets/src/edit-story/app/story/useStoryReducer/test/combineElements.js
@@ -183,6 +183,64 @@ describe('combineElements', () => {
     ]);
   });
 
+  it('should keep the poster of the first video', () => {
+    const { restore, combineElements } = setupReducer();
+
+    const state = getDefaultState4();
+    restore(getDefaultState4());
+
+    // Combine element 789 into 007
+    const result = combineElements({
+      firstElement: state.pages[0].elements[2],
+      secondId: '007',
+    });
+
+    expect(result.pages[0].elements).toStrictEqual([
+      {
+        id: '123',
+        type: 'image',
+        backgroundOverlay: { color: { r: 0, g: 0, b: 0 } },
+        isBackground: true,
+        x: 1,
+        y: 1,
+        width: 1,
+        height: 1,
+      },
+      {
+        id: '456',
+        type: 'image',
+        resource: { type: 'image', src: '1' },
+        x: 10,
+        y: 10,
+        width: 10,
+        height: 10,
+        link: {
+          url: 'https://link456.example/',
+          icon: 'https://link456.example/image.png',
+          desc: 'Lorem ipsum dolor',
+        },
+      },
+      {
+        id: '007',
+        type: 'video',
+        resource: { type: 'video', src: '2' },
+        focalX: 50,
+        focalY: 50,
+        scale: 100,
+        x: 10,
+        y: 10,
+        width: 10,
+        height: 10,
+        link: {
+          url: 'https://link789.example/',
+          icon: 'https://link789.example/image.png',
+          desc: 'Lorem ipsum dolor',
+        },
+        poster: 'img.jpg',
+      },
+    ]);
+  });
+
   it('should not remove background overlay if present on second element', () => {
     const { restore, combineElements } = setupReducer();
 
@@ -375,6 +433,7 @@ describe('combineElements', () => {
         width: 10,
         x: 10,
         y: 10,
+        poster: 'img.jpg',
       });
     });
 
@@ -402,6 +461,7 @@ describe('combineElements', () => {
           src: '3',
           type: 'video',
         },
+        poster: 'img.jpg',
         scale: 100,
         type: 'video',
         width: 10,
@@ -775,6 +835,7 @@ function getDefaultState4() {
               icon: 'https://link789.example/image.png',
               desc: 'Lorem ipsum dolor',
             },
+            poster: 'img.jpg',
           },
           {
             id: '007',


### PR DESCRIPTION
## Summary
Keeps the poster when combining elements, e.g. when setting video as background.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
1. Add a video and set a custom poster image.
2. Now set the video as background.
3. Verify the custom poster image is still there.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. See the steps above.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6963 
