### PR TITLE
Add filter for Ad Manager configuration

### DIFF
--- a/includes/Ad_Manager.php
+++ b/includes/Ad_Manager.php
@@ -86,7 +86,14 @@ class Ad_Manager extends Service_Base {
 
 		$application_json['ad-attributes'] = $ad_attributes;
 		
-		$application_json = apply_filters( 'web_stories_ad_manager_json', $application_json );
+		/**
+		 * Filters Google Ad Manager configuration passed to `<amp-story-auto-ads>`.
+		 *
+		 * @since 1.10.0
+		 *
+		 * @param array $settings Ad Manager configuration.
+		 */
+		$configuration = apply_filters( 'web_stories_ad_manager_configuration', $configuration );
 
 		?>
 		<amp-story-auto-ads>

--- a/includes/Ad_Manager.php
+++ b/includes/Ad_Manager.php
@@ -98,7 +98,7 @@ class Ad_Manager extends Service_Base {
 		?>
 		<amp-story-auto-ads>
 			<script type="application/json">
-				<?php echo wp_json_encode( $configuration, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE ); ?>
+				<?php echo wp_json_encode( $configuration, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ); ?>
 			</script>
 		</amp-story-auto-ads>
 		<?php

--- a/includes/Ad_Manager.php
+++ b/includes/Ad_Manager.php
@@ -77,15 +77,21 @@ class Ad_Manager extends Service_Base {
 		if ( ! $enabled || ! $slot ) {
 			return;
 		}
+
+		$application_json = [];
+
+		$ad_attributes = [];
+		$ad_attributes[ 'type' ] = 'doubleclick';
+		$ad_attributes[ 'data-slot' ] = $slot;
+
+		$application_json['ad-attributes'] = $ad_attributes;
+		
+		$application_json = apply_filters( 'web_stories_ad_manager_json', $application_json );
+
 		?>
 		<amp-story-auto-ads>
 			<script type="application/json">
-				{
-					"ad-attributes": {
-						"type": "doubleclick",
-						"data-slot": "<?php echo esc_js( $slot ); ?>"
-					}
-				}
+				<?php echo wp_json_encode( $application_json, JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT ); ?>
 			</script>
 		</amp-story-auto-ads>
 		<?php

--- a/includes/Ad_Manager.php
+++ b/includes/Ad_Manager.php
@@ -78,7 +78,12 @@ class Ad_Manager extends Service_Base {
 			return;
 		}
 
-		$application_json = [];
+		$configuration = [
+			'ad-attributes' => [
+				'type'      => 'doubleclick',
+				'data-slot' => $slot,
+			],
+		];
 
 		$ad_attributes = [];
 		$ad_attributes[ 'type' ] = 'doubleclick';

--- a/includes/Ad_Manager.php
+++ b/includes/Ad_Manager.php
@@ -85,25 +85,20 @@ class Ad_Manager extends Service_Base {
 			],
 		];
 
-		$ad_attributes = [];
-		$ad_attributes[ 'type' ] = 'doubleclick';
-		$ad_attributes[ 'data-slot' ] = $slot;
-
-		$application_json['ad-attributes'] = $ad_attributes;
-		
 		/**
 		 * Filters Google Ad Manager configuration passed to `<amp-story-auto-ads>`.
 		 *
 		 * @since 1.10.0
 		 *
 		 * @param array $settings Ad Manager configuration.
+		 * @param string $slot Google Ad_Manager slot ID.
 		 */
-		$configuration = apply_filters( 'web_stories_ad_manager_configuration', $configuration );
+		$configuration = apply_filters( 'web_stories_ad_manager_configuration', $configuration, $slot );
 
 		?>
 		<amp-story-auto-ads>
 			<script type="application/json">
-				<?php echo wp_json_encode( $application_json, JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT ); ?>
+				<?php echo wp_json_encode( $configuration, JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE ); ?>
 			</script>
 		</amp-story-auto-ads>
 		<?php


### PR DESCRIPTION
## Context

adding a filter to be able to extend ad manager functionality to be able to add better targeting for ads.
With this filter devs shoudl be able to extend the targeting as defined on https://github.com/ampproject/amphtml/blob/main/extensions/amp-story-auto-ads/amp-story-auto-ads.md#passing-additional-attributes-rtc-targeting-etc

## Summary

extends ad manager json descriptor for targeting ads 

## Relevant Technical Choices

Created a default json object and apply a filter so that devs can implement the filter to increase targetting

## To-do

nothing to do as this is an extensibility hook that devs can take advantage on

## User-facing changes

none

## Testing Instructions

1. Enable Google Ad Manager in the plugin settings.
2. Setup the Slot ID /123456789/a4a/amp_story_dfp_example
3. Open a WebStory and look at the code generated for ad manager it should look like:

`
<amp-story-auto-ads class="i-amphtml-layout-container" i-amphtml-layout="container">
  <script type="application/json">
  {
      "ad-attributes": {
          "type": "doubleclick",
          "data-slot": "/123456789/a4a/amp_story_dfp_example"
      }
  }			
  </script>
</amp-story-auto-ads>
`


### QA

not manual testing



This PR can be tested by following these steps:

1. Enable Google Ad Manager in the plugin settings.
2. Setup the Slot ID /123456789/a4a/amp_story_dfp_example
3. Open a WebStory and look at the code generated for ad manager it should look like:

`
<amp-story-auto-ads class="i-amphtml-layout-container" i-amphtml-layout="container">
  <script type="application/json">
  {
      "ad-attributes": {
          "type": "doubleclick",
          "data-slot": "/123456789/a4a/amp_story_dfp_example"
      }
  }			
  </script>
</amp-story-auto-ads>
`

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
