### PR TITLE
Accessibility: Keyboard Shortcuts Menu Accessibility and I18N Improvements

### DIFF
--- a/assets/src/edit-story/components/keyboardShortcutsMenu/constants.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/constants.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { __, _x } from '@web-stories-wp/i18n';
+import { _x } from '@web-stories-wp/i18n';
 import styled from 'styled-components';
 
 /**
@@ -30,43 +30,56 @@ export const BOTTOM_MARGIN = 8;
 
 export const TOGGLE_SHORTCUTS_MENU = 'mod+/';
 
-export const KEY_SIZE = {
-  NORMAL: '24px',
-  LARGE: 'auto',
-};
-
 const Up = styled(KeyArrowUp)`
   width: 12px;
   transform-origin: 50% 50%;
 `;
-
 const Down = styled(Up)`
   transform: rotate(0.5turn);
 `;
+const Cmd = () => '⌘';
+const Ctrl = () => 'ctrl';
+const Enter = () => '⏎';
+const Shift = () => '⇧';
+const Option = () => '⌥';
+const Alt = () => _x('alt', 'The keyboard key "Alt"', 'web-stories');
+const Delete = () => _x('Delete', 'The keyboard key "Delete"', 'web-stories');
 
 export const SPECIAL_KEYS = {
   COMMAND: {
-    symbol: '⌘',
+    symbol: <Cmd />,
     title: _x('Command', 'The keyboard key "Command"', 'web-stories'),
   },
   CONTROL: {
-    symbol: 'ctrl',
+    symbol: <Ctrl />,
     title: _x('Control', 'The keyboard key "Control"', 'web-stories'),
   },
   ENTER: {
-    symbol: '⏎',
+    symbol: <Enter />,
     title: _x('Enter', 'The keyboard key "Enter"', 'web-stories'),
   },
   SHIFT: {
-    symbol: '⇧',
+    symbol: <Shift />,
     title: _x('Shift', 'The keyboard key "Shift"', 'web-stories'),
   },
   OPTION: {
-    symbol: '⌥',
+    symbol: <Option />,
     title: _x('Option', 'The keyboard key "Option"', 'web-stories'),
   },
-  ALT: _x('alt', 'The keyboard key "Alt"', 'web-stories'),
-  DELETE: _x('Delete', 'The keyboard key "Delete"', 'web-stories'),
-  UP: <Up aria-label={__('Up arrow', 'web-stories')} />,
-  DOWN: <Down aria-label={__('Down arrow', 'web-stories')} />,
+  ALT: {
+    symbol: <Alt />,
+    title: _x('alt', 'The keyboard key "Alt"', 'web-stories'),
+  },
+  DELETE: {
+    symbol: <Delete />,
+    title: _x('Delete', 'The keyboard key "Delete"', 'web-stories'),
+  },
+  UP: {
+    symbol: <Up />,
+    title: _x('Up arrow', 'The keyboard key "Up"', 'web-stories'),
+  },
+  DOWN: {
+    symbol: <Down />,
+    title: _x('Down arrow', 'The keyboard key "Down"', 'web-stories'),
+  },
 };

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutList.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutList.js
@@ -29,12 +29,16 @@ const isMacOs = isPlatformMacOS();
 const cmdOrCtrl = isMacOs ? SPECIAL_KEYS.COMMAND : SPECIAL_KEYS.CONTROL;
 const optionOrAlt = isMacOs ? SPECIAL_KEYS.OPTION : SPECIAL_KEYS.ALT;
 
+const LargeKey = (props) => <kbd className="large-key" {...props} />;
+
 const shortcuts = {
   header: {
     label: __('Keyboard Shortcuts', 'web-stories'),
     shortcut: (
       <kbd>
-        <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+        <kbd aria-label={cmdOrCtrl.title} className="large-key">
+          {cmdOrCtrl.symbol}
+        </kbd>
         <kbd>{'/'}</kbd>
       </kbd>
     ),
@@ -44,7 +48,9 @@ const shortcuts = {
       label: __('Element', 'web-stories'),
       shortcut: (
         <kbd>
-          <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+          <kbd aria-label={cmdOrCtrl.title} className="large-key">
+            {cmdOrCtrl.symbol}
+          </kbd>
           <kbd aria-label={optionOrAlt.title}>{optionOrAlt.symbol}</kbd>
           <kbd>{'1'}</kbd>
         </kbd>
@@ -54,7 +60,9 @@ const shortcuts = {
       label: __('Workspace', 'web-stories'),
       shortcut: (
         <kbd>
-          <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+          <kbd aria-label={cmdOrCtrl.title} className="large-key">
+            {cmdOrCtrl.symbol}
+          </kbd>
           <kbd aria-label={optionOrAlt.title}>{optionOrAlt.symbol}</kbd>
           <kbd>{'2'}</kbd>
         </kbd>
@@ -64,7 +72,9 @@ const shortcuts = {
       label: __('Design panels', 'web-stories'),
       shortcut: (
         <kbd>
-          <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+          <kbd aria-label={cmdOrCtrl.title} className="large-key">
+            {cmdOrCtrl.symbol}
+          </kbd>
           <kbd aria-label={optionOrAlt.title}>{optionOrAlt.symbol}</kbd>
           <kbd>{'3'}</kbd>
         </kbd>
@@ -79,7 +89,9 @@ const shortcuts = {
           label: __('Undo', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'Z'}</kbd>
             </kbd>
           ),
@@ -88,7 +100,9 @@ const shortcuts = {
           label: __('Redo', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd aria-label={SPECIAL_KEYS.SHIFT.title}>
                 {SPECIAL_KEYS.SHIFT.symbol}
               </kbd>
@@ -100,7 +114,9 @@ const shortcuts = {
           label: __('Save', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'S'}</kbd>
             </kbd>
           ),
@@ -116,7 +132,9 @@ const shortcuts = {
           label: __('Insert/edit link', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'K'}</kbd>
             </kbd>
           ),
@@ -125,7 +143,9 @@ const shortcuts = {
           label: __('Bold', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'B'}</kbd>
             </kbd>
           ),
@@ -134,7 +154,9 @@ const shortcuts = {
           label: __('Italic', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'I'}</kbd>
             </kbd>
           ),
@@ -143,7 +165,9 @@ const shortcuts = {
           label: __('Underline', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'U'}</kbd>
             </kbd>
           ),
@@ -157,7 +181,9 @@ const shortcuts = {
           label: __('Copy', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'C'}</kbd>
             </kbd>
           ),
@@ -166,7 +192,9 @@ const shortcuts = {
           label: __('Cut', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'X'}</kbd>
             </kbd>
           ),
@@ -175,7 +203,9 @@ const shortcuts = {
           label: __('Duplicate', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'D'}</kbd>
             </kbd>
           ),
@@ -184,7 +214,9 @@ const shortcuts = {
           label: __('Paste', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'V'}</kbd>
             </kbd>
           ),
@@ -193,7 +225,9 @@ const shortcuts = {
           label: __('Select all', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'A'}</kbd>
             </kbd>
           ),
@@ -227,6 +261,7 @@ const shortcuts = {
               <TranslateWithMarkup
                 mapping={{
                   kbd: <kbd />,
+                  lkbd: <LargeKey />,
                   cmdOrCtrlSymbol: cmdOrCtrl.symbol,
                   upSymbol: SPECIAL_KEYS.UP.symbol,
                   downSymbol: SPECIAL_KEYS.UP.symbol,
@@ -235,7 +270,7 @@ const shortcuts = {
                 {sprintf(
                   /* translators: 1: Cmd/Ctrl key. 2: Up key. 3: Down key. */
                   __(
-                    '<kbd aria-label="%1$s"><cmdOrCtrlSymbol /></kbd><kbd aria-label="%2$s"><upSymbol /></kbd><span> or </span><kbd aria-label="%3$s"><downSymbol /></kbd>',
+                    '<lkbd aria-label="%1$s"><cmdOrCtrlSymbol /></lkbd><kbd aria-label="%2$s"><upSymbol /></kbd><span> or </span><kbd aria-label="%3$s"><downSymbol /></kbd>',
                     'web-stories'
                   ),
                   cmdOrCtrl.title,
