### PR TITLE
Quick Action Menus: Add Karma Check for Accessibility Violations 

### DIFF
--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -545,14 +545,19 @@ describe('Grid view', () => {
       // now the focused item should be the first context menu item
       const [contextMenuList] =
         within(activeStoryContainer).getAllByTestId(/context-menu-list/);
+      await expectAsync(contextMenuList).toHaveNoViolations();
       // it is focused on the link within the list
       const [firstContextMenuItem, secondContextMenuItem] =
         within(contextMenuList).getAllByRole('menuitem');
-      expect(firstContextMenuItem).toEqual(document.activeElement);
+      expect(firstContextMenuItem.innerText).toEqual(
+        document.activeElement.innerText
+      );
 
       // tab to the next item
       await fixture.events.keyboard.press('tab');
-      expect(secondContextMenuItem).toEqual(document.activeElement);
+      expect(secondContextMenuItem.innerText).toEqual(
+        document.activeElement.innerText
+      );
     });
 
     it('should rename a story via keyboard', async () => {

--- a/assets/src/dashboard/components/storyMenu/test/storyMenu.js
+++ b/assets/src/dashboard/components/storyMenu/test/storyMenu.js
@@ -75,8 +75,8 @@ describe('StoryMenu', () => {
       />
     );
 
-    const menuItem = screen.getAllByRole('listitem')[0];
-    const menuItemButton = within(menuItem).getByRole('menuitem');
+    const menuItem = screen.getAllByRole('menuitem')[0];
+    const menuItemButton = within(menuItem).getByRole('button');
 
     fireEvent.click(menuItemButton);
 

--- a/assets/src/design-system/components/contextMenu/contextMenu.js
+++ b/assets/src/design-system/components/contextMenu/contextMenu.js
@@ -28,7 +28,10 @@ const ContextMenu = ({ isAlwaysVisible, items, ...props }) => {
   return (
     <>
       {!isAlwaysVisible && props.isOpen && <Mask onDismiss={props.onDismiss} />}
-      <Popover role="dialog" isOpen={isAlwaysVisible || props.isOpen}>
+      <Popover
+        role={isAlwaysVisible ? '' : 'dialog'}
+        isOpen={isAlwaysVisible || props.isOpen}
+      >
         <Menu items={items} {...props} />
         <Shadow />
       </Popover>

--- a/assets/src/design-system/components/contextMenu/menu.js
+++ b/assets/src/design-system/components/contextMenu/menu.js
@@ -168,7 +168,7 @@ const Menu = ({
   isIconMenu,
   isOpen,
   onDismiss,
-  groupLabel = __('menu options', 'web-stories'),
+  groupLabel = __('Menu options', 'web-stories'),
   disableControlledTabNavigation = false,
   ...props
 }) => {

--- a/assets/src/design-system/components/contextMenu/menu.js
+++ b/assets/src/design-system/components/contextMenu/menu.js
@@ -18,6 +18,7 @@
  */
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { __ } from '@web-stories-wp/i18n';
 import styled, { css } from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 /**
@@ -167,6 +168,7 @@ const Menu = ({
   isIconMenu,
   isOpen,
   onDismiss,
+  groupLabel = __('menu options', 'web-stories'),
   disableControlledTabNavigation = false,
   ...props
 }) => {
@@ -269,17 +271,19 @@ const Menu = ({
   ]);
 
   return (
-    <MenuWrapper isIconMenu={isIconMenu}>
+    <MenuWrapper isIconMenu={isIconMenu} role="menu">
       <MenuList
         data-testid="context-menu-list"
         ref={listRef}
         isIconMenu={isIconMenu}
-        role="menu"
+        aria-label={groupLabel}
+        role="group"
         {...props}
       >
         {items.map(({ separator, onFocus, ...itemProps }, index) => (
           <li
             key={ids[index]}
+            role="menuitem"
             className={
               (separator === 'top' && SEPARATOR_TOP_CLASS) ||
               (separator === 'bottom' && SEPARATOR_BOTTOM_CLASS) ||
@@ -300,6 +304,7 @@ const Menu = ({
 };
 
 export const MenuPropTypes = {
+  groupLabel: PropTypes.string,
   items: PropTypes.arrayOf(
     PropTypes.shape({
       ...MenuItemProps,

--- a/assets/src/design-system/components/contextMenu/menuItem.js
+++ b/assets/src/design-system/components/contextMenu/menuItem.js
@@ -117,7 +117,6 @@ export const MenuItem = ({
         href={href}
         onClick={handleClick}
         onFocus={onFocus}
-        role="menuitem"
         {...newTabProps}
         {...menuItemProps}
       >
@@ -134,7 +133,6 @@ export const MenuItem = ({
         disabled={disabled}
         onClick={handleClick}
         onFocus={onFocus}
-        role="menuitem"
         {...menuItemProps}
       >
         {textContent}

--- a/assets/src/design-system/components/contextMenu/test/contextMenu.js
+++ b/assets/src/design-system/components/contextMenu/test/contextMenu.js
@@ -16,7 +16,7 @@
 /**
  * External dependencies
  */
-import { act, fireEvent, screen } from '@testing-library/react';
+import { act, fireEvent, screen, within } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -75,7 +75,8 @@ describe('ContextMenu', () => {
     const [firstButton] = screen.queryAllByRole('menuitem', {
       name: items[0].label,
     });
-    expect(firstButton).toHaveFocus();
+
+    expect(within(firstButton).getByRole('button')).toHaveFocus();
   });
 });
 

--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -43,6 +43,14 @@ describe('Quick Actions integration', () => {
     fixture.restore();
   });
 
+  describe('quick action menu should have no aXe accessibility violations', () => {
+    it('should pass accessibility tests with the default menu', async () => {
+      await expectAsync(
+        fixture.editor.canvas.quickActionMenu.node
+      ).toHaveNoViolations();
+    });
+  });
+
   describe('no element selected', () => {
     it(`clicking the \`${ACTION_TEXT.CHANGE_BACKGROUND_COLOR}\` button should select the background and open the design panel`, async () => {
       // click quick menu button

--- a/assets/src/edit-story/components/canvas/navLayer.js
+++ b/assets/src/edit-story/components/canvas/navLayer.js
@@ -19,6 +19,7 @@
  */
 import { memo, useCallback } from 'react';
 import { useFeature } from 'flagged';
+import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
@@ -65,6 +66,10 @@ function NavLayer() {
               isAlwaysVisible
               isIconMenu
               disableControlledTabNavigation
+              groupLabel={__(
+                'Group of available options for selected element',
+                'web-stories'
+              )}
               items={quickActions}
               onMouseDown={handleMenuBackgroundClick}
             />

--- a/assets/src/edit-story/karma/fixture/containers/canvas.js
+++ b/assets/src/edit-story/karma/fixture/containers/canvas.js
@@ -63,7 +63,7 @@ export class Canvas extends Container {
 
   get quickActionMenu() {
     return this._get(
-      this.getByRole('dialog'),
+      this.getByRole('menu'),
       'quickActionMenu',
       QuickActionMenu
     );

--- a/assets/src/edit-story/karma/fixture/containers/quickActionMenu.js
+++ b/assets/src/edit-story/karma/fixture/containers/quickActionMenu.js
@@ -25,61 +25,61 @@ export class QuickActionMenu extends Container {
   }
 
   get changeBackgroundColorButton() {
-    return this.queryByRole('menuitem', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.CHANGE_BACKGROUND_COLOR,
     });
   }
 
   get changeColorButton() {
-    return this.queryByRole('menuitem', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.CHANGE_COLOR,
     });
   }
 
   get insertBackgroundMediaButton() {
-    return this.queryByRole('menuitem', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.INSERT_BACKGROUND_MEDIA,
     });
   }
 
   get insertTextButton() {
-    return this.queryByRole('menuitem', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.INSERT_TEXT,
     });
   }
 
   get replaceMediaButton() {
-    return this.queryByRole('menuitem', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.REPLACE_MEDIA,
     });
   }
 
   get replaceBackgroundMediaButton() {
-    return this.queryByRole('menuitem', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.REPLACE_BACKGROUND_MEDIA,
     });
   }
 
   get addAnimationButton() {
-    return this.queryByRole('menuitem', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.ADD_ANIMATION,
     });
   }
 
   get addLinkButton() {
-    return this.queryByRole('menuitem', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.ADD_LINK,
     });
   }
 
   get clearAnimationsButton() {
-    return this.queryByRole('menuitem', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.CLEAR_ANIMATIONS,
     });
   }
 
   get clearAnimationsAndFiltersButton() {
-    return this.queryByRole('menuitem', {
+    return this.queryByRole('button', {
       name: ACTION_TEXT.CLEAR_ANIMATION_AND_FILTERS,
     });
   }


### PR DESCRIPTION

## Context

Per discussion here: https://github.com/google/web-stories-wp/issues/7530#issuecomment-842498164 starting to add in aXe checks for accessibility violations.

## Summary

Tweak the context menu for accessibility testing. 

## Relevant Technical Choices

- Now the `Popover` that holds a context menu will only get set as a dialog when it isn't always on the page, it feels dishonest to have it stated as a dialog in the editor when the menu doesn't actually popup at all, it just is a menu. 
- In the `Menu` the wrapper gets the role of "menu" and its child is a "group"  (the unordered list element) and then the `li` children of the `ul` are now `role=menuitem` to show belonging to the menu instead of the list. This allows us to throw whatever we want into the list items, now that they are menuitem roles it isn't as strict of a hierarchy. 
- The component in `Menu` called `MenuItem` is a touch misleading now since the role of menuitem is given to the list item. Now the `MenuItem`  is just the children of the role=menuitem. This allows us to have buttons and anchors present in our menus dynamically, which is the major key of this whole component. 
- Added 1 aria label to the group to give context to announcements, this has a default label of `menu options`. 
- Two new checks for aXe violations - one for the quickAction menus and then while testing for regressions on the other spots the menu is used I added a second one in the dashboard myStories karma tests. Otherwise, the updates are just to the fixture and unit tests to catch up to the changes I made. 

## To-do

-N/A

## User-facing changes

- None

## Testing Instructions

- Check for regression on the quick action menu for functionality and styles, I only updated roles so I'm not anticipating any weird changes but more eyes are appreciated 
- Verify that tests are passing 
- If you want to you can also use the [aXe dev tools ](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US)and see that the context menu is not throwing any accessibility errors or warnings. 

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7751 
