### PR TITLE
Right Click Menu: Background right click menu - replace background image

### DIFF
--- a/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
+++ b/assets/src/edit-story/app/highlights/quickActions/useQuickActions.js
@@ -176,7 +176,7 @@ const useQuickActions = () => {
       ?.toString()
       .split(':')?.[0];
     const is3PGif =
-      !idOrigin &&
+      (!idOrigin || idOrigin?.toLowerCase() === 'media/tenor') &&
       selectedElements?.[0]?.resource?.type?.toLowerCase() === 'gif';
     const is3PVideo = idOrigin?.toLowerCase() === 'media/coverr';
     const is3PImage = idOrigin?.toLowerCase() === 'media/unsplash';

--- a/assets/src/edit-story/components/canvas/karma/rightClickMenu.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/rightClickMenu.karma.js
@@ -344,7 +344,7 @@ describe('Right Click Menu integration', () => {
 
       // background: click 'scale and crop image' button
       await fixture.events.click(
-        fixture.editor.canvas.rightClickMenu.scaleAndCropImage
+        fixture.editor.canvas.rightClickMenu.scaleAndCropBackgroundImage
       );
 
       // Verify element is being edited

--- a/assets/src/edit-story/components/canvas/karma/rightClickMenu.karma.js
+++ b/assets/src/edit-story/components/canvas/karma/rightClickMenu.karma.js
@@ -859,5 +859,27 @@ describe('Right Click Menu integration', () => {
       // third page should have the default background
       expect(pages[2].elements[0].isDefaultBackground).toBeTrue();
     });
+
+    it('should highlight the media panel', async () => {
+      // add image as background
+      const earthImage = await addEarthImage();
+      await rightClickOnTarget(
+        fixture.editor.canvas.framesLayer.frame(earthImage.id).node
+      );
+      await fixture.events.click(
+        fixture.editor.canvas.rightClickMenu.setAsPageBackground
+      );
+
+      // select replace background image
+      await rightClickOnTarget(
+        fixture.editor.canvas.framesLayer.frame(earthImage.id).node
+      );
+      await fixture.events.click(
+        fixture.editor.canvas.rightClickMenu.replaceBackgroundImage
+      );
+
+      // verify focus
+      expect(document.activeElement).toBe(fixture.editor.library.mediaTab);
+    });
   });
 });

--- a/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
+++ b/assets/src/edit-story/components/library/panes/media/local/mediaPane.js
@@ -284,6 +284,7 @@ function MediaPane(props) {
    * Insert element such image, video and audio into the editor.
    *
    * @param {Object} resource Resource object
+   * @param {string} thumbnailURL The thumbnail's url
    * @return {null|*} Return onInsert or null.
    */
   const insertMediaElement = useCallback(

--- a/assets/src/edit-story/karma/fixture/containers/rightClickMenu.js
+++ b/assets/src/edit-story/karma/fixture/containers/rightClickMenu.js
@@ -115,6 +115,12 @@ export class RightClickMenu extends Container {
     });
   }
 
+  get replaceBackgroundImage() {
+    return this.getByRole('button', {
+      name: /^Replace Background Image/i,
+    });
+  }
+
   get addNewPageBefore() {
     return this.getByRole('button', {
       name: /^Add New Page Before/i,

--- a/assets/src/edit-story/karma/fixture/containers/rightClickMenu.js
+++ b/assets/src/edit-story/karma/fixture/containers/rightClickMenu.js
@@ -79,6 +79,12 @@ export class RightClickMenu extends Container {
     });
   }
 
+  get scaleAndCropBackgroundImage() {
+    return this.getByRole('button', {
+      name: /^Scale & Crop Background Image/i,
+    });
+  }
+
   get duplicatePage() {
     return this.queryByRole('button', {
       name: /Duplicate Page/i,


### PR DESCRIPTION
## Context

Right Click Menu. [Designs](https://www.figma.com/file/1YM3jA9h4QGc4xLdyaXIJS/Stories-Sprint-1.7?node-id=7347%3A60835)

## Summary

Hook up the `Replace Background Image` button in the right click menu. This action is visible when a user right clicks media that is a background element.

## Relevant Technical Choices

This is modeled after the same 'quick action'. This action does not bring a user through UI to directly replace media in the background.

Clicking the button highlights a media panel to bring attention to the panel.

## To-do

n/a

## Testing Instructions

1. Add an image/video/gif to the background
2. Add some styles like opacity and animation
3. Right click the background
4. Select the `Replace Background Image` button
5. Should see the media panel highlight. If the background is 3rd party media then the 3p media panel will highlight.
6. Click and drag an image to the background (doesn't matter from which media panel).
7. Should see styles and animations persist.

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6135
