### PR TITLE
Right Click Menu: Add tracking

### DIFF
--- a/packages/design-system/src/components/snackbar/snackbarMessage.js
+++ b/packages/design-system/src/components/snackbar/snackbarMessage.js
@@ -206,10 +206,13 @@ const SnackbarMessage = ({
     return () => clearTimeout(dismissTimeout);
   }, []);
 
-  const handleAction = useCallback(() => {
-    onAction();
-    !isPreventActionDismiss && onDismiss();
-  }, [onAction, onDismiss, isPreventActionDismiss]);
+  const handleAction = useCallback(
+    (evt) => {
+      onAction(evt);
+      !isPreventActionDismiss && onDismiss();
+    },
+    [onAction, onDismiss, isPreventActionDismiss]
+  );
 
   const hasAction = Boolean(actionLabel);
   const hasThumbnail = Boolean(actionLabel);

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -21,7 +21,7 @@ import {
   useGlobalKeyDownEffect,
 } from '@web-stories-wp/design-system';
 import { __ } from '@web-stories-wp/i18n';
-import { trackClick } from '@web-stories-wp/tracking';
+import { trackEvent } from '@web-stories-wp/tracking';
 import { useFeature } from 'flagged';
 import PropTypes from 'prop-types';
 import {
@@ -176,7 +176,7 @@ function RightClickMenuProvider({ children }) {
   /**
    * Open the menu at the position from the click event.
    *
-   * @param {Object} evt The triggering event
+   * @param {Event} evt The triggering event
    */
   const handleOpenMenu = useCallback((evt) => {
     evt.preventDefault();
@@ -190,7 +190,9 @@ function RightClickMenuProvider({ children }) {
       },
     });
 
-    trackClick(evt, 'context_menu_opened');
+    trackEvent('context_menu_action', {
+      name: 'context_menu_opened',
+    });
   }, []);
 
   /**
@@ -205,7 +207,7 @@ function RightClickMenuProvider({ children }) {
   /**
    * Prevent right click menu from removing focus from the canvas.
    *
-   * @param {Object} evt The triggering event
+   * @param {Event} evt The triggering event
    */
   const handleMouseDown = useCallback((evt) => {
     evt.stopPropagation();
@@ -240,16 +242,17 @@ function RightClickMenuProvider({ children }) {
    *
    * Defaults to adding the new page after all of the existing pages.
    *
-   * @param {Object} evt The triggering event
    * @param {number} index The index
    */
   const handleAddPageAtPosition = useCallback(
-    (evt, index) => {
+    (index) => {
       const position = Boolean(index) || index === 0 ? index : pages.length - 1;
 
       addPageAt({ page: createPage(), position });
 
-      trackClick(evt, 'context_menu_page_added');
+      trackEvent('context_menu_action', {
+        name: 'page_added',
+      });
     },
     [addPageAt, pages?.length]
   );
@@ -259,152 +262,151 @@ function RightClickMenuProvider({ children }) {
    */
   const handleDeletePage = useCallback(() => {
     deleteCurrentPage();
+
+    trackEvent('context_menu_action', {
+      name: 'page_deleted',
+    });
   }, [deleteCurrentPage]);
 
   /**
    * Send element one layer backwards, if possible.
-   *
-   * @param {Object} evt The triggering event
    */
-  const handleSendBackward = useCallback(
-    (evt) => {
-      const newPosition =
-        currentPosition === 1 ? currentPosition : currentPosition - 1;
+  const handleSendBackward = useCallback(() => {
+    const newPosition =
+      currentPosition === 1 ? currentPosition : currentPosition - 1;
 
-      arrangeElement({
-        elementId: selectedElement.id,
-        position: newPosition,
-      });
+    arrangeElement({
+      elementId: selectedElement.id,
+      position: newPosition,
+    });
 
-      trackClick(evt, `context_menu_${selectedElementType}_send_backward`);
-    },
-    [arrangeElement, currentPosition, selectedElement?.id, selectedElementType]
-  );
+    trackEvent('context_menu_action', {
+      name: 'send_backward',
+      element: selectedElementType,
+    });
+  }, [
+    arrangeElement,
+    currentPosition,
+    selectedElement?.id,
+    selectedElementType,
+  ]);
 
   /**
    * Send element all the way back, if possible.
-   *
-   * @param {Object} evt The triggering event
    */
-  const handleSendToBack = useCallback(
-    (evt) => {
-      arrangeElement({
-        elementId: selectedElement.id,
-        position: 1,
-      });
+  const handleSendToBack = useCallback(() => {
+    arrangeElement({
+      elementId: selectedElement.id,
+      position: 1,
+    });
 
-      trackClick(evt, `context_menu_${selectedElementType}_sent_to_back`);
-    },
-    [arrangeElement, selectedElement?.id, selectedElementType]
-  );
+    trackEvent('context_menu_action', {
+      name: 'send_to_back',
+      element: selectedElementType,
+    });
+  }, [arrangeElement, selectedElement?.id, selectedElementType]);
 
   /**
    * Bring element one layer forwards, if possible.
-   *
-   * @param {Object} evt The triggering event
    */
-  const handleBringForward = useCallback(
-    (evt) => {
-      const newPosition =
-        currentPosition >= currentPage.elements.length - 1
-          ? currentPosition
-          : currentPosition + 1;
+  const handleBringForward = useCallback(() => {
+    const newPosition =
+      currentPosition >= currentPage.elements.length - 1
+        ? currentPosition
+        : currentPosition + 1;
 
-      arrangeElement({
-        elementId: selectedElement.id,
-        position: newPosition,
-      });
+    arrangeElement({
+      elementId: selectedElement.id,
+      position: newPosition,
+    });
 
-      trackClick(evt, `context_menu_${selectedElementType}_bring_forward`);
-    },
-    [
-      arrangeElement,
-      currentPage,
-      currentPosition,
-      selectedElement?.id,
-      selectedElementType,
-    ]
-  );
+    trackEvent('context_menu_action', {
+      name: 'bring_forward',
+      element: selectedElementType,
+    });
+  }, [
+    arrangeElement,
+    currentPage,
+    currentPosition,
+    selectedElement?.id,
+    selectedElementType,
+  ]);
 
   /**
    * Send element all the way to the front, if possible.
-   *
-   * @param {Object} evt The triggering event
    */
-  const handleBringToFront = useCallback(
-    (evt) => {
-      arrangeElement({
-        elementId: selectedElement.id,
-        position: currentPage.elements.length - 1,
-      });
+  const handleBringToFront = useCallback(() => {
+    arrangeElement({
+      elementId: selectedElement.id,
+      position: currentPage.elements.length - 1,
+    });
 
-      trackClick(evt, `context_menu_${selectedElementType}_bring_to_front`);
-    },
-    [arrangeElement, currentPage, selectedElement?.id, selectedElementType]
-  );
+    trackEvent('context_menu_action', {
+      name: 'bring_to_front',
+      element: selectedElementType,
+    });
+  }, [arrangeElement, currentPage, selectedElement?.id, selectedElementType]);
 
   /**
    * Set element as the element being 'edited'.
    *
-   * @param {Object} evt The triggering event
+   * @param {Event} evt The triggering event
    */
   const handleOpenScaleAndCrop = useCallback(
     (evt) => {
       setEditingElement(selectedElement?.id, evt);
 
-      trackClick(
-        evt,
-        `context_menu_${selectedElementType}_open_scale_and_crop`
-      );
+      trackEvent('context_menu_action', {
+        name: 'open_scale_and_crop',
+        element: selectedElementType,
+      });
     },
     [selectedElement?.id, selectedElementType, setEditingElement]
   );
 
   /**
    * Copy the styles and animations of the selected element.
-   *
-   * @param {Object} evt The triggering event
    */
-  const handleCopyStyles = useCallback(
-    (evt) => {
-      const oldStyles = { ...copiedElement };
+  const handleCopyStyles = useCallback(() => {
+    const oldStyles = { ...copiedElement };
 
-      dispatch({
-        type: ACTION_TYPES.COPY_ELEMENT_STYLES,
-        payload: {
-          animations: selectedElementAnimations,
-          styles: getElementStyles(selectedElement),
-          type: selectedElementType,
-        },
-      });
+    dispatch({
+      type: ACTION_TYPES.COPY_ELEMENT_STYLES,
+      payload: {
+        animations: selectedElementAnimations,
+        styles: getElementStyles(selectedElement),
+        type: selectedElementType,
+      },
+    });
 
-      showSnackbar({
-        actionLabel: __('Undo', 'web-stories'),
-        dismissable: false,
-        message: __('Copied style.', 'web-stories'),
-        onAction: (undoEvt) => {
-          dispatch({
-            type: ACTION_TYPES.COPY_ELEMENT_STYLES,
-            payload: oldStyles,
-          });
+    showSnackbar({
+      actionLabel: __('Undo', 'web-stories'),
+      dismissable: false,
+      message: __('Copied style.', 'web-stories'),
+      onAction: () => {
+        dispatch({
+          type: ACTION_TYPES.COPY_ELEMENT_STYLES,
+          payload: oldStyles,
+        });
 
-          trackClick(
-            undoEvt,
-            `context_menu_undo_${selectedElementType}_copy_styles`
-          );
-        },
-      });
+        trackEvent('context_menu_action', {
+          name: 'undo_copy_styles',
+          element: selectedElementType,
+        });
+      },
+    });
 
-      trackClick(evt, `context_menu_${selectedElementType}_copy_styles`);
-    },
-    [
-      copiedElement,
-      selectedElement,
-      selectedElementAnimations,
-      selectedElementType,
-      showSnackbar,
-    ]
-  );
+    trackEvent('context_menu_action', {
+      name: 'copy_styles',
+      element: selectedElementType,
+    });
+  }, [
+    copiedElement,
+    selectedElement,
+    selectedElementAnimations,
+    selectedElementType,
+    showSnackbar,
+  ]);
 
   const selectedElementId = selectedElement?.id;
   const pushUpdate = useCallback(
@@ -436,202 +438,191 @@ function RightClickMenuProvider({ children }) {
    *
    * Pasting is not allowed if the copied element styles are from a
    * different element type.
-   *
-   * @param {Object} evt The triggering event
    */
-  const handlePasteStyles = useCallback(
-    (evt) => {
-      const id = selectedElement?.id;
+  const handlePasteStyles = useCallback(() => {
+    const id = selectedElement?.id;
 
-      if (!id || selectedElement?.type !== copiedElement.type) {
-        return;
-      }
+    if (!id || selectedElement?.type !== copiedElement.type) {
+      return;
+    }
 
-      // Delete old animation if one exists
-      const oldAnimationToDelete = selectedElementAnimations.length
-        ? { ...selectedElementAnimations[0], delete: true }
-        : undefined;
+    // Delete old animation if one exists
+    const oldAnimationToDelete = selectedElementAnimations.length
+      ? { ...selectedElementAnimations[0], delete: true }
+      : undefined;
 
-      // Create new animations
-      const newAnimations = copiedElement.animations.map((animation) => ({
-        ...animation,
-        id: uuidv4(),
-        targets: [selectedElement.id],
-      }));
+    // Create new animations
+    const newAnimations = copiedElement.animations.map((animation) => ({
+      ...animation,
+      id: uuidv4(),
+      targets: [selectedElement.id],
+    }));
 
-      addAnimations({ animations: newAnimations });
+    addAnimations({ animations: newAnimations });
 
-      // Text elements need the text styles extracted from content before
-      // applying to the other text
-      if (copiedElement.type === 'text' && copiedElement.styles.content) {
-        const { textStyles } = getTextPresets(
-          [copiedElement.styles],
-          {
-            textStyles: [],
-            colors: [],
-          },
-          PRESET_TYPES.STYLE
-        );
-        const { colors } = getTextPresets(
-          [copiedElement.styles],
-          {
-            textStyles: [],
-            colors: [],
-          },
-          PRESET_TYPES.Color
-        );
-        const { content, ...copiedElementStyles } = copiedElement.styles;
-        const updatedElementStyles = {
-          ...copiedElementStyles,
-          ...textStyles[0],
-          ...colors[0].color,
-          animation: oldAnimationToDelete,
-          border: copiedElementStyles.border || null,
-        };
-        handleApplyStyle(updatedElementStyles);
-      } else {
-        // Add styles and animations to element
-        updateElementsById({
-          elementIds: [selectedElement.id],
-          properties: (currentProperties) =>
-            updateProperties(
-              currentProperties,
-              {
-                ...copiedElement.styles,
-                animation: oldAnimationToDelete,
-              },
-              /* commitValues */ true
-            ),
-        });
-      }
-
-      showSnackbar({
-        actionLabel: __('Undo', 'web-stories'),
-        dismissable: false,
-        message: __('Pasted style.', 'web-stories'),
-        // don't pass a stale reference for undo
-        // need history updates to run so `undo` works correctly.
-        onAction: (undoEvt) => {
-          undoRef.current();
-
-          trackClick(
-            undoEvt,
-            `context_menu_undo_${selectedElementType}_paste_styles`
-          );
+    // Text elements need the text styles extracted from content before
+    // applying to the other text
+    if (copiedElement.type === 'text' && copiedElement.styles.content) {
+      const { textStyles } = getTextPresets(
+        [copiedElement.styles],
+        {
+          textStyles: [],
+          colors: [],
         },
-      });
-
-      trackClick(evt, `context_menu_${selectedElementType}_paste_styles`);
-    },
-    [
-      addAnimations,
-      copiedElement,
-      handleApplyStyle,
-      selectedElement,
-      selectedElementAnimations,
-      selectedElementType,
-      showSnackbar,
-      updateElementsById,
-    ]
-  );
-
-  /**
-   * Revert some element styles to their defaults.
-   *
-   * Each element type has a different set of defaults.
-   *
-   * @param {Object} evt The triggering event
-   */
-  const handleClearElementStyles = useCallback(
-    (evt) => {
-      if (!selectedElement?.id) {
-        return;
-      }
-
-      const resetProperties = getDefaultPropertiesForType(selectedElement.type);
-
-      if (resetProperties) {
-        updateElementsById({
-          elementIds: [selectedElement.id],
-          properties: (currentProperties) =>
-            updateProperties(
-              currentProperties,
-              resetProperties,
-              /* commitValues */ true
-            ),
-        });
-
-        showSnackbar({
-          actionLabel: __('Undo', 'web-stories'),
-          dismissable: false,
-          message: __('Cleared style.', 'web-stories'),
-          // don't pass a stale reference for undo
-          // need history updates to run so `undo` works correctly.
-          onAction: (undoEvt) => {
-            undoRef.current();
-
-            trackClick(
-              undoEvt,
-              `context_menu_undo_${selectedElementType}_clear_styles`
-            );
-          },
-        });
-
-        trackClick(evt, `context_menu_${selectedElementType}_clear_styles`);
-      }
-    },
-    [selectedElement, selectedElementType, showSnackbar, updateElementsById]
-  );
-
-  /**
-   * Set currently selected element as the page's background.
-   *
-   * @param {Object} evt The triggering event
-   */
-  const handleSetPageBackground = useCallback(
-    (evt) => {
-      setBackgroundElement({ elementId: selectedElement.id });
-
-      trackClick(
-        evt,
-        `context_menu_${selectedElementType}_set_page_background`
+        PRESET_TYPES.STYLE
       );
-    },
-    [setBackgroundElement, selectedElement?.id, selectedElementType]
-  );
-
-  /**
-   * Remove media from background and clear opacity and overlay.
-   *
-   * @param {Object} evt The triggering event
-   */
-  const handleRemoveMediaFromBackground = useCallback(
-    (evt) => {
+      const { colors } = getTextPresets(
+        [copiedElement.styles],
+        {
+          textStyles: [],
+          colors: [],
+        },
+        PRESET_TYPES.Color
+      );
+      const { content, ...copiedElementStyles } = copiedElement.styles;
+      const updatedElementStyles = {
+        ...copiedElementStyles,
+        ...textStyles[0],
+        ...colors[0].color,
+        animation: oldAnimationToDelete,
+        border: copiedElementStyles.border || null,
+      };
+      handleApplyStyle(updatedElementStyles);
+    } else {
+      // Add styles and animations to element
       updateElementsById({
         elementIds: [selectedElement.id],
         properties: (currentProperties) =>
           updateProperties(
             currentProperties,
             {
-              isBackground: false,
-              opacity: 100,
-              overlay: null,
+              ...copiedElement.styles,
+              animation: oldAnimationToDelete,
             },
             /* commitValues */ true
           ),
       });
+    }
 
-      clearBackgroundElement();
+    showSnackbar({
+      actionLabel: __('Undo', 'web-stories'),
+      dismissable: false,
+      message: __('Pasted style.', 'web-stories'),
+      // don't pass a stale reference for undo
+      // need history updates to run so `undo` works correctly.
+      onAction: () => {
+        undoRef.current();
 
-      trackClick(evt, `context_menu_${selectedElementType}_remove_background`);
-    },
-    [
-      clearBackgroundElement,
-      selectedElement?.id,
-      selectedElementType,
-      updateElementsById,
-    ]
-  );
+        trackEvent('context_menu_action', {
+          name: 'undo_paste_styles',
+          element: selectedElementType,
+        });
+      },
+    });
+
+    trackEvent('context_menu_action', {
+      name: 'paste_styles',
+      element: selectedElementType,
+    });
+  }, [
+    addAnimations,
+    copiedElement,
+    handleApplyStyle,
+    selectedElement,
+    selectedElementAnimations,
+    selectedElementType,
+    showSnackbar,
+    updateElementsById,
+  ]);
+
+  /**
+   * Revert some element styles to their defaults.
+   *
+   * Each element type has a different set of defaults.
+   */
+  const handleClearElementStyles = useCallback(() => {
+    if (!selectedElement?.id) {
+      return;
+    }
+
+    const resetProperties = getDefaultPropertiesForType(selectedElement.type);
+
+    if (resetProperties) {
+      updateElementsById({
+        elementIds: [selectedElement.id],
+        properties: (currentProperties) =>
+          updateProperties(
+            currentProperties,
+            resetProperties,
+            /* commitValues */ true
+          ),
+      });
+
+      showSnackbar({
+        actionLabel: __('Undo', 'web-stories'),
+        dismissable: false,
+        message: __('Cleared style.', 'web-stories'),
+        // don't pass a stale reference for undo
+        // need history updates to run so `undo` works correctly.
+        onAction: () => {
+          undoRef.current();
+
+          trackEvent('context_menu_action', {
+            name: 'undo_clear_styles',
+            element: selectedElementType,
+          });
+        },
+      });
+
+      trackEvent('context_menu_action', {
+        name: 'clear_styles',
+        element: selectedElementType,
+      });
+    }
+  }, [selectedElement, selectedElementType, showSnackbar, updateElementsById]);
+
+  /**
+   * Set currently selected element as the page's background.
+   */
+  const handleSetPageBackground = useCallback(() => {
+    setBackgroundElement({ elementId: selectedElement.id });
+
+    trackEvent('context_menu_action', {
+      name: 'set_as_page_background',
+      element: selectedElementType,
+    });
+  }, [setBackgroundElement, selectedElement?.id, selectedElementType]);
+
+  /**
+   * Remove media from background and clear opacity and overlay.
+   */
+  const handleRemoveMediaFromBackground = useCallback(() => {
+    updateElementsById({
+      elementIds: [selectedElement.id],
+      properties: (currentProperties) =>
+        updateProperties(
+          currentProperties,
+          {
+            isBackground: false,
+            opacity: 100,
+            overlay: null,
+          },
+          /* commitValues */ true
+        ),
+    });
+
+    clearBackgroundElement();
+
+    trackEvent('context_menu_action', {
+      name: 'remove_media_from_background',
+      element: selectedElementType,
+    });
+  }, [
+    clearBackgroundElement,
+    selectedElement?.id,
+    selectedElementType,
+    updateElementsById,
+  ]);
 
   /**
    * Focus the media or the media3p panel.
@@ -653,7 +644,7 @@ function RightClickMenuProvider({ children }) {
   /**
    * Add text styles to global presets.
    *
-   * @param {Object} evt The triggering event
+   * @param {Event} evt The triggering event
    */
   const handleAddTextPreset = useCallback(
     (evt) => {
@@ -663,22 +654,33 @@ function RightClickMenuProvider({ children }) {
         actionLabel: __('Undo', 'web-stories'),
         dismissable: false,
         message: __('Saved style to "Saved Styles".', 'web-stories'),
-        onAction: (undoEvt) => {
+        onAction: () => {
           deleteGlobalTextPreset(preset);
 
-          trackClick(undoEvt, 'context_menu_remove_text_preset');
+          trackEvent('context_menu_action', {
+            name: 'remove_text_preset',
+            element: selectedElementType,
+          });
         },
       });
 
-      trackClick(evt, 'context_menu_add_text_preset');
+      trackEvent('context_menu_action', {
+        name: 'add_text_preset',
+        element: selectedElementType,
+      });
     },
-    [addGlobalTextPreset, deleteGlobalTextPreset, showSnackbar]
+    [
+      addGlobalTextPreset,
+      deleteGlobalTextPreset,
+      selectedElementType,
+      showSnackbar,
+    ]
   );
 
   /**
    * Add color to global presets.
    *
-   * @param {Object} evt The triggering event
+   * @param {Event} evt The triggering event
    */
   const handleAddColorPreset = useCallback(
     (evt) => {
@@ -688,16 +690,27 @@ function RightClickMenuProvider({ children }) {
         actionLabel: __('Undo', 'web-stories'),
         dismissable: false,
         message: __('Added color to "Saved Colors".', 'web-stories'),
-        onAction: (undoEvt) => {
+        onAction: () => {
           deleteGlobalColorPreset(preset);
 
-          trackClick(undoEvt, 'context_menu_remove_color_preset');
+          trackEvent('context_menu_action', {
+            name: 'remove_color_preset',
+            element: selectedElementType,
+          });
         },
       });
 
-      trackClick(evt, 'context_menu_add_color_preset');
+      trackEvent('context_menu_action', {
+        name: 'add_color_preset',
+        element: selectedElementType,
+      });
     },
-    [addGlobalColorPreset, deleteGlobalColorPreset, showSnackbar]
+    [
+      addGlobalColorPreset,
+      deleteGlobalColorPreset,
+      selectedElementType,
+      showSnackbar,
+    ]
   );
 
   const menuItemProps = useMemo(
@@ -781,12 +794,12 @@ function RightClickMenuProvider({ children }) {
       {
         label: RIGHT_CLICK_MENU_LABELS.ADD_NEW_PAGE_AFTER,
         separator: 'top',
-        onClick: (evt) => handleAddPageAtPosition(evt, currentPageIndex + 1),
+        onClick: () => handleAddPageAtPosition(currentPageIndex + 1),
         ...menuItemProps,
       },
       {
         label: RIGHT_CLICK_MENU_LABELS.ADD_NEW_PAGE_BEFORE,
-        onClick: (evt) => handleAddPageAtPosition(evt, currentPageIndex),
+        onClick: () => handleAddPageAtPosition(currentPageIndex),
         ...menuItemProps,
       },
       {

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -252,9 +252,16 @@ function RightClickMenuProvider({ children }) {
 
       trackEvent('context_menu_action', {
         name: 'page_added',
+        element: selectedElementType,
+        isBackground: selectedElement?.isBackground,
       });
     },
-    [addPageAt, pages?.length]
+    [
+      addPageAt,
+      pages?.length,
+      selectedElement?.isBackground,
+      selectedElementType,
+    ]
   );
 
   /**
@@ -265,8 +272,10 @@ function RightClickMenuProvider({ children }) {
 
     trackEvent('context_menu_action', {
       name: 'page_deleted',
+      element: selectedElementType,
+      isBackground: selectedElement?.isBackground,
     });
-  }, [deleteCurrentPage]);
+  }, [deleteCurrentPage, selectedElement?.isBackground, selectedElementType]);
 
   /**
    * Send element one layer backwards, if possible.
@@ -283,11 +292,13 @@ function RightClickMenuProvider({ children }) {
     trackEvent('context_menu_action', {
       name: 'send_backward',
       element: selectedElementType,
+      isBackground: selectedElement?.isBackground,
     });
   }, [
     arrangeElement,
     currentPosition,
     selectedElement?.id,
+    selectedElement?.isBackground,
     selectedElementType,
   ]);
 
@@ -359,9 +370,15 @@ function RightClickMenuProvider({ children }) {
       trackEvent('context_menu_action', {
         name: 'open_scale_and_crop',
         element: selectedElementType,
+        isBackground: selectedElement?.isBackground,
       });
     },
-    [selectedElement?.id, selectedElementType, setEditingElement]
+    [
+      selectedElement?.id,
+      selectedElement?.isBackground,
+      selectedElementType,
+      setEditingElement,
+    ]
   );
 
   /**
@@ -392,6 +409,7 @@ function RightClickMenuProvider({ children }) {
         trackEvent('context_menu_action', {
           name: 'undo_copy_styles',
           element: selectedElementType,
+          isBackground: selectedElement?.isBackground,
         });
       },
     });
@@ -399,6 +417,7 @@ function RightClickMenuProvider({ children }) {
     trackEvent('context_menu_action', {
       name: 'copy_styles',
       element: selectedElementType,
+      isBackground: selectedElement?.isBackground,
     });
   }, [
     copiedElement,
@@ -516,6 +535,7 @@ function RightClickMenuProvider({ children }) {
         trackEvent('context_menu_action', {
           name: 'undo_paste_styles',
           element: selectedElementType,
+          isBackground: selectedElement?.isBackground,
         });
       },
     });
@@ -523,6 +543,7 @@ function RightClickMenuProvider({ children }) {
     trackEvent('context_menu_action', {
       name: 'paste_styles',
       element: selectedElementType,
+      isBackground: selectedElement?.isBackground,
     });
   }, [
     addAnimations,
@@ -570,6 +591,7 @@ function RightClickMenuProvider({ children }) {
           trackEvent('context_menu_action', {
             name: 'undo_clear_styles',
             element: selectedElementType,
+            isBackground: selectedElement?.isBackground,
           });
         },
       });
@@ -577,6 +599,7 @@ function RightClickMenuProvider({ children }) {
       trackEvent('context_menu_action', {
         name: 'clear_styles',
         element: selectedElementType,
+        isBackground: selectedElement?.isBackground,
       });
     }
   }, [selectedElement, selectedElementType, showSnackbar, updateElementsById]);
@@ -616,10 +639,12 @@ function RightClickMenuProvider({ children }) {
     trackEvent('context_menu_action', {
       name: 'remove_media_from_background',
       element: selectedElementType,
+      isBackground: selectedElement?.isBackground,
     });
   }, [
     clearBackgroundElement,
     selectedElement?.id,
+    selectedElement?.isBackground,
     selectedElementType,
     updateElementsById,
   ]);

--- a/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
@@ -47,6 +47,8 @@ jest.mock('@web-stories-wp/design-system', () => ({
   useSnackbar: jest.fn(),
 }));
 
+jest.mock('@web-stories-wp/tracking');
+
 const mockEvent = {
   preventDefault: jest.fn(),
   stopPropagation: jest.fn(),


### PR DESCRIPTION
## Context

Right Click Menu

## Summary

Add tracking to the right click menu.

## Relevant Technical Choices

Did not add tracking to functions that are being removed in #8679.

## To-do

n/a

## User-facing changes

n/a

## Testing Instructions

Verify that tracking events are sent on:
- menu open
- action click
- snackbar action click

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

Yes!
- Tracks when the menu is opened
- Tracks when a button in the menu is clicked
- Tracks when a user clicks the `Undo` button in snackbars that are triggered from the right click menu actions

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8681
