### PR TITLE
Right Click Menu: Add snackbars to right click menu actions

### DIFF
--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -16,6 +16,7 @@
 /**
  * External dependencies
  */
+import { useSnackbar } from '@web-stories-wp/design-system';
 import { useFeature } from 'flagged';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
@@ -26,6 +27,7 @@ import { v4 as uuidv4 } from 'uuid';
 /**
  * Internal dependencies
  */
+import { __ } from '@web-stories-wp/i18n';
 import { useStory } from '..';
 import { createPage, duplicatePage } from '../../elements';
 import updateProperties from '../../components/inspector/design/updateProperties';
@@ -37,6 +39,9 @@ import { ELEMENT_TYPES } from '../story';
 import { states, useHighlights } from '../highlights';
 import { getTextPresets } from '../../components/panels/design/preset/utils';
 import getUpdatedSizeAndPosition from '../../utils/getUpdatedSizeAndPosition';
+import { useHistory } from '../history';
+import useDeletePreset from '../../components/panels/design/preset/useDeletePreset';
+import { noop } from '../../utils/noop';
 import {
   RIGHT_CLICK_MENU_LABELS,
   RIGHT_CLICK_MENU_SHORTCUTS,
@@ -46,7 +51,7 @@ import rightClickMenuReducer, {
   ACTION_TYPES,
   DEFAULT_RIGHT_CLICK_MENU_STATE,
 } from './reducer';
-import { getDefaultPropertiesForType } from './utils';
+import { getDefaultPropertiesForType, getElementStyles } from './utils';
 
 /**
  * Determines the items displayed in the right click menu
@@ -62,12 +67,19 @@ import { getDefaultPropertiesForType } from './utils';
 function RightClickMenuProvider({ children }) {
   const enableRightClickMenus = useFeature('enableRightClickMenus');
 
-  const { addGlobalPreset: handleAddTextPreset } = useAddPreset({
+  const { addGlobalPreset: addGlobalTextPreset } = useAddPreset({
     presetType: PRESET_TYPES.STYLE,
   });
-
-  const { addGlobalPreset: handleAddColorPreset } = useAddPreset({
+  const { addGlobalPreset: addGlobalColorPreset } = useAddPreset({
     presetType: PRESET_TYPES.COLOR,
+  });
+  const { deleteGlobalPreset: deleteGlobalTextPreset } = useDeletePreset({
+    presetType: PRESET_TYPES.STYLE,
+    setIsEditMode: noop,
+  });
+  const { deleteGlobalPreset: deleteGlobalColorPreset } = useDeletePreset({
+    presetType: PRESET_TYPES.COLOR,
+    setIsEditMode: noop,
   });
   const { setEditingElement } = useCanvas(({ actions }) => ({
     setEditingElement: actions.setEditingElement,
@@ -75,6 +87,10 @@ function RightClickMenuProvider({ children }) {
   const { setHighlights } = useHighlights(({ setHighlights }) => ({
     setHighlights,
   }));
+  const { undo } = useHistory(({ actions: { undo } }) => ({
+    undo,
+  }));
+  const { showSnackbar } = useSnackbar();
   const {
     addAnimations,
     addPage,
@@ -283,14 +299,28 @@ function RightClickMenuProvider({ children }) {
    * Copy the styles and animations of the selected element.
    */
   const handleCopyStyles = useCallback(() => {
+    const oldStyles = { ...copiedElement };
+
     dispatch({
       type: ACTION_TYPES.COPY_ELEMENT_STYLES,
       payload: {
-        element: selectedElement,
         animations: selectedElementAnimations,
+        styles: getElementStyles(selectedElement),
+        type: selectedElement?.type,
       },
     });
-  }, [selectedElement, selectedElementAnimations]);
+
+    showSnackbar({
+      actionLabel: __('Undo', 'web-stories'),
+      dismissable: false,
+      message: __('Copied style.', 'web-stories'),
+      onAction: () =>
+        dispatch({
+          type: ACTION_TYPES.COPY_ELEMENT_STYLES,
+          payload: oldStyles,
+        }),
+    });
+  }, [copiedElement, selectedElement, selectedElementAnimations, showSnackbar]);
 
   const selectedElementId = selectedElement?.id;
   const pushUpdate = useCallback(
@@ -387,13 +417,22 @@ function RightClickMenuProvider({ children }) {
           ),
       });
     }
+
+    showSnackbar({
+      actionLabel: __('Undo', 'web-stories'),
+      dismissable: false,
+      message: __('Pasted style.', 'web-stories'),
+      onAction: undo,
+    });
   }, [
     addAnimations,
     copiedElement,
+    handleApplyStyle,
     selectedElement,
     selectedElementAnimations,
+    showSnackbar,
+    undo,
     updateElementsById,
-    handleApplyStyle,
   ]);
 
   /**
@@ -418,8 +457,15 @@ function RightClickMenuProvider({ children }) {
             /* commitValues */ true
           ),
       });
