### PR TITLE
Hide permalink input when using ugly permalinks

### DIFF
--- a/packages/story-editor/src/components/panels/document/slug/slug.js
+++ b/packages/story-editor/src/components/panels/document/slug/slug.js
@@ -109,24 +109,27 @@ function SlugPanel() {
       ? permalinkConfig.prefix + slug + permalinkConfig.suffix
       : link;
 
+  // In case of non-pretty permalinks, we're not showing the input.
   return (
     <SimplePanel
       name="permalink"
       title={__('Permalink', 'web-stories')}
       collapsedByDefault={false}
     >
-      <PermalinkRow>
-        <Input
-          value={String(slug)}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          placeholder={__('Enter slug', 'web-stories')}
-          aria-label={__('URL slug', 'web-stories')}
-          minLength={MIN_MAX.PERMALINK.MIN}
-          maxLength={MIN_MAX.PERMALINK.MAX}
-          containerStyleOverride={inputContainerStyleOverride}
-        />
-      </PermalinkRow>
+      {permalinkConfig && (
+        <PermalinkRow>
+          <Input
+            value={String(slug)}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            placeholder={__('Enter slug', 'web-stories')}
+            aria-label={__('URL slug', 'web-stories')}
+            minLength={MIN_MAX.PERMALINK.MIN}
+            maxLength={MIN_MAX.PERMALINK.MAX}
+            containerStyleOverride={inputContainerStyleOverride}
+          />
+        </PermalinkRow>
+      )}
       <LinkContainer>
         <Link
           rel="noopener noreferrer"

--- a/packages/story-editor/src/components/panels/document/slug/test/slug.js
+++ b/packages/story-editor/src/components/panels/document/slug/test/slug.js
@@ -26,7 +26,7 @@ import StoryContext from '../../../../../app/story/context';
 import { renderWithTheme } from '../../../../../testUtils';
 import SlugPanel, { MIN_MAX } from '../slug';
 
-function arrange() {
+function arrange(storyConfig = {}) {
   const updateStory = jest.fn();
 
   const storyContextValue = {
@@ -38,6 +38,7 @@ function arrange() {
           prefix: 'https://example.com/',
           suffix: '',
         },
+        ...storyConfig,
       },
     },
     actions: { updateStory },
@@ -74,6 +75,13 @@ describe('SlugPanel', () => {
     arrange();
     const url = screen.getByRole('link', { name: 'https://example.com/foo' });
     expect(url).toBeInTheDocument();
+  });
+
+  it('should not display the input when using non-pretty permalinks', () => {
+    arrange({ permalinkConfig: null });
+    expect(() => screen.getByRole('textbox', { name: 'URL slug' })).toThrow(
+      'Unable to find an accessible element with the role "textbox" and name "URL slug"'
+    );
   });
 
   it('should not allow trailing spaces while typing and onblur', async () => {


### PR DESCRIPTION

## Summary
As in Gutenberg, hides the permalink input in case of using ugly permalinks and displays only the link.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
<img width="303" alt="Screenshot 2021-08-30 at 14 59 59" src="https://user-images.githubusercontent.com/3294597/131335790-cabacc19-a31c-4753-a9fc-9245e5d47d04.png">

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
1. Go to Settings -> Permalinks
2. Set "Plain" and save.
3. Now go to a Story, open the Document tab and see the Permalink panel.
4. Verify that input is not there and it only displays the permalink.
5. Now set anything else as the setting for the Permalinks.
6. Go back to the same story, verify that the input is now visible in the Permalink panel.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #787 
