### PR TITLE
Bug: Fix Inconsistent Secondary Menu Popup Toggles

### DIFF
--- a/assets/src/edit-story/components/carousel/secondaryMenu.js
+++ b/assets/src/edit-story/components/carousel/secondaryMenu.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 /**
  * Internal dependencies
@@ -63,6 +63,10 @@ const Space = styled.span`
 `;
 
 function SecondaryMenu() {
+  const isHelpCenterOpenRef = useRef(false);
+  const isChecklistOpenRef = useRef(false);
+  const isKeyboardShortcutsMenuOpenRef = useRef(false);
+
   const { close: closeHelpCenter, isHelpCenterOpen } = useHelpCenter(
     ({ actions: { close }, state: { isOpen: isHelpCenterOpen } }) => ({
       close,
@@ -106,28 +110,42 @@ function SecondaryMenu() {
   // Only one popup is open at a time
   // we want to close an open popup if a new one is opened.
   useEffect(() => {
-    if (isChecklistOpen) {
+    if (isChecklistOpen && !isChecklistOpenRef.current) {
       closeHelpCenter();
       closeKeyboardShortcutsMenu();
+
+      isChecklistOpenRef.current = true;
+      isKeyboardShortcutsMenuOpenRef.current = false;
+      isHelpCenterOpenRef.current = false;
     }
   }, [closeHelpCenter, closeKeyboardShortcutsMenu, isChecklistOpen]);
 
   useEffect(() => {
-    if (isHelpCenterOpen) {
+    if (isHelpCenterOpen && !isHelpCenterOpenRef.current) {
       closeChecklist();
       closeKeyboardShortcutsMenu();
+      isHelpCenterOpenRef.current = true;
+      isChecklistOpenRef.current = false;
+      isKeyboardShortcutsMenuOpenRef.current = false;
     }
   }, [closeChecklist, closeKeyboardShortcutsMenu, isHelpCenterOpen]);
 
   useEffect(() => {
-    if (isKeyboardShortcutsMenuOpen) {
+    if (
+      isKeyboardShortcutsMenuOpen &&
+      !isKeyboardShortcutsMenuOpenRef.current
+    ) {
       closeChecklist();
       closeHelpCenter();
+      isKeyboardShortcutsMenuOpenRef.current = true;
+      isHelpCenterOpenRef.current = false;
+      isChecklistOpenRef.current = false;
     }
   }, [closeChecklist, closeHelpCenter, isKeyboardShortcutsMenuOpen]);
 
   useEffect(() => {
     if (reviewDialogRequested) {
+      isChecklistOpenRef.current = false;
       onResetReviewDialogRequest();
       openChecklist();
     }

--- a/assets/src/edit-story/components/carousel/secondaryMenu.js
+++ b/assets/src/edit-story/components/carousel/secondaryMenu.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 /**
  * Internal dependencies
@@ -62,10 +62,14 @@ const Space = styled.span`
   width: 8px;
 `;
 
+const POPUPS = {
+  HELP_CENTER: 'help_center',
+  CHECKLIST: 'checklist',
+  KEYBOARD_SHORTCUTS: 'keyboard_shortcuts',
+};
+
 function SecondaryMenu() {
-  const isHelpCenterOpenRef = useRef(false);
-  const isChecklistOpenRef = useRef(false);
-  const isKeyboardShortcutsMenuOpenRef = useRef(false);
+  const expandedPopupRef = useRef('');
 
   const { close: closeHelpCenter, isHelpCenterOpen } = useHelpCenter(
     ({ actions: { close }, state: { isOpen: isHelpCenterOpen } }) => ({
@@ -107,49 +111,66 @@ function SecondaryMenu() {
     })
   );
 
+  const setPopupRef = useCallback((newPopup = '') => {
+    expandedPopupRef.current = newPopup;
+  }, []);
+
   // Only one popup is open at a time
   // we want to close an open popup if a new one is opened.
   useEffect(() => {
-    if (isChecklistOpen && !isChecklistOpenRef.current) {
+    if (isChecklistOpen && expandedPopupRef.current !== POPUPS.CHECKLIST) {
       closeHelpCenter();
       closeKeyboardShortcutsMenu();
-
-      isChecklistOpenRef.current = true;
-      isKeyboardShortcutsMenuOpenRef.current = false;
-      isHelpCenterOpenRef.current = false;
+      setPopupRef(POPUPS.CHECKLIST);
     }
-  }, [closeHelpCenter, closeKeyboardShortcutsMenu, isChecklistOpen]);
+  }, [
+    closeHelpCenter,
+    closeKeyboardShortcutsMenu,
+    isChecklistOpen,
+    setPopupRef,
+  ]);
 
   useEffect(() => {
-    if (isHelpCenterOpen && !isHelpCenterOpenRef.current) {
+    if (isHelpCenterOpen && expandedPopupRef.current !== POPUPS.HELP_CENTER) {
       closeChecklist();
       closeKeyboardShortcutsMenu();
-      isHelpCenterOpenRef.current = true;
-      isChecklistOpenRef.current = false;
-      isKeyboardShortcutsMenuOpenRef.current = false;
+      setPopupRef(POPUPS.HELP_CENTER);
     }
-  }, [closeChecklist, closeKeyboardShortcutsMenu, isHelpCenterOpen]);
+  }, [
+    closeChecklist,
+    closeKeyboardShortcutsMenu,
+    isHelpCenterOpen,
+    setPopupRef,
+  ]);
 
   useEffect(() => {
     if (
       isKeyboardShortcutsMenuOpen &&
-      !isKeyboardShortcutsMenuOpenRef.current
+      expandedPopupRef.current !== POPUPS.KEYBOARD_SHORTCUTS
     ) {
       closeChecklist();
       closeHelpCenter();
-      isKeyboardShortcutsMenuOpenRef.current = true;
-      isHelpCenterOpenRef.current = false;
-      isChecklistOpenRef.current = false;
+      setPopupRef(POPUPS.KEYBOARD_SHORTCUTS);
     }
-  }, [closeChecklist, closeHelpCenter, isKeyboardShortcutsMenuOpen]);
+  }, [
+    closeChecklist,
+    closeHelpCenter,
+    isKeyboardShortcutsMenuOpen,
+    setPopupRef,
+  ]);
 
   useEffect(() => {
     if (reviewDialogRequested) {
-      isChecklistOpenRef.current = false;
+      setPopupRef();
       onResetReviewDialogRequest();
       openChecklist();
     }
-  }, [reviewDialogRequested, onResetReviewDialogRequest, openChecklist]);
+  }, [
+    reviewDialogRequested,
+    onResetReviewDialogRequest,
+    openChecklist,
+    setPopupRef,
+  ]);
 
   return (
     <Wrapper>


### PR DESCRIPTION
## Context

There was an inconsistent toggle in the popup menus of the secondary carousel menu (helpcenter, checklist, keyboard shortcuts)

## Summary

control toggle more closely now that there are 3 potential popups expanded. 

## Relevant Technical Choices

Decided to use refs to control when popups are told to close more closely. There is potential that say, the checklist `isOpen` is still `true` when the keyboard shortcut menu becomes true, then the checklist closes the keyboard. Refs prevent that. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Should have a consistent toggle experience now. 

**Before**

https://user-images.githubusercontent.com/10720454/127924152-9d153166-4c8f-4548-9ef3-bdc1256dcd9d.mp4

**After**

https://user-images.githubusercontent.com/10720454/127924165-24eb9ae2-34c1-4a08-bda9-27912e1fcf50.mp4



## Testing Instructions

Toggling these buttons should work like the video above now.

### QA

When you have a popup expanded and you click on another popup toggle, it should open the one you asked it to open and close the existing expanded popup. 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8538 