+
+      showSnackbar({
+        actionLabel: __('Undo', 'web-stories'),
+        dismissable: false,
+        message: __('Cleared style.', 'web-stories'),
+        onAction: undo,
+      });
     }
-  }, [selectedElement, updateElementsById]);
+  }, [selectedElement, showSnackbar, undo, updateElementsById]);
 
   /**
    * Set currently selected element as the page's background.
@@ -464,6 +510,40 @@ function RightClickMenuProvider({ children }) {
 
     setHighlights({ highlight: panelToFocus });
   }, [selectedElement, setHighlights]);
+
+  /**
+   * Add text styles to global presets.
+   */
+  const handleAddTextPreset = useCallback(
+    (evt) => {
+      const preset = addGlobalTextPreset(evt);
+
+      showSnackbar({
+        actionLabel: __('Undo', 'web-stories'),
+        dismissable: false,
+        message: __('Saved style to "Saved Styles".', 'web-stories'),
+        onAction: () => deleteGlobalTextPreset(preset),
+      });
+    },
+    [addGlobalTextPreset, deleteGlobalTextPreset, showSnackbar]
+  );
+
+  /**
+   * Add color to global presets.
+   */
+  const handleAddColorPreset = useCallback(
+    (evt) => {
+      const preset = addGlobalColorPreset(evt);
+
+      showSnackbar({
+        actionLabel: __('Undo', 'web-stories'),
+        dismissable: false,
+        message: __('Added color to "Saved Colors".', 'web-stories'),
+        onAction: () => deleteGlobalColorPreset(preset),
+      });
+    },
+    [addGlobalColorPreset, deleteGlobalColorPreset, showSnackbar]
+  );
 
   const menuItemProps = useMemo(
     () => ({

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -147,6 +147,10 @@ function RightClickMenuProvider({ children }) {
   // Ref for attaching the context menu
   const rightClickAreaRef = useRef();
 
+  // Needed to not pass stale refs of `undo` to snackbar
+  const undoRef = useRef(undo);
+  undoRef.current = undo;
+
   const [{ copiedElement, copiedPage, isMenuOpen, menuPosition }, dispatch] =
     useReducer(rightClickMenuReducer, DEFAULT_RIGHT_CLICK_MENU_STATE);
 
@@ -422,7 +426,9 @@ function RightClickMenuProvider({ children }) {
       actionLabel: __('Undo', 'web-stories'),
       dismissable: false,
       message: __('Pasted style.', 'web-stories'),
-      onAction: undo,
+      // don't pass a stale reference for undo
+      // need history updates to run so `undo` works correctly.
+      onAction: () => undoRef.current(),
     });
   }, [
     addAnimations,
@@ -431,7 +437,6 @@ function RightClickMenuProvider({ children }) {
     selectedElement,
     selectedElementAnimations,
     showSnackbar,
-    undo,
     updateElementsById,
   ]);
 
@@ -462,10 +467,12 @@ function RightClickMenuProvider({ children }) {
         actionLabel: __('Undo', 'web-stories'),
         dismissable: false,
         message: __('Cleared style.', 'web-stories'),
-        onAction: undo,
+        // don't pass a stale reference for undo
+        // need history updates to run so `undo` works correctly.
+        onAction: () => undoRef.current(),
       });
     }
-  }, [selectedElement, showSnackbar, undo, updateElementsById]);
+  }, [selectedElement, showSnackbar, updateElementsById]);
 
   /**
    * Set currently selected element as the page's background.

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -17,6 +17,7 @@
  * External dependencies
  */
 import { useSnackbar } from '@web-stories-wp/design-system';
+import { __ } from '@web-stories-wp/i18n';
 import { useFeature } from 'flagged';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
@@ -27,7 +28,6 @@ import { v4 as uuidv4 } from 'uuid';
 /**
  * Internal dependencies
  */
-import { __ } from '@web-stories-wp/i18n';
 import { useStory } from '..';
 import { createPage, duplicatePage } from '../../elements';
 import updateProperties from '../../components/inspector/design/updateProperties';

--- a/packages/story-editor/src/app/rightClickMenu/reducer.js
+++ b/packages/story-editor/src/app/rightClickMenu/reducer.js
@@ -18,7 +18,6 @@
  * Internal dependencies
  */
 import { duplicatePage } from '../../elements';
