### PR TITLE
PPC 2.0: Popup Height on smaller screens

### DIFF
--- a/assets/src/edit-story/components/carousel/karma/popups.karma.js
+++ b/assets/src/edit-story/components/carousel/karma/popups.karma.js
@@ -38,9 +38,6 @@ describe('Popup Menus - Help Center and Checklist', () => {
     expect(helpCenterToggle).toBeDefined();
     expect(checklistToggle).toBeDefined();
 
-    expect(
-      fixture.editor.checklist.issues.getAttribute('data-isexpanded')
-    ).toBe('false');
     expect(fixture.editor.helpCenter.quickTips).toBeNull();
   });
 
@@ -77,8 +74,5 @@ describe('Popup Menus - Help Center and Checklist', () => {
     await fixture.events.sleep(500);
 
     expect(quickTips).toBeDefined();
-    expect(
-      fixture.editor.checklist.issues.getAttribute('data-isexpanded')
-    ).toBe('false');
   });
 });

--- a/assets/src/edit-story/components/carousel/secondaryMenu.js
+++ b/assets/src/edit-story/components/carousel/secondaryMenu.js
@@ -27,7 +27,12 @@ import { useFeature } from 'flagged';
 import KeyboardShortcutsMenu from '../keyboardShortcutsMenu';
 import { HelpCenter } from '../helpCenter';
 import { useHelpCenter } from '../../app';
