### PR TITLE
PPC: Loading Bar

### DIFF
--- a/assets/src/design-system/components/index.js
+++ b/assets/src/design-system/components/index.js
@@ -22,6 +22,7 @@ export { Dialog } from './dialog';
 export { DropDown } from './dropDown';
 export { HexInput } from './hex';
 export { Input } from './input';
+export { LoadingBar, LOADING_INDICATOR_CLASS } from './loadingBar';
 export { LoadingSpinner } from './loadingSpinner';
 export { MediaInput } from './mediaInput';
 export { Modal, ModalGlobalStyle } from './modal';

--- a/assets/src/design-system/components/loadingBar/index.js
+++ b/assets/src/design-system/components/loadingBar/index.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { CSSTransition } from 'react-transition-group';
+import styled, { keyframes } from 'styled-components';
+/**
+ * Internal dependencies
+ */
+import { themeHelpers } from '../../theme';
+
+export const LOADING_INDICATOR_CLASS = 'loading-indicator';
+
+const AriaOnlyAlert = styled.span(themeHelpers.visuallyHidden);
+
+const gradientAnimation = keyframes`
+    0% { background-position:0% 50% }
+    50% { background-position:100% 50% }
+    100% { background-position:0% 50% }
+`;
+
+const UploadingIndicator = styled.div`
+  height: 4px;
+  background: ${({ theme }) => theme.colors.gradient.loading};
+  background-size: 400% 400%;
+  position: absolute;
+  bottom: 0px;
+  border-radius: ${({ theme }) =>
+    `0px 0px ${theme.borders.radius.small} ${theme.borders.radius.small}`};
+
+  animation: ${gradientAnimation} 4s ease infinite;
+
+  &.${LOADING_INDICATOR_CLASS} {
+    &.appear {
+      width: 0;
+    }
+
+    &.appear-done {
+      width: 100%;
+      transition: 1s ease-out;
+      transition-property: width;
+    }
+  }
+`;
+
+export const LoadingBar = ({ loadingMessage, ...rest }) => (
+  <>
+    {loadingMessage && (
+      <AriaOnlyAlert role="status">{loadingMessage}</AriaOnlyAlert>
+    )}
+    <CSSTransition in appear timeout={0} className={LOADING_INDICATOR_CLASS}>
+      <UploadingIndicator {...rest} />
+    </CSSTransition>
+  </>
+);
+
+LoadingBar.propTypes = {
+  loadingMessage: PropTypes.string,
+};

--- a/assets/src/design-system/components/loadingBar/stories/index.js
+++ b/assets/src/design-system/components/loadingBar/stories/index.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import { boolean, text } from '@storybook/addon-knobs';
+
+/**
+ * Internal dependencies
+ */
+import { LoadingBar } from '..';
+
+export default {
+  title: 'DesignSystem/Components/LoadingBar',
+  component: LoadingBar,
+};
+
+const Container = styled.div`
+  position: relative;
+  display: flex;
+  width: 100px;
+  height: 200px;
+  margin: 20px;
+  border-radius: 4px;
+  background-color: gray;
+`;
+export const _default = () => {
+  const showLoadingBar = boolean('showLoadingBar', true);
+  return (
+    <Container>
+      {showLoadingBar && (
+        <LoadingBar
+          loadingMessage={text('loadingMessage', 'sample aria loading text')}
+        />
+      )}
+    </Container>
+  );
+};

--- a/assets/src/design-system/theme/colors.js
+++ b/assets/src/design-system/theme/colors.js
@@ -100,6 +100,10 @@ const standard = {
   white: '#FFF',
 };
 