-import { getElementStyles } from './utils';
 
 export const ACTION_TYPES = {
   COPY_ELEMENT_STYLES: 'COPY_ELEMENT_STYLES',
@@ -61,8 +60,8 @@ function rightClickMenuReducer(state, action) {
         ...state,
         copiedElement: {
           animations: action.payload.animations,
-          styles: getElementStyles(action.payload.element),
-          type: action.payload.element?.type,
+          styles: action.payload.styles,
+          type: action.payload.type,
         },
       };
     case ACTION_TYPES.OPEN_MENU:

--- a/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
@@ -61,6 +61,7 @@ const defaultCanvasContext = {
 };
 
 const defaultStoryContext = {
+  addAnimations: jest.fn(),
   addPage: jest.fn(),
   currentPage: {
     elements: [],
@@ -70,6 +71,7 @@ const defaultStoryContext = {
   replaceCurrentPage: jest.fn(),
   selectedElements: [],
   selectedElementAnimations: [],
+  updateElementsById: jest.fn(),
 };
 
 const expectedDefaultActions = [
@@ -292,13 +294,6 @@ describe('useRightClickMenu', () => {
         const copy = result.current.menuItems.find(
           (item) => item.label === RIGHT_CLICK_MENU_LABELS.COPY_IMAGE_STYLES
         );
-        const paste = result.current.menuItems.find(
-          (item) => item.label === RIGHT_CLICK_MENU_LABELS.PASTE_IMAGE_STYLES
-        );
-        const clear = result.current.menuItems.find(
-          (item) => item.label === RIGHT_CLICK_MENU_LABELS.CLEAR_IMAGE_STYLES
-        );
-
         act(() => {
           copy.onClick();
         });
@@ -310,6 +305,9 @@ describe('useRightClickMenu', () => {
           })
         );
 
+        const paste = result.current.menuItems.find(
+          (item) => item.label === RIGHT_CLICK_MENU_LABELS.PASTE_IMAGE_STYLES
+        );
         act(() => {
           paste.onClick();
         });
@@ -321,6 +319,9 @@ describe('useRightClickMenu', () => {
           })
         );
 
+        const clear = result.current.menuItems.find(
+          (item) => item.label === RIGHT_CLICK_MENU_LABELS.CLEAR_IMAGE_STYLES
+        );
         act(() => {
           clear.onClick();
         });

--- a/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
@@ -17,7 +17,7 @@
  * External dependencies
  */
 import { act, renderHook } from '@testing-library/react-hooks';
-import { isPlatformMacOS } from '@web-stories-wp/design-system';
+import { isPlatformMacOS, useSnackbar } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -44,6 +44,7 @@ jest.mock('../../story', () => ({
 jest.mock('@web-stories-wp/design-system', () => ({
   ...jest.requireActual('@web-stories-wp/design-system'),
   isPlatformMacOS: jest.fn(),
+  useSnackbar: jest.fn(),
 }));
 
 const mockEvent = {
@@ -88,12 +89,15 @@ describe('useRightClickMenu', () => {
   const mockUseCanvas = useCanvas;
   const mockUseStory = useStory;
   const mockIsPlatformMacOS = isPlatformMacOS;
+  const mockUseSnackbar = useSnackbar;
+  const mockShowSnackbar = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
 
     mockUseStory.mockReturnValue(defaultStoryContext);
     mockUseCanvas.mockReturnValue(defaultCanvasContext);
+    mockUseSnackbar.mockReturnValue({ showSnackbar: mockShowSnackbar });
     mockIsPlatformMacOS.mockReturnValue(false);
   });
 
@@ -256,6 +260,7 @@ describe('useRightClickMenu', () => {
           {
             id: '991199',
             type: 'video',
+            borderRadius: '4px',
           },
         ],
       });
@@ -276,6 +281,57 @@ describe('useRightClickMenu', () => {
         RIGHT_CLICK_MENU_LABELS.PASTE_IMAGE_STYLES,
         RIGHT_CLICK_MENU_LABELS.CLEAR_IMAGE_STYLES,
       ]);
+    });
+
+    describe('copying, pasting, and clearing styles', () => {
+      it('should show a snackbar when copying, pasting, and clearing styles', () => {
+        const { result } = renderHook(() => useRightClickMenu(), {
+          wrapper: RightClickMenuProvider,
+        });
+
+        const copy = result.current.menuItems.find(
+          (item) => item.label === RIGHT_CLICK_MENU_LABELS.COPY_IMAGE_STYLES
+        );
+        const paste = result.current.menuItems.find(
+          (item) => item.label === RIGHT_CLICK_MENU_LABELS.PASTE_IMAGE_STYLES
+        );
+        const clear = result.current.menuItems.find(
+          (item) => item.label === RIGHT_CLICK_MENU_LABELS.CLEAR_IMAGE_STYLES
+        );
+
+        act(() => {
+          copy.onClick();
+        });
+
+        expect(mockShowSnackbar).toHaveBeenCalledWith(
+          expect.objectContaining({
+            actionLabel: 'Undo',
+            message: 'Copied style.',
+          })
+        );
+
+        act(() => {
+          paste.onClick();
+        });
+
+        expect(mockShowSnackbar).toHaveBeenCalledWith(
+          expect.objectContaining({
+            actionLabel: 'Undo',
+            message: 'Pasted style.',
+          })
+        );
+
+        act(() => {
+          clear.onClick();
+        });
+
+        expect(mockShowSnackbar).toHaveBeenCalledWith(
+          expect.objectContaining({
+            actionLabel: 'Undo',
+            message: 'Cleared style.',
+          })
+        );
+      });
     });
   });
 

--- a/packages/story-editor/src/components/panels/design/preset/useAddPreset.js
+++ b/packages/story-editor/src/components/panels/design/preset/useAddPreset.js
@@ -126,7 +126,11 @@ function useAddPreset({ presetType }) {
         } else {
           updateGlobalPresets(addedPresets, currentPresets);
         }
+
+        return addedPresets;
       }
+
+      return undefined;
     },
     [
       getPresets,
@@ -138,7 +142,7 @@ function useAddPreset({ presetType }) {
   );
   const addGlobalPreset = (evt) => {
     evt.stopPropagation();
-    handleAddPreset({
+    return handleAddPreset({
       textStyles: [],
       colors: [],
     });
@@ -146,7 +150,7 @@ function useAddPreset({ presetType }) {
 
   const addLocalPreset = (evt) => {
     evt.stopPropagation();
-    handleAddPreset(
+    return handleAddPreset(
       {
         colors: [],
       },

--- a/packages/story-editor/src/components/panels/design/preset/useDeletePreset.js
+++ b/packages/story-editor/src/components/panels/design/preset/useDeletePreset.js
@@ -43,10 +43,10 @@ function useDeletePreset({ presetType, setIsEditMode }) {
   const isColor = PRESET_TYPES.COLOR === presetType;
   const isStyle = PRESET_TYPES.STYLE === presetType;
 
-  const { colors, textStyles } = globalStoryStyles;
+  const { colors, textStyles } = globalStoryStyles || {};
   const globalStyles = isColor ? colors : textStyles;
-  const { colors: localColors } = currentStoryStyles;
-  const hasLocalPresets = localColors.length > 0;
+  const { colors: localColors } = currentStoryStyles || {};
+  const hasLocalPresets = localColors?.length > 0;
 
   const deleteGlobalPreset = useCallback(
     (toDelete) => {
@@ -93,7 +93,7 @@ function useDeletePreset({ presetType, setIsEditMode }) {
         setIsEditMode(false);
       }
     },
-    [globalStyles.length, localColors, updateStory, setIsEditMode]
+    [globalStyles?.length, localColors, updateStory, setIsEditMode]
   );
 
   return {


### PR DESCRIPTION
## Context

Right Click Menu. [Designs](https://www.figma.com/file/1YM3jA9h4QGc4xLdyaXIJS/Stories-Sprint-1.7?node-id=7347%3A58837)

## Summary

Add snackbar to actions that need the snackbar as shown in figma.
- copy, paste, and clear styles
- save color to saved colors
- save style to saved styles

## Relevant Technical Choices

n/a

## To-do

- [x] Clicking `undo` after pasting copied text styles doesn't remove the change. However, pressing `cmd + Z` does. Fix this

## User-facing changes

|Action|Snackbar|
|--|--|
|Copy, paste|![paste](https://user-images.githubusercontent.com/22185279/129108887-2475e90e-1c02-4bdf-8ef8-1fbd23b5d7c8.gif)|
|Clear|![clear](https://user-images.githubusercontent.com/22185279/129108906-b2aa9b26-4b4e-4bc9-a34b-cf0f97b4b30a.gif)|
|Save style|![save-style](https://user-images.githubusercontent.com/22185279/128928781-ba39a34f-9d20-4506-8146-7d660ab629da.gif)|
|Save color|![save-color](https://user-images.githubusercontent.com/22185279/128928727-535ad6db-fc1d-41e3-940a-46959cf8680c.gif)|

## Testing Instructions

Test 5 actions and the `undo` buttons with them.
- `Copy`: Should replace the 'copied' styles with the previously 'copied' styles
- `Paste`: Should revert style changes for the element
- `Clear`: Should revert style changes for the element
- `Save Style`: Removes style from the panel
- `Save Color`: Removes color from the panel

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8658
