### PR TITLE
Enable video cache feature by default

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -385,6 +385,7 @@ class Experiments extends Service_Base {
 				'label'       => __( 'Video Cache', 'web-stories' ),
 				'description' => __( 'Reduce hosting costs and improve user experience by serving videos from the Google cache.', 'web-stories' ),
 				'group'       => 'general',
+				'default'     => true,
 			],
 
 			/**


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Public documentation is currently being worked on, so we can totally ship this by defaul.

## Summary

<!-- A brief description of what this PR does. -->

Enables the video cache feature by default (still requires opt-in on the settings page)

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to settings page.
2. See new opt-in for video cache.
3. Toggle checkbox to opt in.
3. Publish a new story with a video in it.
4. View story on the frontend.
5. Verify that there's a `cache="google"` attribute on videos in the source code

If the opt-in was successful, you will be able to see on the browser network tab a
request to `https://*.cdn.ampproject.org/mbv/s/*` that returns a JSON with an
empty list of sources (since the cache missed this video). The video must be public
for the cache to fetch it.

In the following minutes/hours, the video cache will fetch and store the video
contents, so that a later request to this url can return a processed list of video
sources for that origin video.

This can then be verified by observing network requests in the dev tools, where videos will be loaded from the CDN instead of origin.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8643
