### PR TITLE
Media: Add video cache opt-in

### DIFF
--- a/assets/src/dashboard/app/api/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/useSettingsApi.js
@@ -61,6 +61,7 @@ export default function useSettingsApi(
           adNetwork: response.web_stories_ad_network,
           activePublisherLogoId: response.web_stories_active_publisher_logo,
           publisherLogoIds: response.web_stories_publisher_logos,
+          videoCache: response.web_stories_video_cache,
         },
       });
     } catch (err) {
@@ -83,6 +84,7 @@ export default function useSettingsApi(
       publisherLogoIds,
       publisherLogoIdToRemove,
       publisherLogoToMakeDefault,
+      videoCache,
     }) => {
       try {
         const query = {};
@@ -122,6 +124,10 @@ export default function useSettingsApi(
           query.web_stories_active_publisher_logo = publisherLogoToMakeDefault;
         }
 
+        if (videoCache !== undefined) {
+          query.web_stories_video_cache = Boolean(videoCache);
+        }
+
         const response = await dataAdapter.post(
           queryString.stringifyUrl({
             url: globalStoriesSettingsApi,
@@ -139,6 +145,7 @@ export default function useSettingsApi(
             adNetwork: response.web_stories_ad_network,
             activePublisherLogoId: response.web_stories_active_publisher_logo,
             publisherLogoIds: response.web_stories_publisher_logos,
+            videoCache: response.web_stories_video_cache,
           },
         });
       } catch (err) {

--- a/assets/src/dashboard/app/reducer/settings.js
+++ b/assets/src/dashboard/app/reducer/settings.js
@@ -35,6 +35,7 @@ export const defaultSettingsState = {
   adManagerSlotId: '',
   adNetwork: AD_NETWORK_TYPE.NONE,
   publisherLogoIds: [],
+  videoCache: false,
 };
 
 function settingsReducer(state, action) {
@@ -64,6 +65,7 @@ function settingsReducer(state, action) {
             ...action.payload.publisherLogoIds,
           ]),
         ],
+        videoCache: action.payload.videoCache,
       };
     }
 

--- a/assets/src/dashboard/app/views/editorSettings/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/index.js
@@ -37,6 +37,7 @@ import AdManagement from './adManagement';
 import PublisherLogoSettings from './publisherLogo';
 import TelemetrySettings from './telemetry';
 import MediaOptimizationSettings from './mediaOptimization';
+import VideoCacheSettings from './videoCache';
 
 const ACTIVE_DIALOG_REMOVE_LOGO = 'REMOVE_LOGO';
 
