### PR TITLE
PPCv2.0 - Only allow 1 popup at a time

### DIFF
--- a/assets/src/edit-story/components/carousel/carouselContainer.js
+++ b/assets/src/edit-story/components/carousel/carouselContainer.js
@@ -24,6 +24,7 @@ import { useMemo, useRef, useState } from 'react';
  * Internal dependencies
  */
 import { useResizeEffect } from '../../../design-system';
+import { ChecklistProvider } from '../checklist';
 import CarouselLayout from './carouselLayout';
 import CarouselProvider from './carouselProvider';
 import { VERY_WIDE_WORKSPACE_LIMIT, VERY_WIDE_MARGIN } from './constants';
@@ -48,11 +49,13 @@ function CarouselContainer() {
 
   return (
     <CarouselProvider availableSpace={width}>
-      <Outer ref={ref}>
-        <Inner marginRight={margin}>
-          <CarouselLayout />
-        </Inner>
-      </Outer>
+      <ChecklistProvider>
+        <Outer ref={ref}>
+          <Inner marginRight={margin}>
+            <CarouselLayout />
+          </Inner>
+        </Outer>
+      </ChecklistProvider>
     </CarouselProvider>
   );
 }

--- a/assets/src/edit-story/components/carousel/karma/popups.karma.js
+++ b/assets/src/edit-story/components/carousel/karma/popups.karma.js
@@ -32,17 +32,13 @@ describe('Popup Menus - Help Center and Checklist', () => {
     fixture.restore();
   });
 
-  it('should start with both popups closed', async () => {
+  it('should start with both popups closed', () => {
     const { helpCenterToggle, checklistToggle } = fixture.editor.carousel;
 
     expect(helpCenterToggle).toBeDefined();
     expect(checklistToggle).toBeDefined();
 
-    const checklistDialog = await fixture.screen.queryByRole('dialog', {
-      name: /^Checklist/,
-    });
-
-    expect(checklistDialog).toBeNull();
+    expect(fixture.editor.checklist.issues).toBeNull();
     expect(fixture.editor.helpCenter.quickTips).toBeNull();
   });
 
@@ -54,13 +50,9 @@ describe('Popup Menus - Help Center and Checklist', () => {
     expect(quickTips).toBeDefined();
 
     await fixture.events.click(checklistToggle);
-    // TODO FIX ONCE SAMUEL'S PR IS MERGED
-    const checklistHeader = await fixture.screen.getByRole('dialog', {
-      name: /^Checklist/,
-    });
     await fixture.events.sleep(500);
 
-    expect(checklistHeader).toBeDefined();
+    expect(fixture.editor.checklist.issues).toBeDefined();
     expect(fixture.editor.helpCenter.quickTips).toBeNull();
   });
 
@@ -69,11 +61,7 @@ describe('Popup Menus - Help Center and Checklist', () => {
 
     await fixture.events.click(checklistToggle);
 
-    const checklistHeader = await fixture.screen.getByRole('dialog', {
-      name: /^Checklist/,
-    });
-
-    expect(checklistHeader).toBeDefined();
+    expect(fixture.editor.checklist.issues).toBeDefined();
     expect(fixture.editor.helpCenter.quickTips).toBeNull();
 
     await fixture.events.click(helpCenterToggle);
@@ -83,10 +71,6 @@ describe('Popup Menus - Help Center and Checklist', () => {
     await fixture.events.sleep(500);
 
     expect(quickTips).toBeDefined();
-    expect(
-      fixture.screen.queryAllByRole('dialog', {
-        name: /^Checklist/,
-      })
-    ).toEqual([]);
+    expect(fixture.editor.checklist.issues).toBeNull();
   });
 });

--- a/assets/src/edit-story/components/carousel/karma/popups.karma.js
+++ b/assets/src/edit-story/components/carousel/karma/popups.karma.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Fixture } from '../../../karma';
+
+describe('Popup Menus - Help Center and Checklist', () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = new Fixture();
+    fixture.setFlags({ enableChecklistCompanion: true });
+    await fixture.render();
+  });
+
+  afterEach(() => {
+    fixture.restore();
+  });
+
+  it('should start with both popups closed', () => {
+    const { helpCenterToggle, checklistToggle } = fixture.editor.carousel;
+
+    expect(helpCenterToggle).toBeDefined();
+    expect(checklistToggle).toBeDefined();
+  });
+
+  it('should collapse helpCenter when checklist is expanded', async () => {
+    const { helpCenterToggle, checklistToggle } = fixture.editor.carousel;
+    await fixture.events.click(helpCenterToggle);
+
+    const { quickTips } = await fixture.editor.helpCenter;
+    expect(quickTips).toBeDefined();
+
+    await fixture.events.click(checklistToggle);
+    const checklistHeader = await fixture.screen.getByRole('dialog', {
+      name: /^Checklist/,
+    });
+    await fixture.events.sleep(500);
+
+    expect(checklistHeader).toBeDefined();
+    expect(fixture.editor.helpCenter.quickTips).toBeNull();
+  });
+
+  it('should collapse checklist when helpCenter is expanded', async () => {
+    const { helpCenterToggle, checklistToggle } = fixture.editor.carousel;
+
+    await fixture.events.click(checklistToggle);
+
+    const checklistHeader = await fixture.screen.getByRole('dialog', {
+      name: /^Checklist/,
+    });
+
+    expect(checklistHeader).toBeDefined();
+    expect(fixture.editor.helpCenter.quickTips).toBeNull();
+
+    await fixture.events.click(helpCenterToggle);
+
+    const { quickTips } = await fixture.editor.helpCenter;
+
+    await fixture.events.sleep(500);
+
+    expect(quickTips).toBeDefined();
+    expect(
+      fixture.screen.queryAllByRole('dialog', {
+        name: /^Checklist/,
+      })
+    ).toEqual([]);
+  });
+});

