### PR TITLE
Enabled smart colors

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -350,6 +350,7 @@ class Experiments extends Service_Base {
 				'label'       => __( 'Smart text color', 'web-stories' ),
 				'description' => __( 'Enable text insertion with smart color ensuring good contrast with the background', 'web-stories' ),
 				'group'       => 'editor',
+				'default'     => true,
 			],
 			/**
 			 * Author: @merapi
@@ -361,6 +362,7 @@ class Experiments extends Service_Base {
 				'label'       => __( 'Smart text sets color', 'web-stories' ),
 				'description' => __( 'Enable text sets insertion with smart color ensuring good contrast with the background', 'web-stories' ),
 				'group'       => 'editor',
+				'default'     => true,
 			],
 			/**
 			 * Author: @merapi


### PR DESCRIPTION
## Context

This enables smart colors by default.

## Testing Instructions

This PR can be tested by following these steps:

1. Add a text preset or text set to various backgrounds and see the elements added in proper contrasting color (potentially with a background/scrim).
2. Observe that this does not cause a "serious" lag before insertion.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #8238
