### PR TITLE
Editor: Add Play/Stop Animations Keyboard Shortcut

### DIFF
--- a/assets/src/edit-story/components/canvas/pagemenu/animationToggle.js
+++ b/assets/src/edit-story/components/canvas/pagemenu/animationToggle.js
@@ -47,7 +47,7 @@ function AnimationToggle() {
   const label = isPlaying
     ? __('Stop Page Animations', 'web-stories')
     : __('Play Page Animations', 'web-stories');
-  const shortcut = isPlaying ? 'shift+mod+z' : 'mod+z';
+  const shortcut = 'mod+k';
   const Icon = isPlaying ? Icons.StopOutline : Icons.PlayOutline;
 
   const toggleAnimationState = useCallback(() => {

--- a/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutList.js
+++ b/assets/src/edit-story/components/keyboardShortcutsMenu/keyboardShortcutList.js
@@ -120,6 +120,17 @@ const shortcuts = {
             </kbd>
           ),
         },
+        {
+          label: __('Play / Stop', 'web-stories'),
+          shortcut: (
+            <kbd>
+              <kbd aria-label={cmdOrCtrl.title} className="large-key">
+                {cmdOrCtrl.symbol}
+              </kbd>
+              <kbd>{'K'}</kbd>
+            </kbd>
+          ),
+        },
       ],
     },
     {


### PR DESCRIPTION
## Context
Realized Play/Stop animations keyboard shortcut wasn't implemented, but part of the label for the play button. This PR adds the shortcut

## Summary
Original designs had `mod+z` as the shortcut to play animations, but that's already taken by undo/redo. So for this shortcut we looked at available `mod+<key>` combos to see whats available. Ended up going with `mod+k` which wasn't being used.

## Relevant Technical Choices
NA
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- Adds `Play / Stop` keyboard shortcut to editor with `command + K`
- Adds `Play / Stop` keyboard shortcut to shortcut menu
- Updates `Play / Stop` button label to be `command + k`
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Open a story with animations in the editor. See that both the keyboard shortcut menu & label for the `Play / Stop` button show `command + k` as the keyboard shortcut.

Press `command + k` and see that animations play in the editor
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
- Open a story with animations in the editor (or create a new story and add animations to some elements in there)
- Press `command + k` (`control + k` on windows) within the editor and see that the animations play (or stop if you press it while they're playing)
- Hover over the play button in the editor and see that the label has `⌘ + K`
- Open the keyboard shortcuts menu and see that there is a new `⌘ + K ` Play / Stop keyboard shortcut is documented in there

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
Doesn't add any new activity, but does trigger the `canvas_play_animations` tracking event like we do with the play button already.
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8448 