### PR TITLE
Dashboard: remove usage of `stripHTML`

### DIFF
--- a/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
+++ b/assets/src/dashboard/app/views/myStories/karma/myStories.karma.js
@@ -23,7 +23,6 @@ import { getRelativeDisplayDate } from '@web-stories-wp/date';
 /**
  * Internal dependencies
  */
-import stripHTML from '../../../../../edit-story/utils/stripHTML';
 import Fixture from '../../../../karma/fixture';
 import {
   PRIMARY_PATHS,
@@ -282,11 +281,9 @@ describe('Grid view', () => {
 
       await fixture.events.click(draftsTabButton);
 
-      const labelTextContent = stripHTML(
-        STORY_VIEWING_LABELS[STORY_STATUS.DRAFT](numDrafts)
-      );
       const viewDraftsText = fixture.screen.getByText(
-        (_, node) => node.textContent === labelTextContent
+        (_, node) =>
+          node.innerHTML === STORY_VIEWING_LABELS[STORY_STATUS.DRAFT](numDrafts)
       );
 
       expect(viewDraftsText).toBeTruthy();
@@ -312,11 +309,10 @@ describe('Grid view', () => {
 
       await fixture.events.click(publishedTabButton);
 
-      const labelTextContent = stripHTML(
-        STORY_VIEWING_LABELS[STORY_STATUS.PUBLISHED_AND_FUTURE](numPublished)
-      );
       const viewPublishedText = fixture.screen.getByText(
-        (_, node) => node.textContent === labelTextContent
+        (_, node) =>
+          node.innerHTML ===
+          STORY_VIEWING_LABELS[STORY_STATUS.PUBLISHED_AND_FUTURE](numPublished)
       );
       expect(viewPublishedText).toBeTruthy();
 

--- a/assets/src/dashboard/app/views/templateDetails/karma/templateDetails.karma.js
+++ b/assets/src/dashboard/app/views/templateDetails/karma/templateDetails.karma.js
@@ -22,7 +22,6 @@ import qs from 'query-string';
 /**
  * Internal dependencies
  */
-import stripHTML from '../../../../../edit-story/utils/stripHTML';
 import Fixture from '../../../../karma/fixture';
 import {
   TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS,
@@ -116,18 +115,17 @@ describe('CUJ: Creator can browse templates in grid view: See pre-built template
       const templatesGridEl = fixture.screen.getByLabelText(
         'Available templates'
       );
-      const labelTextContent = stripHTML(
-        TEMPLATES_GALLERY_VIEWING_LABELS[TEMPLATES_GALLERY_STATUS.ALL](
-          templatesGridEl.children.length
-        )
-      );
+
       const hasDirectTextChild = (node) =>
         (Array.from(node?.childNodes) || []).some(
           (n) => n?.nodeName === '#text'
         );
       const viewTemplates = fixture.screen.getByText(
         (_, node) =>
-          node.textContent === labelTextContent && hasDirectTextChild(node)
+          node.innerHTML ===
+            TEMPLATES_GALLERY_VIEWING_LABELS[TEMPLATES_GALLERY_STATUS.ALL](
+              templatesGridEl.children.length
+            ) && hasDirectTextChild(node)
       );
 
       expect(viewTemplates).toBeTruthy();


### PR DESCRIPTION
## Context
Part of simplifying deps between packages.

## Summary
Removes `stripHTML` util from dashboard package

## Relevant Technical Choices
NA
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Will be run by CI
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8282 
