### PR TITLE
Text Sets Pane: Add empty state

### DIFF
--- a/packages/story-editor/src/components/emptyContentMessage.js
+++ b/packages/story-editor/src/components/emptyContentMessage.js
@@ -26,8 +26,9 @@ const Message = styled.div`
   align-items: center;
   max-width: 400px;
   margin: 8vh auto;
+  text-align: center;
 
-  & > * {
+  * {
     text-align: center;
     margin: 0 auto;
   }

--- a/packages/story-editor/src/components/emptyContentMessage.js
+++ b/packages/story-editor/src/components/emptyContentMessage.js
@@ -18,7 +18,7 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { DesertColor } from '@web-stories-wp/design-system';
+import { DesertBw } from '@web-stories-wp/design-system';
 
 const Message = styled.div`
   display: flex;
@@ -33,7 +33,7 @@ const Message = styled.div`
   }
 `;
 
-const EmptyImage = styled(DesertColor)`
+const EmptyImage = styled(DesertBw)`
   margin-bottom: 48px;
 `;
 

--- a/packages/story-editor/src/components/emptyContentMessage.js
+++ b/packages/story-editor/src/components/emptyContentMessage.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { DesertColor } from '@web-stories-wp/design-system';
+
+const Message = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 400px;
+  margin: 8vh auto;
+
+  & > * {
+    text-align: center;
+    margin: 0 auto;
+  }
+`;
+
+const EmptyImage = styled(DesertColor)`
+  margin-bottom: 48px;
+`;
+
+function EmptyContentMessage({ children, ...props }) {
+  return (
+    <Message {...props}>
+      <EmptyImage aria-hidden width={274} height={118} />
+      {children}
+    </Message>
+  );
+}
+
+EmptyContentMessage.propTypes = {
+  children: PropTypes.node,
+};
+
+export default EmptyContentMessage;

