### PR TITLE
Change tooltip placement if there's not enough space

### DIFF
--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -75,14 +75,13 @@ function Popup({
   fillWidth = false,
   fillHeight = false,
   onPositionUpdate = noop,
-  onPlacementUpdate = noop,
 }) {
   const [popupState, setPopupState] = useState(null);
   const [mounted, setMounted] = useState(false);
   const popup = useRef(null);
 
   const positionPopup = useCallback(
-    (evt) => {
+    async (evt) => {
       if (!mounted) {
         return;
       }
@@ -91,7 +90,8 @@ function Popup({
       if (evt?.target?.nodeType && popup.current?.contains(evt.target)) {
         return;
       }
-      setPopupState({
+
+      await setPopupState({
         offset:
           anchor?.current && getOffset(placement, spacing, anchor, dock, popup),
       });
@@ -112,8 +112,10 @@ function Popup({
     };
   }, [isOpen, positionPopup]);
 
-  useLayoutEffect(onPositionUpdate, [popupState, onPositionUpdate]);
-  useLayoutEffect(onPlacementUpdate, [popupState, onPlacementUpdate]);
+  useLayoutEffect(
+    () => onPositionUpdate(popupState),
+    [popupState, onPositionUpdate]
+  );
 
   useResizeEffect({ current: document.body }, positionPopup, [positionPopup]);
 
@@ -149,7 +151,6 @@ Popup.propTypes = {
   fillWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   fillHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   onPositionUpdate: PropTypes.func,
-  onPlacementUpdate: PropTypes.func,
 };
 
 export { Popup, PLACEMENT };

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -75,6 +75,7 @@ function Popup({
   fillWidth = false,
   fillHeight = false,
   onPositionUpdate = noop,
+  onPlacementUpdate = noop,
 }) {
   const [popupState, setPopupState] = useState(null);
   const [mounted, setMounted] = useState(false);
@@ -112,6 +113,7 @@ function Popup({
   }, [isOpen, positionPopup]);
 
   useLayoutEffect(onPositionUpdate, [popupState, onPositionUpdate]);
+  useLayoutEffect(onPlacementUpdate, [popupState, onPlacementUpdate]);
 
   useResizeEffect({ current: document.body }, positionPopup, [positionPopup]);
 
@@ -147,6 +149,7 @@ Popup.propTypes = {
   fillWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   fillHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   onPositionUpdate: PropTypes.func,
+  onPlacementUpdate: PropTypes.func,
 };
 
 export { Popup, PLACEMENT };

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -140,7 +140,7 @@ function Tooltip({
     const tooltipElBoundingBox = tooltipRef.current?.getBoundingClientRect();
     if (
       placement.startsWith('bottom') &&
-      tooltipElBoundingBox?.height < window.visualViewport.height
+      tooltipElBoundingBox?.bottom > window.visualViewport.height
     ) {
       dynamicPlacement.current = PLACEMENT.TOP;
     }

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -113,7 +113,7 @@ function Tooltip({
   const anchorRef = useRef(null);
   const tooltipRef = useRef(null);
   const placementRef = useRef(placement);
-  const [realPlacement, setRealPlacement] = useState(placement);
+  const [dynamicPlacement, setDynamicPlacement] = useState(placement);
 
   const spacing = useMemo(
     () => ({
@@ -133,19 +133,18 @@ function Tooltip({
   // cutoff the contents of the tooltip.
   const positionPlacement = useCallback(
     ({ offset }) => {
-      if (offset) {
-        const neededVerticalSpace = offset.y + offset.height;
-        // if the tooltip was assigned as bottom we want to always check it
-        if (realPlacement.startsWith('bottom')) {
-          // check to see if there's an overlap with the window edge
-          if (neededVerticalSpace >= window.innerHeight) {
-            // isn't already overridden
-            setRealPlacement(PLACEMENT.TOP);
-          }
-        }
+      // check to see if there's an overlap with the window edge
+      const neededVerticalSpace = offset.y + offset.height;
+      // if the tooltip was assigned as bottom we want to always check it
+      if (
+        offset &&
+        dynamicPlacement.startsWith('bottom') &&
+        neededVerticalSpace >= window.innerHeight
+      ) {
+        setDynamicPlacement(PLACEMENT.TOP);
       }
     },
-    [realPlacement]
+    [dynamicPlacement]
   );
 
   const positionArrow = useCallback(
@@ -167,7 +166,7 @@ function Tooltip({
   );
 
   const resetPlacement = useDebouncedCallback(() => {
-    setRealPlacement(placementRef.current);
+    setDynamicPlacement(placementRef.current);
   }, 100);
 
   const delay = useRef();
@@ -229,7 +228,7 @@ function Tooltip({
 
       <Popup
         anchor={forceAnchorRef || anchorRef}
-        placement={realPlacement}
+        placement={dynamicPlacement}
         spacing={spacing}
         isOpen={Boolean(shown && (shortcut || title))}
         onPositionUpdate={positionArrow}
@@ -237,7 +236,7 @@ function Tooltip({
         <TooltipContainer
           className={className}
           ref={tooltipRef}
-          placement={realPlacement}
+          placement={dynamicPlacement}
           shown={shown}
           {...tooltipProps}
         >
@@ -254,7 +253,7 @@ function Tooltip({
                   <path d="M1,1 L0.868,1 C0.792,1,0.72,0.853,0.676,0.606 L0.585,0.098 C0.562,-0.033,0.513,-0.033,0.489,0.098 L0.399,0.606 C0.355,0.853,0.283,1,0.207,1 L0,1 L1,1" />
                 </clipPath>
               </SvgForTail>
-              <Tail placement={realPlacement} translateX={arrowDelta} />
+              <Tail placement={dynamicPlacement} translateX={arrowDelta} />
             </>
           )}
         </TooltipContainer>

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -106,7 +106,7 @@ function Tooltip({
   const [arrowDelta, setArrowDelta] = useState(null);
   const anchorRef = useRef(null);
   const tooltipRef = useRef(null);
-  const dynamicPlacement = useRef(null);
+  const [dynamicPlacement, setDynamicPlacement] = useState(null);
 
   const spacing = useMemo(
     () => ({
@@ -137,12 +137,11 @@ function Tooltip({
   // When near the bottom of the viewport and the tooltip is placed on the bottom we want to force the tooltip to the top as to not
   // cutoff the contents of the tooltip.
   const positionPlacement = useCallback(() => {
-    const tooltipElBoundingBox = tooltipRef.current?.getBoundingClientRect();
-    if (
-      placement.startsWith('bottom') &&
-      tooltipElBoundingBox?.bottom > window.visualViewport.height
-    ) {
-      dynamicPlacement.current = PLACEMENT.TOP;
+    if (placement.startsWith('bottom')) {
+      const tooltipElBoundingBox = tooltipRef.current?.getBoundingClientRect();
+      if (tooltipElBoundingBox?.bottom >= window.visualViewport.height) {
+        setDynamicPlacement(PLACEMENT.TOP);
+      }
     }
   }, [placement]);
 
@@ -203,7 +202,7 @@ function Tooltip({
 
       <Popup
         anchor={forceAnchorRef || anchorRef}
-        placement={dynamicPlacement.current || placement}
+        placement={dynamicPlacement || placement}
         spacing={spacing}
         isOpen={Boolean(shown && (shortcut || title))}
         onPositionUpdate={positionArrow}
@@ -212,7 +211,7 @@ function Tooltip({
         <TooltipContainer
           className={className}
           ref={tooltipRef}
-          placement={dynamicPlacement.current || placement}
+          placement={dynamicPlacement || placement}
           shown={shown}
           {...tooltipProps}
         >
@@ -230,7 +229,7 @@ function Tooltip({
                 </clipPath>
               </SvgForTail>
               <Tail
-                placement={dynamicPlacement.current || placement}
+                placement={dynamicPlacement || placement}
                 translateX={arrowDelta}
               />
             </>


### PR DESCRIPTION
## Context
When tooltips are near the bottom of the viewport they can get cutoff. When this occurs we want to force the placement elsewhere to show the entire tooltip content. 
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Relevant Technical Choices

<!-- Please describe your changes. -->
Created a function to dynamically place tooltips at the `TOP` position when they would otherwise be cutoff while in the `BOTTOM` position. I avoided moving the placement from either side as to not conflict between RTL and LTR languages. Horizontal placement is already been addressed via offsets, so this fix was solely for the `bottom` cutoff. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
N/A
## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
### Before
![image](https://user-images.githubusercontent.com/1820266/131930003-67ba4b00-0ba4-4871-9ee0-bd8de631b1e7.png)
### After
![image](https://user-images.githubusercontent.com/1820266/131930114-b9b4c572-fdc6-4de7-940c-6d51150aafaf.png)


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. In the story editor select `Document` from the inspector. 
2. Add an audio file, and hover over the trash can icon.
3. The tooltip should appear above. 


## Reviews

### Does this PR have a security-related impact?
No

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8822