### PR TITLE
Use 3:4 ratio for displaying poster image

### DIFF
--- a/assets/src/edit-story/components/panels/design/videoAccessibility/videoAccessibility.js
+++ b/assets/src/edit-story/components/panels/design/videoAccessibility/videoAccessibility.js
@@ -135,7 +135,7 @@ function VideoAccessibilityPanel({ selectedElements, pushUpdate }) {
           type={allowedImageMimeTypes}
           ariaLabel={__('Video poster', 'web-stories')}
           menuOptions={['edit', 'reset']}
-          resource={cropParams /* Just width / height are relevant */}
+          imgProps={cropParams}
         />
         <InputsWrapper>
           <TextArea

--- a/assets/src/edit-story/components/panels/design/videoAccessibility/videoAccessibility.js
+++ b/assets/src/edit-story/components/panels/design/videoAccessibility/videoAccessibility.js
@@ -135,6 +135,7 @@ function VideoAccessibilityPanel({ selectedElements, pushUpdate }) {
           type={allowedImageMimeTypes}
           ariaLabel={__('Video poster', 'web-stories')}
           menuOptions={['edit', 'reset']}
+          resource={cropParams /* Just width / height are relevant */}
         />
         <InputsWrapper>
           <TextArea

--- a/assets/src/edit-story/components/panels/document/publish/publish.js
+++ b/assets/src/edit-story/components/panels/document/publish/publish.js
@@ -207,7 +207,7 @@ function PublishPanel() {
                 type={allowedImageMimeTypes}
                 ariaLabel={__('Poster image', 'web-stories')}
                 onChangeErrorText={posterErrorMessage}
-                resource={featuredMedia}
+                imgProps={featuredMedia}
               />
             </MediaWrapper>
             <LabelWrapper>

--- a/assets/src/edit-story/components/panels/document/publish/publish.js
+++ b/assets/src/edit-story/components/panels/document/publish/publish.js
@@ -194,7 +194,7 @@ function PublishPanel() {
             <MediaWrapper>
               <StyledMedia
                 ref={posterButtonRef}
-                width={54}
+                width={72}
                 height={96}
                 cropParams={{
                   width: 640,
@@ -207,6 +207,7 @@ function PublishPanel() {
                 type={allowedImageMimeTypes}
                 ariaLabel={__('Poster image', 'web-stories')}
                 onChangeErrorText={posterErrorMessage}
+                resource={featuredMedia}
               />
             </MediaWrapper>
             <LabelWrapper>

--- a/packages/design-system/src/components/mediaInput/index.js
+++ b/packages/design-system/src/components/mediaInput/index.js
@@ -164,6 +164,7 @@ export const MediaInput = forwardRef(function Media(
     onMenuOption,
     openMediaPicker,
     menuProps = {},
+    resource = {},
     ...rest
   },
   ref
@@ -184,7 +185,13 @@ export const MediaInput = forwardRef(function Media(
     <StyledMedia className={className} {...rest}>
       <ImageWrapper variant={variant}>
         {value ? (
-          <Img src={value} alt={alt} crossOrigin="anonymous" />
+          <Img
+            src={value}
+            alt={alt}
+            crossOrigin="anonymous"
+            width={resource?.width || null}
+            height={resource?.height || null}
+          />
         ) : (
           <DefaultImageWrapper>
             <DefaultImage />
@@ -244,4 +251,5 @@ MediaInput.propTypes = {
   onMenuOption: PropTypes.func,
   openMediaPicker: PropTypes.func.isRequired,
   menuProps: PropTypes.object,
+  resource: PropTypes.object,
 };

--- a/packages/design-system/src/components/mediaInput/index.js
+++ b/packages/design-system/src/components/mediaInput/index.js
@@ -164,7 +164,7 @@ export const MediaInput = forwardRef(function Media(
     onMenuOption,
     openMediaPicker,
     menuProps = {},
-    resource = {},
+    imgProps = {},
     ...rest
   },
   ref
@@ -189,8 +189,8 @@ export const MediaInput = forwardRef(function Media(
             src={value}
             alt={alt}
             crossOrigin="anonymous"
-            width={resource?.width || null}
-            height={resource?.height || null}
+            width={imgProps?.width || null}
+            height={imgProps?.height || null}
           />
         ) : (
           <DefaultImageWrapper>
@@ -251,5 +251,5 @@ MediaInput.propTypes = {
   onMenuOption: PropTypes.func,
   openMediaPicker: PropTypes.func.isRequired,
   menuProps: PropTypes.object,
-  resource: PropTypes.object,
+  imgProps: PropTypes.object,
 };


### PR DESCRIPTION
## Summary

See #8323.

## Testing Instructions

### QA

This PR can be tested by following these steps:

- Add story poster in the Document panel
- See the source and verify the poster image is displayed in 4:3 ratio.

## Checklist
<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #8323 
