### PR TITLE
PPC 2.0: Update title length check in pre-publish checklist from 40 to 70 characters

### DIFF
--- a/assets/src/edit-story/app/prepublish/constants.js
+++ b/assets/src/edit-story/app/prepublish/constants.js
@@ -24,7 +24,7 @@ import { Link, THEME_CONSTANTS } from '@web-stories-wp/design-system';
 export const MIN_STORY_PAGES = 4;
 export const MAX_STORY_PAGES = 30;
 export const MAX_STORY_TITLE_LENGTH_WORDS = 10;
-export const MAX_STORY_TITLE_LENGTH_CHARS = 40;
+export const MAX_STORY_TITLE_LENGTH_CHARS = 70;
 const POSTER_DIMENSION_WIDTH_PX = 640;
 const POSTER_DIMENSION_HEIGHT_PX = 853;
 export const ASPECT_RATIO_LEFT = 3;
@@ -405,7 +405,7 @@ export const MESSAGES = {
     },
     STORY_TITLE_TOO_LONG: {
       MAIN_TEXT: sprintf(
-        /* translators: %d: minimum number of story characters. */
+        /* translators: %d: maximum number of story characters. */
         _n(
           'Shorten title to fewer than %d character',
           'Shorten title to fewer than %d characters',

--- a/assets/src/edit-story/app/prepublish/guidance/test/general.js
+++ b/assets/src/edit-story/app/prepublish/guidance/test/general.js
@@ -71,10 +71,10 @@ describe('Pre-publish checklist - general guidelines (guidance)', () => {
     expect(test).not.toBeUndefined();
 
     render(test.help);
-    screen.getByText(/40 characters/);
+    screen.getByText(/70 characters/);
     expect(test.type).toStrictEqual(PRE_PUBLISH_MESSAGE_TYPES.GUIDANCE);
     expect(test.message).toMatchInlineSnapshot(
-      `"Shorten title to fewer than 40 characters"`
+      `"Shorten title to fewer than 70 characters"`
     );
     expect(test.storyId).toStrictEqual(testStory.id);
     expect(testUndefined).toBeUndefined();

--- a/assets/src/edit-story/app/prepublish/test/__snapshots__/getPrepublishErrors.js.snap
+++ b/assets/src/edit-story/app/prepublish/test/__snapshots__/getPrepublishErrors.js.snap
@@ -28,7 +28,7 @@ Array [
         Keep under 10 words
       </li>
       <li>
-        Don't exceed 40 characters
+        Don't exceed 70 characters
       </li>
     </ul>,
     "highlight": "STORY_TITLE",

--- a/assets/src/edit-story/components/checklist/checks/imageElementResolution.js
+++ b/assets/src/edit-story/components/checklist/checks/imageElementResolution.js
@@ -19,7 +19,7 @@
  */
 import { useCallback, useMemo } from 'react';
 import { __ } from '@web-stories-wp/i18n';
-import { List } from '@web-stories-wp/design-system';
+import { List, THEME_CONSTANTS } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -96,7 +96,9 @@ const ImageElementResolution = () => {
         }
         footer={
           <ChecklistCardStyles.CardListWrapper>
-            <List>{footer}</List>
+            <List size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+              {footer}
+            </List>
           </ChecklistCardStyles.CardListWrapper>
         }
         thumbnailCount={failingElements.length}

--- a/assets/src/edit-story/components/checklist/checks/pageTooMuchText.js
+++ b/assets/src/edit-story/components/checklist/checks/pageTooMuchText.js
@@ -18,7 +18,7 @@
  */
 import { useCallback, useMemo } from 'react';
 import { __ } from '@web-stories-wp/i18n';
-import { List } from '@web-stories-wp/design-system';
+import { List, THEME_CONSTANTS } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -88,7 +88,9 @@ const PageTooMuchText = () => {
         }
         footer={
           <ChecklistCardStyles.CardListWrapper>
-            <List>{footer}</List>
+            <List size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+              {footer}
+            </List>
           </ChecklistCardStyles.CardListWrapper>
         }
         thumbnailCount={failingPages.length}

--- a/assets/src/edit-story/components/checklist/checks/publisherLogoSize.js
+++ b/assets/src/edit-story/components/checklist/checks/publisherLogoSize.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import { useCallback } from 'react';
-import { List } from '@web-stories-wp/design-system';
+import { List, THEME_CONSTANTS } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -59,7 +59,9 @@ const PublisherLogoSize = () => {
         }}
         footer={
           <ChecklistCardStyles.CardListWrapper>
-            <List>{footer}</List>
+            <List size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+              {footer}
+            </List>
           </ChecklistCardStyles.CardListWrapper>
         }
       />

--- a/assets/src/edit-story/components/checklist/checks/storyMissingTitle.js
+++ b/assets/src/edit-story/components/checklist/checks/storyMissingTitle.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import { useCallback } from 'react';
-import { List } from '@web-stories-wp/design-system';
+import { List, THEME_CONSTANTS } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -56,7 +56,9 @@ const StoryMissingTitle = () => {
         }}
         footer={
           <ChecklistCardStyles.CardListWrapper>
-            <List>{footer}</List>
+            <List size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+              {footer}
+            </List>
           </ChecklistCardStyles.CardListWrapper>
         }
       />

--- a/assets/src/edit-story/components/checklist/checks/storyPosterAspectRatio.js
+++ b/assets/src/edit-story/components/checklist/checks/storyPosterAspectRatio.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import { useCallback } from 'react';
-import { List } from '@web-stories-wp/design-system';
+import { List, THEME_CONSTANTS } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -74,7 +74,9 @@ const StoryPosterAspectRatio = () => {
         }}
         footer={
           <ChecklistCardStyles.CardListWrapper>
-            <List>{footer}</List>
+            <List size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+              {footer}
+            </List>
           </ChecklistCardStyles.CardListWrapper>
         }
       />

--- a/assets/src/edit-story/components/checklist/checks/storyPosterAttached.js
+++ b/assets/src/edit-story/components/checklist/checks/storyPosterAttached.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import { useCallback } from 'react';
-import { List } from '@web-stories-wp/design-system';
+import { List, THEME_CONSTANTS } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -60,7 +60,9 @@ export function StoryPosterAttached() {
         }}
         footer={
           <ChecklistCardStyles.CardListWrapper>
-            <List>{footer}</List>
+            <List size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+              {footer}
+            </List>
           </ChecklistCardStyles.CardListWrapper>
         }
       />

--- a/assets/src/edit-story/components/checklist/checks/storyPosterPortraitSize.js
+++ b/assets/src/edit-story/components/checklist/checks/storyPosterPortraitSize.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import { useCallback } from 'react';
-import { List } from '@web-stories-wp/design-system';
+import { List, THEME_CONSTANTS } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -67,7 +67,9 @@ const StoryPosterPortraitSize = () => {
         }}
         footer={
           <ChecklistCardStyles.CardListWrapper>
-            <List>{footer}</List>
+            <List size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}>
+              {footer}
+            </List>
           </ChecklistCardStyles.CardListWrapper>
         }
       />

