### PR TITLE
Dev Tools: Add Template checkbox to prepare JSON for export as template

### DIFF
--- a/assets/src/edit-story/components/devTools/devTools.js
+++ b/assets/src/edit-story/components/devTools/devTools.js
@@ -132,9 +132,9 @@ const getResourceFileName = (src) => {
  *
  * @see https://github.com/google/web-stories-wp/issues/7227
  * @param {*} state Current story.
- * @return {*} Updated state for Core Template.
+ * @return {*} Updated state for Template.
  */
-const prepareCoreTemplate = (state) => {
+const prepareTemplate = (state) => {
   const newState = {
     ...state,
     current: null,
@@ -176,7 +176,7 @@ function DevTools() {
   const [isVisible, setIsVisible] = useState(false);
   const [isBase64, setIsBase64] = useState(false);
   const [isDummyResources, setIsDummyResources] = useState(false);
-  const [isCoreTemplate, setIsCoreTemplate] = useState(false);
+  const [isTemplate, setIsTemplate] = useState(false);
   const { showSnackbar } = useSnackbar();
   const textareaRef = useRef();
   const {
@@ -198,12 +198,12 @@ function DevTools() {
   };
   const storyData = isDummyResources
     ? replaceResourcesWithDummy(reducerStateSlice)[0]
-    : isCoreTemplate
-    ? prepareCoreTemplate(reducerStateSlice)
+    : isTemplate
+    ? prepareTemplate(reducerStateSlice)
     : reducerStateSlice;
 
   const toggleDummyResources = () => setIsDummyResources((v) => !v);
-  const toggleCoreTemplate = () => setIsCoreTemplate((v) => !v);
+  const toggleTemplate = () => setIsTemplate((v) => !v);
   const toggleBase64 = () => setIsBase64((v) => !v);
   const toggleVisible = () => setIsVisible((v) => !v);
   const copyToClipboard = () => {
@@ -266,13 +266,13 @@ function DevTools() {
             />
             {'Dummy resources'}
           </Label>
-          <Label title="Export as Core Template">
+          <Label title="Export as Template">
             <input
               type="checkbox"
-              checked={isCoreTemplate}
-              onChange={toggleCoreTemplate}
+              checked={isTemplate}
+              onChange={toggleTemplate}
             />
-            {'Core Template'}
+            {'Template'}
           </Label>
         </div>
         <div>

--- a/assets/src/edit-story/components/devTools/devTools.js
+++ b/assets/src/edit-story/components/devTools/devTools.js
@@ -97,7 +97,7 @@ const replaceResourcesWithDummy = (state) => {
   return [newState, videosToReload];
 };
 
-const coreTemplateResourcePlaceholder =
+const templateResourcePlaceholder =
   '____WEB_STORIES_TEMPLATE_BASE_URL__/images/templates/%%templateName%%/';
 
 const getResourceFileName = (src) => {
@@ -110,7 +110,7 @@ const getResourceFileName = (src) => {
 
   // If file path found, return it with the placeholder for easy replacements.
   if (matchedPaths.length > 1) {
-    return `${coreTemplateResourcePlaceholder}${matchedPaths[1]}`;
+    return `${templateResourcePlaceholder}${matchedPaths[1]}`;
   }
 
   // If file path not found return original URL.
@@ -118,7 +118,7 @@ const getResourceFileName = (src) => {
 };
 
 /**
- * Prepare story JSON to export as core template by resetting few properties
+ * Prepare story JSON to export as template by resetting few properties
  * which are not used and adding handy placeholder strings for easy replacement
  * of template names.
  *

--- a/docs/external-template-creation.md
+++ b/docs/external-template-creation.md
@@ -102,9 +102,9 @@ To get the JSON representation of a story in the editor:
 1. In the editor, open the story.
 2. Press `Command+Shift+Option+J` (Mac) or `Control+Shift+Alt+J` (Windows/Linux) in the editor.
 3. A dialog will appear where you can copy/paste story JSON.
-4. Check the `Core Template` checkbox that is present at the top of the dialog.
+4. Check the `Template` checkbox that is present at the top of the dialog.
 
-   <img width="554" alt="Screenshot 2021-07-11 at 2 40 16 PM" src="https://user-images.githubusercontent.com/6906779/125189481-efe82c80-e255-11eb-93dd-ca875d514f54.png">
+   <img width="554" alt="Screenshot of the dev tools with the Templates checkbox" src="https://user-images.githubusercontent.com/6906779/125189481-efe82c80-e255-11eb-93dd-ca875d514f54.png">
 
 
 #### Alternative
@@ -129,11 +129,11 @@ Once you have the story JSON, several code changes are needed to add it to the l
         - `story: {}`
       - First change all image & video URLs to use `__WEB_STORIES_TEMPLATE_BASE_URL__` as the base, which then will be replaced by the CDN url.
       - Ensure to also change poster image URLs to use `__WEB_STORIES_TEMPLATE_BASE_URL__`.
-      - Change `posterId` and `id` for all elements of type image and video to `0`, these are the WP media ids that are not used in core templates.
+      - Change `posterId` and `id` for all elements of type image and video to `0`, these are the WP media ids that are not used in templates.
       - Make sure that the images and videos have appropriate title and alt text set for better accessibility.
 
    - If the story JSON is copied from the devTools dialog as mentioned  in [Get The Story JSON](#get-the-story-json), the JSON will have some of the changes already present.
-     - The 'Core Template' checkbox does following:
+     - The 'Template' checkbox does following:
        - Resets extraneous properties.
        - Replaces resource URLs with replaceable CDN constant and `static-site` asset path.
        - Resets `sizes` property for images to `[]`.

--- a/docs/external-template-creation.md
+++ b/docs/external-template-creation.md
@@ -102,6 +102,10 @@ To get the JSON representation of a story in the editor:
 1. In the editor, open the story.
 2. Press `Command+Shift+Option+J` (Mac) or `Control+Shift+Alt+J` (Windows/Linux) in the editor.
 3. A dialog will appear where you can copy/paste story JSON.
+4. Check the `Core Template` checkbox that is present at the top of the dialog.
+
+   <img width="554" alt="Screenshot 2021-07-11 at 2 40 16 PM" src="https://user-images.githubusercontent.com/6906779/125189481-efe82c80-e255-11eb-93dd-ca875d514f54.png">
+
 
 #### Alternative
 
@@ -119,10 +123,24 @@ Once you have the story JSON, several code changes are needed to add it to the l
 
 1. In [`packages/templates/src/raw/`](https://github.com/google/web-stories-wp/tree/main/packages/templates/src/raw), create a new directory `<template_name>` for your template. Now add your template's story JSON in a new file e.g. `<template_name>/template.json`.
    - Make following changes to the template JSON,
+      - Reset following extraneous properties,
+        - `current: null`
+        - `selection: []`
+        - `story: {}`
       - First change all image & video URLs to use `__WEB_STORIES_TEMPLATE_BASE_URL__` as the base, which then will be replaced by the CDN url.
       - Ensure to also change poster image URLs to use `__WEB_STORIES_TEMPLATE_BASE_URL__`.
       - Change `posterId` and `id` for all elements of type image and video to `0`, these are the WP media ids that are not used in core templates.
       - Make sure that the images and videos have appropriate title and alt text set for better accessibility.
+
+   - If the story JSON is copied from the devTools dialog as mentioned  in [Get The Story JSON](#get-the-story-json), the JSON will have some of the changes already present.
+     - The 'Core Template' checkbox does following:
+       - Resets extraneous properties.
+       - Replaces resource URLs with replaceable CDN constant and `static-site` asset path.
+       - Resets `sizes` property for images to `[]`.
+       - Resets all `id` and `posterId` to 0 for image and video type resources.
+
+      NOTE: Check all resource URLs and properties are set properly before commiting the template.
+
 
 2. Create a new file `index.js` in your newly created `<template_name>` directory and import the `template.json` file. Your `<template_name>/index.js` file would then look something like this with object corresponding to the new template and properties `id`, `title`, `tags`, `colors`, etc.
 


### PR DESCRIPTION
## Context

With the addition of new templates to the template library, few repetitive tasks were identified like resetting extraneous properties and setting replaceable URLs.

## Summary

This PR adds a new checkbox to the devTools dialog to prepare the story JSON:
- Reset extraneous properties like, `current`, `story`, `selection` etc.
- Set `id` and `posterId` for images / video resources to `0`.
- Set `sizes` property for `images` to empty array.
- Replaces resource URLs to have replaceable CDN constant and `static-site` images path.
- adds `%%templateName%%` placeholder to be replaced by the actual story template name / title as per the path on `static-site`.

Changes: 
<img width="942" alt="Screenshot 2021-07-11 at 2 16 41 PM" src="https://user-images.githubusercontent.com/6906779/125189893-042d2900-e258-11eb-837a-2ae049824638.png">

## User-facing changes

<img width="554" alt="Screenshot 2021-07-11 at 2 40 16 PM" src="https://user-images.githubusercontent.com/6906779/125189481-efe82c80-e255-11eb-93dd-ca875d514f54.png">

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR
