### PR TITLE
Decoupling: Move and refactor `PostPublishDialog` component to `wp-story-editor`

### DIFF
--- a/.storybook/main.cjs
+++ b/.storybook/main.cjs
@@ -19,6 +19,7 @@ module.exports = {
     './stories/**/*.js',
     '../packages/dashboard/src/**/stories/*.@(js|mdx)',
     '../packages/story-editor/src/**/stories/*.@(js|mdx)',
+    '../packages/wp-story-editor/src/**/stories/*.@(js|mdx)',
     '../packages/activation-notice/src/**/stories/*.@(js|mdx)',
     '../packages/design-system/src/**/stories/*.@(js|mdx)',
   ],

--- a/.storybook/stories/playground/index.js
+++ b/.storybook/stories/playground/index.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import App from '@web-stories-wp/story-editor';
+import StoryEditor from '@web-stories-wp/story-editor';
 
 export default {
   title: 'Playground/Stories Editor',
@@ -57,4 +57,4 @@ const config = {
   },
 };
 
-export const _default = () => <App config={config} />;
+export const _default = () => <StoryEditor config={config} />;

--- a/package-lock.json
+++ b/package-lock.json
@@ -40435,7 +40435,8 @@
       },
       "devDependencies": {
         "@storybook/addon-actions": "^6.3.6",
-        "@storybook/addon-knobs": "^6.3.0"
+        "@storybook/addon-knobs": "^6.3.0",
+        "@testing-library/react": "^12.0.0"
       },
       "engines": {
         "node": ">= 15",
@@ -47764,6 +47765,7 @@
       "requires": {
         "@storybook/addon-actions": "^6.3.6",
         "@storybook/addon-knobs": "^6.3.0",
+        "@testing-library/react": "^12.0.0",
         "@web-stories-wp/date": "*",
         "@web-stories-wp/design-system": "*",
         "@web-stories-wp/i18n": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40428,6 +40428,7 @@
       "dependencies": {
         "@web-stories-wp/date": "*",
         "@web-stories-wp/design-system": "*",
+        "@web-stories-wp/i18n": "*",
         "@web-stories-wp/react": "*",
         "@web-stories-wp/story-editor": "*",
         "@web-stories-wp/tracking": "*",
@@ -47761,6 +47762,7 @@
       "requires": {
         "@web-stories-wp/date": "*",
         "@web-stories-wp/design-system": "*",
+        "@web-stories-wp/i18n": "*",
         "@web-stories-wp/react": "*",
         "@web-stories-wp/story-editor": "*",
         "@web-stories-wp/tracking": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "web-stories-wp",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -40434,7 +40433,10 @@
         "@web-stories-wp/tracking": "*",
         "flagged": "^2.0.1"
       },
-      "devDependencies": {},
+      "devDependencies": {
+        "@storybook/addon-actions": "^6.3.6",
+        "@storybook/addon-knobs": "^6.3.0"
+      },
       "engines": {
         "node": ">= 15",
         "npm": "~7"
@@ -47760,6 +47762,8 @@
     "@web-stories-wp/wp-story-editor": {
       "version": "file:packages/wp-story-editor",
       "requires": {
+        "@storybook/addon-actions": "^6.3.6",
+        "@storybook/addon-knobs": "^6.3.0",
         "@web-stories-wp/date": "*",
         "@web-stories-wp/design-system": "*",
         "@web-stories-wp/i18n": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40434,8 +40434,6 @@
         "flagged": "^2.0.1"
       },
       "devDependencies": {
-        "@storybook/addon-actions": "^6.3.6",
-        "@storybook/addon-knobs": "^6.3.0",
         "@testing-library/react": "^12.0.0"
       },
       "engines": {
@@ -47763,8 +47761,6 @@
     "@web-stories-wp/wp-story-editor": {
       "version": "file:packages/wp-story-editor",
       "requires": {
-        "@storybook/addon-actions": "^6.3.6",
-        "@storybook/addon-knobs": "^6.3.0",
         "@testing-library/react": "^12.0.0",
         "@web-stories-wp/date": "*",
         "@web-stories-wp/design-system": "*",

--- a/packages/story-editor/src/app/story/index.js
+++ b/packages/story-editor/src/app/story/index.js
@@ -15,6 +15,7 @@
  */
 
 export { default as StoryProvider } from './storyProvider';
+export { default as StoryContext } from './context';
 export { default as useStory } from './useStory';
 export {
   useStoryTriggers,

--- a/packages/story-editor/src/components/header/buttons/index.js
+++ b/packages/story-editor/src/components/header/buttons/index.js
@@ -18,14 +18,12 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { useState, useEffect } from '@web-stories-wp/react';
 
 /**
  * Internal dependencies
  */
 import { useStory } from '../../../app';
 import CircularProgress from '../../circularProgress';
-import PostPublishDialog from '../postPublishDialog';
 import Preview from './preview';
 import SwitchToDraft from './switchToDraft';
 import Update from './update';
@@ -70,7 +68,7 @@ function Loading() {
 }
 
 function Buttons() {
-  const { status, embedPostLink, link, isFreshlyPublished } = useStory(
+  const { status } = useStory(
     ({
       state: {
         story: { status, embedPostLink, link },
@@ -83,37 +81,24 @@ function Buttons() {
       isFreshlyPublished,
     })
   );
-  const [showDialog, setShowDialog] = useState(false);
-  useEffect(
-    () => setShowDialog(Boolean(isFreshlyPublished)),
-    [isFreshlyPublished]
-  );
 
   const isDraft = 'draft' === status;
 
   return (
-    <>
-      <ButtonList>
-        <List>
-          <IconWithSpinner>
-            <Preview />
-            <Loading />
-          </IconWithSpinner>
-          <Space />
-          {isDraft ? <Update /> : <SwitchToDraft />}
-          <Space />
-          {isDraft && <Publish />}
-          {!isDraft && <Update />}
-          <Space />
-        </List>
-      </ButtonList>
-      <PostPublishDialog
-        isOpen={showDialog}
-        onClose={() => setShowDialog(false)}
-        confirmURL={embedPostLink}
-        storyURL={link}
-      />
-    </>
+    <ButtonList>
+      <List>
+        <IconWithSpinner>
+          <Preview />
+          <Loading />
+        </IconWithSpinner>
+        <Space />
+        {isDraft ? <Update /> : <SwitchToDraft />}
+        <Space />
+        {isDraft && <Publish />}
+        {!isDraft && <Update />}
+        <Space />
+      </List>
+    </ButtonList>
   );
 }
 export default Buttons;

--- a/packages/story-editor/src/components/header/test/buttons.js
+++ b/packages/story-editor/src/components/header/test/buttons.js
@@ -230,18 +230,6 @@ describe('buttons', () => {
     expect(saveStory).not.toHaveBeenCalled();
   });
 
-  it('should display post-publish dialog if recently published', async () => {
-    setupButtons({ meta: { isFreshlyPublished: true } });
-
-    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
-    expect(dismissButton).toBeInTheDocument();
-    fireEvent.click(dismissButton);
-
-    await waitForElementToBeRemoved(() =>
-      screen.getByRole('button', { name: 'Dismiss' })
-    );
-  });
-
   it('should display Switch to draft button when published', () => {
     const { saveStory } = setupButtons({
       story: { status: 'publish' },

--- a/packages/story-editor/src/index.js
+++ b/packages/story-editor/src/index.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import App from './editorApp';
+import StoryEditor from './storyEditor';
 import Dialog from './components/dialog';
 
 export * from './components/transform';
@@ -36,4 +36,4 @@ export { GlobalStyle as CropMoveableGlobalStyle } from './components/moveable/cr
 export { ConfigProvider as EditorConfigProvider } from './app/config';
 
 export { Dialog };
-export default App;
+export default StoryEditor;

--- a/packages/story-editor/src/index.js
+++ b/packages/story-editor/src/index.js
@@ -24,6 +24,7 @@ export * from './components/transform';
 export * from './app/config';
 export * from './app/story';
 export * from './components/previewPage';
+export * from './testUtils';
 
 export { default as base64Encode } from './utils/base64Encode';
 export { default as getStoryPropsToSave } from './app/story/utils/getStoryPropsToSave';

--- a/packages/story-editor/src/index.js
+++ b/packages/story-editor/src/index.js
@@ -18,9 +18,11 @@
  * Internal dependencies
  */
 import App from './editorApp';
+import Dialog from './components/dialog';
 
 export * from './components/transform';
 export * from './app/config';
+export * from './app/story';
 export * from './components/previewPage';
 
 export { default as base64Encode } from './utils/base64Encode';
@@ -33,4 +35,5 @@ export { default as theme } from './theme'; // @todo To be refactored.
 export { GlobalStyle as CropMoveableGlobalStyle } from './components/moveable/cropStyle';
 export { ConfigProvider as EditorConfigProvider } from './app/config';
 
+export { Dialog };
 export default App;

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -35,7 +35,7 @@ import { FixtureEvents } from '@web-stories-wp/karma-fixture';
 /**
  * Internal dependencies
  */
-import App from '../../editorApp';
+import StoryEditor from '../../storyEditor';
 import APIProvider from '../../app/api/apiProvider';
 import APIContext from '../../app/api/context';
 import FileProvider from '../../app/file/provider';
@@ -322,7 +322,7 @@ export class Fixture {
 
     const { container, getByRole } = render(
       <FlagsProvider features={this._flags}>
-        <App key={Math.random()} config={this._config} />
+        <StoryEditor key={Math.random()} config={this._config} />
       </FlagsProvider>,
       {
         container: root,

--- a/packages/story-editor/src/storyEditor.js
+++ b/packages/story-editor/src/storyEditor.js
@@ -52,7 +52,7 @@ import { GlobalStyle as CalendarStyle } from './components/form/dateTime/calenda
 import KeyboardOnlyOutlines from './utils/keyboardOnlyOutline';
 import { MetaBoxesProvider } from './integrations/wordpress/metaBoxes';
 
-function App({ config }) {
+function StoryEditor({ config, children }) {
   const { storyId, isRTL } = config;
   return (
     <StyleSheetManager stylisPlugins={isRTL ? [stylisRTLPlugin] : []}>
@@ -83,6 +83,7 @@ function App({ config }) {
                                       <CalendarStyle />
                                       <KeyboardOnlyOutlines />
                                       <Layout />
+                                      {children}
                                     </HelpCenterProvider>
                                   </DropTargetsProvider>
                                 </TransformProvider>
@@ -103,8 +104,9 @@ function App({ config }) {
   );
 }
 
-App.propTypes = {
+StoryEditor.propTypes = {
   config: PropTypes.object.isRequired,
+  children: PropTypes.node,
 };
 
-export default App;
+export default StoryEditor;

--- a/packages/wp-story-editor/package.json
+++ b/packages/wp-story-editor/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@web-stories-wp/date": "*",
         "@web-stories-wp/design-system": "*",
+	    "@web-stories-wp/i18n": "*",
         "@web-stories-wp/react": "*",
         "@web-stories-wp/story-editor": "*",
         "@web-stories-wp/tracking": "*",

--- a/packages/wp-story-editor/package.json
+++ b/packages/wp-story-editor/package.json
@@ -20,8 +20,6 @@
         "flagged": "^2.0.1"
     },
     "devDependencies": {
-        "@storybook/addon-actions": "^6.3.6",
-        "@storybook/addon-knobs": "^6.3.0",
         "@testing-library/react": "^12.0.0"
     }
 }

--- a/packages/wp-story-editor/package.json
+++ b/packages/wp-story-editor/package.json
@@ -21,6 +21,7 @@
     },
     "devDependencies": {
 	    "@storybook/addon-actions": "^6.3.6",
-	    "@storybook/addon-knobs": "^6.3.0"
+	    "@storybook/addon-knobs": "^6.3.0",
+	    "@testing-library/react": "^12.0.0"
     }
 }

--- a/packages/wp-story-editor/package.json
+++ b/packages/wp-story-editor/package.json
@@ -20,8 +20,8 @@
         "flagged": "^2.0.1"
     },
     "devDependencies": {
-	    "@storybook/addon-actions": "^6.3.6",
-	    "@storybook/addon-knobs": "^6.3.0",
-	    "@testing-library/react": "^12.0.0"
+        "@storybook/addon-actions": "^6.3.6",
+        "@storybook/addon-knobs": "^6.3.0",
+        "@testing-library/react": "^12.0.0"
     }
 }

--- a/packages/wp-story-editor/package.json
+++ b/packages/wp-story-editor/package.json
@@ -13,7 +13,7 @@
     "dependencies": {
         "@web-stories-wp/date": "*",
         "@web-stories-wp/design-system": "*",
-	    "@web-stories-wp/i18n": "*",
+        "@web-stories-wp/i18n": "*",
         "@web-stories-wp/react": "*",
         "@web-stories-wp/story-editor": "*",
         "@web-stories-wp/tracking": "*",

--- a/packages/wp-story-editor/package.json
+++ b/packages/wp-story-editor/package.json
@@ -19,5 +19,8 @@
         "@web-stories-wp/tracking": "*",
         "flagged": "^2.0.1"
     },
-    "devDependencies": {}
+    "devDependencies": {
+	    "@storybook/addon-actions": "^6.3.6",
+	    "@storybook/addon-knobs": "^6.3.0"
+    }
 }

--- a/packages/wp-story-editor/src/components/index.js
+++ b/packages/wp-story-editor/src/components/index.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { default as PostPublishDialog } from './postPublishDialog';

--- a/packages/wp-story-editor/src/components/postPublishDialog/index.js
+++ b/packages/wp-story-editor/src/components/postPublishDialog/index.js
@@ -17,18 +17,34 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
-import { useCallback } from '@web-stories-wp/react';
+import { useCallback, useEffect, useState } from '@web-stories-wp/react';
 import { __, TranslateWithMarkup } from '@web-stories-wp/i18n';
 import { trackClick } from '@web-stories-wp/tracking';
 import { Link, Text, THEME_CONSTANTS } from '@web-stories-wp/design-system';
+import { Dialog, useStory } from '@web-stories-wp/story-editor';
 
-/**
- * Internal dependencies
- */
-import Dialog from '../dialog';
+function PostPublishDialog() {
+  const {
+    embedPostLink: confirmURL,
+    link: storyURL,
+    isFreshlyPublished,
+  } = useStory(
+    ({
+      state: {
+        story: { embedPostLink, link },
+        meta: { isFreshlyPublished },
+      },
+    }) => ({
+      embedPostLink,
+      link,
+      isFreshlyPublished,
+    })
+  );
 
-function PostPublishDialog({ isOpen, onClose, confirmURL, storyURL }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => setIsOpen(Boolean(isFreshlyPublished)), [isFreshlyPublished]);
+
   const onAddToPostClick = useCallback((evt) => {
     trackClick(evt, 'add_story_to_new_post');
   }, []);
@@ -36,6 +52,7 @@ function PostPublishDialog({ isOpen, onClose, confirmURL, storyURL }) {
   const onViewStoryClick = useCallback((evt) => {
     trackClick(evt, 'view_story');
   }, []);
+  const onClose = useCallback(() => setIsOpen(false), []);
 
   const primaryText = confirmURL ? __('Add to new post', 'web-stories') : '';
 
@@ -81,16 +98,5 @@ function PostPublishDialog({ isOpen, onClose, confirmURL, storyURL }) {
     </Dialog>
   );
 }
-
-PostPublishDialog.propTypes = {
-  isOpen: PropTypes.bool.isRequired,
-  onClose: PropTypes.func.isRequired,
-  confirmURL: PropTypes.string,
-  storyURL: PropTypes.string,
-};
-
-PostPublishDialog.defaultProps = {
-  storyURL: '',
-};
 
 export default PostPublishDialog;

--- a/packages/wp-story-editor/src/components/postPublishDialog/stories/postPublishDialog.js
+++ b/packages/wp-story-editor/src/components/postPublishDialog/stories/postPublishDialog.js
@@ -17,8 +17,7 @@
 /**
  * External dependencies
  */
-import { action } from '@storybook/addon-actions';
-import { text } from '@storybook/addon-knobs';
+import { StoryContext } from '@web-stories-wp/story-editor';
 
 /**
  * Internal dependencies
@@ -30,13 +29,23 @@ export default {
   component: PostPublishDialog,
 };
 
+const storyContext = {
+  state: {
+    story: {
+      embedPostLink:
+        'https://example.com/wp-admin/post-new.php?from-web-story=123',
+      link: '',
+    },
+    meta: {
+      isFreshlyPublished: true,
+    },
+  },
+};
+
 export const _default = () => {
   return (
-    <PostPublishDialog
-      isOpen
-      onClose={action('closed')}
-      storyURL={text('Story URL', 'https://example.com')}
-      confirmURL={text('Confirm URL', 'https://example.com')}
-    />
+    <StoryContext.Provider value={storyContext}>
+      <PostPublishDialog />
+    </StoryContext.Provider>
   );
 };

--- a/packages/wp-story-editor/src/components/postPublishDialog/stories/postPublishDialog.js
+++ b/packages/wp-story-editor/src/components/postPublishDialog/stories/postPublishDialog.js
@@ -23,7 +23,7 @@ import { text } from '@storybook/addon-knobs';
 /**
  * Internal dependencies
  */
-import PostPublishDialog from '../postPublishDialog';
+import PostPublishDialog from '..';
 
 export default {
   title: 'Stories Editor/Components/Dialog/Post-Publish',

--- a/packages/wp-story-editor/src/components/postPublishDialog/test/postPublishDialog.js
+++ b/packages/wp-story-editor/src/components/postPublishDialog/test/postPublishDialog.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import {
+  fireEvent,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
+import { setAppElement } from '@web-stories-wp/design-system';
+import { renderWithTheme, StoryContext } from '@web-stories-wp/story-editor';
+
+/**
+ * Internal dependencies
+ */
+import PostPublishDialog from '..';
+
+function setupButtons({ meta: extraMetaProps } = {}) {
+  const storyContextValue = {
+    state: {
+      capabilities: {
+        hasPublishAction: true,
+      },
+      meta: { isSaving: false, isFreshlyPublished: false, ...extraMetaProps },
+      story: {
+        status: 'draft',
+        storyId: 123,
+        date: null,
+        editLink: 'http://localhost/wp-admin/post.php?post=123&action=edit',
+        embedPostLink:
+          'https://example.com/wp-admin/post-new.php?from-web-story=123',
+        previewLink:
+          'http://localhost?preview_id=1679&preview_nonce=b5ea827939&preview=true',
+      },
+    },
+    actions: { saveStory: jest.fn(), autoSave: jest.fn() },
+  };
+
+  renderWithTheme(
+    <StoryContext.Provider value={storyContextValue}>
+      <PostPublishDialog />
+    </StoryContext.Provider>
+  );
+}
+
+describe('buttons', () => {
+  let modalWrapper;
+
+  beforeAll(() => {
+    modalWrapper = document.createElement('aside');
+    document.documentElement.appendChild(modalWrapper);
+    setAppElement(modalWrapper);
+  });
+
+  afterAll(() => {
+    document.documentElement.removeChild(modalWrapper);
+  });
+
+  it('should display post-publish dialog if recently published', async () => {
+    setupButtons({ meta: { isFreshlyPublished: true } });
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
+    expect(dismissButton).toBeInTheDocument();
+    fireEvent.click(dismissButton);
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByRole('button', { name: 'Dismiss' })
+    );
+  });
+});

--- a/packages/wp-story-editor/src/index.js
+++ b/packages/wp-story-editor/src/index.js
@@ -25,7 +25,7 @@ import './publicPath';
 /**
  * External dependencies
  */
-import App from '@web-stories-wp/story-editor';
+import StoryEditor from '@web-stories-wp/story-editor';
 import { setAppElement } from '@web-stories-wp/design-system';
 import { StrictMode, render } from '@web-stories-wp/react';
 import { FlagsProvider } from 'flagged';
@@ -36,6 +36,7 @@ import { initializeTracking } from '@web-stories-wp/tracking';
  * Internal dependencies
  */
 import './style.css'; // This way the general editor styles are loaded before all the component styles.
+import { PostPublishDialog } from './components';
 
 /**
  * Initializes the web stories editor.
@@ -57,7 +58,9 @@ const initialize = (id, config, flags) => {
   render(
     <FlagsProvider features={flags}>
       <StrictMode>
-        <App config={config} />
+        <StoryEditor config={config}>
+          <PostPublishDialog />
+        </StoryEditor>
       </StrictMode>
     </FlagsProvider>,
     appElement


### PR DESCRIPTION
## Context

Move and refactor `PostPublishDialog` component to `wp-story-editor`

## Summary

<!-- A brief description of what this PR does. -->

After creating a new story, a modal notification asks users to create a new blog post in the WordPress block editor that references the story. Users can then directly open it for editing. This is specific to WordPress, and might not be a thing when running the editor standalone or in some other context. _( from decoupling document )_

![post-publish-dialog](https://user-images.githubusercontent.com/6297436/132172329-11b849ae-c2e3-4b2f-904e-03443da9b9be.png)


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

- [x] Rename `App` to `StoryEditor` and change its file name to `storyEditor.js`
- [x] Allow children to be added to the main `StoryEditor` component.
- [x] Move and refactor `PostPublishDialog` component to `wp-story-editor` 
- [x] Move `PostPublishDialog` story and its tests to `wp-story-editor`.

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

-->

Partially addresses https://github.com/google/web-stories-wp/issues/2918