-import { Checklist, useChecklist, useCheckpoint } from '../checklist';
+import {
+  Checklist,
+  ChecklistCountProvider,
+  useChecklist,
+  useCheckpoint,
+} from '../checklist';
 
 const Wrapper = styled.div`
   display: flex;
@@ -116,7 +121,9 @@ function SecondaryMenu() {
         <Space />
         {enableChecklistCompanion && (
           <>
-            <Checklist />
+            <ChecklistCountProvider>
+              <Checklist />
+            </ChecklistCountProvider>
             <Space />
           </>
         )}

--- a/assets/src/edit-story/components/checklist/checklist.js
+++ b/assets/src/edit-story/components/checklist/checklist.js
@@ -36,6 +36,7 @@ import {
   ISSUE_TYPES,
   POPUP_ID,
   PANEL_EXPANSION_BY_CHECKPOINT,
+  PANEL_VISIBILITY_BY_STATE,
 } from './constants';
 import {
   AccessibilityChecks,
@@ -44,9 +45,10 @@ import {
   PriorityChecks,
 } from './checklistContent';
 
-import { ChecklistCountProvider } from './countContext';
+import { useCategoryCount } from './countContext';
 import { useChecklist } from './checklistContext';
 import { useCheckpoint } from './checkpointContext';
+import { getTabPanelMaxHeight } from './styles';
 
 const Wrapper = styled.div`
   /**
@@ -68,6 +70,10 @@ export function Checklist() {
       isOpen,
     })
   );
+
+  const priorityCount = useCategoryCount(ISSUE_TYPES.PRIORITY);
+  const designCount = useCategoryCount(ISSUE_TYPES.DESIGN);
+  const accessibilityCount = useCategoryCount(ISSUE_TYPES.ACCESSIBILITY);
 
   const { checkpoint } = useCheckpoint(({ state: { checkpoint } }) => ({
     checkpoint,
@@ -99,51 +105,74 @@ export function Checklist() {
     }
   }, [checkpoint]);
 
+  const visiblePanels = PANEL_VISIBILITY_BY_STATE[checkpoint];
+  const priorityBadgeCount = visiblePanels.includes(ISSUE_TYPES.PRIORITY)
+    ? priorityCount
+    : 0;
+  const designBadgeCount = visiblePanels.includes(ISSUE_TYPES.DESIGN)
+    ? designCount
+    : 0;
+  const accessibilityBadgeCount = visiblePanels.includes(
+    ISSUE_TYPES.ACCESSIBILITY
+  )
+    ? accessibilityCount
+    : 0;
+
+  const maxPanelHeight = getTabPanelMaxHeight(
+    [priorityBadgeCount, designBadgeCount, accessibilityBadgeCount].filter(
+      (num) => Boolean(num)
+    ).length
+  );
+
   return (
     <DirectionAware>
-      <ChecklistCountProvider>
-        <Wrapper role="region" aria-label={CHECKLIST_TITLE}>
-          <Popup
-            popupId={POPUP_ID}
-            isOpen={isOpen}
-            ariaLabel={CHECKLIST_TITLE}
-            shouldKeepMounted
-          >
-            <StyledNavigationWrapper ref={navRef} isOpen={isOpen}>
-              <TopNavigation
-                onClose={close}
-                label={CHECKLIST_TITLE}
-                popupId={POPUP_ID}
+      <Wrapper role="region" aria-label={CHECKLIST_TITLE}>
+        <Popup
+          popupId={POPUP_ID}
+          isOpen={isOpen}
+          ariaLabel={CHECKLIST_TITLE}
+          shouldKeepMounted
+        >
+          <StyledNavigationWrapper ref={navRef} isOpen={isOpen}>
+            <TopNavigation
+              onClose={close}
+              label={CHECKLIST_TITLE}
+              popupId={POPUP_ID}
+            />
+            <Tablist
+              data-isexpanded={isOpen}
+              aria-label={__(
+                'Potential Story issues by category',
+                'web-stories'
+              )}
+            >
+              <PriorityChecks
+                badgeCount={priorityBadgeCount}
+                isOpen={openPanel === ISSUE_TYPES.PRIORITY}
+                onClick={handleOpenPanel(ISSUE_TYPES.PRIORITY)}
+                maxHeight={maxPanelHeight}
+                title={CATEGORY_LABELS[ISSUE_TYPES.PRIORITY]}
               />
-              <Tablist
-                data-isexpanded={isOpen}
-                aria-label={__(
-                  'Potential Story issues by category',
-                  'web-stories'
-                )}
-              >
-                <PriorityChecks
-                  isOpen={openPanel === ISSUE_TYPES.PRIORITY}
-                  onClick={handleOpenPanel(ISSUE_TYPES.PRIORITY)}
-                  title={CATEGORY_LABELS[ISSUE_TYPES.PRIORITY]}
-                />
-                <DesignChecks
-                  isOpen={openPanel === ISSUE_TYPES.DESIGN}
-                  onClick={handleOpenPanel(ISSUE_TYPES.DESIGN)}
-                  title={CATEGORY_LABELS[ISSUE_TYPES.DESIGN]}
-                />
-                <AccessibilityChecks
-                  isOpen={openPanel === ISSUE_TYPES.ACCESSIBILITY}
-                  onClick={handleOpenPanel(ISSUE_TYPES.ACCESSIBILITY)}
-                  title={CATEGORY_LABELS[ISSUE_TYPES.ACCESSIBILITY]}
-                />
-              </Tablist>
-              <EmptyContentCheck />
-            </StyledNavigationWrapper>
-          </Popup>
-          <Toggle isOpen={isOpen} onClick={toggle} popupId={POPUP_ID} />
-        </Wrapper>
-      </ChecklistCountProvider>
+              <DesignChecks
+                badgeCount={designBadgeCount}
+                isOpen={openPanel === ISSUE_TYPES.DESIGN}
+                onClick={handleOpenPanel(ISSUE_TYPES.DESIGN)}
+                maxHeight={maxPanelHeight}
+                title={CATEGORY_LABELS[ISSUE_TYPES.DESIGN]}
+              />
+              <AccessibilityChecks
+                badgeCount={accessibilityBadgeCount}
+                isOpen={openPanel === ISSUE_TYPES.ACCESSIBILITY}
+                onClick={handleOpenPanel(ISSUE_TYPES.ACCESSIBILITY)}
+                maxHeight={maxPanelHeight}
+                title={CATEGORY_LABELS[ISSUE_TYPES.ACCESSIBILITY]}
+              />
+            </Tablist>
+            <EmptyContentCheck />
+          </StyledNavigationWrapper>
+        </Popup>
+        <Toggle isOpen={isOpen} onClick={toggle} popupId={POPUP_ID} />
+      </Wrapper>
     </DirectionAware>
   );
 }

--- a/assets/src/edit-story/components/checklist/checklistContent/accessibilityChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/accessibilityChecks.js
@@ -33,7 +33,7 @@ import {
   ChecklistCategoryProvider,
   useCategoryCount,
 } from '../countContext/checkCountContext';
-import { PanelText, StyledTablistPanel } from '../styles';
+import { PanelText, StyledTablistPanel, TABPANEL_MAX_HEIGHT } from '../styles';
 import VideoOptimizationToggle from '../videoOptimizationCheckbox';
 
 export function AccessibilityChecks({ isOpen, onClick, title }) {
@@ -52,6 +52,7 @@ export function AccessibilityChecks({ isOpen, onClick, title }) {
         badgeCount={isCheckpointMet ? count : 0}
         isExpanded={isOpen}
         onClick={onClick}
+        panelMaxHeight={TABPANEL_MAX_HEIGHT}
         title={title}
       >
         <PanelText>

--- a/assets/src/edit-story/components/checklist/checklistContent/accessibilityChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/accessibilityChecks.js
@@ -21,38 +21,31 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { __ } from '@web-stories-wp/i18n';
-import { ISSUE_TYPES, PANEL_VISIBILITY_BY_STATE } from '../constants';
+import { ISSUE_TYPES } from '../constants';
 import ElementLinkTappableRegionTooSmall from '../checks/elementLinkTappableRegionTooSmall';
 import ImageElementMissingAlt from '../checks/imageElementMissingAlt';
 import { PageBackgroundTextLowContrast } from '../checks/pageBackgroundLowTextContrast';
 import TextElementFontSizeTooSmall from '../checks/textElementFontSizeTooSmall';
 import VideoElementMissingCaptions from '../checks/videoElementMissingCaptions';
 import VideoElementMissingDescription from '../checks/videoElementMissingDescription';
-import { useCheckpoint } from '../checkpointContext';
-import {
-  ChecklistCategoryProvider,
-  useCategoryCount,
-} from '../countContext/checkCountContext';
-import { PanelText, StyledTablistPanel, TABPANEL_MAX_HEIGHT } from '../styles';
+import { ChecklistCategoryProvider } from '../countContext/checkCountContext';
+import { PanelText, StyledTablistPanel } from '../styles';
 import VideoOptimizationToggle from '../videoOptimizationCheckbox';
 
-export function AccessibilityChecks({ isOpen, onClick, title }) {
-  const count = useCategoryCount(ISSUE_TYPES.ACCESSIBILITY);
-  const { checkpoint } = useCheckpoint(({ state: { checkpoint } }) => ({
-    checkpoint,
-  }));
-
-  const isCheckpointMet = PANEL_VISIBILITY_BY_STATE[checkpoint].includes(
-    ISSUE_TYPES.ACCESSIBILITY
-  );
-
+export function AccessibilityChecks({
+  badgeCount = 0,
+  maxHeight,
+  isOpen,
+  onClick,
+  title,
+}) {
   return (
     <ChecklistCategoryProvider category={ISSUE_TYPES.ACCESSIBILITY}>
       <StyledTablistPanel
-        badgeCount={isCheckpointMet ? count : 0}
+        badgeCount={badgeCount}
         isExpanded={isOpen}
         onClick={onClick}
-        panelMaxHeight={TABPANEL_MAX_HEIGHT}
+        maxHeight={maxHeight}
         title={title}
       >
         <PanelText>
@@ -70,7 +63,9 @@ export function AccessibilityChecks({ isOpen, onClick, title }) {
   );
 }
 AccessibilityChecks.propTypes = {
+  badgeCount: PropTypes.number,
   isOpen: PropTypes.bool,
+  maxHeight: PropTypes.string,
   onClick: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
 };

--- a/assets/src/edit-story/components/checklist/checklistContent/designChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/designChecks.js
@@ -29,7 +29,7 @@ import VideoElementResolution from '../checks/videoElementResolution';
 import ImageElementResolution from '../checks/imageElementResolution';
 import StoryPagesCount from '../checks/storyPagesCount';
 import { ChecklistCategoryProvider, useCategoryCount } from '../countContext';
-import { PanelText, StyledTablistPanel } from '../styles';
+import { PanelText, StyledTablistPanel, TABPANEL_MAX_HEIGHT } from '../styles';
 import { useCheckpoint } from '../checkpointContext';
 
 export function DesignChecks({ isOpen, onClick, title }) {
@@ -47,6 +47,7 @@ export function DesignChecks({ isOpen, onClick, title }) {
         badgeCount={isCheckpointMet ? count : 0}
         isExpanded={isOpen}
         onClick={onClick}
+        panelMaxHeight={TABPANEL_MAX_HEIGHT}
         title={title}
       >
         <PanelText>

--- a/assets/src/edit-story/components/checklist/checklistContent/designChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/designChecks.js
@@ -21,33 +21,30 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { ISSUE_TYPES, PANEL_VISIBILITY_BY_STATE } from '../constants';
+import { ISSUE_TYPES } from '../constants';
 import PageTooManyLinks from '../checks/pageTooManyLinks';
 import PageTooMuchText from '../checks/pageTooMuchText';
 import PageTooLittleText from '../checks/pageTooLittleText';
 import VideoElementResolution from '../checks/videoElementResolution';
 import ImageElementResolution from '../checks/imageElementResolution';
 import StoryPagesCount from '../checks/storyPagesCount';
-import { ChecklistCategoryProvider, useCategoryCount } from '../countContext';
-import { PanelText, StyledTablistPanel, TABPANEL_MAX_HEIGHT } from '../styles';
-import { useCheckpoint } from '../checkpointContext';
+import { ChecklistCategoryProvider } from '../countContext';
+import { PanelText, StyledTablistPanel } from '../styles';
 
-export function DesignChecks({ isOpen, onClick, title }) {
-  const count = useCategoryCount(ISSUE_TYPES.DESIGN);
-  const { checkpoint } = useCheckpoint(({ state: { checkpoint } }) => ({
-    checkpoint,
-  }));
-
-  const isCheckpointMet = PANEL_VISIBILITY_BY_STATE[checkpoint].includes(
-    ISSUE_TYPES.DESIGN
-  );
+export function DesignChecks({
+  badgeCount = 0,
+  isOpen,
+  maxHeight,
+  onClick,
+  title,
+}) {
   return (
     <ChecklistCategoryProvider category={ISSUE_TYPES.DESIGN}>
       <StyledTablistPanel
-        badgeCount={isCheckpointMet ? count : 0}
+        badgeCount={badgeCount}
         isExpanded={isOpen}
         onClick={onClick}
-        panelMaxHeight={TABPANEL_MAX_HEIGHT}
+        maxHeight={maxHeight}
         title={title}
       >
         <PanelText>
@@ -64,7 +61,9 @@ export function DesignChecks({ isOpen, onClick, title }) {
   );
 }
 DesignChecks.propTypes = {
+  badgeCount: PropTypes.number,
   isOpen: PropTypes.bool,
+  maxHeight: PropTypes.string,
   onClick: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
 };

--- a/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
@@ -25,7 +25,7 @@ import { useEffect } from 'react';
 import { useConfig } from '../../../app';
 import useFFmpeg from '../../../app/media/utils/useFFmpeg';
 import { PANEL_STATES } from '../../tablist';
-import { ISSUE_TYPES, PANEL_VISIBILITY_BY_STATE } from '../constants';
+import { ISSUE_TYPES } from '../constants';
 import PublisherLogoSize from '../checks/publisherLogoSize';
 import StoryMissingExcerpt from '../checks/storyMissingExerpt';
 import StoryMissingTitle from '../checks/storyMissingTitle';
@@ -35,25 +35,26 @@ import StoryPosterPortraitSize from '../checks/storyPosterPortraitSize';
 import StoryTitleLength from '../checks/storyTitleLength';
 import VideoElementMissingPoster from '../checks/videoElementMissingPoster';
 import { ChecklistCategoryProvider, useCategoryCount } from '../countContext';
-import { PanelText, StyledTablistPanel, TABPANEL_MAX_HEIGHT } from '../styles';
+import { PanelText, StyledTablistPanel } from '../styles';
 import { useCheckpoint } from '../checkpointContext';
 import VideoOptimization from '../checks/videoOptimization';
 
-export function PriorityChecks({ isOpen, onClick, title }) {
+export function PriorityChecks({
+  badgeCount = 0,
+  maxHeight,
+  isOpen,
+  onClick,
+  title,
+}) {
   const count = useCategoryCount(ISSUE_TYPES.PRIORITY);
-  const { updateHighPriorityCount, checkpoint } = useCheckpoint(
-    ({ actions: { updateHighPriorityCount }, state: { checkpoint } }) => ({
-      checkpoint,
+  const { updateHighPriorityCount } = useCheckpoint(
+    ({ actions: { updateHighPriorityCount } }) => ({
       updateHighPriorityCount,
     })
   );
   useEffect(() => {
     updateHighPriorityCount(count);
   }, [updateHighPriorityCount, count]);
-
-  const isCheckpointMet = PANEL_VISIBILITY_BY_STATE[checkpoint].includes(
-    ISSUE_TYPES.PRIORITY
-  );
 
   const { isFeatureEnabled, isTranscodingEnabled } = useFFmpeg();
   const {
@@ -66,10 +67,10 @@ export function PriorityChecks({ isOpen, onClick, title }) {
   return (
     <ChecklistCategoryProvider category={ISSUE_TYPES.PRIORITY}>
       <StyledTablistPanel
-        badgeCount={isCheckpointMet ? count : 0}
+        badgeCount={badgeCount}
         isExpanded={isOpen}
         onClick={onClick}
-        panelMaxHeight={TABPANEL_MAX_HEIGHT}
+        maxHeight={maxHeight}
         status={PANEL_STATES.DANGER}
         title={title}
       >
@@ -92,7 +93,9 @@ export function PriorityChecks({ isOpen, onClick, title }) {
 }
 
 PriorityChecks.propTypes = {
+  badgeCount: PropTypes.number,
   isOpen: PropTypes.bool,
+  maxHeight: PropTypes.string,
   onClick: PropTypes.func.isRequired,
   title: PropTypes.string.isRequired,
 };

--- a/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
+++ b/assets/src/edit-story/components/checklist/checklistContent/priorityChecks.js
@@ -35,7 +35,7 @@ import StoryPosterPortraitSize from '../checks/storyPosterPortraitSize';
 import StoryTitleLength from '../checks/storyTitleLength';
 import VideoElementMissingPoster from '../checks/videoElementMissingPoster';
 import { ChecklistCategoryProvider, useCategoryCount } from '../countContext';
-import { PanelText, StyledTablistPanel } from '../styles';
+import { PanelText, StyledTablistPanel, TABPANEL_MAX_HEIGHT } from '../styles';
 import { useCheckpoint } from '../checkpointContext';
 import VideoOptimization from '../checks/videoOptimization';
 
@@ -69,6 +69,7 @@ export function PriorityChecks({ isOpen, onClick, title }) {
         badgeCount={isCheckpointMet ? count : 0}
         isExpanded={isOpen}
         onClick={onClick}
+        panelMaxHeight={TABPANEL_MAX_HEIGHT}
         status={PANEL_STATES.DANGER}
         title={title}
       >

--- a/assets/src/edit-story/components/checklist/karma/checklist.karma.js
+++ b/assets/src/edit-story/components/checklist/karma/checklist.karma.js
@@ -50,9 +50,6 @@ describe('Checklist integration', () => {
 
   const openChecklist = async () => {
     const { toggleButton } = fixture.editor.checklist;
-    expect(
-      fixture.editor.checklist.issues.getAttribute('data-isexpanded')
-    ).toBe('false');
     await fixture.events.click(toggleButton);
     // wait for animation
     await fixture.events.sleep(500);
@@ -60,9 +57,6 @@ describe('Checklist integration', () => {
 
   const openChecklistWithKeyboard = async () => {
     const { toggleButton } = fixture.editor.checklist;
-    expect(
-      fixture.editor.checklist.issues.getAttribute('data-isexpanded')
-    ).toBe('false');
     await fixture.events.focus(toggleButton);
     await fixture.events.keyboard.press('Enter');
     // wait for animation
@@ -72,9 +66,6 @@ describe('Checklist integration', () => {
   describe('open and close', () => {
     it('should toggle the checklist', async () => {
       const { toggleButton } = fixture.editor.checklist;
-      expect(
-        fixture.editor.checklist.issues.getAttribute('data-isexpanded')
-      ).toBe('false');
 
       await fixture.events.click(toggleButton);
       // wait for animation
@@ -86,9 +77,6 @@ describe('Checklist integration', () => {
       await fixture.events.click(toggleButton);
       // wait for animation
       await fixture.events.sleep(500);
-      expect(
-        fixture.editor.checklist.issues.getAttribute('data-isexpanded')
-      ).toBe('false');
     });
 
     it('should close the checklist when the "close" button is clicked', async () => {
@@ -96,9 +84,6 @@ describe('Checklist integration', () => {
 
       await fixture.events.click(fixture.editor.checklist.closeButton);
       await fixture.events.sleep(500);
-      expect(
-        fixture.editor.checklist.issues.getAttribute('data-isexpanded')
-      ).toBe('false');
     });
   });
 
@@ -149,9 +134,6 @@ describe('Checklist integration', () => {
       await fixture.events.keyboard.press('Enter');
       // wait for animation
       await fixture.events.sleep(500);
-      expect(
-        fixture.editor.checklist.issues.getAttribute('data-isexpanded')
-      ).toBe('false');
     });
 
     it('should close the Checklist when pressing enter on the "close" button', async () => {
@@ -167,9 +149,6 @@ describe('Checklist integration', () => {
 
       await fixture.events.keyboard.press('Enter');
       await fixture.events.sleep(500);
-      expect(
-        fixture.editor.checklist.issues.getAttribute('data-isexpanded')
-      ).toBe('false');
     });
 
     it('should open the tab panels with tab and enter', async () => {

--- a/assets/src/edit-story/components/checklist/styles.js
+++ b/assets/src/edit-story/components/checklist/styles.js
@@ -29,12 +29,18 @@ import { NAVIGATION_HEIGHT } from '../helpCenter/navigator/constants';
 export const DISTANCE_FROM_TOP = 60 + 32; // toolbar height + input height
 export const DISTANCE_FROM_BOTTOM = 69;
 const BUTTON_HEIGHT = 60;
-export const TABPANEL_MAX_HEIGHT = `100vh - ${
-  NAVIGATION_HEIGHT +
-  3 * BUTTON_HEIGHT +
-  DISTANCE_FROM_TOP +
-  DISTANCE_FROM_BOTTOM
-}px`;
+export const getTabPanelMaxHeight = (buttonCount) => {
+  if (!buttonCount) {
+    return undefined;
+  }
+
+  return `100vh - ${
+    NAVIGATION_HEIGHT +
+    buttonCount * BUTTON_HEIGHT +
+    DISTANCE_FROM_TOP +
+    DISTANCE_FROM_BOTTOM
+  }px`;
+};
 
 export const StyledTablistPanel = styled(TablistPanel)`
   height: ${({ badgeCount }) => (badgeCount === 0 ? 0 : 'auto')};

--- a/assets/src/edit-story/components/checklist/styles.js
+++ b/assets/src/edit-story/components/checklist/styles.js
@@ -24,6 +24,17 @@ import { Text, THEME_CONSTANTS } from '@web-stories-wp/design-system';
  * Internal dependencies
  */
 import { TablistPanel } from '../tablist';
