### PR TITLE
Templates: Add Puppeteer Script to Generate Template Page Screenshots 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -382,6 +382,7 @@
         "packages/commander/**/*.js",
         "packages/fonts/src/cli.js",
         "packages/migration/src/cli.js",
+        "packages/templates/src/cli.js",
         "packages/text-sets/src/cli.js"
       ],
       "rules": {
@@ -409,6 +410,7 @@
         "packages/migration/src/**/*.js",
         "packages/fonts/**/*.js",
         "packages/commander/**/*.js",
+        "packages/templates/src/cli.js",
         "packages/text-sets/src/cli.js"
       ],
       "extends": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -40296,7 +40296,7 @@
       },
       "devDependencies": {
         "@web-stories-wp/stickers": "*",
-        "puppeteer": "*"
+        "puppeteer": "^10.1.0"
       },
       "engines": {
         "node": ">= 15",
@@ -47682,7 +47682,7 @@
         "@web-stories-wp/migration": "*",
         "@web-stories-wp/stickers": "*",
         "@web-stories-wp/tracking": "*",
-        "puppeteer": "*"
+        "puppeteer": "^10.1.0"
       }
     },
     "@web-stories-wp/text-sets": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40291,8 +40291,12 @@
         "@web-stories-wp/migration": "*",
         "@web-stories-wp/tracking": "*"
       },
+      "bin": {
+        "render-template-posters": "src/cli.js"
+      },
       "devDependencies": {
-        "@web-stories-wp/stickers": "*"
+        "@web-stories-wp/stickers": "*",
+        "puppeteer": "*"
       },
       "engines": {
         "node": ">= 15",
@@ -47677,7 +47681,8 @@
         "@web-stories-wp/i18n": "*",
         "@web-stories-wp/migration": "*",
         "@web-stories-wp/stickers": "*",
-        "@web-stories-wp/tracking": "*"
+        "@web-stories-wp/tracking": "*",
+        "puppeteer": "*"
       }
     },
     "@web-stories-wp/text-sets": {

--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "workflow:build-plugin": "commander build-plugin",
     "workflow:fonts": "update-fonts packages/fonts/src/fonts.json",
     "workflow:render-text-sets": "render-text-sets",
+    "workflow:render-template-posters": "render-template-posters",
     "preworkflow:migrate": "[ -f packages/migration/src/module.js ] || npx rollup --config packages/migration/src/rollup.config.migrate.js",
     "workflow:migrate": "npm-run-all --parallel workflow:migrate:*",
     "workflow:migrate:text-sets": "migration packages/text-sets/src/raw",

--- a/packages/dashboard/src/app/api/test/__snapshots__/useTemplateApi.js.snap
+++ b/packages/dashboard/src/app/api/test/__snapshots__/useTemplateApi.js.snap
@@ -28,6 +28,7 @@ Object {
       "id": 0,
     },
   ],
