### PR TITLE
Dashboard: JSX Linting Cleanup

### DIFF
--- a/assets/src/dashboard/components/cardGrid/index.js
+++ b/assets/src/dashboard/components/cardGrid/index.js
@@ -59,8 +59,8 @@ const CardGrid = forwardRef(function CardGrid(
       ref={ref}
       role="list"
       data-testid={'dashboard-grid-list'}
-      // TODO: Investigate
-      // See https://github.com/google/web-stories-wp/issues/6671
+      // Disable Reason: We need to focus this div to engage with `useGridViewKeys`
+      // which is critical to avoiding focus traps for keyboard users.
       // eslint-disable-next-line styled-components-a11y/no-noninteractive-tabindex
       tabIndex={0}
       aria-label={ariaLabel}

--- a/assets/src/dashboard/components/cardGridItem/cardPreview.js
+++ b/assets/src/dashboard/components/cardGridItem/cardPreview.js
@@ -179,8 +179,10 @@ const CardPreviewContainer = ({
         {children}
       </PreviewPane>
       {/*
-        TODO: Investigate
-        See https://github.com/google/web-stories-wp/issues/6671
+        Disable Reason: As the UI stands for the dashboard grid item view we have nested functionality 
+        that is embedded in the grid and requires the user hover or focus a card in order to see options 
+        since keyboard users can't hover we have to also harness focus and active to get consistent behavior
+        the click events on this div show or hide options for each grid item.
         */}
       {/* eslint-disable-next-line styled-components-a11y/click-events-have-key-events, styled-components-a11y/no-static-element-interactions */}
       <EditControls

--- a/assets/src/design-system/components/contextMenu/mask.js
+++ b/assets/src/design-system/components/contextMenu/mask.js
@@ -39,8 +39,7 @@ export default function Mask({ onDismiss }) {
   return (
     <>
       {/*
-        TODO: Investigate
-        See https://github.com/google/web-stories-wp/issues/6671
+        Disable Reason: Allow pointer events to pass through if there's no 'onDismiss' to preserve transition
         */}
       {/* eslint-disable-next-line styled-components-a11y/click-events-have-key-events, styled-components-a11y/no-static-element-interactions */}
       <ScreenMask

--- a/assets/src/design-system/components/dropDown/test/dropDown.js
+++ b/assets/src/design-system/components/dropDown/test/dropDown.js
@@ -173,50 +173,6 @@ describe('DropDown <DropDown />', () => {
     expect(scrollTo).toHaveBeenCalledWith(0, expect.any(Number));
   });
 
-  // TODO: this causes prop type warnings due to bad input. Probably just remove the test.
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should clean badly grouped data', () => {
-    const nestedOptions = [
-      {
-        label: 'section 1',
-        options: [
-          { value: 'one', label: '1' },
-          { value: 'two', label: '2' },
-        ],
-        somethingExtra: [1, 2, 3, 4, 5],
-      },
-      {
-        label: 'section 2',
-        options: [
-          { value: 'three', label: '3' },
-          { value: 'four', label: '4' },
-          { value: 'five', label: '5' },
-        ],
-      },
-      'should be ignored',
-    ];
-    renderWithProviders(
-      <DropDown
-        emptyText={'No options available'}
-        dropDownLabel={'label'}
-        isKeepMenuOpenOnSelection={false}
-        options={nestedOptions}
-      />
-    );
-
-    const select = screen.getByRole('button');
-    expect(select).toBeInTheDocument();
-    fireEvent.click(select);
-
-    const menuItems = screen.getAllByRole('option');
-    expect(menuItems).toHaveLength(5);
-
-    const menuLabels = screen.getAllByRole('presentation');
-    expect(menuLabels).toHaveLength(2);
-
-    expect(screen.queryAllByText('should be ignored')).toStrictEqual([]);
-  });
-
   // Mouse events
   it('should not expand menu when disabled is true', () => {
     renderWithProviders(

--- a/assets/src/design-system/components/typography/text/index.js
+++ b/assets/src/design-system/components/typography/text/index.js
@@ -66,6 +66,8 @@ const Label = styled.label`
 export const Text = ({ as, disabled, ...props }) => {
   switch (as) {
     case 'label':
+      // Disable Reason: This is building block in the design system that is used with inputs
+      // and therefore has no associated control in the text element itself since it is unassembled.
       // eslint-disable-next-line styled-components-a11y/label-has-associated-control
       return <Label disabled={disabled} {...props} />;
     case 'span':


### PR DESCRIPTION
## Context

Follow up to #6671 

## Summary

Add disable reasons to places where jsx linting is ignored. While hunting through for spots where eslint is disabled found an old test that's unnecessary and has been getting skipped, removed that.


## Relevant Technical Choices

There really isn't anything we can do right now (that's worth the time) for the few spots where we're disabling linting for accessibility in the dashboard. The spots where it's complaining are about the grid - these components have keyboard functionality and are fine when testing with keyboard and also a screen reader. There's a line item coming on the roadmap to take a second look at the set up and when that happens I think we'll be able to avoid the set up we have now, there's just no way around it really right now with the layers of functionality that depend on what's active/hovered. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None, just some code clean up

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7734 
