### PR TITLE
Auto-advancement: use media length over default duration

### DIFF
--- a/assets/src/edit-story/output/page.js
+++ b/assets/src/edit-story/output/page.js
@@ -36,15 +36,6 @@ function OutputPage({ page, autoAdvance, defaultPageDuration }) {
   const { id, animations, elements, backgroundColor } = page;
 
   const [backgroundElement, ...regularElements] = elements;
-  const animationDuration = getTotalDuration({ animations }) / 1000;
-  const nonMediaPageDuration = Math.max(
-    animationDuration || 0,
-    defaultPageDuration
-  );
-  const longestMediaElement = getLongestMediaElement(
-    elements,
-    nonMediaPageDuration
-  );
 
   // If the background element has base color set, it's media, use that.
   const baseColor = backgroundElement?.resource?.baseColor;
@@ -57,6 +48,18 @@ function OutputPage({ page, autoAdvance, defaultPageDuration }) {
         ...generatePatternStyles(backgroundColor),
       };
 
+  const animationDuration = getTotalDuration({ animations }) / 1000;
+  // If the page doesn't have media, take either the animations time or the configured default duration time.
+  const nonMediaPageDuration = Math.max(
+    animationDuration || 0,
+    defaultPageDuration
+  );
+  // If we have media, take the media time for advancement time and ignore the default,
+  // but still consider animation time as the minimum, too.
+  const longestMediaElement = getLongestMediaElement(
+    elements,
+    animationDuration || 1
+  );
   const autoAdvanceAfter = longestMediaElement?.id
     ? `el-${longestMediaElement?.id}-media`
     : `${nonMediaPageDuration}s`;

--- a/assets/src/edit-story/output/test/page.js
+++ b/assets/src/edit-story/output/test/page.js
@@ -371,6 +371,64 @@ describe('Page output', () => {
       ).toBeInTheDocument();
     });
 
+    it('should use video element ID for auto-advance-after if video is below defaultPageDuration', async () => {
+      const props = {
+        id: 'foo',
+        backgroundColor: { color: { r: 255, g: 255, b: 255 } },
+        page: {
+          id: 'bar',
+          elements: [
+            {
+              id: 'baz',
+              type: 'video',
+              mimeType: 'video/mp4',
+              scale: 1,
+              origRatio: 9 / 16,
+              x: 50,
+              y: 100,
+              height: 1920,
+              width: 1080,
+              rotationAngle: 0,
+              loop: false,
+              resource: {
+                type: 'video',
+                mimeType: 'video/mp4',
+                id: 123,
+                src: 'https://example.com/video.mp4',
+                poster: 'https://example.com/poster.png',
+                height: 1920,
+                width: 1080,
+                length: 1,
+              },
+            },
+          ],
+        },
+        autoAdvance: true,
+        defaultPageDuration: 7,
+      };
+
+      const { container } = render(<PageOutput {...props} />);
+      const video = queryById(container, 'el-baz-media');
+      await expect(video).toBeInTheDocument();
+      expect(video).toMatchInlineSnapshot(`
+        <amp-video
+          artwork="https://example.com/poster.png"
+          autoplay="autoplay"
+          id="el-baz-media"
+          layout="fill"
+          poster="https://example.com/poster.png"
+        >
+          <source
+            src="https://example.com/video.mp4"
+            type="video/mp4"
+          />
+        </amp-video>
+      `);
+      await expect(
+        queryByAutoAdvanceAfter(container, 'el-baz-media')
+      ).toBeInTheDocument();
+    });
+
     it('should ignore looping video for auto-advance-after and set default instead', async () => {
       const props = {
         id: 'foo',


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- If there is are videos on page, the longest media is taken as the page advancement, even if the longest media is very short
- If there is animation, the longest animation takes priority over the media if applicable.
- If there is animation shorter than the default duration, default duration is used.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
1. Add a few pages
2. Add short video on a page (e.g. 2 seconds)
3. To another page add a short animation
4. To another page add a short video and some animations longer than the video
5. Verify that if there's only a video on page, the page advances right after the video ends, even if very short (previously the default page duration was used instead)
6. Verify that in case of just a short animation on the page, the default page duration is used for advancing
7. Verify that if a short video and long animation are on the page, the page advances after the animation.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
See steps above.
<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7053 
