### PR TITLE
Fix block interaction issues on mobile

### DIFF
--- a/assets/src/web-stories-block/css/core-themes/twentytwentyone.css
+++ b/assets/src/web-stories-block/css/core-themes/twentytwentyone.css
@@ -14,8 +14,33 @@
   }
 
   /* Fix for menu toggle overlap. */
-  .web-stories-theme-header-section .web-stories-list--customizer {
+  .web-stories-theme-header-section .web-stories-list {
     margin-top: 72px;
+  }
+
+  .web-stories-theme-header-section .web-stories-list.is-view-type-circles {
+    margin-top: 72px;
+    padding-top: 0;
+  }
+
+  .web-stories-theme-header-section
+    .web-stories-list.is-carousel.has-archive-link {
+    margin-top: 24px;
+    padding-top: 72px;
+  }
+
+  /* Fix for menu toggle overlap on AMP. */
+  html[amp] .web-stories-theme-header-section .web-stories-list.is-carousel {
+    margin-top: 0;
+    padding-top: 72px; /* same as above */
+  }
+
+  html[amp]
+    .web-stories-theme-header-section
+    .web-stories-list.is-carousel.has-archive-link {
+    padding-top: calc(
+      72px + 24px
+    ); /* default margin from common.css plus above offset */
   }
 
   /* Carousel arrows were visible over primary navigation menu on mobile. */

--- a/assets/src/web-stories-block/css/lightbox.css
+++ b/assets/src/web-stories-block/css/lightbox.css
@@ -15,6 +15,7 @@
   height: 100%;
   opacity: 0;
   transform: translate(0, -100vh);
+  display: none;
 }
 
 /* amp-lightbox needs to have z-index to render on top of other elements in the page. */
@@ -26,6 +27,7 @@
 .web-stories-list__lightbox.show {
   transform: translate(0, 0);
   opacity: 1;
+  display: block;
 }
 
 .web-stories-list__lightbox amp-story-player {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

When using the Web Stories block anywhere on a page, the upper part of the viewport was not usable on mobile.

This scenario typically happens when displaying Web Stories in a circles carousel using the Customizer integration, but it's not limited to that.

The reason for this is some behavior by `amp-story-player` where it occupies the screen while not fully loaded. And because it is just an iframe outside the initial viewport, the browser would lazy load it. After scrolling, it fully loads, making the issue go away.

## Summary

<!-- A brief description of what this PR does. -->

This PR completely hides the lightbox wrapper using `display: none` and only shows it when actually opening the lightbox. Previously this was just using `opacity: 0` and `opacity: 1`, which turns out to be insufficient.

Also improves displaying of the circles carousel customizer section in the Twenty Twenty-One theme.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

See how area was covered **before**:

![IMG-0854](https://user-images.githubusercontent.com/841956/125087220-9d2f3900-e0cc-11eb-81e1-f15877b45e70.PNG)
![Screenshot 2021-07-09 at 14 06 08](https://user-images.githubusercontent.com/841956/125087258-a4564700-e0cc-11eb-8c7d-6832346dc0de.png)


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Enable Web Stories in the Customizer (if not already the case), using the circles carousel option
2. Visit the website on mobile
3. Click on stories in the carousel
4. Verify that story opens in lightbox right away

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8111