--- a/assets/src/edit-story/components/carousel/karma/popups.karma.js
+++ b/assets/src/edit-story/components/carousel/karma/popups.karma.js
@@ -32,11 +32,18 @@ describe('Popup Menus - Help Center and Checklist', () => {
     fixture.restore();
   });
 
-  it('should start with both popups closed', () => {
+  it('should start with both popups closed', async () => {
     const { helpCenterToggle, checklistToggle } = fixture.editor.carousel;
 
     expect(helpCenterToggle).toBeDefined();
     expect(checklistToggle).toBeDefined();
+
+    const checklistDialog = await fixture.screen.queryByRole('dialog', {
+      name: /^Checklist/,
+    });
+
+    expect(checklistDialog).toBeNull();
+    expect(fixture.editor.helpCenter.quickTips).toBeNull();
   });
 
   it('should collapse helpCenter when checklist is expanded', async () => {
@@ -47,6 +54,7 @@ describe('Popup Menus - Help Center and Checklist', () => {
     expect(quickTips).toBeDefined();
 
     await fixture.events.click(checklistToggle);
+    // TODO FIX ONCE SAMUEL'S PR IS MERGED
     const checklistHeader = await fixture.screen.getByRole('dialog', {
       name: /^Checklist/,
     });

--- a/assets/src/edit-story/components/carousel/secondaryMenu.js
+++ b/assets/src/edit-story/components/carousel/secondaryMenu.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import { useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -25,7 +26,8 @@ import styled from 'styled-components';
 import { useFeature } from 'flagged';
 import KeyboardShortcutsMenu from '../keyboardShortcutsMenu';
 import { HelpCenter } from '../helpCenter';
-import { Checklist } from '../checklist';
+import { Checklist, useChecklist } from '../checklist';
+import { useHelpCenter } from '../../app';
 
 const Wrapper = styled.div`
   display: flex;
@@ -56,6 +58,34 @@ const Space = styled.span`
 `;
 
 function SecondaryMenu() {
+  const { close: closeHelpCenter, isHelpCenterOpen } = useHelpCenter(
+    ({ actions: { close }, state: { isOpen: isHelpCenterOpen } }) => ({
+      close,
+      isHelpCenterOpen,
+    })
+  );
+
+  const { close: closeChecklist, isChecklistOpen } = useChecklist(
+    ({ actions: { close }, state: { isOpen: isChecklistOpen } }) => ({
+      close,
+      isChecklistOpen,
+    })
+  );
+
+  // Only one popup is open at a time
+  // we want to close an open popup if a new one is opened.
+  useEffect(() => {
+    if (isChecklistOpen) {
+      closeHelpCenter();
+    }
+  }, [closeHelpCenter, isChecklistOpen]);
+
+  useEffect(() => {
+    if (isHelpCenterOpen) {
+      closeChecklist();
+    }
+  }, [closeChecklist, isHelpCenterOpen]);
+
   const enableChecklistCompanion = useFeature('enableChecklistCompanion');
   return (
     <Wrapper>

--- a/assets/src/edit-story/components/checklist/context/context.js
+++ b/assets/src/edit-story/components/checklist/context/context.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { createContext } from '../../../../design-system/utils/context';
+
+export default createContext({ state: {}, actions: {} });

--- a/assets/src/edit-story/components/checklist/context/index.js
+++ b/assets/src/edit-story/components/checklist/context/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as ChecklistProvider } from './provider';
+export { useChecklist } from './useChecklist';

--- a/assets/src/edit-story/components/checklist/context/provider.js
+++ b/assets/src/edit-story/components/checklist/context/provider.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { useState, useMemo, useCallback } from 'react';
+import { trackEvent } from '@web-stories-wp/tracking';
+
+/**
+ * Internal dependencies
+ */
+import Context from './context';
+
+const ChecklistProvider = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggle = useCallback(() => {
+    trackEvent('checklist_toggled', {
+      status: isOpen ? 'closed' : 'open',
+    });
+    setIsOpen((prevVal) => !prevVal);
+  }, [isOpen]);
+
+  const close = useCallback(() => {
+    trackEvent('checklist_toggled', {
+      status: 'closed',
+    });
+    setIsOpen(false);
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      state: {
+        isOpen,
+      },
+      actions: {
+        toggle,
+        close,
+      },
+    }),
+    [close, isOpen, toggle]
+  );
+
+  return <Context.Provider value={contextValue}>{children}</Context.Provider>;
+};
+
+ChecklistProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+export default ChecklistProvider;

--- a/assets/src/edit-story/components/checklist/context/test/index.js
+++ b/assets/src/edit-story/components/checklist/context/test/index.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { renderHook, act } from '@testing-library/react-hooks';
+/**
+ * Internal dependencies
+ */
+import { ChecklistProvider, useChecklist } from '..';
+
+function setup() {
+  const wrapper = ({ children }) => (
+    <ChecklistProvider>{children}</ChecklistProvider>
+  );
+
+  return renderHook(() => useChecklist(), { wrapper });
+}
+
+describe('useChecklist', () => {
+  it('returns isOpen as false by default', () => {
+    const { result } = setup();
+
+    expect(result.current.state.isOpen).toBe(false);
+  });
+
+  it('updates `isOpen` to false when close fires', async () => {
+    const { result } = setup();
+
+    await act(() => result.current.actions.toggle());
+    expect(result.current.state.isOpen).toBe(true);
+
+    await act(() => result.current.actions.close());
+    expect(result.current.state.isOpen).toBe(false);
+  });
+});

--- a/assets/src/edit-story/components/checklist/context/useChecklist.js
+++ b/assets/src/edit-story/components/checklist/context/useChecklist.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { useContextSelector, identity } from '../../../../design-system';
+import Context from './context';
+
+export function useChecklist(selector) {
+  const context = useContextSelector(Context, selector ?? identity);
+  if (!context) {
+    throw new Error('Must use `useChecklist` within <checklist.Provider />');
+  }
+  return context;
+}

--- a/assets/src/edit-story/components/checklist/index.js
+++ b/assets/src/edit-story/components/checklist/index.js
@@ -23,9 +23,7 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { useFocusOut } from '../../../design-system';
 import { FOCUSABLE_SELECTORS } from '../../constants';
-import { useHelpCenter } from '../../app';
 import DirectionAware from '../directionAware';
 import { Popup } from '../helpCenter/popup';
 import { NavigationWrapper } from '../helpCenter/navigator';
@@ -44,6 +42,7 @@ import { AccessibilityChecks } from './accessibilityChecks';
 import { PriorityChecks } from './priorityChecks';
 import { ChecklistCountProvider } from './checkCountContext';
 import EmptyContentCheck from './emptyContent';
+import { useChecklist } from './context';
 
 const Wrapper = styled.div`
   /**
@@ -55,13 +54,11 @@ const Wrapper = styled.div`
 `;
 
 export function Checklist() {
-  const navRef = useRef();
-  const wrapperRef = useRef();
-  const [isOpen, setIsOpen] = useState(false);
-  const { close: closeHelpCenter } = useHelpCenter(
-    ({ actions: { close }, state: { isOpen: isHelpCenterOpen } }) => ({
+  const { close, toggle, isOpen } = useChecklist(
+    ({ actions: { close, toggle }, state: { isOpen } }) => ({
       close,
-      isHelpCenterOpen,
+      toggle,
+      isOpen,
     })
   );
 
@@ -73,6 +70,7 @@ export function Checklist() {
       ),
     []
   );
+  const navRef = useRef();
 
   // Set Focus within the popup on open
   useEffect(() => {
@@ -84,20 +82,14 @@ export function Checklist() {
     }
   }, [isOpen]);
 
-  // Close this popup when focus leaves
-  // this also functions to close this popup
-  // when either the help center or keyboard
-  // actions are open.
-  useFocusOut(wrapperRef, () => setIsOpen(false), []);
-
   return (
     <DirectionAware>
       <ChecklistCountProvider>
-        <Wrapper role="region" aria-label={CHECKLIST_TITLE} ref={wrapperRef}>
+        <Wrapper role="region" aria-label={CHECKLIST_TITLE}>
           <Popup popupId={POPUP_ID} isOpen={isOpen} ariaLabel={CHECKLIST_TITLE}>
             <NavigationWrapper ref={navRef} isOpen={isOpen}>
               <TopNavigation
-                onClose={() => setIsOpen(false)}
+                onClose={close}
                 label={CHECKLIST_TITLE}
                 popupId={POPUP_ID}
               />
@@ -126,16 +118,11 @@ export function Checklist() {
               <EmptyContentCheck />
             </NavigationWrapper>
           </Popup>
-          <Toggle
-            isOpen={isOpen}
-            onClick={() => {
-              closeHelpCenter();
-              setIsOpen((v) => !v);
-            }}
-            popupId={POPUP_ID}
-          />
+          <Toggle isOpen={isOpen} onClick={toggle} popupId={POPUP_ID} />
         </Wrapper>
       </ChecklistCountProvider>
     </DirectionAware>
   );
 }
+
+export { ChecklistProvider, useChecklist } from './context';

--- a/assets/src/edit-story/karma/fixture/containers/carousel.js
+++ b/assets/src/edit-story/karma/fixture/containers/carousel.js
@@ -51,6 +51,14 @@ export class Carousel extends Container {
     return this.getByRole('button', { name: 'Grid View' });
   }
 
+  get helpCenterToggle() {
+    return this.getByRole('button', { name: /^Help Center/ });
+  }
+
+  get checklistToggle() {
+    return this.getByRole('button', { name: /^Checklist/ });
+  }
+
   get zoomSelector() {
     return this._get(
       this.getByRole('button', { name: 'Zoom Level' }),


### PR DESCRIPTION
## Context

Part of work to move checklist out of inspector and next to help center. 

## Summary

Now that we have 2 popups right next to each other we need to manage their state more closely to make sure only 1 of them is ever open at once. 

## Relevant Technical Choices

- close a previously open popup when a new one opens in the carousel secondaryMenu (help center and checklist). 
- Adding some very basic context to checklist to control isOpen as a toggle and close, mirroring the semantics in the helpCenter. 
- Remove focusOut for checklist so that we can focus issues with our highlight structure and keep the checklist open. 


## To-do

I'd like to move the `ChecklistCategoryProvider` into its own directory within `/checklist` when this feature is wrapping up since I'm adding `useChecklist` (which feels like it definitely is separate) 

## User-facing changes

None, unless you have the new checklist experiment turned on.  

Now you can click on an issue in the checklist and the checklist remains open even though focus moves:
![focus without close](https://user-images.githubusercontent.com/10720454/123832993-c70d8200-d8ba-11eb-9034-4bfd705311fb.gif)

One popup is open at a time:
![one popup](https://user-images.githubusercontent.com/10720454/123833004-c83eaf00-d8ba-11eb-8d09-65c363be34a4.gif)


## Testing Instructions

Turn the new checklist experiment on and expand the help center, now toggle open the checklist. The help center should close. If you now click back on the help center the checklist should close. 

Try testing this with all of the help center tips unread and your local state cleared so that you get the initial help center expanded state on load. 

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #7917 
