### PR TITLE
PPC Video Optimization: Thumbnail Support in Snacks

### DIFF
--- a/assets/src/design-system/components/snackbar/constants.js
+++ b/assets/src/design-system/components/snackbar/constants.js
@@ -31,6 +31,17 @@ export const Placement = PropTypes.oneOf([
   'bottom',
 ]);
 
+export const THUMBNAIL_STATUS = {
+  SUCCESS: 'success',
+  ERROR: 'error',
+};
+
+export const SnackbarNotificationThumbnail = PropTypes.shape({
+  src: PropTypes.string.isRequired,
+  alt: PropTypes.string,
+  status: PropTypes.oneOf(Object.values(THUMBNAIL_STATUS)),
+});
+
 export const SnackbarNotification = PropTypes.shape({
   message: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   actionLabel: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
@@ -40,4 +51,5 @@ export const SnackbarNotification = PropTypes.shape({
   preventActionDismiss: PropTypes.bool,
   preventAutoDismiss: PropTypes.bool,
   timeout: PropTypes.number,
+  thumbnail: SnackbarNotificationThumbnail,
 });

--- a/assets/src/design-system/components/snackbar/index.js
+++ b/assets/src/design-system/components/snackbar/index.js
@@ -19,8 +19,19 @@
  */
 import { SnackbarContainer as Container } from './snackbarContainer';
 import { SnackbarMessage as Message } from './snackbarMessage';
-import { SnackbarNotification, Placement } from './constants';
+import {
+  SnackbarNotification,
+  Placement,
+  THUMBNAIL_STATUS,
+  SnackbarNotificationThumbnail,
+} from './constants';
 
 const Snackbar = { Container, Message };
 
-export { Snackbar, SnackbarNotification, Placement };
+export {
+  Snackbar,
+  SnackbarNotification,
+  Placement,
+  THUMBNAIL_STATUS,
+  SnackbarNotificationThumbnail,
+};

--- a/assets/src/design-system/components/snackbar/snackbarMessage.js
+++ b/assets/src/design-system/components/snackbar/snackbarMessage.js
@@ -236,16 +236,14 @@ const SnackbarMessage = ({
             alt={thumbnail.alt}
             status={thumbnail.status}
           />
-          {thumbnail.status === THUMBNAIL_STATUS.SUCCESS && (
-            <ThumbnailIcon status={thumbnail.status}>
+          <ThumbnailIcon status={thumbnail.status}>
+            {thumbnail.status === THUMBNAIL_STATUS.SUCCESS && (
               <CheckmarkSmall />
-            </ThumbnailIcon>
-          )}
-          {thumbnail.status === THUMBNAIL_STATUS.ERROR && (
-            <ThumbnailIcon status={thumbnail.status}>
+            )}
+            {thumbnail.status === THUMBNAIL_STATUS.ERROR && (
               <ExclamationOutline />
-            </ThumbnailIcon>
-          )}
+            )}
+          </ThumbnailIcon>
         </ThumbnailWrapper>
       )}
       {(actionLabel || showCloseButton) && (

--- a/assets/src/design-system/components/snackbar/stories/index.js
+++ b/assets/src/design-system/components/snackbar/stories/index.js
@@ -24,6 +24,7 @@ import styled, { ThemeProvider } from 'styled-components';
  * Internal dependencies
  */
 import { theme } from '../../..';
+import { DarkThemeProvider } from '../../../storybookUtils/darkThemeProvider';
 import { SnackbarContainer } from '../snackbarContainer';
 import { THUMBNAIL_STATUS } from '../constants';
 
@@ -153,26 +154,32 @@ export const ThumbnailMessage = () => {
   const landscape = boolean('landscape');
 
   return (
-    <SnackbarContainer
-      notifications={[
-        {
-          actionLabel: text('actionLabel', 'Retry'),
-          customZIndex: number('customZIndex'),
-          dismissable: boolean('dismissable'),
-          onAction: action('on action clicked'),
-          onDismiss: action('on dismiss fired'),
-          preventAutoDismiss: boolean('preventAutoDismiss'),
-          message: text(
-            'message',
-            'Optimization failed. Try uploading a different file.'
-          ),
-          thumbnail: {
-            src: `https://picsum.photos/${landscape ? '90/60' : '60/90'}`,
-            alt: 'test',
-            status: success ? THUMBNAIL_STATUS.SUCCESS : THUMBNAIL_STATUS.ERROR,
-          },
-        },
-      ]}
-    />
+    <DarkThemeProvider>
+      <Container>
+        <SnackbarContainer
+          notifications={[
+            {
+              actionLabel: text('actionLabel', 'Retry'),
+              customZIndex: number('customZIndex'),
+              dismissable: boolean('dismissable'),
+              onAction: action('on action clicked'),
+              onDismiss: action('on dismiss fired'),
+              preventAutoDismiss: boolean('preventAutoDismiss'),
+              message: text(
+                'message',
+                'Optimization failed. Try uploading a different file.'
+              ),
+              thumbnail: {
+                src: `https://picsum.photos/${landscape ? '90/60' : '60/90'}`,
+                alt: 'test',
+                status: success
+                  ? THUMBNAIL_STATUS.SUCCESS
+                  : THUMBNAIL_STATUS.ERROR,
+              },
+            },
+          ]}
+        />
+      </Container>
+    </DarkThemeProvider>
   );
 };

--- a/assets/src/design-system/components/snackbar/stories/index.js
+++ b/assets/src/design-system/components/snackbar/stories/index.js
@@ -25,6 +25,7 @@ import styled, { ThemeProvider } from 'styled-components';
  */
 import { theme } from '../../..';
 import { SnackbarContainer } from '../snackbarContainer';
+import { THUMBNAIL_STATUS } from '../constants';
 
 const Container = styled.div`
   background-color: ${(props) => props.theme.colors.bg.primary};
@@ -146,3 +147,32 @@ export const LongMessage = () => (
     ]}
   />
 );
+
+export const ThumbnailMessage = () => {
+  const success = boolean('success');
+  const landscape = boolean('landscape');
+
+  return (
+    <SnackbarContainer
+      notifications={[
+        {
+          actionLabel: text('actionLabel', 'Retry'),
+          customZIndex: number('customZIndex'),
+          dismissable: boolean('dismissable'),
+          onAction: action('on action clicked'),
+          onDismiss: action('on dismiss fired'),
+          preventAutoDismiss: boolean('preventAutoDismiss'),
+          message: text(
+            'message',
+            'Optimization failed. Try uploading a different file.'
+          ),
+          thumbnail: {
+            src: `https://picsum.photos/${landscape ? '90/60' : '60/90'}`,
+            alt: 'test',
+            status: success ? THUMBNAIL_STATUS.SUCCESS : THUMBNAIL_STATUS.ERROR,
+          },
+        },
+      ]}
+    />
+  );
+};