@@ -56,6 +57,7 @@ function EditorSettings() {
     mediaById,
     newlyCreatedMediaIds,
     publisherLogoIds,
+    videoCache,
   } = useApi(
     ({
       actions: {
@@ -71,6 +73,7 @@ function EditorSettings() {
           adNetwork,
           publisherLogoIds,
           activePublisherLogoId,
+          videoCache,
         },
         media: { isLoading: isMediaLoading, mediaById, newlyCreatedMediaIds },
       },
@@ -89,6 +92,7 @@ function EditorSettings() {
       mediaById,
       newlyCreatedMediaIds,
       publisherLogoIds,
+      videoCache,
     })
   );
 
@@ -372,6 +376,12 @@ function EditorSettings() {
                 disabled={disableMediaOptimization}
                 onCheckboxSelected={toggleWebStoriesMediaOptimization}
                 selected={mediaOptimization}
+              />
+            )}
+            {canManageSettings && (
+              <VideoCacheSettings
+                isEnabled={videoCache}
+                updateSettings={updateSettings}
               />
             )}
             {canManageSettings && (

--- a/assets/src/dashboard/app/views/editorSettings/telemetry/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/telemetry/index.js
@@ -57,7 +57,7 @@ export default function TelemetrySettings({
             checked={Boolean(selected)}
           />
           <CheckboxLabelText
-            size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
+            size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
             aria-checked={Boolean(selected)}
             forwardedAs="span"
           >

--- a/assets/src/dashboard/app/views/editorSettings/videoCache/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/videoCache/index.js
@@ -17,10 +17,11 @@
 /**
  * External dependencies
  */
-import propTypes from 'prop-types';
-import { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { useCallback, useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { __ } from '@web-stories-wp/i18n';
+import { useFeature } from 'flagged';
 import { Checkbox, THEME_CONSTANTS } from '@web-stories-wp/design-system';
 
 /**
@@ -33,39 +34,43 @@ import {
   CheckboxLabelText,
 } from '../components';
 
-export default function MediaOptimizationSettings({
-  selected,
-  onCheckboxSelected,
-  disabled,
+export default function VideoCacheSettings({
+  isEnabled = false,
+  updateSettings,
 }) {
-  const mediaOptimizationId = useMemo(
-    () => `media-optimization-${uuidv4()}`,
-    []
+  const videoCacheId = useMemo(() => `video-cache-${uuidv4()}`, []);
+
+  const onChange = useCallback(
+    () => updateSettings({ videoCache: !isEnabled }),
+    [updateSettings, isEnabled]
   );
+
+  const isFeatureEnabled = useFeature('videoCache');
+
+  if (!isFeatureEnabled) {
+    return null;
+  }
 
   return (
     <SettingForm>
       <div>
-        <SettingHeading>
-          {__('Video Optimization', 'web-stories')}
-        </SettingHeading>
+        <SettingHeading>{__('Video Cache', 'web-stories')}</SettingHeading>
       </div>
       <div>
-        <CheckboxLabel forwardedAs="label" htmlFor={mediaOptimizationId}>
+        <CheckboxLabel forwardedAs="label" htmlFor={videoCacheId}>
           <Checkbox
-            id={mediaOptimizationId}
-            data-testid="media-optimization-settings-checkbox"
-            disabled={disabled}
-            onChange={onCheckboxSelected}
-            checked={Boolean(selected)}
+            id={videoCacheId}
+            data-testid="video-cache-settings-checkbox"
+            onChange={onChange}
+            checked={Boolean(isEnabled)}
           />
           <CheckboxLabelText
             size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
-            aria-checked={Boolean(selected)}
+            aria-checked={Boolean(isEnabled)}
             forwardedAs="span"
           >
             {__(
-              'Automatically optimize videos used in Web Stories. We recommend enabling this feature. Video files that are too large or have an unsupported format (like .mov) will otherwise not display properly.',
+              'Reduce hosting costs and improve user experience by serving videos from the Google cache.',
               'web-stories'
             )}
           </CheckboxLabelText>
@@ -75,8 +80,11 @@ export default function MediaOptimizationSettings({
   );
 }
 
-MediaOptimizationSettings.propTypes = {
-  disabled: propTypes.bool.isRequired,
-  selected: propTypes.bool.isRequired,
-  onCheckboxSelected: propTypes.func.isRequired,
+VideoCacheSettings.propTypes = {
+  isEnabled: PropTypes.bool.isRequired,
+  updateSettings: PropTypes.func.isRequired,
+};
+
+VideoCacheSettings.defaultProps = {
+  isEnabled: false,
 };

--- a/assets/src/dashboard/app/views/editorSettings/videoCache/stories/index.js
+++ b/assets/src/dashboard/app/views/editorSettings/videoCache/stories/index.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
+import { FlagsProvider } from 'flagged';
+
+/**
+ * Internal dependencies
+ */
+import VideoCacheSettings from '..';
+
+export default {
+  title: 'Dashboard/Views/EditorSettings/VideoCache',
+  component: VideoCacheSettings,
+};
+
+export const _default = () => {
+  return (
+    <FlagsProvider features={{ videoCache: true }}>
+      <VideoCacheSettings
+        isEnabled={boolean('isEnabled', true)}
+        updateSettings={action('updateSettings fired')}
+      />
+    </FlagsProvider>
+  );
+};

--- a/assets/src/dashboard/app/views/editorSettings/videoCache/test/videoCache.js
+++ b/assets/src/dashboard/app/views/editorSettings/videoCache/test/videoCache.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { fireEvent, screen } from '@testing-library/react';
+import { FlagsProvider } from 'flagged';
+
+/**
+ * Internal dependencies
+ */
+import { renderWithProviders } from '../../../../../testUtils';
+import VideoCache from '..';
+
+describe('Editor Settings: <VideoCache />', function () {
+  it('should not render anything if experiment is not enabled', function () {
+    renderWithProviders(<VideoCache updateSettings={jest.fn()} isEnabled />);
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('should render the video cache setting as checked when isEnabled', function () {
+    renderWithProviders(
+      <FlagsProvider features={{ videoCache: true }}>
+        <VideoCache updateSettings={jest.fn()} isEnabled />
+      </FlagsProvider>
+    );
+
+    expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('should not render the video cache setting as checked when not isEnabled', function () {
+    renderWithProviders(
+      <FlagsProvider features={{ videoCache: true }}>
+        <VideoCache updateSettings={jest.fn()} />
+      </FlagsProvider>
+    );
+
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('should update settings when the checkbox is clicked.', function () {
+    const onChange = jest.fn();
+    renderWithProviders(
+      <FlagsProvider features={{ videoCache: true }}>
+        <VideoCache updateSettings={onChange} />
+      </FlagsProvider>
+    );
+
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ videoCache: true });
+  });
+});

--- a/includes/AMP/Integration/AMP_Story_Sanitizer.php
+++ b/includes/AMP/Integration/AMP_Story_Sanitizer.php
@@ -55,6 +55,7 @@ class AMP_Story_Sanitizer extends AMP_Base_Sanitizer {
 		$this->add_publisher( $this->dom, $this->args['publisher'] );
 		$this->add_poster_images( $this->dom, $this->args['poster_images'] );
 		$this->deduplicate_inline_styles( $this->dom );
+		$this->add_video_cache( $this->dom, $this->args['video_cache'] );
 		$this->remove_blob_urls( $this->dom );
 	}
 }

--- a/includes/AMP/Story_Sanitizer.php
+++ b/includes/AMP/Story_Sanitizer.php
@@ -53,6 +53,7 @@ class Story_Sanitizer extends AMP_Base_Sanitizer {
 		$this->add_publisher( $this->dom, $this->args['publisher'] );
 		$this->add_poster_images( $this->dom, $this->args['poster_images'] );
 		$this->deduplicate_inline_styles( $this->dom );
+		$this->add_video_cache( $this->dom, $this->args['video_cache'] );
 		$this->remove_blob_urls( $this->dom );
 	}
 }

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -255,6 +255,32 @@ trait Sanitization_Utils {
 	}
 
 	/**
+	 * Enables using video cache by adding the necessary attribute to `<amp-video>`
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param Document|AMP_Document $document Document instance.
+	 * @param bool                  $video_cache_enabled Whether video cache is enabled.
+	 * @return void
+	 */
+	private function add_video_cache( &$document, $video_cache_enabled ) {
+		if ( ! $video_cache_enabled ) {
+			return;
+		}
+
+		$videos = $document->body->getElementsByTagName( 'amp-video' );
+
+		/**
+		 * The <amp-video> element
+		 *
+		 * @var DOMElement $video The <amp-video> element
+		 */
+		foreach ( $videos as $video ) {
+			$video->setAttribute( 'cache', 'google' );
+		}
+	}
+
+	/**
 	 * Determines whether a URL is a `blob:` URL.
 	 *
 	 * @since 1.9.0

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -421,6 +421,17 @@ class Experiments extends Service_Base {
 				'description' => __( 'Enable choosing color using an eyedropper', 'web-stories' ),
 				'group'       => 'editor',
 			],
+			/**
+			 * Author: @swissspidy
+			 * Issue: #8310
+			 * Creation date: 2021-07-13
+			 */
+			[
+				'name'        => 'videoCache',
+				'label'       => __( 'Video Cache', 'web-stories' ),
+				'description' => __( 'Reduce hosting costs and improve user experience by serving videos from the Google cache.', 'web-stories' ),
+				'group'       => 'general',
+			],
 		];
 	}
 

--- a/includes/Integrations/AMP.php
+++ b/includes/Integrations/AMP.php
@@ -28,7 +28,9 @@ namespace Google\Web_Stories\Integrations;
 
 use DOMElement;
 use Google\Web_Stories\AMP\Integration\AMP_Story_Sanitizer;
+use Google\Web_Stories\Experiments;
 use Google\Web_Stories\Model\Story;
+use Google\Web_Stories\Settings;
 use Google\Web_Stories\Story_Post_Type;
 use Google\Web_Stories\Traits\Publisher;
 use Google\Web_Stories\Service_Base;
@@ -51,6 +53,24 @@ class AMP extends Service_Base {
 	 * @var string
 	 */
 	const AMP_VALIDATED_URL_POST_TYPE = 'amp_validated_url';
+
+	/**
+	 * Experiments instance.
+	 *
+	 * @var Experiments Experiments instance.
+	 */
+	private $experiments;
+
+	/**
+	 * HTML constructor.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param Experiments $experiments Experiments instance.
+	 */
+	public function __construct( Experiments $experiments ) {
+		$this->experiments = $experiments;
+	}
 
 	/**
 	 * Initializes all hooks.
@@ -129,6 +149,8 @@ class AMP extends Service_Base {
 			return $sanitizers;
 		}
 
+		$video_cache_enabled = $this->experiments->is_experiment_enabled( 'videoCache' ) && (bool) get_option( Settings::SETTING_NAME_VIDEO_CACHE );
+
 		$story = new Story();
 		$story->load_from_post( $post );
 		$sanitizers[ AMP_Story_Sanitizer::class ] = [
@@ -138,6 +160,7 @@ class AMP extends Service_Base {
 			'poster_images'              => [
 				'poster-portrait-src' => $story->get_poster_portrait(),
 			],
+			'video_cache'                => $video_cache_enabled,
 		];
 
 		return $sanitizers;

--- a/includes/Renderer/Story/HTML.php
+++ b/includes/Renderer/Story/HTML.php
@@ -26,6 +26,8 @@
 
 namespace Google\Web_Stories\Renderer\Story;
 
+use Google\Web_Stories\Experiments;
+use Google\Web_Stories\Settings;
 use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
 use Google\Web_Stories\Traits\Publisher;
 use Google\Web_Stories\Model\Story;
@@ -55,14 +57,23 @@ class HTML {
 	protected $document;
 
 	/**
+	 * Experiments instance.
+	 *
+	 * @var Experiments Experiments instance.
+	 */
+	private $experiments;
+
+	/**
 	 * HTML constructor.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param Story $story Story object.
+	 * @param Story       $story Story object.
+	 * @param Experiments $experiments Experiments instance.
 	 */
-	public function __construct( Story $story ) {
-		$this->story = $story;
+	public function __construct( Story $story, Experiments $experiments ) {
+		$this->story       = $story;
+		$this->experiments = $experiments;
 	}
 
 	/**
@@ -128,11 +139,14 @@ class HTML {
 	 * @return array Sanitizers.
 	 */
 	public function add_web_stories_amp_content_sanitizers( $sanitizers ) {
+		$video_cache_enabled = $this->experiments->is_experiment_enabled( 'videoCache' ) && (bool) get_option( Settings::SETTING_NAME_VIDEO_CACHE );
+
 		$sanitizers[ Story_Sanitizer::class ] = [
 			'publisher_logo'             => $this->get_publisher_logo(),
 			'publisher'                  => $this->get_publisher_name(),
 			'publisher_logo_placeholder' => $this->get_publisher_logo_placeholder(),
 			'poster_images'              => $this->get_poster_images(),
+			'video_cache'                => $video_cache_enabled,
 		];
 
 		return $sanitizers;

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -103,6 +103,13 @@ class Settings extends Service_Base {
 	const SETTING_NAME_PUBLISHER_LOGOS = 'web_stories_publisher_logos';
 
 	/**
+	 * Video cache setting name.
+	 *
+	 * @var string
+	 */
+	const SETTING_NAME_VIDEO_CACHE = 'web_stories_video_cache';
+
+	/**
 	 * Initializes the Settings logic.
 	 *
 	 * @since 1.0.0
@@ -215,6 +222,17 @@ class Settings extends Service_Base {
 						],
 					],
 				],
+			]
+		);
+
+		register_setting(
+			self::SETTING_GROUP,
+			self::SETTING_NAME_VIDEO_CACHE,
+			[
+				'description'  => __( 'Video Cache', 'web-stories' ),
+				'type'         => 'boolean',
+				'default'      => false,
+				'show_in_rest' => true,
 			]
 		);
 

--- a/includes/templates/frontend/single-web-story.php
+++ b/includes/templates/frontend/single-web-story.php
@@ -10,6 +10,7 @@
 
 use Google\Web_Stories\Renderer\Story\HTML;
 use Google\Web_Stories\Model\Story;
+use Google\Web_Stories\Services;
 
 /**
  * Copyright 2020 Google LLC
@@ -34,6 +35,6 @@ $current_post = get_post();
 if ( $current_post instanceof WP_Post ) {
 	$story = new Story();
 	$story->load_from_post( $current_post );
-	$renderer = new HTML( $story );
+	$renderer = new HTML( $story, Services::get( 'experiments' ) );
 	echo $renderer->render(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }

--- a/tests/phpunit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/tests/AMP/Story_Sanitizer.php
@@ -77,6 +77,7 @@ class Story_Sanitizer extends Test_Case {
 			'publisher_logo'             => 'https://example.com/publisher_logo.png',
 			'publisher_logo_placeholder' => 'https://example.com/placeholder_logo.png',
 			'poster_images'              => [],
+			'video_cache'                => false,
 		];
 
 		$actual = $this->sanitize_and_get( $source, $args );
@@ -115,6 +116,7 @@ class Story_Sanitizer extends Test_Case {
 			'publisher'                  => '',
 			'publisher_logo_placeholder' => '',
 			'poster_images'              => [],
+			'video_cache'                => false,
 		];
 
 		$actual = $this->sanitize_and_get( $source, $args );
@@ -132,6 +134,7 @@ class Story_Sanitizer extends Test_Case {
 					'publisher'                  => 'New publisher',
 					'publisher_logo_placeholder' => '',
 					'poster_images'              => [],
+					'video_cache'                => false,
 				],
 			],
 			'no_publisher'            => [
@@ -142,6 +145,7 @@ class Story_Sanitizer extends Test_Case {
 					'publisher'                  => 'New publisher',
 					'publisher_logo_placeholder' => '',
 					'poster_images'              => [],
+					'video_cache'                => false,
 				],
 			],
 			'missing_publisher'       => [
@@ -152,6 +156,7 @@ class Story_Sanitizer extends Test_Case {
 					'publisher'                  => '',
 					'publisher_logo_placeholder' => '',
 					'poster_images'              => [],
+					'video_cache'                => false,
 				],
 			],
 			'empty_publisher'         => [
@@ -162,6 +167,7 @@ class Story_Sanitizer extends Test_Case {
 					'publisher'                  => '',
 					'publisher_logo_placeholder' => '',
 					'poster_images'              => [],
+					'video_cache'                => false,
 				],
 			],
 			'double_quotes_publisher' => [
@@ -172,6 +178,7 @@ class Story_Sanitizer extends Test_Case {
 					'publisher'                  => '"double quotes"',
 					'publisher_logo_placeholder' => '',
 					'poster_images'              => [],
+					'video_cache'                => false,
 				],
 			],
 			'single_quotes_publisher' => [
@@ -182,6 +189,7 @@ class Story_Sanitizer extends Test_Case {
 					'publisher'                  => "'single quotes'",
 					'publisher_logo_placeholder' => '',
 					'poster_images'              => [],
+					'video_cache'                => false,
 				],
 			],
 			'not_english_publisher'   => [
@@ -192,6 +200,7 @@ class Story_Sanitizer extends Test_Case {
 					'publisher'                  => 'PRÓXIMA',
 					'publisher_logo_placeholder' => '',
 					'poster_images'              => [],
+					'video_cache'                => false,
 				],
 			],
 			'html_publisher'          => [
@@ -202,6 +211,7 @@ class Story_Sanitizer extends Test_Case {
 					'publisher'                  => 'this > that < that <randomhtml />',
 					'publisher_logo_placeholder' => '',
 					'poster_images'              => [],
+					'video_cache'                => false,
 				],
 			],
 		];
@@ -233,6 +243,7 @@ class Story_Sanitizer extends Test_Case {
 			'publisher'                  => '',
 			'publisher_logo_placeholder' => '',
 			'poster_images'              => [],
+			'video_cache'                => false,
 		];
 
 		$actual = $this->sanitize_and_get( $source, $args );
@@ -251,6 +262,7 @@ class Story_Sanitizer extends Test_Case {
 			'publisher'                  => '',
 			'publisher_logo_placeholder' => '',
 			'poster_images'              => [],
+			'video_cache'                => false,
 		];
 
 		$actual = $this->sanitize_and_get( $source, $args );
@@ -270,6 +282,7 @@ class Story_Sanitizer extends Test_Case {
 			'publisher'                  => '',
 			'publisher_logo_placeholder' => '',
 			'poster_images'              => [],
+			'video_cache'                => false,
 		];
 
 		$actual = $this->sanitize_and_get( $source, $args );
@@ -289,12 +302,51 @@ class Story_Sanitizer extends Test_Case {
 			'publisher'                  => '',
 			'publisher_logo_placeholder' => '',
 			'poster_images'              => [],
+			'video_cache'                => false,
 		];
 
 		$actual = $this->sanitize_and_get( $source, $args );
 
 		$this->assertContains( '<style>._a7988c6{color: blue;}._91f054f{color: blue; background: white;}._f479d19{color: red;}</style>', $actual );
 		$this->assertNotContains( 'style="', $actual );
+	}
+
+	/**
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::add_video_cache
+	 */
+	public function test_add_video_cache_disabled() {
+		$source = '<html><head></head><body><amp-story><amp-video width="720" height="960" poster="https://example.com/poster.jpg" layout="responsive"><source type="video/mp4" src="https://example.com/video.mp4" /></amp-video></amp-story></body></html>';
+
+		$args = [
+			'publisher_logo'             => '',
+			'publisher'                  => '',
+			'publisher_logo_placeholder' => '',
+			'poster_images'              => [],
+			'video_cache'                => false,
+		];
+
+		$actual = $this->sanitize_and_get( $source, $args );
+
+		$this->assertNotContains( 'cache="google"', $actual );
+	}
+
+	/**
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::add_video_cache
+	 */
+	public function test_add_video_cache_enabled() {
+		$source = '<html><head></head><body><amp-story><amp-video width="720" height="960" poster="https://example.com/poster.jpg" layout="responsive"><source type="video/mp4" src="https://example.com/video.mp4" /></amp-video></amp-story></body></html>';
+
+		$args = [
+			'publisher_logo'             => '',
+			'publisher'                  => '',
+			'publisher_logo_placeholder' => '',
+			'poster_images'              => [],
+			'video_cache'                => true,
+		];
+
+		$actual = $this->sanitize_and_get( $source, $args );
+
+		$this->assertContains( 'cache="google"', $actual );
 	}
 
 	/**
@@ -308,6 +360,7 @@ class Story_Sanitizer extends Test_Case {
 			'publisher'                  => '',
 			'publisher_logo_placeholder' => '',
 			'poster_images'              => [],
+			'video_cache'                => false,
 		];
 
 		$actual = $this->sanitize_and_get( $source, $args );

--- a/tests/phpunit/tests/Integrations/AMP.php
+++ b/tests/phpunit/tests/Integrations/AMP.php
@@ -18,6 +18,7 @@
 namespace Google\Web_Stories\Tests\Integrations;
 
 use DOMDocument;
+use Google\Web_Stories\Experiments;
 use Google\Web_Stories\Story_Post_Type;
 use Google\Web_Stories\Tests\Test_Case;
 
@@ -29,7 +30,7 @@ class AMP extends Test_Case {
 	 * @covers ::register
 	 */
 	public function test_register() {
-		$amp = new \Google\Web_Stories\Integrations\AMP();
+		$amp = new \Google\Web_Stories\Integrations\AMP( new Experiments() );
 		$amp->register();
 
 		$this->assertSame( 10, has_filter( 'option_amp-options', [ $amp, 'filter_amp_options' ] ) );
@@ -49,7 +50,7 @@ class AMP extends Test_Case {
 	 * @covers ::filter_amp_options
 	 */
 	public function test_filter_amp_options_if_not_requested_post_type() {
-		$amp = new \Google\Web_Stories\Integrations\AMP();
+		$amp = new \Google\Web_Stories\Integrations\AMP( new Experiments() );
 		$this->assertEqualSets( [], $amp->filter_amp_options( [] ) );
 	}
 
@@ -71,7 +72,7 @@ class AMP extends Test_Case {
 			'supported_templates'  => [ 'is_page', 'is_singular' ],
 		];
 
-		$amp    = new \Google\Web_Stories\Integrations\AMP();
+		$amp    = new \Google\Web_Stories\Integrations\AMP( new Experiments() );
 		$actual = $amp->filter_amp_options( $before );
 
 		unset( $GLOBALS['current_screen'] );
@@ -83,7 +84,7 @@ class AMP extends Test_Case {
 	 * @covers ::filter_supportable_post_types
 	 */
 	public function test_filter_supportable_post_types_if_not_requested_post_type() {
-		$amp = new \Google\Web_Stories\Integrations\AMP();
+		$amp = new \Google\Web_Stories\Integrations\AMP( new Experiments() );
 		$this->assertEqualSets( [], $amp->filter_supportable_post_types( [ Story_Post_Type::POST_TYPE_SLUG ] ) );
 	}
 
@@ -93,7 +94,7 @@ class AMP extends Test_Case {
 	public function test_filter_supportable_post_types() {
 		$GLOBALS['current_screen'] = convert_to_screen( Story_Post_Type::POST_TYPE_SLUG );
 
-		$amp    = new \Google\Web_Stories\Integrations\AMP();
+		$amp    = new \Google\Web_Stories\Integrations\AMP( new Experiments() );
 		$actual = $amp->filter_supportable_post_types( [] );
 
 		unset( $GLOBALS['current_screen'] );
@@ -140,7 +141,7 @@ class AMP extends Test_Case {
 	 * @dataProvider data_test_filter_amp_to_amp_linking_element_excluded
 	 */
 	public function test_filter_amp_to_amp_linking_element_excluded( $args, $expected ) {
-		$amp = new \Google\Web_Stories\Integrations\AMP();
+		$amp = new \Google\Web_Stories\Integrations\AMP( new Experiments() );
 
 		$actual = call_user_func_array( [ $amp, 'filter_amp_to_amp_linking_element_excluded' ], $args );
 		$this->assertSame( $actual, $expected );

--- a/tests/phpunit/tests/Renderer/Story/HTML.php
+++ b/tests/phpunit/tests/Renderer/Story/HTML.php
@@ -17,6 +17,7 @@
 
 namespace Google\Web_Stories\Tests\Renderer\Story;
 
+use Google\Web_Stories\Experiments;
 use Google\Web_Stories\Model\Story;
 use Google\Web_Stories\Settings;
 use Google\Web_Stories\Story_Post_Type;
@@ -135,7 +136,7 @@ class HTML extends Test_Case {
 
 		$story = new Story();
 		$story->load_from_post( $post );
-		$renderer    = new \Google\Web_Stories\Renderer\Story\HTML( $story );
+		$renderer    = new \Google\Web_Stories\Renderer\Story\HTML( $story, new Experiments() );
 		$placeholder = $renderer->get_publisher_logo_placeholder();
 		$logo        = $renderer->get_publisher_logo();
 		$name        = $renderer->get_publisher_name();
@@ -269,7 +270,7 @@ class HTML extends Test_Case {
 		$link_https = set_url_scheme( $link, 'https' );
 
 		$story    = new Story();
-		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story );
+		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story, new Experiments() );
 
 		$result = $this->call_private_method( $renderer, 'replace_url_scheme', [ $link ] );
 		$this->assertEquals( $result, $link_https );
@@ -286,7 +287,7 @@ class HTML extends Test_Case {
 		$link             = 'https://www.google.com';
 
 		$story    = new Story();
-		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story );
+		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story, new Experiments() );
 
 		$result = $this->call_private_method( $renderer, 'replace_url_scheme', [ $link ] );
 		$this->assertEquals( $result, $link );
@@ -308,7 +309,7 @@ class HTML extends Test_Case {
 		);
 
 		$story    = new Story();
-		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story );
+		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story, new Experiments() );
 
 		$actual = $this->call_private_method( $renderer, 'print_analytics', [ $source ] );
 
@@ -325,7 +326,7 @@ class HTML extends Test_Case {
 		$source = '<html><head></head><body><amp-story standalone="" publisher="Web Stories" title="Example Story" publisher-logo-src="https://example.com/image.png" poster-portrait-src="https://example.com/image.png"><amp-story-page id="example"><amp-story-grid-layer template="fill"></amp-story-grid-layer></amp-story-page></amp-story></body></html>';
 
 		$story    = new Story();
-		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story );
+		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story, new Experiments() );
 
 		$actual = $this->call_private_method( $renderer, 'print_analytics', [ $source ] );
 
@@ -341,7 +342,7 @@ class HTML extends Test_Case {
 		$expected = '<html><head></head><body><amp-story standalone="" publisher="Web Stories" title="Example Story" publisher-logo-src="https://example.com/image.png" poster-portrait-src="https://example.com/image.png"><amp-story-page id="example"><amp-story-grid-layer template="fill"></amp-story-grid-layer></amp-story-page><amp-story-social-share layout="nodisplay"><script type="application/json">{"shareProviders":[{"provider":"twitter"},{"provider":"linkedin"},{"provider":"email"},{"provider":"system"}]}</script></amp-story-social-share></amp-story></body></html>';
 
 		$story    = new Story();
-		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story );
+		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story, new Experiments() );
 
 		$actual = $this->call_private_method( $renderer, 'print_social_share', [ $source ] );
 
@@ -358,7 +359,7 @@ class HTML extends Test_Case {
 		$source = '<html><head></head><body><amp-story standalone="" publisher="Web Stories" title="Example Story" publisher-logo-src="https://example.com/image.png" poster-portrait-src="https://example.com/image.png"><amp-story-page id="example"><amp-story-grid-layer template="fill"></amp-story-grid-layer></amp-story-page></amp-story></body></html>';
 
 		$story    = new Story();
-		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story );
+		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story, new Experiments() );
 
 		$actual = $this->call_private_method( $renderer, 'print_social_share', [ $source ] );
 
@@ -378,7 +379,7 @@ class HTML extends Test_Case {
 	protected function setup_renderer( $post ) {
 		$story = new Story();
 		$story->load_from_post( $post );
-		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story );
+		$renderer = new \Google\Web_Stories\Renderer\Story\HTML( $story, new Experiments() );
 		return $renderer->render();
 	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Serving videos in stories directly from Google's cache improves performance and reduces bandwidth costs for creators. We want to allow our users to opt into this new feature.

## Summary

<!-- A brief description of what this PR does. -->

This PR adds a new checkbox to the settings screen for users to opt into serving videos from the Google cache.

It's currently behind a feature flag, so the experiment needs to be enabled first before the checkbox is visible.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

![Screenshot 2021-07-13 at 00 09 14](https://user-images.githubusercontent.com/841956/125431214-1028e0e8-6465-49bf-9734-a8791ec18795.png)


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Enable video cache experiment
2. Opt into video cache on the settings page
3. Publish a new story with a video in it
4. View story on the frontend
5. Verify that there's a `cache="google"` attribute on videos in the source code

If the opt-in was successful, you will be able to see on the browser network tab a
request to `https://*.cdn.ampproject.org/mbv/s/*` that returns a JSON with an
empty list of sources (since the cache missed this video). The video must be public
for the cache to fetch it.

In the following minutes/hours, the video cache will fetch and store the video
contents, so that a later request to this url can return a processed list of video
sources for that origin video.

This can then be verified by observing network requests in the dev tools, where videos will be loaded from the CDN instead of origin.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8310
