### PR TITLE
Dashboard: Snackbars for Successful Setting Saves

### DIFF
--- a/assets/src/dashboard/app/api/useApiAlerts.js
+++ b/assets/src/dashboard/app/api/useApiAlerts.js
@@ -52,30 +52,21 @@ function useApiAlerts() {
   // if there is an API error, display a snackbar
   useEffect(() => {
     if (storyError?.id) {
-      showSnackbar({
-        message: storyError.message,
-        dismissable: true,
-      });
+      debouncedShowSnackbar(storyError.message);
     }
-  }, [storyError, showSnackbar]);
+  }, [storyError, debouncedShowSnackbar]);
 
   useEffect(() => {
     if (templateError?.id) {
-      showSnackbar({
-        message: templateError.message,
-        dismissable: true,
-      });
+      debouncedShowSnackbar(templateError.message);
     }
-  }, [templateError, showSnackbar]);
+  }, [templateError, debouncedShowSnackbar]);
 
   useEffect(() => {
     if (settingsError?.id) {
-      showSnackbar({
-        message: settingsError.message,
-        dismissable: true,
-      });
+      debouncedShowSnackbar(settingsError.message);
     }
-  }, [settingsError, showSnackbar]);
+  }, [settingsError, debouncedShowSnackbar]);
 
   useEffect(() => {
     if (settingSaved) {
@@ -85,11 +76,8 @@ function useApiAlerts() {
 
   useEffect(() => {
     if (mediaError?.id) {
-      showSnackbar({
-        message: mediaError.message,
-        dismissable: true,
-      });
+      debouncedShowSnackbar(mediaError.message);
     }
-  }, [mediaError, showSnackbar]);
+  }, [mediaError, debouncedShowSnackbar]);
 }
 export default useApiAlerts;

--- a/assets/src/dashboard/app/api/useApiAlerts.js
+++ b/assets/src/dashboard/app/api/useApiAlerts.js
@@ -19,30 +19,36 @@
  */
 import { useEffect } from 'react';
 import { useSnackbar } from '@web-stories-wp/design-system';
-
+import { useDebouncedCallback } from 'use-debounce';
 /**
  * Internal dependencies
  */
+import { SUCCESS } from '../textContent';
 import useApi from './useApi';
 
 function useApiAlerts() {
-  const { storyError, templateError, settingsError, mediaError } = useApi(
-    ({
-      state: {
-        stories: { error: storyError },
-        templates: { error: templateError },
-        settings: { error: settingsError },
-        media: { error: mediaError },
-      },
-    }) => ({
-      storyError,
-      templateError,
-      settingsError,
-      mediaError,
-    })
-  );
+  const { storyError, templateError, settingsError, mediaError, settingSaved } =
+    useApi(
+      ({
+        state: {
+          stories: { error: storyError },
+          templates: { error: templateError },
+          settings: { error: settingsError, settingSaved },
+          media: { error: mediaError },
+        },
+      }) => ({
+        storyError,
+        templateError,
+        settingsError,
+        mediaError,
+        settingSaved,
+      })
+    );
   const { showSnackbar } = useSnackbar();
 
+  const debouncedShowSnackbar = useDebouncedCallback((message) => {
+    return showSnackbar({ message, dismissable: true });
+  }, 200);
   // if there is an API error, display a snackbar
   useEffect(() => {
     if (storyError?.id) {
@@ -70,6 +76,12 @@ function useApiAlerts() {
       });
     }
   }, [settingsError, showSnackbar]);
+
+  useEffect(() => {
+    if (settingSaved) {
+      debouncedShowSnackbar(SUCCESS.SETTINGS.UPDATED);
+    }
+  }, [debouncedShowSnackbar, settingSaved]);
 
   useEffect(() => {
     if (mediaError?.id) {

--- a/assets/src/dashboard/app/api/useMediaApi.js
+++ b/assets/src/dashboard/app/api/useMediaApi.js
@@ -19,7 +19,6 @@
  */
 import { useCallback, useMemo, useReducer } from 'react';
 import queryString from 'query-string';
-
 /**
  * Internal dependencies
  */

--- a/assets/src/dashboard/app/api/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/useSettingsApi.js
@@ -86,6 +86,7 @@ export default function useSettingsApi(
       publisherLogoToMakeDefault,
       videoCache,
     }) => {
+      dispatch({ type: SETTINGS_ACTION_TYPES.UPDATE_SETTINGS_REQUESTED });
       try {
         const query = {};
         if (googleAnalyticsId !== undefined) {

--- a/assets/src/dashboard/app/api/useSettingsApi.js
+++ b/assets/src/dashboard/app/api/useSettingsApi.js
@@ -86,7 +86,7 @@ export default function useSettingsApi(
       publisherLogoToMakeDefault,
       videoCache,
     }) => {
-      dispatch({ type: SETTINGS_ACTION_TYPES.UPDATE_SETTINGS_REQUESTED });
+      dispatch({ type: SETTINGS_ACTION_TYPES.SETTING_SAVED });
       try {
         const query = {};
         if (googleAnalyticsId !== undefined) {
@@ -149,6 +149,7 @@ export default function useSettingsApi(
             videoCache: response.web_stories_video_cache,
           },
         });
+        dispatch({ type: SETTINGS_ACTION_TYPES.SETTING_SAVED, payload: true });
       } catch (err) {
         dispatch({
           type: SETTINGS_ACTION_TYPES.UPDATE_SETTINGS_FAILURE,

--- a/assets/src/dashboard/app/reducer/settings.js
+++ b/assets/src/dashboard/app/reducer/settings.js
@@ -22,7 +22,7 @@ import { AD_NETWORK_TYPE } from '../../constants';
 export const ACTION_TYPES = {
   UPDATE_SETTINGS_SUCCESS: 'update_settings_success',
   UPDATE_SETTINGS_FAILURE: 'update_settings_failure',
-  UPDATE_SETTINGS_REQUESTED: 'update_settings_requested',
+  SETTING_SAVED: 'setting_saved',
   FETCH_SETTINGS_SUCCESS: 'fetch_settings_success',
   FETCH_SETTINGS_FAILURE: 'fetch_settings_failure',
 };
@@ -42,10 +42,10 @@ export const defaultSettingsState = {
 
 function settingsReducer(state, action) {
   switch (action.type) {
-    case ACTION_TYPES.UPDATE_SETTINGS_REQUESTED: {
+    case ACTION_TYPES.SETTING_SAVED: {
       return {
         ...state,
-        settingSaved: false,
+        settingSaved: action.payload,
       };
     }
 
@@ -57,32 +57,12 @@ function settingsReducer(state, action) {
       };
     }
 
-    case ACTION_TYPES.FETCH_SETTINGS_SUCCESS: {
-      return {
-        ...state,
-        activePublisherLogoId: action.payload.activePublisherLogoId,
-        error: {},
-        googleAnalyticsId: action.payload.googleAnalyticsId,
-        adSensePublisherId: action.payload.adSensePublisherId,
-        adSenseSlotId: action.payload.adSenseSlotId,
-        adManagerSlotId: action.payload.adManagerSlotId,
-        adNetwork: action.payload.adNetwork,
-        publisherLogoIds: [
-          ...new Set([
-            action.payload.activePublisherLogoId,
-            ...action.payload.publisherLogoIds,
-          ]),
-        ],
-        videoCache: action.payload.videoCache,
-      };
-    }
-
+    case ACTION_TYPES.FETCH_SETTINGS_SUCCESS:
     case ACTION_TYPES.UPDATE_SETTINGS_SUCCESS: {
       return {
         ...state,
         activePublisherLogoId: action.payload.activePublisherLogoId,
         error: {},
-        settingSaved: true,
         googleAnalyticsId: action.payload.googleAnalyticsId,
         adSensePublisherId: action.payload.adSensePublisherId,
         adSenseSlotId: action.payload.adSenseSlotId,

--- a/assets/src/dashboard/app/reducer/settings.js
+++ b/assets/src/dashboard/app/reducer/settings.js
@@ -22,6 +22,7 @@ import { AD_NETWORK_TYPE } from '../../constants';
 export const ACTION_TYPES = {
   UPDATE_SETTINGS_SUCCESS: 'update_settings_success',
   UPDATE_SETTINGS_FAILURE: 'update_settings_failure',
+  UPDATE_SETTINGS_REQUESTED: 'update_settings_requested',
   FETCH_SETTINGS_SUCCESS: 'fetch_settings_success',
   FETCH_SETTINGS_FAILURE: 'fetch_settings_failure',
 };
@@ -36,10 +37,18 @@ export const defaultSettingsState = {
   adNetwork: AD_NETWORK_TYPE.NONE,
   publisherLogoIds: [],
   videoCache: false,
+  settingSaved: false,
 };
 
 function settingsReducer(state, action) {
   switch (action.type) {
+    case ACTION_TYPES.UPDATE_SETTINGS_REQUESTED: {
+      return {
+        ...state,
+        settingSaved: false,
+      };
+    }
+
     case ACTION_TYPES.UPDATE_SETTINGS_FAILURE:
     case ACTION_TYPES.FETCH_SETTINGS_FAILURE: {
       return {
@@ -48,12 +57,32 @@ function settingsReducer(state, action) {
       };
     }
 
-    case ACTION_TYPES.UPDATE_SETTINGS_SUCCESS:
     case ACTION_TYPES.FETCH_SETTINGS_SUCCESS: {
       return {
         ...state,
         activePublisherLogoId: action.payload.activePublisherLogoId,
         error: {},
+        googleAnalyticsId: action.payload.googleAnalyticsId,
+        adSensePublisherId: action.payload.adSensePublisherId,
+        adSenseSlotId: action.payload.adSenseSlotId,
+        adManagerSlotId: action.payload.adManagerSlotId,
+        adNetwork: action.payload.adNetwork,
+        publisherLogoIds: [
+          ...new Set([
+            action.payload.activePublisherLogoId,
+            ...action.payload.publisherLogoIds,
+          ]),
+        ],
+        videoCache: action.payload.videoCache,
+      };
+    }
+
+    case ACTION_TYPES.UPDATE_SETTINGS_SUCCESS: {
+      return {
+        ...state,
+        activePublisherLogoId: action.payload.activePublisherLogoId,
+        error: {},
+        settingSaved: true,
         googleAnalyticsId: action.payload.googleAnalyticsId,
         adSensePublisherId: action.payload.adSensePublisherId,
         adSenseSlotId: action.payload.adSenseSlotId,

--- a/assets/src/dashboard/app/reducer/test/settings.js
+++ b/assets/src/dashboard/app/reducer/test/settings.js
@@ -17,24 +17,13 @@
 /**
  * Internal dependencies
  */
-import { AD_NETWORK_TYPE } from '../../../constants';
 import { ERRORS } from '../../textContent';
-import settingsReducer, { ACTION_TYPES } from '../settings';
+import settingsReducer, {
+  ACTION_TYPES,
+  defaultSettingsState as initialState,
+} from '../settings';
 
 describe('settingsReducer', () => {
-  const initialState = {
-    activePublisherLogoId: null,
-    error: {},
-    googleAnalyticsId: '',
-    adSensePublisherId: '',
-    adSenseSlotId: '',
-    adManagerSlotId: '',
-    adNetwork: AD_NETWORK_TYPE.NONE,
-    publisherLogoIds: [],
-    videoCache: false,
-    settingSaved: false,
-  };
-
   const MOCK_ERROR_ID = Date.now();
 
   beforeAll(() => {
@@ -105,10 +94,19 @@ describe('settingsReducer', () => {
     });
     expect(result).toMatchObject({
       error: {},
-      settingSaved: true,
       googleAnalyticsId: 'fakeId12345NEW',
       activePublisherLogoId: 5,
       publisherLogoIds: [5, 6, 7, 8],
+    });
+  });
+
+  it(`should update settingSaved boolean when ${ACTION_TYPES.SETTING_SAVED} is called`, () => {
+    const result = settingsReducer(initialState, {
+      type: ACTION_TYPES.SETTING_SAVED,
+      payload: true,
+    });
+    expect(result).toMatchObject({
+      settingSaved: true,
     });
   });
 });

--- a/assets/src/dashboard/app/reducer/test/settings.js
+++ b/assets/src/dashboard/app/reducer/test/settings.js
@@ -17,6 +17,7 @@
 /**
  * Internal dependencies
  */
+import { AD_NETWORK_TYPE } from '../../../constants';
 import { ERRORS } from '../../textContent';
 import settingsReducer, { ACTION_TYPES } from '../settings';
 
@@ -24,8 +25,14 @@ describe('settingsReducer', () => {
   const initialState = {
     activePublisherLogoId: null,
     error: {},
-    googleAnalyticsId: null,
+    googleAnalyticsId: '',
+    adSensePublisherId: '',
+    adSenseSlotId: '',
+    adManagerSlotId: '',
+    adNetwork: AD_NETWORK_TYPE.NONE,
     publisherLogoIds: [],
+    videoCache: false,
+    settingSaved: false,
   };
 
   const MOCK_ERROR_ID = Date.now();
@@ -60,7 +67,7 @@ describe('settingsReducer', () => {
       },
     });
     expect(result).toMatchObject({
-      googleAnalyticsId: null,
+      googleAnalyticsId: '',
       error: {
         message: ERRORS.LOAD_SETTINGS.MESSAGE,
         id: MOCK_ERROR_ID,
@@ -78,7 +85,7 @@ describe('settingsReducer', () => {
       },
     });
     expect(result).toMatchObject({
-      googleAnalyticsId: null,
+      googleAnalyticsId: '',
       error: {
         message: ERRORS.UPDATE_EDITOR_SETTINGS.MESSAGE,
         id: MOCK_ERROR_ID,
@@ -89,7 +96,7 @@ describe('settingsReducer', () => {
 
   it(`should update settings state when ${ACTION_TYPES.UPDATE_SETTINGS_SUCCESS} is called`, () => {
     const result = settingsReducer(initialState, {
-      type: ACTION_TYPES.FETCH_SETTINGS_SUCCESS,
+      type: ACTION_TYPES.UPDATE_SETTINGS_SUCCESS,
       payload: {
         googleAnalyticsId: 'fakeId12345NEW',
         activePublisherLogoId: 5,
@@ -98,6 +105,7 @@ describe('settingsReducer', () => {
     });
     expect(result).toMatchObject({
       error: {},
+      settingSaved: true,
       googleAnalyticsId: 'fakeId12345NEW',
       activePublisherLogoId: 5,
       publisherLogoIds: [5, 6, 7, 8],

--- a/assets/src/dashboard/app/textContent/index.js
+++ b/assets/src/dashboard/app/textContent/index.js
@@ -19,6 +19,11 @@
  */
 import { __ } from '@web-stories-wp/i18n';
 
+export const SUCCESS = {
+  SETTINGS: {
+    UPDATED: __('Setting saved.', 'web-stories'),
+  },
+};
 export const ERRORS = {
   LOAD_STORIES: {
     DEFAULT_MESSAGE: __('Cannot connect to data source', 'web-stories'),

--- a/assets/src/dashboard/app/views/editorSettings/karma/editorSettings.karma.js
+++ b/assets/src/dashboard/app/views/editorSettings/karma/editorSettings.karma.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { within } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -78,6 +78,18 @@ describe('Settings View', () => {
     return settings;
   }
 
+  async function snackbarConfirmation() {
+    await waitFor(
+      () => {
+        const alert = fixture.screen.getByRole('alert');
+        expect(alert).toHaveTextContent('Setting saved.');
+      },
+      {
+        timeout: 300,
+      }
+    );
+  }
+
   it('should render', async () => {
     const settingsView = await fixture.screen.getByTestId('editor-settings');
 
@@ -86,7 +98,7 @@ describe('Settings View', () => {
     expect(PageHeading).toBeTruthy();
   });
 
-  it('should update the tracking id when pressing Enter', async () => {
+  it('should update the tracking id when pressing Enter and display snackbar confirmation', async () => {
     const settingsView = await fixture.screen.getByTestId('editor-settings');
 
     const input = within(settingsView).getByRole('textbox');
@@ -109,9 +121,11 @@ describe('Settings View', () => {
     const { googleAnalyticsId } = await getSettingsState();
 
     expect(input.value).toBe(googleAnalyticsId);
+
+    await snackbarConfirmation();
   });
 
-  it('should update the tracking id by clicking the save button', async () => {
+  it('should update the tracking id by clicking the save button and display snackbar confirmation', async () => {
     const settingsView = await fixture.screen.getByTestId('editor-settings');
 
     const { getByRole } = within(settingsView);
@@ -137,9 +151,11 @@ describe('Settings View', () => {
     const { googleAnalyticsId } = await getSettingsState();
 
     expect(input.value).toBe(googleAnalyticsId);
+
+    await snackbarConfirmation();
   });
 
-  it('should allow the analytics id to saved as an empty string', async () => {
+  it('should allow the analytics id to saved as an empty string and display snackbar confirmation', async () => {
     const settingsView = await fixture.screen.getByTestId('editor-settings');
     const { googleAnalyticsId: initialId } = await getSettingsState();
 
@@ -167,6 +183,8 @@ describe('Settings View', () => {
     const { googleAnalyticsId: analyticsId } = await getSettingsState();
 
     expect(analyticsId).toEqual('');
+
+    await snackbarConfirmation();
   });
 
   it('should not allow an invalid analytics id to saved', async () => {
@@ -223,7 +241,7 @@ describe('Settings View', () => {
     expect(errorMessage).toBeTruthy();
   });
 
-  it('should update the default a publisher logo on click', async () => {
+  it('should update the default a publisher logo on click and display snackbar confirmation', async () => {
     const settingsView = await fixture.screen.getByTestId('editor-settings');
 
     const publisherLogosContainer = within(settingsView).getByTestId(
@@ -279,9 +297,11 @@ describe('Settings View', () => {
 
     const confirmDefault = within(NewLogoToMakeDefault).getByText(/^Default/);
     expect(confirmDefault).toBeTruthy();
+
+    await snackbarConfirmation();
   });
 
-  it('should remove a publisher logo on click', async () => {
+  it('should remove a publisher logo on click and display snackbar confirmation', async () => {
     const settingsView = await fixture.screen.getByTestId('editor-settings');
 
     const PublisherLogos = within(settingsView).queryAllByTestId(
@@ -318,9 +338,11 @@ describe('Settings View', () => {
     ).queryAllByTestId(/^uploaded-publisher-logo-/);
 
     expect(UpdatedPublisherLogos.length).toBe(initialPublisherLogosLength - 1);
+
+    await snackbarConfirmation();
   });
 
-  it('should remove a publisher logo on keydown enter', async () => {
+  it('should remove a publisher logo on keydown enter and display snackbar confirmation', async () => {
     const settingsView = await fixture.screen.getByTestId(
       'publisher-logos-container'
     );
@@ -365,9 +387,11 @@ describe('Settings View', () => {
     ).queryAllByTestId(/^uploaded-publisher-logo-/);
 
     expect(updatedLogos.length).toBeLessThan(initialPublisherLogosLength);
+
+    await snackbarConfirmation();
   });
 
-  it('should update the default logo on click', async () => {
+  it('should update the default logo on click and display snackbar confirmation', async () => {
     const settingsView = await fixture.screen.getByTestId('editor-settings');
 
     const PublisherLogos =
@@ -407,9 +431,11 @@ describe('Settings View', () => {
       UpdatedPublisherLogos[1].children
     ).find((node) => node.textContent === 'Default');
     expect(secondPublisherLogoIsDefault).toBeTruthy();
+
+    await snackbarConfirmation();
   });
 
-  it('should update the default logo on keydown enter', async () => {
+  it('should update the default logo on keydown enter and display snackbar confirmation', async () => {
     const settingsView = await fixture.screen.getByTestId(
       'publisher-logos-container'
     );
@@ -455,6 +481,8 @@ describe('Settings View', () => {
     ).find((node) => node.textContent === 'Default');
 
     expect(secondPublisherLogoIsDefault).toBeTruthy();
+
+    await snackbarConfirmation();
   });
 
   it('should render the telemetry settings checkbox', async () => {
@@ -467,7 +495,7 @@ describe('Settings View', () => {
     expect(TelemetrySettingsCheckbox).toBeTruthy();
   });
 
-  it('should toggle the value and call the API provider when the tracking opt in box is clicked', async () => {
+  it('should toggle the value and call the API provider when the tracking opt in box is clicked and display snackbar confirmation', async () => {
     const settingsView = await fixture.screen.getByTestId('editor-settings');
 
     const TelemetrySettingsCheckbox = within(settingsView).queryAllByTestId(
@@ -479,5 +507,7 @@ describe('Settings View', () => {
     await fixture.events.click(TelemetrySettingsCheckbox[0]);
 
     expect(TelemetrySettingsCheckbox[0].checked).toBeFalse();
+
+    await snackbarConfirmation();
   });
 });

--- a/assets/src/dashboard/app/views/shared/useMediaOptimization.js
+++ b/assets/src/dashboard/app/views/shared/useMediaOptimization.js
@@ -19,13 +19,17 @@
  */
 import { useCallback, useEffect, useRef } from 'react';
 import { trackEvent } from '@web-stories-wp/tracking';
+import { useSnackbar } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
  */
 import useApi from '../../api/useApi';
+import { SUCCESS } from '../../textContent';
 
 export default function useMediaOptimization() {
+  const { showSnackbar } = useSnackbar();
+
   const { currentUser, toggleWebStoriesMediaOptimization, fetchCurrentUser } =
     useApi(
       ({
@@ -61,7 +65,8 @@ export default function useMediaOptimization() {
     trackEvent('video_optimization_optin', {
       status: mediaOptimization ? 'off' : 'on',
     });
-  }, [mediaOptimization, toggleWebStoriesMediaOptimization]);
+    showSnackbar({ message: SUCCESS.SETTINGS.UPDATED, dismissable: true });
+  }, [mediaOptimization, showSnackbar, toggleWebStoriesMediaOptimization]);
 
   return {
     mediaOptimization,

--- a/assets/src/dashboard/app/views/shared/useTelemetryOptIn.js
+++ b/assets/src/dashboard/app/views/shared/useTelemetryOptIn.js
@@ -19,6 +19,7 @@
  */
 import { useCallback, useState, useEffect, useRef } from 'react';
 import { enableTracking, disableTracking } from '@web-stories-wp/tracking';
+import { useSnackbar } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -27,6 +28,7 @@ import useApi from '../../api/useApi';
 import { useRouteHistory } from '../../router';
 import { APP_ROUTES } from '../../../constants';
 import localStore from '../../../../edit-story/utils/localStore';
+import { SUCCESS } from '../../textContent';
 
 // The value associated with this key indicates if the user has interacted with
 // the banner previously. If they have, we do not show the banner again.
@@ -39,6 +41,8 @@ function setInitialBannerPreviouslyClosed() {
 }
 
 export default function useTelemetryOptIn() {
+  const { showSnackbar } = useSnackbar();
+
   const [bannerPreviouslyClosed, setBannerPreviouslyClosed] = useState(
     setInitialBannerPreviouslyClosed
   );
@@ -82,7 +86,8 @@ export default function useTelemetryOptIn() {
     toggleWebStoriesTrackingOptIn();
     localStore.setItemByKey(LOCAL_STORAGE_KEY, true);
     setOptInCheckboxClicked(true);
-  }, [toggleWebStoriesTrackingOptIn]);
+    showSnackbar({ message: SUCCESS.SETTINGS.UPDATED, dismissable: true });
+  }, [showSnackbar, toggleWebStoriesTrackingOptIn]);
 
   const closeBanner = useCallback(() => {
     setBannerPreviouslyClosed(true);

--- a/assets/src/dashboard/karma/apiProviderFixture.js
+++ b/assets/src/dashboard/karma/apiProviderFixture.js
@@ -164,6 +164,7 @@ function fetchMediaById(newIds, currentState) {
 function getSettingsState() {
   return {
     error: {},
+    settingSaved: false,
     googleAnalyticsId: '',
     publisherLogoIds: [],
     activePublisherLogoId: fillerPublisherLogoIds[0],
@@ -195,6 +196,8 @@ function updateSettings(updates, currentState) {
     publisherLogoIdToRemove,
     publisherLogoToMakeDefault,
   } = updates;
+  currentState.settingSaved = true;
+
   if (googleAnalyticsId !== undefined) {
     return {
       ...currentState,


### PR DESCRIPTION
## Context

Giving users confirmation that their settings have been saved. 

## Summary

Fairly old follow up ticket that got buried waiting for UX direction and since then (with Pascal's idea of just a snackbar with generic phrasing), we can knock this out and get a helpful message to users.

## Relevant Technical Choices

Just wiring up a new snackbar for success.  Adding `settingSaved` to the settings reducer to trigger the snackbar. One new action to reset the boolean of `settingSaved` at the start of any update to settings so we can trigger multiple. Debounced this snackbar specifically because of how publisher logos get updated (has to go through media and then to settings). Didn't see the need to share this implementation with the other snackbars. Similar wire up for the few settings hooks that are separate. 

## To-do

N/A

## User-facing changes

Update some settings, see some snackbars.

https://user-images.githubusercontent.com/10720454/125857732-195c24d2-7924-47b1-b610-3f5a241b392e.mp4


## Testing Instructions

Go to dashboard settings, update settings, should see snackbar.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #3810 
