### PR TITLE
Perf: Reduce FontPicker impact on text selection latency 

### DIFF
--- a/assets/src/edit-story/components/panels/design/textStyle/fontPicker.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/fontPicker.js
@@ -125,7 +125,7 @@ const FontPicker = forwardRef(function FontPicker(
   const onObserve = (observedFonts) => {
     ensureMenuFontsLoaded(
       observedFonts.filter(
-        (fontName) => fontMap[fontName]?.service === 'fonts.google.com'
+        (fontName) => fontMap.get(fontName)?.service === 'fonts.google.com'
       )
     );
   };

--- a/assets/src/edit-story/components/panels/design/textStyle/fontPicker.js
+++ b/assets/src/edit-story/components/panels/design/textStyle/fontPicker.js
@@ -113,17 +113,14 @@ const FontPicker = forwardRef(function FontPicker(
     ]
   );
 
-  const fontMap = useMemo(
-    () =>
-      [...fonts, ...recentFonts, ...curatedFonts].reduce(
-        (lookup, option) => ({
-          ...lookup,
-          [option.id]: option,
-        }),
-        {}
-      ),
-    [fonts, recentFonts, curatedFonts]
-  );
+  const fontMap = useMemo(() => {
+    const map = new Map();
+    // curatedFonts and recentFonts are subsets of fonts.
+    fonts.forEach((f) => {
+      map.set(f.id, f);
+    });
+    return map;
+  }, [fonts]);
 
   const onObserve = (observedFonts) => {
     ensureMenuFontsLoaded(


### PR DESCRIPTION
## Context

I noticed large element selection latency during the bug bash, and with React Profiler it turned out that `FontPicker` was one of the most expensive renders during text selection.

![Screen Shot 2021-07-08 at 8 41 17 PM](https://user-images.githubusercontent.com/20525523/125006831-03fd1580-e02d-11eb-8626-5d3712058c21.png)

## Summary

Luckily, it turned out that almost all of that cost was from inefficient generation of `fontMap`! 

Using `Array.reduce` to generate a map is about 1000x slower, probably due to O(N) object creation (we should probably take a look at other places that use this pattern).

![Screen Shot 2021-07-08 at 8 50 43 PM](https://user-images.githubusercontent.com/20525523/125007438-30fdf800-e02e-11eb-8f5d-0cf0a375fe5b.png)

Then I realized that we probably can bypass most instances `fontMap` generation since `recentFonts` and `curatedFonts` are just subsets of `fonts` (so it only needs to be run once, ever).

Looks like this might shave a quarter second or more off of text selection latency:

![fontpicker_after](https://user-images.githubusercontent.com/20525523/125006962-50485580-e02d-11eb-9691-22ea76bddfc2.png)

## Relevant Technical Choices

N/A

## To-do

N/A

## User-facing changes

Selecting text elements should be more responsive.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

This PR can be tested by following these steps:

1. Select a text element in the editor
2. The editor should update slightly faster (display selection box & update text panel) 
3. The font picker/dropdown should continue to work as expected

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [X] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Partial for #8259
