### PR TITLE
Fix edit mode for GIFs

### DIFF
--- a/packages/story-editor/src/elements/gif/edit.js
+++ b/packages/story-editor/src/elements/gif/edit.js
@@ -20,8 +20,8 @@
 import StoryPropTypes from '../../types';
 import MediaEdit from '../media/edit';
 
-function GifEdit({ element, box }) {
-  return <MediaEdit element={element} box={box} />;
+function GifEdit({ element, box, ...rest }) {
+  return <MediaEdit element={element} box={box} {...rest} />;
 }
 
 GifEdit.propTypes = {


### PR DESCRIPTION
## Summary
Adds missing props to media edit mode for GIF.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a GIF
2. Enter edit mode. Use scaling and panning.
3. Verify the GIF scales and moves as expected while in the edit mode.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8504 