@@ -253,6 +288,7 @@ const shortcuts = {
               <TranslateWithMarkup
                 mapping={{
                   kbd: <kbd />,
+                  lkbd: <LargeKey />,
                   cmdOrCtrlSymbol: cmdOrCtrl.symbol,
                   shiftSymbol: SPECIAL_KEYS.SHIFT.symbol,
                   upSymbol: SPECIAL_KEYS.UP.symbol,
@@ -262,7 +298,7 @@ const shortcuts = {
                 {sprintf(
                   /* translators: 1: Cmd/Ctrl key. 2: Shift key. 3: Up key. 4: Down key. */
                   __(
-                    '<kbd aria-label="%1$s"><cmdOrCtrlSymbol /></kbd><kbd aria-label="%2$s"><shiftSymbol /></kbd><kbd aria-label="%3$s"><upSymbol /></kbd><span> or </span><kbd aria-label="%4$s"><downSymbol /></kbd>',
+                    '<lkbd aria-label="%1$s"><cmdOrCtrlSymbol /></lkbd><kbd aria-label="%2$s"><shiftSymbol /></kbd><kbd aria-label="%3$s"><upSymbol /></kbd><span> or </span><kbd aria-label="%4$s"><downSymbol /></kbd>',
                     'web-stories'
                   ),
                   cmdOrCtrl.title,
@@ -312,7 +348,9 @@ const shortcuts = {
           label: __('Insert/edit link', 'web-stories'),
           shortcut: (
             <kbd>
-              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
               <kbd>{'A'}</kbd>
             </kbd>
           ),
@@ -322,12 +360,15 @@ const shortcuts = {
           shortcut: (
             <kbd>
               <TranslateWithMarkup
-                mapping={{ kbd: <kbd />, cmdOrCtrlSymbol: cmdOrCtrl.symbol }}
+                mapping={{
+                  lkbd: <LargeKey />,
+                  cmdOrCtrlSymbol: cmdOrCtrl.symbol,
+                }}
               >
                 {sprintf(
                   /* translators: %s: Cmd/Ctrl key. */
                   __(
-                    '<span>Hold </span><kbd aria-label="%s"><cmdOrCtrlSymbol /></kbd>',
+                    '<span>Hold </span><lkbd aria-label="%s"><cmdOrCtrlSymbol /></lkbd>',
                     'web-stories'
                   ),
                   cmdOrCtrl.title

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutList.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutList.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { __, _x } from '@web-stories-wp/i18n';
+import { __, TranslateWithMarkup, sprintf } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
@@ -32,21 +32,43 @@ const optionOrAlt = isMacOs ? SPECIAL_KEYS.OPTION : SPECIAL_KEYS.ALT;
 const shortcuts = {
   header: {
     label: __('Keyboard Shortcuts', 'web-stories'),
-    shortcut: [cmdOrCtrl, '/'],
+    shortcut: (
+      <kbd>
+        <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+        <kbd>{'/'}</kbd>
+      </kbd>
+    ),
   },
-
   landmarks: [
     {
       label: __('Element', 'web-stories'),
-      shortcut: [cmdOrCtrl, optionOrAlt, '1'],
+      shortcut: (
+        <kbd>
+          <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+          <kbd aria-label={optionOrAlt.title}>{optionOrAlt.symbol}</kbd>
+          <kbd>{'1'}</kbd>
+        </kbd>
+      ),
     },
     {
       label: __('Workspace', 'web-stories'),
-      shortcut: [cmdOrCtrl, optionOrAlt, '2'],
+      shortcut: (
+        <kbd>
+          <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+          <kbd aria-label={optionOrAlt.title}>{optionOrAlt.symbol}</kbd>
+          <kbd>{'2'}</kbd>
+        </kbd>
+      ),
     },
     {
       label: __('Design panels', 'web-stories'),
-      shortcut: [cmdOrCtrl, optionOrAlt, '3'],
+      shortcut: (
+        <kbd>
+          <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+          <kbd aria-label={optionOrAlt.title}>{optionOrAlt.symbol}</kbd>
+          <kbd>{'3'}</kbd>
+        </kbd>
+      ),
     },
   ],
   sections: [
@@ -55,15 +77,33 @@ const shortcuts = {
       commands: [
         {
           label: __('Undo', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'Z'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'Z'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Redo', 'web-stories'),
-          shortcut: [cmdOrCtrl, SPECIAL_KEYS.SHIFT, 'Z'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd aria-label={SPECIAL_KEYS.SHIFT.title}>
+                {SPECIAL_KEYS.SHIFT.symbol}
+              </kbd>
+              <kbd>{'Z'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Save', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'S'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'S'}</kbd>
+            </kbd>
+          ),
         },
       ],
     },
@@ -74,19 +114,39 @@ const shortcuts = {
           // Not yet implemented
           disabled: true,
           label: __('Insert/edit link', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'K'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'K'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Bold', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'B'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'B'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Italic', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'I'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'I'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Underline', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'U'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'U'}</kbd>
+            </kbd>
+          ),
         },
       ],
     },
@@ -95,73 +155,186 @@ const shortcuts = {
       commands: [
         {
           label: __('Copy', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'C'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'C'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Cut', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'X'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'X'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Duplicate', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'D'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'D'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Paste', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'V'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'V'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Select all', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'A'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'A'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Select multiple', 'web-stories'),
-          shortcut: [
-            SPECIAL_KEYS.SHIFT,
-            { label: __('+ click', 'web-stories') },
-          ],
+          shortcut: (
+            <kbd>
+              <TranslateWithMarkup
+                mapping={{
+                  kbd: <kbd />,
+                  shift: SPECIAL_KEYS.SHIFT.symbol,
+                }}
+              >
+                {sprintf(
+                  /* translators: %s: Shift key. */
+                  __(
+                    '<kbd aria-label="%s"><shift /></kbd><span> + click</span>',
+                    'web-stories'
+                  ),
+                  SPECIAL_KEYS.SHIFT.title
+                )}
+              </TranslateWithMarkup>
+            </kbd>
+          ),
         },
         {
           label: __('Move forward or back', 'web-stories'),
-          shortcut: [
-            cmdOrCtrl,
-            SPECIAL_KEYS.UP,
-            { label: __('or', 'web-stories') },
-            SPECIAL_KEYS.DOWN,
-          ],
+          shortcut: (
+            <kbd>
+              <TranslateWithMarkup
+                mapping={{
+                  kbd: <kbd />,
+                  cmdOrCtrlSymbol: cmdOrCtrl.symbol,
+                  upSymbol: SPECIAL_KEYS.UP.symbol,
+                  downSymbol: SPECIAL_KEYS.UP.symbol,
+                }}
+              >
+                {sprintf(
+                  /* translators: 1: Cmd/Ctrl key. 2: Up key. 3: Down key. */
+                  __(
+                    '<kbd aria-label="%1$s"><cmdOrCtrlSymbol /></kbd><kbd aria-label="%2$s"><upSymbol /></kbd><span> or </span><kbd aria-label="%3$s"><downSymbol /></kbd>',
+                    'web-stories'
+                  ),
+                  cmdOrCtrl.title,
+                  SPECIAL_KEYS.UP.title,
+                  SPECIAL_KEYS.DOWN.title
+                )}
+              </TranslateWithMarkup>
+            </kbd>
+          ),
         },
         {
           label: __('Move to front or back', 'web-stories'),
-          shortcut: [
-            cmdOrCtrl,
-            SPECIAL_KEYS.SHIFT,
-            SPECIAL_KEYS.UP,
-            { label: __('or', 'web-stories') },
-            SPECIAL_KEYS.DOWN,
-          ],
+          shortcut: (
+            <kbd>
+              <TranslateWithMarkup
+                mapping={{
+                  kbd: <kbd />,
+                  cmdOrCtrlSymbol: cmdOrCtrl.symbol,
+                  shiftSymbol: SPECIAL_KEYS.SHIFT.symbol,
+                  upSymbol: SPECIAL_KEYS.UP.symbol,
+                  downSymbol: SPECIAL_KEYS.DOWN.symbol,
+                }}
+              >
+                {sprintf(
+                  /* translators: 1: Cmd/Ctrl key. 2: Shift key. 3: Up key. 4: Down key. */
+                  __(
+                    '<kbd aria-label="%1$s"><cmdOrCtrlSymbol /></kbd><kbd aria-label="%2$s"><shiftSymbol /></kbd><kbd aria-label="%3$s"><upSymbol /></kbd><span> or </span><kbd aria-label="%4$s"><downSymbol /></kbd>',
+                    'web-stories'
+                  ),
+                  cmdOrCtrl.title,
+                  SPECIAL_KEYS.SHIFT.title,
+                  SPECIAL_KEYS.UP.title,
+                  SPECIAL_KEYS.DOWN.title
+                )}
+              </TranslateWithMarkup>
+            </kbd>
+          ),
         },
         {
           label: __('Enter crop/edit mode', 'web-stories'),
-          shortcut: [
-            SPECIAL_KEYS.ENTER,
-            { label: __('or double-click', 'web-stories') },
-          ],
+          shortcut: (
+            <kbd>
+              <TranslateWithMarkup
+                mapping={{
+                  kbd: <kbd />,
+                  enterSymbol: SPECIAL_KEYS.ENTER.symbol,
+                }}
+              >
+                {sprintf(
+                  /* translators: %s: Enter key. */
+                  __(
+                    '<kbd aria-label="%s"><enterSymbol /></kbd><span> or double-click</span>',
+                    'web-stories'
+                  ),
+                  SPECIAL_KEYS.ENTER.title
+                )}
+              </TranslateWithMarkup>
+            </kbd>
+          ),
         },
         {
           label: __('Delete', 'web-stories'),
-          shortcut: [SPECIAL_KEYS.DELETE],
+          shortcut: (
+            <kbd>
+              <kbd className="large-key" aria-label={SPECIAL_KEYS.DELETE.title}>
+                {SPECIAL_KEYS.DELETE.symbol}
+              </kbd>
+            </kbd>
+          ),
         },
         {
           // Not yet implemented
           disabled: true,
           label: __('Insert/edit link', 'web-stories'),
-          shortcut: [cmdOrCtrl, 'K'],
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title}>{cmdOrCtrl.symbol}</kbd>
+              <kbd>{'A'}</kbd>
+            </kbd>
+          ),
         },
         {
           label: __('Disable snapping', 'web-stories'),
-          shortcut: [
-            { label: _x('Hold', 'verb, i.e. hold down a key', 'web-stories') },
-            cmdOrCtrl,
-          ],
+          shortcut: (
+            <kbd>
+              <TranslateWithMarkup
+                mapping={{ kbd: <kbd />, cmdOrCtrlSymbol: cmdOrCtrl.symbol }}
+              >
+                {sprintf(
+                  /* translators: %s: Cmd/Ctrl key. */
+                  __(
+                    '<span>Hold </span><kbd aria-label="%s"><cmdOrCtrlSymbol /></kbd>',
+                    'web-stories'
+                  ),
+                  cmdOrCtrl.title
+                )}
+              </TranslateWithMarkup>
+            </kbd>
+          ),
         },
       ],
     },

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/shortcutLabel.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/shortcutLabel.js
@@ -23,77 +23,65 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Text, THEME_CONSTANTS } from '../../../design-system';
-import { KEY_SIZE } from './constants';
+import { themeHelpers } from '../../../design-system';
 
 const Wrapper = styled.dd`
-  display: flex;
-  justify-content: ${({ alignment }) => alignment};
-  align-items: center;
+  display: block;
   margin: 0;
-`;
 
-const KeyboardKey = styled(Text).attrs({
-  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL,
-})`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: ${({ keySize }) => keySize};
-  padding: 0 5px;
-  height: 24px;
-  border-radius: ${({ theme }) => theme.borders.radius.medium};
-  border: 1px solid ${({ theme }) => theme.colors.border.defaultNormal};
-  color: ${({ theme }) => theme.colors.fg.primary};
+  kbd {
+    ${themeHelpers.expandTextPreset(
+      ({ paragraph }, { X_SMALL }) => paragraph[X_SMALL]
+    )}
 
-  & + & {
-    margin-left: 2px;
+    display: flex;
+    justify-content: ${({ alignment }) => alignment};
+    align-items: center;
+    margin: 0;
+    padding: 0;
+    color: ${({ theme }) => theme.colors.fg.tertiary};
+    background-color: transparent;
+
+    & > kbd {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 0 5px;
+      height: 24px;
+      width: 24px;
+      border-radius: ${({ theme }) => theme.borders.radius.medium};
+      border: 1px solid ${({ theme }) => theme.colors.border.defaultNormal};
+      color: ${({ theme }) => theme.colors.fg.primary};
+    }
+
+    & > kbd.large-key {
+      width: auto;
+    }
+
+    kbd + kbd {
+      margin-left: 2px;
+    }
+
+    kbd + span {
+      margin-left: 4px;
+    }
+
+    span + kbd {
+      margin-left: 4px;
+    }
   }
-`;
-
-const TextOnly = styled(Text).attrs({
-  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL,
-})`
-  color: ${({ theme }) => theme.colors.fg.tertiary};
-  margin: 0 4px;
 `;
 
 function ShortCutLabel({ keys, alignment = 'center', ...rest }) {
   return (
     <Wrapper alignment={alignment} {...rest}>
-      {keys.map((key, index) =>
-        key.label ? (
-          // Disable reason: some keys consist of just a word, e.g. "or" -- there is nothing else than index unique in these.
-          // eslint-disable-next-line react/no-array-index-key
-          <TextOnly key={`${key.label}-${index}`}>{key.label}</TextOnly>
-        ) : (
-          <KeyboardKey
-            key={JSON.stringify(key)}
-            aria-label={key.title}
-            title={key.title}
-            keySize={
-              (key.symbol || key).length > 1 ? KEY_SIZE.LARGE : KEY_SIZE.NORMAL
-            }
-          >
-            {key.symbol || key}
-          </KeyboardKey>
-        )
-      )}
+      {keys}
     </Wrapper>
   );
 }
 
 ShortCutLabel.propTypes = {
-  keys: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.shape({
-        title: PropTypes.string,
-        label: PropTypes.string,
-        symbol: PropTypes.string,
-      }),
-    ])
-  ),
+  keys: PropTypes.PropTypes.element,
   alignment: PropTypes.oneOf(['left', 'center', 'right']),
 };
 


### PR DESCRIPTION
## Context
Improves translations and accessibility in keyboard shortcuts menu.

## Summary
The translation setup in keyboard shortcuts wasn't fully working because of scenarios involving keys in a statement like `hold ⌘`. Not every language here would put `hold` before `⌘`.

This PR is to create more context around the translations and markup so that statements involving keys are better translated. Also adds `kbd` element for semantic purposes which helps accessibility.

## Relevant Technical Choices
Decreased level of abstraction around rendering and declaring keyboard shortcut definitions. Makes declaring a keyboard shortcut a little more verbose, but much more explicit which removes a lot of logic when rendering. This also benefits translations by giving the translator a higher amount of context like: `hold ⌘` instead of `hold` and `⌘`

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Should be no visual changes, just better translations into other languages and improved accessibility.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Verify that there are no visual or functional changes to the keyboard shortcuts popup menu. Beyond that can try out other translations of try a screenreader on it if you so please.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7478 