+const gradient = {
+  loading: `linear-gradient(270deg, #4285f4 0%, #0f0bc8 57%, #4285f4 110%)`,
+};
+
 const opacity = {
   footprint: 'transparent',
   white64: rgba(standard.white, 0.64),
@@ -117,6 +121,7 @@ const opacity = {
 };
 
 const darkTheme = {
+  gradient,
   fg: {
     primary: brand.gray[5],
     secondary: brand.gray[20],
@@ -202,6 +207,7 @@ const darkTheme = {
 };
 
 const lightTheme = {
+  gradient,
   fg: {
     primary: brand.gray[90],
     secondary: brand.gray[70],

--- a/assets/src/edit-story/components/thumbnail/constants.js
+++ b/assets/src/edit-story/components/thumbnail/constants.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
 
 export const THUMBNAIL_DIMENSIONS = {
   WIDTH: 52,
@@ -29,3 +33,5 @@ export const THUMBNAIL_TYPES = {
 };
 
 export const THUMBNAIL_SCRIM_CLASSNAME = 'thumbnail-scrim';
+export const THUMBNAIL_SHOW_ON_HOVER_FOCUS = 'thumbnail-show-hover-focus';
+export const DEFAULT_LOADING_MESSAGE = __('Loading', 'web-stories');

--- a/assets/src/edit-story/components/thumbnail/stories/index.js
+++ b/assets/src/edit-story/components/thumbnail/stories/index.js
@@ -60,6 +60,11 @@ export const _default = () => {
         'I am some helper text for screen readers. If a tooltip is present, that content should also go here'
       )}
       onClick={() => action(`${thumbnailType} button clicked`)()}
+      isLoading={boolean(`${thumbnailType}_isLoading`, false)}
+      loadingMessage={text(
+        `${thumbnailType}_loadingMessage`,
+        'some aria specific loading copy'
+      )}
     >
       {thumbnailType === THUMBNAIL_TYPES.VIDEO && (
         <Tooltip title="test tooltip">

--- a/assets/src/edit-story/components/thumbnail/styles.js
+++ b/assets/src/edit-story/components/thumbnail/styles.js
@@ -23,7 +23,11 @@ import styled, { css } from 'styled-components';
 /**
  * Internal dependencies
  */
-import { THUMBNAIL_DIMENSIONS, THUMBNAIL_SCRIM_CLASSNAME } from './constants';
+import {
+  THUMBNAIL_DIMENSIONS,
+  THUMBNAIL_SCRIM_CLASSNAME,
+  THUMBNAIL_SHOW_ON_HOVER_FOCUS,
+} from './constants';
 
 /**
  * Set Scrim styles on button state here with the THUMBNAIL_SCRIM_CLASSNAME
@@ -47,6 +51,15 @@ export const Container = styled.button(
       : 'transparent'};
     cursor: pointer;
 
+    .${THUMBNAIL_SHOW_ON_HOVER_FOCUS} {
+      display: none;
+    }
+
+    &:hover {
+      .${THUMBNAIL_SHOW_ON_HOVER_FOCUS} {
+        display: flex;
+      }
+    }
     ${$isError &&
     css`
       .${THUMBNAIL_SCRIM_CLASSNAME} {
@@ -60,6 +73,9 @@ export const Container = styled.button(
 
     &:focus,
       &:focus-within {
+      .${THUMBNAIL_SHOW_ON_HOVER_FOCUS} {
+        display: flex;
+      }
       .${THUMBNAIL_SCRIM_CLASSNAME} {
         background-color: ${theme.colors.opacity.black64};
         border: 1px solid

--- a/assets/src/edit-story/components/thumbnail/thumbnail.js
+++ b/assets/src/edit-story/components/thumbnail/thumbnail.js
@@ -21,8 +21,13 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Icons } from '../../../design-system';
-import { THUMBNAIL_TYPES, THUMBNAIL_SCRIM_CLASSNAME } from './constants';
+import { Icons, LoadingBar } from '../../../design-system';
+import {
+  THUMBNAIL_TYPES,
+  THUMBNAIL_SCRIM_CLASSNAME,
+  DEFAULT_LOADING_MESSAGE,
+  THUMBNAIL_SHOW_ON_HOVER_FOCUS,
+} from './constants';
 import { Container, Background, NestedIconContainer, Scrim } from './styles';
 
 const includeDefaultScrimBackground = [
@@ -36,6 +41,8 @@ const includeDefaultScrimBackground = [
  * @param {Object} props Component props.
  * @param {Node} props.displayBackground Node that renders the element. Relies on PagePreview or LayerIcon (getDefinitionForType, see panels/design/layer) to keep element rendering consistent with carousel and layer panels. See /storybook for demo.
  * @param {boolean} props.isError Thumbnail errors don't prevent further interaction with the thumbnail, they just change the presentation so user knows the action failed.
+ * @param {boolean} props.isLoading If a thumbnail needs to show a loading progress bar this should be true.
+ * @param {string} props.loadingMessage If a thumbnail needs an aria alert with loading bar this should be used.
  * @param {Function} props.onClick If a thumbnail has an action, it's called on onClick. Responsible for making sure the thumbnail is rendered as a button instead of a div.
  * @param {string} props.type One of the values of THUMBNAIL_TYPES. Responsible for specific context renderings based on thumbnail type.
  * @param {Node} props.children Content rendered within a thumbnail, according to designs, are icons with tooltips.
@@ -46,6 +53,8 @@ const Thumbnail = ({
   isError,
   onClick,
   type,
+  isLoading,
+  loadingMessage = DEFAULT_LOADING_MESSAGE,
   children,
   ...rest
 }) => (
@@ -55,8 +64,11 @@ const Thumbnail = ({
     $isError={isError}
     {...rest}
   >
-    {!isError && children && (
-      <NestedIconContainer>{children}</NestedIconContainer>
+    {isLoading && <LoadingBar loadingMessage={loadingMessage} />}
+    {!isError && !isLoading && children && (
+      <NestedIconContainer className={THUMBNAIL_SHOW_ON_HOVER_FOCUS}>
+        {children}
+      </NestedIconContainer>
     )}
     {isError && (
       <NestedIconContainer $isError={isError}>
@@ -89,5 +101,7 @@ Thumbnail.propTypes = {
   ]),
   onClick: PropTypes.func,
   isError: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  loadingMessage: PropTypes.string,
 };
 export default Thumbnail;


### PR DESCRIPTION
## Context
The loading state for thumbnails in the new checklist was simplified quite a bit from the animated border to a loading bar that mirrors the loading state of the media panel. 

## Summary

Loading bar in the design system based entirely on the loading bar used in [local media panel](https://github.com/google/web-stories-wp/blob/main/assets/src/edit-story/components/library/panes/media/common/mediaElement.js). 

Realized that thumbnail icons (mostly for media) are only supposed to show up when hover or focus so I fixed that to better demo the loading state too in the thumbnails.

## Relevant Technical Choices

New design system component called `LoadingBar`, adds an aria alert when a message is passed to the component. 


## To-do

Follow this PR up with another to swap out the media element loading bar with the shared one. That has to go through QA whereas the thumbnails aren't in use yet and I want this merged to avoid slowing down. Thus, the separation of concerns. 

## User-facing changes

None

## Testing Instructions

Spin up a local instance of storybook. You'll see the loadingBar in 2 places. 1) designSystem/components/loadingBar and 2) editStory/components/thumbnail - you can toggle knobs to see it. 

(it's not as clunky as these screen grabs are IRL)
![loadingBar](https://user-images.githubusercontent.com/10720454/122828639-c95c5480-d29a-11eb-86aa-8d950b4b6ef8.gif)
![loading thumbnail](https://user-images.githubusercontent.com/10720454/122828644-c9f4eb00-d29a-11eb-9efa-0aca71a9e72a.gif)


### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7976 
