### PR TITLE
Fix not being able to add shapes in case of small screens

### DIFF
--- a/assets/src/edit-story/components/library/panes/shared/libraryMoveable.js
+++ b/assets/src/edit-story/components/library/panes/shared/libraryMoveable.js
@@ -41,14 +41,8 @@ import objectWithout from '../../../../utils/objectWithout';
 
 const TargetBox = styled.div`
   position: absolute;
-  width: ${({ width }) => `${width}px`};
-  height: ${({ height }) => `${height}px`};
-  ${({ isDragging }) =>
-    !isDragging &&
-    `
-      max-width: 100%;
-      max-height: 100%;
-    `};
+  width: 100%;
+  height: 100%;
   top: 0;
   z-index: 1;
   cursor: pointer;
@@ -62,7 +56,6 @@ function LibraryMoveable({
   onClick,
   cloneElement,
   cloneProps,
-  previewSize,
   elements = [],
   active = false,
 }) {
@@ -215,14 +208,8 @@ function LibraryMoveable({
     // Assign new size to targetbox so that it would match the clone, for snapping.
     targetBoxRef.current.style.width = `${cloneProps.width}px`;
     targetBoxRef.current.style.height = `${cloneProps.height}px`;
-    let x1 = targetBox.left - offsetX;
-    let y1 = targetBox.top - offsetY;
-    // In case of shapes, the clone is larger than the preview
-    // so we position it to center.
-    if ('shape' === type) {
-      x1 = x1 - (cloneProps.width - targetBox.width) / 2;
-      y1 = y1 - (cloneProps.height - targetBox.height) / 2;
-    }
+    const x1 = targetBox.left - offsetX;
+    const y1 = targetBox.top - offsetY;
     cloneRef.current.style.left = `${x1}px`;
     cloneRef.current.style.top = `${y1}px`;
     // Update moveable to take the new size of the target for snapping.
@@ -284,17 +271,12 @@ function LibraryMoveable({
     snappingOffsetX,
   });
 
-  const targetSize = previewSize ?? cloneProps;
-  const { width, height } = targetSize;
   return (
     <>
       <TargetBox
         ref={targetBoxRef}
-        width={width}
-        height={height}
         onPointerOver={() => setHover(true)}
         onPointerOut={() => setHover(false)}
-        isDragging={isDragging || hover}
       />
       {(isDragging || active || hover) && (
         <>
@@ -334,7 +316,6 @@ LibraryMoveable.propTypes = {
   cloneElement: PropTypes.object.isRequired,
   cloneProps: PropTypes.object.isRequired,
   active: PropTypes.bool,
-  previewSize: PropTypes.object,
   elements: PropTypes.array,
 };
 

--- a/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
+++ b/assets/src/edit-story/components/library/panes/text/textSets/textSet.js
@@ -129,10 +129,6 @@ function TextSet({ elements, translateY, translateX, ...rest }, ref) {
           elements={elements}
           elementProps={{}}
           onClick={onClick}
-          previewSize={{
-            width: TEXT_SET_SIZE,
-            height: TEXT_SET_SIZE,
-          }}
           cloneElement={DragContainer}
           cloneProps={{
             width: dragWidth,


### PR DESCRIPTION
## Summary
Always covers the whole library element area with Moveable so clicking anywhere adds the element.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
1. Open the shape library
2. Zoom canvas to 25% (pinch to zoom)
3. Click on the right bottom corner of a shape.
4. Verify the shape is added.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. See above

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7802 
