### PR TITLE
Keyboard Shortcuts: Translate the keyboard shortcuts

### DIFF
--- a/assets/src/edit-story/components/keyboardShortcutsMenu/landmarkShortcuts.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/landmarkShortcuts.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { Fragment } from 'react';
+import { sprintf, TranslateWithMarkup, __ } from '@web-stories-wp/i18n';
 import styled from 'styled-components';
 
 /**
@@ -52,12 +52,23 @@ function LandmarkShortcuts() {
   return (
     <LandmarksWrapper role="group">
       {landmarks.map(({ label, shortcut }) => (
-        <Fragment key={label}>
-          <Landmark role="listitem">
-            <Label>{label}</Label>
-            <ShortcutLabel keys={shortcut} />
-          </Landmark>
-        </Fragment>
+        <Landmark key={label} role="listitem">
+          <TranslateWithMarkup
+            mapping={{
+              label: <Label />,
+              listOfShortcuts: <ShortcutLabel keys={shortcut} />,
+            }}
+          >
+            {sprintf(
+              /* translators: %s: action or label */
+              __(
+                '<label>%s</label> <listOfShortcuts></listOfShortcuts>',
+                'web-stories'
+              ),
+              label
+            )}
+          </TranslateWithMarkup>
+        </Landmark>
       ))}
     </LandmarksWrapper>
   );

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/shortcutMenuSection.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/shortcutMenuSection.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { Fragment } from 'react';
+import { sprintf, TranslateWithMarkup, __ } from '@web-stories-wp/i18n';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { v4 as uuidv4 } from 'uuid';
@@ -58,10 +58,24 @@ function ShortcutMenuSection({ title, commands }) {
       <Header id={headerId}>{title}</Header>
       <List role="group" aria-labelledby={headerId}>
         {commands.map(({ label, shortcut }) => (
-          <Fragment key={label}>
-            <ShortcutLabel keys={shortcut} alignment={'left'} />
-            <Label role="listitem">{label}</Label>
-          </Fragment>
+          <TranslateWithMarkup
+            mapping={{
+              label: <Label role="listitem" />,
+              listOfShortcuts: (
+                <ShortcutLabel keys={shortcut} alignment="left" />
+              ),
+            }}
+            key={label}
+          >
+            {sprintf(
+              /* translators: %s: action or label */
+              __(
+                '<listOfShortcuts></listOfShortcuts> <label>%s</label> ',
+                'web-stories'
+              ),
+              label
+            )}
+          </TranslateWithMarkup>
         ))}
       </List>
     </>


### PR DESCRIPTION
- don't think this is right. The shortcuts are still not being translated, so will need to refactor our `ShortcutList` idea

## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

don't think this is right still. The keyboard shortcuts aren't actually getting translated still. Just injected into the string with the label.

Tomorrow gonna rip this apart and see what we can do about translating before we get to rendering? bleh

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
