### PR TITLE
Color Picker: Avoid overflow with saved colors

### DIFF
--- a/packages/story-editor/src/components/popup/index.js
+++ b/packages/story-editor/src/components/popup/index.js
@@ -28,6 +28,7 @@ import {
   createPortal,
 } from '@web-stories-wp/react';
 import PropTypes from 'prop-types';
+import { THEME_CONSTANTS } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -60,7 +61,7 @@ const Container = styled.div.attrs(
   position: fixed;
   z-index: 2;
   overflow-y: auto;
-  max-height: 100vh;
+  max-height: calc(100vh - ${THEME_CONSTANTS.WP_ADMIN.TOOLBAR_HEIGHT}px);
 `;
 
 function Popup({

--- a/packages/story-editor/src/components/popup/utils.js
+++ b/packages/story-editor/src/components/popup/utils.js
@@ -15,6 +15,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { THEME_CONSTANTS } from '@web-stories-wp/design-system';
+
+/**
  * Internal dependencies
  */
 import { Placement } from './constants';
@@ -156,7 +161,10 @@ export function getOffset(placement, spacing, anchor, dock, popup, isRTL) {
   // Clamp values
   return {
     x: Math.max(0, Math.min(offsetX, maxOffsetX)),
-    y: Math.max(0, Math.min(offsetY, maxOffsetY)),
+    y: Math.max(
+      THEME_CONSTANTS.WP_ADMIN.TOOLBAR_HEIGHT,
+      Math.min(offsetY, maxOffsetY)
+    ),
     width: anchorRect.width,
     height: anchorRect.height,
   };


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## Testing Instructions
1. Add a bunch of global Saved colors so that multiple rows would appear in the color picker.
2. Resize the window so that the color picker would not fit fully and open the color picker.
3. Verify that the color picker header is not hidden behind the admin bar.
4. Verify there is a scrollbar and all the colors are visible when scrolling.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8656 
