### PR TITLE
PPCv2.0: "warning" checks with new structure

### DIFF
--- a/assets/src/edit-story/components/checklist/checks/elementLinkTappableRegionTooSmall.js
+++ b/assets/src/edit-story/components/checklist/checks/elementLinkTappableRegionTooSmall.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+/**
+ * External dependencies
+ */
+import { sprintf, __ } from '@web-stories-wp/i18n';
+import { Text, THEME_CONSTANTS } from '../../../../design-system';
+import { useStory } from '../../../app';
+import { ChecklistCard } from '../../checklistCard';
+import { filterStoryElements } from '../utils';
+
+const LINK_TAPPABLE_REGION_MIN_WIDTH = 48;
+const LINK_TAPPABLE_REGION_MIN_HEIGHT = 48;
+
+export function elementLinkTappableRegionTooSmall(element) {
+  if (
+    !['text', 'image', 'shape', 'gif', 'video'].includes(element.type) ||
+    !element.link?.url?.length
+  ) {
+    return false;
+  }
+
+  return (
+    element.width < LINK_TAPPABLE_REGION_MIN_WIDTH ||
+    element.height < LINK_TAPPABLE_REGION_MIN_HEIGHT
+  );
+}
+
+const ElementLinkTappableRegionTooSmall = () => {
+  const story = useStory(({ state }) => state);
+  const elements = filterStoryElements(
+    story,
+    elementLinkTappableRegionTooSmall
+  );
+  return (
+    elements.length > 0 && (
+      <ChecklistCard
+        title={sprintf(
+          /* translators: %s: minimum tappable region size width x minimum tappable region size height. */
+          __('Increase tap area size to at least %s', 'web-stories'),
+          `${LINK_TAPPABLE_REGION_MIN_WIDTH}x${LINK_TAPPABLE_REGION_MIN_HEIGHT}px`
+        )}
+        /* titleProps={{ onClick: () => { perform highlight here } }} */
+        footer={
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+            {__(
+              'Make the linked element large enough for users to easily tap it',
+              'web-stories'
+            )}
+            {
+              //       <Link
+              //         href={'#' /* figure out what this links to */}
+              //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+              //       >
+              //         {'Learn more'}
+              //       </Link>
+            }
+          </Text>
+        }
+        /*
+          todo thumbnails for pages
+          thumbnailCount={elements.length}
+          thumbnail={<>
+              {elements.map(() => <Thumbnail />)}
+            </>}
+        */
+      />
+    )
+  );
+};
+
+export default ElementLinkTappableRegionTooSmall;

--- a/assets/src/edit-story/components/checklist/checks/elementLinkTappableRegionTooSmall.js
+++ b/assets/src/edit-story/components/checklist/checks/elementLinkTappableRegionTooSmall.js
@@ -20,10 +20,10 @@
 /**
  * External dependencies
  */
-import { sprintf, __ } from '@web-stories-wp/i18n';
-import { Text, THEME_CONSTANTS } from '../../../../design-system';
+// import { sprintf, __ } from '@web-stories-wp/i18n';
+// import { Text, THEME_CONSTANTS } from '../../../../design-system';
 import { useStory } from '../../../app';
-import { ChecklistCard } from '../../checklistCard';
+// import { ChecklistCard } from '../../checklistCard';
 import { filterStoryElements } from '../utils';
 
 const LINK_TAPPABLE_REGION_MIN_WIDTH = 48;
@@ -50,39 +50,38 @@ const ElementLinkTappableRegionTooSmall = () => {
     elementLinkTappableRegionTooSmall
   );
   return (
-    elements.length > 0 && (
-      <ChecklistCard
-        title={sprintf(
-          /* translators: %s: minimum tappable region size width x minimum tappable region size height. */
-          __('Increase tap area size to at least %s', 'web-stories'),
-          `${LINK_TAPPABLE_REGION_MIN_WIDTH}x${LINK_TAPPABLE_REGION_MIN_HEIGHT}px`
-        )}
-        /* titleProps={{ onClick: () => { perform highlight here } }} */
-        footer={
-          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
-            {__(
-              'Make the linked element large enough for users to easily tap it',
-              'web-stories'
-            )}
-            {
-              //       <Link
-              //         href={'#' /* figure out what this links to */}
-              //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-              //       >
-              //         {'Learn more'}
-              //       </Link>
-            }
-          </Text>
-        }
-        /*
-          todo thumbnails for pages
-          thumbnailCount={elements.length}
-          thumbnail={<>
-              {elements.map(() => <Thumbnail />)}
-            </>}
-        */
-      />
-    )
+    elements.length > 0 && null
+    // <ChecklistCard
+    //   title={sprintf(
+    //     /* translators: %s: minimum tappable region size width x minimum tappable region size height. */
+    //     __('Increase tap area size to at least %s', 'web-stories'),
+    //     `${LINK_TAPPABLE_REGION_MIN_WIDTH}x${LINK_TAPPABLE_REGION_MIN_HEIGHT}px`
+    //   )}
+    //   /* titleProps={{ onClick: () => { perform highlight here } }} */
+    //   footer={
+    //     <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+    //       {__(
+    //         'Make the linked element large enough for users to easily tap it',
+    //         'web-stories'
+    //       )}
+    //       {
+    //         //       <Link
+    //         //         href={'#' /* figure out what this links to */}
+    //         //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+    //         //       >
+    //         //         {'Learn more'}
+    //         //       </Link>
+    //       }
+    //     </Text>
+    //   }
+    //   /*
+    //     todo thumbnails for pages
+    //     thumbnailCount={elements.length}
+    //     thumbnail={<>
+    //         {elements.map(() => <Thumbnail />)}
+    //       </>}
+    //   */
+    // />
   );
 };
 

--- a/assets/src/edit-story/components/checklist/checks/elementLinkTappableRegionTooSmall.js
+++ b/assets/src/edit-story/components/checklist/checks/elementLinkTappableRegionTooSmall.js
@@ -20,10 +20,10 @@
 /**
  * External dependencies
  */
-// import { sprintf, __ } from '@web-stories-wp/i18n';
-// import { Text, THEME_CONSTANTS } from '../../../../design-system';
+import { sprintf, __ } from '@web-stories-wp/i18n';
+import { Text, THEME_CONSTANTS } from '../../../../design-system';
 import { useStory } from '../../../app';
-// import { ChecklistCard } from '../../checklistCard';
+import { ChecklistCard } from '../../checklistCard';
 import { filterStoryElements } from '../utils';
 
 const LINK_TAPPABLE_REGION_MIN_WIDTH = 48;
@@ -50,38 +50,39 @@ const ElementLinkTappableRegionTooSmall = () => {
     elementLinkTappableRegionTooSmall
   );
   return (
-    elements.length > 0 && null
-    // <ChecklistCard
-    //   title={sprintf(
-    //     /* translators: %s: minimum tappable region size width x minimum tappable region size height. */
-    //     __('Increase tap area size to at least %s', 'web-stories'),
-    //     `${LINK_TAPPABLE_REGION_MIN_WIDTH}x${LINK_TAPPABLE_REGION_MIN_HEIGHT}px`
-    //   )}
-    //   /* titleProps={{ onClick: () => { perform highlight here } }} */
-    //   footer={
-    //     <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
-    //       {__(
-    //         'Make the linked element large enough for users to easily tap it',
-    //         'web-stories'
-    //       )}
-    //       {
-    //         //       <Link
-    //         //         href={'#' /* figure out what this links to */}
-    //         //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-    //         //       >
-    //         //         {'Learn more'}
-    //         //       </Link>
-    //       }
-    //     </Text>
-    //   }
-    //   /*
-    //     todo thumbnails for pages
-    //     thumbnailCount={elements.length}
-    //     thumbnail={<>
-    //         {elements.map(() => <Thumbnail />)}
-    //       </>}
-    //   */
-    // />
+    elements.length > 0 && (
+      <ChecklistCard
+        title={sprintf(
+          /* translators: %s: minimum tappable region size width x minimum tappable region size height. */
+          __('Increase tap area size to at least %s', 'web-stories'),
+          `${LINK_TAPPABLE_REGION_MIN_WIDTH}x${LINK_TAPPABLE_REGION_MIN_HEIGHT}px`
+        )}
+        /* titleProps={{ onClick: () => { perform highlight here } }} */
+        footer={
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+            {__(
+              'Make the linked element large enough for users to easily tap it',
+              'web-stories'
+            )}
+            {
+              //       <Link
+              //         href={'#' /* figure out what this links to */}
+              //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+              //       >
+              //         {'Learn more'}
+              //       </Link>
+            }
+          </Text>
+        }
+        /*
+        todo thumbnails for pages
+        thumbnailCount={elements.length}
+        thumbnail={<>
+            {elements.map(() => <Thumbnail />)}
+          </>}
+      */
+      />
+    )
   );
 };
 

