### PR TITLE
Color Picker: Propagate dimensions when switching mode

### DIFF
--- a/packages/story-editor/src/components/colorPicker/colorPicker.js
+++ b/packages/story-editor/src/components/colorPicker/colorPicker.js
@@ -72,13 +72,20 @@ function ColorPicker({
   allowsSavedColors = false,
   onClose = () => {},
   changedStyle = 'background',
+  onDimensionChange = () => {},
 }) {
   // If initial color is a gradient, start by showing a custom color picker.
   // Note that no such switch happens if the color later changes to a gradient,
   // only if it was a gradient at the moment the color picker mounted.
   const [isCustomPicker, setCustomPicker] = useState(hasGradient(color));
-  const showCustomPicker = useCallback(() => setCustomPicker(true), []);
-  const hideCustomPicker = useCallback(() => setCustomPicker(false), []);
+  const showCustomPicker = useCallback(() => {
+    setCustomPicker(true);
+    onDimensionChange();
+  }, [onDimensionChange]);
+  const hideCustomPicker = useCallback(() => {
+    setCustomPicker(false);
+    onDimensionChange();
+  }, [onDimensionChange]);
 
   const {
     actions: { pushTransform },
@@ -170,6 +177,7 @@ ColorPicker.propTypes = {
   isEyedropperActive: PropTypes.bool,
   color: PatternPropType,
   changedStyle: PropTypes.string,
+  onDimensionChange: PropTypes.func,
 };
 
 export default ColorPicker;

--- a/packages/story-editor/src/components/form/color/colorInput.js
+++ b/packages/story-editor/src/components/form/color/colorInput.js
@@ -230,7 +230,7 @@ const ColorInput = forwardRef(function ColorInput(
         placement={PLACEMENT.LEFT_START}
         spacing={spacing}
         invisible={isEyedropperActive}
-        renderContents={() => (
+        renderContents={({ propagateDimensionChange }) => (
           <ColorPicker
             color={isMixed ? null : value}
             isEyedropperActive={isEyedropperActive}
@@ -240,6 +240,7 @@ const ColorInput = forwardRef(function ColorInput(
             allowsSavedColors={allowsSavedColors}
             onClose={onClose}
             changedStyle={changedStyle}
+            onDimensionChange={propagateDimensionChange}
           />
         )}
       />


### PR DESCRIPTION
## Summary
Ensures part of the color picker doesn't get hidden when switching views.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
![cpicker](https://user-images.githubusercontent.com/3294597/132843462-0e50e599-52be-435a-84bc-539dd1c75c0a.gif)

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Make sure to have 7+ saved global colors.
2. Add a shape and assign radial color from the Custom picker mode.
3. Close the Color Picker
4. Scroll so that the Color Input in the design panel would be in the bottom part of the screen.
5. Now open the color picker for the radial color.
6. Switch to Basic Color Picker view 
7. Verify that all the lower parts of the Color Picker are visible (and not out of the screen), including the "Custom" button.


## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8673 
