### PR TITLE
 Stickers: Clean up panel

### DIFF
--- a/assets/src/edit-story/components/library/constants.js
+++ b/assets/src/edit-story/components/library/constants.js
@@ -50,7 +50,7 @@ export const TEXT = {
 };
 export const SHAPES = {
   icon: ShapesIcon,
-  tooltip: __('Shapes', 'web-stories'),
+  tooltip: __('Shapes & Stickers', 'web-stories'),
   Pane: ShapesPane,
   id: 'shapes',
 };

--- a/assets/src/edit-story/components/library/karma/shapes/shapes.karma.js
+++ b/assets/src/edit-story/components/library/karma/shapes/shapes.karma.js
@@ -17,13 +17,14 @@
 /**
  * External dependencies
  */
-// import STICKERS from '@web-stories-wp/stickers';
+import STICKERS from '@web-stories-wp/stickers';
+
 /**
  * Internal dependencies
  */
 import { Fixture } from '../../../../karma/fixture';
 
-// const testSticker = Object.values(STICKERS)[0];
+const testStickerType = Object.keys(STICKERS)[0];
 
 describe('Shape library integration', () => {
   let fixture;
@@ -93,76 +94,96 @@ describe('Shape library integration', () => {
   });
 });
 
-// describe('Sticker library integration', () => {
-//   let fixture;
+describe('Sticker library integration', () => {
+  let fixture;
 
-//   beforeEach(async () => {
-//     fixture = new Fixture();
-//     await fixture.render();
-//   });
+  beforeEach(async () => {
+    fixture = new Fixture();
+    fixture.setFlags({ enableStickers: true });
+    await fixture.render();
+  });
 
-//   afterEach(() => {
-//     fixture.restore();
-//   });
+  afterEach(() => {
+    fixture.restore();
+  });
 
-//   it('add sticker via clicking on sticker preview', async () => {
-//     // Only background initially
-//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
+  it('add sticker via clicking on sticker preview', async () => {
+    // Only background initially
+    expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
 
-//     // Switch to shapes tab and click the triangle
-//     await fixture.events.click(fixture.editor.library.shapesTab);
-//     await fixture.events.click(
-//       fixture.editor.library.shapes.sticker(testSticker.title)
-//     );
+    // Switch to shapes tab and click the first sticker
+    await fixture.events.click(fixture.editor.library.shapesTab);
+    await fixture.events.click(
+      fixture.editor.library.shapes.sticker(testStickerType)
+    );
 
-//     // Now background + 1 extra element
-//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(2);
-//   });
+    // Now background + 1 extra element
+    expect(fixture.editor.canvas.framesLayer.frames.length).toBe(2);
+  });
 
-//   it('add shape via dragging from shape preview', async () => {
-//     // Only background initially
-//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
+  it('add sticker via keyboard naviation to sticker preview', async () => {
+    // Only background initially
+    expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
 
-//     // Switch to the shapes tab and drag the triangle to the canvas
-//     await fixture.events.click(fixture.editor.library.shapesTab);
-//     const stickerButton = fixture.editor.library.shapes.sticker(
-//       testSticker.title
-//     );
-//     const bgFrame = fixture.editor.canvas.framesLayer.frames[0].node;
-//     await fixture.events.mouse.seq(({ moveRel, down, up }) => [
-//       moveRel(stickerButton, 10, 10),
-//       down(),
-//       /* The steps give time for Moveable to react and display a clone to drag */
-//       moveRel(bgFrame, 50, 50, { steps: 20 }),
-//       up(),
-//     ]);
+    // Switch to shapes tab and click the first sticker
+    await fixture.events.click(fixture.editor.library.shapesTab);
+    let limit = 0;
+    const stickersTab = fixture.editor.library.shapes.getByTestId(
+      'stickers-library-pane'
+    );
+    while (!stickersTab.contains(document.activeElement) && limit < 10) {
+      // eslint-disable-next-line no-await-in-loop
+      await fixture.events.keyboard.press('tab');
+      limit++;
+    }
+    await fixture.events.keyboard.press('Enter');
 
-//     // Now background + 1 extra element
-//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(2);
-//   });
+    // Now background + 1 extra element
+    expect(fixture.editor.canvas.framesLayer.frames.length).toBe(2);
+  });
 
-//   it('should not add shape dragged out of the page area', async () => {
-//     // Only background initially
-//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
+  it('add sticker via dragging from sticker preview', async () => {
+    // Only background initially
+    expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
 
-//     // Switch to the shapes tab and drag the triangle to the canvas
-//     await fixture.events.click(fixture.editor.library.shapesTab);
-//     const stickerButton = fixture.editor.library.shapes.sticker(
-//       testSticker.title
-//     );
-//     const bgFrame = fixture.editor.canvas.framesLayer.frames[0].node;
+    // Switch to the shapes tab and drag the first sticker to the canvas
+    await fixture.events.click(fixture.editor.library.shapesTab);
+    const stickerButton =
+      fixture.editor.library.shapes.sticker(testStickerType);
+    const bgFrame = fixture.editor.canvas.framesLayer.frames[0].node;
+    await fixture.events.mouse.seq(({ moveRel, down, up }) => [
+      moveRel(stickerButton, 10, 10),
+      down(),
+      /* The steps give time for Moveable to react and display a clone to drag */
+      moveRel(bgFrame, 50, 50, { steps: 20 }),
+      up(),
+    ]);
 
-//     // Shape is 1/3 of the page's width by default.
-//     const { width: pageWidth } = bgFrame.getBoundingClientRect();
-//     await fixture.events.mouse.seq(({ moveRel, down, up }) => [
-//       moveRel(stickerButton, 10, 10),
-//       down(),
-//       /* The steps give time for Moveable to react and display a clone to drag */
-//       moveRel(bgFrame, -(pageWidth / 3 + 20), 50, { steps: 20 }),
-//       up(),
-//     ]);
+    // Now background + 1 extra element
+    expect(fixture.editor.canvas.framesLayer.frames.length).toBe(2);
+  });
 
-//     // Still only background.
-//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
-//   });
-// });
+  it('should not add sticker dragged out of the page area', async () => {
+    // Only background initially
+    expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
+
+    // Switch to the shapes tab and drag the first sticker to the canvas
+    await fixture.events.click(fixture.editor.library.shapesTab);
+    const stickerButton =
+      fixture.editor.library.shapes.sticker(testStickerType);
+    const bgFrame = fixture.editor.canvas.framesLayer.frames[0].node;
+
+    // Shape is 1/3 of the page's width by default.
+    const { width: pageWidth } = bgFrame.getBoundingClientRect();
+    await fixture.events.mouse.seq(({ moveRel, down, up }) => [
+      moveRel(stickerButton, 10, 10),
+      down(),
+      /* The steps give time for Moveable to react and display a clone to drag */
+      moveRel(bgFrame, -(pageWidth / 3 + 20), 50, { steps: 20 }),
+      up(),
+    ]);
+
+    // Still only background.
+    expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
+  });
+});