+import { NAVIGATION_HEIGHT } from '../helpCenter/navigator/constants';
+
+export const DISTANCE_FROM_TOP = 60 + 32; // toolbar height + input height
+export const DISTANCE_FROM_BOTTOM = 69;
+const BUTTON_HEIGHT = 60;
+export const TABPANEL_MAX_HEIGHT = `100vh - ${
+  NAVIGATION_HEIGHT +
+  3 * BUTTON_HEIGHT +
+  DISTANCE_FROM_TOP +
+  DISTANCE_FROM_BOTTOM
+}px`;
 
 export const StyledTablistPanel = styled(TablistPanel)`
   height: ${({ badgeCount }) => (badgeCount === 0 ? 0 : 'auto')};

--- a/assets/src/edit-story/components/helpCenter/index.js
+++ b/assets/src/edit-story/components/helpCenter/index.js
@@ -81,6 +81,7 @@ export const HelpCenter = () => {
             ariaLabel={__('Help Center', 'web-stories')}
           >
             <Navigator
+              isOpen={state.isOpen}
               onNext={actions.goToNext}
               onPrev={actions.goToPrev}
               onAllTips={actions.goToMenu}

--- a/assets/src/edit-story/components/helpCenter/navigator/index.js
+++ b/assets/src/edit-story/components/helpCenter/navigator/index.js
@@ -19,7 +19,7 @@
 import { __ } from '@web-stories-wp/i18n';
 import PropTypes from 'prop-types';
 import { useEffect, useRef } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { themeHelpers } from '@web-stories-wp/design-system';
 
 /**
@@ -43,12 +43,22 @@ export const NavigationWrapper = styled.div`
   left: 0;
   bottom: 0;
   max-height: calc(100vh - ${DISTANCE_FROM_TOP + DISTANCE_FROM_BOTTOM}px);
