### PR TITLE
PPC 2: Integrate Highlights, Messages & ChecklistCard into Initial Example Checks

### DIFF
--- a/assets/src/design-system/components/typography/text/index.js
+++ b/assets/src/design-system/components/typography/text/index.js
@@ -56,6 +56,10 @@ const Span = styled.span`
   ${textCss};
 `;
 
+const Div = styled.div`
+  ${textCss};
+`;
+
 const Kbd = styled.kbd`
   ${textCss};
   white-space: nowrap;
@@ -77,6 +81,8 @@ export const Text = ({ as, disabled, ...props }) => {
       return <Label disabled={disabled} {...props} />;
     case 'span':
       return <Span {...props} />;
+    case 'div':
+      return <Div {...props} />;
     case 'kbd':
       return <Kbd {...props} />;
     default:

--- a/assets/src/edit-story/app/prepublish/newConstants.js
+++ b/assets/src/edit-story/app/prepublish/newConstants.js
@@ -43,6 +43,8 @@ const POSTER_DIMENSION_HEIGHT_PX = 853;
 const PUBLISHER_LOGO_DIMENSION = 96;
 const PUBLISHER_LOGO_RATIO = 1;
 
+export const LEARN_MORE = __('Learn more', 'web-stories');
+
 export const ISSUE_TYPES = {
   ACCESSIBILITY: 'accessibility',
   DESIGN: 'design',

--- a/assets/src/edit-story/components/checklist/accessibilityChecks.js
+++ b/assets/src/edit-story/components/checklist/accessibilityChecks.js
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 export function AccessibilityChecks() {
-  return <div>{'accessibility'}</div>;
+  return null;
 }

--- a/assets/src/edit-story/components/checklist/checks/index.js
+++ b/assets/src/edit-story/components/checklist/checks/index.js
@@ -13,10 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export { default as ChecklistCard } from './checklistCard';
-export * from './constants';
-export * from './styles';
-export { DefaultCtaButton } from './defaultCtaButton';
-export { DefaultFooterText } from './defaultFooterText';
-export { LearnMoreLink } from './components';
+export { PageTooMuchText } from './pageTooMuchText';
+export { StoryPosterAttached } from './storyPosterAttached';

--- a/assets/src/edit-story/components/checklist/checks/pageTooMuchText.js
+++ b/assets/src/edit-story/components/checklist/checks/pageTooMuchText.js
@@ -16,15 +16,29 @@
 /**
  * External dependencies
  */
-// import { __ } from '@web-stories-wp/i18n';
 import { useMemo } from 'react';
 
 /**
  * Internal dependencies
  */
+import { THEME_CONSTANTS, List } from '../../../../design-system';
+import { useHighlights } from '../../../app/highlights';
 import { useStory } from '../../../app/story';
+import { DESIGN_COPY } from '../../../app/prepublish/newConstants';
 import { characterCountForPage, filterStoryPages } from '../utils';
-// import ChecklistCard from '../../../checklistCard';
+import {
+  ChecklistCard,
+  FooterText,
+  CardListWrapper,
+  CARD_TYPE,
+  LearnMoreLink,
+} from '../../checklistCard';
+import {
+  Thumbnail,
+  THUMBNAIL_TYPES,
+  THUMBNAIL_DIMENSIONS,
+} from '../../thumbnail';
+import PagePreview from '../../carousel/pagepreview';
 
 const MAX_PAGE_CHARACTER_COUNT = 200;
 
@@ -48,26 +62,50 @@ export function PageTooMuchText() {
     () => filterStoryPages(story, pageTooMuchText),
     [story]
   );
-  return failingPages.length > 0
-    ? // <ChecklistCard
-      //   title={__('Reduce amount of text on pages', 'web-stories')}
-      //   titleProps={{
-      //     onClick: () => {
-      //       /* perform highlight here */
-      //     },
-      //   }}
-      //   footer={
-      //     <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
-      //       {__('Keep text to max 200 characters per page.', 'web-stories')}
-      //       <Link
-      //         href={'#' /* figure out what this links to */}
-      //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-      //       >
-      //         {'Learn more'}
-      //       </Link>
-      //     </Text>
-      //   }
-      // />
-      null
-    : null;
+  const setHighlights = useHighlights(({ setHighlights }) => setHighlights);
+  return failingPages.length > 0 ? (
+    <ChecklistCard
+      title={DESIGN_COPY.tooMuchPageText.title}
+      cardType={
+        failingPages.length > 1
+          ? CARD_TYPE.MULTIPLE_ISSUE
+          : CARD_TYPE.SINGLE_ISSUE
+      }
+      thumbnailCount={failingPages.length}
+      thumbnail={
+        <>
+          {failingPages.map((page) => (
+            <Thumbnail
+              key={page.id}
+              onClick={() => {
+                setHighlights({
+                  pageId: page.id,
+                });
+              }}
+              type={THUMBNAIL_TYPES.PAGE}
+              displayBackground={
+                <PagePreview
+                  page={page}
+                  width={THUMBNAIL_DIMENSIONS.WIDTH}
+                  height={THUMBNAIL_DIMENSIONS.HEIGHT}
+                  as="div"
+                />
+              }
+              aria-label="my helper text describing this thumbnail image"
+            />
+          ))}
+        </>
+      }
+      footer={
+        <FooterText>
+          <CardListWrapper>
+            <List size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+              {DESIGN_COPY.tooMuchPageText.footer}
+            </List>
+            <LearnMoreLink />
+          </CardListWrapper>
+        </FooterText>
+      }
+    />
+  ) : null;
 }

--- a/assets/src/edit-story/components/checklist/checks/storyPosterAttached.js
+++ b/assets/src/edit-story/components/checklist/checks/storyPosterAttached.js
@@ -16,14 +16,22 @@
 /**
  * External dependencies
  */
-// import { __ } from '@web-stories-wp/i18n';
-
+import { __ } from '@web-stories-wp/i18n';
 /**
  * Internal dependencies
  */
 import { useStory } from '../../../app/story';
+import { states, useHighlights } from '../../../app/highlights';
+import { PRIORITY_COPY } from '../../../app/prepublish/newConstants';
+import { List, THEME_CONSTANTS } from '../../../../design-system';
+import {
+  ChecklistCard,
+  CardListWrapper,
+  FooterText,
+  DefaultCtaButton,
+  LearnMoreLink,
+} from '../../checklistCard';
 import { hasNoFeaturedMedia } from '../utils';
-// import ChecklistCard from '../../../checklistCard';
 
 export function storyHasNoPosterAttached(story) {
   return (
@@ -34,46 +42,32 @@ export function storyHasNoPosterAttached(story) {
 export function StoryPosterAttached() {
   //@TODO refine this context selector and storyHasNoPosterAttached to run more selectively
   const story = useStory(({ state }) => state);
-  return storyHasNoPosterAttached(story)
-    ? // <ChecklistCard
-      //   title={__('Add Web Story poster image', 'web-stories')}
-      //   titleProps={{
-      //     onClick: () => {
-      //       /* perform highlight here */
-      //     },
-      //   }}
-      //   footer={
-      //     <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
-      //       <ul>
-      //         <li>
-      //           {__('Use as a representation of the story.', 'web-stories')}
-      //         </li>
-      //         <li>{__('Avoid images with embedded text.', 'web-stories')}</li>
-      //         <li>
-      //           {__("Use an image that's at least 640x853px.", 'web-stories')}
-      //         </li>
-      //         <li>{__('Maintain a 3:4 aspect ratio.', 'web-stories')}</li>
-      //       </ul>
-      //       <Link
-      //         href={'#' /* figure out what this links to */}
-      //         size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-      //       >
-      //         {'Learn more'}
-      //       </Link>
-      //     </Text>
-      //   }
-      //   cta={
-      //     <Button
-      //       size={BUTTON_SIZES.SMALL}
-      //       type={BUTTON_TYPES.SECONDARY}
-      //       onClick={() => {
-      //         /* perform highlight here */
-      //       }}
-      //     >
-      //       {__('Upload', 'web-stories')}
-      //     </Button>
-      //   }
-      // />
-      null
-    : null;
+  const setHighlights = useHighlights(({ setHighlights }) => setHighlights);
+
+  return storyHasNoPosterAttached(story) ? (
+    <ChecklistCard
+      title={PRIORITY_COPY.storyMissingPoster.title}
+      footer={
+        <FooterText>
+          <CardListWrapper>
+            <List size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+              {PRIORITY_COPY.storyMissingPoster.footer}
+            </List>
+            <LearnMoreLink />
+          </CardListWrapper>
+        </FooterText>
+      }
+      cta={
+        <DefaultCtaButton
+          onClick={() =>
+            setHighlights({
+              highlight: states.POSTER,
+            })
+          }
+        >
+          {__('Upload', 'web-stories')}
+        </DefaultCtaButton>
+      }
+    />
+  ) : null;
 }

--- a/assets/src/edit-story/components/checklist/designChecks.js
+++ b/assets/src/edit-story/components/checklist/designChecks.js
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Internal dependencies
+ */
+import { PageTooMuchText } from './checks';
+
 export function DesignChecks() {
-  return <div>{'design'}</div>;
+  return <PageTooMuchText />;
 }

--- a/assets/src/edit-story/components/checklist/priorityChecks.js
+++ b/assets/src/edit-story/components/checklist/priorityChecks.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Internal dependencies
+ */
+import { StoryPosterAttached } from './checks';
 export function PriorityChecks() {
-  return <div>{'priority'}</div>;
+  return <StoryPosterAttached />;
 }

--- a/assets/src/edit-story/components/checklistCard/components/index.js
+++ b/assets/src/edit-story/components/checklistCard/components/index.js
@@ -13,10 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export { default as ChecklistCard } from './checklistCard';
-export * from './constants';
-export * from './styles';
-export { DefaultCtaButton } from './defaultCtaButton';
-export { DefaultFooterText } from './defaultFooterText';
-export { LearnMoreLink } from './components';
+export { LearnMoreLink } from './learnMoreLink';

--- a/assets/src/edit-story/components/checklistCard/components/learnMoreLink.js
+++ b/assets/src/edit-story/components/checklistCard/components/learnMoreLink.js
@@ -13,10 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Internal dependencies
+ */
+import { LEARN_MORE } from '../../../app/prepublish/newConstants';
+import { THEME_CONSTANTS, Link } from '../../../../design-system';
 
-export { default as ChecklistCard } from './checklistCard';
-export * from './constants';
-export * from './styles';
-export { DefaultCtaButton } from './defaultCtaButton';
-export { DefaultFooterText } from './defaultFooterText';
-export { LearnMoreLink } from './components';
+export function LearnMoreLink() {
+  return (
+    <Link
+      href={'/#' /* figure out what this links to */}
+      size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+    >
+      {LEARN_MORE}
+    </Link>
+  );
+}

--- a/assets/src/edit-story/components/checklistCard/styles.js
+++ b/assets/src/edit-story/components/checklistCard/styles.js
@@ -23,6 +23,7 @@ import styled, { css } from 'styled-components';
  * Internal dependencies
  */
 import { focusableOutlineCSS } from '../../../design-system/theme/helpers';
+import { THEME_CONSTANTS } from '../../../design-system';
 import { OverflowThumbnail } from '../thumbnail';
 import { GRID_TEMPLATE_AREA, GRID_VARIANT } from './constants';
 
@@ -31,6 +32,16 @@ export const Wrapper = styled.div`
   display: flex;
   border-radius: 4px;
   background: ${({ theme }) => theme.colors.bg.secondary};
