### PR TITLE
PPCv2.0: Add video optimization card to new checklist

### DIFF
--- a/assets/src/edit-story/app/media/useUploadMedia.js
+++ b/assets/src/edit-story/app/media/useUploadMedia.js
@@ -170,9 +170,11 @@ function useUploadMedia({
             'File could not be uploaded. Please try a different file.',
             'web-stories'
           ),
-        thumbnail: {
-          src: resource.type === 'video' ? resource.poster : resource.src,
-          alt: resource.alt,
+        thumbnail: resource && {
+          src: ['video', 'gif'].includes(resource.type)
+            ? resource.poster
+            : resource.src,
+          alt: resource?.alt,
         },
         dismissable: true,
       });

--- a/assets/src/edit-story/app/media/useUploadMedia.js
+++ b/assets/src/edit-story/app/media/useUploadMedia.js
@@ -156,7 +156,7 @@ function useUploadMedia({
   // Handle *failed* items.
   // Remove resources from media library and canvas.
   useEffect(() => {
-    for (const { id, onUploadError, error } of failures) {
+    for (const { id, onUploadError, error, resource } of failures) {
       if (onUploadError) {
         onUploadError({ id });
       }
@@ -170,6 +170,10 @@ function useUploadMedia({
             'File could not be uploaded. Please try a different file.',
             'web-stories'
           ),
+        thumbnail: {
+          src: resource.type === 'video' ? resource.poster : resource.src,
+          alt: resource.alt,
+        },
         dismissable: true,
       });
     }

--- a/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
@@ -35,6 +35,7 @@ import VideoElementMissingPoster from '../checks/videoElementMissingPoster';
 import { ChecklistCategoryProvider, useCategoryCount } from '../countContext';
 import { PanelText, StyledTablistPanel } from '../styles';
 import { useCheckpoint } from '../checkpointContext';
+import VideoOptimization from '../checks/videoOptimization';
 
 export function PriorityChecks({ isOpen, onClick, title }) {
   const count = useCategoryCount(ISSUE_TYPES.PRIORITY);
@@ -73,6 +74,7 @@ export function PriorityChecks({ isOpen, onClick, title }) {
         <StoryPosterAspectRatio />
         <PublisherLogoSize />
         <VideoElementMissingPoster />
+        <VideoOptimization />
       </StyledTablistPanel>
     </ChecklistCategoryProvider>
   );

--- a/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
@@ -22,7 +22,8 @@ import { useEffect } from 'react';
 /**
  * Internal dependencies
  */
-import { useCurrentUser, useConfig } from '../../../app';
+import { useConfig } from '../../../app';
+import useFFmpeg from '../../../app/media/utils/useFFmpeg';
 import { PANEL_STATES } from '../../tablist';
 import { ISSUE_TYPES, PANEL_VISIBILITY_BY_STATE } from '../constants';
 import PublisherLogoSize from '../checks/publisherLogoSize';
@@ -54,19 +55,13 @@ export function PriorityChecks({ isOpen, onClick, title }) {
     ISSUE_TYPES.PRIORITY
   );
 
-  const { currentUser } = useCurrentUser(({ state, actions }) => ({
-    currentUser: state.currentUser,
-    toggleWebStoriesMediaOptimization:
-      actions.toggleWebStoriesMediaOptimization,
-  }));
+  const { isFeatureEnabled, isTranscodingEnabled } = useFFmpeg();
   const {
     capabilities: { hasUploadMediaAction },
   } = useConfig();
 
   const isVideoOptimizationSettingEnabled =
-    Boolean(window?.crossOriginIsolated) &&
-    currentUser?.meta?.web_stories_media_optimization &&
-    hasUploadMediaAction;
+    isFeatureEnabled && isTranscodingEnabled && hasUploadMediaAction;
 
   return (
     <ChecklistCategoryProvider category={ISSUE_TYPES.PRIORITY}>

--- a/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
@@ -22,7 +22,7 @@ import { useEffect } from 'react';
 /**
  * Internal dependencies
  */
-import { useCurrentUser } from '../../../app';
+import { useCurrentUser, useConfig } from '../../../app';
 import { PANEL_STATES } from '../../tablist';
 import { ISSUE_TYPES, PANEL_VISIBILITY_BY_STATE } from '../constants';
 import PublisherLogoSize from '../checks/publisherLogoSize';
@@ -59,9 +59,14 @@ export function PriorityChecks({ isOpen, onClick, title }) {
     toggleWebStoriesMediaOptimization:
       actions.toggleWebStoriesMediaOptimization,
   }));
+  const {
+    capabilities: { hasUploadMediaAction },
+  } = useConfig();
+
   const isVideoOptimizationSettingEnabled =
     Boolean(window?.crossOriginIsolated) &&
-    currentUser?.meta?.web_stories_media_optimization;
+    currentUser?.meta?.web_stories_media_optimization &&
+    hasUploadMediaAction;
 
   return (
     <ChecklistCategoryProvider category={ISSUE_TYPES.PRIORITY}>

--- a/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
@@ -22,6 +22,7 @@ import { useEffect } from 'react';
 /**
  * Internal dependencies
  */
+import { useCurrentUser } from '../../../app';
 import { PANEL_STATES } from '../../tablist';
 import { ISSUE_TYPES, PANEL_VISIBILITY_BY_STATE } from '../constants';
 import PublisherLogoSize from '../checks/publisherLogoSize';
@@ -53,6 +54,11 @@ export function PriorityChecks({ isOpen, onClick, title }) {
     ISSUE_TYPES.PRIORITY
   );
 
+  const { currentUser } = useCurrentUser(({ state, actions }) => ({
+    currentUser: state.currentUser,
+    toggleWebStoriesMediaOptimization:
+      actions.toggleWebStoriesMediaOptimization,
+  }));
   return (
     <ChecklistCategoryProvider category={ISSUE_TYPES.PRIORITY}>
       <StyledTablistPanel
@@ -75,10 +81,17 @@ export function PriorityChecks({ isOpen, onClick, title }) {
         <PublisherLogoSize />
         <VideoElementMissingPoster />
         <VideoOptimization />
+        {
+          // todo video optimization fails when auto optimization is turned off
+          currentUser?.meta?.web_stories_media_optimization && (
+            <VideoOptimization />
+          )
+        }
       </StyledTablistPanel>
     </ChecklistCategoryProvider>
   );
 }
+
 PriorityChecks.propTypes = {
   isOpen: PropTypes.bool,
   onClick: PropTypes.func.isRequired,

--- a/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
@@ -59,6 +59,10 @@ export function PriorityChecks({ isOpen, onClick, title }) {
     toggleWebStoriesMediaOptimization:
       actions.toggleWebStoriesMediaOptimization,
   }));
+  const isVideoOptimizationSettingEnabled =
+    Boolean(window?.crossOriginIsolated) &&
+    currentUser?.meta?.web_stories_media_optimization;
+
   return (
     <ChecklistCategoryProvider category={ISSUE_TYPES.PRIORITY}>
       <StyledTablistPanel
@@ -80,13 +84,7 @@ export function PriorityChecks({ isOpen, onClick, title }) {
         <StoryPosterAspectRatio />
         <PublisherLogoSize />
         <VideoElementMissingPoster />
-        <VideoOptimization />
-        {
-          // todo video optimization fails when auto optimization is turned off
-          currentUser?.meta?.web_stories_media_optimization && (
-            <VideoOptimization />
-          )
-        }
+        {isVideoOptimizationSettingEnabled && <VideoOptimization />}
       </StyledTablistPanel>
     </ChecklistCategoryProvider>
   );

--- a/assets/src/edit-story/components/checklist/checks/test/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/test/videoOptimization.js
@@ -52,7 +52,7 @@ describe('videoOptimization (pre-publish checklist card)', () => {
     expect(result).toBe(true);
   });
 
-  it('should not return true if the video element is larger than 1080x1920 and Optimized', () => {
+  it('should return false if the video element is larger than 1080x1920 and Optimized', () => {
     const largeUnoptimizedVideo = {
       id: 202,
       type: 'video',
@@ -68,7 +68,7 @@ describe('videoOptimization (pre-publish checklist card)', () => {
     expect(result).toBe(false);
   });
 
-  it('should not return a message if the video element is smaller than 1080x1920', () => {
+  it('should return false if the video element is smaller than 1080x1920', () => {
     const smallUnoptimizedVideo = {
       id: 202,
       type: 'video',

--- a/assets/src/edit-story/components/checklist/checks/test/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/test/videoOptimization.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { videoElementOptimized } from '../videoOptimization';
+
+describe('videoOptimization (pre-publish checklist card)', () => {
+  it('should return true if the video element is currently being transcoded', () => {
+    const largeUnoptimizedVideo = {
+      id: 202,
+      type: 'video',
+      resource: {
+        isTranscoding: true,
+        isOptimized: false,
+        height: 2160,
+        width: 3840,
+        local: false,
+      },
+    };
+
+    const result = videoElementOptimized(largeUnoptimizedVideo);
+    expect(result).toBe(true);
+  });
+  it('should return true if the video element is larger than 1080x1920 and not optimized', () => {
+    const largeUnoptimizedVideo = {
+      id: 202,
+      type: 'video',
+      resource: {
+        isOptimized: false,
+        height: 2160,
+        width: 3840,
+        local: false,
+      },
+    };
+
+    const result = videoElementOptimized(largeUnoptimizedVideo);
+    expect(result).toBe(true);
+  });
+
+  it('should not return true if the video element is larger than 1080x1920 and Optimized', () => {
+    const largeUnoptimizedVideo = {
+      id: 202,
+      type: 'video',
+      resource: {
+        isOptimized: true,
+        height: 2160,
+        width: 3840,
+        local: false,
+      },
+    };
+
+    const result = videoElementOptimized(largeUnoptimizedVideo);
+    expect(result).toBe(false);
+  });
+
+  it('should not return a message if the video element is smaller than 1080x1920', () => {
+    const smallUnoptimizedVideo = {
+      id: 202,
+      type: 'video',
+      resource: {
+        isOptimized: false,
+        height: 300,
+        width: 400,
+        local: false,
+      },
+    };
+    const smallOptimizedVideo = {
+      id: 203,
+      type: 'video',
+      resource: {
+        isOptimized: true,
+        height: 300,
+        width: 400,
+        local: false,
+      },
+    };
+
+    expect(videoElementOptimized(smallUnoptimizedVideo)).toBe(false);
+    expect(videoElementOptimized(smallOptimizedVideo)).toBe(false);
+  });
+});

--- a/assets/src/edit-story/components/checklist/checks/test/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/test/videoOptimization.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { isVideoElementOptimized } from '../videoOptimization';
+import { videoElementsNotOptimized } from '../videoOptimization';
 
 describe('videoOptimization (pre-publish checklist card)', () => {
   it('should return true if the video element is currently being transcoded', () => {
@@ -33,7 +33,7 @@ describe('videoOptimization (pre-publish checklist card)', () => {
       },
     };
 
-    const result = isVideoElementOptimized(largeUnoptimizedVideo);
+    const result = videoElementsNotOptimized(largeUnoptimizedVideo);
     expect(result).toBe(true);
   });
   it('should return true if the video element is larger than 1080x1920 and not optimized', () => {
@@ -48,7 +48,7 @@ describe('videoOptimization (pre-publish checklist card)', () => {
       },
     };
 
-    const result = isVideoElementOptimized(largeUnoptimizedVideo);
+    const result = videoElementsNotOptimized(largeUnoptimizedVideo);
     expect(result).toBe(true);
   });
 
@@ -64,7 +64,7 @@ describe('videoOptimization (pre-publish checklist card)', () => {
       },
     };
 
-    const result = isVideoElementOptimized(largeUnoptimizedVideo);
+    const result = videoElementsNotOptimized(largeUnoptimizedVideo);
     expect(result).toBe(false);
   });
 
@@ -90,7 +90,7 @@ describe('videoOptimization (pre-publish checklist card)', () => {
       },
     };
 
-    expect(isVideoElementOptimized(smallUnoptimizedVideo)).toBe(false);
-    expect(isVideoElementOptimized(smallOptimizedVideo)).toBe(false);
+    expect(videoElementsNotOptimized(smallUnoptimizedVideo)).toBe(false);
+    expect(videoElementsNotOptimized(smallOptimizedVideo)).toBe(false);
   });
 });

--- a/assets/src/edit-story/components/checklist/checks/test/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/test/videoOptimization.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import { videoElementOptimized } from '../videoOptimization';
+import { isVideoElementOptimized } from '../videoOptimization';
 
 describe('videoOptimization (pre-publish checklist card)', () => {
   it('should return true if the video element is currently being transcoded', () => {
@@ -33,7 +33,7 @@ describe('videoOptimization (pre-publish checklist card)', () => {
       },
     };
 
-    const result = videoElementOptimized(largeUnoptimizedVideo);
+    const result = isVideoElementOptimized(largeUnoptimizedVideo);
     expect(result).toBe(true);
   });
   it('should return true if the video element is larger than 1080x1920 and not optimized', () => {
@@ -48,7 +48,7 @@ describe('videoOptimization (pre-publish checklist card)', () => {
       },
     };
 
-    const result = videoElementOptimized(largeUnoptimizedVideo);
+    const result = isVideoElementOptimized(largeUnoptimizedVideo);
     expect(result).toBe(true);
   });
 
@@ -64,7 +64,7 @@ describe('videoOptimization (pre-publish checklist card)', () => {
       },
     };
 
-    const result = videoElementOptimized(largeUnoptimizedVideo);
+    const result = isVideoElementOptimized(largeUnoptimizedVideo);
     expect(result).toBe(false);
   });
 
@@ -90,7 +90,7 @@ describe('videoOptimization (pre-publish checklist card)', () => {
       },
     };
 
-    expect(videoElementOptimized(smallUnoptimizedVideo)).toBe(false);
-    expect(videoElementOptimized(smallOptimizedVideo)).toBe(false);
+    expect(isVideoElementOptimized(smallUnoptimizedVideo)).toBe(false);
+    expect(isVideoElementOptimized(smallOptimizedVideo)).toBe(false);
   });
 });

--- a/assets/src/edit-story/components/checklist/checks/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/videoOptimization.js
@@ -36,6 +36,7 @@ import {
 import { filterStoryElements } from '../utils/filterStoryElements';
 import { Button, BUTTON_SIZES, BUTTON_TYPES } from '../../../../design-system';
 import { useHighlights } from '../../../app/highlights';
+import { useRegisterCheck } from '../checkCountContext';
 
 const OptimizeButton = styled(Button)`
   margin-top: 4px;
@@ -102,8 +103,12 @@ export const BulkVideoOptimization = () => {
       unoptimizedVideos.some((video) => video.resource?.isTranscoding),
     [isOptimizing, unoptimizedVideos]
   );
+
+  const isRendered = unoptimizedVideos.length > 0;
+  useRegisterCheck('VideoOptimization', isRendered);
+
   return (
-    unoptimizedVideos.length > 0 && (
+    isRendered && (
       <ChecklistCard
         cta={
           <OptimizeButton

--- a/assets/src/edit-story/components/checklist/checks/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/videoOptimization.js
@@ -25,7 +25,7 @@ import styled from 'styled-components';
  */
 import { useCallback, useMemo, useRef } from 'react';
 import { useFeature } from 'flagged';
-import { useLocalMedia, useStory } from '../../../app';
+import { useConfig, useLocalMedia, useStory } from '../../../app';
 import { VIDEO_SIZE_THRESHOLD } from '../../../app/media/utils/useFFmpeg';
 import { PRIORITY_COPY } from '../constants';
 import { LayerThumbnail, Thumbnail, THUMBNAIL_TYPES } from '../../thumbnail';
@@ -59,11 +59,7 @@ export function isVideoElementOptimized(element = {}) {
     return true;
   }
 
-  if (
-    element.type !== 'video' ||
-    element.resource?.local ||
-    element.resource?.isOptimized
-  ) {
+  if (element.resource?.local || element.resource?.isOptimized) {
     return false;
   }
 
@@ -76,10 +72,17 @@ export function isVideoElementOptimized(element = {}) {
 
 export const BulkVideoOptimization = () => {
   const enableBulkVideoOptimization = useFeature('enableBulkVideoOptimization');
+  const { allowedTranscodableMimeTypes } = useConfig();
 
   const story = useStory(({ state }) => state);
   const optimizingResourcesRef = useRef({});
-  const unoptimizedVideos = filterStoryElements(story, isVideoElementOptimized);
+  const unoptimizedVideos = filterStoryElements(story, (element) => {
+    return (
+      element.type === 'video' &&
+      allowedTranscodableMimeTypes.includes(element.resource?.mimeType) &&
+      isVideoElementOptimized(element)
+    );
+  });
 
   const setHighlights = useHighlights(({ setHighlights }) => setHighlights);
 

--- a/assets/src/edit-story/components/checklist/checks/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/videoOptimization.js
@@ -45,6 +45,11 @@ import { useHighlights } from '../../../app/highlights';
 import { useRegisterCheck } from '../checkCountContext';
 import { StyledVideoOptimizationIcon } from '../../checklistCard/styles';
 
+const STATES = {
+  UPLOADING: 'UPLOADING',
+  UPLOADED: 'UPLOADED',
+};
+
 const OptimizeButton = styled(Button)`
   margin-top: 4px;
 `;
@@ -91,7 +96,7 @@ export const BulkVideoOptimization = () => {
       optimizingResources
         .map(({ resource }) => async () => {
           await optimizeVideo({ resource }).finally(() => {
-            optimizingResourcesRef.current[resource.id] = 'UPLOADED';
+            optimizingResourcesRef.current[resource.id] = STATES.UPLOADED;
           });
         })
         .reduce((p, fn) => p.then(fn), Promise.resolve())
@@ -104,7 +109,7 @@ export const BulkVideoOptimization = () => {
   const handleUpdateVideos = useCallback(async () => {
     unoptimizedVideos.forEach(({ resource }) => {
       if (!resource.isTranscoding) {
-        optimizingResourcesRef.current[resource.id] = 'UPLOADING';
+        optimizingResourcesRef.current[resource.id] = STATES.UPLOADING;
       }
     });
     await sequencedVideoOptimization();
@@ -118,13 +123,13 @@ export const BulkVideoOptimization = () => {
       });
       if (
         !element.resource?.isTranscoding &&
-        !['UPLOADING'].includes(
+        ![STATES.UPLOADING].includes(
           optimizingResourcesRef.current[element.resource.id]
         )
       ) {
-        optimizingResourcesRef.current[element.resource.id] = 'UPLOADING';
+        optimizingResourcesRef.current[element.resource.id] = STATES.UPLOADING;
         await optimizeVideo({ resource: element.resource }).finally(() => {
-          optimizingResourcesRef.current[element.resource.id] = 'UPLOADED';
+          optimizingResourcesRef.current[element.resource.id] = STATES.UPLOADED;
         });
       }
     },
@@ -135,8 +140,9 @@ export const BulkVideoOptimization = () => {
 
   const isTranscoding = useMemo(
     () =>
-      Object.values(optimizingResourcesRef.current).includes('UPLOADING') ||
-      unoptimizedVideos.some((video) => video.resource?.isTranscoding),
+      Object.values(optimizingResourcesRef.current).includes(
+        STATES.UPLOADING
+      ) || unoptimizedVideos.some((video) => video.resource?.isTranscoding),
     [unoptimizedVideos]
   );
 
@@ -190,7 +196,7 @@ export const BulkVideoOptimization = () => {
           >
             <Tooltip
               title={
-                ['UPLOADING'].includes(
+                [STATES.UPLOADING].includes(
                   optimizingResourcesRef.current[element.resource?.id]
                 ) || element.resource?.isTranscoding
                   ? __('Video optimization in progress', 'web-stories')

--- a/assets/src/edit-story/components/checklist/checks/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/videoOptimization.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { useCallback, useMemo, useState } from 'react';
+import { useLocalMedia, useStory } from '../../../app';
+import { VIDEO_SIZE_THRESHOLD } from '../../../app/media/utils/useFFmpeg';
+import { PRIORITY_COPY } from '../constants';
+import { LayerThumbnail, Thumbnail, THUMBNAIL_TYPES } from '../../thumbnail';
+import {
+  CARD_TYPE,
+  ChecklistCard,
+  DefaultFooterText,
+} from '../../checklistCard';
+import { filterStoryElements } from '../utils/filterStoryElements';
+import { Button, BUTTON_SIZES, BUTTON_TYPES } from '../../../../design-system';
+import { useHighlights } from '../../../app/highlights';
+
+const OptimizeButton = styled(Button)`
+  margin-top: 4px;
+  border: ${({ theme }) => `1px solid ${theme.colors.border.defaultNormal}`};
+`;
+
+export function videoElementOptimized(element = {}) {
+  if (element.resource?.isTranscoding) {
+    return true;
+  }
+
+  if (
+    element.type !== 'video' ||
+    element.resource?.local ||
+    element.resource?.isOptimized
+  ) {
+    return false;
+  }
+
+  const videoArea =
+    (element.resource?.height ?? 0) * (element.resource?.width ?? 0);
+  const isLargeVideo =
+    videoArea >= VIDEO_SIZE_THRESHOLD.WIDTH * VIDEO_SIZE_THRESHOLD.HEIGHT;
+  return isLargeVideo;
+}
+
+export const BulkVideoOptimization = () => {
+  const story = useStory(({ state }) => state);
+  const unoptimizedVideos = filterStoryElements(story, videoElementOptimized);
+
+  const setHighlights = useHighlights(({ setHighlights }) => setHighlights);
+
+  const { optimizeVideo } = useLocalMedia((state) => ({
+    optimizeVideo: state.actions.optimizeVideo,
+  }));
+
+  const [isOptimizing, setIsOptimizing] = useState(false);
+
+  const sequencedVideoOptimization = useCallback(() => {
+    return new Promise((res) => {
+      unoptimizedVideos
+        .filter(({ resource }) => !resource?.isTranscoding)
+        .map(({ resource }) => async () => {
+          await optimizeVideo({ resource });
+        })
+        .reduce((p, fn) => p.then(fn), Promise.resolve())
+        .then(() => {
+          res();
+        });
+    });
+  }, [unoptimizedVideos, optimizeVideo]);
+
+  const handleUpdateVideos = useCallback(async () => {
+    setIsOptimizing(true);
+    await sequencedVideoOptimization();
+    setIsOptimizing(false);
+  }, [sequencedVideoOptimization]);
+
+  const { footer, title } = PRIORITY_COPY.videoNotOptimized;
+
+  const isTranscoding = useMemo(
+    () =>
+      isOptimizing ||
+      unoptimizedVideos.some((video) => video.resource?.isTranscoding),
+    [isOptimizing, unoptimizedVideos]
+  );
+  return (
+    unoptimizedVideos.length > 0 && (
+      <ChecklistCard
+        cta={
+          <OptimizeButton
+            type={BUTTON_TYPES.TERTIARY}
+            size={BUTTON_SIZES.SMALL}
+            onClick={handleUpdateVideos}
+            disabled={isTranscoding}
+          >
+            {isTranscoding
+              ? __('Optimizing videos', 'web-stories')
+              : __('Optimize all videos', 'web-stories')}
+          </OptimizeButton>
+        }
+        title={title}
+        cardType={
+          unoptimizedVideos.length > 1
+            ? CARD_TYPE.MULTIPLE_ISSUE
+            : CARD_TYPE.SINGLE_ISSUE
+        }
+        footer={<DefaultFooterText>{footer}</DefaultFooterText>}
+        thumbnailCount={unoptimizedVideos.length}
+        thumbnail={
+          <>
+            {unoptimizedVideos.map((element) => (
+              <Thumbnail
+                key={element.id}
+                onClick={() => {
+                  setHighlights({
+                    elementId: element.id,
+                  });
+                }}
+                isLoading={element.resource?.isTranscoding}
+                type={THUMBNAIL_TYPES.VIDEO}
+                displayBackground={<LayerThumbnail page={element} />}
+                aria-label={__('Go to offending video', 'web-stories')}
+              />
+            ))}
+          </>
+        }
+      />
+    )
+  );
+};
+
+export default BulkVideoOptimization;

--- a/assets/src/edit-story/components/checklist/checks/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/videoOptimization.js
@@ -25,6 +25,12 @@ import styled from 'styled-components';
  */
 import { useCallback, useMemo, useReducer } from 'react';
 import { useFeature } from 'flagged';
+import {
+  Button,
+  BUTTON_SIZES,
+  BUTTON_TYPES,
+  Tooltip,
+} from '@web-stories-wp/design-system';
 import { useLocalMedia, useStory } from '../../../app';
 import { VIDEO_SIZE_THRESHOLD } from '../../../app/media/utils/useFFmpeg';
 import { PRIORITY_COPY } from '../constants';
@@ -35,14 +41,8 @@ import {
   DefaultFooterText,
 } from '../../checklistCard';
 import { filterStoryElements } from '../utils/filterStoryElements';
-import {
-  Button,
-  BUTTON_SIZES,
-  BUTTON_TYPES,
-  Tooltip,
-} from '../../../../design-system';
 import { useHighlights } from '../../../app/highlights';
-import { useRegisterCheck } from '../checkCountContext';
+import { useRegisterCheck } from '../countContext';
 import { StyledVideoOptimizationIcon } from '../../checklistCard/styles';
 
 const OptimizeButton = styled(Button)`

--- a/assets/src/edit-story/components/checklist/checks/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/videoOptimization.js
@@ -43,7 +43,7 @@ const OptimizeButton = styled(Button)`
   border: ${({ theme }) => `1px solid ${theme.colors.border.defaultNormal}`};
 `;
 
-export function videoElementOptimized(element = {}) {
+export function isVideoElementOptimized(element = {}) {
   if (element.resource?.isTranscoding) {
     return true;
   }
@@ -65,7 +65,7 @@ export function videoElementOptimized(element = {}) {
 
 export const BulkVideoOptimization = () => {
   const story = useStory(({ state }) => state);
-  const unoptimizedVideos = filterStoryElements(story, videoElementOptimized);
+  const unoptimizedVideos = filterStoryElements(story, isVideoElementOptimized);
 
   const setHighlights = useHighlights(({ setHighlights }) => setHighlights);
 

--- a/assets/src/edit-story/components/checklist/constants.js
+++ b/assets/src/edit-story/components/checklist/constants.js
@@ -38,7 +38,6 @@ export const MAX_VIDEO_LENGTH_SECONDS = 60;
 const MAX_VIDEO_LENGTH_MINUTES = Math.floor(MAX_VIDEO_LENGTH_SECONDS / 60);
 const MIN_TAP_REGION_WIDTH = 48;
 export const MAX_LINKS_PER_PAGE = 3;
-const MAX_VIDEO_RESOLUTION = 720;
 const MIN_VIDEO_RESOLUTION = 480;
 const MIN_VIDEO_FPS = 24;
 const POSTER_DIMENSION_WIDTH_PX = 640;
@@ -459,15 +458,8 @@ export const PRIORITY_COPY = {
     ),
   },
   videoNotOptimized: {
-    title: __('Optimize videos', 'web-stories'),
-    footer: sprintf(
-      /* translators: %s: video resolution (720p) */
-      __(
-        'Videos larger than %s can cause slower loading and higher bandwidth costs.',
-        'web-stories'
-      ),
-      `${MAX_VIDEO_RESOLUTION}p`
-    ),
+    title: __('Videos not optimized', 'web-stories'),
+    footer: __('Unoptimized videos may cause playback issues.', 'web-stories'),
   },
 };
 

--- a/assets/src/edit-story/components/checklist/constants.js
+++ b/assets/src/edit-story/components/checklist/constants.js
@@ -38,6 +38,7 @@ export const MAX_VIDEO_LENGTH_SECONDS = 60;
 const MAX_VIDEO_LENGTH_MINUTES = Math.floor(MAX_VIDEO_LENGTH_SECONDS / 60);
 const MIN_TAP_REGION_WIDTH = 48;
 export const MAX_LINKS_PER_PAGE = 3;
+const MAX_VIDEO_RESOLUTION = 720;
 const MIN_VIDEO_RESOLUTION = 480;
 const MIN_VIDEO_FPS = 24;
 const POSTER_DIMENSION_WIDTH_PX = 640;
@@ -458,8 +459,15 @@ export const PRIORITY_COPY = {
     ),
   },
   videoNotOptimized: {
-    title: __('Videos not optimized', 'web-stories'),
-    footer: __('Unoptimized videos may cause playback issues.', 'web-stories'),
+    title: __('Optimize videos', 'web-stories'),
+    footer: sprintf(
+      /* translators: %s: video resolution (720p) */
+      __(
+        'Videos larger than %s can cause slower loading and higher bandwidth costs.',
+        'web-stories'
+      ),
+      `${MAX_VIDEO_RESOLUTION}p`
+    ),
   },
 };
 

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -219,7 +219,7 @@ class Experiments extends Service_Base {
 	 */
 	public function get_experiments() {
 		return [
-      /**
+			/**
 			 * Author: @embarks
 			 * Issue: 8113
 			 * Creation date: 2021-06-28

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -219,6 +219,17 @@ class Experiments extends Service_Base {
 	 */
 	public function get_experiments() {
 		return [
+      /**
+			 * Author: @embarks
+			 * Issue: 8113
+			 * Creation date: 2021-06-28
+			 */
+			[
+				'name'        => 'enableBulkVideoOptimization',
+				'label'       => __( 'Enable bulk video optimization', 'web-stories' ),
+				'description' => __( 'Enables an option to optimize multiple videos at once in v2 of prepublish checklist.', 'web-stories' ),
+				'group'       => 'editor',
+			], 
 			/**
 			 * Author: @littlemilkstudio
 			 * Issue: 7965


### PR DESCRIPTION
## Context
This PR adds the Video Optimization card to the priority issues.
- I tried out a sequenced promise approach here in the original structure: https://github.com/google/web-stories-wp/pull/7922 and we decided to block that ticket to focus on restructuring the PPC. Now that a lot of the bulk work is done there, I'm revisiting this particular card now in this PR.
- I am using the sequenced for each approach to get the styles done for the PPC and make the optimize video option available to users, though there may be some perf issues. (see thread linked above)
 
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- add video optimization card under /checks
- add VideoOptimization component to the priorityChecks list
- updated the failure snackbar to include a thumbnail of the video in case of failure
- update the video check so that it includes currently transcoding videos so we can show the loading indicator
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- noticed the checklist is not showing overflow, might be hard to see the check until whale's nice panel work is in. I commented out the other checks under `priorityChecks` and `accessibilityChecks` so I could see it for manual testing.
- There are definite perf issues with this impl depending on the resources available or what browser you're using, but in Chrome it can optimize several (I tried ~4-5) short videos pretty well! This is why I tried sequencing the upload promises, so expensive operations didn't occur all at once. Definite improvement on `Promise.all([ /*optimizeVideo*/ ])` but transcodes still occur in parallel in threads.
- for now, I am disabling the optimize button if any transcodes are happening, whether they were triggered by PPC or not.
<!-- Please describe your changes. -->

## To-do
- [x] investigate/fix issue with single videos (not in Firefox) if it is related to my code, otherwise create a bug ticket
- [x] set poster in snackbar if it exists
- [x] fix test descriptions
- [x] add the auto optimize checkbox
- [x] optional chaining on resource.alt
- [x] fix optimize button styles
- [x] add a tooltip to the optimize button
- [x] optimize single video from tooltip
- [x] use register hook
- [x] copy/display case for a single video
- [x] add a feature flag and wrap the "optimize all videos" button to distinguish it as a separate feature
- [x] change name of videoElementOptimized function
- [x] error handling
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

![Screen Shot 2021-06-24 at 4 08 17 PM](https://user-images.githubusercontent.com/41136059/123345474-0038a180-d50b-11eb-8337-ce75315ab441.png)
![Screen Shot 2021-06-24 at 5 03 37 PM](https://user-images.githubusercontent.com/41136059/123349848-a0dc9080-d50e-11eb-8a5e-c928c2a3c023.png)
![Screen Shot 2021-06-24 at 5 03 49 PM](https://user-images.githubusercontent.com/41136059/123349851-a1752700-d50e-11eb-8677-f1f384cbeaf5.png)
![Screen Shot 2021-06-24 at 5 03 27 PM](https://user-images.githubusercontent.com/41136059/123349852-a1752700-d50e-11eb-8967-89ec0006d1bb.png)
![Screen Shot 2021-06-24 at 5 02 26 PM](https://user-images.githubusercontent.com/41136059/123349855-a20dbd80-d50e-11eb-93de-c9dd83c39938.png)
![Screen Shot 2021-06-24 at 4 52 37 PM](https://user-images.githubusercontent.com/41136059/123349856-a20dbd80-d50e-11eb-8912-baf808e26b2d.png)
![Screen Shot 2021-06-24 at 4 52 27 PM](https://user-images.githubusercontent.com/41136059/123349858-a2a65400-d50e-11eb-8ce2-7cc0c3a0a779.png)
![Screen Shot 2021-06-24 at 4 52 16 PM](https://user-images.githubusercontent.com/41136059/123349860-a2a65400-d50e-11eb-859d-98956475aa36.png)

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7309