+  "slug": "beauty",
   "status": "template",
   "tags": Array [
     "Health",

--- a/packages/dashboard/src/app/api/test/useTemplateApi.js
+++ b/packages/dashboard/src/app/api/test/useTemplateApi.js
@@ -25,6 +25,7 @@ import { reshapeTemplateObject } from '../useTemplateApi';
 describe('reshapeTemplateObject', () => {
   const templateData = {
     id: 1,
+    slug: 'beauty',
     title: 'Beauty',
     createdBy: 'Google',
     modified: '2020-04-21T07:00:00.000Z',

--- a/packages/dashboard/src/app/api/useTemplateApi.js
+++ b/packages/dashboard/src/app/api/useTemplateApi.js
@@ -35,6 +35,7 @@ import { ERRORS } from '../textContent';
 export function reshapeTemplateObject(isLocal) {
   return ({
     id,
+    slug,
     title,
     modified,
     tags,
@@ -49,6 +50,7 @@ export function reshapeTemplateObject(isLocal) {
     title,
     createdBy,
     description,
+    slug,
     status: 'template',
     modified: toUTCDate(modified),
     tags,

--- a/packages/dashboard/src/app/views/shared/templateGridView.js
+++ b/packages/dashboard/src/app/views/shared/templateGridView.js
@@ -107,6 +107,8 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
             <CardGridItem
               key={template.id}
               role="listitem"
+              id={`template-grid-item-${template.id}`}
+              className="templateGridItem"
               data-testid={`template-grid-item-${template.id}`}
               ref={(el) => {
                 itemRefs.current[template.id] = el;
@@ -125,11 +127,7 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
                 )}
               />
               <CardPreviewContainer
-                ariaLabel={sprintf(
-                  /* translators: %s: template title.*/
-                  __('Viewing template: %s', 'web-stories'),
-                  template.title
-                )}
+                ariaLabel={template.title}
                 tabIndex={tabIndex}
                 pageSize={pageSize}
                 story={template}
@@ -142,6 +140,8 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
                   ariaLabel: __('Go to template details', 'web-stories'),
                 }}
                 bottomAction={{
+                  dataTestId: 'use_template_button',
+                  templateId: template.id,
                   targetAction: targetAction(template),
                   label: __('Use template', 'web-stories'),
                   ariaLabel: __('Use this template', 'web-stories'),

--- a/packages/dashboard/src/app/views/shared/templateGridView.js
+++ b/packages/dashboard/src/app/views/shared/templateGridView.js
@@ -127,10 +127,15 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
                 )}
               />
               <CardPreviewContainer
-                ariaLabel={template.title}
+                ariaLabel={sprintf(
+                  /* translators: %s: template title.*/
+                  __('Viewing template: %s', 'web-stories'),
+                  template.title
+                )}
                 tabIndex={tabIndex}
                 pageSize={pageSize}
                 story={template}
+                slug={template.slug}
                 centerAction={{
                   targetAction: template.centerTargetAction,
                   label:

--- a/packages/dashboard/src/app/views/shared/templateGridView.js
+++ b/packages/dashboard/src/app/views/shared/templateGridView.js
@@ -140,8 +140,6 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
                   ariaLabel: __('Go to template details', 'web-stories'),
                 }}
                 bottomAction={{
-                  dataTestId: 'use_template_button',
-                  templateId: template.id,
                   targetAction: targetAction(template),
                   label: __('Use template', 'web-stories'),
                   ariaLabel: __('Use this template', 'web-stories'),

--- a/packages/dashboard/src/components/cardGridItem/cardPreview.js
+++ b/packages/dashboard/src/components/cardGridItem/cardPreview.js
@@ -241,8 +241,6 @@ const CardPreviewContainer = ({
               isDisabled={!bottomAction.targetAction}
               type={BUTTON_TYPES.PRIMARY}
               size={BUTTON_SIZES.SMALL}
-              data-test-id={bottomAction?.dataTestId}
-              id={bottomAction.templateId}
             >
               {bottomAction.label}
             </Button>
@@ -260,8 +258,6 @@ const ActionButtonPropType = PropTypes.shape({
     .isRequired,
   label: ActionLabel,
   ariaLabel: PropTypes.string,
-  dataTestId: PropTypes.string,
-  templateId: PropTypes.string,
 });
 
 CardPreviewContainer.propTypes = {

--- a/packages/dashboard/src/components/cardGridItem/cardPreview.js
+++ b/packages/dashboard/src/components/cardGridItem/cardPreview.js
@@ -130,6 +130,7 @@ const CardPreviewContainer = ({
   centerAction,
   bottomAction,
   topAction,
+  slug = '',
   story,
   pageSize,
   ariaLabel,
@@ -194,6 +195,7 @@ const CardPreviewContainer = ({
       <EditControls
         aria-label={ariaLabel}
         data-testid="card-action-container"
+        data-template-slug={slug}
         ref={containElem}
         cardSize={pageSize}
         isActive={CARD_STATE.ACTIVE === cardState}
@@ -268,6 +270,7 @@ CardPreviewContainer.propTypes = {
   topAction: ActionButtonPropType,
   containerAction: PropTypes.func,
   pageSize: PageSizePropType.isRequired,
+  slug: PropTypes.string,
   story: StoryPropType,
   tabIndex: PropTypes.number,
 };

--- a/packages/dashboard/src/components/cardGridItem/cardPreview.js
+++ b/packages/dashboard/src/components/cardGridItem/cardPreview.js
@@ -241,6 +241,8 @@ const CardPreviewContainer = ({
               isDisabled={!bottomAction.targetAction}
               type={BUTTON_TYPES.PRIMARY}
               size={BUTTON_SIZES.SMALL}
+              data-test-id={bottomAction?.dataTestId}
+              id={bottomAction.templateId}
             >
               {bottomAction.label}
             </Button>
@@ -258,6 +260,8 @@ const ActionButtonPropType = PropTypes.shape({
     .isRequired,
   label: ActionLabel,
   ariaLabel: PropTypes.string,
+  dataTestId: PropTypes.string,
+  templateId: PropTypes.string,
 });
 
 CardPreviewContainer.propTypes = {

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -5,3 +5,9 @@ This package contains the templates used by the dashboard and the editor (as par
 ## Template Creation
 
 See [External Template Creation](../../docs/external-template-creation.md).
+
+## Generating images for templates
+
+_Note: This script requires the development environment to be running with `DISABLE_OPTIMIZED_RENDERING` so the templates are rendered as components not images._
+
+Run `npm run workflow:render-template-posters` to generate and save the first page of templates as images in the `build/template-posters/` folder. Then move and commit the images to the `static-site` branch.

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -8,6 +8,4 @@ See [External Template Creation](../../docs/external-template-creation.md).
 
 ## Generating images for templates
 
-_Note: This script requires the development environment to be running with `DISABLE_OPTIMIZED_RENDERING` so the templates are rendered as components not images._
-
-Run `npm run workflow:render-template-posters` to generate and save each template page as an image in the `build/template-posters/` folder. Then move and commit the images to the `static-site` branch.
+Run `npm run workflow:render-template-posters` to generate and save each template page as an image in the `build/template-posters/` folder. Then move and commit the images to the `static-site` branch under `public/static/main/images/templates/<template-name>/posters`.

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -10,4 +10,4 @@ See [External Template Creation](../../docs/external-template-creation.md).
 
 _Note: This script requires the development environment to be running with `DISABLE_OPTIMIZED_RENDERING` so the templates are rendered as components not images._
 
-Run `npm run workflow:render-template-posters` to generate and save the first page of templates as images in the `build/template-posters/` folder. Then move and commit the images to the `static-site` branch.
+Run `npm run workflow:render-template-posters` to generate and save each template page as an image in the `build/template-posters/` folder. Then move and commit the images to the `static-site` branch.

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -20,6 +20,6 @@
   },
   "devDependencies": {
     "@web-stories-wp/stickers": "*",
-    "puppeteer": "*"
+    "puppeteer": "^10.1.0"
   }
 }

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -10,12 +10,16 @@
   },
   "main": "./src/index.js",
   "type": "module",
+  "bin": {
+    "render-template-posters": "./src/cli.js"
+  },
   "dependencies": {
     "@web-stories-wp/i18n": "*",
     "@web-stories-wp/migration": "*",
     "@web-stories-wp/tracking": "*"
   },
   "devDependencies": {
-    "@web-stories-wp/stickers": "*"
+    "@web-stories-wp/stickers": "*",
+    "puppeteer": "*"
   }
 }

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -64,7 +64,7 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
     currentTemplate <= templateCount;
     currentTemplate++
   ) {
-    // Use the template, this will open up the editor
+    // Get the template name and remove spaces to use as part of file name.
     const templateName = await page.evaluate((gridItemId) => {
       return document
         .querySelector(
@@ -76,6 +76,7 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
 
     console.log(`getting screenshots for ${templateName}`);
 
+    // Use the template, this will open up the editor
     await page.click(
       `div#template-grid-item-${currentTemplate} button[aria-label="Use this template"]`
     );
@@ -97,6 +98,14 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
       height: 800,
       deviceScaleFactor: 2,
     });
+    // set prefers-reduced-motion to get story without animations so screenshots are complete page views
+    await pagePreview.emulateMediaFeatures([
+      { name: 'prefers-reduced-motion', value: 'reduce' },
+    ]);
+    await pagePreview.evaluate(
+      () => matchMedia('(prefers-reduced-motion: reduce)').matches
+    );
+
     await pagePreview.goto(previewUrl);
 
     const totalPages = await pagePreview.evaluate(() => {
@@ -116,8 +125,10 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
       }
     }
 
+    // Close the preview
     await pagePreview.close();
 
+    // Use the original browser page to go back to the template gallery for the next template.
     await page.goto(
       'http://localhost:8899/wp-admin/edit.php?post_type=web-story&page=stories-dashboard#/templates-gallery'
     );

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -107,6 +107,8 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
     );
 
     await pagePreview.goto(previewUrl);
+    // Ensure that the page's ready before looping
+    await pagePreview.waitForSelector('aria/Next page');
 
     const totalPages = await pagePreview.evaluate(() => {
       return document.querySelectorAll('amp-story-page').length;
@@ -122,6 +124,8 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
 
       if (currentPage !== totalPages - 1) {
         await pagePreview.click('aria/Next page');
+        // Wait 2 seconds, prevents screenshots not capturing the full page. Without this some pages won't load in time.
+        await pagePreview.waitForTimeout(2000);
       }
     }
 

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -148,8 +148,6 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
     );
   }
 
-  process.stdout.write('.');
-
   await browser.close();
   console.log(
     `\nTemplate images generated in ${screenshotsPath}, please move and commit them to the static-site branch`

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -73,6 +73,7 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
         .getAttribute('data-template-slug');
     }, currentTemplate);
     // Prep a directory for the template screenshots
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
     fs.mkdirSync(`${screenshotsPath}${templateName}`, { recursive: true });
 
     console.log(`Getting screenshots for ${templateName}`);

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -90,6 +90,10 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
     const previewUrl = `http://localhost:8899/?post_type=web-story&p=${storyId}&preview=true`;
 
     // Need to click preview for the story to save and be loadable in a second window.
+    // This is because the "Save" button is disabled at this point.
+    // Also not using the tab opened by the preview button and instead assembling `pagePreview`
+    // ourselves so that we can emulate `prefers-reduced-motion` and don't have to deal with
+    // the story dev tools.
     await page.waitForSelector('aria/Preview');
     await page.click('aria/Preview');
 

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -50,7 +50,7 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
   await page.waitForSelector('aria/Explore Templates');
   await page.click('aria/Explore Templates');
 
-  // wait for templates to be rendered
+  // Wait for templates to be rendered
   await page.waitForSelector('div.templateGridItem');
 
   // total templates to generate screenshots from
@@ -64,7 +64,7 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
     currentTemplate <= templateCount;
     currentTemplate++
   ) {
-    // Get the template name to use as build directory.
+    // Get the template name to use as build directory
     const templateName = await page.evaluate((gridItemId) => {
       return document
         .querySelector(

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable no-await-in-loop, no-console */
+
+/**
+ * External dependencies
+ */
+import fs from 'fs';
+import puppeteer from 'puppeteer';
+
+const screenshotsPath = `build/template-posters/`;
+
+fs.mkdirSync(screenshotsPath, { recursive: true });
+
+(async () => {
+  const browser = await puppeteer.launch({
+    defaultViewport: null,
+    headless: true,
+    args: [`--window-size=1600,800`],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({
+    width: 1600,
+    height: 800,
+    deviceScaleFactor: 2,
+  });
+  await page.goto(
+    'http://localhost:8899/wp-admin/edit.php?post_type=web-story&page=stories-dashboard#/templates-gallery'
+  );
+  await page.type('#user_login', 'admin');
+  await page.type('#user_pass', 'password');
+  await page.click('#wp-submit');
+  await page.waitForNavigation({ waitUntil: 'networkidle2' });
+
+  await page.waitForSelector('aria/Explore Templates');
+  await page.click('aria/Explore Templates');
+
+  // wait for templates to be rendered
+  await page.waitForSelector('div.templateGridItem');
+
+  // total templates to generate screenshots from
+  const templateCount = await page.evaluate(() => {
+    return document.querySelectorAll('.templateGridItem').length;
+  });
+
+  // Now let's go through each template
+  for (
+    let currentTemplate = 1;
+    currentTemplate <= templateCount;
+    currentTemplate++
+  ) {
+    // Use the template, this will open up the editor
+    const templateName = await page.evaluate((gridItemId) => {
+      return document
+        .querySelector(
+          `div#template-grid-item-${gridItemId} div[data-testid="card-action-container"]`
+        )
+        .getAttribute('aria-label')
+        .replace(/\s/g, '');
+    }, currentTemplate);
+
+    console.log(`getting screenshots for ${templateName}`);
+
+    await page.click(
+      `div#template-grid-item-${currentTemplate} button[aria-label="Use this template"]`
+    );
+
+    // Load the template in the editor to get story id to render preview
+    await page.waitForNavigation({ waitUntil: 'networkidle2' });
+    const editorUrl = await page.url(); // 'http://localhost:8899/wp-admin/post.php?post=1163&action=edit#page=%252217fa9c85-89c7-47d0-a7a8-29f6ef56e161%2522'
+    const storyId = editorUrl.split('post=')[1].split('&')[0];
+
+    const previewUrl = `http://localhost:8899/?post_type=web-story&p=${storyId}&preview=true`;
+
+    // Need to click preview for the story to save and be loadable in a second window.
+    await page.waitForSelector('aria/Preview');
+    await page.click('aria/Preview');
+
+    const pagePreview = await browser.newPage();
+    await pagePreview.setViewport({
+      width: 1600,
+      height: 800,
+      deviceScaleFactor: 2,
+    });
+    await pagePreview.goto(previewUrl);
+
+    const totalPages = await pagePreview.evaluate(() => {
+      return document.querySelectorAll('amp-story-page').length;
+    });
+
+    for (let currentPage = 1; currentPage < totalPages; currentPage++) {
+      const templatePageSafeArea = await pagePreview.$(
+        `amp-story-page:nth-child(${currentPage}) .page-safe-area`
+      );
+      await templatePageSafeArea.screenshot({
+        path: `${screenshotsPath}/${templateName}-${currentPage}.png`,
+      });
+
+      if (currentPage !== totalPages - 1) {
+        await pagePreview.click('aria/Next page');
+      }
+    }
+
+    await pagePreview.close();
+
+    await page.goto(
+      'http://localhost:8899/wp-admin/edit.php?post_type=web-story&page=stories-dashboard#/templates-gallery'
+    );
+  }
+
+  process.stdout.write('.');
+
+  await browser.close();
+  console.log(
+    `\nTemplate images generated in ${screenshotsPath}, please move and commit them to the static-site branch`
+  );
+})();
+
+/* eslint-enable */

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -25,6 +25,7 @@ import puppeteer from 'puppeteer';
 
 const screenshotsPath = `build/template-posters/`;
 
+// eslint-disable-next-line security/detect-non-literal-fs-filename
 fs.mkdirSync(screenshotsPath, { recursive: true });
 
 (async () => {

--- a/packages/templates/src/raw/12-hours-in-barcelona/index.js
+++ b/packages/templates/src/raw/12-hours-in-barcelona/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: '12-hours-in-barcelona',
   title: _x('12 Hours in Barcelona', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/a-day-in-the-life/index.js
+++ b/packages/templates/src/raw/a-day-in-the-life/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'a-day-in-the-life',
   title: _x('A Day in the Life', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/ace-hotel-kyoto-review/index.js
+++ b/packages/templates/src/raw/ace-hotel-kyoto-review/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'ace-hotel-kyoto-review',
   title: _x('Ace Hotel Kyoto Review', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/album-releases/index.js
+++ b/packages/templates/src/raw/album-releases/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'album-releases',
   title: _x('Album Releases', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/almodos-films/index.js
+++ b/packages/templates/src/raw/almodos-films/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'almodos-films',
   title: _x('Almodo’s Films', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/art-books-gift-guide/index.js
+++ b/packages/templates/src/raw/art-books-gift-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'art-books-gift-guide',
   title: _x('Art Books Gift Guide', 'template name', 'web-stories'),
   tags: [
     _x('Art', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/baking-bread-guide/index.js
+++ b/packages/templates/src/raw/baking-bread-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'baking-bread-guide',
   title: _x('Baking Bread Guide ', 'template name', 'web-stories'),
   tags: [
     _x('Food', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/beauty-quiz/index.js
+++ b/packages/templates/src/raw/beauty-quiz/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'beauty-quiz',
   title: _x('Beauty Quiz', 'template name', 'web-stories'),
   tags: [
     _x('Fashion & Beauty', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/belly-fat-workout/index.js
+++ b/packages/templates/src/raw/belly-fat-workout/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'belly-fat-workout',
   title: _x('Belly Fat Workout', 'template name', 'web-stories'),
   tags: [
     _x('Health', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/buying-art-on-the-internet/index.js
+++ b/packages/templates/src/raw/buying-art-on-the-internet/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'buying-art-on-the-internet',
   title: _x('Buying Art on the Internet', 'template name', 'web-stories'),
   tags: [
     _x('Arts & Craft', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/celebrity-q-and-a/index.js
+++ b/packages/templates/src/raw/celebrity-q-and-a/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'celebrity-q-a',
   title: _x('Celebrity Q & A', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/diy-home-office/index.js
+++ b/packages/templates/src/raw/diy-home-office/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'diy-home-office',
   title: _x('DIY Home Office', 'template name', 'web-stories'),
   tags: [
     _x('Arts & Craft', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/doers-get-more-done/index.js
+++ b/packages/templates/src/raw/doers-get-more-done/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'doers-get-more-done',
   title: _x('Doers Get More Done', 'template name', 'web-stories'),
   tags: [
     _x('Doers', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/elegant-travel-itinerary/index.js
+++ b/packages/templates/src/raw/elegant-travel-itinerary/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'elegant-travel-itinerary',
   title: _x('Elegant Travel Itinerary', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/experience-thailand/index.js
+++ b/packages/templates/src/raw/experience-thailand/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'experience-thailand',
   title: _x('Experience Thailand', 'template name', 'web-stories'),
   tags: [
     _x('Explore', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fashion-inspiration/index.js
+++ b/packages/templates/src/raw/fashion-inspiration/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'fashion-inspiration',
   title: _x('Fashion Inspiration', 'template name', 'web-stories'),
   tags: [
     _x('Fashion', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fashion-on-the-go/index.js
+++ b/packages/templates/src/raw/fashion-on-the-go/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'fashion-on-the-go',
   title: _x('Fashion On The Go', 'template name', 'web-stories'),
   tags: [
     _x('Clothing', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fitness-apps-ranked/index.js
+++ b/packages/templates/src/raw/fitness-apps-ranked/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'fitness-apps-ranked',
   title: _x('Fitness Apps Ranked', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/food-and-stuff/index.js
+++ b/packages/templates/src/raw/food-and-stuff/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'food-stuff',
   title: _x('Food & Stuff', 'template name', 'web-stories'),
   tags: [
     _x('Delicious', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/fresh-and-bright/index.js
+++ b/packages/templates/src/raw/fresh-and-bright/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'fresh-bright',
   title: _x('Fresh & Bright', 'template name', 'web-stories'),
   tags: [
     _x('Health', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/google-music-studio-tour/index.js
+++ b/packages/templates/src/raw/google-music-studio-tour/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'google-music-studio-tour',
   title: _x('Google Music Studio Tour', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/hawaii-travel-packing-list/index.js
+++ b/packages/templates/src/raw/hawaii-travel-packing-list/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'hawaii-travel-packing-list',
   title: _x('Hawaii Travel Packing List', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/honeymooning-in-italy/index.js
+++ b/packages/templates/src/raw/honeymooning-in-italy/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'honeymooning-in-italy',
   title: _x('Honeymooning in Italy', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/house-hunting/index.js
+++ b/packages/templates/src/raw/house-hunting/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'house-hunting',
   title: _x('House Hunting', 'template name', 'web-stories'),
   tags: [
     _x('Home', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/how-contact-tracing-works/index.js
+++ b/packages/templates/src/raw/how-contact-tracing-works/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'how-contact-tracing-works',
   title: _x('How Contact Tracing Works', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/how-video-calls-saved-the-day/index.js
+++ b/packages/templates/src/raw/how-video-calls-saved-the-day/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'how-video-calls-saved-the-day',
   title: _x('How Video Calls Saved the Day', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/indoor-garden-oasis/index.js
+++ b/packages/templates/src/raw/indoor-garden-oasis/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'indoor-garden-oasis-diy',
   title: _x('Indoor Garden Oasis DIY', 'template name', 'web-stories'),
   tags: [
     _x('Home', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/kitchen-makeover/index.js
+++ b/packages/templates/src/raw/kitchen-makeover/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'kitchen-makeover',
   title: _x('Kitchen Makeover', 'template name', 'web-stories'),
   tags: [
     _x('Home & Garden', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/kitchen-stories/index.js
+++ b/packages/templates/src/raw/kitchen-stories/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'kitchen-stories',
   title: _x('Kitchen Stories', 'template name', 'web-stories'),
   tags: [
     _x('Cooking', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/laptop-buying-guide/index.js
+++ b/packages/templates/src/raw/laptop-buying-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'laptop-buying-guide',
   title: _x('Laptop Buying Guide', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/los-angeles-city-guide/index.js
+++ b/packages/templates/src/raw/los-angeles-city-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'los-angeles-city-guide',
   title: _x('Los Angeles City Guide', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/magazine-article/index.js
+++ b/packages/templates/src/raw/magazine-article/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'magazine-article',
   title: _x('Magazine Article', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/modernist-travel-guide/index.js
+++ b/packages/templates/src/raw/modernist-travel-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'modernist-travel-guide',
   title: _x('Modernist Travel Guide', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/new-york-party-round-up/index.js
+++ b/packages/templates/src/raw/new-york-party-round-up/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'new-york-party-round-up',
   title: _x('New York Party Round-up', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/no-days-off/index.js
+++ b/packages/templates/src/raw/no-days-off/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'no-days-off',
   title: _x('No Days Off', 'template name', 'web-stories'),
   tags: [
     _x('Exercise', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/pizzas-in-nyc/index.js
+++ b/packages/templates/src/raw/pizzas-in-nyc/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'pizzas-in-nyc',
   title: _x('Pizzas in NYC', 'template name', 'web-stories'),
   tags: [
     _x('Travel', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/plant-based-dyes/index.js
+++ b/packages/templates/src/raw/plant-based-dyes/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'plant-based-dyes-diy',
   title: _x('Plant Based Dyes DIY', 'template name', 'web-stories'),
   tags: [
     _x('Crafts', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/pride-month-watchlist/index.js
+++ b/packages/templates/src/raw/pride-month-watchlist/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'pride-month-watchlist',
   title: _x('Pride Month Watchlist', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/rock-music-festival/index.js
+++ b/packages/templates/src/raw/rock-music-festival/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'rock-music-festival',
   title: _x('Rock Music Festival', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/sangria-artichoke/index.js
+++ b/packages/templates/src/raw/sangria-artichoke/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'trendy-winter-veggie',
   title: _x('Trendy Winter Veggie', 'template name', 'web-stories'),
   tags: [
     _x('Food', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/sangria-artichoke/index.js
+++ b/packages/templates/src/raw/sangria-artichoke/index.js
@@ -25,7 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
-  slug: 'trendy-winter-veggie',
+  slug: 'sangria-artichoke',
   title: _x('Trendy Winter Veggie', 'template name', 'web-stories'),
   tags: [
     _x('Food', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/self-care-guide/index.js
+++ b/packages/templates/src/raw/self-care-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'self-care-guide',
   title: _x('Self-care Guide', 'template name', 'web-stories'),
   tags: [
     _x('Health & Wellness', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/simple-tech-tutorial/index.js
+++ b/packages/templates/src/raw/simple-tech-tutorial/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'simple-tech-tutorial',
   title: _x('Simple Tech Tutorial ', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/skin-care-at-home/index.js
+++ b/packages/templates/src/raw/skin-care-at-home/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'skin-care-at-home',
   title: _x('Skin Care at Home', 'template name', 'web-stories'),
   tags: [
     _x('Beauty', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/sleep/index.js
+++ b/packages/templates/src/raw/sleep/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'sleep',
   title: _x('Sleep', 'template name', 'web-stories'),
   tags: [
     _x('Health', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/street-style-on-the-go/index.js
+++ b/packages/templates/src/raw/street-style-on-the-go/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'street-style-on-the-go',
   title: _x('Street Style On The Go', 'template name', 'web-stories'),
   tags: [
     _x('Fashion', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/summer-fashion-collection/index.js
+++ b/packages/templates/src/raw/summer-fashion-collection/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'summer-fashion-collection',
   title: _x('Summer Fashion Collection', 'template name', 'web-stories'),
   tags: [
     _x('Fashion', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/tv-show-recap/index.js
+++ b/packages/templates/src/raw/tv-show-recap/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'tv-show-recap',
   title: _x('TV Show Recap', 'template name', 'web-stories'),
   tags: [
     _x('Entertainment', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/ultimate-comparison/index.js
+++ b/packages/templates/src/raw/ultimate-comparison/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'ultimate-comparison',
   title: _x('Ultimate Comparison', 'template name', 'web-stories'),
   tags: [
     _x('Technology', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/vintage-chairs-buying-guide/index.js
+++ b/packages/templates/src/raw/vintage-chairs-buying-guide/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'vintage-chair-buying-guide',
   title: _x('Vintage Chair Buying Guide', 'template name', 'web-stories'),
   tags: [
     _x('Home', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/ways-to-eat-avocado/index.js
+++ b/packages/templates/src/raw/ways-to-eat-avocado/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'ways-to-eat-avocado',
   title: _x('Ways to Eat Avocado', 'template name', 'web-stories'),
   tags: [
     _x('Nutrition', 'template keyword', 'web-stories'),

--- a/packages/templates/src/raw/weekly-entertainment/index.js
+++ b/packages/templates/src/raw/weekly-entertainment/index.js
@@ -25,6 +25,7 @@ import { __, _x } from '@web-stories-wp/i18n';
 import { default as template } from './template';
 
 export default {
+  slug: 'weekly-entertainment',
   title: _x('Weekly Entertainment', 'template name', 'web-stories'),
   tags: [
     _x('Funny', 'template keyword', 'web-stories'),

--- a/packages/templates/src/test/raw.js
+++ b/packages/templates/src/test/raw.js
@@ -207,4 +207,16 @@ describe('raw template files', () => {
       }
     }
   );
+
+  // @see https://github.com/google/web-stories-wp/pull/8692
+  it.each(templates)(
+    '%s template should contain a slug for screenshot referencing',
+    async (template) => {
+      const { default: templateData } = await import(
+        /* webpackChunkName: "chunk-web-stories-template-[index]" */ `../raw/${template}`
+      );
+
+      expect(templateData.slug).toBeString();
+    }
+  );
 });


### PR DESCRIPTION
## Context

Following work done by @merapi this is the first step in getting template pages as images to render instead of Stories in the dashboard (as well as for page layouts in the editor).  

References: https://github.com/google/web-stories-wp/pull/8491, https://github.com/merapi/test-amp-screenshot/blob/master/index.js 

Thanks Marcin! This is such a cool idea, totally credit to you. 



## Summary

Adds script to templates package to run that will generate screenshots of every template page ( `npm run workflow:render-template-posters`).  
Screenshots added here: https://github.com/google/web-stories-wp/pull/8727

## Relevant Technical Choices

- Using emulateMediaFeatures to set 'prefers-reduced-motion' when looking at the preview of a template to prevent animations from running so that screenshots get all elements on the page. 
- Add a `slug` to each template and pass it through to use for asset naming so it's consistent. Added a test to make sure each template has one moving forward.

## To-do

- [x] Despite prefers-reduced-motion doing the bulk of the heavy lifting, there's a few template pages that don't look right. It might be just timing? 

- ~The Honeymooning in Italy template is broken. I filed a bug here. #8691  If you want to run the script locally to test it you'll need to comment out that template in `getTemplates` (`templateNames`).~
- We should add an option to run this for just one template so that it's less time consuming for templates added moving forward. This is my first time working with puppeteer like this though so I wanted to do it separately incase there's improvements I can make here that would come in handy with that. 

## User-facing changes

None

## Testing Instructions

Try running the script locally. If you don't want to watch this thing for an hour, just set the `templateCount` to like 3 and you can see it run. 

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [ ] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #8373
