### PR TITLE
Taxonomies: Add Hierarchical Input UI to the inspector 

### DIFF
--- a/packages/design-system/src/components/input/index.js
+++ b/packages/design-system/src/components/input/index.js
@@ -31,15 +31,18 @@ import { labelAccessibilityValidator } from '../../utils';
 
 const Container = styled.div`
   position: relative;
+  display: inline-block;
   width: 100%;
   min-width: 40px;
 `;
 
 const Label = styled(Text)`
   margin-bottom: 12px;
+  display: inline-block;
 `;
 
 const Hint = styled(Text)`
+  display: inline-block;
   margin-top: 12px;
   color: ${({ hasError, theme }) =>
     theme.colors.fg[hasError ? 'negative' : 'tertiary']};

--- a/packages/story-editor/src/components/form/hierarchical/index.js
+++ b/packages/story-editor/src/components/form/hierarchical/index.js
@@ -46,6 +46,11 @@ import {
   filterOptionsByLabelText,
 } from './utils';
 
+const Container = styled.div`
+  margin-bottom: 8px;
+  display: block;
+`;
+
 const Label = styled(Text).attrs({
   forwardedAs: 'label',
   size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
@@ -128,6 +133,7 @@ const OptionPropType = {
 Option.propTypes = OptionPropType;
 
 const HierarchicalInput = ({
+  className,
   label,
   noOptionsText = __('Category Not Found', 'web-stories'),
   options,
@@ -187,8 +193,11 @@ const HierarchicalInput = ({
     }
   }, [debouncedSpeak, filteredOptions, inputText, previousInput]);
 
+  const showOptionArea =
+    Boolean(filteredOptions.length) || Boolean(inputText.length);
+
   return (
-    <>
+    <Container className={className}>
       <Input
         value={inputText}
         onChange={handleInputChange}
@@ -201,31 +210,34 @@ const HierarchicalInput = ({
         type="search"
         {...inputProps}
       />
-      <Border>
-        <DirectionAware>
-          <CheckboxArea role="group">
-            {filteredOptions.length ? (
-              filteredOptions.map((option) => (
-                <Option
-                  key={option.id}
-                  {...option}
-                  onChange={handleCheckboxChange}
-                />
-              ))
-            ) : (
-              <NoResultsText
-                size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
-              >
-                {noOptionsText}
-              </NoResultsText>
-            )}
-          </CheckboxArea>
-        </DirectionAware>
-      </Border>
-    </>
+      {showOptionArea && (
+        <Border>
+          <DirectionAware>
+            <CheckboxArea role="group">
+              {filteredOptions.length ? (
+                filteredOptions.map((option) => (
+                  <Option
+                    key={option.id}
+                    {...option}
+                    onChange={handleCheckboxChange}
+                  />
+                ))
+              ) : (
+                <NoResultsText
+                  size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}
+                >
+                  {noOptionsText}
+                </NoResultsText>
+              )}
+            </CheckboxArea>
+          </DirectionAware>
+        </Border>
+      )}
+    </Container>
   );
 };
 HierarchicalInput.propTypes = {
+  className: PropTypes.string,
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   label: PropTypes.string.isRequired,
   noOptionsText: PropTypes.string,

--- a/packages/story-editor/src/components/form/index.js
+++ b/packages/story-editor/src/components/form/index.js
@@ -28,3 +28,4 @@ export { default as DateTime } from './dateTime';
 export { default as Required } from './required';
 export { default as RadioGroup } from './radioGroup';
 export { default as Select } from './select';
+export { default as HierarchicalInput } from './hierarchical';

--- a/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
@@ -18,18 +18,146 @@
  * External dependencies
  */
 import { __ } from '@web-stories-wp/i18n';
+import {
+  Button,
+  BUTTON_SIZES,
+  BUTTON_TYPES,
+  BUTTON_VARIANTS,
+  DropDown,
+  Headline,
+  Input,
+  Text,
+  themeHelpers,
+  THEME_CONSTANTS,
+} from '@web-stories-wp/design-system';
+import { useCallback, useMemo, useState } from '@web-stories-wp/react';
+import { v4 as uuidv4 } from 'uuid';
 /**
  * Internal dependencies
  */
+import styled from 'styled-components';
 import { SimplePanel } from '../../panel';
+import { HierarchicalInput } from '../../../form';
+import { noop } from '../../../../utils/noop';
+
+const ContentArea = styled.div`
+  label,
+  * > label {
+    ${({ theme }) =>
+      themeHelpers.expandPresetStyles({
+        preset:
+          theme.typography.presets.label[
+            THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL
+          ],
+        theme,
+      })};
+
+    color: ${({ theme }) => theme.colors.fg.secondary};
+  }
+`;
+
+const ContentHeading = styled(Headline).attrs({
+  as: 'h3',
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.XXX_SMALL,
+})`
+  margin: 4px 0 16px;
+  font-weight: ${({ theme }) => theme.typography.weight.regular};
+`;
+
+const AddNewCategoryArea = styled.div`
+  margin: 24px 0 16px;
+`;
+
+const LinkButton = styled(Button).attrs({
+  variant: BUTTON_VARIANTS.LINK,
+})`
+  margin-bottom: 16px;
+
+  ${({ theme }) =>
+    themeHelpers.expandPresetStyles({
+      preset:
+        theme.typography.presets.link[
+          THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL
+        ],
+      theme,
+    })};
+
+  font-weight: 500;
+`;
+
+const Label = styled(Text).attrs({
+  forwardedAs: 'label',
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
+})`
+  display: inline-block;
+  margin: 12px 0;
+`;
+
+const AddNewCategoryButton = styled(Button).attrs({
+  variant: BUTTON_VARIANTS.RECTANGLE,
+  size: BUTTON_SIZES.SMALL,
+  type: BUTTON_TYPES.SECONDARY,
+})`
+  margin-top: 20px;
+`;
 
 function TaxonomiesPanel({ ...props }) {
+  const [showAddNewCategory, setShowAddNewCategory] = useState(false);
+  const [newCategoryName, setNewCategoryName] = useState('');
+  const dropdownId = useMemo(uuidv4, []);
+
+  const handleShowAddNewCategoryClick = useCallback(() => {
+    setShowAddNewCategory(true);
+  }, []);
+
+  const handleChangeNewCategoryName = useCallback((evt) => {
+    setNewCategoryName(evt.target.value);
+  }, []);
+
+  const handleAddCategory = useCallback(() => {
+    setShowAddNewCategory(false);
+  }, []);
+
   return (
     <SimplePanel
       name="taxonomies"
       title={__('Categories and Tags', 'web-stories')}
       {...props}
-    />
+    >
+      <ContentArea>
+        <ContentHeading>{__('Categories', 'web-stories')}</ContentHeading>
+        <HierarchicalInput
+          label={__('Search Categories', 'web-stories')}
+          options={[]}
+          onChange={noop}
+        />
+        {showAddNewCategory ? (
+          <AddNewCategoryArea>
+            <Input
+              label={__('New Category Name', 'web-stories')}
+              value={newCategoryName}
+              onChange={handleChangeNewCategoryName}
+            />
+            <Label htmlFor={dropdownId}>
+              {__('Parent Category', 'web-stories')}
+            </Label>
+            <DropDown
+              id={dropdownId}
+              ariaLabel={__('Parent Category', 'web-stories')}
+              placeholder={__('Parent Category', 'web-stories')}
+              options={[]}
+            />
+            <AddNewCategoryButton onClick={handleAddCategory}>
+              {__('Add Category', 'web-stories')}
+            </AddNewCategoryButton>
+          </AddNewCategoryArea>
+        ) : (
+          <LinkButton onClick={handleShowAddNewCategoryClick}>
+            {__('Add New Category', 'web-stories')}
+          </LinkButton>
+        )}
+      </ContentArea>
+    </SimplePanel>
   );
 }
 

--- a/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
@@ -31,11 +31,11 @@ import {
   THEME_CONSTANTS,
 } from '@web-stories-wp/design-system';
 import { useCallback, useMemo, useState } from '@web-stories-wp/react';
+import styled from 'styled-components';
 import { v4 as uuidv4 } from 'uuid';
 /**
  * Internal dependencies
  */
-import styled from 'styled-components';
 import { SimplePanel } from '../../panel';
 import { HierarchicalInput } from '../../../form';
 import { noop } from '../../../../utils/noop';


### PR DESCRIPTION
## Context

Taxonomies. [Designs](https://www.figma.com/file/1YM3jA9h4QGc4xLdyaXIJS/Stories-Sprint-1.7?node-id=9721%3A383514)

## Summary

Adds the UI for categories to the taxonomies section. Nothing is hooked up to the backend yet.

## Relevant Technical Choices

Waiting on #9004 to hook it all up, so this PR is purely presentational.

## To-do

n/a

## User-facing changes

![categories](https://user-images.githubusercontent.com/22185279/133332291-2207b6c5-4961-4535-a266-51f2c24f4ae9.gif)

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Enable the taxonomies feature flag
2. Open a story
3. Click on the `Document` tab in the inspector
4. Mess with the new UI - should be accessible and fun to play with


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #8841
