### PR TITLE
Include image zoom in "sizes" attribute generation

### DIFF
--- a/assets/src/edit-story/elements/image/output.js
+++ b/assets/src/edit-story/elements/image/output.js
@@ -47,7 +47,8 @@ function ImageOutput({ element, box }) {
 
     // If `srcset` exists but `sizes` doesn't, amp-img will generate a sizes attribute
     // with best-guess values that can result in poor image selection.
-    const imageWidthPercent = element.width / PAGE_WIDTH;
+    const imageWidthPercent =
+      (element.width * (element.scale / 100)) / PAGE_WIDTH;
     const mobileWidth = Math.round(imageWidthPercent * 100) + 'vw';
     // Width of a story page in desktop mode is 45vh.
     const desktopWidth = Math.round(imageWidthPercent * 45) + 'vh';

--- a/assets/src/edit-story/elements/image/test/output.js
+++ b/assets/src/edit-story/elements/image/test/output.js
@@ -30,7 +30,7 @@ describe('Image output', () => {
       id: '123',
       type: 'image',
       mimeType: 'image/png',
-      scale: 1,
+      scale: 200,
       origRatio: 16 / 9,
       x: 50,
       y: 100,
@@ -83,8 +83,9 @@ describe('Image output', () => {
     );
     // Generated sizes attribute should match: "(min-width: <desktop_screen_width>) <desktop_image_width>, <mobile_image_width>".
     // The image size is 412px wide, which is full page width. 45vh is the page width of stories in desktop mode.
+    // The image zoom is 200 (2x) so double both measurements.
     await expect(outputStr).toStrictEqual(
-      expect.stringMatching(/sizes="\(min-width: 1024px\) 45vh, 100vw"/)
+      expect.stringMatching(/sizes="\(min-width: 1024px\) 90vh, 200vw"/)
     );
     // The "disable-inline-width" attribute should accompany the "sizes" attribute.
     await expect(outputStr).toStrictEqual(


### PR DESCRIPTION
## Context

Fixes bug where images with high zoom/scale look blurry images in output story.

## Summary

Includes image zoom/scale in element width calculation for sizes.

## Relevant Technical Choices

N/A

## To-do

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

This PR can be tested by following these steps:

1. Add an image onto a new story
2. Double-click and increase zoom of the image to the max
3. Preview the story
4. The image in the story preview should not look blurry anymore

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

No.

### Does this PR change what data or activity we track or use?

No.

### Does this PR have a legal-related impact?

No.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8344
