### PR TITLE
Added video trim dummy as a new edit mode

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -424,6 +424,18 @@ class Experiments extends Service_Base {
 				'description' => __( 'Enable support of tags and categories for stories', 'web-stories' ),
 				'group'       => 'editor',
 			],
+
+			/**
+			 * Author: @barklund
+			 * Issue: #8877
+			 * Creation date: 2021-09-01
+			 */
+			[
+				'name'        => 'enableVideoTrim',
+				'label'       => __( 'Video trimming', 'web-stories' ),
+				'description' => __( 'Enable video trimming', 'web-stories' ),
+				'group'       => 'editor',
+			],
 		];
 	}
 

--- a/packages/story-editor/src/components/canvas/editLayer.js
+++ b/packages/story-editor/src/components/canvas/editLayer.js
@@ -30,7 +30,7 @@ import { getDefinitionForType } from '../../elements';
 import { useStory, useCanvas } from '../../app';
 import withOverlay from '../overlay/withOverlay';
 import EditElement from './editElement';
-import { Layer, PageArea, Z_INDEX } from './layout';
+import { Layer, PageArea, MenuArea, Z_INDEX } from './layout';
 import useFocusCanvas from './useFocusCanvas';
 
 const LayerWithGrayout = styled(Layer)`
@@ -63,7 +63,7 @@ function EditLayer() {
 function EditLayerForElement({ element }) {
   const ref = useRef(null);
   const pageAreaRef = useRef(null);
-  const { editModeGrayout } = getDefinitionForType(element.type);
+  const { editModeGrayout, EditMenu } = getDefinitionForType(element.type);
 
   const { clearEditing } = useCanvas((state) => ({
     clearEditing: state.actions.clearEditing,
@@ -102,6 +102,11 @@ function EditLayerForElement({ element }) {
       >
         <EditElement element={element} />
       </EditPageArea>
+      {EditMenu && (
+        <MenuArea>
+          <EditMenu />
+        </MenuArea>
+      )}
     </LayerWithGrayout>
   );
 }

--- a/packages/story-editor/src/components/panels/design/videoOptions/videoOptions.js
+++ b/packages/story-editor/src/components/panels/design/videoOptions/videoOptions.js
@@ -38,6 +38,7 @@ import { useCallback, useMemo, useEffect } from '@web-stories-wp/react';
 /**
  * Internal dependencies
  */
+import useCanvas from '../../../../app/canvas/useCanvas';
 import { Row as DefaultRow } from '../../../form';
 import { SimplePanel } from '../../panel';
 import { getCommonValue } from '../../shared';
@@ -50,6 +51,10 @@ const Row = styled(DefaultRow)`
 
 const StyledButton = styled(Button)`
   padding: 12px 8px;
+`;
+
+const TrimButton = styled(StyledButton)`
+  margin-left: 20px;
 `;
 
 const Label = styled.label`
@@ -72,6 +77,7 @@ const HelperText = styled(Text).attrs({
 
 function VideoOptionsPanel({ selectedElements, pushUpdate }) {
   const isMuteVideoEnabled = useFeature('enableMuteVideo');
+  const isVideoTrimEnabled = useFeature('enableVideoTrim');
   const { isTranscodingEnabled } = useFFmpeg();
   const { muteExistingVideo } = useLocalMedia((state) => ({
     muteExistingVideo: state.actions.muteExistingVideo,
@@ -105,11 +111,26 @@ function VideoOptionsPanel({ selectedElements, pushUpdate }) {
     isMuting,
   ]);
 
+  const shouldDisplayTrimButton = useMemo(
+    () => isSingleElement && isVideoTrimEnabled,
+    [isSingleElement, isVideoTrimEnabled]
+  );
+
   const buttonText = useMemo(() => {
     return isMuting
       ? __('Removing audio', 'web-stories')
       : __('Remove audio', 'web-stories');
   }, [isMuting]);
+
+  const { setEditingElementWithState } = useCanvas(
+    ({ actions: { setEditingElementWithState } }) => ({
+      setEditingElementWithState,
+    })
+  );
+
+  const handleTrim = useCallback(() => {
+    setEditingElementWithState(selectedElements[0].id, { isTrimming: true });
+  }, [setEditingElementWithState, selectedElements]);
 
   const speak = useLiveRegion();
 
@@ -137,6 +158,16 @@ function VideoOptionsPanel({ selectedElements, pushUpdate }) {
             {__('Loop', 'web-stories')}
           </Text>
         </Label>
+        {shouldDisplayTrimButton && (
+          <TrimButton
+            variant={BUTTON_VARIANTS.RECTANGLE}
+            type={BUTTON_TYPES.SECONDARY}
+            size={BUTTON_SIZES.SMALL}
+            onClick={handleTrim}
+          >
+            {__('Trim', 'web-stories')}
+          </TrimButton>
+        )}
       </Row>
       {shouldDisplayMuteButton && (
         <>

--- a/packages/story-editor/src/components/panels/design/videoOptions/videoOptions.js
+++ b/packages/story-editor/src/components/panels/design/videoOptions/videoOptions.js
@@ -122,15 +122,24 @@ function VideoOptionsPanel({ selectedElements, pushUpdate }) {
       : __('Remove audio', 'web-stories');
   }, [isMuting]);
 
-  const { setEditingElementWithState } = useCanvas(
-    ({ actions: { setEditingElementWithState } }) => ({
+  const { isEditing, setEditingElementWithState, clearEditing } = useCanvas(
+    ({
+      state: { isEditing },
+      actions: { setEditingElementWithState, clearEditing },
+    }) => ({
+      isEditing,
       setEditingElementWithState,
+      clearEditing,
     })
   );
 
   const handleTrim = useCallback(() => {
-    setEditingElementWithState(selectedElements[0].id, { isTrimming: true });
-  }, [setEditingElementWithState, selectedElements]);
+    if (isEditing) {
+      clearEditing();
+    } else {
+      setEditingElementWithState(selectedElements[0].id, { isTrimming: true });
+    }
+  }, [setEditingElementWithState, selectedElements, clearEditing, isEditing]);
 
   const speak = useLiveRegion();
 

--- a/packages/story-editor/src/elements/video/editMenu.js
+++ b/packages/story-editor/src/elements/video/editMenu.js
@@ -18,25 +18,21 @@
  * Internal dependencies
  */
 import useCanvas from '../../app/canvas/useCanvas';
-import StoryPropTypes from '../../types';
-import MediaEdit from '../media/edit';
-import Trim from './trim';
 
-function VideoEdit({ element, box, ...rest }) {
+function VideoEditMenu() {
   const { editingElementState } = useCanvas((state) => ({
     editingElementState: state.state.editingElementState,
   }));
 
-  if (editingElementState?.isTrimming) {
-    return <Trim element={element} box={box} {...rest} />;
+  if (!editingElementState?.isTrimming) {
+    return false;
   }
 
-  return <MediaEdit element={element} box={box} {...rest} />;
+  return (
+    <div style={{ border: '2px solid red', backgroundColor: 'hotpink' }}>
+      {'Dummy Edit Menu'}
+    </div>
+  );
 }
 
-VideoEdit.propTypes = {
-  element: StoryPropTypes.elements.video.isRequired,
-  box: StoryPropTypes.box.isRequired,
-};
-
-export default VideoEdit;
+export default VideoEditMenu;

--- a/packages/story-editor/src/elements/video/index.js
+++ b/packages/story-editor/src/elements/video/index.js
@@ -19,6 +19,7 @@
  */
 export { default as Display } from './display';
 export { default as Edit } from './edit';
+export { default as EditMenu } from './editMenu';
 export { default as Frame } from './frame';
 export { default as Controls } from './controls';
 export { default as Output } from './output';

--- a/packages/story-editor/src/elements/video/trim.js
+++ b/packages/story-editor/src/elements/video/trim.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import { useRef } from '@web-stories-wp/react';
+import { getMediaSizePositionProps } from '@web-stories-wp/media';
+/**
+ * Internal dependencies
+ */
+import StoryPropTypes from '../../types';
+import MediaDisplay from '../media/display';
+import { getBackgroundStyle, videoWithScale } from './util';
+
+const Video = styled.video`
+  position: absolute;
+  max-width: initial;
+  max-height: initial;
+  ${videoWithScale}
+`;
+
+function VideoTrim({ box: { width, height }, element }) {
+  const { poster, resource, tracks, isBackground, scale, focalX, focalY } =
+    element;
+  const ref = useRef();
+  let style = {};
+  if (isBackground) {
+    const styleProps = getBackgroundStyle();
+    style = {
+      ...style,
+      ...styleProps,
+    };
+  }
+
+  const videoProps = getMediaSizePositionProps(
+    resource,
+    width,
+    height,
+    scale,
+    focalX,
+    focalY
+  );
+
+  videoProps.crossOrigin = 'anonymous';
+
+  return (
+    <MediaDisplay
+      element={element}
+      mediaRef={ref}
+      showPlaceholder
+      previewMode={false}
+    >
+      <Video
+        poster={poster || resource.poster}
+        style={style}
+        {...videoProps}
+        preload="metadata"
+        loop
+        muted
+        autoPlay
+        tabIndex={0}
+        ref={ref}
+      >
+        {resource.src && <source src={resource.src} type={resource.mimeType} />}
+        {tracks &&
+          tracks.map(({ srclang, label, kind, track: src, id: key }, i) => (
+            <track
+              srcLang={srclang}
+              label={label}
+              kind={kind}
+              src={src}
+              key={key}
+              default={i === 0}
+            />
+          ))}
+      </Video>
+    </MediaDisplay>
+  );
+}
+
+VideoTrim.propTypes = {
+  previewMode: PropTypes.bool,
+  element: StoryPropTypes.elements.video.isRequired,
+  box: StoryPropTypes.box.isRequired,
+};
+
+export default VideoTrim;


### PR DESCRIPTION
## Context

This implements the first step of allowing video trimming in the editor.

## Relevant Technical Choices

* I decided to re-use the existing edit mode to do video trimming, as it made sense in the context. It is merely an edit element state flag. Edit element state was previously only used for text edit, but now also for video. This new edit mode can be triggered elsewhere by setting this state flag when entering edit mode.

## To-do

_Copied from #8877:_

* [x] Add a new feature flag
* [x] Add a button to the video setting panel trigger video trim mode (~for now, ignore UX weirdness with the "mute button" if both are present~ - this is actually solved properly)
* [x] Add the new video trim mode to the canvas
* [x] ~For now, just show the video poster image on the canvas, not the actual video (as we do for the existing video edit component)~ For now show the video muted, looping and auto-playing
* [x] Show a placeholder video trimmer in place of the page menu (most likely on top of the existing page menu). Don't create the actual trim component, just a placeholder.
* [x] Clicking on the element or the video trimmer does nothing. Clicking outside either exits video trim mode. Pressing <kbd>esc</kbd> exits video trim mode.

## User-facing changes

This gif demos that both the regular video edit mode and the new video trim mode co-exists:
![trim-mode](https://user-images.githubusercontent.com/637548/131771404-618fb53d-2d0d-45fc-8436-ed858ed5a07b.gif)

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #8877