--- a/assets/src/edit-story/components/checklist/constants.js
+++ b/assets/src/edit-story/components/checklist/constants.js
@@ -33,7 +33,7 @@ export const MAX_PAGE_CHARACTER_COUNT = 200;
 export const MIN_STORY_PAGES = 4;
 export const MAX_STORY_PAGES = 30;
 export const MAX_STORY_TITLE_LENGTH_WORDS = 10;
-export const MAX_STORY_TITLE_LENGTH_CHARS = 40;
+export const MAX_STORY_TITLE_LENGTH_CHARS = 70;
 export const MAX_VIDEO_LENGTH_SECONDS = 60;
 const MAX_VIDEO_LENGTH_MINUTES = Math.floor(MAX_VIDEO_LENGTH_SECONDS / 60);
 const MIN_TAP_REGION_WIDTH = 48;
@@ -363,7 +363,7 @@ export const PRIORITY_COPY = {
   },
   storyTitleTooLong: {
     title: sprintf(
-      /* translators: %d: minimum number of story characters. */
+      /* translators: %d: maximum number of story characters. */
       _n(
         'Shorten title to fewer than %d character',
         'Shorten title to fewer than %d characters',


### PR DESCRIPTION
## Context

PPC 2.0

## Summary

- Update max title length from 40 to 70 characters (for the checklist)
- Update font size for card footers to 12px to match designs and other cards

## Relevant Technical Choices

There was two different font sizes in the new checklist for the footer text - I checked the [designs](https://www.figma.com/file/1YM3jA9h4QGc4xLdyaXIJS/Stories-Sprint-1.7?node-id=8378%3A3528) and saw that the list elements should have a font size of 12px. Decided to update that here since it should be quick.

## To-do

- [x] update spreadsheet of copy text

## User-facing changes

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/22185279/124018592-3eb7db80-d9a5-11eb-99f1-33e3cc04ee44.png)|![image](https://user-images.githubusercontent.com/22185279/124018329-f7314f80-d9a4-11eb-9f6a-920127f6896c.png)|

## Testing Instructions

1. Turn on ppc 2.0 experiment
2. Go to editor
3. Make sure the title is empty or less than 10 characters
4. Open the checklist to see the error and the updated card styles

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8119
