### PR TITLE
Fix flaky cloning test

### DIFF
--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -47,7 +47,6 @@ fdescribe('Clone element integration', () => {
 
     // Save final objects
     img1 = await getElementByIndex(2);
-    img2 = await getElementByIndex(3);
   });
 
   afterEach(() => {
@@ -76,7 +75,6 @@ fdescribe('Clone element integration', () => {
     expect(await getNumElements()).toBe(2);
   });
 
-  // Disable reason: Flaky test, to be fixed in #8677
   it('should correctly clone 1 element', async () => {
     await fixture.snapshot('image is selected');
     // Press clone shortcut

--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -77,7 +77,7 @@ fdescribe('Clone element integration', () => {
     // Select the added shape.
     const shape = await getElementByIndex(2);
     await clickElement(shape.id);
-
+    await fixture.snapshot('shape selected');
     // Press clone shortcut
     await fixture.events.keyboard.shortcut('mod+d');
     // Expect a new image to have been added

--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -94,13 +94,12 @@ describe('Clone element integration', () => {
   });
 
   // Disable reason: Flaky test, to be fixed in #8677
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should correctly clone 1 element', async () => {
+  fit('should correctly clone 1 element', async () => {
     // Select img2
     await clickElement(img2.id);
-
+    await fixture.snapshot('image is selected');
     // Press clone shortcut
-    await fixture.events.keyboard.shortcut('mod+d');
+    /*await fixture.events.keyboard.shortcut('mod+d');
     // Expect a new image to have been added
     expect(await getNumElements()).toBe(4);
 
@@ -114,7 +113,7 @@ describe('Clone element integration', () => {
         x: img2.x + 30,
         y: img2.y + 30,
       })
-    );
+    );*/
   });
 
   it('should correctly clone 2 elements', async () => {

--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -76,7 +76,6 @@ fdescribe('Clone element integration', () => {
   });
 
   it('should correctly clone 1 element', async () => {
-    await fixture.snapshot('image is selected');
     // Press clone shortcut
     await fixture.events.keyboard.shortcut('mod+d');
     // Expect a new image to have been added

--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -64,11 +64,20 @@ fdescribe('Clone element integration', () => {
     expect(await getNumElements()).toBe(2);
   });
 
-  it('should correctly clone 1 element', async () => {
+  fit('should correctly clone 1 element', async () => {
     // Switch to shapes tab and add a triangle
     await fixture.events.click(fixture.editor.library.shapesTab);
-    await fixture.events.click(fixture.editor.library.shapes.shape('Triangle'));
+    await fixture.events.click(
+      fixture.editor.library.shapes.shape('Rectangle')
+    );
+
+    // Select background to clear element selection.
+    await clickElement(bg.id);
+
+    // Select the added shape.
     const shape = await getElementByIndex(2);
+    await clickElement(shape.id);
+
     // Press clone shortcut
     await fixture.events.keyboard.shortcut('mod+d');
     // Expect a new image to have been added
@@ -79,7 +88,7 @@ fdescribe('Clone element integration', () => {
     expect(clonedShape).toEqual(
       jasmine.objectContaining({
         mask: {
-          type: 'triangle',
+          type: 'rectangle',
         },
         x: shape.x + 30,
         y: shape.y + 30,

--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -20,7 +20,7 @@
 import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
 
-fdescribe('Clone element integration', () => {
+describe('Clone element integration', () => {
   let fixture;
   let bg, bgRect;
 
@@ -77,7 +77,7 @@ fdescribe('Clone element integration', () => {
     // Select the added shape.
     const shape = await getElementByIndex(2);
     await clickElement(shape.id);
-    await fixture.snapshot('shape selected');
+
     // Press clone shortcut
     await fixture.events.keyboard.shortcut('mod+d');
     // Expect a new image to have been added

--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -64,7 +64,7 @@ fdescribe('Clone element integration', () => {
     expect(await getNumElements()).toBe(2);
   });
 
-  fit('should correctly clone 1 element', async () => {
+  it('should correctly clone 1 element', async () => {
     // Switch to shapes tab and add a triangle
     await fixture.events.click(fixture.editor.library.shapesTab);
     await fixture.events.click(

--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -99,9 +99,9 @@ describe('Clone element integration', () => {
     await clickElement(img2.id);
     await fixture.snapshot('image is selected');
     // Press clone shortcut
-    /*await fixture.events.keyboard.shortcut('mod+d');
+    await fixture.events.keyboard.shortcut('mod+d');
     // Expect a new image to have been added
-    expect(await getNumElements()).toBe(4);
+    /*expect(await getNumElements()).toBe(4);
 
     // Verify new element is in fact a clone and in correct position
     const clonedImg = await getElementByIndex(4);

--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -20,18 +20,16 @@
 import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
 
-describe('Clone element integration', () => {
+fdescribe('Clone element integration', () => {
   let fixture;
-  let bg, img1, img2;
+  let bg, img1, img2, bgRect;
 
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
 
     bg = await getElementByIndex(1);
-    const bgRect = (
-      await getCanvasElementWrapperById(bg.id)
-    ).getBoundingClientRect();
+    bgRect = (await getCanvasElementWrapperById(bg.id)).getBoundingClientRect();
 
     // Add first image to page
     await fixture.events.click(getMediaElement(/blue-marble/));
@@ -44,21 +42,6 @@ describe('Clone element integration', () => {
       move(rect1.left + 10, rect1.top + 10),
       down(),
       move(bgRect.left + 50, bgRect.top + 50, { steps: 2 }),
-      up(),
-    ]);
-
-    // Add second image to page
-    await fixture.events.click(getMediaElement(/saturn/));
-    img2 = await getElementByIndex(3);
-
-    // Drag it to (100,100)
-    const rect2 = (
-      await getCanvasElementWrapperById(img2.id)
-    ).getBoundingClientRect();
-    await fixture.events.mouse.seq(({ move, down, up }) => [
-      move(rect2.left + 10, rect2.top + 10),
-      down(),
-      move(bgRect.left + 100, bgRect.top + 100, { steps: 2 }),
       up(),
     ]);
 
@@ -79,7 +62,7 @@ describe('Clone element integration', () => {
     await fixture.events.keyboard.shortcut('mod+d');
 
     // Expect nothing to have changed
-    expect(await getNumElements()).toBe(3);
+    expect(await getNumElements()).toBe(2);
   });
 
   it('should correctly do nothing if background is selected', async () => {
@@ -90,34 +73,48 @@ describe('Clone element integration', () => {
     await fixture.events.keyboard.shortcut('mod+d');
 
     // Expect nothing to have changed
-    expect(await getNumElements()).toBe(3);
+    expect(await getNumElements()).toBe(2);
   });
 
   // Disable reason: Flaky test, to be fixed in #8677
-  fit('should correctly clone 1 element', async () => {
-    // Select img2
-    await clickElement(img2.id);
+  it('should correctly clone 1 element', async () => {
     await fixture.snapshot('image is selected');
     // Press clone shortcut
     await fixture.events.keyboard.shortcut('mod+d');
     // Expect a new image to have been added
-    /*expect(await getNumElements()).toBe(4);
+    expect(await getNumElements()).toBe(3);
 
     // Verify new element is in fact a clone and in correct position
-    const clonedImg = await getElementByIndex(4);
+    const clonedImg = await getElementByIndex(3);
     expect(clonedImg).toEqual(
       jasmine.objectContaining({
         resource: jasmine.objectContaining({
-          src: img2.resource.src,
+          src: img1.resource.src,
         }),
-        x: img2.x + 30,
-        y: img2.y + 30,
+        x: img1.x + 30,
+        y: img1.y + 30,
       })
-    );*/
+    );
   });
 
   it('should correctly clone 2 elements', async () => {
-    // Select img1 and img2
+    // Add second image to page
+    await fixture.events.click(getMediaElement(/saturn/));
+    img2 = await getElementByIndex(3);
+
+    // Drag it to (100,100)
+    const rect2 = (
+      await getCanvasElementWrapperById(img2.id)
+    ).getBoundingClientRect();
+    await fixture.events.mouse.seq(({ move, down, up }) => [
+      move(rect2.left + 10, rect2.top + 10),
+      down(),
+      move(bgRect.left + 100, bgRect.top + 100, { steps: 2 }),
+      up(),
+    ]);
+    img2 = await getElementByIndex(3);
+
+    // Select img1 and img2.
     await clickElement(img1.id);
     await clickElement(img2.id, /* isMultiSelect */ true);
 
@@ -174,7 +171,7 @@ describe('Clone element integration', () => {
       // hold shift
       await fixture.events.keyboard.down('shift');
     }
-    await fixture.events.mouse.click(rect.left + 1, rect.top + 1);
+    await fixture.events.mouse.click(rect.left + 10, rect.top + 10);
     if (isMultiSelect) {
       // release shift
       await fixture.events.keyboard.up('shift');


### PR DESCRIPTION
## Context
Fixes the testing of cloning an element (`should correctly clone 1 element`)
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
- This PR also switches to using shapes instead of images in case of some tests. This is for avoiding the going over the safezone. We can change that back though if preferred since it doesn't seem to really make a difference. However, it might be good to test with more than 1 element type.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8677 
