### PR TITLE
Fix I18N lint workflow

### DIFF
--- a/.github/workflows/lint-i18n.yml
+++ b/.github/workflows/lint-i18n.yml
@@ -36,11 +36,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # TODO: Switch to WP-CLI stable (wp-cli.phar) once 2.5.0 is out.
       - name: Install WP-CLI
         run: |
-          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar
-          mv wp-cli-nightly.phar wp-cli.phar
+          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+          mv wp-cli.phar wp-cli.phar
           chmod +x wp-cli.phar
           mkdir -p bin
           mv wp-cli.phar bin/wp
@@ -48,6 +47,12 @@ jobs:
 
       - name: WP-CLI Info
         run: wp cli info
+
+      - name: Install latest version of i18n-command
+        run: wp package install git@github.com:wp-cli/i18n-command.git
+
+      - name: List packages
+        run: wp package list
 
       - name: Read .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
@@ -100,7 +105,6 @@ jobs:
       # See https://github.com/wp-cli/i18n-command/issues/154
       - name: Generate POT file
         run: |
-          wp i18n make-pot build/web-stories build/web-stories.pot
           OUTPUT=$((wp i18n make-pot build/web-stories build/web-stories.pot) 2>&1 >/dev/null)
 
           HAS_ERROR=false

--- a/.github/workflows/lint-i18n.yml
+++ b/.github/workflows/lint-i18n.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Install WP-CLI
         run: |
           curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
-          mv wp-cli.phar wp-cli.phar
           chmod +x wp-cli.phar
           mkdir -p bin
           mv wp-cli.phar bin/wp

--- a/.github/workflows/lint-i18n.yml
+++ b/.github/workflows/lint-i18n.yml
@@ -100,6 +100,7 @@ jobs:
       # See https://github.com/wp-cli/i18n-command/issues/154
       - name: Generate POT file
         run: |
+          wp i18n make-pot build/web-stories build/web-stories.pot
           OUTPUT=$((wp i18n make-pot build/web-stories build/web-stories.pot) 2>&1 >/dev/null)
 
           HAS_ERROR=false


### PR DESCRIPTION
Updates to use WP-CLI stable and the development version of the i18n command.