### PR TITLE
Added feature flag for thumbnail caching, default off

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -390,6 +390,18 @@ class Experiments extends Service_Base {
 				'description' => __( 'Enable video trimming', 'web-stories' ),
 				'group'       => 'editor',
 			],
+
+			/**
+			 * Author: @barklund
+			 * Issue: #8973
+			 * Creation date: 2021-09-07
+			 */
+			[
+				'name'        => 'enableThumbnailCaching',
+				'label'       => __( 'Thumbnail Caching', 'web-stories' ),
+				'description' => __( 'Enable thumbnail caching', 'web-stories' ),
+				'group'       => 'editor',
+			],
 		];
 	}
 

--- a/packages/story-editor/src/components/carousel/pagepreview/index.js
+++ b/packages/story-editor/src/components/carousel/pagepreview/index.js
@@ -28,6 +28,7 @@ import {
   useCallback,
   useEffect,
 } from '@web-stories-wp/react';
+import { useFeature } from 'flagged';
 
 /**
  * Internal dependencies
@@ -102,6 +103,7 @@ function PagePreview({ page, label, ...props }) {
   const setPageRef = useCallback((node) => node && setPageNode(node), []);
   const hasImage = !isActive && imageBlob;
   const pageAtGenerationTime = useRef();
+  const enableThumbnailCaching = useFeature('enableThumbnailCaching');
 
   // Whenever the page is re-generated and this is not the active page
   // remove the old (and now stale) image blob
@@ -113,9 +115,9 @@ function PagePreview({ page, label, ...props }) {
   }, [page, isActive]);
 
   useEffect(() => {
-    // If this is not the active page, there is a page node and we
-    // don't already have a snapshot
-    if (!isActive && pageNode && !imageBlob) {
+    // If this is not the active page, there is a page node, we
+    // don't already have a snapshot and thumbnail caching is active
+    if (enableThumbnailCaching && !isActive && pageNode && !imageBlob) {
       // Schedule an idle callback to actually generate the image
       const id = requestIdleCallback(
         () => {
@@ -134,7 +136,7 @@ function PagePreview({ page, label, ...props }) {
     }
     // Required because of eslint: consistent-return
     return undefined;
-  }, [isActive, pageNode, imageBlob, page]);
+  }, [enableThumbnailCaching, isActive, pageNode, imageBlob, page]);
 
   return (
     <UnitsProvider pageSize={{ width, height }}>


### PR DESCRIPTION
## Context

This hides thumbnail caching behind a feature flag, that is turned off by default.

## Testing instructions

1. Observe that the new feature flag "Enabled thumbnail caching" is off by default
2. Create a story with multiple pages with content on each page
3. Observe that all the page thumbnails are rendered as complex HTML fragments in the carousel while the feature flag is disabled
4. Enable the feature flag
5. Observe that all the page thumbnails (except for the current one) are rendered as a single image in the carousel while the feature flag is enabled

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #8973
