### PR TITLE
Animation: Fixed Delta for Background Zoom Animations

### DIFF
--- a/assets/src/animation/effects/backgroundZoom/index.js
+++ b/assets/src/animation/effects/backgroundZoom/index.js
@@ -19,7 +19,13 @@
  */
 import { BG_MIN_SCALE, BG_MAX_SCALE, SCALE_DIRECTION } from '../../constants';
 import { AnimationZoom } from '../../parts/zoom';
-import { lerp, getMediaOrigin, getMediaBoundOffsets } from '../../utils';
+import {
+  lerp,
+  getMediaOrigin,
+  getMediaBoundOffsets,
+  clamp,
+  progress,
+} from '../../utils';
 
 export function EffectBackgroundZoom({
   element,
@@ -29,13 +35,22 @@ export function EffectBackgroundZoom({
   easing = 'cubic-bezier(.3,0,.55,1)',
   transformOrigin,
 }) {
-  // Define the range based off the element scale
+  // Define the min/max range based off the element scale
   // at element scale 400, the range should be [1/4, 1]
   // at element scale 100, the range should be [1, 4]
   const range = [BG_MIN_SCALE / element.scale, BG_MAX_SCALE / element.scale];
 
+  // Compute what a 50% difference is relative to [0%, 400%]
+  const normalizedDelta = progress(50, [0, BG_MAX_SCALE]);
+  // Interpret the normalized delta into the compounded scale coordinate space.
+  const delta = lerp(normalizedDelta, [0, range[1]]);
+  // Apply the interpretted fixed delta to the elements scale
+  const zoomFrom =
+    1 + (zoomDirection === SCALE_DIRECTION.SCALE_OUT ? 1 : -1) * delta;
+
   return AnimationZoom({
-    zoomFrom: lerp(zoomDirection === SCALE_DIRECTION.SCALE_OUT ? 1 : 0, range),
+    // make sure we stay within min/max range so image always fills canvas
+    zoomFrom: clamp(zoomFrom, range),
     zoomTo: 1,
     duration,
     delay,


### PR DESCRIPTION
## Context
This is an exploration ticket in the work to make animation defaults nicer for users.

## Summary
This PR sets a fixed delta of 50% fo the Background zoom animations. The math is a little hairy to accommodate and translate the fixed delta into the inherited coordinate space of the elements static scale.

## Relevant Technical Choices
Just added moar maths.

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Zoom should now not look so jarring when animating as we only animate 50% in either direction instead of from the largest/smallest the bg image can be scaled.

currently looks like:
https://user-images.githubusercontent.com/35983235/120692871-f375e000-c46d-11eb-9745-113059468ec2.mp4


<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
In the editor, add a background element and checkout the `zoom in` and `zoom out` animations as well as the `pan and zoom` animation. Also change the background images static scale and see that the zoom animations are never jarring.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
Follow testing instructions above. (apologies there's not much to test here beyond the animations should "look better" which is a little open ended/subjective)
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7752 