-  width: ${NAVIGATION_WIDTH}px;
+  width: ${NAVIGATION_WIDTH + 2}px; /* account for border width */
   color: ${({ theme }) => theme.colors.fg.primary};
   background-color: ${({ theme }) => theme.colors.bg.primary};
   border: 1px solid ${({ theme }) => theme.colors.bg.tertiary};
   border-radius: ${({ theme }) => theme.borders.radius.small};
-  overflow-y: hidden;
+  overflow: hidden;
+
+  ${({ isOpen }) =>
+    !isOpen &&
+    css`
+      &,
+      * {
+        height: 0;
+        visibility: hidden;
+      }
+    `}
 `;
 
 const Layout = styled.div`
@@ -63,6 +73,7 @@ const ContentInner = styled.div`
 
 export function Navigator({
   children,
+  isOpen,
   onClose,
   onNext,
   onPrev,
@@ -89,7 +100,7 @@ export function Navigator({
   );
 
   return (
-    <NavigationWrapper>
+    <NavigationWrapper isOpen={isOpen}>
       <TopNavigation
         onClose={onClose}
         label={__('Quick Tips', 'web-stories')}
@@ -113,6 +124,7 @@ export function Navigator({
 }
 
 Navigator.propTypes = {
+  isOpen: PropTypes.bool,
   children: PropTypes.node.isRequired,
   onClose: PropTypes.func.isRequired,
   onNext: PropTypes.func.isRequired,

--- a/assets/src/edit-story/components/helpCenter/navigator/index.js
+++ b/assets/src/edit-story/components/helpCenter/navigator/index.js
@@ -26,6 +26,10 @@ import { themeHelpers } from '@web-stories-wp/design-system';
  * Internal dependencies
  */
 import { POPUP_ID } from '../constants';
+import {
+  DISTANCE_FROM_TOP,
+  DISTANCE_FROM_BOTTOM,
+} from '../../checklist/styles';
 import { BottomNavigation } from './bottomNavigation';
 import { NAVIGATION_WIDTH } from './constants';
 import { TopNavigation } from './topNavigation';
@@ -34,21 +38,17 @@ import {
   syncOuterHeightWithInner,
 } from './utils';
 
-const DISTANCE_TO_TOP = 59 + 32; // height from input + toolbar height
-const DISTANCE_TO_BOTTOM = 69;
-
 export const NavigationWrapper = styled.div`
   position: absolute;
   left: 0;
   bottom: 0;
