### PR TITLE
PPC 2.0: thumbnails in checklist ignore page background

### DIFF
--- a/assets/src/edit-story/components/thumbnail/stories/demoThumbnails.js
+++ b/assets/src/edit-story/components/thumbnail/stories/demoThumbnails.js
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
 
 /**
  * Internal dependencies
@@ -20,8 +24,15 @@
 import PagePreview from '../../carousel/pagepreview';
 import { THUMBNAIL_TYPES, THUMBNAIL_DIMENSIONS } from '..';
 
+const Image = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+`;
+
 const LayerIconImageOutput = (
-  <img
+  <Image
     src="http://placekitten.com/200/300"
     alt="a cute little kitten"
     height="20"
@@ -30,7 +41,7 @@ const LayerIconImageOutput = (
 );
 
 const LayerIconVideoOutput = (
-  <img
+  <Image
     src="https://storage.coverr.co/p/rhOM3iuhDqxedD7lKLpPO34yN2lhf5Kk"
     alt="media/coverr:hWGAKF358u"
     width="28"

--- a/assets/src/edit-story/components/thumbnail/stories/demoThumbnails.js
+++ b/assets/src/edit-story/components/thumbnail/stories/demoThumbnails.js
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * External dependencies
- */
-import styled from 'styled-components';
 
 /**
  * Internal dependencies
@@ -24,15 +20,8 @@ import styled from 'styled-components';
 import PagePreview from '../../carousel/pagepreview';
 import { THUMBNAIL_TYPES, THUMBNAIL_DIMENSIONS } from '..';
 
-const Image = styled.img`
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border-radius: ${({ theme }) => theme.borders.radius.small};
-`;
-
 const LayerIconImageOutput = (
-  <Image
+  <img
     src="http://placekitten.com/200/300"
     alt="a cute little kitten"
     height="20"
@@ -41,7 +30,7 @@ const LayerIconImageOutput = (
 );
 
 const LayerIconVideoOutput = (
-  <Image
+  <img
     src="https://storage.coverr.co/p/rhOM3iuhDqxedD7lKLpPO34yN2lhf5Kk"
     alt="media/coverr:hWGAKF358u"
     width="28"

--- a/assets/src/edit-story/components/thumbnail/styles.js
+++ b/assets/src/edit-story/components/thumbnail/styles.js
@@ -107,14 +107,6 @@ export const Background = styled.div(
     display: flex;
     border-radius: ${theme.borders.radius.small};
 
-    img,
-    video {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      border-radius: ${theme.borders.radius.small};
-    }
-
     & > div {
       display: flex;
       height: 100%;

--- a/assets/src/edit-story/components/thumbnail/styles.js
+++ b/assets/src/edit-story/components/thumbnail/styles.js
@@ -107,6 +107,18 @@ export const Background = styled.div(
     display: flex;
     border-radius: ${theme.borders.radius.small};
 
+    /*
+    Only reach one level deep so that images and videos
+    in stories are not affected.
+    */
+    & > img,
+    & > video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: ${theme.borders.radius.small};
+    }
+
     & > div {
       display: flex;
       height: 100%;


### PR DESCRIPTION
## Context

PPC 2.0 bug found in bugbash

## Summary

The `Background` component in the `Thumbnail` was styling the `PagePreview` component in ways that we did not want.

## Relevant Technical Choices

The `Thumbnail` component had some styles that targeted all `img` and `video` tags. This was nice in Storybook when we weren't using the `PagePreview` component.

However, the `PagePreview` component (along with the `UnitProvider`) does its own calculations into the spacing and display of all `img` and `video` elements.

I removed the styles that targeted all of the `img` and `video` tags. Now those styles will be the responsibility of the child rather than the `Background` component.

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![not-it](https://user-images.githubusercontent.com/22185279/125834295-21813ff7-ab4a-479b-9c49-bd6d3f31b7ed.gif)|![it](https://user-images.githubusercontent.com/22185279/125834221-566847d3-cdf3-4df2-a723-4931a2d9809c.gif)|


## Testing Instructions

1. Open editor
2. Add an image to the page background. If you want, add more things to your story.
3. Add pages until the checklist has the `Design` section open.
4. The story preview should look like a tiny version of your story 🎉

### QA

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8271 
