### PR TITLE
Update PHPUnit workflow

### DIFF
--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: mysql
-          coverage: xdebug
+          coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           tools: composer, cs2pr
 
       - name: Install dependencies

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -134,6 +134,9 @@ jobs:
           composer dump-autoload --no-interaction
         if: ${{ matrix.php == '8.0' }}
 
+      - name: Set up problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
       - name: Run tests
         run: |
           npm run test:php


### PR DESCRIPTION
See https://github.com/marketplace/actions/setup-php-action#problem-matchers for info on problem matchers. Basically this way we can have PHPUnit error output inline.