+  max-height: calc(100vh - ${DISTANCE_FROM_TOP + DISTANCE_FROM_BOTTOM}px);
   width: ${NAVIGATION_WIDTH}px;
   color: ${({ theme }) => theme.colors.fg.primary};
   background-color: ${({ theme }) => theme.colors.bg.primary};
   border: 1px solid ${({ theme }) => theme.colors.bg.tertiary};
   border-radius: ${({ theme }) => theme.borders.radius.small};
-  /* overflow-y: hidden;
-  overflow-x: visible; */
-  max-height: calc(100vh - ${DISTANCE_TO_TOP + DISTANCE_TO_BOTTOM}px);
+  overflow-y: hidden;
 `;
 
 const Layout = styled.div`

--- a/assets/src/edit-story/components/helpCenter/navigator/index.js
+++ b/assets/src/edit-story/components/helpCenter/navigator/index.js
@@ -34,6 +34,9 @@ import {
   syncOuterHeightWithInner,
 } from './utils';
 
+const DISTANCE_TO_TOP = 59 + 32; // height from input + toolbar height
+const DISTANCE_TO_BOTTOM = 69;
+
 export const NavigationWrapper = styled.div`
   position: absolute;
   left: 0;
@@ -43,7 +46,9 @@ export const NavigationWrapper = styled.div`
   background-color: ${({ theme }) => theme.colors.bg.primary};
   border: 1px solid ${({ theme }) => theme.colors.bg.tertiary};
   border-radius: ${({ theme }) => theme.borders.radius.small};
