### PR TITLE
E2E Tests: Improve flakey .mov insertion test

### DIFF
--- a/packages/e2e-tests/src/specs/editor/media/insertMovVideo.js
+++ b/packages/e2e-tests/src/specs/editor/media/insertMovVideo.js
@@ -55,11 +55,6 @@ describe('Handling .mov files', () => {
 
     await expect(page).toClick('button', { text: 'Insert into page' });
 
-    await page.waitForSelector('.ReactModal__Content');
-    await expect(page).toClick('button', {
-      text: /Sounds good/,
-    });
-
     await page.waitForSelector('[data-testid="videoElement"]');
     await expect(page).toMatchElement('[data-testid="videoElement"]');
   });

--- a/packages/e2e-tests/src/specs/editor/media/insertMovVideo.js
+++ b/packages/e2e-tests/src/specs/editor/media/insertMovVideo.js
@@ -55,8 +55,12 @@ describe('Handling .mov files', () => {
 
     await expect(page).toClick('button', { text: 'Insert into page' });
 
-    await page.waitForSelector('[data-testid="videoElement"]');
-    await expect(page).toMatchElement('[data-testid="videoElement"]');
+    await page.waitForSelector('[data-testid="videoElement"]', {
+      visible: false,
+    });
+    await expect(page).toMatchElement('[data-testid="videoElement"]', {
+      visible: false,
+    });
   });
 
   describe('Inserting .mov from dialog', () => {


### PR DESCRIPTION
The video optimization dialog might only pop up if it didn't already earlier.
Because it is only displayed once, it should not be awaited for in tests.