--- a/assets/src/edit-story/components/library/karma/shapes/shapes.karma.js
+++ b/assets/src/edit-story/components/library/karma/shapes/shapes.karma.js
@@ -15,9 +15,15 @@
  */
 
 /**
+ * External dependencies
+ */
+// import STICKERS from '@web-stories-wp/stickers';
+/**
  * Internal dependencies
  */
 import { Fixture } from '../../../../karma/fixture';
+
+// const testSticker = Object.values(STICKERS)[0];
 
 describe('Shape library integration', () => {
   let fixture;
@@ -86,3 +92,77 @@ describe('Shape library integration', () => {
     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
   });
 });
+
+// describe('Sticker library integration', () => {
+//   let fixture;
+
+//   beforeEach(async () => {
+//     fixture = new Fixture();
+//     await fixture.render();
+//   });
+
+//   afterEach(() => {
+//     fixture.restore();
+//   });
+
+//   it('add sticker via clicking on sticker preview', async () => {
+//     // Only background initially
+//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
+
+//     // Switch to shapes tab and click the triangle
+//     await fixture.events.click(fixture.editor.library.shapesTab);
+//     await fixture.events.click(
+//       fixture.editor.library.shapes.sticker(testSticker.title)
+//     );
+
+//     // Now background + 1 extra element
+//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(2);
+//   });
+
+//   it('add shape via dragging from shape preview', async () => {
+//     // Only background initially
+//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
+
+//     // Switch to the shapes tab and drag the triangle to the canvas
+//     await fixture.events.click(fixture.editor.library.shapesTab);
+//     const stickerButton = fixture.editor.library.shapes.sticker(
+//       testSticker.title
+//     );
+//     const bgFrame = fixture.editor.canvas.framesLayer.frames[0].node;
+//     await fixture.events.mouse.seq(({ moveRel, down, up }) => [
+//       moveRel(stickerButton, 10, 10),
+//       down(),
+//       /* The steps give time for Moveable to react and display a clone to drag */
+//       moveRel(bgFrame, 50, 50, { steps: 20 }),
+//       up(),
+//     ]);
+
+//     // Now background + 1 extra element
+//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(2);
+//   });
+
+//   it('should not add shape dragged out of the page area', async () => {
+//     // Only background initially
+//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
+
+//     // Switch to the shapes tab and drag the triangle to the canvas
+//     await fixture.events.click(fixture.editor.library.shapesTab);
+//     const stickerButton = fixture.editor.library.shapes.sticker(
+//       testSticker.title
+//     );
+//     const bgFrame = fixture.editor.canvas.framesLayer.frames[0].node;
+
+//     // Shape is 1/3 of the page's width by default.
+//     const { width: pageWidth } = bgFrame.getBoundingClientRect();
+//     await fixture.events.mouse.seq(({ moveRel, down, up }) => [
+//       moveRel(stickerButton, 10, 10),
+//       down(),
+//       /* The steps give time for Moveable to react and display a clone to drag */
+//       moveRel(bgFrame, -(pageWidth / 3 + 20), 50, { steps: 20 }),
+//       up(),
+//     ]);
+
+//     // Still only background.
+//     expect(fixture.editor.canvas.framesLayer.frames.length).toBe(1);
+//   });
+// });

