### PR TITLE
Quick action menu: remove feature flag

### DIFF
--- a/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/quickActions.karma.js
@@ -36,7 +36,6 @@ describe('Quick Actions integration', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ enableQuickActionMenus: true });
     await fixture.render();
   });
 

--- a/assets/src/edit-story/components/canvas/navLayer.js
+++ b/assets/src/edit-story/components/canvas/navLayer.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import { memo, useCallback } from 'react';
-import { useFeature } from 'flagged';
 import { __ } from '@web-stories-wp/i18n';
 import { ContextMenu } from '@web-stories-wp/design-system';
 
@@ -39,7 +38,6 @@ import {
 } from './layout';
 
 function NavLayer() {
-  const enableQuickActionMenu = useFeature('enableQuickActionMenus');
   const { hasHorizontalOverflow } = useLayout(
     ({ state: { hasHorizontalOverflow } }) => ({ hasHorizontalOverflow })
   );
@@ -55,9 +53,7 @@ function NavLayer() {
   }, []);
 
   const showQuickActions =
-    enableQuickActionMenu &&
-    !hasHorizontalOverflow &&
-    Boolean(quickActions.length);
+    !hasHorizontalOverflow && Boolean(quickActions.length);
 
   return (
     <Layer

--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -255,18 +255,6 @@ class Experiments extends Service_Base {
 				'group'       => 'editor',
 			],
 			/**
-			 * Author: @brittanyirl
-			 * Issue: 6148
-			 * Creation date: 2021-05-11
-			 */
-			[
-				'name'        => 'enableQuickActionMenus',
-				'label'       => __( 'Quick action menus', 'web-stories' ),
-				'description' => __( 'Enable a contextual shortcut menu to side of canvas in editor', 'web-stories' ),
-				'group'       => 'editor',
-				'default'     => true,
-			],
-			/**
 			 * Author: @littlemilkstudio
 			 * Issue: 6708
 			 * Creation date: 2021-03-23


### PR DESCRIPTION
## Context

Quick action menus have been enabled for >1 release so it's time to remove the flag.

## Summary

Remove quick action feature flag. Now the menu is enabled _forever_.

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

Nothing visually changed in the app other than the experiment option being removed.

## Testing Instructions

1. Open app
2. Go to dashboard settings
3. Should see experiment gone
4. Go to editor - should still see same behavior of quick action menu.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8228
