### PR TITLE
Editor: Make secondary nav button padding consistent

### DIFF
--- a/packages/story-editor/src/components/carousel/secondaryMenu.js
+++ b/packages/story-editor/src/components/carousel/secondaryMenu.js
@@ -50,14 +50,6 @@ const MenuItems = styled.div`
   margin: 0 16px 16px;
 `;
 
-const Box = styled.div`
-  width: 32px;
-  height: 32px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
-
 const Space = styled.span`
   width: 8px;
 `;
@@ -181,9 +173,7 @@ function SecondaryMenu() {
           <Checklist />
         </ChecklistCountProvider>
         <Space />
-        <Box>
-          <KeyboardShortcutsMenu />
-        </Box>
+        <KeyboardShortcutsMenu />
       </MenuItems>
     </Wrapper>
   );

--- a/packages/story-editor/src/components/helpCenter/toggle/index.js
+++ b/packages/story-editor/src/components/helpCenter/toggle/index.js
@@ -31,6 +31,10 @@ const MainIcon = styled(Icons.QuestionMarkOutline)`
   width: auto;
   display: block;
 `;
+const StyledToggleButton = styled(ToggleButton)`
+  padding-left: 3px;
+  padding-right: 3px;
+`;
 
 function Toggle({
   isOpen = false,
@@ -39,7 +43,7 @@ function Toggle({
   notificationCount = 0,
 }) {
   return (
-    <ToggleButton
+    <StyledToggleButton
       aria-owns={popupId}
       aria-label={
         notificationCount > 0

--- a/packages/story-editor/src/components/keyboardShortcutsMenu/index.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/index.js
@@ -34,6 +34,12 @@ import ShortcutMenu from './shortcutMenu';
 import { TOGGLE_SHORTCUTS_MENU } from './constants';
 import { useKeyboardShortcutsMenu } from './keyboardShortcutsMenuContext';
 
+const StyledToggleButton = styled(ToggleButton)`
+  padding-left: 3px;
+  padding-right: 3px;
+  width: auto;
+`;
+
 const Wrapper = styled.div`
   /**
     * sibling inherits parent z-index of Z_INDEX.EDIT
@@ -79,7 +85,7 @@ function KeyboardShortcutsMenu() {
           <ShortcutMenu toggleMenu={toggle} />
         </Popup>
 
-        <ToggleButton
+        <StyledToggleButton
           ref={anchorRef}
           isOpen={isOpen}
           aria-owns="keyboard_shortcut_menu"


### PR DESCRIPTION
## Context
Small design tweak.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Makes the horizontal space between icons and button border consistent within the secondary nav of the carousel.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
All have to have different padding to accommodate different spaces embedded in all the svgs.
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Updated button padding:
<img width="302" alt="Screen Shot 2021-08-23 at 3 40 04 PM" src="https://user-images.githubusercontent.com/35983235/130518673-d316019c-e933-4a88-959f-40935720c231.png">

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
NA
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8612 
