### PR TITLE
E2E Tests: fix flakey snapshot in Selected Stories block

### DIFF
--- a/packages/e2e-tests/src/specs/wordpress/webStoriesBlock.js
+++ b/packages/e2e-tests/src/specs/wordpress/webStoriesBlock.js
@@ -118,8 +118,14 @@ describe('Web Stories Block', () => {
 
     await page.waitForSelector('.components-modal__screen-overlay');
     await expect(page).toMatchElement('.components-modal__screen-overlay');
+
+    await page.waitForFunction(
+      () => !document.querySelector('.components-spinner')
+    );
+
     await percySnapshot(page, 'Story select modal');
   });
+
   // Disable for https://github.com/google/web-stories-wp/issues/6237
   // eslint-disable-next-line jest/no-disabled-tests
   describe.skip('AMP validation', () => {


### PR DESCRIPTION
Wait until all stories in the story picker have been loaded before taking a percy snapshot.
