### PR TITLE
Templates: Re-sort templates so that new ones are at the top

### DIFF
--- a/docs/external-template-creation.md
+++ b/docs/external-template-creation.md
@@ -142,7 +142,7 @@ Once you have the story JSON, several code changes are needed to add it to the l
       NOTE: Check all resource URLs and properties are set properly before commiting the template.
 
 
-2. Create a new file `index.js` in your newly created `<template_name>` directory and import the `template.json` file. Your `<template_name>/index.js` file would then look something like this with object corresponding to the new template and properties `id`, `title`, `tags`, `colors`, etc.
+2. Create a new file `index.js` in your newly created `<template_name>` directory and import the `template.json` file. Your `<template_name>/index.js` file would then look something like this with object corresponding to the new template and properties `id`, `title`, `tags`, `colors`, `creationDate`, etc.
 
    ```js
     //...
@@ -158,6 +158,8 @@ Once you have the story JSON, several code changes are needed to add it to the l
     import { default as template } from './template';
 
     export default {
+      // day this template was added to the codebase
+      creationDate: new Date(2021, 0, 1),
       title: _x('Your Template Title', 'template name', 'web-stories'),
       tags: [
         _x('Tags', 'template keyword', 'web-stories'),

--- a/packages/templates/src/getTemplates.js
+++ b/packages/templates/src/getTemplates.js
@@ -127,7 +127,7 @@ async function getTemplates(imageBaseUrl) {
 
   trackTiming();
 
-  return templates;
+  return templates.sort((a, b) => b.creationDate - a.creationDate);
 }
 
 export default getTemplates;

--- a/packages/templates/src/raw/12-hours-in-barcelona/index.js
+++ b/packages/templates/src/raw/12-hours-in-barcelona/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 12),
   title: _x('12 Hours in Barcelona', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/12-hours-in-barcelona/index.js
+++ b/packages/templates/src/raw/12-hours-in-barcelona/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('12 Hours in Barcelona', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/a-day-in-the-life/index.js
+++ b/packages/templates/src/raw/a-day-in-the-life/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('A Day in the Life', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/a-day-in-the-life/index.js
+++ b/packages/templates/src/raw/a-day-in-the-life/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 9),
   title: _x('A Day in the Life', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/ace-hotel-kyoto-review/index.js
+++ b/packages/templates/src/raw/ace-hotel-kyoto-review/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 29),
   title: _x('Ace Hotel Kyoto Review', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/ace-hotel-kyoto-review/index.js
+++ b/packages/templates/src/raw/ace-hotel-kyoto-review/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Ace Hotel Kyoto Review', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/album-releases/index.js
+++ b/packages/templates/src/raw/album-releases/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 5, 28),
   title: _x('Album Releases', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/album-releases/index.js
+++ b/packages/templates/src/raw/album-releases/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Album Releases', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/almodos-films/index.js
+++ b/packages/templates/src/raw/almodos-films/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 12),
   title: _x('Almodo’s Films', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/almodos-films/index.js
+++ b/packages/templates/src/raw/almodos-films/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Almodo’s Films', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/art-books-gift-guide/index.js
+++ b/packages/templates/src/raw/art-books-gift-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Art Books Gift Guide', 'template name', 'web-stories'),
   tags: [
     _x('Art', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/art-books-gift-guide/index.js
+++ b/packages/templates/src/raw/art-books-gift-guide/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 9),
   title: _x('Art Books Gift Guide', 'template name', 'web-stories'),
   tags: [
     _x('Art', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/baking-bread-guide/index.js
+++ b/packages/templates/src/raw/baking-bread-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Baking Bread Guide ', 'template name', 'web-stories'),
   tags: [
     _x('Food', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/baking-bread-guide/index.js
+++ b/packages/templates/src/raw/baking-bread-guide/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 13),
   title: _x('Baking Bread Guide ', 'template name', 'web-stories'),
   tags: [
     _x('Food', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/beauty-quiz/index.js
+++ b/packages/templates/src/raw/beauty-quiz/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 5, 28),
   title: _x('Beauty Quiz', 'template name', 'web-stories'),
   tags: [
     _x('Fashion & Beauty', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/beauty-quiz/index.js
+++ b/packages/templates/src/raw/beauty-quiz/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Beauty Quiz', 'template name', 'web-stories'),
   tags: [
     _x('Fashion & Beauty', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/belly-fat-workout/index.js
+++ b/packages/templates/src/raw/belly-fat-workout/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Belly Fat Workout', 'template name', 'web-stories'),
   tags: [
     _x('Health', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/belly-fat-workout/index.js
+++ b/packages/templates/src/raw/belly-fat-workout/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 12),
   title: _x('Belly Fat Workout', 'template name', 'web-stories'),
   tags: [
     _x('Health', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/buying-art-on-the-internet/index.js
+++ b/packages/templates/src/raw/buying-art-on-the-internet/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Buying Art on the Internet', 'template name', 'web-stories'),
   tags: [
     _x('Arts & Craft', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/buying-art-on-the-internet/index.js
+++ b/packages/templates/src/raw/buying-art-on-the-internet/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 3),
   title: _x('Buying Art on the Internet', 'template name', 'web-stories'),
   tags: [
     _x('Arts & Craft', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/celebrity-q-and-a/index.js
+++ b/packages/templates/src/raw/celebrity-q-and-a/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Celebrity Q & A', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/celebrity-q-and-a/index.js
+++ b/packages/templates/src/raw/celebrity-q-and-a/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 3),
   title: _x('Celebrity Q & A', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/diy-home-office/index.js
+++ b/packages/templates/src/raw/diy-home-office/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('DIY Home Office', 'template name', 'web-stories'),
   tags: [
     _x('Arts & Craft', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/diy-home-office/index.js
+++ b/packages/templates/src/raw/diy-home-office/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 29),
   title: _x('DIY Home Office', 'template name', 'web-stories'),
   tags: [
     _x('Arts & Craft', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/doers-get-more-done/index.js
+++ b/packages/templates/src/raw/doers-get-more-done/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 6, 1),
   title: _x('Doers Get More Done', 'template name', 'web-stories'),
   tags: [
     _x('Doers', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/doers-get-more-done/index.js
+++ b/packages/templates/src/raw/doers-get-more-done/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 6, 1),
+  creationDate: new Date(2021, 4, 29),
   title: _x('Doers Get More Done', 'template name', 'web-stories'),
   tags: [
     _x('Doers', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/elegant-travel-itinerary/index.js
+++ b/packages/templates/src/raw/elegant-travel-itinerary/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Elegant Travel Itinerary', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/elegant-travel-itinerary/index.js
+++ b/packages/templates/src/raw/elegant-travel-itinerary/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 9),
   title: _x('Elegant Travel Itinerary', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/experience-thailand/index.js
+++ b/packages/templates/src/raw/experience-thailand/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 6, 1),
+  creationDate: new Date(2021, 4, 29),
   title: _x('Experience Thailand', 'template name', 'web-stories'),
   tags: [
     _x('Explore', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/experience-thailand/index.js
+++ b/packages/templates/src/raw/experience-thailand/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 6, 1),
   title: _x('Experience Thailand', 'template name', 'web-stories'),
   tags: [
     _x('Explore', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fashion-inspiration/index.js
+++ b/packages/templates/src/raw/fashion-inspiration/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Fashion Inspiration', 'template name', 'web-stories'),
   tags: [
     _x('Fashion', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fashion-inspiration/index.js
+++ b/packages/templates/src/raw/fashion-inspiration/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 9),
   title: _x('Fashion Inspiration', 'template name', 'web-stories'),
   tags: [
     _x('Fashion', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fashion-on-the-go/index.js
+++ b/packages/templates/src/raw/fashion-on-the-go/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 6, 1),
   title: _x('Fashion On The Go', 'template name', 'web-stories'),
   tags: [
     _x('Clothing', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fashion-on-the-go/index.js
+++ b/packages/templates/src/raw/fashion-on-the-go/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 6, 1),
+  creationDate: new Date(2021, 4, 29),
   title: _x('Fashion On The Go', 'template name', 'web-stories'),
   tags: [
     _x('Clothing', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fitness-apps-ranked/index.js
+++ b/packages/templates/src/raw/fitness-apps-ranked/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Fitness Apps Ranked', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fitness-apps-ranked/index.js
+++ b/packages/templates/src/raw/fitness-apps-ranked/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 12),
   title: _x('Fitness Apps Ranked', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/food-and-stuff/index.js
+++ b/packages/templates/src/raw/food-and-stuff/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 6, 1),
+  creationDate: new Date(2021, 4, 29),
   title: _x('Food & Stuff', 'template name', 'web-stories'),
   tags: [
     _x('Delicious', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/food-and-stuff/index.js
+++ b/packages/templates/src/raw/food-and-stuff/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 6, 1),
   title: _x('Food & Stuff', 'template name', 'web-stories'),
   tags: [
     _x('Delicious', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fresh-and-bright/index.js
+++ b/packages/templates/src/raw/fresh-and-bright/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 6, 1),
   title: _x('Fresh & Bright', 'template name', 'web-stories'),
   tags: [
     _x('Health', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fresh-and-bright/index.js
+++ b/packages/templates/src/raw/fresh-and-bright/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 6, 1),
+  creationDate: new Date(2021, 4, 29),
   title: _x('Fresh & Bright', 'template name', 'web-stories'),
   tags: [
     _x('Health', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/google-music-studio-tour/index.js
+++ b/packages/templates/src/raw/google-music-studio-tour/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Google Music Studio Tour', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/google-music-studio-tour/index.js
+++ b/packages/templates/src/raw/google-music-studio-tour/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 3),
   title: _x('Google Music Studio Tour', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/hawaii-travel-packing-list/index.js
+++ b/packages/templates/src/raw/hawaii-travel-packing-list/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 3),
   title: _x('Hawaii Travel Packing List', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/hawaii-travel-packing-list/index.js
+++ b/packages/templates/src/raw/hawaii-travel-packing-list/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Hawaii Travel Packing List', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/honeymooning-in-italy/index.js
+++ b/packages/templates/src/raw/honeymooning-in-italy/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 29),
   title: _x('Honeymooning in Italy', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/honeymooning-in-italy/index.js
+++ b/packages/templates/src/raw/honeymooning-in-italy/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Honeymooning in Italy', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/house-hunting/index.js
+++ b/packages/templates/src/raw/house-hunting/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 3),
   title: _x('House Hunting', 'template name', 'web-stories'),
   tags: [
     _x('Home', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/house-hunting/index.js
+++ b/packages/templates/src/raw/house-hunting/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('House Hunting', 'template name', 'web-stories'),
   tags: [
     _x('Home', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/how-contact-tracing-works/index.js
+++ b/packages/templates/src/raw/how-contact-tracing-works/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 3),
   title: _x('How Contact Tracing Works', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/how-contact-tracing-works/index.js
+++ b/packages/templates/src/raw/how-contact-tracing-works/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('How Contact Tracing Works', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/how-video-calls-saved-the-day/index.js
+++ b/packages/templates/src/raw/how-video-calls-saved-the-day/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('How Video Calls Saved the Day', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/how-video-calls-saved-the-day/index.js
+++ b/packages/templates/src/raw/how-video-calls-saved-the-day/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 29),
   title: _x('How Video Calls Saved the Day', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/indoor-garden-oasis/index.js
+++ b/packages/templates/src/raw/indoor-garden-oasis/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Indoor Garden Oasis DIY', 'template name', 'web-stories'),
   tags: [
     _x('Home', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/indoor-garden-oasis/index.js
+++ b/packages/templates/src/raw/indoor-garden-oasis/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 12),
   title: _x('Indoor Garden Oasis DIY', 'template name', 'web-stories'),
   tags: [
     _x('Home', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/kitchen-makeover/index.js
+++ b/packages/templates/src/raw/kitchen-makeover/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 29),
   title: _x('Kitchen Makeover', 'template name', 'web-stories'),
   tags: [
     _x('Home & Garden', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/kitchen-makeover/index.js
+++ b/packages/templates/src/raw/kitchen-makeover/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Kitchen Makeover', 'template name', 'web-stories'),
   tags: [
     _x('Home & Garden', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/kitchen-stories/index.js
+++ b/packages/templates/src/raw/kitchen-stories/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 5, 28),
   title: _x('Kitchen Stories', 'template name', 'web-stories'),
   tags: [
     _x('Cooking', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/kitchen-stories/index.js
+++ b/packages/templates/src/raw/kitchen-stories/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Kitchen Stories', 'template name', 'web-stories'),
   tags: [
     _x('Cooking', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/laptop-buying-guide/index.js
+++ b/packages/templates/src/raw/laptop-buying-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Laptop Buying Guide', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/laptop-buying-guide/index.js
+++ b/packages/templates/src/raw/laptop-buying-guide/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 29),
   title: _x('Laptop Buying Guide', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/los-angeles-city-guide/index.js
+++ b/packages/templates/src/raw/los-angeles-city-guide/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 3),
   title: _x('Los Angeles City Guide', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/los-angeles-city-guide/index.js
+++ b/packages/templates/src/raw/los-angeles-city-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Los Angeles City Guide', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/magazine-article/index.js
+++ b/packages/templates/src/raw/magazine-article/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 9),
   title: _x('Magazine Article', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/magazine-article/index.js
+++ b/packages/templates/src/raw/magazine-article/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Magazine Article', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/modernist-travel-guide/index.js
+++ b/packages/templates/src/raw/modernist-travel-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Modernist Travel Guide', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/modernist-travel-guide/index.js
+++ b/packages/templates/src/raw/modernist-travel-guide/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 9),
   title: _x('Modernist Travel Guide', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/new-york-party-round-up/index.js
+++ b/packages/templates/src/raw/new-york-party-round-up/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 9),
   title: _x('New York Party Round-up', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/new-york-party-round-up/index.js
+++ b/packages/templates/src/raw/new-york-party-round-up/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('New York Party Round-up', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/no-days-off/index.js
+++ b/packages/templates/src/raw/no-days-off/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 6, 1),
+  creationDate: new Date(2021, 4, 29),
   title: _x('No Days Off', 'template name', 'web-stories'),
   tags: [
     _x('Exercise', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/no-days-off/index.js
+++ b/packages/templates/src/raw/no-days-off/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 6, 1),
   title: _x('No Days Off', 'template name', 'web-stories'),
   tags: [
     _x('Exercise', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/pizzas-in-nyc/index.js
+++ b/packages/templates/src/raw/pizzas-in-nyc/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Pizzas in NYC', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/pizzas-in-nyc/index.js
+++ b/packages/templates/src/raw/pizzas-in-nyc/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 12),
   title: _x('Pizzas in NYC', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/plant-based-dyes/index.js
+++ b/packages/templates/src/raw/plant-based-dyes/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 12),
   title: _x('Plant Based Dyes DIY', 'template name', 'web-stories'),
   tags: [
     _x('Crafts', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/plant-based-dyes/index.js
+++ b/packages/templates/src/raw/plant-based-dyes/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Plant Based Dyes DIY', 'template name', 'web-stories'),
   tags: [
     _x('Crafts', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/pride-month-watchlist/index.js
+++ b/packages/templates/src/raw/pride-month-watchlist/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 29),
   title: _x('Pride Month Watchlist', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/pride-month-watchlist/index.js
+++ b/packages/templates/src/raw/pride-month-watchlist/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Pride Month Watchlist', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/rock-music-festival/index.js
+++ b/packages/templates/src/raw/rock-music-festival/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Rock Music Festival', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/rock-music-festival/index.js
+++ b/packages/templates/src/raw/rock-music-festival/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 3),
   title: _x('Rock Music Festival', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/sangria-artichoke/index.js
+++ b/packages/templates/src/raw/sangria-artichoke/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Trendy Winter Veggie', 'template name', 'web-stories'),
   tags: [
     _x('Food', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/sangria-artichoke/index.js
+++ b/packages/templates/src/raw/sangria-artichoke/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 5, 28),
   title: _x('Trendy Winter Veggie', 'template name', 'web-stories'),
   tags: [
     _x('Food', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/self-care-guide/index.js
+++ b/packages/templates/src/raw/self-care-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Self-care Guide', 'template name', 'web-stories'),
   tags: [
     _x('Health & Wellness', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/self-care-guide/index.js
+++ b/packages/templates/src/raw/self-care-guide/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 29),
   title: _x('Self-care Guide', 'template name', 'web-stories'),
   tags: [
     _x('Health & Wellness', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/simple-tech-tutorial/index.js
+++ b/packages/templates/src/raw/simple-tech-tutorial/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Simple Tech Tutorial ', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/simple-tech-tutorial/index.js
+++ b/packages/templates/src/raw/simple-tech-tutorial/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 9),
   title: _x('Simple Tech Tutorial ', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/skin-care-at-home/index.js
+++ b/packages/templates/src/raw/skin-care-at-home/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Skin Care at Home', 'template name', 'web-stories'),
   tags: [
     _x('Beauty', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/skin-care-at-home/index.js
+++ b/packages/templates/src/raw/skin-care-at-home/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 9),
   title: _x('Skin Care at Home', 'template name', 'web-stories'),
   tags: [
     _x('Beauty', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/sleep/index.js
+++ b/packages/templates/src/raw/sleep/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 6, 1),
+  creationDate: new Date(2021, 4, 29),
   title: _x('Sleep', 'template name', 'web-stories'),
   tags: [
     _x('Health', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/sleep/index.js
+++ b/packages/templates/src/raw/sleep/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 6, 1),
   title: _x('Sleep', 'template name', 'web-stories'),
   tags: [
     _x('Health', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/street-style-on-the-go/index.js
+++ b/packages/templates/src/raw/street-style-on-the-go/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Street Style On The Go', 'template name', 'web-stories'),
   tags: [
     _x('Fashion', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/street-style-on-the-go/index.js
+++ b/packages/templates/src/raw/street-style-on-the-go/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 12),
   title: _x('Street Style On The Go', 'template name', 'web-stories'),
   tags: [
     _x('Fashion', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/summer-fashion-collection/index.js
+++ b/packages/templates/src/raw/summer-fashion-collection/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 3),
   title: _x('Summer Fashion Collection', 'template name', 'web-stories'),
   tags: [
     _x('Fashion', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/summer-fashion-collection/index.js
+++ b/packages/templates/src/raw/summer-fashion-collection/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Summer Fashion Collection', 'template name', 'web-stories'),
   tags: [
     _x('Fashion', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/tv-show-recap/index.js
+++ b/packages/templates/src/raw/tv-show-recap/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 29),
   title: _x('TV Show Recap', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/tv-show-recap/index.js
+++ b/packages/templates/src/raw/tv-show-recap/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('TV Show Recap', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/ultimate-comparison/index.js
+++ b/packages/templates/src/raw/ultimate-comparison/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Ultimate Comparison', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/ultimate-comparison/index.js
+++ b/packages/templates/src/raw/ultimate-comparison/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 6, 12),
   title: _x('Ultimate Comparison', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/vintage-chairs-buying-guide/index.js
+++ b/packages/templates/src/raw/vintage-chairs-buying-guide/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 7, 9),
   title: _x('Vintage Chair Buying Guide', 'template name', 'web-stories'),
   tags: [
     _x('Home', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/vintage-chairs-buying-guide/index.js
+++ b/packages/templates/src/raw/vintage-chairs-buying-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Vintage Chair Buying Guide', 'template name', 'web-stories'),
   tags: [
     _x('Home', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/ways-to-eat-avocado/index.js
+++ b/packages/templates/src/raw/ways-to-eat-avocado/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 7, 1),
+  creationDate: new Date(2021, 5, 28),
   title: _x('Ways to Eat Avocado', 'template name', 'web-stories'),
   tags: [
     _x('Nutrition', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/ways-to-eat-avocado/index.js
+++ b/packages/templates/src/raw/ways-to-eat-avocado/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 7, 1),
   title: _x('Ways to Eat Avocado', 'template name', 'web-stories'),
   tags: [
     _x('Nutrition', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/weekly-entertainment/index.js
+++ b/packages/templates/src/raw/weekly-entertainment/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  creationDate: new Date(2021, 6, 1),
   title: _x('Weekly Entertainment', 'template name', 'web-stories'),
   tags: [
     _x('Funny', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/weekly-entertainment/index.js
+++ b/packages/templates/src/raw/weekly-entertainment/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  creationDate: new Date(2021, 6, 1),
+  creationDate: new Date(2021, 4, 29),
   title: _x('Weekly Entertainment', 'template name', 'web-stories'),
   tags: [
     _x('Funny', 'template keyword', 'web-stories'),

--- a/packages/templates/src/test/raw.js
+++ b/packages/templates/src/test/raw.js
@@ -21,6 +21,10 @@ import { readdirSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import stickers from '@web-stories-wp/stickers';
 
+function isValidDate(date) {
+  return date instanceof Date && !isNaN(date);
+}
+
 describe('raw template files', () => {
   const templates = readdirSync(
     resolve(process.cwd(), 'packages/templates/src/raw')
@@ -205,6 +209,16 @@ describe('raw template files', () => {
           );
         }
       }
+    }
+  );
+
+  it.each(templates)(
+    '%s template should contain a valid createdDate',
+    async (template) => {
+      const { default: templateData } = await import(
+        /* webpackChunkName: "chunk-web-stories-template-[index]" */ `../raw/${template}`
+      );
+      expect(isValidDate(templateData.creationDate)).toBe(true);
     }
   );
 });


### PR DESCRIPTION
## Context
Part of making new templates more visible to users

## Summary
- Adds `creationDate` to all templates
- Adds a smoll unit test to make sure there's a valid `creationDate` on all the templates
- Updates the template creation README to include `creationDate`
- Sorts templates by `creationDate` , newest appearing first.

## Relevant Technical Choices
NA
<!-- Please describe your changes. -->

## To-do
- [x] go through and see if we want any more specific ordering of templates beyond "new ones at the top"
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Templates should now appear in a new order where the original templates are at the bottom.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
- Open up `Explore Templates`
- Scroll to the bottom and see that the original templates are at at the bottom of the template gallery with newer ones on top
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA
- Open up `Explore Templates`
- Scroll to the bottom and see that the original templates are at at the bottom of the template gallery with newer ones on top

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8465 
