### PR TITLE
Fix colour picker focus styles

### DIFF
--- a/assets/src/edit-story/components/colorPicker/header.js
+++ b/assets/src/edit-story/components/colorPicker/header.js
@@ -31,6 +31,7 @@ import {
   BUTTON_VARIANTS,
 } from '../../../design-system/components/button';
 import { Button, Icons } from '../../../design-system';
+import { focusStyle } from '../panels/shared';
 
 const HEADER_FOOTER_HEIGHT = 52;
 
@@ -55,6 +56,7 @@ const TypeSelector = styled.button`
   border-radius: 100px;
   opacity: 1;
   margin-right: 16px;
+  ${focusStyle};
 `;
 
 const Solid = styled(TypeSelector)`

--- a/assets/src/edit-story/components/panels/design/preset/colorPreset/colorPresetActions.js
+++ b/assets/src/edit-story/components/panels/design/preset/colorPreset/colorPresetActions.js
@@ -31,6 +31,7 @@ import { PatternPropType } from '../../../../../types';
 import { Select } from '../../../../form';
 import { findMatchingColor } from '../utils';
 import { SAVED_COLOR_SIZE } from '../../../../../constants';
+import { focusStyle } from '../../../shared';
 import ColorGroup from './colorGroup';
 import useApplyColor from './useApplyColor';
 
@@ -56,6 +57,7 @@ const AddColorPreset = styled.button`
     width: 32px;
     height: 32px;
   }
+  ${focusStyle};
 `;
 
 const CtaWrapper = styled.div`
@@ -72,8 +74,10 @@ const CtaWrapper = styled.div`
 `;
 
 const ColorsWrapper = styled.div`
-  margin-top: 10px;
   max-height: ${SAVED_COLOR_SIZE * 3 + 2 * COLOR_GAP}px;
+  padding: 4px;
+  margin: 6px 0 0 -4px;
+  width: calc(100% + 8px);
   overflow-x: hidden;
   overflow-y: auto;
 `;


### PR DESCRIPTION
## Summary
Fixes colour picker focus styles for buttons / swatches.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
![focus](https://user-images.githubusercontent.com/3294597/120485142-1774eb00-c3b4-11eb-97eb-cea217123884.gif)

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
1. Open the colour picker, e.g. for a shape
2. Tab through the colour picker and verify that all the buttons have focus style from the redesign (instead of the blue+white double border).
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6721 
