### PR TITLE
Media Hotlinking: Improve the logic in case of empty value

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/local/hotlink/hotlinkModal.js
+++ b/packages/story-editor/src/components/library/panes/media/local/hotlink/hotlinkModal.js
@@ -85,12 +85,13 @@ function HotlinkModal({ isOpen, onClose }) {
 
   const onChange = useCallback(
     (value) => {
-      if (!value?.length) {
+      // Always set the error to null when changing.
+      if (errorMsg) {
         setErrorMsg(null);
       }
       setLink(value);
     },
-    [setLink]
+    [setLink, errorMsg]
   );
 
   return (

--- a/packages/story-editor/src/components/library/panes/media/local/hotlink/hotlinkModal.js
+++ b/packages/story-editor/src/components/library/panes/media/local/hotlink/hotlinkModal.js
@@ -75,11 +75,23 @@ function HotlinkModal({ isOpen, onClose }) {
   });
 
   const onBlur = useCallback(() => {
-    setLink(withProtocol(link));
-    if (!isValidUrl(link)) {
-      setErrorMsg(__('Invalid link.', 'web-stories'));
+    if (link?.length > 0) {
+      setLink(withProtocol(link));
+      if (!isValidUrl(link)) {
+        setErrorMsg(__('Invalid link.', 'web-stories'));
+      }
     }
   }, [link]);
+
+  const onChange = useCallback(
+    (value) => {
+      if (!value?.length) {
+        setErrorMsg(null);
+      }
+      setLink(value);
+    },
+    [setLink]
+  );
 
   return (
     <Dialog
@@ -97,7 +109,7 @@ function HotlinkModal({ isOpen, onClose }) {
       <InputWrapper>
         <Input
           ref={inputRef}
-          onChange={({ target: { value } }) => setLink(value)}
+          onChange={({ target: { value } }) => onChange(value)}
           value={link}
           hint={errorMsg?.length ? errorMsg : description}
           hasError={Boolean(errorMsg?.length)}

--- a/packages/story-editor/src/components/library/panes/media/local/hotlink/useInsert.js
+++ b/packages/story-editor/src/components/library/panes/media/local/hotlink/useInsert.js
@@ -111,7 +111,7 @@ function useInsert({ link, setLink, setErrorMsg, onClose }) {
   );
 
   const onInsert = useCallback(() => {
-    if (!link?.length) {
+    if (!link) {
       return;
     }
     if (!isValidUrl(link)) {

--- a/packages/story-editor/src/components/library/panes/media/local/hotlink/useInsert.js
+++ b/packages/story-editor/src/components/library/panes/media/local/hotlink/useInsert.js
@@ -111,6 +111,9 @@ function useInsert({ link, setLink, setErrorMsg, onClose }) {
   );
 
   const onInsert = useCallback(() => {
+    if (!link?.length) {
+      return;
+    }
     if (!isValidUrl(link)) {
       setErrorMsg(__('Invalid link.', 'web-stories'));
       return;

--- a/packages/story-editor/src/components/library/panes/media/local/karma/hotlink.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/hotlink.karma.js
@@ -54,12 +54,25 @@ describe('Embedding hotlinked media', () => {
       name: 'Insert',
     });
 
+    // Try inserting from a string that's not a link at all.
+    await fixture.events.click(input);
+    await fixture.events.keyboard.type('d');
+    await fixture.events.click(insertBtn);
+    let dialog = screen.getByRole('dialog');
+    await waitFor(() => expect(dialog.textContent).toContain('Invalid link'));
+
+    // Delete the value, verify now the informative message show instead again.
+    await fixture.events.click(input, { clickCount: 3 });
+    await fixture.events.keyboard.press('Del');
+    dialog = screen.getByRole('dialog');
+    await waitFor(() => expect(dialog.textContent).toContain('You can insert'));
+
     await fixture.events.click(input);
     await fixture.events.keyboard.type('https://example.jpg');
     await fixture.events.click(insertBtn);
 
     await fixture.events.sleep(500);
-    const dialog = screen.getByRole('dialog');
+    dialog = screen.getByRole('dialog');
     await waitFor(() =>
       expect(dialog.textContent).toContain('Media failed to load')
     );


### PR DESCRIPTION
## Summary
Improves how the messages are handled in case of empty link values.
- When link is empty, Insert button doesn't do anything
- When there's an error and the user changes the link, the informative message about file types to use is displayed again
- When the input is empty and the users tabs away from it, nothing happens.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
![empty-link](https://user-images.githubusercontent.com/3294597/131515759-20e3f59b-e1e1-4596-90ed-1c8b98a77379.gif)

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8847 
