### PR TITLE
Code Quality: Address excess re-render of `updateCurrentUser`

### DIFF
--- a/assets/src/edit-story/app/helpCenter/provider.js
+++ b/assets/src/edit-story/app/helpCenter/provider.js
@@ -27,10 +27,7 @@ import { clamp } from '@web-stories-wp/animation';
  */
 import { useCurrentUser } from '../currentUser';
 import localStore, { LOCAL_STORAGE_PREFIX } from '../../utils/localStore';
-import {
-  BASE_NAVIGATION_FLOW,
-  TRANSITION_DURATION,
-} from '../../components/helpCenter/constants';
+import { BASE_NAVIGATION_FLOW } from '../../components/helpCenter/constants';
 import Context from './context';
 import {
   composeEffects,
@@ -253,30 +250,20 @@ function HelpCenterProvider({ children }) {
   const isInitialHydrationUpdate = useRef(false);
   useEffect(() => {
     if (!persistenceKey && !isHydrated) {
-      return () => {};
+      return;
     }
 
     // We don't want to persist when the update is from
     // the initial hydrate call
     if (!isInitialHydrationUpdate.current) {
       isInitialHydrationUpdate.current = true;
-      return () => {};
+      return;
     }
-    // The call to `updateCurrentUser` causes the entire app to rerender
-    // which causes noticable jank in our transition. This is just
-    // a short term fix to not have that render occur during
-    // the transition.
-    const id = setTimeout(
-      () =>
-        updateCurrentUser({
-          meta: {
-            web_stories_onboarding: createBooleanMapFromKey(persistenceKey),
-          },
-        }).catch(actions.persistingReadTipsError),
-      // duration of menu transition which takes the longest
-      TRANSITION_DURATION * 1.2
-    );
-    return () => clearTimeout(id);
+    updateCurrentUser({
+      meta: {
+        web_stories_onboarding: createBooleanMapFromKey(persistenceKey),
+      },
+    }).catch(actions.persistingReadTipsError);
   }, [actions, updateCurrentUser, persistenceKey, isHydrated]);
 
   // Components wrapped in a Transition no longer receive


### PR DESCRIPTION
## Context
Part of performance sprint

## Summary
the excess re-render is no longer happening so removed old code accommodating for it in the help center

## Relevant Technical Choices
Before we were getting an app wide re-render when calling `updateCurrentUser`. to accommodate for the perf impact of this app wide rerender causing jank in the help center tip transition animations, we originally just delayed the call to `updateCurrentUser` till after the transition.

However, based on inspection in this PR, the call to `updateCurrentUser` is no longer causing an app wide re-render like it was when the ticket was created, so I just cleaned up the help center comments and removed the delayed call to `updateCurrentUser` and instead made it an immediate one.

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Not really anything to test here without inspecting rerenders in the code. I guess just unread all your tips by typing this into the console:
```
await wp.apiFetch({ path: '/web-stories/v1/users/me', method: 'POST', data: { meta: { web_stories_onboarding: {} }}})
```

Then reload the page and see that the help center still reads tips properly. (only difference is not delaying the syncing up of read tips till after the tip transition animation vs delaying it. so there should be no updates to business logic here or behavior)
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6309 
