### PR TITLE
Animations: Prevent 'None' selections from stacking up

### DIFF
--- a/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
+++ b/assets/src/edit-story/components/panels/design/animation/effectChooserDropdown/effectChooserDropdown.js
@@ -120,7 +120,7 @@ const EffectChooserDropdown = forwardRef(function EffectChooserDropdown(
     (event, value) => {
       event.preventDefault();
       if (value === NO_ANIMATION) {
-        onNoEffectSelected();
+        Boolean(selectedValue) && onNoEffectSelected();
         return;
       }
 
@@ -141,9 +141,10 @@ const EffectChooserDropdown = forwardRef(function EffectChooserDropdown(
     },
     [
       animationOptionsObject,
-      onAnimationSelected,
-      onNoEffectSelected,
       disabledTypeOptionsMap,
+      onAnimationSelected,
+      selectedValue,
+      onNoEffectSelected,
     ]
   );
 


### PR DESCRIPTION
## Context
Found in #7753 by @samwhale while testing a quick action menu based on a page template. 

## Summary

Prevent multiple instances of none as the selected animation from getting added to the selected element.


https://user-images.githubusercontent.com/10720454/120514021-b16f7000-c381-11eb-8bca-4716bd62b681.mp4



## Relevant Technical Choices

We don't want to block clicks of the currently chosen animation in the effect drop down because the animations play on selection, however we don't need to do that for "none" being clicked when "none" is already the selected value. When "none" is the existing effect and it was clicked again it was getting passed to `pushUpdateForObject` which was adding "none" as an effect itself instead of stripping the previous selection. Only an issue with "none". 

## To-do

None

## User-facing changes

None

## Testing Instructions

- Verify swapping animations works as expected still (and also "none")
- Once #7753 is merged and this branch is rebased we can confirm that the "clear animations" button isn't popping up out of the blue when "none" is the animation effect value. 

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7797 
