### PR TITLE
Right Click Menu: Fix drop shadow flicker

### DIFF
--- a/packages/design-system/src/components/contextMenu/contextMenu.js
+++ b/packages/design-system/src/components/contextMenu/contextMenu.js
@@ -39,6 +39,7 @@ const ContextMenu = ({ animate, isAlwaysVisible, items, ...props }) => {
         isOpen={isAlwaysVisible || props.isOpen}
       >
         <Menu aria-expanded={props.isOpen} items={items} {...props} />
+        {/* <AnimationContainer /> has a <Shadow />. Don't double the shadow. */}
         {!animate && <Shadow />}
       </Wrapper>
       {!isAlwaysVisible && props.isOpen && <Mask onDismiss={props.onDismiss} />}

--- a/packages/design-system/src/components/contextMenu/contextMenu.js
+++ b/packages/design-system/src/components/contextMenu/contextMenu.js
@@ -39,7 +39,7 @@ const ContextMenu = ({ animate, isAlwaysVisible, items, ...props }) => {
         isOpen={isAlwaysVisible || props.isOpen}
       >
         <Menu aria-expanded={props.isOpen} items={items} {...props} />
-        <Shadow />
+        {!animate && <Shadow />}
       </Wrapper>
       {!isAlwaysVisible && props.isOpen && <Mask onDismiss={props.onDismiss} />}
     </>


### PR DESCRIPTION
## Context



## Summary

Removes the extra `<Shadow />` component that was being rendered.

## Relevant Technical Choices

Two `<Shadow />` components were being rendered. The `<AnimationContainer />` has a shadow that animates, so that's the one we should use when animating the context menu.

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![broke](https://user-images.githubusercontent.com/22185279/131887507-5b697591-7e49-41ea-8135-1376296929d4.gif)|![fixed](https://user-images.githubusercontent.com/22185279/131887458-a3daef92-23a1-4f62-a2d6-0e1cb9281729.gif)|

## Testing Instructions

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open the editor
2. Right click on the background
3. Notice that the shadow around the menu does not flicker anymore.


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8885
