### PR TITLE
PPC: Video Optimization Bulk Optimize Button Count

### DIFF
--- a/assets/src/edit-story/components/checklist/checks/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/videoOptimization.js
@@ -185,7 +185,6 @@ export const BulkVideoOptimization = () => {
   const isRendered = unoptimizedVideos.length > 0;
   useRegisterCheck('VideoOptimization', isRendered);
 
-  // todo copy should count the number of videos
   let optimizeButtonCopy =
     unoptimizedVideos.length === 1
       ? __('Optimize video', 'web-stories')
@@ -233,7 +232,7 @@ export const BulkVideoOptimization = () => {
         thumbnailCount={unoptimizedVideos.length}
         thumbnail={unoptimizedVideos.map((element) => (
           <Thumbnail
-            key={element.id}
+            key={element.resource.id}
             onClick={handleClickThumbnail(element)}
             isLoading={element.resource.isTranscoding}
             type={THUMBNAIL_TYPES.VIDEO}

--- a/assets/src/edit-story/components/checklist/checks/videoOptimization.js
+++ b/assets/src/edit-story/components/checklist/checks/videoOptimization.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@web-stories-wp/i18n';
+import { sprintf, _n, __ } from '@web-stories-wp/i18n';
 import styled from 'styled-components';
 
 /**
@@ -170,11 +170,16 @@ export const BulkVideoOptimization = () => {
 
   const { footer, title } = PRIORITY_COPY.videoNotOptimized;
 
+  const currentlyUploading = useMemo(
+    () =>
+      Object.values(state).filter((value) => value === actionTypes.uploading),
+    [state]
+  );
   const isTranscoding = useMemo(
     () =>
-      Object.values(state).includes(actionTypes.uploading) ||
+      currentlyUploading.length > 0 ||
       unoptimizedVideos.some((video) => video.resource?.isTranscoding),
-    [state, unoptimizedVideos]
+    [currentlyUploading, unoptimizedVideos]
   );
 
   const isRendered = unoptimizedVideos.length > 0;
@@ -187,10 +192,20 @@ export const BulkVideoOptimization = () => {
       : __('Optimize all videos', 'web-stories');
 
   if (isTranscoding) {
-    optimizeButtonCopy =
-      unoptimizedVideos.length === 1
-        ? __('Optimizing video', 'web-stories')
-        : __('Optimizing videos', 'web-stories');
+    const numTranscoding =
+      currentlyUploading.length +
+      unoptimizedVideos.filter((video) => video.resource?.isTranscoding).length;
+    optimizeButtonCopy = sprintf(
+      /* translators: 1: number of videos currently transcoding. 2: total number of videos in list. */
+      _n(
+        'Optimizing %1$d of %2$d',
+        'Optimizing %1$d of %2$d',
+        numTranscoding,
+        'web-stories'
+      ),
+      numTranscoding,
+      unoptimizedVideos.length
+    );
   }
 
   return (


### PR DESCRIPTION
## Context
- In the designs for the prepublish checklist video optimization panel, there is a count of videos being optimized. We want to add that count to the button.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- Count the number of currently uploading and transcoding videos and add that count to the button
- Also add the total count of videos  "1 of 1" "1 of 2" "2 of 2" , etc
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
There is some state change that results in a bit of an offset when the loading bar is showing and when the . This is because the element and the element list changes when their transcoding state changes. I went with the solution that ends up looking like this:

https://user-images.githubusercontent.com/41136059/124807149-53025800-df12-11eb-8cb4-c7cab2783768.mp4

Over these two others:

https://user-images.githubusercontent.com/41136059/124807196-5dbced00-df12-11eb-9e42-35f13b08e599.mp4

In the above I'm trying to sync the loading state with the "uploading" AND "transcoding" states the lists can be in. But because of the state change (how I'm tracking whether a video is being uploaded for transcoding) there is a flash when the content is reset and the loading bar resets. :/

https://user-images.githubusercontent.com/41136059/124807210-60b7dd80-df12-11eb-9b59-f168f73c8ef4.mp4

In the above I'm counting "0 of 2" because I'm not counting the "currently uploading" videos -- just the currently transcoding videos -- in order to avoid rerendering the thumb when that state changes. This syncs up the loading state with the transcoding state, but has the state where we are disabled and preventing additional clicks while we await the first "upload" call, which seemed awkward.

So, I went with what seemed best with the solutions I tried. Definitely into feedback for state magic I can cast to sync up the loading state with the button count in a more prettier way. 💅 

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open a new story
2. Add two or more videos with a resolution higher than 1920x1080
3. Add several empty pages (at least 5 total) in order to trigger the priority issues on the checklist
4. See that the video optimization panel is visible under the prepublish checklist
5. Click the button that says "optimize all videos" (make sure your video optimization setting is on and in experiments that the bulk video optimization experiment is on, if applicable)
6. See that the video starts uploading by the button becoming disabled and counting: "Optimizing 1 of n" (n being the number of videos total in the list) and the loading bar appears when the new transcoding video is added to the gallery.
7. That process should repeat for multiple videos

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8130 
