### PR TITLE
Bug: Scroll To Top Button Visible When It Shouldn't Be

### DIFF
--- a/packages/dashboard/src/components/layout/provider.js
+++ b/packages/dashboard/src/components/layout/provider.js
@@ -16,23 +16,32 @@
 /**
  * External dependencies
  */
-import { useMemo, useRef, useCallback, useState } from 'react';
+import { useEffect, useMemo, useRef, useCallback, useState } from 'react';
 import { createContext } from '@web-stories-wp/react';
 import PropTypes from 'prop-types';
 
 export const LayoutContext = createContext(null);
 
 const Provider = ({ children }) => {
+  const firstFocusableContentRef = useRef();
   const scrollFrameRef = useRef(null);
   const [telemetryBannerOpen, setTelemetryBannerOpen] = useState(false);
 
+  // Get the first focusable content in the dashboard
+  // so we can send focus there without having to
+  // tab through the whole WordPress dashboard to get back.
+  useEffect(() => {
+    firstFocusableContentRef.current = document
+      .getElementById('web-stories-dashboard')
+      .querySelector(['button', 'a']);
+  }, []);
+
   const scrollToTop = useCallback(() => {
-    const scrollFrameEl = scrollFrameRef.current;
     document.documentElement?.scrollTo?.({
       top: 0,
       behavior: 'smooth',
     });
-    scrollFrameEl?.children[0]?.focus();
+    firstFocusableContentRef.current?.focus();
   }, []);
 
   const value = useMemo(

--- a/packages/dashboard/src/components/layout/provider.js
+++ b/packages/dashboard/src/components/layout/provider.js
@@ -32,8 +32,8 @@ const Provider = ({ children }) => {
   // tab through the whole WordPress dashboard to get back.
   useEffect(() => {
     firstFocusableContentRef.current = document
-      .getElementById('web-stories-dashboard')
-      .querySelector(['button', 'a']);
+      ?.getElementById('web-stories-dashboard')
+      ?.querySelector(['button', 'a']);
   }, []);
 
   const scrollToTop = useCallback(() => {

--- a/packages/dashboard/src/components/pageStructure/index.js
+++ b/packages/dashboard/src/components/pageStructure/index.js
@@ -164,7 +164,6 @@ export function LeftRail() {
       onClickCapture={onContainerClickCapture}
       ref={leftRailRef}
       isOpen={sideBarVisible}
-      tabIndex={-1}
       role="navigation"
       aria-label={__('Main dashboard navigation', 'web-stories')}
     >

--- a/packages/dashboard/src/components/scrollToTop/index.js
+++ b/packages/dashboard/src/components/scrollToTop/index.js
@@ -29,7 +29,7 @@ import { Button, BUTTON_VARIANTS, Icons } from '@web-stories-wp/design-system';
 import { useLayoutContext } from '../layout';
 
 const StyledButton = styled(Button)(
-  ({ isVisible, theme }) => css`
+  ({ $isVisible, theme }) => css`
     position: fixed;
     right: 40px;
     bottom: 40px;
@@ -42,14 +42,10 @@ const StyledButton = styled(Button)(
     contain: content;
     padding: 8px;
     background-color: ${theme.colors.opacity.white64};
-    pointer-events: ${isVisible ? 'auto' : 'none'};
+    pointer-events: ${$isVisible ? 'auto' : 'none'};
     box-shadow: 0px 4px 14px rgba(0, 0, 0, 0.25);
-    opacity: ${Number(isVisible)};
+    opacity: ${Number($isVisible)};
     transition: opacity 300ms ease-in-out;
-    &:focus {
-      opacity: 1;
-      pointer-events: 'auto';
-    }
   `
 );
 
@@ -78,10 +74,10 @@ const ScrollToTop = () => {
 
   return (
     <StyledButton
-      aria-hidden={!isVisible}
+      disabled={!isVisible}
       aria-label={__('Scroll back to top', 'web-stories')}
       data-testid="scroll-to-top-button"
-      isVisible={isVisible}
+      $isVisible={isVisible}
       onClick={scrollToTop}
       variant={BUTTON_VARIANTS.CIRCLE}
     >


### PR DESCRIPTION
## Context

Bug found in bugbash 1.10

## Summary

Depending on how you click the scroll to top button in the dashboard it'll stay visible (because focus is retained). This was originally done to preserve sanity for using a keyboard because if you tab to the scroll to top button while at the top of the page your focus gets lost and if you tab to it while it is visible, click it, and then it would disappear you'd also get lost and sent back to the very top of the DOM which is very annoying because of all the WordPress nav you have to get through to go back to the Dashboard. 

History lesson as context, TLDR we can do better :) 

## Relevant Technical Choices

- Hide the scroll to top button when it's not visible so that it's not focusable. [Today I learned that not all browsers treat `aria-hidden` to mean don't focus](https://accessibilityinsights.io/info-examples/web/aria-hidden-focus/). Now we don't have the problem I described above where you tab at the top of the view and get lost because the button is invisible. 
-  Update button to be hidden after click regardless of cursor or keyboard. 
-  Set a new ref in the layout provider to find the first focusable element in the Dashboard. When `scrollToTop` is fired, focus there instead of the top of the grid - feels more consistent. We could possibly return it to the grid focus if we update to not use the same focus pattern as the grid view in the editor, for now focusing the first item in the Dashboard that's focusable seems more robust and uniform.



## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

| Cursor Demo | Keyboard Demo | 
| --- | --- |
| ![scroll](https://user-images.githubusercontent.com/10720454/128083630-4a937d8f-9c34-4f6d-9362-b7ea991637bc.gif) | ![tab](https://user-images.githubusercontent.com/10720454/128083620-ffbe84c7-4b8d-48de-a037-dfe2ac81b543.gif) |

Fun little bonus here, fixes an issue aXe has been grumpy about!

<img width="648" alt="Screen Shot 2021-08-03 at 12 43 21 PM" src="https://user-images.githubusercontent.com/10720454/128083807-d3cddfcf-ca2e-47ab-9560-5a0778717a40.png">

## Testing Instructions

- Go to dashboard, scroll a bit and see the scroll to top button appear. Click it, see it goes away. 
- Navigate the grid with keyboard - as a refresher, tab to the grid (which is a list) and then use your keyboard arrows to navigate the actual grid items (list items). Once you've scrolled the page a bit, hit tab to escape the grid and land on the scroll to top button. Clicking this button will now refocus you to the first button or link (create new story) available on the dashboard. 
- Same behavior should be apparent for Explore Templates
- Should be consistent across browsers. 

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8566 
