### PR TITLE
Remove unneeded `FlagsProvider` usage in story output

### DIFF
--- a/assets/src/edit-story/app/story/actions/useAutoSave.js
+++ b/assets/src/edit-story/app/story/actions/useAutoSave.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import { useCallback, useState } from 'react';
-import { useFeatures } from 'flagged';
 
 /**
  * Internal dependencies
@@ -42,18 +41,17 @@ function useAutoSave({ storyId, pages, story }) {
   } = useAPI();
   const { metadata } = useConfig();
   const [isAutoSaving, setIsAutoSaving] = useState(false);
-  const flags = useFeatures();
 
   const autoSave = useCallback(
     (props) => {
       setIsAutoSaving(true);
       return autoSaveById({
         storyId,
-        ...getStoryPropsToSave({ story, pages, metadata, flags }),
+        ...getStoryPropsToSave({ story, pages, metadata }),
         ...props,
       }).finally(() => setIsAutoSaving(false));
     },
-    [story, pages, metadata, autoSaveById, storyId, flags]
+    [story, pages, metadata, autoSaveById, storyId]
   );
 
   return { autoSave, isAutoSaving };

--- a/assets/src/edit-story/app/story/actions/useSaveStory.js
+++ b/assets/src/edit-story/app/story/actions/useSaveStory.js
@@ -19,7 +19,6 @@
  */
 import { __ } from '@web-stories-wp/i18n';
 import { useCallback, useState } from 'react';
-import { useFeatures } from 'flagged';
 import { getTimeTracker } from '@web-stories-wp/tracking';
 import { useSnackbar } from '@web-stories-wp/design-system';
 
@@ -50,7 +49,6 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
   const {
     actions: { resetNewChanges },
   } = useHistory();
-  const flags = useFeatures();
   const { metadata } = useConfig();
   const { showSnackbar } = useSnackbar();
   const [isSaving, setIsSaving] = useState(false);
@@ -71,7 +69,7 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
 
       return saveStoryById({
         storyId,
-        ...getStoryPropsToSave({ story, pages, metadata, flags }),
+        ...getStoryPropsToSave({ story, pages, metadata }),
         ...props,
       })
         .then((post) => {
@@ -104,7 +102,6 @@ function useSaveStory({ storyId, pages, story, updateStory }) {
     [
       story,
       pages,
-      flags,
       metadata,
       saveStoryById,
       storyId,

--- a/assets/src/edit-story/app/story/utils/getStoryPropsToSave.js
+++ b/assets/src/edit-story/app/story/utils/getStoryPropsToSave.js
@@ -19,7 +19,7 @@
 import objectPick from '../../../utils/objectPick';
 import getStoryMarkup from '../../../output/utils/getStoryMarkup';
 
-function getStoryPropsToSave({ story, pages, metadata, flags }) {
+function getStoryPropsToSave({ story, pages, metadata }) {
   const propsFromStory = objectPick(story, [
     'title',
     'status',
@@ -37,7 +37,7 @@ function getStoryPropsToSave({ story, pages, metadata, flags }) {
     'defaultPageDuration',
   ]);
 
-  const content = getStoryMarkup(story, pages, metadata, flags);
+  const content = getStoryMarkup(story, pages, metadata);
   return {
     content,
     pages,

--- a/assets/src/edit-story/app/story/utils/test/getStoryPropsToSave.js
+++ b/assets/src/edit-story/app/story/utils/test/getStoryPropsToSave.js
@@ -51,7 +51,7 @@ describe('getStoryPropsToSave', () => {
     getStoryMarkup.mockImplementation(() => {
       return 'Hello World!';
     });
-    const props = getStoryPropsToSave({ story, pages, metadata, flags: {} });
+    const props = getStoryPropsToSave({ story, pages, metadata });
 
     expect(props).toStrictEqual({
       content: 'Hello World!',

--- a/assets/src/edit-story/components/statusCheck/utils.js
+++ b/assets/src/edit-story/components/statusCheck/utils.js
@@ -57,5 +57,5 @@ export function getContent() {
     },
   };
 
-  return getStoryMarkup(story, pages, metadata, {});
+  return getStoryMarkup(story, pages, metadata);
 }

--- a/assets/src/edit-story/output/utils/getStoryMarkup.js
+++ b/assets/src/edit-story/output/utils/getStoryMarkup.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 import { renderToStaticMarkup } from 'react-dom/server';
-import { FlagsProvider } from 'flagged';
 
 /**
  * Internal dependencies
@@ -31,17 +30,14 @@ import OutputStory from '../story';
  * @param {import('../../../types').Story} story Story object.
  * @param {Array<Object>} pages List of pages.
  * @param {Object} metadata Metadata.
- * @param {Object} featureFlags Boolean flags to enable/disable features
  * @return {string} Story markup.
  */
-export default function getStoryMarkup(story, pages, metadata, featureFlags) {
+export default function getStoryMarkup(story, pages, metadata) {
   // Note that react-dom/server will warn about useLayoutEffect usage here.
   // Not because of any wrongdoing in our code, but mostly because
   // of its own profiler.
   // See https://github.com/facebook/react/issues/14927
   return renderToStaticMarkup(
-    <FlagsProvider features={featureFlags}>
-      <OutputStory story={story} pages={pages} metadata={metadata} />
-    </FlagsProvider>
+    <OutputStory story={story} pages={pages} metadata={metadata} />
   );
 }

--- a/assets/src/edit-story/output/utils/test/getStoryMarkup.js
+++ b/assets/src/edit-story/output/utils/test/getStoryMarkup.js
@@ -18,7 +18,6 @@
  * External dependencies
  */
 jest.mock('flagged');
-import { useFeature, FlagsProvider } from 'flagged';
 
 /**
  * Internal dependencies
@@ -26,9 +25,6 @@ import { useFeature, FlagsProvider } from 'flagged';
 import getStoryMarkup from '../getStoryMarkup';
 
 describe('getStoryMarkup', () => {
-  useFeature.mockImplementation(() => true);
-  FlagsProvider.mockImplementation(({ children }) => children);
-
   it('should generate expected story markup', () => {
     const story = {
       storyId: 1,
@@ -94,7 +90,7 @@ describe('getStoryMarkup', () => {
         ],
       },
     ];
-    const markup = getStoryMarkup(story, pages, meta, {});
+    const markup = getStoryMarkup(story, pages, meta);
     expect(markup).toContain('Hello World');
     expect(markup).toContain('transform:rotate(1deg)');
     expect(markup).toContain(


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Ever since the flag for animations got removed, there's no need anymore for using `FlagsProvider` in story output.

## Summary

<!-- A brief description of what this PR does. -->

Removes some unneeded code

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
