### PR TITLE
[WIP] Test: Render thumbnails as images

### DIFF
--- a/assets/src/edit-story/components/carousel/carouselPage.js
+++ b/assets/src/edit-story/components/carousel/carouselPage.js
@@ -148,6 +148,7 @@ function CarouselPage({ pageId, index }) {
                 )
           }
           isActive={isCurrentPage && hasMultiplePages}
+          isCurrentPage={isCurrentPage}
           page={page}
           width={pageThumbWidth}
           height={pageThumbHeight}

--- a/assets/src/edit-story/components/carousel/carouselProvider.js
+++ b/assets/src/edit-story/components/carousel/carouselProvider.js
@@ -17,8 +17,9 @@
 /**
  * External dependencies
  */
+import * as htmlToImage from 'html-to-image';
 import PropTypes from 'prop-types';
-import { useCallback, useRef, useMemo, useState } from 'react';
+import { useCallback, useRef, useMemo, useState, useLayoutEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -39,6 +40,27 @@ function CarouselProvider({ availableSpace, children }) {
 
   const [listElement, setListElement] = useState(null);
   const pageRefs = useRef([]);
+
+  const previewImages = useRef(null);
+
+  useLayoutEffect(() => {
+    if (pages && pageRefs.current?.[pages[0]?.id] && !previewImages.current) {
+      previewImages.current = {};
+      pages.forEach(({ id }) => {
+        const element = pageRefs.current[id];
+        const preview = element.querySelector('button');
+        htmlToImage
+          .toCanvas(preview)
+          .then(function (canvas) {
+            previewImages.current[id] = canvas;
+          })
+          .catch(function (error) {
+            // eslint-disable-next-line no-console
+            console.error('Oops, something went wrong!', error);
+          });
+      });
+    }
+  }, [pages]);
 
   const numPages = pages.length;
 

--- a/assets/src/edit-story/components/carousel/carouselProvider.js
+++ b/assets/src/edit-story/components/carousel/carouselProvider.js
@@ -39,20 +39,19 @@ function CarouselProvider({ availableSpace, children }) {
   );
 
   const [listElement, setListElement] = useState(null);
+  const [previewImages, setPreviewImages] = useState(null);
   const pageRefs = useRef([]);
 
-  const previewImages = useRef(null);
-
   useLayoutEffect(() => {
-    if (pages && pageRefs.current?.[pages[0]?.id] && !previewImages.current) {
-      previewImages.current = {};
+    // @todo Only do this if there's a specific GET param in the URL.
+    if (pages && pageRefs.current?.[pages[0]?.id] && !previewImages) {
       pages.forEach(({ id }) => {
         const element = pageRefs.current[id];
         const preview = element.querySelector('button');
         htmlToImage
-          .toCanvas(preview)
-          .then(function (canvas) {
-            previewImages.current[id] = canvas;
+          .toJpeg(preview)
+          .then(function (dataUrl) {
+            setPreviewImages((oldImages) => ({ ...oldImages, [id]: dataUrl }));
           })
           .catch(function (error) {
             // eslint-disable-next-line no-console
@@ -60,7 +59,7 @@ function CarouselProvider({ availableSpace, children }) {
           });
       });
     }
-  }, [pages]);
+  }, [pages, previewImages]);
 
   const numPages = pages.length;
 
@@ -115,6 +114,7 @@ function CarouselProvider({ availableSpace, children }) {
       hasOverflow,
       pages,
       pageIds,
+      previewImages,
       numPages,
       currentPageId,
       canScrollBack,

--- a/assets/src/edit-story/components/carousel/carouselProvider.js
+++ b/assets/src/edit-story/components/carousel/carouselProvider.js
@@ -41,18 +41,22 @@ function CarouselProvider({ availableSpace, children }) {
   const [listElement, setListElement] = useState(null);
   const [previewImages, setPreviewImages] = useState(null);
   const pageRefs = useRef([]);
+  const previewRefs = useRef(null);
 
   useLayoutEffect(() => {
-    // @todo Only do this if there's a specific GET param in the URL.
-    if (pages && pageRefs.current?.[pages[0]?.id] && !previewImages) {
+    if (pages && pageRefs.current?.[pages[0]?.id] && !previewRefs.current) {
       pages.forEach(({ id }) => {
         const element = pageRefs.current[id];
         const preview = element.querySelector('button');
         htmlToImage
-          .toJpeg(preview)
+          .toSvg(preview)
           .then(function (dataUrl) {
-            setPreviewImages((oldImages) => ({ ...oldImages, [id]: dataUrl }));
+            if (!previewRefs.current) {
+              previewRefs.current = {};
+            }
+            previewRefs.current[id] = dataUrl;
           })
+          .then(() => setPreviewImages(previewRefs.current))
           .catch(function (error) {
             // eslint-disable-next-line no-console
             console.error('Oops, something went wrong!', error);

--- a/assets/src/edit-story/components/carousel/carouselProvider.js
+++ b/assets/src/edit-story/components/carousel/carouselProvider.js
@@ -43,6 +43,8 @@ function CarouselProvider({ availableSpace, children }) {
   const pageRefs = useRef([]);
   const previewRefs = useRef(null);
 
+  const numPages = pages.length;
+
   useLayoutEffect(() => {
     if (pages && pageRefs.current?.[pages[0]?.id] && !previewRefs.current) {
       pages.forEach(({ id }) => {
@@ -55,8 +57,11 @@ function CarouselProvider({ availableSpace, children }) {
               previewRefs.current = {};
             }
             previewRefs.current[id] = dataUrl;
+            if (Object.keys(previewRefs.current).length === pages.length) {
+              console.log('All done');
+              setPreviewImages(previewRefs.current);
+            }
           })
-          .then(() => setPreviewImages(previewRefs.current))
           .catch(function (error) {
             // eslint-disable-next-line no-console
             console.error('Oops, something went wrong!', error);
@@ -64,8 +69,6 @@ function CarouselProvider({ availableSpace, children }) {
       });
     }
   }, [pages, previewImages]);
-
-  const numPages = pages.length;
 
   const pageIds = useMemo(() => pages.map(({ id }) => id), [pages]);
 

--- a/assets/src/edit-story/components/carousel/carouselProvider.js
+++ b/assets/src/edit-story/components/carousel/carouselProvider.js
@@ -51,7 +51,7 @@ function CarouselProvider({ availableSpace, children }) {
         const element = pageRefs.current[id];
         const preview = element.querySelector('button');
         htmlToImage
-          .toSvg(preview)
+          .toJpeg(preview, { quality: 0.75 })
           .then(function (dataUrl) {
             if (!previewRefs.current) {
               previewRefs.current = {};

--- a/assets/src/edit-story/components/carousel/pagepreview/index.js
+++ b/assets/src/edit-story/components/carousel/pagepreview/index.js
@@ -20,6 +20,7 @@
 import styled, { css } from 'styled-components';
 import { rgba } from 'polished';
 import PropTypes from 'prop-types';
+import { Profiler } from 'react';
 
 /**
  * Internal dependencies
@@ -30,6 +31,7 @@ import { UnitsProvider } from '../../../units';
 import DisplayElement from '../../canvas/displayElement';
 import generatePatternStyles from '../../../utils/generatePatternStyles';
 import useCarousel from '../useCarousel';
+import { getProfileData, logProfileData } from '../../../profiler';
 
 const Page = styled.button`
   display: block;
@@ -95,31 +97,43 @@ function PagePreview({ page, isCurrentPage, ...props }) {
   const displayImagePreview = !isCurrentPage && previewImages?.[page.id];
   if (displayImagePreview) {
     return (
-      <Page {...props}>
-        <PreviewWrapper background={backgroundColor}>
-          <PreviewImage src={previewImages?.[page.id]} alt="" />
-        </PreviewWrapper>
-      </Page>
+      <Profiler
+        id="PagePreview image"
+        onRender={(...profileData) =>
+          logProfileData(getProfileData(profileData))
+        }
+      >
+        <Page {...props}>
+          <PreviewWrapper background={backgroundColor}>
+            <PreviewImage src={previewImages?.[page.id]} alt="" />
+          </PreviewWrapper>
+        </Page>
+      </Profiler>
     );
   }
 
   return (
-    <UnitsProvider pageSize={{ width, height }}>
-      <TransformProvider>
-        <Page {...props}>
-          <PreviewWrapper background={backgroundColor}>
-            {page.elements.map(({ id, ...rest }) => (
-              <DisplayElement
-                key={id}
-                previewMode
-                element={{ id, ...rest }}
-                page={page}
-              />
-            ))}
-          </PreviewWrapper>
-        </Page>
-      </TransformProvider>
-    </UnitsProvider>
+    <Profiler
+      id="PagePreview normal"
+      onRender={(...profileData) => logProfileData(getProfileData(profileData))}
+    >
+      <UnitsProvider pageSize={{ width, height }}>
+        <TransformProvider>
+          <Page {...props}>
+            <PreviewWrapper background={backgroundColor}>
+              {page.elements.map(({ id, ...rest }) => (
+                <DisplayElement
+                  key={id}
+                  previewMode
+                  element={{ id, ...rest }}
+                  page={page}
+                />
+              ))}
+            </PreviewWrapper>
+          </Page>
+        </TransformProvider>
+      </UnitsProvider>
+    </Profiler>
   );
 }
 

--- a/assets/src/edit-story/components/carousel/pagepreview/index.js
+++ b/assets/src/edit-story/components/carousel/pagepreview/index.js
@@ -80,6 +80,10 @@ const PreviewWrapper = styled.div`
   ${({ background }) => generatePatternStyles(background)}
 `;
 
+const PreviewImage = styled.img`
+  width: 100%;
+`;
+
 function PagePreview({ page, isCurrentPage, ...props }) {
   const { backgroundColor } = page;
   const { width, height } = props;
@@ -88,23 +92,30 @@ function PagePreview({ page, isCurrentPage, ...props }) {
     previewImages,
   }));
 
+  const displayImagePreview = !isCurrentPage && previewImages?.[page.id];
+  if (displayImagePreview) {
+    return (
+      <Page {...props}>
+        <PreviewWrapper background={backgroundColor}>
+          <PreviewImage src={previewImages?.[page.id]} alt="" />
+        </PreviewWrapper>
+      </Page>
+    );
+  }
+
   return (
     <UnitsProvider pageSize={{ width, height }}>
       <TransformProvider>
         <Page {...props}>
           <PreviewWrapper background={backgroundColor}>
-            {!isCurrentPage && previewImages?.[page.id] && (
-              <img src={previewImages[page.id]} alt="Preview" />
-            )}
-            {(!previewImages?.[page.id] || isCurrentPage) &&
-              page.elements.map(({ id, ...rest }) => (
-                <DisplayElement
-                  key={id}
-                  previewMode
-                  element={{ id, ...rest }}
-                  page={page}
-                />
-              ))}
+            {page.elements.map(({ id, ...rest }) => (
+              <DisplayElement
+                key={id}
+                previewMode
+                element={{ id, ...rest }}
+                page={page}
+              />
+            ))}
           </PreviewWrapper>
         </Page>
       </TransformProvider>

--- a/assets/src/edit-story/components/carousel/pagepreview/index.js
+++ b/assets/src/edit-story/components/carousel/pagepreview/index.js
@@ -29,6 +29,7 @@ import { TransformProvider } from '../../transform';
 import { UnitsProvider } from '../../../units';
 import DisplayElement from '../../canvas/displayElement';
 import generatePatternStyles from '../../../utils/generatePatternStyles';
+import useCarousel from '../useCarousel';
 
 const Page = styled.button`
   display: block;
@@ -79,23 +80,31 @@ const PreviewWrapper = styled.div`
   ${({ background }) => generatePatternStyles(background)}
 `;
 
-function PagePreview({ page, ...props }) {
+function PagePreview({ page, isCurrentPage, ...props }) {
   const { backgroundColor } = page;
   const { width, height } = props;
+
+  const { previewImages } = useCarousel(({ state: { previewImages } }) => ({
+    previewImages,
+  }));
 
   return (
     <UnitsProvider pageSize={{ width, height }}>
       <TransformProvider>
         <Page {...props}>
           <PreviewWrapper background={backgroundColor}>
-            {page.elements.map(({ id, ...rest }) => (
-              <DisplayElement
-                key={id}
-                previewMode
-                element={{ id, ...rest }}
-                page={page}
-              />
-            ))}
+            {!isCurrentPage && previewImages?.[page.id] && (
+              <img src={previewImages[page.id]} alt="Preview" />
+            )}
+            {(!previewImages?.[page.id] || isCurrentPage) &&
+              page.elements.map(({ id, ...rest }) => (
+                <DisplayElement
+                  key={id}
+                  previewMode
+                  element={{ id, ...rest }}
+                  page={page}
+                />
+              ))}
           </PreviewWrapper>
         </Page>
       </TransformProvider>
@@ -110,6 +119,7 @@ PagePreview.propTypes = {
   isInteractive: PropTypes.bool,
   isActive: PropTypes.bool,
   tabIndex: PropTypes.number,
+  isCurrentPage: PropTypes.bool.isRequired,
 };
 
 export default PagePreview;

--- a/assets/src/edit-story/components/carousel/pagepreview/index.js
+++ b/assets/src/edit-story/components/carousel/pagepreview/index.js
@@ -94,7 +94,7 @@ function PagePreview({ page, isCurrentPage, ...props }) {
     previewImages,
   }));
 
-  const displayImagePreview = !isCurrentPage && previewImages?.[page.id];
+  const displayImagePreview = previewImages?.[page.id];
   if (displayImagePreview) {
     return (
       <Profiler

--- a/assets/src/edit-story/profiler.js
+++ b/assets/src/edit-story/profiler.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const cumulativeDuration = {};
+
+// profiler callback
+// https://reactjs.org/docs/profiler.html#onrender-callback
+export const getProfileData = ([
+  id, // the "id" prop of the Profiler tree that has just committed
+  phase, // either "mount" (if the tree just mounted) or "update" (if it re-rendered)
+  actualDuration, // time spent rendering the committed update
+  baseDuration, // estimated time to render the entire subtree without memoization
+  startTime, // when React began rendering this update
+  commitTime, // when React committed this update
+  interactions, // the Set of interactions belonging to this update
+]) => {
+  if (!cumulativeDuration[id]) {
+    cumulativeDuration[id] = 0;
+  }
+  cumulativeDuration[id] = Number(
+    (cumulativeDuration[id] + actualDuration).toFixed(2)
+  );
+  return {
+    id,
+    interactions,
+    phase,
+    actualDuration: Number(actualDuration.toFixed(2)),
+    baseDuration: Number(baseDuration.toFixed(2)),
+    commitTime: Number(commitTime.toFixed(2)),
+    cumulativeDuration: cumulativeDuration[id],
+    startTime: Number(startTime.toFixed(2)),
+  };
+};
+
+export const logProfileData = ({
+  actualDuration,
+  baseDuration,
+  cumulativeDuration,
+  phase,
+  id,
+}) => {
+  console.group(id);
+  console.table({
+    actualDuration,
+    baseDuration,
+    cumulativeDuration,
+  });
+  console.groupEnd();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "web-stories-wp",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -47,6 +48,7 @@
         "focus-visible": "^5.2.0",
         "glider-js": "^1.7.6",
         "history": "^5.0.0",
+        "html-to-image": "^1.6.2",
         "mousetrap": "^1.6.5",
         "patch-package": "^6.4.7",
         "polished": "^4.1.2",
@@ -24581,6 +24583,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.6.2.tgz",
+      "integrity": "sha512-X6X7wJW2KQ+AGqMeBITdntCcQnxBgZY62MdGOi042Y70+0SMe8/iJCzUv8RNaUoXqUjWw5FPyoTDmdGoapTQIQ=="
     },
     "node_modules/html-void-elements": {
       "version": "1.0.5",
@@ -65501,6 +65508,11 @@
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
       "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
       "dev": true
+    },
+    "html-to-image": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.6.2.tgz",
+      "integrity": "sha512-X6X7wJW2KQ+AGqMeBITdntCcQnxBgZY62MdGOi042Y70+0SMe8/iJCzUv8RNaUoXqUjWw5FPyoTDmdGoapTQIQ=="
     },
     "html-void-elements": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "focus-visible": "^5.2.0",
     "glider-js": "^1.7.6",
     "history": "^5.0.0",
+    "html-to-image": "^1.6.2",
     "mousetrap": "^1.6.5",
     "patch-package": "^6.4.7",
     "polished": "^4.1.2",


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Generates images for the thumbnails when loading a page and uses those instead of rendering all elements on thumbnails.

This PR has been created for testing the performance of this solution compared to the current logic and also to SVG rendering.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7812 
