### PR TITLE
E2E Tests: Fix flakey Web Stories widget block test

### DIFF
--- a/packages/e2e-tests/src/specs/wordpress/blockWidget.js
+++ b/packages/e2e-tests/src/specs/wordpress/blockWidget.js
@@ -36,18 +36,16 @@ describe('Web Stories Widget Block', () => {
     await deleteWidgets();
   });
 
-  // Disable reason: https://github.com/google/web-stories-wp/issues/8402
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip('should insert a new web stories block', async () => {
+  it('should insert a new web stories block', async () => {
     await visitBlockWidgetScreen();
     await expect(page).toClick('button[aria-label="Add block"]');
     await page.type('.block-editor-inserter__search-input', 'Web Stories');
     await expect(page).toClick('button span', { text: 'Web Stories' });
 
     await page.waitForSelector('.web-stories-block-configuration-panel');
-    await expect(page).toMatchElement('.web-stories-block-configuration-panel');
+    await expect(page).toClick('.web-stories-block-configuration-panel');
 
-    await expect(page).toClick('button', { text: 'Story URL' });
+    await expect(page).toClick('button[aria-label="Embed a visual story."]');
 
     await expect(page).toMatchElement('input[aria-label="Story URL"]');
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8402
