### PR TITLE
Avoid excess Styled Components classes in element preview mode

### DIFF
--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -42,10 +42,24 @@ import {
   shouldDisplayBorder,
 } from '../../utils/elementBorder';
 
-const Wrapper = styled.div`
-  ${elementWithPosition}
-  ${elementWithSize}
-  ${elementWithRotation}
+// Using attributes to avoid creation of hundreds of classes by styled components for previewMode.
+const Wrapper = styled.div.attrs(
+  ({ previewMode, x, y, width, height, rotationAngle }) => {
+    const style = {
+      position: 'absolute',
+      zIndex: 1,
+      left: `${x}px`,
+      top: `${y}px`,
+      width: `${width}px`,
+      height: `${height}px`,
+      transform: `rotate(${rotationAngle}deg)`,
+    };
+    return previewMode ? { style } : {};
+  }
+)`
+  ${({ previewMode }) => !previewMode && elementWithPosition}
+  ${({ previewMode }) => !previewMode && elementWithSize}
+  ${({ previewMode }) => !previewMode && elementWithRotation}
   contain: layout;
   transition: opacity 0.15s cubic-bezier(0, 0, 0.54, 1);
 
@@ -167,6 +181,7 @@ function DisplayElement({ element, previewMode, isAnimatable = false }) {
       ref={wrapperRef}
       data-element-id={id}
       isBackground={element.isBackground}
+      previewMode={previewMode}
       {...box}
     >
       <AnimationWrapper id={id} isAnimatable={isAnimatable}>

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -52,6 +52,7 @@ import {
   getHighlightLineheight,
   generateParagraphTextStyle,
   calcFontMetrics,
+  generateFontFamily,
 } from './util';
 
 const OutsideBorder = styled.div`
@@ -97,12 +98,46 @@ const ForegroundSpan = styled(Span)`
   background: none;
 `;
 
-// Using attributes to avoid creation of hundreds of classes by styled components.
-const FillElement = styled.p`
+// Using attributes to avoid creation of hundreds of classes by styled components for previewMode.
+const FillElement = styled.p.attrs(
+  ({
+    theme,
+    previewMode,
+    fontStyle,
+    fontSize,
+    fontWeight,
+    font,
+    marginOffset,
+    padding,
+    lineHeight,
+    textAlign,
+    dataToEditorY,
+  }) => {
+    return previewMode
+      ? {
+          style: {
+            zIndex: 1,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+            letterSpacing: 'normal',
+            color: theme.colors.standard.black,
+            fontStyle,
+            fontSize: `${fontSize}px`,
+            fontWeight,
+            fontFamily: generateFontFamily(font),
+            margin: `${-dataToEditorY(marginOffset / 2)}px 0`,
+            padding: padding || 0,
+            lineHeight,
+            textAlign,
+          },
+        }
+      : {};
+  }
+)`
   margin: 0;
   ${elementFillContent}
-  ${elementWithFont}
-  ${elementWithTextParagraphStyle}
+  ${({ previewMode }) => !previewMode && elementWithFont}
+  ${({ previewMode }) => !previewMode && elementWithTextParagraphStyle}
 `;
 
 const Background = styled.div`
@@ -282,6 +317,7 @@ function TextDisplay({
         dangerouslySetInnerHTML={{
           __html: content,
         }}
+        previewMode={previewMode}
         {...props}
       />
     </Background>


### PR DESCRIPTION
## Summary
Uses inline styles in case of `previewMode` to avoid excess classes. This will influence everything except for the element displayed on canvas.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Open the text sets panels. Scroll up and down a few times, filtering the text sets. Verify that no warning about creating over 200 classes is displayed.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5797 
