### PR TITLE
Updates a string for "Tips for Throwing an Outdoor Luau" template

### DIFF
--- a/packages/templates/src/raw/tips-for-throwing-an-outdoor-luau/template.json
+++ b/packages/templates/src/raw/tips-for-throwing-an-outdoor-luau/template.json
@@ -2479,7 +2479,7 @@
           "lineHeight": 1.5,
           "textAlign": "initial",
           "padding": { "locked": true, "hasHiddenPadding": false },
-          "content": "<span style=\"font-weight: 500; color: #fff\">A paper-themed children’s birth</span>",
+          "content": "<span style=\"font-weight: 500; color: #fff\">A paper-themed children’s birthday party</span>",
           "fontWeight": 700,
           "borderRadius": {
             "locked": true,
@@ -2488,8 +2488,8 @@
             "bottomRight": 2,
             "bottomLeft": 2
           },
-          "width": 148,
-          "height": 46,
+          "width": 162,
+          "height": 65,
           "scale": 100,
           "focalX": 50,
           "focalY": 50,


### PR DESCRIPTION
## Summary

Updates the text on last page of the template 'Tips for Throwing an Outdoor Luau' from,
"A paper themed child's birth"

to:
"A paper themed child's birthday party"

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

This PR can be tested by following these steps:

1. Go to 'Explore Templates' page, `/wp-admin/edit.php?post_type=web-story&page=stories-dashboard#/templates-gallery`
2. Create a new story from the 'Tips for Throwing an Outdoor Luau' template,
3. Go to the last page of the story check the text below first image should read "A paper themed child's birthday party"

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8937 
Companion: #8968