-  overflow: ${({ isOpen }) => (isOpen ? 'visible' : 'hidden')};
+  /* overflow-y: hidden;
+  overflow-x: visible; */
+  max-height: calc(100vh - ${DISTANCE_TO_TOP + DISTANCE_TO_BOTTOM}px);
 `;
 
 const Layout = styled.div`

--- a/assets/src/edit-story/components/tablist/index.js
+++ b/assets/src/edit-story/components/tablist/index.js
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-export { default as TablistPanel } from './panel';
+export { default as TablistPanel } from './tablistPanel';
 export { PANEL_STATES } from './constants';
 export { Tablist } from './styles';

--- a/assets/src/edit-story/components/tablist/panel.js
+++ b/assets/src/edit-story/components/tablist/panel.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import styled from 'styled-components';
 import { sprintf, _n } from '@web-stories-wp/i18n';
 import PropTypes from 'prop-types';
 import { useMemo } from 'react';
@@ -35,6 +36,10 @@ import {
   TabButton,
   TabPanel,
 } from './styles';
+
+const Scrollable = styled.div`
+  position: absolute;
+`;
 
 const Panel = ({
   badgeCount = 0,
@@ -74,9 +79,11 @@ const Panel = ({
           <PanelText aria-hidden>{badgeCount}</PanelText>
         </Badge>
       </TabButton>
+      {/* <Scrollable> */}
       <TabPanel aria-labelledby={`${title}-${panelId}`} role="tabpanel">
         {children}
       </TabPanel>
+      {/* </Scrollable> */}
     </PanelWrapper>
   );
 };

--- a/assets/src/edit-story/components/tablist/stories/index.js
+++ b/assets/src/edit-story/components/tablist/stories/index.js
@@ -35,7 +35,7 @@ import { StyledVideoOptimizationIcon } from '../../checklistCard/styles';
 import { DefaultCtaButton } from '../../checklistCard/defaultCtaButton';
 import { DefaultFooterText } from '../../checklistCard/defaultFooterText';
 import { Tablist } from '../styles';
-import TablistPanel from '../panel';
+import TablistPanel from '../tablistPanel';
 import { CheckboxCta } from '../../checklistCard/checkboxCta';
 import { ChecklistCard } from '../../checklistCard';
 import { PANEL_STATES } from '../constants';

--- a/assets/src/edit-story/components/tablist/styles.js
+++ b/assets/src/edit-story/components/tablist/styles.js
@@ -31,11 +31,9 @@ import {
 /**
  * Internal dependencies
  */
-import { NAVIGATION_WIDTH } from '../helpCenter/navigator/constants';
 import { PANEL_STATES } from './constants';
 
 export const Tablist = styled.div.attrs({ role: 'tablist' })`
-  width: ${NAVIGATION_WIDTH}px;
   background: ${({ theme }) => theme.colors.bg.primary};
 `;
 Tablist.propTypes = {
@@ -127,9 +125,9 @@ export const PanelWrapper = styled.div`
         }
       }
 
-      & > ${TabPanel} {
+      * > ${TabPanel} {
         height: 560px;
-        padding: 0 16px 16px;
+        padding: 0 0 16px 16px;
         visibility: visible;
       }
     `};
@@ -174,6 +172,7 @@ export const TabPanel = styled.div`
   padding: 0;
   visibility: hidden;
   overflow-y: scroll;
+  overflow-x: hidden;
   background: ${({ theme }) => theme.colors.bg.primary};
   transition: 250ms ease-in;
 

--- a/assets/src/edit-story/components/tablist/styles.js
+++ b/assets/src/edit-story/components/tablist/styles.js
@@ -35,7 +35,7 @@ import { NAVIGATION_WIDTH } from '../helpCenter/navigator/constants';
 import { PANEL_STATES } from './constants';
 
 export const Tablist = styled.div.attrs({ role: 'tablist' })`
-  width: ${NAVIGATION_WIDTH};
+  width: ${NAVIGATION_WIDTH}px;
   background: ${({ theme }) => theme.colors.bg.primary};
 `;
 Tablist.propTypes = {

--- a/assets/src/edit-story/components/tablist/tablistPanel.js
+++ b/assets/src/edit-story/components/tablist/tablistPanel.js
@@ -38,15 +38,17 @@ import {
 } from './styles';
 
 const Scrollable = styled.div`
-  position: absolute;
+  max-height: ${({ maxHeight }) => (maxHeight ? `calc(${maxHeight})` : 'none')};
+  overflow-y: ${({ maxHeight }) => (maxHeight ? 'scroll' : 'auto')};
 `;
 
-const Panel = ({
+const TablistPanel = ({
   badgeCount = 0,
   children,
   className,
   isExpanded,
   onClick,
+  panelMaxHeight,
   status = PANEL_STATES.NORMAL,
   title,
 }) => {
@@ -79,22 +81,23 @@ const Panel = ({
           <PanelText aria-hidden>{badgeCount}</PanelText>
         </Badge>
       </TabButton>
-      {/* <Scrollable> */}
-      <TabPanel aria-labelledby={`${title}-${panelId}`} role="tabpanel">
-        {children}
-      </TabPanel>
-      {/* </Scrollable> */}
+      <Scrollable maxHeight={panelMaxHeight}>
+        <TabPanel aria-labelledby={`${title}-${panelId}`} role="tabpanel">
+          {children}
+        </TabPanel>
+      </Scrollable>
     </PanelWrapper>
   );
 };
-Panel.propTypes = {
+TablistPanel.propTypes = {
   badgeCount: PropTypes.number,
   children: PropTypes.node,
   className: PropTypes.string,
   isExpanded: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
+  panelMaxHeight: PropTypes.string,
   status: PropTypes.oneOf(Object.values(PANEL_STATES)),
   title: PropTypes.string.isRequired,
 };
 
-export default Panel;
+export default TablistPanel;

--- a/assets/src/edit-story/components/tablist/tablistPanel.js
+++ b/assets/src/edit-story/components/tablist/tablistPanel.js
@@ -48,7 +48,7 @@ const TablistPanel = ({
   className,
   isExpanded,
   onClick,
-  panelMaxHeight,
+  maxHeight,
   status = PANEL_STATES.NORMAL,
   title,
 }) => {
@@ -81,7 +81,7 @@ const TablistPanel = ({
           <PanelText aria-hidden>{badgeCount}</PanelText>
         </Badge>
       </TabButton>
-      <Scrollable maxHeight={panelMaxHeight}>
+      <Scrollable maxHeight={maxHeight}>
         <TabPanel aria-labelledby={`${title}-${panelId}`} role="tabpanel">
           {children}
         </TabPanel>
@@ -95,7 +95,7 @@ TablistPanel.propTypes = {
   className: PropTypes.string,
   isExpanded: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
-  panelMaxHeight: PropTypes.string,
+  maxHeight: PropTypes.string,
   status: PropTypes.oneOf(Object.values(PANEL_STATES)),
   title: PropTypes.string.isRequired,
 };


### PR DESCRIPTION
## Context

PPC 2.0 was looking bad on shorter viewports because the open panel wasn't scrolling.

## Summary

Add a scrollable container with a max height to the ppc so that the panel content can be hidden and scrolled. The close button is now always visible and the input won't be obscured.

Also hides the checklist from screen readers when the checklist is closed and allows the user to click on content that would be behind it when it's open!
<img src="https://user-images.githubusercontent.com/22185279/124329216-54b1d180-db48-11eb-9a33-2c772b11b080.gif" height="350px" />

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![not-fixed](https://user-images.githubusercontent.com/22185279/124311270-b5321600-db2a-11eb-9e54-221d91394a46.gif)|![fixed-it](https://user-images.githubusercontent.com/22185279/124311171-90d63980-db2a-11eb-8198-8fe4b929dc27.gif)|

## Testing Instructions

1. Enable ppc 2.0 experiment
2. Go to editor
3. Shrink your window height
4. Open the checklist - should be able to see the 'title' input at the top of the editor and the close button on the checklist.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8131
