### PR TITLE
Fix assets version for 1.8.0 branch

### DIFF
--- a/web-stories.php
+++ b/web-stories.php
@@ -49,7 +49,7 @@ define( 'WEBSTORIES_PLUGIN_DIR_URL', plugin_dir_url( WEBSTORIES_PLUGIN_FILE ) );
 define( 'WEBSTORIES_ASSETS_URL', WEBSTORIES_PLUGIN_DIR_URL . 'assets' );
 define( 'WEBSTORIES_MINIMUM_PHP_VERSION', '5.6' );
 define( 'WEBSTORIES_MINIMUM_WP_VERSION', '5.3' );
-define( 'WEBSTORIES_CDN_URL', 'https://wp.stories.google/static/main' );
+define( 'WEBSTORIES_CDN_URL', 'https://wp.stories.google/static/9' );
 
 if ( ! defined( 'WEBSTORIES_DEV_MODE' ) ) {
 	define( 'WEBSTORIES_DEV_MODE', false );


### PR DESCRIPTION
Assets have been updated in 26051c61440478f2c81e4111b7cb32a412edd17a.

This includes the assets for the new templates we’ll ship with 1.8.1

Fixes #8045