### PR TITLE
Media Library: Show video without delay if missing poster

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/common/innerElement.js
+++ b/packages/story-editor/src/components/library/panes/media/common/innerElement.js
@@ -175,7 +175,7 @@ function InnerElement({
     muted: true,
     preload: 'metadata',
     poster: displayPoster,
-    showWithoutDelay: Boolean(newVideoPosterRef.current),
+    showWithoutDelay: !poster || Boolean(newVideoPosterRef.current),
   };
 
   if (type === ContentType.IMAGE) {

--- a/packages/story-editor/src/components/library/panes/media/common/innerElement.js
+++ b/packages/story-editor/src/components/library/panes/media/common/innerElement.js
@@ -201,7 +201,7 @@ function InnerElement({
             />
           )}
         </Video>
-        {!newVideoPosterRef.current && (
+        {!newVideoPosterRef.current && poster && (
           /* eslint-disable-next-line styled-components-a11y/alt-text -- False positive. */
           <HiddenPosterImage
             ref={hiddenPoster}

--- a/packages/story-editor/src/components/library/panes/media/common/innerElement.js
+++ b/packages/story-editor/src/components/library/panes/media/common/innerElement.js
@@ -201,7 +201,7 @@ function InnerElement({
             />
           )}
         </Video>
-        {!newVideoPosterRef.current && poster && (
+        {displayPoster && (
           /* eslint-disable-next-line styled-components-a11y/alt-text -- False positive. */
           <HiddenPosterImage
             ref={hiddenPoster}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

I noticed that videos were not properly displayed in the media library if they have a missing poster. All one would see is a dark rectangle, because the video had `opacity: 0` and there was no `HiddenPosterImage` to display in its place.

## Summary

<!-- A brief description of what this PR does. -->

Fixes an issue where videos are displayed with a black rectangle instead of a preview/poster.

Changes the rendering so that videos are shown without delay if there is no poster to load in its place.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Before:

![Screenshot 2021-08-18 at 11 59 09](https://user-images.githubusercontent.com/841956/129879747-6ef06cb5-898c-447b-8aab-94e9ad6ca0bd.png)

After:

![Screenshot 2021-08-18 at 11 59 14](https://user-images.githubusercontent.com/841956/129879765-3705e118-5deb-44e3-9035-995ab9aaf0ee.png)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Upload video to the WordPress media library (so it has no poster)
2. Log in as contributor (so no poster image can be generated & uploaded)
3. See video in the media library without a dark rectangle but an actual preview/poster

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Related: #8449
