### PR TITLE
Right Click Menus: UI prep

### DIFF
--- a/assets/src/design-system/components/contextMenu/menu.js
+++ b/assets/src/design-system/components/contextMenu/menu.js
@@ -53,13 +53,13 @@ const separatorCSS = css`
   content: '';
   width: 100%;
   height: 1px;
-  background-color: ${({ theme }) => theme.colors.bg.tertiary};
+  background-color: ${({ theme }) => theme.colors.divider.primary};
   ${({ isIconMenu, theme }) =>
     isIconMenu &&
     css`
       width: 40%;
       margin: auto;
-      background-color: ${theme.colors.fg.primary};
+      background-color: ${theme.colors.divider.primary};
     `}
 `;
 separatorCSS.propTypes = {

--- a/assets/src/design-system/components/contextMenu/menuItem.js
+++ b/assets/src/design-system/components/contextMenu/menuItem.js
@@ -18,7 +18,7 @@
  */
 import PropTypes from 'prop-types';
 import { useCallback, useMemo, useRef } from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 /**
  * Internal dependencies
  */
@@ -34,13 +34,9 @@ const ItemText = styled(Text)`
   width: 200px;
   text-align: left;
 `;
-
-const Shortcut = styled(Text)(
-  ({ theme }) => css`
-    color: ${theme.colors.border.disable};
-    white-space: nowrap;
-  `
-);
+const Shortcut = styled(Text)`
+  color: ${({ theme }) => theme.colors.border.disable};
+`;
 
 const IconWrapper = styled.span`
   width: 32px;
@@ -91,12 +87,13 @@ export const MenuItem = ({
         >
           {label}
         </ItemText>
-        {shortcut && (
+        {shortcut?.title && (
           <Shortcut
             size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
-            forwardedAs="span"
+            forwardedAs="kbd"
+            aria-label={shortcut.title}
           >
-            {shortcut}
+            {shortcut?.display}
           </Shortcut>
         )}
       </>
@@ -195,7 +192,10 @@ export const MenuItemProps = {
   onClick: PropTypes.func,
   onDismiss: PropTypes.func,
   onFocus: PropTypes.func,
-  shortcut: PropTypes.string,
+  shortcut: PropTypes.shape({
+    display: PropTypes.string,
+    title: PropTypes.string,
+  }),
   Icon: PropTypes.func,
   tooltipPlacement: PropTypes.oneOf(Object.values(PLACEMENT)),
 };

--- a/assets/src/design-system/components/contextMenu/menuItem.js
+++ b/assets/src/design-system/components/contextMenu/menuItem.js
@@ -98,7 +98,7 @@ export const MenuItem = ({
         >
           {label}
         </ItemText>
-        {shortcut?.title && (
+        {shortcut?.display && (
           <Shortcut
             size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
             forwardedAs="kbd"

--- a/assets/src/design-system/components/contextMenu/menuItem.js
+++ b/assets/src/design-system/components/contextMenu/menuItem.js
@@ -19,6 +19,8 @@
 import PropTypes from 'prop-types';
 import { useCallback, useMemo, useRef } from 'react';
 import styled from 'styled-components';
+import { sprintf, __ } from '@web-stories-wp/i18n';
+
 /**
  * Internal dependencies
  */
@@ -69,6 +71,15 @@ export const MenuItem = ({
     [onClick, onDismiss]
   );
 
+  const itemLabel = shortcut?.title
+    ? sprintf(
+        /* translators: 1: Menu Item Text Label. 2: Keyboard shortcut value. */
+        __('%1$s, or use %2$s on a keyboard', 'web-stories'),
+        ariaLabel || label,
+        shortcut.title
+      )
+    : ariaLabel || label;
+
   const textContent = useMemo(() => {
     if (Icon) {
       return (
@@ -91,7 +102,6 @@ export const MenuItem = ({
           <Shortcut
             size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
             forwardedAs="kbd"
-            aria-label={shortcut.title}
           >
             {shortcut?.display}
           </Shortcut>
@@ -111,7 +121,7 @@ export const MenuItem = ({
     return (
       <Link
         ref={itemRef}
-        aria-label={ariaLabel || label}
+        aria-label={itemLabel}
         href={href}
         onClick={handleClick}
         onFocus={onFocus}
@@ -127,7 +137,7 @@ export const MenuItem = ({
     return (
       <Button
         ref={itemRef}
-        aria-label={ariaLabel || label}
+        aria-label={itemLabel}
         disabled={disabled}
         onClick={handleClick}
         onFocus={onFocus}

--- a/assets/src/design-system/components/contextMenu/menuItem.js
+++ b/assets/src/design-system/components/contextMenu/menuItem.js
@@ -48,6 +48,7 @@ const IconWrapper = styled.span`
 `;
 
 export const MenuItem = ({
+  ariaLabel,
   disabled,
   href,
   label,
@@ -113,7 +114,7 @@ export const MenuItem = ({
     return (
       <Link
         ref={itemRef}
-        aria-label={label}
+        aria-label={ariaLabel || label}
         href={href}
         onClick={handleClick}
         onFocus={onFocus}
@@ -129,7 +130,7 @@ export const MenuItem = ({
     return (
       <Button
         ref={itemRef}
-        aria-label={label}
+        aria-label={ariaLabel || label}
         disabled={disabled}
         onClick={handleClick}
         onFocus={onFocus}
@@ -189,6 +190,7 @@ export const MenuItemProps = {
   disabled: PropTypes.bool,
   href: linkOrButtonValidator,
   label: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string,
   newTab: PropTypes.bool,
   onClick: PropTypes.func,
   onDismiss: PropTypes.func,

--- a/assets/src/design-system/components/contextMenu/stories/index.js
+++ b/assets/src/design-system/components/contextMenu/stories/index.js
@@ -20,6 +20,7 @@
 import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
 import styled from 'styled-components';
+import { useState } from 'react';
 
 /**
  * Internal dependencies
@@ -39,6 +40,7 @@ import {
   PictureSwap,
 } from '../../../icons';
 import { Text } from '../../typography';
+import { Button } from '../../button';
 
 const items = [
   { label: 'Copy', shortcut: '⌘ X' },
@@ -112,7 +114,6 @@ const Grid = styled.div`
 
   ${Container} {
     width: 300px;
-    max-height: 300px;
     margin: 0 auto;
   }
 `;
@@ -288,6 +289,153 @@ export const QuickActionMenu = () => {
           items={generateMenuItemsWithEventHandler(textItems)}
           isIconMenu
           isAlwaysVisible
+        />
+      </Container>
+    </Grid>
+  );
+};
+
+// todo these shortcuts need  translations!
+// todo  why don't  all  options  get  short cuts?
+
+const rightClickMenuMainOptions = [
+  { label: 'Copy', ariaLabel: 'Copy element', shortcut: '⌘X' },
+  { label: 'Paste', ariaLabel: 'Paste element', shortcut: '⌘C' },
+  { label: 'Delete', ariaLabel: 'Delete element', shortcut: 'DEL' },
+];
+
+const rightClickMenuLayeringOptions = [
+  { label: 'Send to Back', separator: 'top', shortcut: '⌥⌘[' },
+  { label: 'Send Backwards', shortcut: '⌘[' },
+  { label: 'Bring Forward', shortcut: '⌘]' },
+  { label: 'Bring to Front', shortcut: '⌥⌘]' },
+];
+
+const rightClickMenuPageAddOptions = [
+  { label: 'Add new page before', separator: 'top' },
+  { label: 'Add new page after' },
+];
+
+const rightClickMenuPageDeleteOptions = [
+  { label: 'Duplicate page' },
+  { label: 'Delete page' },
+];
+
+const rightClickMenuStyleOptions = [
+  { label: 'Copy styles', separator: 'top', shortcut: '⌥⌘C' },
+  { label: 'Paste styles', shortcut: '⌥⌘V' },
+  { label: 'Clear style' },
+];
+
+const pageElement = [
+  ...rightClickMenuMainOptions,
+  ...rightClickMenuPageAddOptions,
+  ...rightClickMenuPageDeleteOptions,
+];
+
+const shapeElement = [
+  ...rightClickMenuMainOptions,
+  ...rightClickMenuLayeringOptions,
+  ...rightClickMenuStyleOptions,
+  { label: 'Add color to "Saved  colors"' },
+];
+
+const foregroundMediaElement = [
+  ...rightClickMenuMainOptions,
+  ...rightClickMenuLayeringOptions,
+  { label: 'Set as page background', separator: 'top' },
+  { label: 'Scale & crop image' },
+  ...rightClickMenuStyleOptions,
+];
+
+const backgroundMediaElement = [
+  ...rightClickMenuMainOptions,
+  { label: 'Detach image from background', separator: 'top' },
+  { label: 'Replace background image' },
+  { label: 'Scale & crop background image' },
+  { label: 'Clear style' },
+  ...rightClickMenuPageAddOptions,
+  ...rightClickMenuPageDeleteOptions,
+];
+
+const textElement = [
+  ...rightClickMenuMainOptions,
+  ...rightClickMenuLayeringOptions,
+  ...rightClickMenuStyleOptions,
+  { label: 'Add style to "Saved styles"' },
+  { label: 'Add color to "Saved colors"' },
+];
+
+export const RightClickMenu = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const generateMenuItemsWithEventHandler = (i) =>
+    i.map((item) => ({
+      ...item,
+      onClick: () => {
+        action(`Clicked on \`${item.label}\``)();
+        setIsOpen(false);
+      },
+    }));
+
+  // TODO set this style up like canvas to prep
+  return (
+    <ViewportContainer>
+      <Button onClick={() => setIsOpen((val) => !val)}>{'Open menu'}</Button>
+      <AnimatedContainerWrapper>
+        <AnimatedContextMenu
+          isOpen={isOpen}
+          onDismiss={() => setIsOpen(false)}
+          items={generateMenuItemsWithEventHandler(pageElement)}
+        />
+      </AnimatedContainerWrapper>
+    </ViewportContainer>
+  );
+};
+export const RightClickMenuStaticValues = () => {
+  const generateMenuItemsWithEventHandler = (i) =>
+    i.map((item) => ({
+      ...item,
+      onClick: () => {
+        action(`Clicked on \`${item.label}\``)();
+      },
+    }));
+
+  return (
+    <Grid>
+      <Container>
+        <Text>{'Right click on page element'}</Text>
+        <ContextMenu
+          isOpen={boolean('isOpen', true)}
+          items={generateMenuItemsWithEventHandler(pageElement)}
+        />
+      </Container>
+      <Container>
+        <Text>{'Right click on shape element'}</Text>
+        <ContextMenu
+          isOpen={boolean('isOpen', true)}
+          items={generateMenuItemsWithEventHandler(shapeElement)}
+        />
+      </Container>
+      <Container>
+        <Text>{'Right click on foreground media element'}</Text>
+        <ContextMenu
+          isOpen={boolean('isOpen', true)}
+          items={generateMenuItemsWithEventHandler(foregroundMediaElement)}
+        />
+      </Container>
+      <Container>
+        <Text>{'Right click on background element'}</Text>
+        <ContextMenu
+          isOpen={boolean('isOpen', true)}
+          items={generateMenuItemsWithEventHandler(backgroundMediaElement)}
+        />
+      </Container>
+      <Container>
+        <Text>{'Right click on text element'}</Text>
+        <ContextMenu
+          isOpen={boolean('isOpen', true)}
+          items={generateMenuItemsWithEventHandler(textElement)}
         />
       </Container>
     </Grid>

--- a/assets/src/design-system/components/contextMenu/stories/index.js
+++ b/assets/src/design-system/components/contextMenu/stories/index.js
@@ -21,7 +21,7 @@ import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
 import styled from 'styled-components';
 import { useState, useRef } from 'react';
-import { __ } from '@web-stories-wp/i18n';
+import { _x, __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
@@ -43,20 +43,15 @@ import {
 import { Text } from '../../typography';
 
 const items = [
-  { label: 'Copy', shortcut: '⌘ X' },
-  { label: 'Paste', shortcut: '⌘ C' },
-  { label: 'Delete', shortcut: 'DEL' },
-  { label: 'Send to back', shortcut: '⌥ ⌘ [', separator: 'top' },
-  { label: 'Send backward', shortcut: '⌘ [', disabled: true },
-  { label: 'Bring forward', shortcut: '⌘ ]', disabled: true },
   {
     label: 'Bring to front',
-    shortcut: '⌥ ⌘ [',
+    shortcut: {
+      display: '⌥ ⌘ [',
+      title: 'my aria label for this shortcut!',
+    },
     disabled: true,
     separator: 'bottom',
   },
-  { label: 'Copy style', shortcut: '⌥ ⌘ C' },
-  { label: 'Paste Style', shortcut: '⌥ ⌘ V' },
   { label: 'Clear text styles' },
   { label: 'Add style to "Saved style"' },
   { label: 'Add color to "Saved colors"' },
@@ -64,15 +59,18 @@ const items = [
 
 const randomItems = [
   { label: 'one' },
-  { label: 'two', shortcut: '%C' },
-  { label: 'i am a button!', shortcut: '$$$' },
+  { label: 'two' },
+  { label: 'i am a button!' },
   { label: 'neither a button nor a link' },
   { label: 'this is disabled', disabled: true },
   { label: 'three', separator: 'top' },
   {
     label: 'i am a link!',
     href: 'https://www.google.com/',
-    shortcut: '⌥ ⌘ A',
+    shortcut: {
+      title: 'option command and the letter A',
+      display: '⌥ ⌘ A',
+    },
   },
   {
     label: 'i am a very very very very very very very long label',
@@ -300,17 +298,34 @@ const rightClickMenuMainOptions = [
   {
     label: __('Copy', 'web-stories'),
     ariaLabel: __('Copy element', 'web-stories'),
-    shortcut: '⌘X',
+    shortcut: {
+      display: '⌘X',
+      title: _x(
+        'Command X',
+        'The keyboard keys "Command" and "X"',
+        'web-stories'
+      ),
+    },
   },
   {
     label: __('Paste', 'web-stories'),
     ariaLabel: __('Paste element', 'web-stories'),
-    shortcut: '⌘C',
+    shortcut: {
+      display: '⌘C',
+      title: _x(
+        'Command C',
+        'The keyboard keys "Command" and "C"',
+        'web-stories'
+      ),
+    },
   },
   {
     label: __('Delete', 'web-stories'),
     ariaLabel: __('Delete element', 'web-stories'),
-    shortcut: 'DEL',
+    shortcut: {
+      display: 'DEL',
+      title: _x('Delete', 'The keyboard key "Delete"', 'web-stories'),
+    },
   },
 ];
 
@@ -318,11 +333,48 @@ const rightClickMenuLayeringOptions = [
   {
     label: __('Send to Back', 'web-stories'),
     separator: 'top',
-    shortcut: '⌥⌘[',
+    shortcut: {
+      display: '⌥⌘[',
+      title: _x(
+        'Option Command Left Square Bracket',
+        'The keyboard keys "Option", "Command" and "Left Square Bracket"',
+        'web-stories'
+      ),
+    },
   },
-  { label: __('Send Backwards', 'web-stories'), shortcut: '⌘[' },
-  { label: __('Bring Forward', 'web-stories'), shortcut: '⌘]' },
-  { label: __('Bring to Front', 'web-stories'), shortcut: '⌥⌘]' },
+  {
+    label: __('Send Backwards', 'web-stories'),
+    shortcut: {
+      display: '⌘[',
+      title: _x(
+        'Command Left Square Bracket',
+        'The keyboard keys "Command" and "Left Square Bracket"',
+        'web-stories'
+      ),
+    },
+  },
+  {
+    label: __('Bring Forward', 'web-stories'),
+    shortcut: {
+      display: '⌘]',
+      title: _x(
+        'Command Right Square Bracket',
+        'The keyboard keys "Command" and "Right Square Bracket"',
+        'web-stories'
+      ),
+    },
+  },
+  {
+    label: __('Bring to Front', 'web-stories'),
+    shortcut: {
+      display: '⌥⌘]',
+      title: _x(
+        'Option Command Right Square Bracket',
+        'The keyboard keys "Option" "Command" and "Right Square Bracket"',
+        'web-stories'
+      ),
+    },
+  },
 ];
 
 const rightClickMenuPageAddOptions = [
@@ -336,8 +388,29 @@ const rightClickMenuPageDeleteOptions = [
 ];
 
 const rightClickMenuStyleOptions = [
-  { label: __('Copy style', 'web-stories'), separator: 'top', shortcut: '⌥⌘C' },
-  { label: __('Paste style', 'web-stories'), shortcut: '⌥⌘V' },
+  {
+    label: __('Copy style', 'web-stories'),
+    separator: 'top',
+    shortcut: {
+      display: '⌥⌘C',
+      title: _x(
+        'Option Command C',
+        'The keyboard keys "Option" "Command" and the letter "C"',
+        'web-stories'
+      ),
+    },
+  },
+  {
+    label: __('Paste style', 'web-stories'),
+    shortcut: {
+      display: '⌥⌘V',
+      title: _x(
+        'Option Command V',
+        'The keyboard keys "Option" "Command" and the letter "V"',
+        'web-stories'
+      ),
+    },
+  },
   { label: __('Clear style', 'web-stories') },
 ];
 

--- a/assets/src/design-system/components/contextMenu/stories/index.js
+++ b/assets/src/design-system/components/contextMenu/stories/index.js
@@ -409,19 +409,26 @@ export const RightClickMenu = () => {
         setIsOpen(false);
       },
     }));
-  const layoutRect = layoutRef.current.getBoundingClientRect();
   const handleMenu = (e) => {
     e.preventDefault();
+    const layoutRect = layoutRef?.current?.getBoundingClientRect();
+
     setIsOpen(true);
     setMenuPosition({
-      x: e.clientX - layoutRect.left,
-      y: e.clientY - layoutRect.top,
+      x: e.clientX - layoutRect?.left,
+      y: e.clientY - layoutRect?.top,
     });
   };
-  // TODO what kind of role would this make the layout?
   return (
     <ViewportContainer>
-      <SampleLayout ref={layoutRef} onClick={handleMenu} />
+      {/*eslint-disable-next-line styled-components-a11y/no-noninteractive-element-interactions*/}
+      <SampleLayout
+        ref={layoutRef}
+        onClick={handleMenu}
+        // TODO: confirm we don't need this menu to  show up for keyboards since they have a separate menu
+        role="region"
+        onKeyDown={() => {}}
+      />
       <RightClickContextMenuContainer position={menuPosition}>
         <AnimatedContextMenu
           isOpen={isOpen}

--- a/assets/src/design-system/components/contextMenu/stories/index.js
+++ b/assets/src/design-system/components/contextMenu/stories/index.js
@@ -322,8 +322,8 @@ const rightClickMenuPageDeleteOptions = [
 ];
 
 const rightClickMenuStyleOptions = [
-  { label: 'Copy styles', separator: 'top', shortcut: '⌥⌘C' },
-  { label: 'Paste styles', shortcut: '⌥⌘V' },
+  { label: 'Copy style', separator: 'top', shortcut: '⌥⌘C' },
+  { label: 'Paste style', shortcut: '⌥⌘V' },
   { label: 'Clear style' },
 ];
 

--- a/assets/src/design-system/components/contextMenu/stories/index.js
+++ b/assets/src/design-system/components/contextMenu/stories/index.js
@@ -20,7 +20,8 @@
 import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useState, useRef } from 'react';
+import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
@@ -40,7 +41,6 @@ import {
   PictureSwap,
 } from '../../../icons';
 import { Text } from '../../typography';
-import { Button } from '../../button';
 
 const items = [
   { label: 'Copy', shortcut: '⌘ X' },
@@ -296,35 +296,49 @@ export const QuickActionMenu = () => {
 };
 
 // todo these shortcuts need  translations!
-// todo  why don't  all  options  get  short cuts?
-
 const rightClickMenuMainOptions = [
-  { label: 'Copy', ariaLabel: 'Copy element', shortcut: '⌘X' },
-  { label: 'Paste', ariaLabel: 'Paste element', shortcut: '⌘C' },
-  { label: 'Delete', ariaLabel: 'Delete element', shortcut: 'DEL' },
+  {
+    label: __('Copy', 'web-stories'),
+    ariaLabel: __('Copy element', 'web-stories'),
+    shortcut: '⌘X',
+  },
+  {
+    label: __('Paste', 'web-stories'),
+    ariaLabel: __('Paste element', 'web-stories'),
+    shortcut: '⌘C',
+  },
+  {
+    label: __('Delete', 'web-stories'),
+    ariaLabel: __('Delete element', 'web-stories'),
+    shortcut: 'DEL',
+  },
 ];
 
 const rightClickMenuLayeringOptions = [
-  { label: 'Send to Back', separator: 'top', shortcut: '⌥⌘[' },
-  { label: 'Send Backwards', shortcut: '⌘[' },
-  { label: 'Bring Forward', shortcut: '⌘]' },
-  { label: 'Bring to Front', shortcut: '⌥⌘]' },
+  {
+    label: __('Send to Back', 'web-stories'),
+    separator: 'top',
+    shortcut: '⌥⌘[',
+  },
+  { label: __('Send Backwards', 'web-stories'), shortcut: '⌘[' },
+  { label: __('Bring Forward', 'web-stories'), shortcut: '⌘]' },
+  { label: __('Bring to Front', 'web-stories'), shortcut: '⌥⌘]' },
 ];
 
 const rightClickMenuPageAddOptions = [
-  { label: 'Add new page before', separator: 'top' },
-  { label: 'Add new page after' },
+  { label: __('Add new page before', 'web-stories'), separator: 'top' },
+  { label: __('Add new page after', 'web-stories') },
 ];
 
 const rightClickMenuPageDeleteOptions = [
-  { label: 'Duplicate page' },
-  { label: 'Delete page' },
+  { label: __('Duplicate page', 'web-stories') },
+  { label: __('Delete page', 'web-stories') },
 ];
 
 const rightClickMenuStyleOptions = [
-  { label: 'Copy style', separator: 'top', shortcut: '⌥⌘C' },
-  { label: 'Paste style', shortcut: '⌥⌘V' },
-  { label: 'Clear style' },
+  { label: __('Copy style', 'web-stories'), separator: 'top', shortcut: '⌥⌘C' },
+  { label: __('Paste style', 'web-stories'), shortcut: '⌥⌘V' },
+  { label: __('Clear style', 'web-stories') },
 ];
 
 const pageElement = [
@@ -337,23 +351,26 @@ const shapeElement = [
   ...rightClickMenuMainOptions,
   ...rightClickMenuLayeringOptions,
   ...rightClickMenuStyleOptions,
-  { label: 'Add color to "Saved  colors"' },
+  { label: __('Add color to "Saved colors"', 'web-stories') },
 ];
 
 const foregroundMediaElement = [
   ...rightClickMenuMainOptions,
   ...rightClickMenuLayeringOptions,
-  { label: 'Set as page background', separator: 'top' },
-  { label: 'Scale & crop image' },
+  { label: __('Set as page background', 'web-stories'), separator: 'top' },
+  { label: __('Scale & crop image', 'web-stories') },
   ...rightClickMenuStyleOptions,
 ];
 
 const backgroundMediaElement = [
   ...rightClickMenuMainOptions,
-  { label: 'Detach image from background', separator: 'top' },
-  { label: 'Replace background image' },
-  { label: 'Scale & crop background image' },
-  { label: 'Clear style' },
+  {
+    label: __('Detach image from background', 'web-stories'),
+    separator: 'top',
+  },
+  { label: __('Replace background image', 'web-stories') },
+  { label: __('Scale & crop background image', 'web-stories') },
+  { label: __('Clear style', 'web-stories') },
   ...rightClickMenuPageAddOptions,
   ...rightClickMenuPageDeleteOptions,
 ];
@@ -362,12 +379,27 @@ const textElement = [
   ...rightClickMenuMainOptions,
   ...rightClickMenuLayeringOptions,
   ...rightClickMenuStyleOptions,
-  { label: 'Add style to "Saved styles"' },
-  { label: 'Add color to "Saved colors"' },
+  { label: __('Add style to "Saved styles"', 'web-stories') },
+  { label: __('Add color to "Saved colors"', 'web-stories') },
 ];
+
+const SampleLayout = styled.div`
+  display: block;
+  width: 400px;
+  height: 800px;
+  border: 1px solid black;
+`;
+
+const RightClickContextMenuContainer = styled.div`
+  position: absolute;
+  top: ${({ position }) => position?.y ?? 0}px;
+  left: ${({ position }) => position?.x ?? 0}px;
+`;
 
 export const RightClickMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({});
+  const layoutRef = useRef();
 
   const generateMenuItemsWithEventHandler = (i) =>
     i.map((item) => ({
@@ -377,18 +409,26 @@ export const RightClickMenu = () => {
         setIsOpen(false);
       },
     }));
-
-  // TODO set this style up like canvas to prep
+  const layoutRect = layoutRef.current.getBoundingClientRect();
+  const handleMenu = (e) => {
+    e.preventDefault();
+    setIsOpen(true);
+    setMenuPosition({
+      x: e.clientX - layoutRect.left,
+      y: e.clientY - layoutRect.top,
+    });
+  };
+  // TODO what kind of role would this make the layout?
   return (
     <ViewportContainer>
-      <Button onClick={() => setIsOpen((val) => !val)}>{'Open menu'}</Button>
-      <AnimatedContainerWrapper>
+      <SampleLayout ref={layoutRef} onClick={handleMenu} />
+      <RightClickContextMenuContainer position={menuPosition}>
         <AnimatedContextMenu
           isOpen={isOpen}
           onDismiss={() => setIsOpen(false)}
           items={generateMenuItemsWithEventHandler(pageElement)}
         />
-      </AnimatedContainerWrapper>
+      </RightClickContextMenuContainer>
     </ViewportContainer>
   );
 };

--- a/assets/src/design-system/components/contextMenu/stories/index.js
+++ b/assets/src/design-system/components/contextMenu/stories/index.js
@@ -293,7 +293,6 @@ export const QuickActionMenu = () => {
   );
 };
 
-// todo these shortcuts need  translations!
 const rightClickMenuMainOptions = [
   {
     label: __('Copy', 'web-stories'),

--- a/assets/src/design-system/components/typography/text/index.js
+++ b/assets/src/design-system/components/typography/text/index.js
@@ -56,6 +56,11 @@ const Span = styled.span`
   ${textCss};
 `;
 
+const Kbd = styled.kbd`
+  ${textCss};
+  white-space: nowrap;
+`;
+
 const Label = styled.label`
   ${labelTextCss};
 
@@ -72,13 +77,15 @@ export const Text = ({ as, disabled, ...props }) => {
       return <Label disabled={disabled} {...props} />;
     case 'span':
       return <Span {...props} />;
+    case 'kbd':
+      return <Kbd {...props} />;
     default:
       return <Paragraph {...props} />;
   }
 };
 
 Text.propTypes = {
-  as: PropTypes.oneOf(['p', 'span', 'label']),
+  as: PropTypes.oneOf(['p', 'span', 'label', 'kbd']),
   /** only applies to label styling */
   disabled: PropTypes.bool,
   isBold: PropTypes.bool,


### PR DESCRIPTION
## Context

Intro work on right click menus - feature in 1.9 release. 

## Summary

storybook for right click menus to start looking at overlap and structure. Possible demo of dismissing menus all the time for everything.  Hopefully a chunk of this can be copied over to the right click menu architecture. Solve for keyboard shortcuts, do translations, copy issues, ask some functionality questions up front, fix border colors, play with container styling and positioning.

| Text Element | Background Element | Foreground Media | Shape Element | Page Element | 
| --- | --- | --- | --- | --- | 
| <img width="274" alt="Screen Shot 2021-06-10 at 3 12 22 PM" src="https://user-images.githubusercontent.com/10720454/121603867-5b906d00-c9fe-11eb-8c3b-a675235f8dc3.png"> | <img width="283" alt="Screen Shot 2021-06-10 at 3 12 16 PM" src="https://user-images.githubusercontent.com/10720454/121603870-5d5a3080-c9fe-11eb-8556-6ebb290a3c12.png"> | <img width="320" alt="Screen Shot 2021-06-10 at 3 12 11 PM" src="https://user-images.githubusercontent.com/10720454/121603871-5df2c700-c9fe-11eb-80a2-baa9bef16eda.png"> | <img width="264" alt="Screen Shot 2021-06-10 at 3 12 06 PM" src="https://user-images.githubusercontent.com/10720454/121603872-5e8b5d80-c9fe-11eb-84c7-87c79a35c311.png"> | <img width="264" alt="Screen Shot 2021-06-10 at 3 12 01 PM" src="https://user-images.githubusercontent.com/10720454/121603874-5e8b5d80-c9fe-11eb-8e3d-9d6c9c136819.png"> |

![menu demo](https://user-images.githubusercontent.com/10720454/121603996-9befeb00-c9fe-11eb-9e1e-a0a289a8d39d.gif)



## Relevant Technical Choices

- Adding ariaLabel to context menu, if present use that for aria-label of menu items, otherwise just use the visible label (there are a few new actions on these menus that could use a bit more description for non visual users).
- Also checking for a shortcut title while assembling `aria-label` for menu items since we shouldn't nest aria-labels and the shortcut lives in the button. Took a stab at combining the labels with `sprintf` that makes sense to me, would love eyes on that. 
- Using `kbd` for shortcuts, per #7478, updated context menu in design system. shortcuts aren't used for context menus elsewhere yet. 
- Add `kbd` as a text element type accepted in typography
- Tried to make the right click context menu constants something that was copy/paste-able from storybook here, so created some reusable objects for the sections of menu items that repeat through the menus. 
- Talked to Omar about consistent copy, so the copy in storybook for the right click menu demo is accurate. 
- Included a way to get the proper coords for the click functionality. 
- Updated the menu separator color, it's supposed to be the `colors.divider`.

## To-do

- [x] Translations 
- [x] Check out structure of animated context menu with the canvas and tend to any `display` needs to get the positioning right. 
- [x] Follow up with design about copy (message out to them in slack) 
- [x] Check a11y 

## User-facing changes

Just the separator line color change on quick action menus. 

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6133 
Fixes #7897 
