### PR TITLE
prevent browser's context menu when right clicking on our ContextMenu

### DIFF
--- a/packages/story-editor/src/components/canvas/rightClickMenu.js
+++ b/packages/story-editor/src/components/canvas/rightClickMenu.js
@@ -43,10 +43,18 @@ const RightClickMenu = () => {
   } = useRightClickMenu();
   const ref = useRef();
   // If ContextMenu is already rendered prevent browser's context menu when right clicking on ContextMenu
+  const preventAdditionalContext = (evt) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+  };
+
   useEffect(() => {
     const node = ref.current;
 
-    node.addEventListener('contextmenu', (evt) => evt.preventDefault(), false);
+    node.addEventListener('contextmenu', preventAdditionalContext);
+    return () => {
+      node.removeEventListener('contextmenu', preventAdditionalContext);
+    };
   }, [ref]);
 
   return createPortal(

--- a/packages/story-editor/src/components/canvas/rightClickMenu.js
+++ b/packages/story-editor/src/components/canvas/rightClickMenu.js
@@ -18,7 +18,7 @@
  */
 import { __ } from '@web-stories-wp/i18n';
 import { ContextMenu } from '@web-stories-wp/design-system';
-import { createPortal } from '@web-stories-wp/react';
+import { createPortal, useRef, useEffect } from '@web-stories-wp/react';
 import styled from 'styled-components';
 /**
  * Internal dependencies
@@ -41,10 +41,17 @@ const RightClickMenu = () => {
     onCloseMenu,
     maskRef,
   } = useRightClickMenu();
+  const ref = useRef();
+  // If ContextMenu is already rendered prevent browser's context menu when right clicking on ContextMenu
+  useEffect(() => {
+    const node = ref.current;
+
+    node.addEventListener('contextmenu', (evt) => evt.preventDefault(), false);
+  }, [ref]);
 
   return createPortal(
     <DirectionAware>
-      <RightClickMenuContainer position={menuPosition}>
+      <RightClickMenuContainer position={menuPosition} ref={ref}>
         <ContextMenu
           animate
           data-testid="right-click-context-menu"


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
When right clicking on our custom ContextMenu, the browser's default menu pops up. We want to prevent the browser's context menu if the user already has the ContextMenu open. 

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Nothing will happen if you right-click on the right-click menu.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. In the editor, right-click on the canvas to open our `ContextMenu`
2. Right click anywhere on that menu
3. Nothing happens 🎉


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->
No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8936