--- a/assets/src/edit-story/components/library/panes/shapes/shapePreview.js
+++ b/assets/src/edit-story/components/library/panes/shapes/shapePreview.js
@@ -167,7 +167,7 @@ function ShapePreview({ mask, isPreview, index }) {
   // We use rovingTabIndex for navigating so only the first item will have 0 as tabIndex.
   // onClick on Aspect is for the keyboard only.
   return (
-    <Aspect ref={ref} tabIndex={index === 0 ? 0 : -1}>
+    <Aspect ref={ref} onClick={onClick} tabIndex={index === 0 ? 0 : -1}>
       <AspectInner>
         <ShapePreviewContainer key={mask.type} aria-label={mask.name}>
           <ShapePreviewSizer />
@@ -177,7 +177,6 @@ function ShapePreview({ mask, isPreview, index }) {
       <LibraryMoveable
         type={'shape'}
         elementProps={shapeData}
-        onClick={onClick}
         cloneElement={ShapeClone}
         cloneProps={{
           width: dataToEditorX(DEFAULT_ELEMENT_WIDTH * mask.ratio),

--- a/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
+++ b/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
@@ -59,7 +59,7 @@ function ShapesPane(props) {
   const ref = useRef();
   useRovingTabIndex({ ref });
 
-  const stickersRef = useRef();
+  const stickersRef = useRef(null);
   useRovingTabIndex({ ref: stickersRef });
   return (
     <Pane id={paneId} {...props} isOverflowScrollable={enableStickers}>
@@ -71,7 +71,10 @@ function ShapesPane(props) {
           disabled
         />
       )}
-      <Section title={__('Shapes', 'web-stories')}>
+      <Section
+        data-testid="shapes-library-pane"
+        title={__('Shapes', 'web-stories')}
+      >
         <SectionContent ref={ref}>
           {MASKS.filter((mask) => mask.showInLibrary).map((mask, i) => (
             <ShapePreview mask={mask} key={mask.type} index={i} isPreview />
@@ -79,7 +82,10 @@ function ShapesPane(props) {
         </SectionContent>
       </Section>
       {enableStickers && (
-        <Section title={__('Stickers', 'web-stories')}>
+        <Section
+          data-testid="stickers-library-pane"
+          title={__('Stickers', 'web-stories')}
+        >
           <SectionContent ref={stickersRef}>
             {STICKER_TYPES.map((stickerType, i) => (
               <StickerPreview

--- a/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
+++ b/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
@@ -81,8 +81,12 @@ function ShapesPane(props) {
       {enableStickers && (
         <Section title={__('Stickers', 'web-stories')}>
           <SectionContent ref={stickersRef}>
-            {STICKER_TYPES.map((stickerType) => (
-              <StickerPreview key={stickerType} stickerType={stickerType} />
+            {STICKER_TYPES.map((stickerType, i) => (
+              <StickerPreview
+                key={stickerType}
+                index={i}
+                stickerType={stickerType}
+              />
             ))}
           </SectionContent>
         </Section>

--- a/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
+++ b/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
@@ -31,7 +31,7 @@ import { Section, SearchInput } from '../../common';
 import { Pane } from '../shared';
 import useRovingTabIndex from '../../../../utils/useRovingTabIndex';
 import ShapePreview from './shapePreview';
-import StickerButton from './stickerButton';
+import StickerPreview from './stickerButton';
 import paneId from './paneId';
 
 const SectionContent = styled.div`
@@ -58,6 +58,9 @@ function ShapesPane(props) {
 
   const ref = useRef();
   useRovingTabIndex({ ref });
+
+  const stickersRef = useRef();
+  useRovingTabIndex({ ref: stickersRef });
   return (
     <Pane id={paneId} {...props} isOverflowScrollable={enableStickers}>
       {showTextAndShapesSearchInput && (
@@ -77,9 +80,9 @@ function ShapesPane(props) {
       </Section>
       {enableStickers && (
         <Section title={__('Stickers', 'web-stories')}>
-          <SectionContent>
+          <SectionContent ref={stickersRef}>
             {STICKER_TYPES.map((stickerType) => (
-              <StickerButton key={stickerType} stickerType={stickerType} />
+              <StickerPreview key={stickerType} stickerType={stickerType} />
             ))}
           </SectionContent>
         </Section>

--- a/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
+++ b/assets/src/edit-story/components/library/panes/shapes/shapesPane.js
@@ -31,7 +31,7 @@ import { Section, SearchInput } from '../../common';
 import { Pane } from '../shared';
 import useRovingTabIndex from '../../../../utils/useRovingTabIndex';
 import ShapePreview from './shapePreview';
-import StickerPreview from './stickerButton';
+import StickerPreview from './stickerPreview';
 import paneId from './paneId';
 
 const SectionContent = styled.div`

--- a/assets/src/edit-story/components/library/panes/shapes/stickerButton.js
+++ b/assets/src/edit-story/components/library/panes/shapes/stickerButton.js
@@ -39,12 +39,24 @@ const StickerButton = styled(Button).attrs({
   type: BUTTON_TYPES.SECONDARY,
 })`
   position: relative;
+  padding: 0 0 95.5% 0;
   margin: 0;
   height: 60px;
   background-color: ${({ theme }) => theme.colors.interactiveBg.previewOverlay};
 `;
 
-function StickerPreview({ stickerType }) {
+const StickerInner = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+function StickerPreview({ stickerType, index }) {
   const { insertElement } = useLibrary((state) => ({
     insertElement: state.actions.insertElement,
   }));
@@ -74,14 +86,6 @@ function StickerPreview({ stickerType }) {
     opacity: 0;
     width: ${({ width }) => `${width}px`};
     height: ${({ height }) => `${height}px`};
-    svg {
-      display: inline-block;
-      width: 100%;
-      height: 100%;
-      path {
-        fill: #c4c4c4;
-      }
-    }
   `;
 
   const Svg = sticker.svg;
@@ -93,42 +97,50 @@ function StickerPreview({ stickerType }) {
           sticker: { type: stickerType },
         })
       }
+      tabIndex={index === 0 ? 0 : -1}
     >
-      <Svg
-        style={{
-          height: 'auto',
-          width: '100%',
-        }}
-      />
-      <LibraryMoveable
-        type={'sticker'}
-        elementProps={stickerData}
-        cloneElement={StickerClone}
-        onClick={() =>
-          insertElement('sticker', {
-            width: DEFAULT_ELEMENT_WIDTH,
-            sticker: { type: stickerType },
-          })
-        }
-        cloneProps={{
-          width: dataToEditorX(DEFAULT_ELEMENT_WIDTH * aspectRatio),
-          height: dataToEditorY(DEFAULT_ELEMENT_WIDTH),
-          children: (
-            <Svg
-              style={{
-                height: 'auto',
-                width: '100%',
-              }}
-            />
-          ),
-        }}
-      />
+      <StickerInner>
+        <Svg
+          style={{
+            height: aspectRatio < 0.955 ? '60%' : 'auto',
+            width: aspectRatio < 0.955 ? 'auto' : '60%',
+          }}
+        />
+        <LibraryMoveable
+          type={'sticker'}
+          elementProps={stickerData}
+          cloneElement={StickerClone}
+          onClick={() =>
+            insertElement('sticker', {
+              width: DEFAULT_ELEMENT_WIDTH,
+              sticker: { type: stickerType },
+            })
+          }
+          cloneProps={{
+            width: dataToEditorX(
+              DEFAULT_ELEMENT_WIDTH * (aspectRatio < 1 ? aspectRatio : 1)
+            ),
+            height: dataToEditorY(
+              DEFAULT_ELEMENT_WIDTH / (aspectRatio < 1 ? 1 : aspectRatio)
+            ),
+            children: (
+              <Svg
+                style={{
+                  height: 'auto',
+                  width: '100%',
+                }}
+              />
+            ),
+          }}
+        />
+      </StickerInner>
     </StickerButton>
   );
 }
 
 StickerPreview.propTypes = {
   stickerType: PropTypes.string.isRequired,
+  index: PropTypes.number,
 };
 
 export default StickerPreview;

--- a/assets/src/edit-story/components/library/panes/shapes/stickerButton.js
+++ b/assets/src/edit-story/components/library/panes/shapes/stickerButton.js
@@ -17,6 +17,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import STICKERS from '@web-stories-wp/stickers';
 import {
   Button,
@@ -30,27 +31,29 @@ import {
 import useLibrary from '../../useLibrary';
 import { DEFAULT_ELEMENT_WIDTH } from './shapePreview';
 
-function StickerButton({ stickerType }) {
+const StickerButton = styled(Button).attrs({
+  size: BUTTON_SIZES.SMALL,
+  type: BUTTON_TYPES.SECONDARY,
+})`
+  margin: 0 10px 10px 0;
+  height: 60px;
+  background-color: ${({ theme }) => theme.colors.interactiveBg.previewOverlay};
+`;
+
+function StickerPreview({ stickerType }) {
   const { insertElement } = useLibrary((state) => ({
     insertElement: state.actions.insertElement,
   }));
 
   const Svg = STICKERS?.[stickerType]?.svg;
   return (
-    <Button
-      size={BUTTON_SIZES.SMALL}
-      type={BUTTON_TYPES.SECONDARY}
+    <StickerButton
       onClick={() =>
         insertElement('sticker', {
           width: DEFAULT_ELEMENT_WIDTH,
           sticker: { type: stickerType },
         })
       }
-      style={{
-        marginBottom: 10,
-        marginRight: 10,
-        height: 60,
-      }}
     >
       <Svg
         style={{
@@ -58,12 +61,12 @@ function StickerButton({ stickerType }) {
           width: 'auto',
         }}
       />
-    </Button>
+    </StickerButton>
   );
 }
 
-StickerButton.propTypes = {
+StickerPreview.propTypes = {
   stickerType: PropTypes.string.isRequired,
 };
 
-export default StickerButton;
+export default StickerPreview;

--- a/assets/src/edit-story/components/library/panes/shapes/stickerButton.js
+++ b/assets/src/edit-story/components/library/panes/shapes/stickerButton.js
@@ -16,6 +16,7 @@
 /**
  * External dependencies
  */
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import STICKERS from '@web-stories-wp/stickers';
@@ -24,18 +25,21 @@ import {
   BUTTON_SIZES,
   BUTTON_TYPES,
 } from '@web-stories-wp/design-system';
+import { useUnits } from '@web-stories-wp/units';
 
 /**
  * Internal dependencies
  */
 import useLibrary from '../../useLibrary';
+import LibraryMoveable from '../shared/libraryMoveable';
 import { DEFAULT_ELEMENT_WIDTH } from './shapePreview';
 
 const StickerButton = styled(Button).attrs({
   size: BUTTON_SIZES.SMALL,
   type: BUTTON_TYPES.SECONDARY,
 })`
-  margin: 0 10px 10px 0;
+  position: relative;
+  margin: 0;
   height: 60px;
   background-color: ${({ theme }) => theme.colors.interactiveBg.previewOverlay};
 `;
@@ -45,7 +49,42 @@ function StickerPreview({ stickerType }) {
     insertElement: state.actions.insertElement,
   }));
 
-  const Svg = STICKERS?.[stickerType]?.svg;
+  const { dataToEditorX, dataToEditorY } = useUnits((state) => ({
+    dataToEditorX: state.actions.dataToEditorX,
+    dataToEditorY: state.actions.dataToEditorY,
+  }));
+
+  const sticker = STICKERS[stickerType];
+  const aspectRatio = sticker.aspectRatio;
+  const stickerData = useMemo(
+    () => ({
+      width: DEFAULT_ELEMENT_WIDTH * aspectRatio,
+      height: DEFAULT_ELEMENT_WIDTH,
+      sticker: {
+        type: stickerType,
+      },
+    }),
+    [aspectRatio, stickerType]
+  );
+
+  const StickerClone = styled.div`
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0;
+    width: ${({ width }) => `${width}px`};
+    height: ${({ height }) => `${height}px`};
+    svg {
+      display: inline-block;
+      width: 100%;
+      height: 100%;
+      path {
+        fill: #c4c4c4;
+      }
+    }
+  `;
+
+  const Svg = sticker.svg;
   return (
     <StickerButton
       onClick={() =>
@@ -57,8 +96,31 @@ function StickerPreview({ stickerType }) {
     >
       <Svg
         style={{
-          height: '100%',
-          width: 'auto',
+          height: 'auto',
+          width: '100%',
+        }}
+      />
+      <LibraryMoveable
+        type={'sticker'}
+        elementProps={stickerData}
+        cloneElement={StickerClone}
+        onClick={() =>
+          insertElement('sticker', {
+            width: DEFAULT_ELEMENT_WIDTH,
+            sticker: { type: stickerType },
+          })
+        }
+        cloneProps={{
+          width: dataToEditorX(DEFAULT_ELEMENT_WIDTH * aspectRatio),
+          height: dataToEditorY(DEFAULT_ELEMENT_WIDTH),
+          children: (
+            <Svg
+              style={{
+                height: 'auto',
+                width: '100%',
+              }}
+            />
+          ),
         }}
       />
     </StickerButton>

--- a/assets/src/edit-story/components/library/panes/shapes/stickerPreview.js
+++ b/assets/src/edit-story/components/library/panes/shapes/stickerPreview.js
@@ -139,7 +139,7 @@ function StickerPreview({ stickerType, index }) {
 }
 
 StickerPreview.propTypes = {
-  stickerType: PropTypes.string.isRequired,
+  stickerType: PropTypes.oneOf(Object.keys(STICKERS)).isRequired,
   index: PropTypes.number,
 };
 

--- a/assets/src/edit-story/components/library/panes/shapes/stickerPreview.js
+++ b/assets/src/edit-story/components/library/panes/shapes/stickerPreview.js
@@ -91,6 +91,7 @@ function StickerPreview({ stickerType, index }) {
   const Svg = sticker.svg;
   return (
     <StickerButton
+      data-testid={`library-sticker-${sticker.title}`}
       onClick={() =>
         insertElement('sticker', {
           width: DEFAULT_ELEMENT_WIDTH,

--- a/assets/src/edit-story/components/library/panes/shapes/stickerPreview.js
+++ b/assets/src/edit-story/components/library/panes/shapes/stickerPreview.js
@@ -91,7 +91,7 @@ function StickerPreview({ stickerType, index }) {
   const Svg = sticker.svg;
   return (
     <StickerButton
-      data-testid={`library-sticker-${sticker.title}`}
+      data-testid={`library-sticker-${stickerType}`}
       onClick={() =>
         insertElement('sticker', {
           width: DEFAULT_ELEMENT_WIDTH,
@@ -111,12 +111,6 @@ function StickerPreview({ stickerType, index }) {
           type={'sticker'}
           elementProps={stickerData}
           cloneElement={StickerClone}
-          onClick={() =>
-            insertElement('sticker', {
-              width: DEFAULT_ELEMENT_WIDTH,
-              sticker: { type: stickerType },
-            })
-          }
           cloneProps={{
             width: dataToEditorX(
               DEFAULT_ELEMENT_WIDTH * (aspectRatio < 1 ? aspectRatio : 1)

--- a/assets/src/edit-story/components/library/panes/shared/libraryMoveable.js
+++ b/assets/src/edit-story/components/library/panes/shared/libraryMoveable.js
@@ -37,6 +37,7 @@ import isTargetOutOfContainer from '../../../../utils/isTargetOutOfContainer';
 import useSnapping from '../../../canvas/utils/useSnapping';
 import { useStory, useCanvas } from '../../../../app';
 import objectWithout from '../../../../utils/objectWithout';
+import { noop } from '../../../../utils/noop';
 
 const TargetBox = styled.div`
   position: absolute;
@@ -52,7 +53,7 @@ function LibraryMoveable({
   elementProps = {},
   handleDrag,
   handleDragEnd,
-  onClick,
+  onClick = noop,
   cloneElement,
   cloneProps,
   elements = [],
@@ -311,7 +312,7 @@ LibraryMoveable.propTypes = {
   handleDrag: PropTypes.func,
   handleDragEnd: PropTypes.func,
   elementProps: PropTypes.object,
-  onClick: PropTypes.func.isRequired,
+  onClick: PropTypes.func,
   cloneElement: PropTypes.object.isRequired,
   cloneProps: PropTypes.object.isRequired,
   active: PropTypes.bool,

--- a/assets/src/edit-story/components/library/test/shapes/stickerPreview.js
+++ b/assets/src/edit-story/components/library/test/shapes/stickerPreview.js
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { act, screen } from '@testing-library/react';
+import { UnitsProvider, PAGE_RATIO } from '@web-stories-wp/units';
+import STICKERS from '@web-stories-wp/stickers';
+
+/**
+ * Internal dependencies
+ */
+import StickerPreview from '../../panes/shapes/stickerPreview';
+import { renderWithTheme } from '../../../../testUtils';
+import useLibrary from '../../useLibrary';
+import { TEXT_SET_SIZE } from '../../../../constants';
+import CanvasContext from '../../../../app/canvas/context';
+
+jest.mock('../../useLibrary');
+
+describe('StickerPreview', () => {
+  const insertElement = jest.fn();
+
+  beforeAll(() => {
+    useLibrary.mockImplementation(() => ({
+      actions: {
+        insertElement: insertElement,
+      },
+    }));
+  });
+
+  it('should render', () => {
+    let stickerPreviewElement;
+    act(() => {
+      const canvasValue = {
+        state: {
+          nodesById: {},
+          pageSize: {},
+          pageContainer: document.body,
+          canvasContainer: document.body,
+          designSpaceGuideline: {},
+        },
+      };
+      renderWithTheme(
+        <CanvasContext.Provider value={canvasValue}>
+          <UnitsProvider
+            pageSize={{
+              width: TEXT_SET_SIZE,
+              height: TEXT_SET_SIZE / PAGE_RATIO,
+            }}
+            dataToEditorX={jest.fn()}
+            dataToEditorY={jest.fn()}
+          >
+            <StickerPreview stickerType={'beautyCta'} />
+          </UnitsProvider>
+        </CanvasContext.Provider>
+      );
+
+      // Stickers render title in svg <title>...</title> element
+      stickerPreviewElement = screen.getByText(STICKERS.beautyCta.title);
+    });
+
+    expect(stickerPreviewElement).toBeInTheDocument();
+  });
+});

--- a/assets/src/edit-story/karma/fixture/containers/container.js
+++ b/assets/src/edit-story/karma/fixture/containers/container.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import {
+  getByTestId,
   getByRole,
   getAllByRole,
   queryByRole,
@@ -26,6 +27,7 @@ import {
 
 /** @typedef {import('@testing-library/dom').Matcher} Matcher */
 /** @typedef {import('@testing-library/dom').ByRoleOptions} ByRoleOptions */
+/** @typedef {import('@testing-library/dom').ByTestIdOptions} ByTestIdOptions */
 
 export class Container {
   /**
@@ -70,6 +72,17 @@ export class Container {
         throw new Error(`Focus is not set within the <${this._path}> yet`);
       }
     });
+  }
+
+  /**
+   * See https://testing-library.com/docs/queries/bytestid
+   *
+   * @param {Matcher} text test id.
+   * @param {ByRoleOptions} options Options.
+   * @return {HTMLElement} The found element.
+   */
+  getByTestId(text, options) {
+    return getByTestId(this._node, text, options);
   }
 
   /**

--- a/assets/src/edit-story/karma/fixture/containers/library/index.js
+++ b/assets/src/edit-story/karma/fixture/containers/library/index.js
@@ -102,6 +102,10 @@ export class Shapes extends Container {
   shape(name) {
     return this.getByRole('button', { name });
   }
+
+  sticker(title) {
+    return this.getByTestId(`library-sticker-${title}`);
+  }
 }
 
 export class Media extends Container {

--- a/assets/src/edit-story/karma/fixture/containers/library/index.js
+++ b/assets/src/edit-story/karma/fixture/containers/library/index.js
@@ -100,11 +100,13 @@ export class Shapes extends Container {
   }
 
   shape(name) {
-    return this.getByRole('button', { name });
+    return this.getByRole('button', {
+      name,
+    });
   }
 
-  sticker(title) {
-    return this.getByTestId(`library-sticker-${title}`);
+  sticker(type) {
+    return this.getByTestId(`library-sticker-${type}`);
   }
 }
 


### PR DESCRIPTION
## Context
Part of exposing stickers panel to users
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Hits these implementation brief points for the stickers panel:
- Follow the design system panel of 'shapes' to implement the design for stickers.
- Stickers will be kept separate from shapes but share a panel (as they currently do)
- Make sure that stickers are navigable via keyboard and no focus trapping occurs.
- Stickers should be draggable
- Stickers should be able to click to be added
- Add tests accordingly
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Predominately just followed existing practices and setup in the existing shapes part of the panel
<!-- Please describe your changes. -->

## To-do
- maybe cleanup shareable constants a little 🤷 
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
- Go to experiments and enable `Stickers`
- Open a story in the editor
- go to the shapes panel and you should now see a library of stickers under the shapes
- visually check them, keyboard navigate through them and see that they drag n drop just like the shapes in the shapes panel

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
- Go to experiments and enable `Stickers`
- Open a story in the editor
- go to the shapes panel and you should now see a library of stickers under the shapes
- visually check them, keyboard navigate through them and see that they drag n drop just like the shapes in the shapes panel

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6187 
