### PR TITLE
Composer: remove `—no-suggest` option

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          composer install --prefer-dist --no-suggest --no-progress --no-interaction
+          composer install --prefer-dist --no-progress --no-interaction
         env:
           CI: true
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true

--- a/.github/workflows/lint-i18n.yml
+++ b/.github/workflows/lint-i18n.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          composer install --prefer-dist --no-suggest --no-progress --no-interaction
+          composer install --prefer-dist --no-progress --no-interaction
         env:
           CI: true
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -61,7 +61,7 @@ jobs:
         run: composer --no-interaction validate --no-check-all
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-suggest --no-progress --no-interaction
+        run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Detect coding standard violations (PHPCS)
         run: vendor/bin/phpcs -q --report=checkstyle --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 | cs2pr --graceful-warnings

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -340,7 +340,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          composer install --prefer-dist --no-suggest --no-progress --no-interaction
+          composer install --prefer-dist --no-progress --no-interaction
         env:
           CI: true
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           npm ci
           npm install puppeteer
-          composer install --prefer-dist --no-suggest --no-progress --no-interaction
+          composer install --prefer-dist --no-progress --no-interaction
         env:
           CI: true
           PUPPETEER_PRODUCT: ${{ matrix.browser }}

--- a/.github/workflows/tests-unit-php.yml
+++ b/.github/workflows/tests-unit-php.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install prefixed dependencies
         run: |
-          composer install --prefer-dist --no-suggest --no-progress --no-interaction
+          composer install --prefer-dist --no-progress --no-interaction
           rm -rf vendor/*
 
       - name: Setup PHP
@@ -110,7 +110,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer install --prefer-dist --no-suggest --no-progress --no-interaction --no-scripts
+          composer install --prefer-dist --no-progress --no-interaction --no-scripts
           composer dump-autoload --no-interaction
 
       - name: Shutdown default MySQL service

--- a/bin/local-env/install-composer.sh
+++ b/bin/local-env/install-composer.sh
@@ -37,5 +37,5 @@ fi
 # Install/update packages
 if [ "$CI" != "true" ]; then
   echo -e $(status_message "Installing and updating Composer packages..." )
-  composer install --optimize-autoloader --no-interaction --prefer-dist --no-suggest --ignore-platform-reqs
+  composer install --optimize-autoloader --no-interaction --prefer-dist --ignore-platform-reqs
 fi


### PR DESCRIPTION
This option is deprecated in Composer v2

```
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
```

Noticed when looking at CI output, e.g. https://github.com/google/web-stories-wp/runs/2773543544#step:10:5