### PR TITLE
Context Menu: Keyboard Shortcut Color Contrast

### DIFF
--- a/packages/design-system/src/components/contextMenu/menuItem.js
+++ b/packages/design-system/src/components/contextMenu/menuItem.js
@@ -40,6 +40,9 @@ const Shortcut = styled(Text)`
   color: ${({ theme, disabled }) =>
     disabled ? theme.colors.fg.disable : theme.colors.fg.secondary};
 `;
+Shortcut.propTypes = {
+  disabled: PropTypes.bool,
+};
 
 const IconWrapper = styled.span`
   width: 32px;
@@ -96,7 +99,6 @@ export const MenuItem = ({
         <ItemText
           size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
           forwardedAs="span"
-          disabled={disabled}
         >
           {label}
         </ItemText>

--- a/packages/design-system/src/components/contextMenu/menuItem.js
+++ b/packages/design-system/src/components/contextMenu/menuItem.js
@@ -108,12 +108,12 @@ export const MenuItem = ({
             size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
             forwardedAs="kbd"
           >
-            {shortcut?.display}
+            {shortcut.display}
           </Shortcut>
         )}
       </>
     );
-  }, [Icon, disabled, label, shortcut?.display, tooltipPlacement]);
+  }, [Icon, disabled, label, shortcut, tooltipPlacement]);
 
   if (href) {
     const newTabProps = newTab

--- a/packages/design-system/src/components/contextMenu/menuItem.js
+++ b/packages/design-system/src/components/contextMenu/menuItem.js
@@ -35,9 +35,12 @@ import { PLACEMENT } from '../popup';
 const ItemText = styled(Text)`
   width: 200px;
   text-align: left;
+  color: ${({ theme, disabled }) =>
+    disabled ? theme.colors.fg.disable : theme.colors.fg.secondary};
 `;
 const Shortcut = styled(Text)`
-  color: ${({ theme }) => theme.colors.border.disable};
+  color: ${({ theme, disabled }) =>
+    disabled ? theme.colors.fg.disable : theme.colors.fg.secondary};
 `;
 
 const IconWrapper = styled.span`
@@ -95,11 +98,13 @@ export const MenuItem = ({
         <ItemText
           size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
           forwardedAs="span"
+          disabled={disabled}
         >
           {label}
         </ItemText>
         {shortcut?.display && (
           <Shortcut
+            disabled={disabled}
             size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
             forwardedAs="kbd"
           >
@@ -108,7 +113,7 @@ export const MenuItem = ({
         )}
       </>
     );
-  }, [Icon, label, shortcut, tooltipPlacement]);
+  }, [Icon, disabled, label, shortcut?.display, tooltipPlacement]);
 
   if (href) {
     const newTabProps = newTab

--- a/packages/design-system/src/components/contextMenu/menuItem.js
+++ b/packages/design-system/src/components/contextMenu/menuItem.js
@@ -35,8 +35,6 @@ import { PLACEMENT } from '../popup';
 const ItemText = styled(Text)`
   width: 200px;
   text-align: left;
-  color: ${({ theme, disabled }) =>
-    disabled ? theme.colors.fg.disable : theme.colors.fg.secondary};
 `;
 const Shortcut = styled(Text)`
   color: ${({ theme, disabled }) =>

--- a/packages/design-system/src/components/contextMenu/stories/index.js
+++ b/packages/design-system/src/components/contextMenu/stories/index.js
@@ -49,10 +49,16 @@ const items = [
       display: '⌥ ⌘ [',
       title: 'my aria label for this shortcut!',
     },
-    disabled: true,
     separator: 'bottom',
   },
-  { label: 'Clear text styles' },
+  {
+    label: 'Clear text styles',
+    shortcut: {
+      display: '⌥ ⌘ ]',
+      title: 'my aria label for this shortcut!',
+    },
+    disabled: true,
+  },
   { label: 'Add style to "Saved style"' },
   { label: 'Add color to "Saved colors"' },
 ];


### PR DESCRIPTION


## Context

The right click menus that are set for 1.11 release (next month) have keyboard shortcuts listed. The contrast set in figma fails accessibility standards. This fixes it. 

## Summary

keyboard shortcuts that are enabled now have `fg.secondary` (`#5E6668`) color value. This value matches keyboard popup color usage (inverted for how the component is visually). It now passes contrast with 8.47:1 ratio. Disabled context menu items that have a keyboard shortcut are using the disabled color and don't have a high contrast, however since it's disabled it doesn't need to pass contrast so it's ok. 

## Relevant Technical Choices

https://webaim.org/resources/contrastchecker/?fcolor=5E6668&bcolor=131516

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

No user facing changes, no where in the app do we use keyboard shortcuts that isn't behind a feature flag. You can enable the right click menu and take a look if you want. Or load storybook. 

<img width="233" alt="Screen Shot 2021-07-28 at 4 00 26 PM" src="https://user-images.githubusercontent.com/10720454/127407545-513e33da-720e-4bac-bee4-f771099af942.png">


## Testing Instructions

- See the color change in storybook or the right click experiment.  You can check color contrast with aXe dev tools or by loading the color and bg color into a contrast checker like the above one.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8044 
