### PR TITLE
Media: Improve handling of uploads in progress

### DIFF
--- a/packages/story-editor/src/app/media/test/useUploadMedia.js
+++ b/packages/story-editor/src/app/media/test/useUploadMedia.js
@@ -50,7 +50,7 @@ jest.mock('../utils/useMediaUploadQueue', () => ({
       isTranscoding: false,
       pending: [],
       progress: [],
-      posterProcessed: [],
+      uploaded: [],
       failures: [],
     },
   })),

--- a/packages/story-editor/src/app/media/useUploadMedia.js
+++ b/packages/story-editor/src/app/media/useUploadMedia.js
@@ -63,7 +63,7 @@ function useUploadMedia({
       isTranscoding,
       pending,
       progress,
-      posterProcessed,
+      uploaded,
       failures,
     },
     actions: { addItem, removeItem },
@@ -137,7 +137,7 @@ function useUploadMedia({
   // Handle *processed* items.
   // Update resources in media library and on canvas.
   useEffect(() => {
-    for (const { id, resource, onUploadSuccess } of posterProcessed) {
+    for (const { id, resource, onUploadSuccess } of uploaded) {
       if (!resource) {
         continue;
       }
@@ -150,7 +150,7 @@ function useUploadMedia({
 
       removeItem({ id });
     }
-  }, [posterProcessed, updateMediaElement, removeItem]);
+  }, [uploaded, updateMediaElement, removeItem]);
 
   // Handle *failed* items.
   // Remove resources from media library and canvas.

--- a/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
+++ b/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
@@ -359,7 +359,9 @@ function useMediaUploadQueue() {
         pending: state.queue.filter((item) => item.state === 'PENDING'),
         uploaded: state.queue.filter((item) => item.state === 'UPLOADED'),
         failures: state.queue.filter((item) => item.state === 'CANCELLED'),
-        isUploading: state.queue.length !== 0,
+        isUploading: state.queue.some(
+          (item) => !['UPLOADED', 'CANCELLED', 'PENDING'].includes(item.state)
+        ),
         isTranscoding: state.queue.some((item) => item.state === 'TRANSCODING'),
         isMuting: state.queue.some((item) => item.state === 'MUTING'),
       },

--- a/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
+++ b/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
@@ -357,9 +357,7 @@ function useMediaUploadQueue() {
           (item) => !['UPLOADED', 'CANCELLED', 'PENDING'].includes(item.state)
         ),
         pending: state.queue.filter((item) => item.state === 'PENDING'),
-        posterProcessed: state.queue.filter(
-          (item) => item.state === 'UPLOADED'
-        ),
+        uploaded: state.queue.filter((item) => item.state === 'UPLOADED'),
         failures: state.queue.filter((item) => item.state === 'CANCELLED'),
         isUploading: state.queue.length !== 0,
         isTranscoding: state.queue.some((item) => item.state === 'TRANSCODING'),

--- a/packages/story-editor/src/app/media/utils/useMediaUploadQueue/test/useMediaUploadQueue.js
+++ b/packages/story-editor/src/app/media/utils/useMediaUploadQueue/test/useMediaUploadQueue.js
@@ -111,7 +111,7 @@ describe('useMediaUploadQueue', () => {
 
     await waitForNextUpdate();
 
-    expect(result.current.state.isUploading).toBeTrue();
+    expect(result.current.state.isUploading).toBeFalse();
     expect(result.current.state.uploaded).toHaveLength(1);
 
     const { id } = result.current.state.uploaded[0];

--- a/packages/story-editor/src/app/media/utils/useMediaUploadQueue/test/useMediaUploadQueue.js
+++ b/packages/story-editor/src/app/media/utils/useMediaUploadQueue/test/useMediaUploadQueue.js
@@ -85,7 +85,7 @@ describe('useMediaUploadQueue', () => {
       expect(result.current.state).toStrictEqual({
         pending: [],
         failures: [],
-        posterProcessed: [],
+        uploaded: [],
         progress: [],
         isUploading: false,
         isTranscoding: false,
@@ -112,14 +112,14 @@ describe('useMediaUploadQueue', () => {
     await waitForNextUpdate();
 
     expect(result.current.state.isUploading).toBeTrue();
-    expect(result.current.state.posterProcessed).toHaveLength(1);
+    expect(result.current.state.uploaded).toHaveLength(1);
 
-    const { id } = result.current.state.posterProcessed[0];
+    const { id } = result.current.state.uploaded[0];
 
     act(() => result.current.actions.removeItem({ id }));
 
     expect(result.current.state.isUploading).toBeFalse();
-    expect(result.current.state.posterProcessed).toHaveLength(0);
+    expect(result.current.state.uploaded).toHaveLength(0);
   });
 
   it('allows removing items from the queue', async () => {
@@ -136,11 +136,11 @@ describe('useMediaUploadQueue', () => {
     await waitForNextUpdate();
 
     expect(result.current.state.failures).toHaveLength(0);
-    expect(result.current.state.posterProcessed).toHaveLength(1);
+    expect(result.current.state.uploaded).toHaveLength(1);
 
     act(() =>
       result.current.actions.removeItem({
-        id: result.current.state.posterProcessed[0].id,
+        id: result.current.state.uploaded[0].id,
       })
     );
 
@@ -148,7 +148,7 @@ describe('useMediaUploadQueue', () => {
       expect(result.current.state).toStrictEqual({
         pending: [],
         failures: [],
-        posterProcessed: [],
+        uploaded: [],
         progress: [],
         isUploading: false,
         isTranscoding: false,

--- a/packages/story-editor/src/components/header/buttons/buttonWithChecklistWarning.js
+++ b/packages/story-editor/src/components/header/buttons/buttonWithChecklistWarning.js
@@ -46,7 +46,7 @@ const Button = styled(DefaultButton)`
   }
 `;
 
-function ButtonWithChecklistWarning({ text, ...buttonProps }) {
+function ButtonWithChecklistWarning({ text, isUploading, ...buttonProps }) {
   const { checkpoint, shouldReviewDialogBeSeen } = useCheckpoint(
     ({ state: { checkpoint, shouldReviewDialogBeSeen } }) => ({
       checkpoint,
@@ -80,8 +80,16 @@ function ButtonWithChecklistWarning({ text, ...buttonProps }) {
     [PPC_CHECKPOINT_STATE.UNAVAILABLE]: '',
   };
 
+  const TOOLTIP_TEXT_UPLOADING = __(
+    'Saving is disabled due to media currently being uploaded.',
+    'web-stories'
+  );
+
   return (
-    <Tooltip title={TOOLTIP_TEXT[checkpoint]} hasTail>
+    <Tooltip
+      title={isUploading ? TOOLTIP_TEXT_UPLOADING : TOOLTIP_TEXT[checkpoint]}
+      hasTail
+    >
       {button}
     </Tooltip>
   );
@@ -89,6 +97,7 @@ function ButtonWithChecklistWarning({ text, ...buttonProps }) {
 
 ButtonWithChecklistWarning.propTypes = {
   text: PropTypes.node.isRequired,
+  isUploading: PropTypes.bool.isRequired,
 };
 
 export default ButtonWithChecklistWarning;

--- a/packages/story-editor/src/components/header/buttons/publish.js
+++ b/packages/story-editor/src/components/header/buttons/publish.js
@@ -124,6 +124,7 @@ function Publish() {
         onClick={handlePublish}
         disabled={!capabilities?.hasPublishAction || isSaving || isUploading}
         text={text}
+        isUploading={isUploading}
       />
       <ReviewChecklistDialog
         isOpen={showDialog}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

There were cases where the publish button kept being disabled forever due to some lingering media upload.

## Summary

<!-- A brief description of what this PR does. -->

This PR improves the way to determine whether there's any upload in progress. Previously, any non-empty queue would mean an upload is in progress, whereas now we check for the state of the queued items.

This helps prevent cases where the publish button was disabled forever due to some lingering uploads. This scenario happened to a few users in the support forums, but so far we haven't been able to reproduce it. But this change should help mitigate that.

A tooltip is being added to further improve UX for uploads in progress.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Adds a tooltip to the publish button when an upload is in progress, so users better understand what's going on.

![Screenshot 2021-08-30 at 21 26 55](https://user-images.githubusercontent.com/841956/131393958-bb266b03-a5ce-45df-b7c0-f0f770cd3c8c.png)


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Drop a larger video or image into the canvas for upload
2. Hover over the publish button to see a tooltip about upload being in progress


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8701
