### PR TITLE
DevTools: Add 'pageTemplateType' property to all page elements

### DIFF
--- a/assets/src/edit-story/components/devTools/devTools.js
+++ b/assets/src/edit-story/components/devTools/devTools.js
@@ -98,7 +98,7 @@ const replaceResourcesWithDummy = (state) => {
 };
 
 const templateResourcePlaceholder =
-  '____WEB_STORIES_TEMPLATE_BASE_URL__/images/templates/%%templateName%%/';
+  '__WEB_STORIES_TEMPLATE_BASE_URL__/images/templates/%%templateName%%/';
 
 const getResourceFileName = (src) => {
   // If empty source return empty.
@@ -166,6 +166,7 @@ const prepareTemplate = (state) => {
         }
         return newElement;
       }),
+      pageTemplateType: page?.pageTemplateType ?? '',
     })),
   };
 


### PR DESCRIPTION
## Summary

- Fixes typo in asset url placeholder that was previously introduced `Template` options to get the template JSON for external use. 
- Adds 'pageTemplateType' to all page elements in template default to empty string if not set by the template.

## Testing Instructions

- Go to web story editor
- Access devTools with `Command+Shift+Option+J` (Mac) or `Control+Shift+Alt+J` (Windows/Linux) in the editor.
- Check `Template` check box
- Template JSON shown in the dialog should have `pageTemplateType` set for each `page` object.

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->


