### PR TITLE
Carousel Grid: Add 2nd Row

### DIFF
--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -87,7 +87,7 @@ const Layer = styled.section`
     '. . . . . . .' ${MENU_GAP}px
     'm m m m m m m' ${MENU_HEIGHT}px
     '. . . . . . .' 1fr
-    'c c c c c c c' ${CAROUSEL_HEIGHT}px
+    'c c c c c c c' ${CAROUSEL_HEIGHT * 1.5}px
     /
     1fr
     var(--page-nav-width)

--- a/assets/src/edit-story/components/carousel/carouselLayout.js
+++ b/assets/src/edit-story/components/carousel/carouselLayout.js
@@ -28,23 +28,23 @@ import PrimaryMenu from './primaryMenu';
 import SecondaryMenu from './secondaryMenu';
 import CarouselList from './carouselList';
 import useCarousel from './useCarousel';
-import { MENU_GUTTER, BUTTON_WIDTH, BUTTON_GAP } from './constants';
+import { BUTTON_WIDTH, BUTTON_GAP } from './constants';
 
 const Wrapper = styled.section`
   position: relative;
   display: grid;
   grid:
     /* Note the two empty 1fr areas each side of the buttons - that's on purpose */
-    'secondary . prev-navigation . carousel . next-navigation . primary' auto /
-    ${MENU_GUTTER}px
-    1fr
-    ${BUTTON_WIDTH}px
-    ${BUTTON_GAP}px
-    auto
+    [row1-start] '. prev-navigation . carousel . next-navigation .' [row1-end]
+    [row2-start] 'secondary secondary . none . . primary' [row2-end]
+    /
     ${BUTTON_GAP}px
     ${BUTTON_WIDTH}px
+    ${BUTTON_GAP}px
     1fr
-    ${MENU_GUTTER}px;
+    ${BUTTON_GAP}px
+    ${BUTTON_WIDTH}px
+    ${BUTTON_GAP}px;
   width: 100%;
   height: 100%;
 `;

--- a/assets/src/edit-story/components/carousel/useCarouselSizing.js
+++ b/assets/src/edit-story/components/carousel/useCarouselSizing.js
@@ -24,7 +24,6 @@ import { useMemo } from 'react';
  */
 import {
   BUTTON_GUTTER,
-  MENU_GUTTER,
   WIDE_WORKSPACE_LIMIT,
   WIDE_THUMBNAIL_WIDTH,
   WIDE_THUMBNAIL_HEIGHT,
@@ -36,8 +35,7 @@ import {
 function useCarouselSizing({ availableSpace, numPages }) {
   return useMemo(() => {
     const isWideWorkspace = availableSpace >= WIDE_WORKSPACE_LIMIT;
-    const spaceForCarousel =
-      availableSpace - 2 * MENU_GUTTER - 2 * BUTTON_GUTTER;
+    const spaceForCarousel = availableSpace - 4 * BUTTON_GUTTER;
     const pageThumbWidth = isWideWorkspace
       ? WIDE_THUMBNAIL_WIDTH
       : NARROW_THUMBNAIL_WIDTH;


### PR DESCRIPTION
(Kinda just tagged everyone, feels like a face lift that's good to make sure everyone knows about/make sure there's nothing weird I don't know about this structure that I'm ruining on accident. Feel free to ignore if it's irrelevant to you.)

## Context

We're making the prepublish checklist a new toggle button next to the help center. It does this when there's "alot" of pages.

<img width="913" alt="Screen Shot 2021-06-24 at 12 48 53 PM" src="https://user-images.githubusercontent.com/10720454/123340084-81d70200-d500-11eb-9b8f-bb93811a5e86.png">


## Summary

Proposing we add a second row to the carousel area to allow the page carousel to take up space for easier usage while allowing us enough space to also have all of the buttons and toggles that are part of this grouping. 

## Relevant Technical Choices

- Tried to make the minimum amount of tweaks. What ended up working was cutting out the `MENU_GUTTER` and adding `BUTTON_GAP` in its place so that there's still outside space. Now the carousel space calculation just multiples the button gap by 4 instead of 2, and menu_gutter isn't accounted for. 
- The carousel column width is now the only `1fr` so that it will always be as wide as possible, this keeps our second row of buttons with space between without additional work. 


## To-do

Waiting for product and design stamps of approval, wanted to loop people in who are in earlier timezones just in case they have feedback. <3 

## User-facing changes


https://user-images.githubusercontent.com/10720454/123339853-3290d180-d500-11eb-8904-f8b75e8f539d.mp4

(without the incoming checklist toggle)
<img width="580" alt="Screen Shot 2021-06-24 at 3 07 32 PM" src="https://user-images.githubusercontent.com/10720454/123339947-57854480-d500-11eb-9f67-531b13748a26.png">


## Testing Instructions

Open the editor and see that the carousel and the buttons in it work as expected (a mirror of staging). 
Try enabling the new PPC 2.0 experiment and verify the carousel area is still working as expected. 

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #7917
