### PR TITLE
Canvas: fix disabling nav buttons if there's no page

### DIFF
--- a/packages/design-system/src/components/button/button.js
+++ b/packages/design-system/src/components/button/button.js
@@ -69,7 +69,8 @@ const Base = styled.button(
       }
     `}
 
-    &:disabled {
+    &:disabled,
+    &[aria-disabled="true"] {
       pointer-events: none;
       background-color: ${theme.colors.interactiveBg.disable};
       color: ${theme.colors.fg.disable};
@@ -120,7 +121,8 @@ const tertiaryColors = ({ theme }) => css`
     background-color: ${theme.colors.interactiveBg.tertiaryHover};
   }
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled="true"] {
     background-color: ${theme.colors.interactiveBg.tertiaryNormal};
     &:hover,
     &:focus {
@@ -155,7 +157,8 @@ const quaternaryColors = ({ theme }) => css`
       border-color: ${theme.colors.border.defaultPress};
     `}
 
-  &:disabled {
+  &:disabled,
+  &[aria-disabled="true"] {
     border-color: ${theme.colors.border.disable};
     background-color: ${theme.colors.interactiveBg.quaternaryNormal};
   }
@@ -225,7 +228,8 @@ const ButtonLink = styled(Base)`
       color: ${theme.colors.fg.linkHover};
     }
     &:active,
-    &:disabled {
+    &:disabled,
+    &[aria-disabled="true"] {
       background-color: ${theme.colors.opacity.footprint};
     }
   `}

--- a/packages/design-system/src/components/button/button.js
+++ b/packages/design-system/src/components/button/button.js
@@ -122,7 +122,7 @@ const tertiaryColors = ({ theme }) => css`
   }
 
   &:disabled,
-  &[aria-disabled="true"] {
+  &[aria-disabled='true'] {
     background-color: ${theme.colors.interactiveBg.tertiaryNormal};
     &:hover,
     &:focus {
@@ -158,7 +158,7 @@ const quaternaryColors = ({ theme }) => css`
     `}
 
   &:disabled,
-  &[aria-disabled="true"] {
+  &[aria-disabled='true'] {
     border-color: ${theme.colors.border.disable};
     background-color: ${theme.colors.interactiveBg.quaternaryNormal};
   }
@@ -229,7 +229,7 @@ const ButtonLink = styled(Base)`
     }
     &:active,
     &:disabled,
-    &[aria-disabled="true"] {
+    &[aria-disabled='true'] {
       background-color: ${theme.colors.opacity.footprint};
     }
   `}

--- a/packages/story-editor/src/components/canvas/pagenav/index.js
+++ b/packages/story-editor/src/components/canvas/pagenav/index.js
@@ -97,8 +97,7 @@ function PageNav({ isNext = true }) {
         variant={BUTTON_VARIANTS.SQUARE}
         type={BUTTON_TYPES.TERTIARY}
         size={BUTTON_SIZES.MEDIUM}
-        isDisabled={!displayNav}
-        isHidden={!displayNav}
+        aria-disabled={!displayNav}
         aria-label={
           isNext
             ? __('Next Page', 'web-stories')


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

The next/previous navigation buttons next to the canvas ought to be disabled if there's no page to navigate to.

However, this was somehow forgotten during some refactoring, passing some non-existent `isDisabled` and `isHidden` props.

## Summary

<!-- A brief description of what this PR does. -->

This PR addresses this by disabling the buttons using `aria-disabled`, which means they can still receive focus and can get tabbed to, to ensure accessibility.

We probably need to do this in many other places too, but this is a start.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Updates the button component from the design system so it can 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Before:

![Screenshot 2021-08-26 at 16 21 46](https://user-images.githubusercontent.com/841956/130993855-b8fa1857-f248-4e71-b2e1-370f56b748fa.png)

After:

![Screenshot 2021-08-26 at 17 41 18](https://user-images.githubusercontent.com/841956/130993882-acced4eb-a5c3-4556-8794-9f5a6af60c95.png)
![Screenshot 2021-08-26 at 17 41 14](https://user-images.githubusercontent.com/841956/130993886-c5c7be3a-48c8-4cc2-b56c-f23e8e26d1a9.png)
![Screenshot 2021-08-26 at 17 41 10](https://user-images.githubusercontent.com/841956/130993888-50e55d1c-3af7-4c8c-a74f-d09046e80281.png)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. See that next/prev buttons are disabled on the canvas when there's no page to navigate to

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
