### PR TITLE
Editor: Stop importing Moveable dynamically

### DIFF
--- a/assets/src/edit-story/components/moveable/index.js
+++ b/assets/src/edit-story/components/moveable/index.js
@@ -17,7 +17,8 @@
 /**
  * External dependencies
  */
-import { forwardRef, lazy, Suspense } from 'react';
+import { forwardRef } from 'react';
+import Moveable from 'react-moveable';
 
 /**
  * Internal dependencies
@@ -26,22 +27,13 @@ import InOverlay from '../overlay';
 
 const DEFAULT_Z_INDEX = 10;
 
-const Moveable = lazy(() =>
-  import(
-    /* webpackPrefetch: true, webpackChunkName: "chunk-react-moveable" */ 'react-moveable'
-  )
-);
 function MoveableWithRef({ ...moveableProps }, ref) {
   return (
     <InOverlay
       zIndex={DEFAULT_Z_INDEX}
       pointerEvents="initial"
       render={({ container }) => {
-        return (
-          <Suspense fallback={null}>
-            <Moveable ref={ref} container={container} {...moveableProps} />
-          </Suspense>
-        );
+        return <Moveable ref={ref} container={container} {...moveableProps} />;
       }}
     />
   );

--- a/packages/e2e-tests/src/specs/editor/media/insertWebMVideo.js
+++ b/packages/e2e-tests/src/specs/editor/media/insertWebMVideo.js
@@ -61,9 +61,6 @@ describe('Inserting WebM Video', () => {
     await page.waitForSelector('[data-testid="mediaElement-video"]');
     // Clicking will only act on the first element.
     await expect(page).toClick('[data-testid="mediaElement-video"]');
-    // TODO: figure out why this second click is needed.
-    // The first click does not appear to do anything, it just plays the video in the media library.
-    await expect(page).toClick('[data-testid="mediaElement-video"]');
 
     await page.waitForSelector('[data-testid="videoElement"]');
     await expect(page).toMatchElement('[data-testid="videoElement"]');
@@ -83,9 +80,6 @@ describe('Inserting WebM Video', () => {
 
     await page.waitForSelector('[data-testid="mediaElement-video"]');
     // Clicking will only act on the first element.
-    await expect(page).toClick('[data-testid="mediaElement-video"]');
-    // TODO: figure out why this second click is needed.
-    // The first click does not appear to do anything, it just plays the video in the media library.
     await expect(page).toClick('[data-testid="mediaElement-video"]');
 
     await page.waitForSelector('[data-testid="videoElement"]');


### PR DESCRIPTION
## Context

Reverts the dynamic import, should fix all issues with first click/dnd not being registered.

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
