### PR TITLE
Story Locking: Fix permission error 

### DIFF
--- a/includes/REST_API/Lock_Controller.php
+++ b/includes/REST_API/Lock_Controller.php
@@ -202,7 +202,12 @@ abstract class Lock_Controller extends REST_Controller {
 	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
-		return $this->parent_controller->update_item_permissions_check( $request );
+		$check = $this->parent_controller->get_item_permissions_check( $request );
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+
+		return $this->get_post_type_cap( $this->post_type, 'edit_posts' );
 	}
 
 	/**

--- a/includes/REST_API/Lock_Controller.php
+++ b/includes/REST_API/Lock_Controller.php
@@ -199,7 +199,7 @@ abstract class Lock_Controller extends REST_Controller {
 	 * Checks if a given request has access to read a lock.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
-	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
+	 * @return bool|WP_Error True if the request has read access for the item, WP_Error object otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
 		$check = $this->parent_controller->get_item_permissions_check( $request );

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -30,6 +30,7 @@ use Google\Web_Stories\Demo_Content;
 use Google\Web_Stories\Media\Media;
 use Google\Web_Stories\Settings;
 use Google\Web_Stories\Story_Post_Type;
+use Google\Web_Stories\Traits\Post_Type;
 use Google\Web_Stories\Traits\Publisher;
 use WP_Query;
 use WP_Error;
@@ -43,7 +44,7 @@ use WP_REST_Response;
  * @SuppressWarnings(PHPMD.ExcessiveClassComplexity)
  */
 class Stories_Controller extends Stories_Base_Controller {
-	use Publisher;
+	use Publisher, Post_Type;
 	/**
 	 * Default style presets to pass if not set.
 	 */
@@ -463,6 +464,11 @@ class Stories_Controller extends Stories_Base_Controller {
 		remove_post_type_support( Story_Post_Type::POST_TYPE_SLUG, 'revisions' );
 		$links = parent::prepare_links( $post );
 		add_post_type_support( Story_Post_Type::POST_TYPE_SLUG, 'revisions' );
+
+		// Ensure that no data about story locks, leaks publically. 
+		if ( ! $this->get_post_type_cap( $this->post_type, 'edit_posts' ) ) {
+			return $links;
+		}
 
 		$base     = sprintf( '%s/%s', $this->namespace, $this->rest_base );
 		$lock_url = rest_url( trailingslashit( $base ) . $post->ID . '/lock' );

--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -465,7 +465,7 @@ class Stories_Controller extends Stories_Base_Controller {
 		$links = parent::prepare_links( $post );
 		add_post_type_support( Story_Post_Type::POST_TYPE_SLUG, 'revisions' );
 
-		// Ensure that no data about story locks, leaks publically. 
+		// Ensure that no data about story locks leaks publicly. 
 		if ( ! $this->get_post_type_cap( $this->post_type, 'edit_posts' ) ) {
 			return $links;
 		}

--- a/tests/phpunit/tests/REST_API/Lock_Controller.php
+++ b/tests/phpunit/tests/REST_API/Lock_Controller.php
@@ -158,7 +158,7 @@ class Lock_Controller extends Test_REST_TestCase {
 		);
 		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/web-story/' . $story . '/lock' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_edit', $response, 401 );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 401 );
 	}
 
 	/**
@@ -176,7 +176,7 @@ class Lock_Controller extends Test_REST_TestCase {
 		);
 		$request  = new WP_REST_Request( \WP_REST_Server::READABLE, '/web-stories/v1/web-story/' . $story . '/lock' );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertErrorResponse( 'rest_cannot_edit', $response, 403 );
+		$this->assertErrorResponse( 'rest_forbidden', $response, 403 );
 	}
 
 	/**


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Author / contributors could not embed lock users because of a permission error. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

#### Before
<img width="1904" alt="Screenshot 2021-08-05 at 12 43 01" src="https://user-images.githubusercontent.com/237508/128344595-d808b6d9-e92f-4ee6-bca7-041920498f1f.png">

#### After
<img width="1904" alt="Screenshot 2021-08-05 at 12 42 49" src="https://user-images.githubusercontent.com/237508/128344604-643e580d-4c34-4fbd-8329-75084546edd9.png">


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:
Ensure that post lock experiment is enabled. 

1. Edit a story as an administrator
2. In a different browser or an incognito window, log in as an author user
3. Go to the dashboard

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8588
