### PR TITLE
Animation: Add opacity to scale in animation

### DIFF
--- a/packages/animation/src/effects/zoom/index.js
+++ b/packages/animation/src/effects/zoom/index.js
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/**
+ * External dependencies
+ */
+import { v4 as uuidv4 } from 'uuid';
 /**
  * Internal dependencies
  */
 import { AnimationZoom } from '../../parts/zoom';
+import { AnimationFade } from '../../parts/fade';
 import { SCALE_DIRECTION } from '../../constants';
 
 export function EffectZoom({
@@ -26,11 +30,65 @@ export function EffectZoom({
   delay,
   easing = 'cubic-bezier(.3,0,.55,1)',
 }) {
-  return AnimationZoom({
+  const id = uuidv4();
+
+  const {
+    WAAPIAnimation: ZoomWAAPIAnimation,
+    AMPTarget: ZoomAMPTarget,
+    AMPAnimation: ZoomAMPAnimation,
+    generatedKeyframes: zoomKeyframes,
+  } = AnimationZoom({
     zoomFrom: scaleDirection === SCALE_DIRECTION.SCALE_OUT ? 3 : 1 / 3,
     zoomTo: 1,
     duration,
     delay,
     easing,
   });
+
+  const {
+    WAAPIAnimation: FadeWAAPIAnimation,
+    AMPTarget: FadeAMPTarget,
+    AMPAnimation: FadeAMPAnimation,
+    generatedKeyframes: fadeKeyframes,
+  } = AnimationFade({
+    fadeFrom: scaleDirection === SCALE_DIRECTION.SCALE_OUT ? 1 : 0,
+    fadeTo: 1,
+    duration: duration,
+    delay,
+    easing,
+  });
+
+  return {
+    id,
+    // eslint-disable-next-line react/prop-types
+    WAAPIAnimation: function WAAPIAnimation({ children, hoistAnimation }) {
+      return (
+        <FadeWAAPIAnimation hoistAnimation={hoistAnimation}>
+          <ZoomWAAPIAnimation hoistAnimation={hoistAnimation}>
+            {children}
+          </ZoomWAAPIAnimation>
+        </FadeWAAPIAnimation>
+      );
+    },
+    // eslint-disable-next-line react/prop-types
+    AMPTarget: function AMPTarget({ children, style }) {
+      return (
+        <FadeAMPTarget style={style}>
+          <ZoomAMPTarget style={style}>{children}</ZoomAMPTarget>
+        </FadeAMPTarget>
+      );
+    },
+    AMPAnimation: function AMPAnimation() {
+      return (
+        <>
+          <FadeAMPAnimation />
+          <ZoomAMPAnimation />
+        </>
+      );
+    },
+    generatedKeyframes: {
+      ...fadeKeyframes,
+      ...zoomKeyframes,
+    },
+  };
 }


### PR DESCRIPTION
## Context
Added to help while image may be loading higher res version of itself in the bg and animating.
https://xwp.slack.com/archives/C0144TS0EFJ/p1623166565035200

## Summary
Just adds opacity: 0 value that animates to opacity: 1 with the scale-in animation as requested in the animation channel
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
NA
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Scale in animation now fades in from 0 -> 1
Scale out remains the same as it was with no fade
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Open the editor and see that the scale-in animation also fades in now
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
- Open the editor
- Add an element and apply a scale-in animation
- See that the element starts at 0 opacity in the scale in animation and animates the opacity to 1 by the end of the animation
- click preview and see that the animation looks the same in the preview as well
- Go back to the editor
- update the animation to scale-out
- see that the opacity stays at 1 the entire lifetime of the scale-out animation
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7867 
