### PR TITLE
Editor: reduce number of fields in API responses

### DIFF
--- a/assets/src/edit-story/app/story/actions/useSaveStory.js
+++ b/assets/src/edit-story/app/story/actions/useSaveStory.js
@@ -26,7 +26,6 @@ import { useSnackbar } from '@web-stories-wp/design-system';
 /**
  * Internal dependencies
  */
-import objectPick from '../../../utils/objectPick';
 import { useAPI } from '../../api';
 import { useConfig } from '../../config';
 import useRefreshPostEditURL from '../../../utils/useRefreshPostEditURL';

--- a/assets/src/edit-story/app/story/actions/useSaveStory.js
+++ b/assets/src/edit-story/app/story/actions/useSaveStory.js
@@ -74,19 +74,21 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
         ...getStoryPropsToSave({ story, pages, metadata, flags }),
         ...props,
       })
-        .then((post) => {
+        .then((data) => {
           const properties = {
-            ...objectPick(post, ['status', 'slug', 'link']),
-            featuredMediaUrl: post.featured_media_url,
-            previewLink: post.preview_link,
-            editLink: post.edit_link,
-            embedPostLink: post.embed_post_link,
+            status: data.status,
+            slug: data.slug,
+            link: data.link,
+            featuredMediaUrl: data.featured_media_url,
+            previewLink: data.preview_link,
+            editLink: data.edit_link,
+            embedPostLink: data.embed_post_link,
           };
           updateStory({ properties });
 
           refreshPostEditURL();
 
-          const isStoryPublished = ['publish', 'future'].includes(post.status);
+          const isStoryPublished = ['publish', 'future'].includes(data.status);
           setIsFreshlyPublished(!isStoryAlreadyPublished && isStoryPublished);
         })
         .catch(() => {

--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -39,9 +39,37 @@ $demo              = ( isset( $_GET['web-stories-demo'] ) && (bool) $_GET['web-s
 $preload_paths = [
 	"/web-stories/v1/$stories_rest_base/{$post->ID}/?" . build_query(
 		[
-			'_embed'           => urlencode( 'wp:featuredmedia,wp:lockuser,author' ),
+			'_embed'           => urlencode(
+				implode(
+					',',
+					[ 'wp:featuredmedia', 'wp:lockuser', 'author' ]
+				)
+			),
 			'context'          => 'edit',
 			'web_stories_demo' => $demo,
+			'_fields'          => urlencode(
+				implode(
+					',',
+					[
+						'id',
+						'title',
+						'status',
+						'slug',
+						'date',
+						'modified',
+						'excerpt',
+						'link',
+						'story_data',
+						'preview_link',
+						'edit_link',
+						'embed_post_link',
+						'publisher_logo_url',
+						'permalink_template',
+						'style_presets',
+						'password',
+					]
+				)
+			),
 		]
 	),
 	'/web-stories/v1/media/?' . build_query(


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

While some fields like `content` need to be _saved_, we don't need them in the API responses.

## Summary

<!-- A brief description of what this PR does. -->

By using the `_fields` param, we can massively reduce number of bytes sent over the wire and avoid preloading unneeded data.

For instance, when saving a story, we only want to return the fields actually used by `useSaveStory()`.

This change easily saves **up to 10 MB per request** for large stories. **So turning 10MB into ~1KB**.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8534