### PR DESCRIPTION
## Context
Part of these two tickets in sprint:
https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/7315
https://app.zenhub.com/workspaces/web-stories-5e94d3aced449034e1e9b226/issues/google/web-stories-wp/7309

## Summary
Adds support for thumbnail images with success/error states in our snackbar. To add a snack with a thumbnail, simply add a thumbnail property to your snack:
```
showSnackbar({
   ...,
   thumbnail: {
     src,
     alt,
     status,
   },
})
```

<img width="646" alt="Screen Shot 2021-06-15 at 9 40 04 AM" src="https://user-images.githubusercontent.com/35983235/122074329-bd662380-cdbe-11eb-9454-5f4c2ddc0fae.png">
<img width="643" alt="Screen Shot 2021-06-15 at 9 39 56 AM" src="https://user-images.githubusercontent.com/35983235/122074332-bdfeba00-cdbe-11eb-9d1f-6fcc113d9346.png">
<img width="352" alt="Screen Shot 2021-06-15 at 9 38 51 AM" src="https://user-images.githubusercontent.com/35983235/122074333-be975080-cdbe-11eb-8a86-1be057646318.png">
<img width="512" alt="Screen Shot 2021-06-15 at 9 38 45 AM" src="https://user-images.githubusercontent.com/35983235/122074334-be975080-cdbe-11eb-8c00-b7f6d7d74a18.png">

## Relevant Technical Choices
Just a storybook implementation for now.
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Open up story book. Go to Design system -> components -> snackbar -> thumbnail message

See that the thumbnail messages match design here:
https://www.figma.com/file/1YM3jA9h4QGc4xLdyaXIJS/Stories---Sprint-1.7%2B?node-id=7122%3A22242
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #7315 