+`;
+
+export const FooterText = styled(Text).attrs({
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL,
+  as: 'div',
+})`
+  &,
+  li {
+    color: ${({ theme }) => theme.colors.fg.secondary};
+  }
 `;
 
 export const Container = styled.div`

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -227,7 +227,7 @@ class Experiments extends Service_Base {
 			[
 				'name'        => 'enableChecklistCompanion',
 				'label'       => __( 'Enable Checklist Companion', 'web-stories' ),
-				'description' => __( 'Enables v2 of prepublish checklist as a popup in the editor.', 'web-stories' ),
+				'description' => __( 'Enable v2 of prepublish checklist as a popup in the editor.', 'web-stories' ),
 				'group'       => 'editor',
 			],
 			/**


### PR DESCRIPTION
## Context
Part of the PPC redesign. First tie up of all the moving pieces around PPC redesign we've been doing.

## Summary
This PR shows how we'll tie all the work together around the checklist redesign with regard to the individual checks. This PR brings in the awesome work @BrittanyIRL has been doing on presentational bits of the new PPC, incorporating the new `ChecklistCard` component as well as the `Thumbnail` component into the new PPC checks. Also incorporates the highlight functionality as well as the `_COPY` constants we're using to centralize all the translatable string in the PPC.

## Relevant Technical Choices
NA

## To-do
NA

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
With the `enableChecklistCompanion` flag turned on, there should be working checks for the story poster image and too much text on page checks. They aren't really positioned inside the popup yet, but that work is to come in: https://github.com/google/web-stories-wp/issues/7918

Here, we're just looking to see that the cards look nice and work well.

Expected appearance:
<img width="501" alt="Screen Shot 2021-06-22 at 9 40 08 AM" src="https://user-images.githubusercontent.com/35983235/122946253-d6328400-d33e-11eb-9c64-e11bef2be36e.png">

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #7920
