### PR TITLE
Color Picker: use '000000' instead of 'transparent'.

### DIFF
--- a/packages/story-editor/src/components/colorPicker/currentColorPicker.js
+++ b/packages/story-editor/src/components/colorPicker/currentColorPicker.js
@@ -139,7 +139,12 @@ function CurrentColorPicker({ rgb, hsl, hsv, hex, onChange, showOpacity }) {
   const alphaPercentage = String(Math.round(rgb.a * 100));
   const hexValue = hex[0] === '#' ? hex.substr(1) : hex;
 
-  const handleFormatHex = useCallback((v) => `#${v}`, []);
+  const handleFormatHex = useCallback((v) => {
+    if ('transparent' === v) {
+      v = '000000';
+    }
+    return `#${v}`;
+  }, []);
   const handleFormatPercentage = useCallback((v) => `${v}%`, []);
 
   const handleHexInputChange = useCallback(

--- a/packages/story-editor/src/components/colorPicker/editablePreview.js
+++ b/packages/story-editor/src/components/colorPicker/editablePreview.js
@@ -131,11 +131,14 @@ function EditablePreview({ label, value, width, format, onChange }) {
     );
   }
 
+  // The value is set to 'transparent' by the library if it's black with 0 opacity.
+  // We want to always display hex though.
+  const editValue = value === 'transparent' ? '000000' : value;
   return (
     <Wrapper ref={wrapperRef} tabIndex={-1} onBlur={handleOnBlur}>
       <Suspense fallback={null}>
         <EditableInput
-          value={value}
+          value={editValue}
           ref={editableRef}
           onChange={onChange}
           onChangeComplete={disableEditing}


### PR DESCRIPTION
## Summary
Uses '000000' as the display value instead of `transparent` which is used by default by the color picker library.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
1. Add a shape.
2. Open the color picker and go to the Custom Color picker.
3. Set the color to black ('000000')
4. Now set the opacity to 0.
5. Verify that '000000' is displayed in the hex input of the Color Picker. Click on the value to enter edit mode of the input and verify it displays '000000' there, too.
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7896 
