### PR TITLE
Use `rest_parse_embed_param()` in `rest_preload_api_request()`

### DIFF
--- a/includes/namespace.php
+++ b/includes/namespace.php
@@ -213,12 +213,13 @@ add_action( 'init', __NAMESPACE__ . '\includes' );
  *
  * Like rest_preload_api_request() in core, but embeds links and removes trailing slashes.
  *
- * @link  https://core.trac.wordpress.org/ticket/51722
+ * @link https://core.trac.wordpress.org/ticket/51722
+ * @link https://core.trac.wordpress.org/ticket/51636
+ *
+ * @SuppressWarnings(PHPMD.NPathComplexity)
  *
  * @since 1.2.0
- *
- * @see   \rest_preload_api_request
- * @SuppressWarnings(PHPMD.NPathComplexity)
+ * @see \rest_preload_api_request
  *
  * @param array        $memo Reduce accumulator.
  * @param string|array $path REST API path to preload.
@@ -252,17 +253,16 @@ function rest_preload_api_request( $memo, $path ): array {
 	}
 
 	$request = new WP_REST_Request( $method, untrailingslashit( $path_parts['path'] ) );
-	$embed   = false;
 	if ( ! empty( $path_parts['query'] ) ) {
 		$query_params = [];
 		parse_str( $path_parts['query'], $query_params );
-		$embed = $query_params['_embed'] ?? false;
 		$request->set_query_params( $query_params );
 	}
 
 	$response = rest_do_request( $request );
 	if ( 200 === $response->status ) {
 		$server = rest_get_server();
+		$embed  = $request->has_param( '_embed' ) ? rest_parse_embed_param( $request['_embed'] ) : false;
 		$data   = $server->response_to_data( $response, $embed );
 
 		if ( 'OPTIONS' === $method ) {


### PR DESCRIPTION
Context: https://xwp.slack.com/archives/C013J2EGH8R/p1627291234202200