--- a/packages/story-editor/src/components/library/libraryProvider.js
+++ b/packages/story-editor/src/components/library/libraryProvider.js
@@ -46,6 +46,7 @@ const LIBRARY_TAB_IDS = new Set(
 function LibraryProvider({ children }) {
   const [tab, setTab] = useState(MEDIA.id);
   const [textSets, setTextSets] = useState({});
+  const [areTextSetsLoading, setAreTextSetsLoading] = useState({});
   const [savedTemplates, setSavedTemplates] = useState(null);
   // The first page of templates to fetch is 1.
   const [nextTemplatesToFetch, setNextTemplatesToFetch] = useState(1);
@@ -105,6 +106,7 @@ function LibraryProvider({ children }) {
   const state = useMemo(
     () => ({
       state: {
+        areTextSetsLoading,
         tab,
         tabRefs,
         textSets,
@@ -124,6 +126,7 @@ function LibraryProvider({ children }) {
       },
     }),
     [
+      areTextSetsLoading,
       tab,
       tabRefs,
       textSets,
@@ -139,8 +142,10 @@ function LibraryProvider({ children }) {
   useEffect(() => {
     async function getTextSets() {
       const trackTiming = getTimeTracker('load_text_sets');
+      setAreTextSetsLoading(true);
       setTextSets(await loadTextSets());
       trackTiming();
+      setAreTextSetsLoading(false);
     }
     // if text sets have not been loaded but are needed fetch dynamically imported text sets
     if (tab === TEXT.id && !Object.keys(textSets).length) {

--- a/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
+++ b/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
@@ -192,6 +192,18 @@ function TextSetsPane({ paneRef }) {
 
   const sectionId = useMemo(() => `section-${uuidv4()}`, []);
   const toggleId = useMemo(() => `toggle_text_sets_${uuidv4()}`, []);
+
+  const emptyContentMessage = useMemo(
+    () =>
+      showInUse
+        ? __(
+            'No matching Text Sets available. Try adding text to your story.',
+            'web-stories'
+          )
+        : __('No Text Sets available.', 'web-stories'),
+    [showInUse]
+  );
+
   return (
     <SectionContainer id={sectionId}>
       <TitleBar>
@@ -229,9 +241,7 @@ function TextSetsPane({ paneRef }) {
       </FullWidthWrapper>
       <TextSetsWrapper>
         {!filteredTextSets?.length && !areTextSetsLoading ? (
-          <EmptyContentMessage>
-            {__('No Text Sets available.', 'web-stories')}
-          </EmptyContentMessage>
+          <EmptyContentMessage>{emptyContentMessage}</EmptyContentMessage>
         ) : (
           <TextSets paneRef={paneRef} filteredTextSets={filteredTextSets} />
         )}

--- a/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
+++ b/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
@@ -230,7 +230,7 @@ function TextSetsPane({ paneRef }) {
       <TextSetsWrapper>
         {!filteredTextSets?.length && !areTextSetsLoading ? (
           <EmptyContentMessage>
-            {__('No text sets available.', 'web-stories')}
+            {__('No Text Sets available.', 'web-stories')}
           </EmptyContentMessage>
         ) : (
           <TextSets paneRef={paneRef} filteredTextSets={filteredTextSets} />

--- a/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
+++ b/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
@@ -82,7 +82,12 @@ const TextSetsWrapper = styled.div`
 `;
 
 function TextSetsPane({ paneRef }) {
-  const { textSets } = useLibrary(({ state: { textSets } }) => ({ textSets }));
+  const { areTextSetsLoading, textSets } = useLibrary(
+    ({ state: { areTextSetsLoading, textSets } }) => ({
+      areTextSetsLoading,
+      textSets,
+    })
+  );
   const [showInUse, setShowInUse] = useState(false);
 
   const allTextSets = useMemo(() => Object.values(textSets).flat(), [textSets]);
@@ -223,12 +228,12 @@ function TextSetsPane({ paneRef }) {
         />
       </FullWidthWrapper>
       <TextSetsWrapper>
-        {filteredTextSets?.length ? (
-          <TextSets paneRef={paneRef} filteredTextSets={filteredTextSets} />
-        ) : (
+        {!filteredTextSets?.length && !areTextSetsLoading ? (
           <EmptyContentMessage>
             {__('No text sets available.', 'web-stories')}
           </EmptyContentMessage>
+        ) : (
+          <TextSets paneRef={paneRef} filteredTextSets={filteredTextSets} />
         )}
       </TextSetsWrapper>
     </SectionContainer>

--- a/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
+++ b/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
@@ -57,6 +57,7 @@ import {
 } from '../../../../../utils/getInUseFonts';
 import { Container as SectionContainer } from '../../../common/section';
 import { virtualPaneContainer } from '../../shared/virtualizedPanelGrid';
+import EmptyContentMessage from '../../../../emptyContentMessage';
 import TextSets from './textSets';
 import { CATEGORIES, PANE_TEXT } from './constants';
 
@@ -222,7 +223,13 @@ function TextSetsPane({ paneRef }) {
         />
       </FullWidthWrapper>
       <TextSetsWrapper>
-        <TextSets paneRef={paneRef} filteredTextSets={filteredTextSets} />
+        {filteredTextSets?.length ? (
+          <TextSets paneRef={paneRef} filteredTextSets={filteredTextSets} />
+        ) : (
+          <EmptyContentMessage>
+            {__('No text sets available.', 'web-stories')}
+          </EmptyContentMessage>
+        )}
       </TextSetsWrapper>
     </SectionContainer>
   );


### PR DESCRIPTION
## Summary

Add empty state to text sets pane.

## Relevant Technical Choices

Added a loading state too so that the empty message didn't show while the text sets are loading.

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/22185279/131180587-4ca4a80f-2dc7-4a1b-afd2-f1d2b9cdf0d1.png)|![image](https://user-images.githubusercontent.com/22185279/131183544-036df340-e27f-4ad2-92df-69e77ccd66bc.png)|


## Testing Instructions

Difficult to test without actually editing the code.

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to `packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js`
2. Replace lines 230 - 238 with this:

```js
      <TextSetsWrapper>
        {true ? (
          <EmptyContentMessage>
            {__('No text sets available.', 'web-stories')}
          </EmptyContentMessage>
        ) : (
          <TextSets paneRef={paneRef} filteredTextSets={filteredTextSets} />
        )}
      </TextSetsWrapper>
```


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6806 
