### PR TITLE
Bug: Checklist intercepting pointer events when closed

### DIFF
--- a/packages/story-editor/src/components/checklist/videoOptimizationCheckbox/index.js
+++ b/packages/story-editor/src/components/checklist/videoOptimizationCheckbox/index.js
@@ -30,6 +30,7 @@ import styled from 'styled-components';
  */
 import { useConfig, useCurrentUser } from '../../../app';
 import { CARD_WIDTH } from '../../secondaryPopup';
+import { useIsChecklistMounted } from '../popupMountedContext';
 
 const Container = styled.div`
   display: flex;
@@ -63,6 +64,7 @@ const CheckboxLabel = styled(DescriptionText)`
 `;
 
 function VideoOptimizationCheckbox() {
+  const isChecklistMounted = useIsChecklistMounted();
   const { capabilities: { hasUploadMediaAction } = {}, dashboardSettingsLink } =
     useConfig();
   const { currentUser, toggleWebStoriesMediaOptimization } = useCurrentUser(
@@ -76,7 +78,7 @@ function VideoOptimizationCheckbox() {
   const checked = currentUser?.meta?.web_stories_media_optimization;
   const showCheckbox = !checked && hasUploadMediaAction;
 
-  return showCheckbox ? (
+  return showCheckbox && isChecklistMounted ? (
     <Container>
       <DescriptionText>
         {__(

--- a/packages/story-editor/src/components/checklist/videoOptimizationCheckbox/test/index.js
+++ b/packages/story-editor/src/components/checklist/videoOptimizationCheckbox/test/index.js
@@ -30,6 +30,10 @@ jest.mock('../../../../app', () => ({
   useCurrentUser: jest.fn(),
 }));
 
+jest.mock('../../popupMountedContext', () => ({
+  useIsChecklistMounted: jest.fn(() => true),
+}));
+
 const mockUseConfig = useConfig;
 const mockUseCurrentUser = useCurrentUser;
 const mockToggleWebStoriesMediaOptimization = jest.fn();


### PR DESCRIPTION
## Context
Some pointer events around the carousel thumbnails were getting blocked by the checklist.

## Summary
This Fixes the pointer events from getting blocked when the checklist is closed.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
NA
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8846 
