### PR TITLE
Disable flaky clone element test

### DIFF
--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -93,7 +93,9 @@ describe('Clone element integration', () => {
     expect(await getNumElements()).toBe(3);
   });
 
-  it('should correctly clone 1 element', async () => {
+  // Disable reason: Flaky test, to be fixed in #8677
+  // eslint-disable-next-line jasmine/no-disabled-tests
+  xit('should correctly clone 1 element', async () => {
     // Select img2
     await clickElement(img2.id);
 


### PR DESCRIPTION
## Context

This disables a flaky test. #8677 was created to fix the test.

## Testing Instructions

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- ~This PR addresses an existing issue and I have linked this PR to it in ZenHub~
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR
