### PR TITLE
Edit Story: Freeform Taxonomy Component

### DIFF
--- a/packages/design-system/src/components/index.js
+++ b/packages/design-system/src/components/index.js
@@ -21,7 +21,7 @@ export { Chip } from './chip';
 export { Dialog } from './dialog';
 export { DropDown, DropDownSelect } from './dropDown';
 export { HexInput } from './hex';
-export { Input } from './input';
+export { Input, BaseInput } from './input';
 export { LoadingBar, LOADING_INDICATOR_CLASS } from './loadingBar';
 export { LoadingSpinner } from './loadingSpinner';
 export { MediaInput, MEDIA_VARIANTS } from './mediaInput';

--- a/packages/design-system/src/components/input/index.js
+++ b/packages/design-system/src/components/input/index.js
@@ -91,7 +91,7 @@ const InputContainer = styled.div(
   `
 );
 
-const StyledInput = styled.input(
+export const BaseInput = styled.input(
   ({ hasSuffix, theme }) => css`
     height: 100%;
     width: 100%;
@@ -180,7 +180,7 @@ export const Input = forwardRef(
           hasError={hasError}
           styleOverride={containerStyleOverride}
         >
-          <StyledInput
+          <BaseInput
             id={inputId}
             disabled={disabled}
             ref={(input) => {

--- a/packages/story-editor/src/components/form/stories/tags.js
+++ b/packages/story-editor/src/components/form/stories/tags.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import Tags from '../tags';
+
+const Bg = styled.div`
+  height: calc(100vh - 32px);
+  background: ${({ theme }) => theme.colors.bg.primary};
+`;
+
+const Wrapper = styled.div`
+  position: relative;
+  width: 250px;
+  inset: 15vh 0 0 0;
+  margin: auto;
+`;
+
+export default {
+  title: 'Stories Editor/Components/Form/Tags',
+  component: Tags,
+};
+
+export const _default = () => {
+  return (
+    <Bg>
+      <Wrapper>
+        <Tags.Label>{'Add New Tag'}</Tags.Label>
+        <Tags.Input />
+        <Tags.Description>
+          {'Separate with commas or the Enter key.'}
+        </Tags.Description>
+      </Wrapper>
+    </Bg>
+  );
+};

--- a/packages/story-editor/src/components/form/stories/tags.js
+++ b/packages/story-editor/src/components/form/stories/tags.js
@@ -44,9 +44,9 @@ export const _default = () => {
   return (
     <Bg>
       <Wrapper>
-        <Tags.Label>{'Add New Tag'}</Tags.Label>
-        <Tags.Input />
-        <Tags.Description>
+        <Tags.Label htmlFor="tags-input">{'Add New Tag'}</Tags.Label>
+        <Tags.Input id="tags-input" aria-describedby="tags-description" />
+        <Tags.Description id="tags-description">
           {'Separate with commas or the Enter key.'}
         </Tags.Description>
       </Wrapper>

--- a/packages/story-editor/src/components/form/stories/tags.js
+++ b/packages/story-editor/src/components/form/stories/tags.js
@@ -45,7 +45,11 @@ export const _default = () => {
     <Bg>
       <Wrapper>
         <Tags.Label htmlFor="tags-input">{'Add New Tag'}</Tags.Label>
-        <Tags.Input id="tags-input" aria-describedby="tags-description" />
+        <Tags.Input
+          id="tags-input"
+          aria-describedby="tags-description"
+          name="story-tags"
+        />
         <Tags.Description id="tags-description">
           {'Separate with commas or the Enter key.'}
         </Tags.Description>

--- a/packages/story-editor/src/components/form/tags/description.js
+++ b/packages/story-editor/src/components/form/tags/description.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import { Text, THEME_CONSTANTS } from '@web-stories-wp/design-system';
+
+export default styled(Text).attrs({
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
+})`
+  color: ${({ theme }) => theme.colors.fg.secondary};
+`;

--- a/packages/story-editor/src/components/form/tags/index.js
+++ b/packages/story-editor/src/components/form/tags/index.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { default as Input } from './input';
+import { default as Description } from './description';
+import { default as Label } from './label';
+
+const Tags = {
+  Input,
+  Description,
+  Label,
+};
+
+export default Tags;

--- a/packages/story-editor/src/components/form/tags/input.js
+++ b/packages/story-editor/src/components/form/tags/input.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { themeHelpers } from '@web-stories-wp/design-system';
+import { useMemo, useReducer, useState } from '@web-stories-wp/react';
+import styled, { css } from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import reducer, { ACTIONS } from './reducer';
+import Tag from './tag';
+
+const Border = styled.div`
+  ${({ theme, isInputFocused }) => css`
+    color: ${theme.colors.fg.primary};
+    border: 1px solid ${theme.colors.border.defaultNormal};
+    border-radius: ${theme.borders.radius.small};
+    ${isInputFocused && themeHelpers.focusCSS};
+  `}
+  display: flex;
+  flex-wrap: wrap;
+  padding: 3px 6px;
+  margin-bottom: 6px;
+
+  > input {
+    ${themeHelpers.expandTextPreset(
+      ({ paragraph }, { SMALL }) => paragraph[SMALL]
+    )}
+    border: none;
+    outline: none;
+    background: transparent;
+    color: inherit;
+    flex-grow: 1;
+    height: 38px;
+    margin: 3px 0;
+  }
+`;
+
+function Input(props) {
+  const [{ value, tags }, dispatch] = useReducer(reducer, {
+    value: '',
+    tags: [],
+  });
+  const [isInputFocused, setIsInputFocued] = useState(false);
+
+  const { handleFocus, handleBlur, handleKeyDown, handleChange, removeTag } =
+    useMemo(
+      () => ({
+        handleChange: (e) => {
+          dispatch({ type: ACTIONS.UPDATE_VALUE, payload: e.target.value });
+        },
+        handleKeyDown: (e) => {
+          if (['Comma', 'Enter'].includes(e.code)) {
+            dispatch({ type: ACTIONS.SUBMIT_VALUE });
+          }
+        },
+        removeTag: (tag) => () => {
+          dispatch({ type: ACTIONS.REMOVE_TAG, payload: tag });
+        },
+        handleFocus: () => setIsInputFocued(true),
+        handleBlur: () => setIsInputFocued(false),
+      }),
+      []
+    );
+
+  return (
+    <Border isInputFocused={isInputFocused}>
+      {tags.map((tag) => (
+        <Tag key={tag} onDismiss={removeTag(tag)}>
+          {tag}
+        </Tag>
+      ))}
+      <input
+        {...props}
+        type="text"
+        value={value}
+        onKeyDown={handleKeyDown}
+        onChange={handleChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+      />
+    </Border>
+  );
+}
+
+export default Input;

--- a/packages/story-editor/src/components/form/tags/input.js
+++ b/packages/story-editor/src/components/form/tags/input.js
@@ -16,7 +16,7 @@
 /**
  * External dependencies
  */
-import { themeHelpers } from '@web-stories-wp/design-system';
+import { themeHelpers, BaseInput } from '@web-stories-wp/design-system';
 import {
   useEffect,
   useMemo,
@@ -48,15 +48,9 @@ const Border = styled.div`
   margin-bottom: 6px;
 `;
 
-const TextInput = styled.input.attrs({ type: 'text' })`
-  ${themeHelpers.expandTextPreset(
-    ({ paragraph }, { SMALL }) => paragraph[SMALL]
-  )}
+const TextInput = styled(BaseInput).attrs({ type: 'text' })`
+  width: auto;
   flex-grow: 1;
-  border: none;
-  outline: none;
-  background: transparent;
-  color: inherit;
   height: 38px;
   margin: 3px 0;
 `;

--- a/packages/story-editor/src/components/form/tags/input.js
+++ b/packages/story-editor/src/components/form/tags/input.js
@@ -17,7 +17,14 @@
  * External dependencies
  */
 import { themeHelpers } from '@web-stories-wp/design-system';
-import { useMemo, useReducer, useState } from '@web-stories-wp/react';
+import {
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from '@web-stories-wp/react';
+import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 /**
@@ -54,13 +61,21 @@ const TextInput = styled.input.attrs({ type: 'text' })`
   margin: 3px 0;
 `;
 
-function Input(props) {
+function Input({ onChange, ...props }) {
   const [{ value, tags, offset }, dispatch] = useReducer(reducer, {
     value: '',
     tags: [],
     offset: 0,
   });
   const [isInputFocused, setIsInputFocued] = useState(false);
+
+  // Allow parents to pass onChange callback
+  // that updates as tags does.
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  useEffect(() => {
+    onChangeRef.current(tags);
+  }, [tags]);
 
   // Prepare and memoize event handlers to be as self
   // contained and descriptive as possible
@@ -132,5 +147,7 @@ function Input(props) {
     </Border>
   );
 }
-
+Input.propTypes = {
+  onChange: PropTypes.func,
+};
 export default Input;

--- a/packages/story-editor/src/components/form/tags/input.js
+++ b/packages/story-editor/src/components/form/tags/input.js
@@ -46,7 +46,6 @@ const TextInput = styled.input.attrs({ type: 'text' })`
     ({ paragraph }, { SMALL }) => paragraph[SMALL]
   )}
   flex-grow: 1;
-  flex-basis: 5ch;
   border: none;
   outline: none;
   background: transparent;
@@ -63,12 +62,13 @@ function Input(props) {
   });
   const [isInputFocused, setIsInputFocued] = useState(false);
 
+  // Prepare and memoize event handlers to be as self
+  // contained and descriptive as possible
   const { handleFocus, handleBlur, handleKeyDown, handleChange, removeTag } =
     useMemo(
       () => ({
-        handleChange: (e) => {
-          dispatch({ type: ACTIONS.UPDATE_VALUE, payload: e.target.value });
-        },
+        // Key interactions are modeled after WordPress Tag input UX
+        // and are only available when focused on the text input
         handleKeyDown: (e) => {
           if (e.key === 'ArrowLeft' && e.target.value === '') {
             dispatch({ type: ACTIONS.INCREMENT_OFFSET });
@@ -82,6 +82,9 @@ function Input(props) {
           if (['Comma', 'Enter'].includes(e.key)) {
             dispatch({ type: ACTIONS.SUBMIT_VALUE });
           }
+        },
+        handleChange: (e) => {
+          dispatch({ type: ACTIONS.UPDATE_VALUE, payload: e.target.value });
         },
         removeTag: (tag) => () => {
           dispatch({ type: ACTIONS.REMOVE_TAG, payload: tag });
@@ -99,27 +102,33 @@ function Input(props) {
 
   return (
     <Border isInputFocused={isInputFocused}>
-      {[
-        ...tags.slice(0, tags.length - offset),
-        INPUT_KEY,
-        ...tags.slice(tags.length - offset),
-      ].map((tag) =>
-        tag === INPUT_KEY ? (
-          <TextInput
-            key={INPUT_KEY}
-            {...props}
-            value={value}
-            onKeyDown={handleKeyDown}
-            onChange={handleChange}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-          />
-        ) : (
-          <Tag key={tag} onDismiss={removeTag(tag)}>
-            {tag}
-          </Tag>
+      {
+        // Text input should move, relative to end, with offset
+        // this helps with natural tab order and visuals
+        // as you ArrowLeft or ArrowRight through tags
+        [
+          ...tags.slice(0, tags.length - offset),
+          INPUT_KEY,
+          ...tags.slice(tags.length - offset),
+        ].map((tag) =>
+          tag === INPUT_KEY ? (
+            <TextInput
+              {...props}
+              key={INPUT_KEY}
+              value={value}
+              onKeyDown={handleKeyDown}
+              onChange={handleChange}
+              onFocus={handleFocus}
+              onBlur={handleBlur}
+              size="4"
+            />
+          ) : (
+            <Tag key={tag} onDismiss={removeTag(tag)}>
+              {tag}
+            </Tag>
+          )
         )
-      )}
+      }
     </Border>
   );
 }

--- a/packages/story-editor/src/components/form/tags/input.js
+++ b/packages/story-editor/src/components/form/tags/input.js
@@ -74,7 +74,7 @@ function Input({ onChange, ...props }) {
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
   useEffect(() => {
-    onChangeRef.current(tags);
+    onChangeRef.current?.(tags);
   }, [tags]);
 
   // Prepare and memoize event handlers to be as self

--- a/packages/story-editor/src/components/form/tags/label.js
+++ b/packages/story-editor/src/components/form/tags/label.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import { Text, THEME_CONSTANTS } from '@web-stories-wp/design-system';
+
+export default styled(Text).attrs({
+  forwardedAs: 'label',
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
+})`
+  display: inline-block;
+  color: ${({ theme }) => theme.colors.fg.secondary};
+  margin-bottom: 8px;
+`;

--- a/packages/story-editor/src/components/form/tags/reducer.js
+++ b/packages/story-editor/src/components/form/tags/reducer.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+function formatTag(tag) {
+  return tag.replace(/( +)/g, ' ').trim();
+}
+
+function uniquesOnly(arr) {
+  return [...new Set(arr)];
+}
+
+export const ACTIONS = {
+  UPDATE_VALUE: 'updateValue',
+  SUBMIT_VALUE: 'submitValue',
+};
+
+function reducer(state, action) {
+  switch (action.type) {
+    case ACTIONS.UPDATE_VALUE: {
+      const values = action.payload.split(',');
+      const newTags = values
+        .slice(0, -1)
+        .map(formatTag)
+        .filter((tag) => tag.length);
+      const value = values[values.length - 1];
+      return {
+        value,
+        tags: uniquesOnly([...state.tags, ...newTags]),
+      };
+    }
+    case ACTIONS.SUBMIT_VALUE: {
+      return {
+        value: '',
+        tags: uniquesOnly([...state.tags, formatTag(state.value)]),
+      };
+    }
+    case ACTIONS.REMOVE_TAG: {
+      const removedTagIndex = state.tags.findIndex(
+        (tag) => tag === action.payload
+      );
+      return {
+        ...state,
+        tags: [
+          ...state.tags.slice(0, removedTagIndex),
+          ...state.tags.slice(removedTagIndex + 1),
+        ],
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+export default reducer;

--- a/packages/story-editor/src/components/form/tags/reducer.js
+++ b/packages/story-editor/src/components/form/tags/reducer.js
@@ -47,9 +47,9 @@ function reducer(state, action) {
         ...state,
         value,
         tags: uniquesOnly([
-          ...state.tags.slice(0, state.tags - state.offset),
+          ...state.tags.slice(0, state.tags.length - state.offset),
           ...newTags,
-          ...state.tags.slice(state.tags - state.offset),
+          ...state.tags.slice(state.tags.length - state.offset),
         ]),
       };
     }

--- a/packages/story-editor/src/components/form/tags/tag.js
+++ b/packages/story-editor/src/components/form/tags/tag.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import {
+  Text,
+  THEME_CONSTANTS,
+  themeHelpers,
+  Icons,
+} from '@web-stories-wp/design-system';
+
+const Dismiss = styled.button`
+  all: unset;
+  cursor: pointer;
+  border-radius: ${({ theme }) => theme.borders.radius.small};
+  ${themeHelpers.focusableOutlineCSS};
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  svg {
+    height: 16px;
+    width: 16px;
+    margin: auto;
+  }
+`;
+
+const Token = styled.span`
+  ${({ theme }) => css`
+    color: ${theme.colors.fg.primary};
+    border: 1px solid ${theme.colors.border.defaultNormal};
+    border-radius: ${theme.borders.radius.small};
+  `}
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 3px 2px;
+  margin: 3px 5px 3px 0;
+  max-width: calc(100% - 16px);
+`;
+
+const TokenText = styled(Text).attrs({
+  forwardedAs: 'span',
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
+})`
+  padding-left: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+function Tag({ children, onDismiss }) {
+  return (
+    <Token>
+      <TokenText>{children}</TokenText>
+      <Dismiss onClick={onDismiss}>
+        <Icons.Cross />
+      </Dismiss>
+    </Token>
+  );
+}
+
+Tag.propTypes = {
+  children: PropTypes.node.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+};
+
+export default Tag;

--- a/packages/story-editor/src/components/form/tags/tag.js
+++ b/packages/story-editor/src/components/form/tags/tag.js
@@ -16,14 +16,17 @@
 /**
  * External dependencies
  */
+import {
+  Icons,
+  Text,
+  themeHelpers,
+  THEME_CONSTANTS,
+  Tooltip,
+  TOOLTIP_PLACEMENT,
+} from '@web-stories-wp/design-system';
+import { __ } from '@web-stories-wp/i18n';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import {
-  Text,
-  THEME_CONSTANTS,
-  themeHelpers,
-  Icons,
-} from '@web-stories-wp/design-system';
 
 const Dismiss = styled.button`
   all: unset;
@@ -72,9 +75,15 @@ function Tag({ children, onDismiss }) {
   return (
     <Token>
       <TokenText>{children}</TokenText>
-      <Dismiss onClick={onDismiss}>
-        <Icons.Cross />
-      </Dismiss>
+      <Tooltip
+        title={__('Remove Tag', 'web-stories')}
+        placement={TOOLTIP_PLACEMENT.BOTTOM}
+        hasTail
+      >
+        <Dismiss onClick={onDismiss}>
+          <Icons.Cross />
+        </Dismiss>
+      </Tooltip>
     </Token>
   );
 }

--- a/packages/story-editor/src/components/form/tags/tag.js
+++ b/packages/story-editor/src/components/form/tags/tag.js
@@ -25,8 +25,10 @@ import {
   TOOLTIP_PLACEMENT,
 } from '@web-stories-wp/design-system';
 import { __ } from '@web-stories-wp/i18n';
+import { useMemo } from '@web-stories-wp/react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
+import { v4 as uuidv4 } from 'uuid';
 
 const Dismiss = styled.button`
   all: unset;
@@ -72,15 +74,20 @@ const TokenText = styled(Text).attrs({
 `;
 
 function Tag({ children, onDismiss }) {
+  const id = useMemo(() => uuidv4(), []);
   return (
     <Token>
-      <TokenText>{children}</TokenText>
+      <TokenText id={id}>{children}</TokenText>
       <Tooltip
         title={__('Remove Tag', 'web-stories')}
         placement={TOOLTIP_PLACEMENT.BOTTOM}
         hasTail
       >
-        <Dismiss onClick={onDismiss}>
+        <Dismiss
+          onClick={onDismiss}
+          aria-label={__('Remove Tag', 'web-stories')}
+          aria-describedby={id}
+        >
           <Icons.Cross />
         </Dismiss>
       </Tooltip>

--- a/packages/story-editor/src/components/form/tags/test/reducer.js
+++ b/packages/story-editor/src/components/form/tags/test/reducer.js
@@ -47,7 +47,7 @@ describe('<Tags.Input /> Reducer', () => {
       };
       const expectedState = {
         offset: 0,
-        value: 'pizza pie',
+        value: ' pizza pie',
         tags: ['tag1', 'potato', 'tomato'],
       };
       expect(reducer(oldState, action)).toStrictEqual(expectedState);
@@ -83,8 +83,227 @@ describe('<Tags.Input /> Reducer', () => {
       };
       const expectedState = {
         offset: 1,
-        value: 'pizza pie',
+        value: ' pizza pie',
         tags: ['potato', 'tomato', 'tag1'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+  });
+
+  describe('ACTIONS.SUBMIT_VALUE', () => {
+    it('adds the value as a tag on submit and clears the value', () => {
+      const oldState = {
+        offset: 0,
+        value: 'tag2',
+        tags: ['tag1'],
+      };
+      const action = { type: ACTIONS.SUBMIT_VALUE };
+      const expectedState = {
+        offset: 0,
+        value: '',
+        tags: ['tag1', 'tag2'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+
+    it('formats the new value on submit', () => {
+      const oldState = {
+        offset: 0,
+        value: '   tag   two    ',
+        tags: ['tag1'],
+      };
+      const action = { type: ACTIONS.SUBMIT_VALUE };
+      const expectedState = {
+        offset: 0,
+        value: '',
+        tags: ['tag1', 'tag two'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+
+    it('returns the original state if the value is empty', () => {
+      const oldState = {
+        offset: 0,
+        value: '    ',
+        tags: ['tag1'],
+      };
+      const action = { type: ACTIONS.SUBMIT_VALUE };
+      expect(reducer(oldState, action)).toStrictEqual(oldState);
+    });
+
+    it('respects the offset when adding tags', () => {
+      const oldState = {
+        offset: 1,
+        value: 'tag2',
+        tags: ['tag1', 'tag3'],
+      };
+      const action = { type: ACTIONS.SUBMIT_VALUE };
+      const expectedState = {
+        offset: 1,
+        value: '',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+  });
+
+  describe('ACTIONS.REMOVE_TAG', () => {
+    it('removes the tag specified in the payload', () => {
+      const oldState = {
+        offset: 1,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      const action = { type: ACTIONS.REMOVE_TAG, payload: 'tag2' };
+      const expectedState = {
+        offset: 1,
+        value: 'tag4',
+        tags: ['tag1', 'tag3'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+    it('returns original state when tag not found', () => {
+      const oldState = {
+        offset: 1,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      const action = { type: ACTIONS.REMOVE_TAG, payload: 'tag8' };
+      const expectedState = oldState;
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+
+    it('removes tag from index dictated by offset when no payload present', () => {
+      let oldState = {
+        offset: 3,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      let action = { type: ACTIONS.REMOVE_TAG };
+      let expectedState = {
+        offset: 3,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+
+      oldState = {
+        offset: 2,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      action = { type: ACTIONS.REMOVE_TAG };
+      expectedState = {
+        offset: 2,
+        value: 'tag4',
+        tags: ['tag2', 'tag3'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+
+      oldState = {
+        offset: 1,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      action = { type: ACTIONS.REMOVE_TAG };
+      expectedState = {
+        offset: 1,
+        value: 'tag4',
+        tags: ['tag1', 'tag3'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+
+      oldState = {
+        offset: 0,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      action = { type: ACTIONS.REMOVE_TAG };
+      expectedState = {
+        offset: 0,
+        value: 'tag4',
+        tags: ['tag1', 'tag2'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+  });
+
+  describe('ACTIONS.INCREMENT_OFFSET', () => {
+    it('should increase offset by 1', () => {
+      const oldState = {
+        offset: 0,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      const action = { type: ACTIONS.INCREMENT_OFFSET };
+      const expectedState = {
+        offset: 1,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+
+    it('should not let offset exceed tag length', () => {
+      const oldState = {
+        offset: 3,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      const action = { type: ACTIONS.INCREMENT_OFFSET };
+      const expectedState = {
+        offset: 3,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+  });
+
+  describe('ACTIONS.DECREMENT_OFFSET', () => {
+    it('should decrease offset by 1', () => {
+      const oldState = {
+        offset: 3,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      const action = { type: ACTIONS.DECREMENT_OFFSET };
+      const expectedState = {
+        offset: 2,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+
+    it('should not let offset go below 0', () => {
+      const oldState = {
+        offset: 0,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      const action = { type: ACTIONS.DECREMENT_OFFSET };
+      const expectedState = {
+        offset: 0,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+  });
+
+  describe('ACTIONS.RESET_OFFSET', () => {
+    it('should reset offset to 0', () => {
+      const oldState = {
+        offset: 3,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
+      };
+      const action = { type: ACTIONS.RESET_OFFSET };
+      const expectedState = {
+        offset: 0,
+        value: 'tag4',
+        tags: ['tag1', 'tag2', 'tag3'],
       };
       expect(reducer(oldState, action)).toStrictEqual(expectedState);
     });

--- a/packages/story-editor/src/components/form/tags/test/reducer.js
+++ b/packages/story-editor/src/components/form/tags/test/reducer.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import reducer, { ACTIONS } from '../reducer';
+
+describe('<Tags.Input /> Reducer', () => {
+  describe('ACTIONS.UPDATE_VALUE', () => {
+    it('should update the value', () => {
+      const oldState = {
+        offset: 0,
+        value: '',
+        tags: ['tag1'],
+      };
+      const action = { type: ACTIONS.UPDATE_VALUE, payload: 'potato' };
+      const expectedState = {
+        offset: 0,
+        value: 'potato',
+        tags: ['tag1'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+
+    it('should add tags when theres postfixed commas in the value', () => {
+      const oldState = {
+        offset: 0,
+        value: '',
+        tags: ['tag1'],
+      };
+      const action = {
+        type: ACTIONS.UPDATE_VALUE,
+        payload: 'potato, tomato, pizza pie',
+      };
+      const expectedState = {
+        offset: 0,
+        value: 'pizza pie',
+        tags: ['tag1', 'potato', 'tomato'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+
+    it('should strip extraneous spaces once added as a tag', () => {
+      const oldState = {
+        offset: 0,
+        value: '',
+        tags: ['tag1'],
+      };
+      const action = {
+        type: ACTIONS.UPDATE_VALUE,
+        payload: 'potato, tomato     , pizza   pie',
+      };
+      const expectedState = {
+        offset: 0,
+        value: ' pizza   pie',
+        tags: ['tag1', 'potato', 'tomato'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+
+    it('should respect the offset when adding new tags', () => {
+      const oldState = {
+        offset: 1,
+        value: '',
+        tags: ['tag1'],
+      };
+      const action = {
+        type: ACTIONS.UPDATE_VALUE,
+        payload: 'potato, tomato, pizza pie',
+      };
+      const expectedState = {
+        offset: 1,
+        value: 'pizza pie',
+        tags: ['potato', 'tomato', 'tag1'],
+      };
+      expect(reducer(oldState, action)).toStrictEqual(expectedState);
+    });
+  });
+});


### PR DESCRIPTION
## Context
Part of story taxonomy support

## Summary
Adds a freeform taxonomy (tags) input component with a storybook implementation and unit tests.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
just a storybook component for now, not introduced into the editor yet
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
- `npm run storybook`
- `edit story -> components -> form -> tags`
- mess with the tags input and see that it behaves like the WP one mentioned in the ticket.

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8831 
