### PR TITLE
Color Picker: Hide rotation button for radial

### DIFF
--- a/packages/story-editor/src/components/colorPicker/customColorPicker.js
+++ b/packages/story-editor/src/components/colorPicker/customColorPicker.js
@@ -116,6 +116,7 @@ function CustomColorPicker({
             onDelete={removeCurrentStop}
             onRotate={rotateClockwise}
             onMove={moveCurrentStopBy}
+            type={type}
           />
         )}
         <CurrentColorPicker

--- a/packages/story-editor/src/components/colorPicker/gradientPicker.js
+++ b/packages/story-editor/src/components/colorPicker/gradientPicker.js
@@ -62,6 +62,7 @@ const SmallButton = styled(Button)`
 function GradientPicker({
   stops,
   currentStopIndex,
+  type,
 
   onSelect,
   onAdd,
@@ -95,17 +96,19 @@ function GradientPicker({
             <Icons.ArrowsLeftright />
           </SmallButton>
         </Tooltip>
-        <Tooltip hasTail title={rotateLabel}>
-          <SmallButton
-            onClick={onRotate}
-            aria-label={rotateLabel}
-            type={BUTTON_TYPES.QUATERNARY}
-            size={BUTTON_SIZES.SMALL}
-            variant={BUTTON_VARIANTS.SQUARE}
-          >
-            <Icons.ArrowRightCurved id="gradient-rotator" />
-          </SmallButton>
-        </Tooltip>
+        {type !== 'radial' && (
+          <Tooltip hasTail title={rotateLabel}>
+            <SmallButton
+              onClick={onRotate}
+              aria-label={rotateLabel}
+              type={BUTTON_TYPES.QUATERNARY}
+              size={BUTTON_SIZES.SMALL}
+              variant={BUTTON_VARIANTS.SQUARE}
+            >
+              <Icons.ArrowRightCurved id="gradient-rotator"/>
+            </SmallButton>
+          </Tooltip>
+        )}
       </Buttons>
     </Wrapper>
   );
@@ -114,6 +117,7 @@ function GradientPicker({
 GradientPicker.propTypes = {
   stops: PropTypes.arrayOf(ColorStopPropType),
   currentStopIndex: PropTypes.number.isRequired,
+  type: PropTypes.string.isRequired,
 
   onSelect: PropTypes.func.isRequired,
   onAdd: PropTypes.func.isRequired,

--- a/packages/story-editor/src/components/colorPicker/gradientPicker.js
+++ b/packages/story-editor/src/components/colorPicker/gradientPicker.js
@@ -74,6 +74,7 @@ function GradientPicker({
 }) {
   const reverseLabel = __('Reverse gradient stops', 'web-stories');
   const rotateLabel = __('Rotate gradient', 'web-stories');
+  const canRotate = type !== 'radial';
   return (
     <Wrapper>
       <GradientLine
@@ -96,7 +97,7 @@ function GradientPicker({
             <Icons.ArrowsLeftright />
           </SmallButton>
         </Tooltip>
-        {type !== 'radial' && (
+        {canRotate && (
           <Tooltip hasTail title={rotateLabel}>
             <SmallButton
               onClick={onRotate}

--- a/packages/story-editor/src/components/colorPicker/gradientPicker.js
+++ b/packages/story-editor/src/components/colorPicker/gradientPicker.js
@@ -105,7 +105,7 @@ function GradientPicker({
               size={BUTTON_SIZES.SMALL}
               variant={BUTTON_VARIANTS.SQUARE}
             >
-              <Icons.ArrowRightCurved id="gradient-rotator"/>
+              <Icons.ArrowRightCurved id="gradient-rotator" />
             </SmallButton>
           </Tooltip>
         )}


### PR DESCRIPTION
## Summary
Remove the rotation button for radial colors.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a shape.
2. Open the color picker for the shape background and add radial color type from the Custom view.
3. Verify that when Radial type is chosen, the icon for rotation is not available (see the screenshot below for locating the rotation icon)
4. Verify it's still available for linear gradient.

Rotation icon is this:
<img width="259" alt="Screenshot 2021-09-10 at 15 32 19" src="https://user-images.githubusercontent.com/3294597/132853825-d9a17630-b853-4c13-b306-3efe8f235a4e.png">



## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8916 