--- a/assets/src/edit-story/components/checklist/checks/imageElementMissingAlt.js
+++ b/assets/src/edit-story/components/checklist/checks/imageElementMissingAlt.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { sprintf, __ } from '@web-stories-wp/i18n';
+import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
@@ -27,42 +27,25 @@ import { useStory } from '../../../app';
 import { ChecklistCard } from '../../checklistCard';
 import { filterStoryElements } from '../utils';
 
-const LINK_TAPPABLE_REGION_MIN_WIDTH = 48;
-const LINK_TAPPABLE_REGION_MIN_HEIGHT = 48;
-
-export function elementLinkTappableRegionTooSmall(element) {
-  if (
-    !['text', 'image', 'shape', 'gif', 'video'].includes(element.type) ||
-    !element.link?.url?.length
-  ) {
-    return false;
-  }
-
+export function imageElementMissingAlt(element) {
   return (
-    element.width < LINK_TAPPABLE_REGION_MIN_WIDTH ||
-    element.height < LINK_TAPPABLE_REGION_MIN_HEIGHT
+    ['gif', 'image'].includes(element.type) &&
+    !element.alt?.length &&
+    !element.resource?.alt?.length
   );
 }
 
-const ElementLinkTappableRegionTooSmall = () => {
+const ImageElementMissingAlt = () => {
   const story = useStory(({ state }) => state);
-  const elements = filterStoryElements(
-    story,
-    elementLinkTappableRegionTooSmall
-  );
+  const elements = filterStoryElements(story, imageElementMissingAlt);
   return (
     elements.length > 0 && (
       <ChecklistCard
-        title={sprintf(
-          /* translators: %s: minimum tappable region size width x minimum tappable region size height. */
-          __('Increase tap area size to at least %s', 'web-stories'),
-          `${LINK_TAPPABLE_REGION_MIN_WIDTH}x${LINK_TAPPABLE_REGION_MIN_HEIGHT}px`
-        )}
-        /* titleProps={{ onClick: () => { perform highlight here } }} */
+        title={__('Add assistive text to images', 'web-stories')}
         footer={
           <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
             {__(
-              'Make the linked element large enough for users to easily tap it',
+              'Optimize accessibility and indexability with meaningful text to better assist users',
               'web-stories'
             )}
             {
@@ -76,15 +59,15 @@ const ElementLinkTappableRegionTooSmall = () => {
           </Text>
         }
         /*
-        todo thumbnails for pages
-        thumbnailCount={elements.length}
-        thumbnail={<>
-            {elements.map(() => <Thumbnail />)}
-          </>}
-      */
+         todo thumbnails for pages
+         thumbnailCount={elements.length}
+         thumbnail={<>
+             {elements.map(() => <Thumbnail onClick={ perform highlight here } />)}
+           </>}
+       */
       />
     )
   );
 };
 
-export default ElementLinkTappableRegionTooSmall;
+export default ImageElementMissingAlt;

--- a/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/check.js
+++ b/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/check.js
@@ -1,0 +1,425 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import {
+  PAGE_RATIO,
+  FULLBLEED_RATIO,
+  dataToFontSizeY,
+  dataFontEm,
+  getBox,
+  getBoundRect,
+} from '@web-stories-wp/units';
+import { getMediaSizePositionProps } from '@web-stories-wp/media';
+
+/**
+ * Internal dependencies
+ */
+import {
+  setOrCreateImage,
+  getImgNodeId,
+} from '../../../../utils/getMediaBaseColor';
+import {
+  calculateLuminanceFromRGB,
+  calculateLuminanceFromStyleColor,
+  checkContrastFromLuminances,
+} from '../../../../utils/contrastUtils';
+import { getSpansFromContent } from '../../utils';
+
+/**
+ * @typedef {import('../../../../types').Page} Page
+ * @typedef {import('../../../../types').Element} Element
+ * @typedef RGB The shape of color objects used for calculating color use against accessibility standards
+ * @property {number} r red value
+ * @property {number} g green value
+ * @property {number} b blue value
+ */
+
+/**
+ *
+ * @param {number} fontSize The text element's font size in editor pixels
+ * @return {number} the true font size for measuring against accessibility standards
+ */
+function getPtFromEditorFontSize(fontSize) {
+  // 1 point = 1.333333 px
+  return dataFontEm(dataToFontSizeY(fontSize, 100)) * 1.333333;
+}
+
+/**
+ *
+ * @param {Element} a An element with a position and size
+ * @param {Element} b An element with a position and size
+ * @return {number} The total area of the elements' overlapping rectangles
+ */
+function getOverlappingArea(a, b) {
+  const dx = Math.min(a.endX, b.endX) - Math.max(a.startX, b.startX);
+  const dy = Math.min(a.endY, b.endY) - Math.max(a.startY, b.startY);
+  if (dx >= 0 && dy >= 0) {
+    return dx * dy;
+  }
+  return 0;
+}
+
+const OVERLAP_RATIO = 1 / 3;
+/**
+ *
+ * @param {number} overlapArea The amount of area that the text element overlaps with the element
+ * @param {number} textBoxArea The amount of area of the text element
+ * @return {boolean} True if the amount of overlap is visually significant
+ */
+function isOverlapSignificant(overlapArea, textBoxArea) {
+  return overlapArea >= OVERLAP_RATIO * textBoxArea;
+}
+
+/**
+ * Returns the provided background elements filtered for elements which overlap significantly
+ * with the text element and are not occluded by the other elements
+ *
+ * @param {Element} textElement The text element which is in front of the potential background elements
+ * @param {Element[]} potentialBackgroundElements All the elements behind the text element
+ * @param {Page} page The page with all the elements
+ * @return {Element[]} The visually significant background elements
+ */
+function getBackgroundsForElement(
+  textElement,
+  potentialBackgroundElements,
+  page
+) {
+  const { pageSize } = page;
+  const textPos = getBox(textElement, pageSize?.width, pageSize?.height);
+  const textBox = getBoundRect([textPos]);
+  const textBoxArea = textBox.width * textBox.height;
+
+  const elementOverlaps = [...potentialBackgroundElements]
+    .map((element, index) => {
+      const bgPos = getBox(element, pageSize?.width, pageSize?.height);
+      const bgBox = getBoundRect([bgPos]);
+      const overlappingArea = getOverlappingArea(textBox, bgBox);
+      return {
+        element:
+          // if the element is the background element use the page's background color
+          // image backgrounds will ignore this property
+          element.isBackground || element.isDefaultBackground
+            ? { ...element, backgroundColor: page?.backgroundColor }
+            : element,
+        area: overlappingArea,
+        index,
+      };
+    })
+    // elements are ordered from lowest to highest
+    // so the first elements in the reversed array are occluding the text box area behind it;
+    .reverse();
+
+  let unoccludedArea = textBoxArea;
+  const significantElements = [];
+  for (const overlap of elementOverlaps) {
+    if (!isOverlapSignificant(unoccludedArea, textBoxArea)) {
+      break;
+    }
+    if (isOverlapSignificant(overlap.area, textBoxArea)) {
+      significantElements.push(overlap.element);
+    }
+    unoccludedArea -= overlap.area;
+  }
+  return significantElements;
+}
+
+/**
+ * @param {Object} arguments The arguments
+ * @param {Element} arguments.background The image-type background element
+ * @param {Element} arguments.text The text-type element
+ * @param {Page} arguments.page The page with both elements
+ * @return {Promise<RGB>} Resolves to the dominant color of the section of the image behind the text element
+ */
+function getTextImageBackgroundColor({ background, text, page }) {
+  const { pageSize, id: pageId } = page;
+  const { id: elementId } = text;
+  const safeZoneDiff =
+    (pageSize?.width / FULLBLEED_RATIO - pageSize?.width / PAGE_RATIO) / 2;
+
+  const textPos = getBox(text, pageSize?.width, pageSize?.height);
+  const textBox = getBoundRect([textPos]);
+
+  const { resource, scale, focalX, focalY } = background;
+  const bgBox = getBox(background, pageSize?.width, pageSize?.height);
+  const { width, height } = bgBox;
+
+  const bgMediaBox = getMediaSizePositionProps(
+    resource,
+    width,
+    height,
+    scale,
+    focalX,
+    focalY
+  );
+
+  const bgImage = {
+    offsetX: bgMediaBox.offsetX,
+    offsetY: bgMediaBox.offsetY,
+    src: background.resource.src,
+    width: bgMediaBox.width,
+    height: bgMediaBox.height,
+    rotationAngle: background.isBackground
+      ? undefined
+      : background.rotationAngle,
+    flip: background.flip,
+  };
+
+  const overlapBox = {
+    x: background.isBackground
+      ? bgMediaBox.offsetX + Math.abs(textBox.startX)
+      : bgMediaBox.offsetX + Math.abs(textBox.startX) - bgBox.x,
+    y: background.isBackground
+      ? bgMediaBox.offsetY + Math.abs(textBox.startY + safeZoneDiff)
+      : bgMediaBox.offsetY +
+        Math.abs(textBox.startY + safeZoneDiff) -
+        (bgBox.y + safeZoneDiff),
+    width: textBox.width,
+    height: textBox.height,
+  };
+
+  return getOverlapBgColor({
+    elementId,
+    pageId,
+    bgImage,
+    bgBox,
+    overlapBox,
+  })
+    .catch(() => {
+      // ignore errors
+    })
+    .finally(() => {
+      cleanupDOM({ pageId, elementId });
+    });
+}
+
+const TO_RADIANS = Math.PI / 180;
+/**
+ * @param {Object} arguments The arguments
+ * @param {string} arguments.elementId The unique ID of the element being checked for contrast
+ * @param {string} arguments.pageId The unique ID of the page with elements being checked for contrast
+ * @param {Element} arguments.bgImage The background element
+ * @param {{ width: number, height: number }} arguments.bgBox The containing box of the background image - needed for calculating canvas translations for rotated elements
+ * @param {{ x: number, y: number, width: number, height: number }} arguments.overlapBox The position and size of the text element relative to the scaled and roated background image
+ * @return {Promise<RGB>} Resolves to the dominant color of the background image in the overlap box area
+ */
+function getOverlapBgColor({ elementId, pageId, bgImage, bgBox, overlapBox }) {
+  function getOnloadCallback(nodeKey, resolve, reject) {
+    return () => {
+      try {
+        const node = document.body[nodeKey];
+        const canvas = document.createElement('canvas');
+
+        canvas.width = bgImage.width;
+        canvas.height = bgImage.height;
+
+        const ctx = canvas.getContext('2d');
+
+        if (bgImage.rotationAngle) {
+          const translationOffsetX = bgImage.offsetX + bgBox.width / 2;
+          const translationOffsetY = bgImage.offsetY + bgBox.height / 2;
+          ctx.translate(translationOffsetX, translationOffsetY);
+          ctx.rotate(bgImage.rotationAngle * TO_RADIANS);
+          ctx.translate(-translationOffsetX, -translationOffsetY);
+        }
+
+        let xPos = 0,
+          yPos = 0;
+
+        const { flip } = bgImage;
+        if (flip.vertical || flip.horizontal) {
+          xPos = flip.horizontal ? bgImage.width * -1 : 0;
+          yPos = flip.vertical ? bgImage.height * -1 : 0;
+          ctx.scale(flip.horizontal ? -1 : 1, flip.vertical ? -1 : 1);
+        }
+
+        ctx.drawImage(
+          node.firstElementChild,
+          xPos,
+          yPos,
+          bgImage.width,
+          bgImage.height
+        );
+
+        const imageData = ctx.getImageData(
+          overlapBox.x,
+          overlapBox.y,
+          overlapBox.width,
+          overlapBox.height
+        );
+
+        resolve(imageData);
+      } catch (e) {
+        reject(e);
+      }
+    };
+  }
+  return setOrCreateImage(
+    { src: bgImage.src, id: pageId },
+    getOnloadCallback
+  ).then((imgData) => {
+    const cropCanvas = document.createElement('canvas');
+    cropCanvas.width = overlapBox.width; // size of the new image / text container
+    cropCanvas.height = overlapBox.height;
+    const cropCtx = cropCanvas.getContext('2d');
+    const cropImage = new Image();
+    cropImage.crossOrigin = 'anonymous';
+    cropCtx.putImageData(imgData, 0, 0);
+    cropImage.src = cropCanvas.toDataURL();
+    return setOrCreateImage({
+      src: cropImage.src,
+      id: elementId,
+    }).then(([r, g, b]) => ({ r, g, b }));
+  });
+}
+
+/**
+ *
+ * @param {Element} element The text element to get font colors from
+ * @return {Array} the style colors from the span tags in text element content
+ */
+function getTextStyleColors(element) {
+  const spans = getSpansFromContent(element.content);
+  const textStyleColors = spans
+    .map((span) => span.style?.color)
+    .filter(Boolean);
+  // if no colors were retrieved but there are spans, there is a black default color
+  const noColorStyleOnSpans =
+    textStyleColors.length === 0 && spans.length !== 0;
+  // if no spans were retrieved but there is content, there is a black default color
+  const noSpans = element.content.length !== 0 && spans.length === 0;
+  if (noColorStyleOnSpans || noSpans) {
+    textStyleColors.push('rgb(0, 0, 0)');
+  }
+  return textStyleColors;
+}
+
+function getTextShapeBackgroundColor({ background }) {
+  const { color } = background.backgroundColor;
+  return color;
+}
+
+/**
+ * Returns guidance if the contrast between any of the text style colors and the background color is too low
+ *
+ * @param {Object} arguments The arguments
+ * @param {RGB} arguments.backgroundColor The r, g, b object representing a background color to compare to the text colors
+ * @param {Array} arguments.textStyleColors The array of style colors of the text being checked
+ * @param {number} arguments.fontSize The font size (in editor pixels) of the text being checked
+ * @return {boolean} If true, there is a contrast issue with some text
+ */
+function textBackgroundHasLowContrast({
+  backgroundColor,
+  textStyleColors,
+  fontSize,
+}) {
+  const noColorsToCompare = !textStyleColors || !backgroundColor;
+  if (noColorsToCompare) {
+    return false;
+  }
+
+  return textStyleColors.some((styleColor) => {
+    if (!styleColor) {
+      return false;
+    }
+    const textLuminance = calculateLuminanceFromStyleColor(styleColor);
+    const backgroundLuminance = calculateLuminanceFromRGB(backgroundColor);
+    const contrastCheck = checkContrastFromLuminances(
+      textLuminance,
+      backgroundLuminance,
+      fontSize && getPtFromEditorFontSize(fontSize)
+    );
+    return !contrastCheck.WCAG_AA;
+  });
+}
+
+function getBackgroundColorByType(element) {
+  switch (element.type) {
+    case 'image':
+      return getTextImageBackgroundColor;
+    case 'shape':
+      return getTextShapeBackgroundColor;
+    default:
+      return () => undefined;
+  }
+}
+
+export async function pageBackgroundTextLowContrast(page) {
+  // getting the background color can be async, prepare to resolve them with Promise.all
+  const backgroundColorPromises = [];
+
+  // for every element on the page, collect the text elements and check their background colors
+  page.elements.forEach((element, index) => {
+    // we don't need to check non-text elements and text that have a background mode
+    if (element.type === 'text' && element.backgroundTextMode === 'NONE') {
+      // get all the colors on the text spans
+      const textStyleColors = getTextStyleColors(element);
+      // all the elements "behind" the text element are potential background elements
+      const potentialBackgroundElements = page.elements.slice(0, index);
+      // get the background elements which overlap significantly with the text element
+      const textBackgrounds = getBackgroundsForElement(
+        element,
+        potentialBackgroundElements,
+        page
+      );
+
+      // loop through the background elements which overlap significantly with the text element
+      for (const backgroundElement of textBackgrounds) {
+        // elements with different types have different methods for comparing colors
+        const getBackgroundColor = getBackgroundColorByType(backgroundElement)(
+          // call that method to get the promise of a background color, or the background color itself
+          {
+            background: backgroundElement,
+            text: element,
+            page,
+          }
+        );
+
+        // prepare background color promises for the textBackgroundHasLowContrast parameter
+        const prepare = (getBackgroundColorResult) => {
+          return {
+            backgroundColor: getBackgroundColorResult,
+            textStyleColors,
+            fontSize: element.fontSize,
+          };
+        };
+
+        const bgColorCompare =
+          getBackgroundColor instanceof Promise
+            ? getBackgroundColor.then(prepare)
+            : prepare(getBackgroundColor);
+
+        backgroundColorPromises.push(bgColorCompare);
+      }
+    }
+  });
+
+  // resolve promises
+  const bgColorComparisons = await Promise.all(backgroundColorPromises);
+
+  return bgColorComparisons.some((compareObj) =>
+    textBackgroundHasLowContrast(compareObj)
+  );
+}
+
+function cleanupDOM({ elementId, pageId }) {
+  const nodes = [
+    document.getElementById(getImgNodeId(elementId)),
+    document.getElementById(getImgNodeId(pageId)),
+  ];
+  nodes.forEach((node) => node?.remove());
+}

--- a/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/check.js
+++ b/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/check.js
@@ -326,7 +326,7 @@ function textBackgroundHasLowContrast({
   backgroundColor,
   textStyleColors,
   fontSize,
-}) {
+} = {}) {
   const noColorsToCompare = !textStyleColors || !backgroundColor;
   if (noColorsToCompare) {
     return false;
@@ -391,11 +391,13 @@ export async function pageBackgroundTextLowContrast(page) {
 
         // prepare background color promises for the textBackgroundHasLowContrast parameter
         const prepare = (getBackgroundColorResult) => {
-          return {
-            backgroundColor: getBackgroundColorResult,
-            textStyleColors,
-            fontSize: element.fontSize,
-          };
+          return (
+            getBackgroundColorResult && {
+              backgroundColor: getBackgroundColorResult,
+              textStyleColors,
+              fontSize: element.fontSize,
+            }
+          );
         };
 
         const bgColorCompare =

--- a/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/component.js
+++ b/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/component.js
@@ -35,31 +35,40 @@ const PageBackgroundTextLowContrast = () => {
     () => filterStoryPages(story, pageBackgroundTextLowContrast),
     [story]
   );
-  return failingPages.length > 0 ? (
-    <ChecklistCard
-      title={__(
-        'Increase contrast between text and background color',
-        'web-stories'
-      )}
-      /* titleProps={{ onClick: () => { perform highlight here } }} */
-      footer={
-        <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
-          {__(
-            'Ensure legibility of text and ease of reading by increasing color contrast',
-            'web-stories'
-          )}
-          {
-            //       <Link
-            //         href={'#' /* figure out what this links to */}
-            //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-            //       >
-            //         {'Learn more'}
-            //       </Link>
-          }
-        </Text>
-      }
-    />
-  ) : null;
+  return (
+    failingPages.length > 0 && (
+      <ChecklistCard
+        title={__(
+          'Increase contrast between text and background color',
+          'web-stories'
+        )}
+        /* titleProps={{ onClick: () => { perform highlight here } }} */
+        footer={
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+            {__(
+              'Ensure legibility of text and ease of reading by increasing color contrast',
+              'web-stories'
+            )}
+            {
+              //       <Link
+              //         href={'#' /* figure out what this links to */}
+              //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+              //       >
+              //         {'Learn more'}
+              //       </Link>
+            }
+          </Text>
+        }
+        /*
+          todo thumbnails for pages
+          thumbnailCount={failingPages.length}
+          thumbnail={<>
+              {failingPages.map(() => <Thumbnail />)}
+            </>}
+        */
+      />
+    )
+  );
 };
 
 export default PageBackgroundTextLowContrast;

--- a/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/component.js
+++ b/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/component.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+import { __ } from '@web-stories-wp/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useStory } from '../../../../app';
+import { ChecklistCard } from '../../../checklistCard';
+import { filterStoryPages } from '../../utils';
+import { Text, THEME_CONSTANTS } from '../../../../../design-system';
+import { pageBackgroundTextLowContrast } from './check';
+
+const PageBackgroundTextLowContrast = () => {
+  const story = useStory(({ state }) => state);
+  const failingPages = useMemo(
+    () => filterStoryPages(story, pageBackgroundTextLowContrast),
+    [story]
+  );
+  return failingPages.length > 0 ? (
+    <ChecklistCard
+      title={__(
+        'Increase contrast between text and background color',
+        'web-stories'
+      )}
+      /* titleProps={{ onClick: () => { perform highlight here } }} */
+      footer={
+        <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+          {__(
+            'Ensure legibility of text and ease of reading by increasing color contrast',
+            'web-stories'
+          )}
+          {
+            //       <Link
+            //         href={'#' /* figure out what this links to */}
+            //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+            //       >
+            //         {'Learn more'}
+            //       </Link>
+          }
+        </Text>
+      }
+    />
+  ) : null;
+};
+
+export default PageBackgroundTextLowContrast;

--- a/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/component.js
+++ b/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/component.js
@@ -18,15 +18,15 @@
  * External dependencies
  */
 import { useMemo } from 'react';
-// import { __ } from '@web-stories-wp/i18n';
+import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
  */
 import { useStory } from '../../../../app';
-// import { ChecklistCard } from '../../../checklistCard';
+import { ChecklistCard } from '../../../checklistCard';
 import { filterStoryPages } from '../../utils';
-// import { Text, THEME_CONSTANTS } from '../../../../../design-system';
+import { Text, THEME_CONSTANTS } from '../../../../../design-system';
 import { pageBackgroundTextLowContrast } from './check';
 
 const PageBackgroundTextLowContrast = () => {
@@ -36,37 +36,38 @@ const PageBackgroundTextLowContrast = () => {
     [story]
   );
   return (
-    failingPages.length > 0 && null
-    // <ChecklistCard
-    //   title={__(
-    //     'Increase contrast between text and background color',
-    //     'web-stories'
-    //   )}
-    //   /* titleProps={{ onClick: () => { perform highlight here } }} */
-    //   footer={
-    //     <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
-    //       {__(
-    //         'Ensure legibility of text and ease of reading by increasing color contrast',
-    //         'web-stories'
-    //       )}
-    //       {
-    //         //       <Link
-    //         //         href={'#' /* figure out what this links to */}
-    //         //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-    //         //       >
-    //         //         {'Learn more'}
-    //         //       </Link>
-    //       }
-    //     </Text>
-    //   }
-    //   /*
-    //     todo thumbnails for pages
-    //     thumbnailCount={failingPages.length}
-    //     thumbnail={<>
-    //         {failingPages.map(() => <Thumbnail />)}
-    //       </>}
-    //   */
-    // />
+    failingPages.length > 0 && (
+      <ChecklistCard
+        title={__(
+          'Increase contrast between text and background color',
+          'web-stories'
+        )}
+        /* titleProps={{ onClick: () => { perform highlight here } }} */
+        footer={
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+            {__(
+              'Ensure legibility of text and ease of reading by increasing color contrast',
+              'web-stories'
+            )}
+            {
+              //       <Link
+              //         href={'#' /* figure out what this links to */}
+              //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+              //       >
+              //         {'Learn more'}
+              //       </Link>
+            }
+          </Text>
+        }
+        /*
+        todo thumbnails for pages
+        thumbnailCount={failingPages.length}
+        thumbnail={<>
+            {failingPages.map(() => <Thumbnail />)}
+          </>}
+      */
+      />
+    )
   );
 };
 

--- a/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/component.js
+++ b/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/component.js
@@ -18,15 +18,15 @@
  * External dependencies
  */
 import { useMemo } from 'react';
-import { __ } from '@web-stories-wp/i18n';
+// import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
  */
 import { useStory } from '../../../../app';
-import { ChecklistCard } from '../../../checklistCard';
+// import { ChecklistCard } from '../../../checklistCard';
 import { filterStoryPages } from '../../utils';
-import { Text, THEME_CONSTANTS } from '../../../../../design-system';
+// import { Text, THEME_CONSTANTS } from '../../../../../design-system';
 import { pageBackgroundTextLowContrast } from './check';
 
 const PageBackgroundTextLowContrast = () => {
@@ -36,38 +36,37 @@ const PageBackgroundTextLowContrast = () => {
     [story]
   );
   return (
-    failingPages.length > 0 && (
-      <ChecklistCard
-        title={__(
-          'Increase contrast between text and background color',
-          'web-stories'
-        )}
-        /* titleProps={{ onClick: () => { perform highlight here } }} */
-        footer={
-          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
-            {__(
-              'Ensure legibility of text and ease of reading by increasing color contrast',
-              'web-stories'
-            )}
-            {
-              //       <Link
-              //         href={'#' /* figure out what this links to */}
-              //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-              //       >
-              //         {'Learn more'}
-              //       </Link>
-            }
-          </Text>
-        }
-        /*
-          todo thumbnails for pages
-          thumbnailCount={failingPages.length}
-          thumbnail={<>
-              {failingPages.map(() => <Thumbnail />)}
-            </>}
-        */
-      />
-    )
+    failingPages.length > 0 && null
+    // <ChecklistCard
+    //   title={__(
+    //     'Increase contrast between text and background color',
+    //     'web-stories'
+    //   )}
+    //   /* titleProps={{ onClick: () => { perform highlight here } }} */
+    //   footer={
+    //     <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+    //       {__(
+    //         'Ensure legibility of text and ease of reading by increasing color contrast',
+    //         'web-stories'
+    //       )}
+    //       {
+    //         //       <Link
+    //         //         href={'#' /* figure out what this links to */}
+    //         //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+    //         //       >
+    //         //         {'Learn more'}
+    //         //       </Link>
+    //       }
+    //     </Text>
+    //   }
+    //   /*
+    //     todo thumbnails for pages
+    //     thumbnailCount={failingPages.length}
+    //     thumbnail={<>
+    //         {failingPages.map(() => <Thumbnail />)}
+    //       </>}
+    //   */
+    // />
   );
 };
 

--- a/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/index.js
+++ b/assets/src/edit-story/components/checklist/checks/pageBackgroundLowTextContrast/index.js
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { hasNoFeaturedMedia } from './hasNoFeaturedMedia';
-export { characterCountForPage } from './characterCountForPage';
-export { filterStoryPages } from './filterStoryPages';
-export { filterStoryElements } from './filterStoryElements';
-export { getSpansFromContent } from './getSpansFromContent';
+
+export { default as PageBackgroundTextLowContrast } from './component';
+export { pageBackgroundTextLowContrast } from './check';

--- a/assets/src/edit-story/components/checklist/checks/pageTooManyLinks.js
+++ b/assets/src/edit-story/components/checklist/checks/pageTooManyLinks.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useMemo } from 'react';
+import { __, sprintf } from '@web-stories-wp/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useStory } from '../../../app';
+import { ChecklistCard } from '../../checklistCard';
+import { filterStoryPages } from '../utils';
+import { Text, THEME_CONSTANTS } from '../../../../design-system';
+
+const MAX_LINKS_PER_PAGE = 3;
+
+export function pageTooManyLinks(page) {
+  const elementsWithLinks = page.elements.filter((element) => {
+    return Boolean(element.link?.url?.length);
+  });
+
+  return elementsWithLinks.length > MAX_LINKS_PER_PAGE;
+}
+
+const PageTooManyLinks = () => {
+  const story = useStory(({ state }) => state);
+  const failingPages = useMemo(
+    () => filterStoryPages(story, pageTooManyLinks),
+    [story]
+  );
+  return (
+    failingPages.length > 0 && (
+      <ChecklistCard
+        title={sprintf(
+          /* translators: %s: maximum number of links per page. */
+          __('Avoid including more than %s links per page', 'web-stories'),
+          MAX_LINKS_PER_PAGE
+        )}
+        footer={
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+            {sprintf(
+              /* translators: %s: maximum number of links per page. */
+              __('Avoid having more than %s links on one page', 'web-stories'),
+              MAX_LINKS_PER_PAGE
+            )}
+            {
+              //       <Link
+              //         href={'#' /* figure out what this links to */}
+              //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+              //       >
+              //         {'Learn more'}
+              //       </Link>
+            }
+          </Text>
+        }
+        /*
+         todo thumbnails for pages
+         thumbnailCount={failingPages.length}
+         thumbnail={<>
+             {failingPages.map(() => <Thumbnail onClick={ perform highlight here }  />)}
+           </>}
+       */
+      />
+    )
+  );
+};
+
+export default PageTooManyLinks;

--- a/assets/src/edit-story/components/checklist/checks/storyMissingExerpt.js
+++ b/assets/src/edit-story/components/checklist/checks/storyMissingExerpt.js
@@ -16,14 +16,14 @@
 /**
  * External dependencies
  */
-import { __ } from '@web-stories-wp/i18n';
+// import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
  */
-import { Text, THEME_CONSTANTS } from '../../../../design-system';
+// import { Text, THEME_CONSTANTS } from '../../../../design-system';
 import { useStory } from '../../../app';
-import { ChecklistCard } from '../../checklistCard';
+// import { ChecklistCard } from '../../checklistCard';
 
 export function storyMissingExcerpt(story) {
   return !story.excerpt?.length;
@@ -32,28 +32,27 @@ export function storyMissingExcerpt(story) {
 const StoryMissingExcerpt = () => {
   const story = useStory(({ state }) => state);
   return (
-    storyMissingExcerpt(story) && (
-      <ChecklistCard
-        title={__('Add Web Story description', 'web-stories')}
-        /* titleProps={{ onClick: () => { perform highlight here } }} */
-        footer={
-          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
-            {__(
-              'Incorporate a brief description for better user experience',
-              'web-stories'
-            )}
-            {
-              //  <Link
-              //   href={'#' /* figure out what this links to */
-              //   size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-              // >
-              //   {'Learn more'}
-              // </Link>
-            }
-          </Text>
-        }
-      />
-    )
+    storyMissingExcerpt(story) && null
+    // <ChecklistCard
+    //   title={__('Add Web Story description', 'web-stories')}
+    //   /* titleProps={{ onClick: () => { perform highlight here } }} */
+    //   footer={
+    //     <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+    //       {__(
+    //         'Incorporate a brief description for better user experience',
+    //         'web-stories'
+    //       )}
+    //       {
+    //         //  <Link
+    //         //   href={'#' /* figure out what this links to */
+    //         //   size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+    //         // >
+    //         //   {'Learn more'}
+    //         // </Link>
+    //       }
+    //     </Text>
+    //   }
+    // />
   );
 };
 

--- a/assets/src/edit-story/components/checklist/checks/storyMissingExerpt.js
+++ b/assets/src/edit-story/components/checklist/checks/storyMissingExerpt.js
@@ -31,28 +31,30 @@ export function storyMissingExcerpt(story) {
 
 const StoryMissingExcerpt = () => {
   const story = useStory(({ state }) => state);
-  return storyMissingExcerpt(story) ? (
-    <ChecklistCard
-      title={__('Add Web Story description', 'web-stories')}
-      /* titleProps={{ onClick: () => { perform highlight here } }} */
-      footer={
-        <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
-          {__(
-            'Incorporate a brief description for better user experience',
-            'web-stories'
-          )}
-          {
-            //  <Link
-            //   href={'#' /* figure out what this links to */
-            //   size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-            // >
-            //   {'Learn more'}
-            // </Link>
-          }
-        </Text>
-      }
-    />
-  ) : null;
+  return (
+    storyMissingExcerpt(story) && (
+      <ChecklistCard
+        title={__('Add Web Story description', 'web-stories')}
+        /* titleProps={{ onClick: () => { perform highlight here } }} */
+        footer={
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+            {__(
+              'Incorporate a brief description for better user experience',
+              'web-stories'
+            )}
+            {
+              //  <Link
+              //   href={'#' /* figure out what this links to */
+              //   size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+              // >
+              //   {'Learn more'}
+              // </Link>
+            }
+          </Text>
+        }
+      />
+    )
+  );
 };
 
 export default StoryMissingExcerpt;

--- a/assets/src/edit-story/components/checklist/checks/storyMissingExerpt.js
+++ b/assets/src/edit-story/components/checklist/checks/storyMissingExerpt.js
@@ -16,14 +16,14 @@
 /**
  * External dependencies
  */
-// import { __ } from '@web-stories-wp/i18n';
+import { __ } from '@web-stories-wp/i18n';
 
 /**
  * Internal dependencies
  */
-// import { Text, THEME_CONSTANTS } from '../../../../design-system';
+import { Text, THEME_CONSTANTS } from '../../../../design-system';
 import { useStory } from '../../../app';
-// import { ChecklistCard } from '../../checklistCard';
+import { ChecklistCard } from '../../checklistCard';
 
 export function storyMissingExcerpt(story) {
   return !story.excerpt?.length;
@@ -32,27 +32,28 @@ export function storyMissingExcerpt(story) {
 const StoryMissingExcerpt = () => {
   const story = useStory(({ state }) => state);
   return (
-    storyMissingExcerpt(story) && null
-    // <ChecklistCard
-    //   title={__('Add Web Story description', 'web-stories')}
-    //   /* titleProps={{ onClick: () => { perform highlight here } }} */
-    //   footer={
-    //     <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
-    //       {__(
-    //         'Incorporate a brief description for better user experience',
-    //         'web-stories'
-    //       )}
-    //       {
-    //         //  <Link
-    //         //   href={'#' /* figure out what this links to */
-    //         //   size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-    //         // >
-    //         //   {'Learn more'}
-    //         // </Link>
-    //       }
-    //     </Text>
-    //   }
-    // />
+    storyMissingExcerpt(story) && (
+      <ChecklistCard
+        title={__('Add Web Story description', 'web-stories')}
+        /* titleProps={{ onClick: () => { perform highlight here } }} */
+        footer={
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+            {__(
+              'Incorporate a brief description for better user experience',
+              'web-stories'
+            )}
+            {
+              //  <Link
+              //   href={'#' /* figure out what this links to */
+              //   size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+              // >
+              //   {'Learn more'}
+              // </Link>
+            }
+          </Text>
+        }
+      />
+    )
   );
 };
 

--- a/assets/src/edit-story/components/checklist/checks/storyMissingExerpt.js
+++ b/assets/src/edit-story/components/checklist/checks/storyMissingExerpt.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Text, THEME_CONSTANTS } from '../../../../design-system';
+import { useStory } from '../../../app';
+import { ChecklistCard } from '../../checklistCard';
+
+export function storyMissingExcerpt(story) {
+  return !story.excerpt?.length;
+}
+
+const StoryMissingExcerpt = () => {
+  const story = useStory(({ state }) => state);
+  return storyMissingExcerpt(story) ? (
+    <ChecklistCard
+      title={__('Add Web Story description', 'web-stories')}
+      /* titleProps={{ onClick: () => { perform highlight here } }} */
+      footer={
+        <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+          {__(
+            'Incorporate a brief description for better user experience',
+            'web-stories'
+          )}
+          {
+            //  <Link
+            //   href={'#' /* figure out what this links to */
+            //   size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+            // >
+            //   {'Learn more'}
+            // </Link>
+          }
+        </Text>
+      }
+    />
+  ) : null;
+};
+
+export default StoryMissingExcerpt;

--- a/assets/src/edit-story/components/checklist/checks/test/elementLinkTappableRegionTooSmall.js
+++ b/assets/src/edit-story/components/checklist/checks/test/elementLinkTappableRegionTooSmall.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { elementLinkTappableRegionTooSmall } from '../elementLinkTappableRegionTooSmall';
+
+describe('elementLinkTappableRegionTooSmall', () => {
+  it('should return true if element tappable region is too small', () => {
+    const element = {
+      id: 'elementid',
+      type: 'text',
+      link: {
+        url: 'https://google.com',
+      },
+      content: 'G',
+      width: 40,
+      height: 40,
+    };
+    expect(elementLinkTappableRegionTooSmall(element)).toBe(true);
+  });
+
+  it('should return false if element has large enough tappable region', () => {
+    const element = {
+      id: 'elementid',
+      type: 'text',
+      link: {
+        url: 'https://google.com',
+      },
+      content: 'G',
+      width: 48,
+      height: 48,
+    };
+    expect(elementLinkTappableRegionTooSmall(element)).toBe(false);
+  });
+
+  it('should return false if not an element with link', () => {
+    const element = {
+      id: 'elementid',
+      type: 'text',
+      content: 'G',
+      width: 40,
+      height: 40,
+    };
+    expect(elementLinkTappableRegionTooSmall(element)).toBe(false);
+  });
+
+  it('should return false for an element of an unknown type', () => {
+    const element = {
+      id: 'elementid',
+      type: 'unknown',
+      link: {
+        url: 'https://google.com',
+      },
+      content: 'G',
+      width: 40,
+      height: 40,
+    };
+    expect(elementLinkTappableRegionTooSmall(element)).toBe(false);
+  });
+});

--- a/assets/src/edit-story/components/checklist/checks/test/imageElementMissingAlt.js
+++ b/assets/src/edit-story/components/checklist/checks/test/imageElementMissingAlt.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { imageElementMissingAlt } from '../imageElementMissingAlt';
+
+describe('imageElementMissingAlt', () => {
+  it('should return true if image element missing alt', () => {
+    const element = {
+      id: 'elementid',
+      type: 'image',
+      resource: {},
+    };
+    const test = imageElementMissingAlt(element);
+    expect(test).toBe(true);
+  });
+
+  it('should return true if image element has empty alt', () => {
+    const element = {
+      id: 'elementid',
+      type: 'image',
+      alt: '',
+      resource: {
+        alt: '',
+      },
+    };
+    const test = imageElementMissingAlt(element);
+    expect(test).toBe(true);
+  });
+
+  it('should return false if image element has alt', () => {
+    const element = {
+      id: 'elementid',
+      type: 'image',
+      alt: 'Image is about things',
+      resource: {},
+    };
+    expect(imageElementMissingAlt(element)).toBe(false);
+  });
+
+  it('should return false if image element has a resource alt', () => {
+    const element = {
+      id: 'elementid',
+      type: 'image',
+      resource: { alt: 'Image is about things' },
+    };
+    expect(imageElementMissingAlt(element)).toBe(false);
+  });
+
+  it(`should return false if it's not an image element`, () => {
+    const element = {
+      type: 'video',
+      id: 'elementid',
+      resource: { alt: '' },
+    };
+    expect(imageElementMissingAlt(element)).toBe(false);
+  });
+});

--- a/assets/src/edit-story/components/checklist/checks/test/pageBackgroundLowTextContrast.js
+++ b/assets/src/edit-story/components/checklist/checks/test/pageBackgroundLowTextContrast.js
@@ -65,10 +65,10 @@ describe('pageBackgroundTextLowContrast', () => {
     },
   };
 
-  it('should return a warning if the default font (no spans, no colors added) does not have high enough contrast with the page', async () => {
+  it('should return true if the default font (no spans, no colors added) does not have high enough contrast with the page', async () => {
     expect(await pageBackgroundTextLowContrast(page)).toBe(true);
   });
-  it('should return undefined if the text size is large enough', async () => {
+  it('should return false if the text size is large enough', async () => {
     const largeGreyTextEl = {
       ...textEl,
       content: '<span style="color:#777777">I woke up like this</span>',
@@ -101,7 +101,7 @@ describe('pageBackgroundTextLowContrast', () => {
     expect(fail).toBe(true);
   });
 
-  it('should return undefined if the contrast is great enough', async () => {
+  it('should return false if the contrast is great enough', async () => {
     const whiteBackgroundColor = { color: { r: 255, g: 255, b: 255 } };
     const check = await pageBackgroundTextLowContrast({
       ...page,

--- a/assets/src/edit-story/components/checklist/checks/test/pageBackgroundLowTextContrast.js
+++ b/assets/src/edit-story/components/checklist/checks/test/pageBackgroundLowTextContrast.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { PAGE_HEIGHT, PAGE_WIDTH } from '@web-stories-wp/units';
+
+/**
+ * Internal dependencies
+ */
+import { pageBackgroundTextLowContrast } from '../pageBackgroundLowTextContrast';
+
+describe('pageBackgroundTextLowContrast', () => {
+  const bgEl = {
+    x: 1,
+    y: 1,
+    type: 'shape',
+    isBackground: true,
+    height: PAGE_HEIGHT,
+    width: PAGE_WIDTH,
+    backgroundColor: {
+      color: {
+        r: 255,
+        g: 255,
+        b: 255,
+      },
+    },
+  };
+  const textEl = {
+    type: 'text',
+    backgroundTextMode: 'NONE',
+    content: 'Fill with text',
+    x: 1,
+    y: 1,
+    width: 175,
+    height: 36,
+    fontSize: 12,
+  };
+  const page = {
+    id: 123,
+    pageSize: {
+      height: PAGE_HEIGHT,
+      width: PAGE_WIDTH,
+    },
+    elements: [bgEl, textEl],
+    backgroundColor: {
+      color: {
+        r: 2,
+        g: 12,
+        b: 1,
+      },
+    },
+  };
+
+  it('should return a warning if the default font (no spans, no colors added) does not have high enough contrast with the page', async () => {
+    expect(await pageBackgroundTextLowContrast(page)).toBe(true);
+  });
+  it('should return undefined if the text size is large enough', async () => {
+    const largeGreyTextEl = {
+      ...textEl,
+      content: '<span style="color:#777777">I woke up like this</span>',
+      fontSize: 84,
+    };
+    const smallGreyTextEl = {
+      ...textEl,
+      content: '<span style="color:#777777">I woke up like this</span>',
+    };
+
+    const whiteBgPage = {
+      ...page,
+      backgroundColor: {
+        color: {
+          r: 255,
+          g: 255,
+          b: 255,
+        },
+      },
+    };
+    const pass = await pageBackgroundTextLowContrast({
+      ...whiteBgPage,
+      elements: [bgEl, largeGreyTextEl],
+    });
+    expect(pass).toBe(false);
+    const fail = await pageBackgroundTextLowContrast({
+      ...whiteBgPage,
+      elements: [bgEl, smallGreyTextEl],
+    });
+    expect(fail).toBe(true);
+  });
+
+  it('should return undefined if the contrast is great enough', async () => {
+    const whiteBackgroundColor = { color: { r: 255, g: 255, b: 255 } };
+    const check = await pageBackgroundTextLowContrast({
+      ...page,
+      backgroundColor: whiteBackgroundColor,
+    });
+    expect(check).toBe(false);
+  });
+});

--- a/assets/src/edit-story/components/checklist/checks/test/pageTooManyLinks.js
+++ b/assets/src/edit-story/components/checklist/checks/test/pageTooManyLinks.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { pageTooManyLinks } from '../pageTooManyLinks';
+
+describe('pageTooManyLinks', () => {
+  it('should return true if page has too many links', () => {
+    const linkElements = [
+      {
+        type: 'text',
+        link: {
+          url: 'https://google.com',
+        },
+      },
+      {
+        type: 'image',
+        link: {
+          url: 'https://google.com',
+        },
+      },
+      {
+        type: 'text',
+        link: {
+          url: 'https://google.com',
+        },
+      },
+      {
+        type: 'text',
+        link: {
+          url: 'https://google.com',
+        },
+      },
+    ];
+
+    const page = {
+      id: 'pageid',
+      elements: [
+        { type: 'text' },
+        { type: 'video' },
+        {
+          type: 'text',
+          link: {
+            url: '',
+          },
+        },
+        ...linkElements,
+      ],
+    };
+    expect(pageTooManyLinks(page)).toBe(true);
+  });
+
+  it('should return undefined if page has a reasonable number of links', () => {
+    const page = {
+      elements: [
+        { type: 'text' },
+        { type: 'video' },
+        {
+          type: 'text',
+          link: {
+            url: 'https://google.com',
+          },
+        },
+        {
+          type: 'image',
+          link: {
+            url: 'https://google.com',
+          },
+        },
+        {
+          type: 'text',
+          link: {
+            url: '',
+          },
+        },
+        {
+          type: 'text',
+          link: {
+            url: 'https://google.com',
+          },
+        },
+      ],
+    };
+    expect(pageTooManyLinks(page)).toBeFalse();
+  });
+});

--- a/assets/src/edit-story/components/checklist/checks/test/storyMissingExcerpt.js
+++ b/assets/src/edit-story/components/checklist/checks/test/storyMissingExcerpt.js
@@ -19,7 +19,7 @@
 import { storyMissingExcerpt } from '../storyMissingExerpt';
 
 describe('storyMissingExcerpt', () => {
-  it('should return a warning if story is missing excerpt', () => {
+  it('should return true if story is missing excerpt', () => {
     const story = {
       id: 'storyid',
     };
@@ -27,7 +27,7 @@ describe('storyMissingExcerpt', () => {
     expect(test).toBe(true);
   });
 
-  it('should return a warning if story has empty excerpt', () => {
+  it('should return true if story has empty excerpt', () => {
     const story = {
       id: 'storyid',
       excerpt: '',
@@ -37,7 +37,7 @@ describe('storyMissingExcerpt', () => {
     expect(test).toBe(true);
   });
 
-  it('should return undefined if story has excerpt', () => {
+  it('should return true if story has excerpt', () => {
     const story = {
       id: 'storyid',
       excerpt: 'This is an excerpt',

--- a/assets/src/edit-story/components/checklist/checks/test/storyMissingExcerpt.js
+++ b/assets/src/edit-story/components/checklist/checks/test/storyMissingExcerpt.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { storyMissingExcerpt } from '../storyMissingExerpt';
+
+describe('storyMissingExcerpt', () => {
+  it('should return a warning if story is missing excerpt', () => {
+    const story = {
+      id: 'storyid',
+    };
+    const test = storyMissingExcerpt(story);
+    expect(test).toBe(true);
+  });
+
+  it('should return a warning if story has empty excerpt', () => {
+    const story = {
+      id: 'storyid',
+      excerpt: '',
+    };
+    const test = storyMissingExcerpt(story);
+
+    expect(test).toBe(true);
+  });
+
+  it('should return undefined if story has excerpt', () => {
+    const story = {
+      id: 'storyid',
+      excerpt: 'This is an excerpt',
+    };
+    const test = storyMissingExcerpt(story);
+    expect(test).toBe(false);
+  });
+});

--- a/assets/src/edit-story/components/checklist/checks/test/textElementFontSizeTooSmall.js
+++ b/assets/src/edit-story/components/checklist/checks/test/textElementFontSizeTooSmall.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { textElementFontSizeTooSmall } from '../textElementFontSizeTooSmall';
+
+describe('textElementFontSizeTooSmall', () => {
+  it('should return true if text element font size is too small', () => {
+    const element = {
+      id: 'elementid',
+      type: 'text',
+      fontSize: 11,
+    };
+    expect(textElementFontSizeTooSmall(element)).toBe(true);
+  });
+
+  it('should return false if text element font size is large enough', () => {
+    const element = {
+      id: 'elementid',
+      type: 'text',
+      fontSize: 12,
+    };
+    expect(textElementFontSizeTooSmall(element)).toBe(false);
+  });
+});

--- a/assets/src/edit-story/components/checklist/checks/test/videoElementMissingCaptions.js
+++ b/assets/src/edit-story/components/checklist/checks/test/videoElementMissingCaptions.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { videoElementMissingCaptions } from '../videoElementMissingCaptions';
+
+describe('videoElementMissingCaptions', () => {
+  it('should return a warning if video element missing captions', () => {
+    const element = {
+      id: 'elementid',
+      type: 'video',
+    };
+
+    const test = videoElementMissingCaptions(element);
+    expect(test).toBe(true);
+  });
+
+  it('should return a warning if video element has empty captions', () => {
+    const element = {
+      id: 'elementid',
+      type: 'video',
+      tracks: [],
+    };
+    const test = videoElementMissingCaptions(element);
+    expect(test).toBe(true);
+  });
+
+  it('should return undefined if video element has captions', () => {
+    const element = {
+      id: 'elementid',
+      type: 'text',
+      tracks: [{ id: 'trackid' }],
+    };
+    expect(videoElementMissingCaptions(element)).toBe(false);
+  });
+});

--- a/assets/src/edit-story/components/checklist/checks/test/videoElementMissingDescription.js
+++ b/assets/src/edit-story/components/checklist/checks/test/videoElementMissingDescription.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { videoElementMissingDescription } from '../videoElementMissingDescription';
+
+describe('videoElementMissingDescription', () => {
+  it('should return a warning if video element missing title', () => {
+    const element = {
+      id: 'elementid',
+      type: 'video',
+      resource: {},
+    };
+    const test = videoElementMissingDescription(element);
+    expect(test).toBe(true);
+  });
+
+  it('should return a warning if video element has empty description', () => {
+    const element = {
+      id: 'elementid',
+      type: 'video',
+      alt: '',
+      resource: {
+        alt: '',
+      },
+    };
+    const test = videoElementMissingDescription(element);
+    expect(test).toBe(true);
+  });
+
+  it('should return undefined if video element has title', () => {
+    const element = {
+      id: 'elementid',
+      type: 'video',
+      alt: 'Video description',
+      resource: {},
+    };
+    expect(videoElementMissingDescription(element)).toBe(false);
+  });
+
+  it('should return undefined if video resource has title', () => {
+    const element = {
+      id: 'elementid',
+      type: 'video',
+      resource: {
+        alt: 'Video description',
+      },
+    };
+    expect(videoElementMissingDescription(element)).toBe(false);
+  });
+});

--- a/assets/src/edit-story/components/checklist/checks/textElementFontSizeTooSmall.js
+++ b/assets/src/edit-story/components/checklist/checks/textElementFontSizeTooSmall.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { sprintf, __ } from '@web-stories-wp/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { THEME_CONSTANTS, Text } from '../../../../design-system';
+import { useStory } from '../../../app';
+import { ChecklistCard } from '../../checklistCard';
+import { filterStoryElements } from '../utils';
+
+const MIN_FONT_SIZE = 12;
+
+export function textElementFontSizeTooSmall(element) {
+  return (
+    element.type === 'text' &&
+    element.fontSize &&
+    element.fontSize < MIN_FONT_SIZE
+  );
+}
+
+const TextElementFontSizeTooSmall = () => {
+  const story = useStory(({ state }) => state);
+  const elements = filterStoryElements(story, textElementFontSizeTooSmall);
+  return (
+    elements.length > 0 && (
+      <ChecklistCard
+        title={sprintf(
+          /* translators: %d: minimum font size. */
+          __('Increase font size to %s or above', 'web-stories'),
+          MIN_FONT_SIZE
+        )}
+        footer={
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+            {sprintf(
+              /* translators: %d: minimum font size. */
+              __(
+                'Ensure legibility by selecting text size %d or greater',
+                'web-stories'
+              ),
+              MIN_FONT_SIZE
+            )}
+            {
+              //       <Link
+              //         href={'#' /* figure out what this links to */}
+              //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+              //       >
+              //         {'Learn more'}
+              //       </Link>
+            }
+          </Text>
+        }
+        /*
+        todo thumbnails for elements
+        thumbnailCount={elements.length}
+        thumbnail={<>
+            {elements.map(() => <Thumbnail />)}
+          </>}
+      */
+      />
+    )
+  );
+};
+
+export default TextElementFontSizeTooSmall;

--- a/assets/src/edit-story/components/checklist/checks/videoElementMissingCaptions.js
+++ b/assets/src/edit-story/components/checklist/checks/videoElementMissingCaptions.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Text, THEME_CONSTANTS } from '../../../../design-system';
+import { useStory } from '../../../app';
+import { ChecklistCard } from '../../checklistCard';
+import { filterStoryElements } from '../utils';
+
+export function videoElementMissingCaptions(element) {
+  return element.type === 'video' && !element.tracks?.length;
+}
+
+const VideoElementMissingCaptions = () => {
+  const story = useStory(({ state }) => state);
+  const elements = filterStoryElements(story, videoElementMissingCaptions);
+  return (
+    elements.length > 0 && (
+      <ChecklistCard
+        title={__('Add assistive text to images', 'web-stories')}
+        footer={
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+            {__(
+              'Optimize accessibility and indexability with meaningful text to better assist users',
+              'web-stories'
+            )}
+            {
+              //       <Link
+              //         href={'#' /* figure out what this links to */}
+              //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+              //       >
+              //         {'Learn more'}
+              //       </Link>
+            }
+          </Text>
+        }
+        /*
+         todo thumbnails for pages
+         thumbnailCount={elements.length}
+         thumbnail={<>
+             {elements.map(() => <Thumbnail onClick={ perform highlight here } />)}
+           </>}
+       */
+      />
+    )
+  );
+};
+export default VideoElementMissingCaptions;

--- a/assets/src/edit-story/components/checklist/checks/videoElementMissingDescription.js
+++ b/assets/src/edit-story/components/checklist/checks/videoElementMissingDescription.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
+
+/**
+ * Internal dependencies
+ */
+/**
+ * Internal dependencies
+ */
+import { Text, THEME_CONSTANTS } from '../../../../design-system';
+import { useStory } from '../../../app';
+import { ChecklistCard } from '../../checklistCard';
+import { filterStoryElements } from '../utils';
+
+export function videoElementMissingDescription(element) {
+  return (
+    element.type === 'video' &&
+    !element.alt?.length &&
+    !element.resource?.alt?.length
+  );
+}
+
+const VideoElementMissingDescription = () => {
+  const story = useStory(({ state }) => state);
+  const elements = filterStoryElements(story, videoElementMissingDescription);
+  return (
+    elements.length > 0 && (
+      <ChecklistCard
+        title={__('Add video description', 'web-stories')}
+        footer={
+          <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+            {__(
+              'Improves indexability and accessibility (for videos without captions)',
+              'web-stories'
+            )}
+            {
+              //       <Link
+              //         href={'#' /* figure out what this links to */}
+              //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+              //       >
+              //         {'Learn more'}
+              //       </Link>
+            }
+          </Text>
+        }
+        /*
+          todo thumbnails for pages
+          thumbnailCount={elements.length}
+          thumbnail={<>
+              {elements.map(() => <Thumbnail onClick={ perform highlight here } />)}
+            </>}
+        */
+      />
+    )
+  );
+};
+export default VideoElementMissingDescription;

--- a/assets/src/edit-story/components/checklist/utils/getSpansFromContent.js
+++ b/assets/src/edit-story/components/checklist/utils/getSpansFromContent.js
@@ -13,8 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { hasNoFeaturedMedia } from './hasNoFeaturedMedia';
-export { characterCountForPage } from './characterCountForPage';
-export { filterStoryPages } from './filterStoryPages';
-export { filterStoryElements } from './filterStoryElements';
-export { getSpansFromContent } from './getSpansFromContent';
+
+let spansFromContentBuffer;
+/**
+ *
+ * @param {string} content the buffer containing text element content
+ * @return {Array} list of individual span elements from the content
+ */
+export function getSpansFromContent(content) {
+  // memoize buffer
+  if (!spansFromContentBuffer) {
+    spansFromContentBuffer = document.createElement('div');
+  }
+
+  spansFromContentBuffer.innerHTML = content;
+
+  // return Array instead of HtmlCollection
+  return Array.prototype.slice.call(
+    spansFromContentBuffer.getElementsByTagName('span')
+  );
+}


### PR DESCRIPTION
## Context
- we have to refactor the check functions for PPC v2.0, which are now grouped by ISSUE TYPE rather than page order.
- the original check implementation did not make this very easy, so we are splitting up the checklist functions into their own components.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- we decided to go with a hooks-based approach where each check gets its own component and hooks into the story. they will be rendered explicitly under their check-type.
-  I am not yet rendering the thumbnails or doing any of the highlighting. This PR is to establish the larger pattern and prepare for integrating the new popup/container for checklist items. So each check just renders its text for now.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- This is a pretty significant refactor and I will split the rest of the checks that are left up into another PR. These are all the checks that were under `warning/index` before.
- **Before** suggesting a big refactor I started working on bulk video optimization and found it was really difficult to work with the `array.reduce` that is still powering the checklist and this was before we even started reorganizing the checks. We would have had to refactor that to work with the way the checklist was being passed to the displaying tab in order to re-organize the checks by issue type anyway, so I started looking into ways we could quickly refactor the checklist.
- The main problem, which Pascal pointed out a while ago, was always that the big `async getPrepublishErrors` was just not a great solution. It runs over the whole story object every time the story updates, which was not performant, and the results of the function were essentially the contents of the entire checklist! 
- To the above, while this solution is probably not much more performant, I think it's much easier to read and understand what's going on with each check, whereas before everything was hidden in a huge function, this solution uses the relatively cheap context selector to get access to the story and rerenders each check rather than the entire checklist. Performance could be improved on a per-check basis, as well, with triggers or simply improving what context we're selecting.
- Every check now has its own component, with its own display logic (but you'll see they follow a pattern that relies on common utils made by Max, thank you Max <3). Checks have changed a lot visually so this gives us a lot more flexibility for what the checklist can display.
- Most of the components under `checks` now hook into story updates themselves and we will render them explicitly under container components such as `priorityChecks` rather than mapping over an array of objects produced by `getPrepublishErrors`
- The checks themselves are identical to how they were before, but instead of returning "guidance" objects where we were storing all the copy and display logic for checks before, they are now filter functions which return a Boolean. the component runs a filter on the story it's hooked into and uses the checks to decide whether to display itself in the list.
<!-- Please describe your changes. -->

## To-do
warnings (this PR)
- [x] storyMissingExcerpt
- [x] pageTooManyLinks
- [x] pageBackgroundTextLowContrast
- [x] textElementFontSizeTooSmall
- [x] elementLinkTappableRegionTooSmall
- [x] imageElementMissingAlt
- [x] videoElementMissingDescription
- [x] videoElementMissingCaptions

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Behind a feature flag -- none;
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->


### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

continues #7920
