### PR TITLE
Fix text element issues with transformations

### DIFF
--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -25,7 +25,11 @@ import styled, { css } from 'styled-components';
  */
 import { StoryAnimation } from '../../../animation';
 import { getDefinitionForType } from '../../elements';
-import { elementWithRotation } from '../../elements/shared';
+import {
+  elementWithPosition,
+  elementWithRotation,
+  elementWithSize,
+} from '../../elements/shared';
 import WithMask from '../../masks/display';
 import StoryPropTypes from '../../types';
 import { useUnits } from '../../units';
@@ -38,17 +42,9 @@ import {
   shouldDisplayBorder,
 } from '../../utils/elementBorder';
 
-// Using attributes to avoid creation of hundreds of classes by styled components.
-const Wrapper = styled.div.attrs(({ x, y, width, height }) => ({
-  style: {
-    left: `${x}px`,
-    top: `${y}px`,
-    width: `${width}px`,
-    height: `${height}px`,
-  },
-}))`
-  position: absolute;
-  z-index: 1;
+const Wrapper = styled.div`
+  ${elementWithPosition}
+  ${elementWithSize}
   ${elementWithRotation}
   contain: layout;
   transition: opacity 0.15s cubic-bezier(0, 0, 0.54, 1);
@@ -140,6 +136,8 @@ function DisplayElement({ element, previewMode, isAnimatable = false }) {
     const target = wrapperRef.current;
     if (transform === null) {
       target.style.transform = '';
+      target.style.width = '';
+      target.style.height = '';
     } else {
       const { translate, rotate, resize, dropTargets } = transform;
       target.style.transform = `translate(${translate?.[0]}px, ${translate?.[1]}px) rotate(${rotate}deg)`;

--- a/assets/src/edit-story/components/canvas/singleSelectionMoveable/index.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMoveable/index.js
@@ -157,6 +157,8 @@ function SingleSelectionMoveable({
       // Inline start resetting has to be done very carefully here to avoid
       // conflicts with stylesheets. See #3951.
       target.style.transform = '';
+      target.style.width = '';
+      target.style.height = '';
       if (moveable.current) {
         moveable.current.updateRect();
       }

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -52,7 +52,6 @@ import {
   getHighlightLineheight,
   generateParagraphTextStyle,
   calcFontMetrics,
-  generateFontFamily,
 } from './util';
 
 const OutsideBorder = styled.div`
@@ -99,39 +98,11 @@ const ForegroundSpan = styled(Span)`
 `;
 
 // Using attributes to avoid creation of hundreds of classes by styled components.
-const FillElement = styled.p.attrs(
-  ({
-    fontStyle,
-    fontSize,
-    fontWeight,
-    font,
-    marginOffset,
-    padding,
-    lineHeight,
-    textAlign,
-    dataToEditorY,
-  }) => ({
-    style: {
-      fontStyle,
-      fontSize: `${fontSize}px`,
-      fontWeight,
-      fontFamily: generateFontFamily(font),
-      margin: `${-dataToEditorY(marginOffset / 2)}px 0`,
-      padding: padding || 0,
-      lineHeight,
-      textAlign,
-    },
-  })
-)`
+const FillElement = styled.p`
   margin: 0;
-  position: absolute;
-  z-index: 1;
-  white-space: pre-wrap;
-  overflow-wrap: break-word;
-  word-break: break-word;
-  letter-spacing: normal;
-  color: ${({ theme }) => theme.colors.standard.black};
   ${elementFillContent}
+  ${elementWithFont}
+  ${elementWithTextParagraphStyle}
 `;
 
 const Background = styled.div`
@@ -311,8 +282,6 @@ function TextDisplay({
         dangerouslySetInnerHTML={{
           __html: content,
         }}
-        marginOffset={marginOffset}
-        dataToEditorY={dataToEditorY}
         {...props}
       />
     </Background>


### PR DESCRIPTION
## Summary
There was a regression from https://github.com/google/web-stories-wp/pull/7719 for the text element, editing the text element has various connected parts which are relying on modifying the style of the element directly. The logic for removing excess classes interferes with it and breaks various parts of it, e.g. line-height, font-size, margin for the font, etc.

Once we have SVG rendering in place, we can adjust the rendering logic for the library only not to create excess classes.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
1. Add a text element
2. Assign line height to it
3. Verify everything looks normal and the frame is in sync with the displayed text.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7764 
