### PR TITLE
Media: Add `isMuted` property to `getVideoResource`

### DIFF
--- a/packages/story-editor/src/app/media/utils/getResourceFromLocalFile.js
+++ b/packages/story-editor/src/app/media/utils/getResourceFromLocalFile.js
@@ -27,6 +27,7 @@ import {
   getFileName,
   getImageDimensions,
   createFileReader,
+  hasVideoGotAudio,
 } from '@web-stories-wp/media';
 
 /**
@@ -99,6 +100,7 @@ const getVideoResource = async (file) => {
     });
   }
   const posterFile = await getFirstFrameOfVideo(src);
+  const hasAudio = await hasVideoGotAudio(src);
   const poster = createBlob(posterFile);
   const { width, height } = await getImageDimensions(poster);
 
@@ -108,6 +110,7 @@ const getVideoResource = async (file) => {
     src: canPlayVideo ? src : '',
     ...getResourceSize({ width, height }),
     poster,
+    isMuted: !hasAudio,
     length,
     lengthFormatted,
     alt,


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Add isMuted property to getVideoResource, so mute icon shows while video is transcoding / uploading. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

### QA

<!--
Not all changes require manual QA.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Drag video ( that has no audio ) into editor. 
2. See preview uploading, have muted icon. 

### UAT

<!--
Sometimes the testing instructions for UAT can differ from the ones for QA.
-->

<!-- ignore-task-list-start -->
- [x] UAT should use the same steps as above.
<!-- ignore-task-list-end -->

<!--
If the above checkbox has not been checked, write down all steps necessary for user acceptance testing take to test this PR.
-->
This PR can be tested by following these steps:

1.

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This PR contains automated tests (unit, integration, and/or e2e) to verify the code works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.
Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
