### PR TITLE
Code Quality: Styled Components Warning in Sticker Panel

### DIFF
--- a/packages/story-editor/src/components/library/panes/shapes/stickerPreview.js
+++ b/packages/story-editor/src/components/library/panes/shapes/stickerPreview.js
@@ -56,6 +56,15 @@ const StickerInner = styled.div`
   justify-content: center;
 `;
 
+const StickerClone = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  width: ${({ width }) => `${width}px`};
+  height: ${({ height }) => `${height}px`};
+`;
+
 function StickerPreview({ stickerType, index }) {
   const { insertElement } = useLibrary((state) => ({
     insertElement: state.actions.insertElement,
@@ -78,15 +87,6 @@ function StickerPreview({ stickerType, index }) {
     }),
     [aspectRatio, stickerType]
   );
-
-  const StickerClone = styled.div`
-    position: absolute;
-    top: 0;
-    left: 0;
-    opacity: 0;
-    width: ${({ width }) => `${width}px`};
-    height: ${({ height }) => `${height}px`};
-  `;
 
   const Svg = sticker.svg;
   return (


### PR DESCRIPTION
## Context
We were getting warnings in the console when the sticker panel was rendering

## Summary
For some reason a styled component definition made its way into the body of a component and it certainly didn't need to be there. This PR fixes that and eliminates the warning from printing to the console.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
NA
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Open the editor and navigate to the stickers/shapes panel. See that there's no more warning in the console about dynamic SC generation.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8732 
