### PR TITLE
Quick action menu: Hide quick actions if canvas is overflowing

### DIFF
--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -44,6 +44,19 @@ describe('Quick Actions integration', () => {
     fixture.restore();
   });
 
+  describe('menu visibility', () => {
+    it('quick menu should not be visible if the canvas is overflowing', async () => {
+      const { zoomSelector } = fixture.editor.carousel;
+
+      await fixture.events.click(zoomSelector.select);
+      await fixture.events.sleep(300);
+      await fixture.events.click(await zoomSelector.option('Fill'));
+      await fixture.events.sleep(300);
+
+      expect(fixture.screen.queryByRole('dialog')).toBeNull();
+    });
+  });
+
   describe('quick action menu should have no aXe accessibility violations', () => {
     it('should pass accessibility tests with the default menu', async () => {
       await expectAsync(

--- a/assets/src/edit-story/components/canvas/navLayer.js
+++ b/assets/src/edit-story/components/canvas/navLayer.js
@@ -29,6 +29,7 @@ import { useQuickActions } from '../../app/highlights';
 import DirectionAware from '../directionAware';
 import Header from '../header';
 import Carousel from '../carousel';
+import { useLayout } from '../../app';
 import {
   Layer,
   HeadArea,
@@ -39,6 +40,9 @@ import {
 
 function NavLayer() {
   const enableQuickActionMenu = useFeature('enableQuickActionMenus');
+  const { hasHorizontalOverflow } = useLayout(
+    ({ state: { hasHorizontalOverflow } }) => ({ hasHorizontalOverflow })
+  );
   const quickActions = useQuickActions();
 
   /**
@@ -50,6 +54,9 @@ function NavLayer() {
     ev.stopPropagation();
   }, []);
 
+  const showQuickActions =
+    enableQuickActionMenu && !hasHorizontalOverflow && quickActions.length;
+
   return (
     <Layer
       pointerEvents="none"
@@ -59,7 +66,7 @@ function NavLayer() {
       <HeadArea pointerEvents="initial">
         <Header />
       </HeadArea>
-      {enableQuickActionMenu && quickActions.length && (
+      {showQuickActions && (
         <DirectionAware>
           <QuickActionsArea>
             <ContextMenu


### PR DESCRIPTION
## Context

quick actions

## Summary

Hide quick action menu if the canvas is overscrolling. This is set by the `zoom` dropdown.

## Relevant Technical Choices

We only wanted to hide the quick actions menu _if_ the canvas is overflowing. If it's not overflowing, the quick actions menu will still be visible. This is viewport dependent, so not all screens will see the menu disappear when they change the zoom level.

## To-do

n/a

## User-facing changes

Now setting the zoom will hide the quick actions IF the canvas overflows horizontally.

![Kapture 2021-06-01 at 11 35 09](https://user-images.githubusercontent.com/22185279/120367039-a22eea80-c2cd-11eb-9a49-3ee860c8bc55.gif)

## Testing Instructions

1. Enable quick actions in experiments
2. Go to editor
3. Click the background or another element in the canvs
4. Change the zoom level like in the gif below
5. If the canvas overflows horizontally - then the quick actions menu will be hidden

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7572
