### PR TITLE
Bug: PPCv2.0 Checklist Panel Focus Border

### DIFF
--- a/assets/src/edit-story/components/checklistCard/styles.js
+++ b/assets/src/edit-story/components/checklistCard/styles.js
@@ -71,7 +71,11 @@ export const Title = styled.div`
     text-align: left;
     cursor: pointer;
     border-radius: ${({ theme }) => theme.borders.radius.small};
-    ${focusableOutlineCSS};
+    ${({ theme }) =>
+      focusableOutlineCSS(
+        theme.colors.border.focus,
+        theme.colors.bg.secondary
+      )};
   }
 `;
 

--- a/assets/src/edit-story/components/tablist/styles.js
+++ b/assets/src/edit-story/components/tablist/styles.js
@@ -52,7 +52,7 @@ export const TabButtonWrapper = styled.div`
   position: relative;
   height: 60px;
   width: 100%;
-  padding: 4px 4px;
+  padding: 5px 4px;
 
   &,
   :hover,
@@ -69,7 +69,7 @@ export const TabButton = styled(Button).attrs({
   display: flex;
   justify-content: space-between;
   width: calc(100% - 8px);
-  height: calc(100% - 8px);
+  height: calc(100% - 10px);
   padding: 16px;
   border-radius: 0;
 

--- a/assets/src/edit-story/components/tablist/styles.js
+++ b/assets/src/edit-story/components/tablist/styles.js
@@ -80,6 +80,12 @@ export const TabButton = styled(Button).attrs({
     background-color: ${({ theme }) => theme.colors.bg.secondary};
   }
 
+  ${({ theme }) =>
+    themeHelpers.focusableOutlineCSS(
+      theme.colors.border.focus,
+      theme.colors.bg.secondary
+    )};
+
   ${PanelText} {
     opacity: 0.8;
   }
@@ -105,8 +111,6 @@ export const PanelWrapper = styled.div`
   &:not(:first-child) > ${TabButton} {
     box-shadow: 0px -1px 0 0 ${({ theme }) => theme.colors.divider.tertiary};
     margin-top: 1px;
-
-    ${themeHelpers.focusableOutlineCSS};
   }
 
   ${({ isExpanded, theme }) =>

--- a/assets/src/edit-story/components/tablist/styles.js
+++ b/assets/src/edit-story/components/tablist/styles.js
@@ -48,14 +48,28 @@ export const PanelText = styled(Headline).attrs({
   transition: background-color 300ms ease-in;
 `;
 
+export const TabButtonWrapper = styled.div`
+  position: relative;
+  height: 60px;
+  width: 100%;
+  padding: 4px 4px;
+
+  &,
+  :hover,
+  :focus-within,
+  .${ThemeGlobals.FOCUS_VISIBLE_SELECTOR} {
+    background-color: ${({ theme }) => theme.colors.bg.secondary};
+  }
+`;
+
 export const TabButton = styled(Button).attrs({
   variant: BUTTON_VARIANTS.PLAIN,
 })`
-  position: relative;
+  position: absolute;
   display: flex;
   justify-content: space-between;
-  height: 60px;
-  width: 100%;
+  width: calc(100% - 8px);
+  height: calc(100% - 8px);
   padding: 16px;
   border-radius: 0;
 
@@ -64,11 +78,6 @@ export const TabButton = styled(Button).attrs({
   :focus,
   .${ThemeGlobals.FOCUS_VISIBLE_SELECTOR} {
     background-color: ${({ theme }) => theme.colors.bg.secondary};
-  }
-
-  :focus,
-  &.${ThemeGlobals.FOCUS_VISIBLE_SELECTOR} {
-    z-index: 2;
   }
 
   ${PanelText} {
@@ -103,7 +112,7 @@ export const PanelWrapper = styled.div`
   ${({ isExpanded, theme }) =>
     isExpanded &&
     css`
-      & > ${TabButton} {
+      & ${TabButton}, & ${TabButtonWrapper} {
         :not(:last-child) {
           box-shadow: none;
         }
@@ -125,7 +134,7 @@ export const PanelWrapper = styled.div`
         }
       }
 
-      * > ${TabPanel} {
+      * ${TabPanel} {
         height: 560px;
         padding: 0 0 16px 16px;
         overflow-y: scroll;

--- a/assets/src/edit-story/components/tablist/tablistPanel.js
+++ b/assets/src/edit-story/components/tablist/tablistPanel.js
@@ -35,6 +35,7 @@ import {
   ScrollableContent,
   TabButton,
   TabPanel,
+  TabButtonWrapper,
 } from './styles';
 
 const TablistPanel = ({
@@ -53,38 +54,40 @@ const TablistPanel = ({
 
   return (
     <PanelWrapper className={className} isExpanded={isExpanded}>
-      <TabButton
-        aria-controls={panelId}
-        aria-selected={isExpanded}
-        onClick={onClick}
-        role="tab"
-        status={status}
-      >
-        <ButtonText>
-          <IconContainer>
-            <Icons.ChevronDownSmall />
-          </IconContainer>
-          <PanelText
-            id={`${title}-${panelId}`}
-            aria-label={sprintf(
-              /* translators: 1: number of issues. 2: type of issue, for example "High Priority". */
-              _n(
-                '%1$d %2$s issue',
-                '%1$d %2$s issues',
+      <TabButtonWrapper>
+        <TabButton
+          aria-controls={panelId}
+          aria-selected={isExpanded}
+          onClick={onClick}
+          role="tab"
+          status={status}
+        >
+          <ButtonText>
+            <IconContainer>
+              <Icons.ChevronDownSmall />
+            </IconContainer>
+            <PanelText
+              id={`${title}-${panelId}`}
+              aria-label={sprintf(
+                /* translators: 1: number of issues. 2: type of issue, for example "High Priority". */
+                _n(
+                  '%1$d %2$s issue',
+                  '%1$d %2$s issues',
+                  badgeCount,
+                  'web-stories'
+                ),
                 badgeCount,
-                'web-stories'
-              ),
-              badgeCount,
-              title
-            )}
-          >
-            {title}
-          </PanelText>
-        </ButtonText>
-        <Badge>
-          <PanelText aria-hidden>{badgeCount}</PanelText>
-        </Badge>
-      </TabButton>
+                title
+              )}
+            >
+              {title}
+            </PanelText>
+          </ButtonText>
+          <Badge>
+            <PanelText aria-hidden>{badgeCount}</PanelText>
+          </Badge>
+        </TabButton>
+      </TabButtonWrapper>
       <ScrollableContent maxHeight={maxHeight}>
         <TabPanel
           id={panelId}


### PR DESCRIPTION
## Context
Small style bug fix for focus styles in the PPCv2.0

## Summary
Allows full focus border for the tablists to be visible within PPCv2.0.

**Before**
![124328235-7a3ddb80-db46-11eb-8a04-e98b9ce2f5b7](https://user-images.githubusercontent.com/35983235/124796500-da51ca80-df16-11eb-8edb-fdfedf703730.gif)


**After**
https://user-images.githubusercontent.com/35983235/124796208-85ae4f80-df16-11eb-9766-d5fdc692a6b1.mp4



## Relevant Technical Choices
Just shrank the button a bit and spoofed the bg so that focus border fits within the space and the button has no visual discrepancies from before

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Focus styles when using keyboard should now be fully visible on the tablist button here.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Enable PPC companion in experiments and keyboard navigate onto the open state of it. Should now see full focus border when focused on a tablist button component. Reference screenshots above if needed.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
- Go to Experiments
- Enable the editor check: `Enable Checklist Companion`
- Open an existing story or create a new one in the editor
- Ensure there's at least 5 pages and some content so the Prepublish checklist checks start populating
- use your keyboard to navigate into the Prepublish checklist
- Tab between check categories and see that the full focus border is visible like in the `After` screencasts above
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8175 
