### PR TITLE
Animations: fix prefers-reduced-motion workaround

### DIFF
--- a/assets/src/animation/utils/getInitialStyleFromKeyframes.js
+++ b/assets/src/animation/utils/getInitialStyleFromKeyframes.js
@@ -41,6 +41,8 @@ function getInitialStyleFromKeyframes(keyframes) {
   Object.keys(frame).forEach((key) => {
     if (ALLOWLIST.includes(key.toLowerCase())) {
       const value = frame[key];
+      initialStyle[`--initial-opacity`] = 1;
+      initialStyle[`--initial-transform`] = 'none';
       if (Array.isArray(value)) {
         initialStyle[`--initial-${key}`] = value[0];
       } else {

--- a/assets/src/animation/utils/getInitialStyleFromKeyframes.js
+++ b/assets/src/animation/utils/getInitialStyleFromKeyframes.js
@@ -38,11 +38,14 @@ function getInitialStyleFromKeyframes(keyframes) {
     return initialStyle;
   }
 
+  // Set initial opacity and transforms so that
+  // unspecified opacity & transforms aren't inherited
+  initialStyle[`--initial-opacity`] = 1;
+  initialStyle[`--initial-transform`] = 'none';
+
   Object.keys(frame).forEach((key) => {
     if (ALLOWLIST.includes(key.toLowerCase())) {
       const value = frame[key];
-      initialStyle[`--initial-opacity`] = 1;
-      initialStyle[`--initial-transform`] = 'none';
       if (Array.isArray(value)) {
         initialStyle[`--initial-${key}`] = value[0];
       } else {

--- a/assets/src/animation/utils/test/getInitialStyleFromKeyframes.js
+++ b/assets/src/animation/utils/test/getInitialStyleFromKeyframes.js
@@ -29,6 +29,7 @@ describe('getInitialStyleFromKeyframes', () => {
 
     expect(getInitialStyleFromKeyframes(keyframes)).toStrictEqual({
       '--initial-opacity': 1,
+      '--initial-transform': 'none',
     });
   });
 
@@ -40,6 +41,7 @@ describe('getInitialStyleFromKeyframes', () => {
 
     expect(getInitialStyleFromKeyframes(keyframes)).toStrictEqual({
       '--initial-opacity': 0,
+      '--initial-transform': 'none',
     });
   });
 
@@ -59,6 +61,7 @@ describe('getInitialStyleFromKeyframes', () => {
 
     expect(getInitialStyleFromKeyframes(easingSample)).toStrictEqual({
       '--initial-transform': 'scale(0)',
+      '--initial-opacity': 1,
     });
 
     // offset


### PR DESCRIPTION
## Context
Small regression in ` prefers-reduced-motion` approach breaking whoosh in

## Summary
All elements are using css vars if user has motion enabled like so:
```
            @media (prefers-reduced-motion: no-preference) {
                .animation-wrapper {
                  opacity: var(--initial-opacity);
                  transform: var(--initial-transform);
                }
              }
```

Issue was stemming from element hierarchy like this:
```
<wrapper1 --initial-transform: scale(2)>
  <wrapper2 --initial-opacity: 0>
    <wrapper3 --initial-transform: translateX(100px)>
```

In this scenario `wrapper2` would end up having these styles:
```
.wrapper1 {
  transform: scale(2);
}

.wrapper2 {
  opacity: 0;
  transform: scale(2);
}

.wrapper3 {
  opacity: 0;
  transform: translateX(100px)
}
```
## Relevant Technical Choices
Reset initial vars at every level of the hierarchy so it only sets the initial style of the property that's being animated
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Fixes whoosh in animation in preview
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

Check out whoosh in animation in the preview. should look the same as the animation within the editor


This PR can be tested by following these steps:

- Go to story editor
- Add a foreground element and apply the `WHOOSH IN` animation
- Go to your computer settings and enable reduced motion
- Go back to the editor and click the `preview` button
- see that no animation plays, but the element remains visible
- Go back to your computer settings and disable reduced motion
- Refresh the story preview 
- See that the whoosh in animations looks the same as it does in the editor

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8046 
