### PR TITLE
Quick Actions: Add focus border around animation panel dropdown when highlighting

### DIFF
--- a/assets/src/design-system/components/dropDown/select/components.js
+++ b/assets/src/design-system/components/dropDown/select/components.js
@@ -46,15 +46,7 @@ export const SelectButton = styled.button(
     text-overflow: ellipsis;
     cursor: pointer;
 
-    /* focus-visible class does not get applied to elements programmatically focused with a pointer (see #7772) */
-    :focus {
-      ${themeHelpers.focusCSS(
-        theme.colors.border.focus,
-        theme.colors.bg.secondary
-      )};
-    }
-
-    ${themeHelpers.focusableOutlineCSS};
+    ${themeHelpers.focusableOutlineCSS}
 
     &:hover {
       border-color: ${theme.colors.border[

--- a/assets/src/design-system/components/dropDown/select/components.js
+++ b/assets/src/design-system/components/dropDown/select/components.js
@@ -46,6 +46,7 @@ export const SelectButton = styled.button(
     text-overflow: ellipsis;
     cursor: pointer;
 
+    /* focus-visible class does not get applied to elements programmatically focused with a pointer (see #7772) */
     :focus {
       ${themeHelpers.focusCSS(
         theme.colors.border.focus,
@@ -53,7 +54,7 @@ export const SelectButton = styled.button(
       )};
     }
 
-    ${themeHelpers.focusableOutlineCSS}
+    ${themeHelpers.focusableOutlineCSS};
 
     &:hover {
       border-color: ${theme.colors.border[
@@ -65,7 +66,7 @@ export const SelectButton = styled.button(
     css`
       ${themeHelpers.focusableOutlineCSS(
         theme.colors.interactiveBg.negativeNormal
-      )};
+      )}
       border-color: ${theme.colors.interactiveBg.negativeNormal};
 
       &:active,

--- a/assets/src/design-system/components/dropDown/select/components.js
+++ b/assets/src/design-system/components/dropDown/select/components.js
@@ -46,6 +46,13 @@ export const SelectButton = styled.button(
     text-overflow: ellipsis;
     cursor: pointer;
 
+    :focus {
+      ${themeHelpers.focusCSS(
+        theme.colors.border.focus,
+        theme.colors.bg.secondary
+      )};
+    }
+
     ${themeHelpers.focusableOutlineCSS}
 
     &:hover {

--- a/assets/src/edit-story/app/highlights/styles.js
+++ b/assets/src/edit-story/app/highlights/styles.js
@@ -35,5 +35,6 @@ export const FLASH = css`
 `;
 
 export const OUTLINE = css`
-  ${({ theme }) => themeHelpers.focusCSS(theme.colors.border.focus)};
+  ${themeHelpers.focusCSS};
+  border-radius: ${dsTheme.borders.radius.small};
 `;

--- a/assets/src/edit-story/app/highlights/styles.js
+++ b/assets/src/edit-story/app/highlights/styles.js
@@ -36,5 +36,4 @@ export const FLASH = css`
 
 export const OUTLINE = css`
   ${themeHelpers.focusCSS};
-  border-radius: ${dsTheme.borders.radius.small};
 `;

--- a/assets/src/edit-story/app/highlights/styles.js
+++ b/assets/src/edit-story/app/highlights/styles.js
@@ -21,7 +21,7 @@ import { css, keyframes } from 'styled-components';
 /**
  * Internal dependencies
  */
-import { theme as dsTheme } from '../../../design-system';
+import { theme as dsTheme, themeHelpers } from '../../../design-system';
 
 const flash = keyframes`
   50% {
@@ -35,6 +35,5 @@ export const FLASH = css`
 `;
 
 export const OUTLINE = css`
-  box-shadow: 0 0 0 2px ${dsTheme.colors.border.focus};
-  border-radius: ${dsTheme.borders.radius.small};
+  ${({ theme }) => themeHelpers.focusCSS(theme.colors.border.focus)};
 `;

--- a/assets/src/edit-story/components/panels/design/animation/animation.js
+++ b/assets/src/edit-story/components/panels/design/animation/animation.js
@@ -252,6 +252,7 @@ function AnimationPanel({
             disabledTypeOptionsMap={disabledTypeOptionsMap}
             direction={getEffectDirection(updatedAnimations[0])}
             selectedEffectType={updatedAnimations[0]?.type}
+            selectButtonStylesOverride={highlight?.focus && styles.OUTLINE}
           />
         </StyledRow>
         {updatedAnimations[0] && (

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
@@ -25,6 +25,7 @@ import { __ } from '@web-stories-wp/i18n';
  * Internal dependencies
  */
 import { useFeatures } from 'flagged';
+import { css } from 'styled-components';
 import { DropDown, PLACEMENT } from '../../../../../../design-system';
 
 import { focusStyle } from '../../../shared';
@@ -146,6 +147,16 @@ const EffectChooserDropdown = forwardRef(function EffectChooserDropdown(
     ]
   );
 
+  const innerStyleOverrides =
+    selectedValue && selectedValue !== NO_ANIMATION
+      ? styleOverrideForSelectButton
+      : focusStyle;
+  const buttonStyleOverride = css`
+    ${innerStyleOverrides}
+    ${typeof selectButtonStylesOverride !== 'undefined' &&
+    selectButtonStylesOverride}
+  `;
+
   return (
     <DropDown
       ref={ref}
@@ -158,12 +169,7 @@ const EffectChooserDropdown = forwardRef(function EffectChooserDropdown(
       onMenuItemClick={handleSelect}
       placement={expandedPlacement}
       isKeepMenuOpenOnSelection
-      selectButtonStylesOverride={
-        selectButtonStylesOverride ??
-        (selectedValue && selectedValue !== NO_ANIMATION
-          ? styleOverrideForSelectButton
-          : focusStyle)
-      }
+      selectButtonStylesOverride={buttonStyleOverride}
     />
   );
 });

--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
@@ -52,6 +52,7 @@ const EffectChooserDropdown = forwardRef(function EffectChooserDropdown(
     selectedEffectType,
     disabledTypeOptionsMap,
     direction,
+    selectButtonStylesOverride,
   },
   ref
 ) {
@@ -158,9 +159,10 @@ const EffectChooserDropdown = forwardRef(function EffectChooserDropdown(
       placement={expandedPlacement}
       isKeepMenuOpenOnSelection
       selectButtonStylesOverride={
-        selectedValue && selectedValue !== NO_ANIMATION
+        selectButtonStylesOverride ??
+        (selectedValue && selectedValue !== NO_ANIMATION
           ? styleOverrideForSelectButton
-          : focusStyle
+          : focusStyle)
       }
     />
   );
@@ -178,6 +180,10 @@ EffectChooserDropdown.propTypes = {
       options: PropTypes.arrayOf(PropTypes.string),
     })
   ),
+  selectButtonStylesOverride: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.array,
+  ]),
 };
 
 export default EffectChooserDropdown;


### PR DESCRIPTION
## Context
- Border around the animation select button wasn't showing up when programmatically focused
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- added extra styles to the button which is focused, now it shows the ring when it is focused by the highlight functionality
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- focus-visible class doesn't show up when the button is programmatically selected, so I added explicit `button:focus` styles. 
- https://github.com/WICG/focus-visible/issues/88
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

https://user-images.githubusercontent.com/41136059/120052883-63064e00-bfdc-11eb-9d06-e9614234c4e6.mp4


<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->


### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7626 
