### PR TITLE
Workflow: Add GitHub action for tagging PRs with releases

### DIFF
--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
-  ISSUE_REFERENCE_REGEX: \(#([0-9]+)\)$
+  ISSUE_REFERENCE_REGEX: \(#([0-9]+)\)
   ZENHUB_REPO_ID: 235435637
 
 jobs:

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           echo "Getting list of releases from ZenHub"
 
-          RELEASES=$(curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" "https://api.zenhub.com/p1/repositories/$“ZENHUB_REPO_ID}/reports/releases")
-          NEXT_RELEASE=$((echo $RELEASES ) | jq -r 'first(sort_by(.start_date) | .[] | select( .state == "open" )) | .release_id')
+          RELEASES=$(curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" "https://api.zenhub.com/p1/repositories/${ZENHUB_REPO_ID}/reports/releases")
+          NEXT_RELEASE=$((echo $RELEASES ) | jq -r 'first(sort_by(.desired_end_date) | .[] | select( .state == "open" )) | .release_id')
 
           echo "Determined release with ID $NEXT_RELEASE to be the next one"
 

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -1,0 +1,71 @@
+# Once a PR fixing a particular issue has been merged,
+# this action adds it to the next milestone.
+#
+# See https://github.com/google/web-stories-wp/issues/6301
+
+name: Add release milestone to closed issues
+
+on:
+  pull_request:
+    # Todo: Only keep 'closed' after testing.
+    types:
+      - opened
+      - edited
+      - closed
+
+env:
+  COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+  ISSUE_REFERENCE_REGEX: \(#([0-9]+)\)$
+  ZENHUB_REPO_ID: 235435637
+
+jobs:
+  add-milestone:
+    name: Add milestone
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # Todo: Uncomment after testing.
+    # if: github.event.pull_request.merged == true
+    steps:
+      - name: Get issue number
+        id: issue_number
+        run: |
+          echo "Looking for issue number in commit message: $COMMIT_MESSAGE"
+          if [[ $COMMIT_MESSAGE =~ $ISSUE_REFERENCE_REGEX ]]; then
+            ISSUE_NUMBER = ${BASH_REMATCH[1]}
+          else
+            echo "No issue number found, cancelling"
+            # exit 0
+          fi
+
+          # Todo: remove after testing.
+          ISSUE_NUMBER=6770
+
+          echo "This merged PR closes issue $ISSUE_NUMBER"
+          echo "::set-output name=issue_number::$ISSUE_NUMBER"
+
+      # See ZenHub API docs for context.
+      # https://github.com/ZenHubIO/API#get-release-reports-for-a-repository
+      # https://github.com/ZenHubIO/API#add-or-remove-issues-to-or-from-a-release-report
+      - name: Get next release
+        id: release
+        run: |
+          RELEASES=$(curl -H "X-Authentication-Token: $ZENHUB_API_TOKEN" "https://api.zenhub.com/p1/repositories/$ZENHUB_REPO_ID/reports/releases")
+          NEXT_RELEASE=$((echo $RELEASES ) | jq -r 'first(sort_by(.start_date) | .[] | select( .state == "open" )) | .release_id')
+
+          echo "Determined release with ID $NEXT_RELEASE to be the next one"
+
+          echo "::set-output name=release_id::$NEXT_RELEASE"
+        env:
+          ZENHUB_API_TOKEN: ${{ secrets.ZENHUB_API_TOKEN }}
+
+      # https://github.com/ZenHubIO/API#add-or-remove-issues-to-or-from-a-release-report
+      - name: Add issue to release
+        run: |
+          echo "Adding issue $ISSUE_NUMBER to release $RELEASE_ID"
+
+          curl -H "X-Authentication-Token: $ZENHUB_API_TOKEN" -H 'Content-Type: application/json' -X PATCH "https://api.zenhub.com/p1/reports/release/$RELEASE_ID/issues" -d '{ "add_issues": [{ "repo_id": $ZENHUB_REPO_ID, "issue_number": $ISSUE_NUMBER }], "remove_issues": [] }'
+          echo "::set-output name=RELEASES::$RELEASES"
+        env:
+          ZENHUB_API_TOKEN: ${{ secrets.ZENHUB_API_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.issue_number.outputs.issue_number }}
+          RELEASE_ID: ${{ steps.release.outputs.release_id }}

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -22,7 +22,7 @@ jobs:
   add-milestone:
     name: Add milestone
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 5
     # Todo: Uncomment after testing.
     # if: github.event.pull_request.merged == true
     steps:

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -33,8 +33,7 @@ jobs:
           if [[ $COMMIT_MESSAGE =~ $ISSUE_REFERENCE_REGEX ]]; then
             ISSUE_NUMBER = ${BASH_REMATCH[1]}
           else
-            echo "No issue number found, cancelling"
-            # exit 0
+            echo "No issue number found"
           fi
 
           # Todo: remove after testing.
@@ -43,7 +42,6 @@ jobs:
           echo "This merged PR closes issue $ISSUE_NUMBER"
           echo "::set-output name=issue_number::$ISSUE_NUMBER"
 
-      # See ZenHub API docs for context.
       # https://github.com/ZenHubIO/API#get-release-reports-for-a-repository
       # https://github.com/ZenHubIO/API#add-or-remove-issues-to-or-from-a-release-report
       - name: Get next release
@@ -57,8 +55,10 @@ jobs:
           echo "Determined release with ID $NEXT_RELEASE to be the next one"
 
           echo "::set-output name=release_id::$NEXT_RELEASE"
+        if: ${{ env.ISSUE_NUMBER }}
         env:
           ZENHUB_API_TOKEN: ${{ secrets.ZENHUB_API_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.issue_number.outputs.issue_number }}
 
       # https://github.com/ZenHubIO/API#add-or-remove-issues-to-or-from-a-release-report
       - name: Add issue to release
@@ -66,6 +66,7 @@ jobs:
           echo "Adding issue $ISSUE_NUMBER to release $RELEASE_ID"
 
           curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" -H 'Content-Type: application/json' -X PATCH "https://api.zenhub.com/p1/reports/release/${RELEASE_ID}/issues" -d '{ "add_issues": [{ "repo_id": '"$ZENHUB_REPO_ID"', "issue_number": '"$ISSUE_NUMBER"' }], "remove_issues": [] }'
+        if: ${{ env.ISSUE_NUMBER }}
         env:
           ZENHUB_API_TOKEN: ${{ secrets.ZENHUB_API_TOKEN }}
           ISSUE_NUMBER: ${{ steps.issue_number.outputs.issue_number }}

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -1,5 +1,4 @@
-# Once a PR fixing a particular issue has been merged,
-# this action adds it to the next milestone.
+# Once a PR has been merged, this action adds it to the upcoming release.
 #
 # See https://github.com/google/web-stories-wp/issues/6301
 
@@ -14,7 +13,7 @@ on:
       - closed
 
 env:
-  COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
   ISSUE_REFERENCE_REGEX: \(#([0-9]+)\)
   ZENHUB_REPO_ID: 235435637
 
@@ -26,22 +25,6 @@ jobs:
     # Todo: Uncomment after testing.
     # if: github.event.pull_request.merged == true
     steps:
-      - name: Get issue number
-        id: issue_number
-        run: |
-          echo "Looking for issue number in commit message: $COMMIT_MESSAGE"
-          if [[ $COMMIT_MESSAGE =~ $ISSUE_REFERENCE_REGEX ]]; then
-            ISSUE_NUMBER = ${BASH_REMATCH[1]}
-          else
-            echo "No issue number found"
-          fi
-
-          # Todo: remove after testing.
-          ISSUE_NUMBER=6770
-
-          echo "This merged PR closes issue $ISSUE_NUMBER"
-          echo "::set-output name=issue_number::$ISSUE_NUMBER"
-
       # https://github.com/ZenHubIO/API#get-release-reports-for-a-repository
       # https://github.com/ZenHubIO/API#add-or-remove-issues-to-or-from-a-release-report
       - name: Get next release
@@ -55,19 +38,15 @@ jobs:
           echo "Determined release with ID $NEXT_RELEASE to be the next one"
 
           echo "::set-output name=release_id::$NEXT_RELEASE"
-        if: ${{ env.ISSUE_NUMBER }}
         env:
           ZENHUB_API_TOKEN: ${{ secrets.ZENHUB_API_TOKEN }}
-          ISSUE_NUMBER: ${{ steps.issue_number.outputs.issue_number }}
 
       # https://github.com/ZenHubIO/API#add-or-remove-issues-to-or-from-a-release-report
       - name: Add issue to release
         run: |
-          echo "Adding issue $ISSUE_NUMBER to release $RELEASE_ID"
+          echo "Adding PR $PR_NUMBER to release $RELEASE_ID"
 
-          curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" -H 'Content-Type: application/json' -X PATCH "https://api.zenhub.com/p1/reports/release/${RELEASE_ID}/issues" -d '{ "add_issues": [{ "repo_id": '"$ZENHUB_REPO_ID"', "issue_number": '"$ISSUE_NUMBER"' }], "remove_issues": [] }'
-        if: ${{ env.ISSUE_NUMBER }}
+          curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" -H 'Content-Type: application/json' -X PATCH "https://api.zenhub.com/p1/reports/release/${RELEASE_ID}/issues" -d '{ "add_issues": [{ "repo_id": '"$ZENHUB_REPO_ID"', "issue_number": '"$PR_NUMBER"' }], "remove_issues": [] }'
         env:
           ZENHUB_API_TOKEN: ${{ secrets.ZENHUB_API_TOKEN }}
-          ISSUE_NUMBER: ${{ steps.issue_number.outputs.issue_number }}
           RELEASE_ID: ${{ steps.release.outputs.release_id }}

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -6,10 +6,7 @@ name: Add milestone
 
 on:
   pull_request:
-    # Todo: Only keep 'closed' after testing.
     types:
-      - opened
-      - edited
       - closed
 
 env:
@@ -22,8 +19,7 @@ jobs:
     name: Add milestone
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Todo: Uncomment after testing.
-    # if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     steps:
       # https://github.com/ZenHubIO/API#get-release-reports-for-a-repository
       # https://github.com/ZenHubIO/API#add-or-remove-issues-to-or-from-a-release-report
@@ -42,7 +38,7 @@ jobs:
           ZENHUB_API_TOKEN: ${{ secrets.ZENHUB_API_TOKEN }}
 
       # https://github.com/ZenHubIO/API#add-or-remove-issues-to-or-from-a-release-report
-      - name: Add issue to release
+      - name: Add PR to release
         run: |
           echo "Adding PR $PR_NUMBER to release $RELEASE_ID"
 

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -15,7 +15,7 @@ on:
 env:
   PR_NUMBER: ${{ github.event.pull_request.number }}
   ISSUE_REFERENCE_REGEX: \(#([0-9]+)\)
-  ZENHUB_REPO_ID: 235435637
+  GITHUB_REPO_ID: 235435637
 
 jobs:
   add-milestone:
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo "Getting list of releases from ZenHub"
 
-          RELEASES=$(curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" "https://api.zenhub.com/p1/repositories/${ZENHUB_REPO_ID}/reports/releases")
+          RELEASES=$(curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" "https://api.zenhub.com/p1/repositories/${GITHUB_REPO_ID}/reports/releases")
           NEXT_RELEASE=$((echo $RELEASES ) | jq -r 'first(sort_by(.desired_end_date) | .[] | select( .state == "open" )) | .release_id')
 
           echo "Determined release with ID $NEXT_RELEASE to be the next one"
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo "Adding PR $PR_NUMBER to release $RELEASE_ID"
 
-          curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" -H 'Content-Type: application/json' -X PATCH "https://api.zenhub.com/p1/reports/release/${RELEASE_ID}/issues" -d '{ "add_issues": [{ "repo_id": '"$ZENHUB_REPO_ID"', "issue_number": '"$PR_NUMBER"' }], "remove_issues": [] }'
+          curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" -H 'Content-Type: application/json' -X PATCH "https://api.zenhub.com/p1/reports/release/${RELEASE_ID}/issues" -d '{ "add_issues": [{ "repo_id": '"$GITHUB_REPO_ID"', "issue_number": '"$PR_NUMBER"' }], "remove_issues": [] }'
         env:
           ZENHUB_API_TOKEN: ${{ secrets.ZENHUB_API_TOKEN }}
           RELEASE_ID: ${{ steps.release.outputs.release_id }}

--- a/.github/workflows/add-milestone.yml
+++ b/.github/workflows/add-milestone.yml
@@ -3,7 +3,7 @@
 #
 # See https://github.com/google/web-stories-wp/issues/6301
 
-name: Add release milestone to closed issues
+name: Add milestone
 
 on:
   pull_request:
@@ -49,7 +49,9 @@ jobs:
       - name: Get next release
         id: release
         run: |
-          RELEASES=$(curl -H "X-Authentication-Token: $ZENHUB_API_TOKEN" "https://api.zenhub.com/p1/repositories/$ZENHUB_REPO_ID/reports/releases")
+          echo "Getting list of releases from ZenHub"
+
+          RELEASES=$(curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" "https://api.zenhub.com/p1/repositories/$“ZENHUB_REPO_ID}/reports/releases")
           NEXT_RELEASE=$((echo $RELEASES ) | jq -r 'first(sort_by(.start_date) | .[] | select( .state == "open" )) | .release_id')
 
           echo "Determined release with ID $NEXT_RELEASE to be the next one"
@@ -63,8 +65,7 @@ jobs:
         run: |
           echo "Adding issue $ISSUE_NUMBER to release $RELEASE_ID"
 
-          curl -H "X-Authentication-Token: $ZENHUB_API_TOKEN" -H 'Content-Type: application/json' -X PATCH "https://api.zenhub.com/p1/reports/release/$RELEASE_ID/issues" -d '{ "add_issues": [{ "repo_id": $ZENHUB_REPO_ID, "issue_number": $ISSUE_NUMBER }], "remove_issues": [] }'
-          echo "::set-output name=RELEASES::$RELEASES"
+          curl -s -H "X-Authentication-Token: $ZENHUB_API_TOKEN" -H 'Content-Type: application/json' -X PATCH "https://api.zenhub.com/p1/reports/release/${RELEASE_ID}/issues" -d '{ "add_issues": [{ "repo_id": '"$ZENHUB_REPO_ID"', "issue_number": '"$ISSUE_NUMBER"' }], "remove_issues": [] }'
         env:
           ZENHUB_API_TOKEN: ${{ secrets.ZENHUB_API_TOKEN }}
           ISSUE_NUMBER: ${{ steps.issue_number.outputs.issue_number }}

--- a/.github/workflows/cleanup-pr-assets.yml
+++ b/.github/workflows/cleanup-pr-assets.yml
@@ -3,7 +3,7 @@
 #
 # See https://github.com/google/web-stories-wp/issues/1398
 
-name: Clean up PR assets for closed PRs
+name: Clean up PR assets
 
 on:
   pull_request:


### PR DESCRIPTION
Once a PR fixing a particular issue has been merged, this action automatically adds _the PR_ to the next milestone.

This way we have a better picture of which release a change has landed in and the overall scope of a release.

Since there's no robust way of getting issues linked to a PR for adding _the issue_ to the release, this workflow uses the easy way of simply adding _the PR_ to the release instead.

This can be revisited should the capabilities of the GitHub or ZenHub APIs change.

Fixes #6301
