### PR TITLE
Video Muting: ensure VideoPress compatibility

### DIFF
--- a/tests/phpunit/tests/Integrations/Jetpack.php
+++ b/tests/phpunit/tests/Integrations/Jetpack.php
@@ -206,6 +206,20 @@ class Jetpack extends Test_Case {
 	}
 
 	/**
+	 * @covers ::filter_default_value_is_muted
+	 */
+	public function test_filter_default_value_is_muted() {
+		$jetpack = new Jetpack_Integration();
+		$result  = $jetpack->filter_default_value_is_muted( true, 999, \Google\Web_Stories\Media\Media::IS_MUTED_POST_META_KEY, true );
+		$this->assertTrue( $result );
+		add_filter( 'get_post_metadata', [ $this, 'filter_wp_get_attachment_metadata' ], 10, 3 );
+		$result = $jetpack->filter_default_value_is_muted( true, 999, \Google\Web_Stories\Media\Media::IS_MUTED_POST_META_KEY, true );
+		$this->assertFalse( $result );
+		remove_filter( 'get_post_metadata', [ $this, 'filter_wp_get_attachment_metadata' ] );
+	}
+
+
+	/**
 	 * @param $value
 	 * @param $object_id
 	 * @param $meta_key


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Sadly videopress overwrites the metadata attached to attachments, meaning we can't check at server level if a video is muted. See screenshot. This PR, defaults video to not muted, as it is the best guess. 

<img width="634" alt="Screenshot 2021-07-30 at 15 14 54" src="https://user-images.githubusercontent.com/237508/127666519-8d51291a-d37f-44f0-8b61-f90537063bfc.png">


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8499
