### PR TITLE
KSES: Fix typo to allow `amp-story-page-outlink`

### DIFF
--- a/includes/KSES.php
+++ b/includes/KSES.php
@@ -518,7 +518,7 @@ class KSES extends Service_Base {
 				'href'  => true,
 				'theme' => true,
 			],
-			'amp-story-page-outline'    => [
+			'amp-story-page-outlink'    => [
 				'cta-image'          => true,
 				'theme'              => true,
 				'cta-accent-color'   => true,

--- a/tests/phpunit/tests/KSES.php
+++ b/tests/phpunit/tests/KSES.php
@@ -417,6 +417,10 @@ class KSES extends Test_Case {
 				'<amp-img layout="fill" src="https://example.com/image.jpg" alt="example" srcset="https://example.com/image.jpg 900w,https://example.com/image-768x1024.jpg 768w,https://example.com/image-640x853.jpg 640w,https://example.com/image-225x300.jpg 225w,https://example.com/image-150x200.jpg 150w" sizes="(min-width: 1024px) 14vh, 32vw" disable-inline-width="true"></amp-img>',
 				'<amp-img layout="fill" src="https://example.com/image.jpg" alt="example" srcset="https://example.com/image.jpg 900w,https://example.com/image-768x1024.jpg 768w,https://example.com/image-640x853.jpg 640w,https://example.com/image-225x300.jpg 225w,https://example.com/image-150x200.jpg 150w" sizes="(min-width: 1024px) 14vh, 32vw" disable-inline-width="true"></amp-img>',
 			],
+			'Page Outlink'                     => [
+				'<amp-story-page-outlink layout="nodisplay" theme="custom" cta-accent-color="#0047FF" cta-image="https://example.com/32x32icon.jpg" cta-accent-element="background"><a href="https://www.google.com">Read More</a></amp-story-page-outlink>',
+				'<amp-story-page-outlink layout="nodisplay" theme="custom" cta-accent-color="#0047FF" cta-image="https://example.com/32x32icon.jpg" cta-accent-element="background"><a href="https://www.google.com">Read More</a></amp-story-page-outlink>',
+			],
 		];
 	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Authors can't use page attachments because `amp-story-page-outlink` was missing from the allowlist due to a typo.

## Summary

<!-- A brief description of what this PR does. -->

Fix typo to allow `amp-story-page-outlink` 

## Relevant Technical Choices

<!-- Please describe your changes. -->

Adds a unit test for this change.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Page attachments should not be removed on the frontend anymore if publishing as an author.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Publish a story with page attachment as an author.
2. Look for page attachment on the frontend.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8784
