### PR TITLE
PPC 2.0: Empty state in storybook

### DIFF
--- a/assets/src/edit-story/components/checklist/emptyContent.js
+++ b/assets/src/edit-story/components/checklist/emptyContent.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
+import styled from 'styled-components';
+/**
+ * Internal dependencies
+ */
+import { Icons, Text, THEME_CONSTANTS } from '../../../design-system';
+
+const Wrapper = styled.div`
+  display: grid;
+  grid-template-rows: 113px 64px;
+  width: 308px;
+  margin: 0 auto 32px;
+
+  & > * {
+    display: flex;
+    align-self: center;
+    justify-self: center;
+    color: ${({ theme }) => theme.colors.fg.secondary};
+  }
+
+  p {
+    width: 226px;
+    text-align: center;
+  }
+`;
+
+const IconContainer = styled.div`
+  height: 50px;
+  width: 50px;
+`;
+
+export const EmptyContent = () => {
+  return (
+    <Wrapper>
+      <IconContainer>
+        <Icons.CheckmarkCircle />
+      </IconContainer>
+      <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
+        {__(
+          'You are all set for now. Return to this checklist as you build your Web Story for tips on how to improve it.',
+          'web-stories'
+        )}
+      </Text>
+    </Wrapper>
+  );
+};

--- a/assets/src/edit-story/components/checklist/stories/index.js
+++ b/assets/src/edit-story/components/checklist/stories/index.js
@@ -48,7 +48,7 @@ const Container = styled.div`
   margin-bottom: 10px;
 `;
 
-export const _default = () => {
+export const EmptyState = () => {
   return (
     <Page>
       <Container>

--- a/assets/src/edit-story/components/checklist/stories/index.js
+++ b/assets/src/edit-story/components/checklist/stories/index.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
+import styled from 'styled-components';
+/**
+ * Internal dependencies
+ */
+import { Checklist } from '..';
+import { noop } from '../../../utils/noop';
+import { NavigationWrapper } from '../../helpCenter/navigator';
+import { TopNavigation } from '../../helpCenter/navigator/topNavigation';
+import { Popup } from '../../helpCenter/popup';
+import { EmptyContent } from '../emptyContent';
+
+export default {
+  title: 'Stories Editor/Components/Checklist',
+  component: Checklist,
+};
+
+const Page = styled.div`
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  height: 300px;
+  width: 900px;
+  background-color: ${({ theme }) => theme.colors.bg.primary};
+`;
+
+const Container = styled.div`
+  position: relative;
+  margin-left: 20px;
+  margin-bottom: 10px;
+`;
+
+export const _default = () => {
+  return (
+    <Page>
+      <Container>
+        <Popup
+          popupId={'1234'}
+          isOpen
+          ariaLabel={__('Checklist', 'web-stories')}
+        >
+          <NavigationWrapper>
+            <TopNavigation
+              onClose={noop}
+              label={__('Checklist', 'web-stories')}
+              popupId={'1234'}
+            />
+            <EmptyContent />
+          </NavigationWrapper>
+        </Popup>
+      </Container>
+    </Page>
+  );
+};


### PR DESCRIPTION
## Context

PPC 2.0. [Empty state designs](https://www.figma.com/file/bMhG3KyrJF8vIAODgmbeqT/Design-System?node-id=8393%3A38)

## Summary

Add empty state for the Pre publish checklist in storybook.

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

no user facing changes, all in storybook

|Designs|Storybook|
|--|--|
|![image](https://user-images.githubusercontent.com/22185279/123331686-d8424180-d4fc-11eb-93a6-5cd83415f82f.png)|![image](https://user-images.githubusercontent.com/22185279/123331669-d1b3ca00-d4fc-11eb-82c9-872979f5a1a1.png)|


## Testing Instructions

Storybook -> stories editor -> checklist -> empty state

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7919 
