### PR TITLE
Bugfix: Prevent 2 popups open at once in carousel

### DIFF
--- a/assets/src/edit-story/components/carousel/carouselContainer.js
+++ b/assets/src/edit-story/components/carousel/carouselContainer.js
@@ -25,6 +25,7 @@ import { useResizeEffect } from '@web-stories-wp/design-system';
  * Internal dependencies
  */
 import { ChecklistProvider } from '../checklist';
+import { KeyboardShortcutsMenuProvider } from '../keyboardShortcutsMenu/keyboardShortcutsMenuContext';
 import CarouselLayout from './carouselLayout';
 import CarouselProvider from './carouselProvider';
 import { VERY_WIDE_WORKSPACE_LIMIT, VERY_WIDE_MARGIN } from './constants';
@@ -50,11 +51,13 @@ function CarouselContainer() {
   return (
     <CarouselProvider availableSpace={width}>
       <ChecklistProvider>
-        <Outer ref={ref}>
-          <Inner marginRight={margin}>
-            <CarouselLayout />
-          </Inner>
-        </Outer>
+        <KeyboardShortcutsMenuProvider>
+          <Outer ref={ref}>
+            <Inner marginRight={margin}>
+              <CarouselLayout />
+            </Inner>
+          </Outer>
+        </KeyboardShortcutsMenuProvider>
       </ChecklistProvider>
     </CarouselProvider>
   );

--- a/assets/src/edit-story/components/carousel/karma/popups.karma.js
+++ b/assets/src/edit-story/components/carousel/karma/popups.karma.js
@@ -19,7 +19,7 @@
  */
 import { Fixture } from '../../../karma';
 
-describe('Popup Menus - Help Center and Checklist', () => {
+describe('Popup Menus - Help Center, KeyboardShortcuts, and Checklist', () => {
   let fixture;
 
   beforeEach(async () => {
@@ -32,16 +32,17 @@ describe('Popup Menus - Help Center and Checklist', () => {
     fixture.restore();
   });
 
-  it('should start with both popups closed', () => {
-    const { helpCenterToggle, checklistToggle } = fixture.editor.carousel;
+  it('should start with all popups closed', () => {
+    const { helpCenterToggle, checklistToggle, keyboardShortcutsToggle } =
+      fixture.editor.carousel;
 
     expect(helpCenterToggle).toBeDefined();
     expect(checklistToggle).toBeDefined();
-
+    expect(keyboardShortcutsToggle).toBeDefined();
     expect(fixture.editor.helpCenter.quickTips).toBeNull();
   });
 
-  it('should collapse helpCenter when checklist is expanded', async () => {
+  it('should collapse helpCenter and keyboard shortcuts when checklist is expanded', async () => {
     const { helpCenterToggle, checklistToggle } = fixture.editor.carousel;
     await fixture.events.click(helpCenterToggle);
 
@@ -55,6 +56,7 @@ describe('Popup Menus - Help Center and Checklist', () => {
       fixture.editor.checklist.issues.getAttribute('data-isexpanded')
     ).toBe('true');
     expect(fixture.editor.helpCenter.quickTips).toBeNull();
+    expect(fixture.editor.keyboardShortcuts.keyboardShortcutsMenu).toBeNull();
   });
 
   it('should collapse checklist when helpCenter is expanded', async () => {
@@ -74,5 +76,25 @@ describe('Popup Menus - Help Center and Checklist', () => {
     await fixture.events.sleep(500);
 
     expect(quickTips).toBeDefined();
+  });
+
+  it('should collapse checklist and helpCenter when keyboard shortcuts menu is expanded', async () => {
+    const { checklistToggle, keyboardShortcutsToggle } =
+      fixture.editor.carousel;
+
+    await fixture.events.click(checklistToggle);
+
+    expect(
+      fixture.editor.checklist.issues.getAttribute('data-isexpanded')
+    ).toBe('true');
+    expect(fixture.editor.helpCenter.quickTips).toBeNull();
+
+    await fixture.events.click(keyboardShortcutsToggle);
+
+    const { keyboardShortcutsMenu } = await fixture.editor.keyboardShortcuts;
+
+    await fixture.events.sleep(500);
+
+    expect(keyboardShortcutsMenu).toBeDefined();
   });
 });

--- a/assets/src/edit-story/components/carousel/secondaryMenu.js
+++ b/assets/src/edit-story/components/carousel/secondaryMenu.js
@@ -33,6 +33,7 @@ import {
   useChecklist,
   useCheckpoint,
 } from '../checklist';
+import { useKeyboardShortcutsMenu } from '../keyboardShortcutsMenu/keyboardShortcutsMenuContext';
 
 const Wrapper = styled.div`
   display: flex;
@@ -82,6 +83,17 @@ function SecondaryMenu() {
     })
   );
 
+  const { close: closeKeyboardShortcutsMenu, isKeyboardShortcutsMenuOpen } =
+    useKeyboardShortcutsMenu(
+      ({
+        actions: { close },
+        state: { isOpen: isKeyboardShortcutsMenuOpen },
+      }) => ({
+        close,
+        isKeyboardShortcutsMenuOpen,
+      })
+    );
+
   const { onResetReviewDialogRequest, reviewDialogRequested } = useCheckpoint(
     ({
       actions: { onResetReviewDialogRequest },
@@ -97,14 +109,23 @@ function SecondaryMenu() {
   useEffect(() => {
     if (isChecklistOpen) {
       closeHelpCenter();
+      closeKeyboardShortcutsMenu();
     }
-  }, [closeHelpCenter, isChecklistOpen]);
+  }, [closeHelpCenter, closeKeyboardShortcutsMenu, isChecklistOpen]);
 
   useEffect(() => {
     if (isHelpCenterOpen) {
       closeChecklist();
+      closeKeyboardShortcutsMenu();
     }
-  }, [closeChecklist, isHelpCenterOpen]);
+  }, [closeChecklist, closeKeyboardShortcutsMenu, isHelpCenterOpen]);
+
+  useEffect(() => {
+    if (isKeyboardShortcutsMenuOpen) {
+      closeChecklist();
+      closeHelpCenter();
+    }
+  }, [closeChecklist, closeHelpCenter, isKeyboardShortcutsMenuOpen]);
 
   useEffect(() => {
     if (reviewDialogRequested) {

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
@@ -32,18 +32,6 @@ describe('Keyboard Shortcuts Menu', () => {
   const openDelay = 100;
   const closeDelay = 300;
 
-  const getKeyboardShortcutsMenu = () => {
-    return fixture.screen.queryByRole('list', {
-      name: /^Keyboard Shortcuts$/,
-    });
-  };
-
-  const getKeyboardShortcutsToggle = () => {
-    return fixture.editor.getByRole('button', {
-      name: /^Keyboard Shortcuts$/,
-    });
-  };
-
   beforeEach(async () => {
     fixture = new Fixture();
 
@@ -56,34 +44,35 @@ describe('Keyboard Shortcuts Menu', () => {
 
   describe('CUJ: User can interact with menu using mouse: Click toggle button to open, click close button to close menu', () => {
     it('should be able to open menu by clicking on keyboard shortcut button', async () => {
-      const hiddenMenu = getKeyboardShortcutsMenu();
+      const { keyboardShortcutsToggle } = fixture.editor.carousel;
+
       // Menu should be closed
-      expect(hiddenMenu).toBeNull();
+      await expect(
+        fixture.editor.keyboardShortcuts.keyboardShortcutsMenu
+      ).toBeNull();
 
-      const menuToggle = getKeyboardShortcutsToggle();
-
-      await fixture.events.click(menuToggle);
+      await fixture.events.click(keyboardShortcutsToggle);
       await fixture.events.sleep(openDelay);
 
-      const openMenu = getKeyboardShortcutsMenu();
-
-      expect(openMenu).toBeTruthy();
+      await expect(
+        fixture.editor.keyboardShortcuts.keyboardShortcutsMenu
+      ).toBeTruthy();
 
       await fixture.snapshot('shortcuts dialog open');
     });
 
     describe('when menu is open', () => {
       beforeEach(async () => {
-        const menuToggle = getKeyboardShortcutsToggle();
+        const { keyboardShortcutsToggle } = fixture.editor.carousel;
 
-        await fixture.events.click(menuToggle);
+        await fixture.events.click(keyboardShortcutsToggle);
       });
 
       it('should be able to close menu by clicking on close button', async () => {
-        const openMenu = getKeyboardShortcutsMenu();
-        expect(openMenu).toBeTruthy();
+        const { keyboardShortcutsMenu } = fixture.editor.keyboardShortcuts;
+        expect(keyboardShortcutsMenu).toBeTruthy();
 
-        const menu = within(openMenu);
+        const menu = within(keyboardShortcutsMenu);
         const closeButton = menu.getByRole('button', {
           name: /^Close Menu$/,
         });
@@ -91,69 +80,70 @@ describe('Keyboard Shortcuts Menu', () => {
         // Give time for menu to close
         await fixture.events.sleep(closeDelay);
 
-        const closedMenu = getKeyboardShortcutsMenu();
-
-        expect(closedMenu).toBeNull();
+        expect(
+          fixture.editor.keyboardShortcuts.keyboardShortcutsMenu
+        ).toBeNull();
       });
 
       it('should be able to close menu by clicking outside the menu', async () => {
-        const openMenu = getKeyboardShortcutsMenu();
-        expect(openMenu).toBeTruthy();
+        const { keyboardShortcutsMenu } = fixture.editor.keyboardShortcuts;
+        expect(keyboardShortcutsMenu).toBeTruthy();
 
         // Click outside menu
-        await fixture.events.mouse.clickOn(openMenu, -10, -10);
+        await fixture.events.mouse.clickOn(keyboardShortcutsMenu, -10, -10);
         // Give time for menu to close
         await fixture.events.sleep(closeDelay);
 
-        const closedMenu = getKeyboardShortcutsMenu();
-
-        expect(closedMenu).toBeNull();
+        expect(
+          fixture.editor.keyboardShortcuts.keyboardShortcutsMenu
+        ).toBeNull();
       });
 
       it('should not close menu when clicking inside the menu', async () => {
-        const openMenu = getKeyboardShortcutsMenu();
-        expect(openMenu).toBeTruthy();
+        const { keyboardShortcutsMenu } = fixture.editor.keyboardShortcuts;
+        expect(keyboardShortcutsMenu).toBeTruthy();
 
         // Click inside menu
-        await fixture.events.mouse.clickOn(openMenu, 10, 10);
+        await fixture.events.mouse.clickOn(keyboardShortcutsMenu, 10, 10);
 
-        const menu = within(openMenu);
+        const menu = within(keyboardShortcutsMenu);
         const menuItem = await menu.queryAllByRole('listitem')[0];
         // Click on element inside menu
         await fixture.events.click(menuItem);
         // Give time for menu to process clicks
         await fixture.events.sleep(closeDelay);
 
-        const stillOpenMenu = getKeyboardShortcutsMenu();
-
         // Menu should still be open
-        expect(stillOpenMenu).toBeTruthy();
+        expect(
+          fixture.editor.keyboardShortcuts.keyboardShortcutsMenu
+        ).toBeTruthy();
       });
     });
   });
 
   describe('CUJ: User can interact with menu using keyboard: Tab to menu, enter to open, esc to close', () => {
     it('should be able to toggle menu open with Enter key', async () => {
-      const hiddenMenu = getKeyboardShortcutsMenu();
+      const { keyboardShortcutsMenu } = fixture.editor.keyboardShortcuts;
+
       // Menu should be closed
-      expect(hiddenMenu).toBeNull();
+      expect(keyboardShortcutsMenu).toBeNull();
 
-      const menuToggle = getKeyboardShortcutsToggle();
+      const { keyboardShortcutsToggle } = fixture.editor.carousel;
 
-      await fixture.events.focus(menuToggle);
+      await fixture.events.focus(keyboardShortcutsToggle);
       await fixture.events.keyboard.press('Enter');
       await fixture.events.sleep(openDelay);
 
-      const openMenu = getKeyboardShortcutsMenu();
-
-      expect(openMenu).toBeTruthy();
+      expect(
+        fixture.editor.keyboardShortcuts.keyboardShortcutsMenu
+      ).toBeTruthy();
     });
 
     describe('when menu is open', () => {
       beforeEach(async () => {
-        const menuToggle = getKeyboardShortcutsToggle();
+        const { keyboardShortcutsToggle } = fixture.editor.carousel;
 
-        await fixture.events.focus(menuToggle);
+        await fixture.events.focus(keyboardShortcutsToggle);
         // Tab back and forth to trigger app to think we're a keyboard user
         await fixture.events.keyboard.press('tab');
         await fixture.events.keyboard.shortcut('shift+tab');
@@ -162,23 +152,23 @@ describe('Keyboard Shortcuts Menu', () => {
       });
 
       it('should be able to close open menu using Esc key', async () => {
-        const openMenu = getKeyboardShortcutsMenu();
-        expect(openMenu).toBeTruthy();
+        const { keyboardShortcutsMenu } = fixture.editor.keyboardShortcuts;
+        expect(keyboardShortcutsMenu).toBeTruthy();
 
         await fixture.events.keyboard.press('Escape');
         // Give time for menu to close
         await fixture.events.sleep(closeDelay);
 
-        const closedMenu = getKeyboardShortcutsMenu();
-
-        expect(closedMenu).toBeNull();
+        expect(
+          fixture.editor.keyboardShortcuts.keyboardShortcutsMenu
+        ).toBeNull();
       });
 
       it('should place focus on close button when menu opens', () => {
-        const openMenu = getKeyboardShortcutsMenu();
-        expect(openMenu).toBeTruthy();
+        const { keyboardShortcutsMenu } = fixture.editor.keyboardShortcuts;
+        expect(keyboardShortcutsMenu).toBeTruthy();
 
-        const menu = within(openMenu);
+        const menu = within(keyboardShortcutsMenu);
         const closeButton = menu.getByRole('button', {
           name: /^Close Menu$/,
         });
@@ -187,10 +177,10 @@ describe('Keyboard Shortcuts Menu', () => {
       });
 
       it('should be able to close menu with close button', async () => {
-        const openMenu = getKeyboardShortcutsMenu();
-        expect(openMenu).toBeTruthy();
+        const { keyboardShortcutsMenu } = fixture.editor.keyboardShortcuts;
+        expect(keyboardShortcutsMenu).toBeTruthy();
 
-        const menu = within(openMenu);
+        const menu = within(keyboardShortcutsMenu);
         const closeButton = menu.getByRole('button', {
           name: /^Close Menu$/,
         });
@@ -200,9 +190,9 @@ describe('Keyboard Shortcuts Menu', () => {
         // Give time for menu to close
         await fixture.events.sleep(closeDelay);
 
-        const closedMenu = getKeyboardShortcutsMenu();
-
-        expect(closedMenu).toBeNull();
+        expect(
+          fixture.editor.keyboardShortcuts.keyboardShortcutsMenu
+        ).toBeNull();
       });
     });
   });

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutsMenuContext/context.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutsMenuContext/context.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { createContext } from '@web-stories-wp/design-system';
+
+export default createContext({ state: {}, actions: {} });

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutsMenuContext/index.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutsMenuContext/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as KeyboardShortcutsMenuProvider } from './provider';
+export { useKeyboardShortcutsMenu } from './useKeyboardShortcutsMenu';

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutsMenuContext/provider.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutsMenuContext/provider.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { useState, useMemo, useCallback } from 'react';
+import { trackEvent } from '@web-stories-wp/tracking';
+
+/**
+ * Internal dependencies
+ */
+import Context from './context';
+
+const KeyboardShortcutsMenuProvider = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggle = useCallback(
+    (e) => {
+      e.preventDefault();
+      trackEvent('shortcuts_menu_toggled', {
+        status: isOpen ? 'closed' : 'open',
+      });
+
+      setIsOpen((prevIsOpen) => !prevIsOpen);
+    },
+    [isOpen]
+  );
+
+  const close = useCallback(() => {
+    trackEvent('shortcuts_menu_toggled', {
+      status: 'closed',
+    });
+    setIsOpen(false);
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      state: {
+        isOpen,
+      },
+      actions: {
+        toggle,
+        close,
+      },
+    }),
+    [close, isOpen, toggle]
+  );
+
+  return <Context.Provider value={contextValue}>{children}</Context.Provider>;
+};
+
+KeyboardShortcutsMenuProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+export default KeyboardShortcutsMenuProvider;

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutsMenuContext/useKeyboardShortcutsMenu.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutsMenuContext/useKeyboardShortcutsMenu.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useContextSelector, identity } from '@web-stories-wp/design-system';
+
+/**
+ * Internal dependencies
+ */
+import Context from './context';
+
+export function useKeyboardShortcutsMenu(selector) {
+  const context = useContextSelector(Context, selector ?? identity);
+  if (!context) {
+    throw new Error(
+      'Must use `useKeyboardShortcutsMenu` within <keyboardShortcutsMenu.Provider />'
+    );
+  }
+  return context;
+}

--- a/assets/src/edit-story/karma/fixture/containers/carousel.js
+++ b/assets/src/edit-story/karma/fixture/containers/carousel.js
@@ -59,6 +59,10 @@ export class Carousel extends Container {
     return this.getByRole('button', { name: /^Checklist/ });
   }
 
+  get keyboardShortcutsToggle() {
+    return this.getByRole('button', { name: /^Keyboard Shortcuts$/ });
+  }
+
   get zoomSelector() {
     return this._get(
       this.getByRole('button', { name: 'Zoom Level' }),

--- a/assets/src/edit-story/karma/fixture/containers/editor.js
+++ b/assets/src/edit-story/karma/fixture/containers/editor.js
@@ -26,6 +26,7 @@ import { Inspector } from './inspector';
 import { Header } from './header';
 import { HelpCenter } from './helpCenter';
 import { Checklist } from './checklist';
+import { KeyboardShortcuts } from './keyboardShortcuts';
 
 /**
  * The complete editor container, including library, canvas, inspector, etc.
@@ -98,6 +99,14 @@ export class Editor extends Container {
       this.getByRole('region', { name: 'Checklist' }),
       'checklist',
       Checklist
+    );
+  }
+
+  get keyboardShortcuts() {
+    return this._get(
+      this.getByRole('region', { name: 'Page Carousel' }),
+      'keyboardShortcuts',
+      KeyboardShortcuts
     );
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/keyboardShortcuts.js
+++ b/assets/src/edit-story/karma/fixture/containers/keyboardShortcuts.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Container } from './container';
+
+/**
+ * The help center that can be toggled open
+ * or will show for specific interaction to help first time users.
+ */
+export class KeyboardShortcuts extends Container {
+  constructor(node, path) {
+    super(node, path);
+  }
+  get keyboardShortcutsMenu() {
+    return this.queryByRole('list', {
+      name: /^Keyboard Shortcuts$/,
+    });
+  }
+}


### PR DESCRIPTION
## Context

Pascal found a bug in the new implementation of the checklist!

## Summary

 I forgot about the keyboard shortcut menu when I set up making sure the help center and checklist weren't open at the same time. This just adds in the keyboard shortcut to that mix. 

## Relevant Technical Choices

- give keyboard shortcuts menu some context so that we can lift the toggle and is open state into the secondary menu with the other popups in the same manner
- little cleanup for shortcuts menu karma tests


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

In the secondary menu of the carousel section (help center, checklist (if enabled), and keyboard shortcuts), there can only ever be one of those 3 open at a given time. 
This isn't really new unless you have the checklist experiment enabled since that PR is still in QA.

## Testing Instructions

Verify that only one of the three listed above popups is open at an time. 

https://user-images.githubusercontent.com/10720454/124674201-23e6da80-de6f-11eb-9f4b-52c0a2df39b0.mp4



### QA

Toggle through the 3 listed popups (helpcenter, keyboard shortcuts, checklist (if enabled)) and verify that when one expands and there's already another open that previously open popup closes. Should work with mouse or keyboard. 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8205 
