### PR TITLE
Decoupling: Remove `X-WP-*` HTTP headers from the core editor

### DIFF
--- a/packages/story-editor/src/app/api/test/_utils.js
+++ b/packages/story-editor/src/app/api/test/_utils.js
@@ -30,8 +30,8 @@ export function createStory(properties = {}) {
 }
 
 export const GET_MEDIA_RESPONSE_HEADER = {
-  'X-WP-Total': 1,
-  'X-WP-TotalPages': 1,
+  totalItems: 1,
+  totalPages: 1,
 };
 export const GET_MEDIA_RESPONSE_BODY = [
   {

--- a/packages/story-editor/src/app/media/local/useContextValueProvider.js
+++ b/packages/story-editor/src/app/media/local/useContextValueProvider.js
@@ -90,8 +90,8 @@ export default function useContextValueProvider(reducerState, reducerActions) {
         cacheBust: cacheBust,
       })
         .then(({ data, headers }) => {
-          const totalPages = parseInt(headers['X-WP-TotalPages']);
-          const totalItems = parseInt(headers['X-WP-Total']);
+          const totalPages = parseInt(headers.totalPages);
+          const totalItems = parseInt(headers.totalItems);
           const mediaArray = data.map(getResourceFromAttachment);
           const hasMore = p < totalPages;
           callback({

--- a/packages/story-editor/src/components/library/test/_utils/index.js
+++ b/packages/story-editor/src/components/library/test/_utils/index.js
@@ -75,7 +75,7 @@ export async function arrange({ mediaResponse = [] }) {
   };
   const getMediaPromise = Promise.resolve({
     data: mediaResponse,
-    headers: { 'X-WP-TotalPages': 1 },
+    headers: { totalPages: 1 },
   });
   const getAllFontsPromise = Promise.resolve([]);
   const allPromises = [getMediaPromise, getAllFontsPromise];

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -838,7 +838,7 @@ class APIProviderFixture {
             .slice((pagingNum - 1) * MEDIA_PER_PAGE, pagingNum * MEDIA_PER_PAGE)
             .filter(filterByMediaType)
             .filter(filterBySearchTerm),
-          headers: { 'X-WP-TotalPages': 3 },
+          headers: { totalPages: 3 },
         });
       }, []);
       const uploadMedia = useCallback(

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -75,9 +75,14 @@ export function getMedia(
     apiPath = addQueryArgs(apiPath, { cache_bust: true });
   }
 
-  return apiFetch({ path: apiPath }).then((response) => {
-    return { data: response.body, headers: response.headers };
-  });
+  return apiFetch({ path: apiPath }).then(({ body, headers }) => ({
+    data: body,
+    headers: {
+      ...headers,
+      totalItems: headers['X-WP-Total'],
+      totalPages: headers['X-WP-TotalPages'],
+    },
+  }));
 }
 
 /**


### PR DESCRIPTION
## Context

Remove `X-WP-*` HTTP headers from the core editor

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123

See #789
-->

Partially addresses https://github.com/google/web-stories-wp/issues/2918
