### PR TITLE
Make taxonomy selection more agnostic

### DIFF
--- a/packages/story-editor/src/app/story/actions/test/useAutoSave.js
+++ b/packages/story-editor/src/app/story/actions/test/useAutoSave.js
@@ -75,6 +75,7 @@ describe('useAutoSave', () => {
       featuredMedia: { id: 0 },
       password: '',
       globalStoryStyles: '',
+      taxonomies: [],
     };
     const pages = [
       {
@@ -116,6 +117,7 @@ describe('useAutoSave', () => {
       },
     };
     delete expected.publisherLogo;
+    delete expected.taxonomies;
     expect(autoSaveById).toHaveBeenCalledWith(expected);
   });
 });

--- a/packages/story-editor/src/app/story/effects/useLoadStory.js
+++ b/packages/story-editor/src/app/story/effects/useLoadStory.js
@@ -60,9 +60,6 @@ function useLoadStory({ storyId, shouldLoad, restore, isDemo }) {
           embed_post_link: embedPostLink,
           _embedded: embedded = {},
           _links: links = {},
-          // TODO  #8849 Make these dynamic
-          'story-tags': storyTags = [],
-          'story-categories': storyCategories = [],
         } = post;
 
         const capabilities = {
@@ -95,8 +92,6 @@ function useLoadStory({ storyId, shouldLoad, restore, isDemo }) {
           url: embedded?.['wp:featuredmedia']?.[0]?.source_url || '',
         };
 
-        let embeddedTerms = [];
-
         const publisherLogo = {
           id: embedded?.['wp:publisherlogo']?.[0].id || 0,
           height:
@@ -105,9 +100,9 @@ function useLoadStory({ storyId, shouldLoad, restore, isDemo }) {
           url: embedded?.['wp:publisherlogo']?.[0]?.source_url || '',
         };
 
-        if ('wp:term' in embedded) {
-          embeddedTerms = embedded['wp:term'];
-        }
+        const taxonomies =
+          links?.['wp:term']?.map(({ taxonomy }) => taxonomy) || [];
+        const terms = embedded?.['wp:term'] || [];
 
         const [prefix, suffix] = permalinkTemplate.split(
           /%(?:postname|pagename)%/
@@ -174,9 +169,8 @@ function useLoadStory({ storyId, shouldLoad, restore, isDemo }) {
           autoAdvance: storyData?.autoAdvance,
           defaultPageDuration: storyData?.defaultPageDuration,
           backgroundAudio: storyData?.backgroundAudio,
-          embeddedTerms,
-          'story-tags': storyTags,
-          'story-categories': storyCategories,
+          taxonomies,
+          terms,
         };
 
         // TODO read current page and selection from deeplink?

--- a/packages/story-editor/src/app/story/utils/getStoryPropsToSave.js
+++ b/packages/story-editor/src/app/story/utils/getStoryPropsToSave.js
@@ -35,9 +35,7 @@ function getStoryPropsToSave({ story, pages, metadata }) {
     'autoAdvance',
     'defaultPageDuration',
     'backgroundAudio',
-    // TODO #8849 make this dynamic based on
-    // taxonomies returned from WP at some point.
-    'story-tags',
+    ...story.taxonomies,
   ]);
 
   const content = getStoryMarkup(story, pages, metadata);

--- a/packages/story-editor/src/app/story/utils/test/getStoryPropsToSave.js
+++ b/packages/story-editor/src/app/story/utils/test/getStoryPropsToSave.js
@@ -47,6 +47,7 @@ describe('getStoryPropsToSave', () => {
         id: 123,
         mimeType: 'audio/mpeg',
       },
+      taxonomies: [],
     };
     const extraProps = {
       storyId: 1,
@@ -72,6 +73,7 @@ describe('getStoryPropsToSave', () => {
       },
     };
     delete expected.publisherLogo;
+    delete expected.taxonomies;
 
     expect(props).toStrictEqual(expected);
   });

--- a/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { useCallback, useDebouncedCallback } from '@web-stories-wp/react';
+
+/**
+ * Internal dependencies
+ */
+import Tags from '../../../form/tags';
+import cleanForSlug from '../../../../utils/cleanForSlug';
+import { useTaxonomy } from '../../../../app/taxonomy';
+import { ContentHeading } from './shared';
+
+function FlatTermSelector({ taxonomy }) {
+  const {
+    createTerm,
+    termCache,
+    addSearchResultsToCache,
+    setSelectedTaxonomySlugs,
+    selectedSlugs,
+  } = useTaxonomy(
+    ({
+      state: { termCache, selectedSlugs },
+      actions: {
+        createTerm,
+        addSearchResultsToCache,
+        setSelectedTaxonomySlugs,
+      },
+    }) => ({
+      termCache,
+      createTerm,
+      addSearchResultsToCache,
+      setSelectedTaxonomySlugs,
+      selectedSlugs,
+    })
+  );
+
+  const handleFreeformTermsChange = useCallback(
+    (termNames) => {
+      termNames.forEach((termName) => createTerm(taxonomy, termName));
+      setSelectedTaxonomySlugs(
+        taxonomy,
+        termNames.map((termName) => cleanForSlug(termName))
+      );
+    },
+    [taxonomy, createTerm, setSelectedTaxonomySlugs]
+  );
+
+  const handleFreeformInputChange = useDebouncedCallback((value) => {
+    if (value.length < 3) {
+      return;
+    }
+    addSearchResultsToCache(taxonomy, value);
+  }, 1000);
+
+  const termDisplayTransformer = useCallback(
+    (tagName) => termCache[taxonomy]?.[cleanForSlug(tagName)]?.name,
+    [taxonomy, termCache]
+  );
+
+  return (
+    <>
+      <ContentHeading>{taxonomy.labels.name}</ContentHeading>
+      <div key={taxonomy.slug}>
+        <Tags.Label htmlFor={`${taxonomy.slug}-input`}>
+          {taxonomy.labels.add_new_item}
+        </Tags.Label>
+        <Tags.Input
+          id={`${taxonomy.slug}-input`}
+          aria-describedby={`${taxonomy.slug}-description`}
+          name={taxonomy.slug}
+          onTagsChange={handleFreeformTermsChange}
+          onInputChange={handleFreeformInputChange}
+          tagDisplayTransformer={termDisplayTransformer}
+          initialTags={selectedSlugs?.[taxonomy.rest_base] || []}
+        />
+        <Tags.Description id={`${taxonomy.slug}-description`}>
+          {taxonomy.labels.separate_items_with_commas}
+        </Tags.Description>
+      </div>
+    </>
+  );
+}
+
+FlatTermSelector.propTypes = {
+  // TODO: Define better prop type.
+  taxonomy: PropTypes.object,
+};
+
+export default FlatTermSelector;

--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { __ } from '@web-stories-wp/i18n';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  BUTTON_SIZES,
+  BUTTON_TYPES,
+  BUTTON_VARIANTS,
+  DropDown,
+  Input,
+  Text,
+  THEME_CONSTANTS,
+  themeHelpers,
+} from '@web-stories-wp/design-system';
+import styled from 'styled-components';
+import { useCallback, useMemo, useState } from '@web-stories-wp/react';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * Internal dependencies
+ */
+import { noop } from '../../../../utils/noop';
+import { HierarchicalInput } from '../../../form';
+import { ContentHeading } from './shared';
+
+const ContentArea = styled.div`
+  label,
+  * > label {
+    ${({ theme }) =>
+      themeHelpers.expandPresetStyles({
+        preset:
+          theme.typography.presets.label[
+            THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL
+          ],
+        theme,
+      })};
+
+    color: ${({ theme }) => theme.colors.fg.secondary};
+  }
+`;
+
+const AddNewCategoryArea = styled.div`
+  margin: 24px 0 16px;
+`;
+
+const LinkButton = styled(Button).attrs({
+  variant: BUTTON_VARIANTS.LINK,
+})`
+  margin-bottom: 16px;
+
+  ${({ theme }) =>
+    themeHelpers.expandPresetStyles({
+      preset:
+        theme.typography.presets.link[
+          THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL
+        ],
+      theme,
+    })};
+
+  font-weight: 500;
+`;
+
+const Label = styled(Text).attrs({
+  forwardedAs: 'label',
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
+})`
+  display: inline-block;
+  margin: 12px 0;
+`;
+
+const AddNewCategoryButton = styled(Button).attrs({
+  variant: BUTTON_VARIANTS.RECTANGLE,
+  size: BUTTON_SIZES.SMALL,
+  type: BUTTON_TYPES.SECONDARY,
+})`
+  margin-top: 20px;
+`;
+
+function HierarchicalTermSelector({ taxonomy }) {
+  const [showAddNewCategory, setShowAddNewCategory] = useState(false);
+  const [newCategoryName, setNewCategoryName] = useState('');
+  const dropdownId = useMemo(uuidv4, []);
+
+  const handleShowAddNewCategoryClick = useCallback(() => {
+    setShowAddNewCategory(true);
+  }, []);
+
+  const handleChangeNewCategoryName = useCallback((evt) => {
+    setNewCategoryName(evt.target.value);
+  }, []);
+
+  const handleAddCategory = useCallback(() => {
+    setShowAddNewCategory(false);
+  }, []);
+
+  return (
+    <ContentArea>
+      <ContentHeading>{taxonomy.labels.name}</ContentHeading>
+      <HierarchicalInput
+        label={taxonomy.labels.search_items}
+        options={[]}
+        onChange={noop}
+      />
+      {showAddNewCategory ? (
+        <AddNewCategoryArea>
+          <Input
+            label={taxonomy.labels.new_item_name}
+            value={newCategoryName}
+            onChange={handleChangeNewCategoryName}
+          />
+          <Label htmlFor={dropdownId}>{taxonomy.labels.parent_item}</Label>
+          <DropDown
+            id={dropdownId}
+            ariaLabel={taxonomy.labels.parent_item}
+            placeholder={taxonomy.labels.parent_item}
+            options={[]}
+          />
+          <AddNewCategoryButton onClick={handleAddCategory}>
+            {__('Add', 'web-stories')}
+          </AddNewCategoryButton>
+        </AddNewCategoryArea>
+      ) : (
+        <LinkButton onClick={handleShowAddNewCategoryClick}>
+          {taxonomy.labels.add_new_item}
+        </LinkButton>
+      )}
+    </ContentArea>
+  );
+}
+
+HierarchicalTermSelector.propTypes = {
+  // TODO: Define better prop type.
+  taxonomy: PropTypes.object,
+};
+
+export default HierarchicalTermSelector;

--- a/packages/story-editor/src/components/panels/document/taxonomies/shared.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/shared.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import { Headline, THEME_CONSTANTS } from '@web-stories-wp/design-system';
+
+export const ContentHeading = styled(Headline).attrs({
+  as: 'h3',
+  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.XXX_SMALL,
+})`
+  margin: 4px 0 16px;
+  font-weight: ${({ theme }) => theme.typography.weight.regular};
+`;

--- a/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
@@ -18,188 +18,23 @@
  * External dependencies
  */
 import { __ } from '@web-stories-wp/i18n';
-import {
-  Button,
-  BUTTON_SIZES,
-  BUTTON_TYPES,
-  BUTTON_VARIANTS,
-  DropDown,
-  Headline,
-  Input,
-  Text,
-  themeHelpers,
-  THEME_CONSTANTS,
-} from '@web-stories-wp/design-system';
-import {
-  useCallback,
-  useDebouncedCallback,
-  useMemo,
-  useState,
-} from '@web-stories-wp/react';
-import styled from 'styled-components';
-import { v4 as uuidv4 } from 'uuid';
 
 /**
  * Internal dependencies
  */
 import { useTaxonomy } from '../../../../app/taxonomy';
-import cleanForSlug from '../../../../utils/cleanForSlug';
-import Tags from '../../../form/tags';
 import { SimplePanel } from '../../panel';
-import { HierarchicalInput } from '../../../form';
-import { noop } from '../../../../utils/noop';
-
-const ContentArea = styled.div`
-  label,
-  * > label {
-    ${({ theme }) =>
-      themeHelpers.expandPresetStyles({
-        preset:
-          theme.typography.presets.label[
-            THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL
-          ],
-        theme,
-      })};
-
-    color: ${({ theme }) => theme.colors.fg.secondary};
-  }
-`;
-
-const ContentHeading = styled(Headline).attrs({
-  as: 'h3',
-  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.XXX_SMALL,
-})`
-  margin: 4px 0 16px;
-  font-weight: ${({ theme }) => theme.typography.weight.regular};
-`;
-
-const AddNewCategoryArea = styled.div`
-  margin: 24px 0 16px;
-`;
-
-const LinkButton = styled(Button).attrs({
-  variant: BUTTON_VARIANTS.LINK,
-})`
-  margin-bottom: 16px;
-
-  ${({ theme }) =>
-    themeHelpers.expandPresetStyles({
-      preset:
-        theme.typography.presets.link[
-          THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL
-        ],
-      theme,
-    })};
-
-  font-weight: 500;
-`;
-
-const Label = styled(Text).attrs({
-  forwardedAs: 'label',
-  size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
-})`
-  display: inline-block;
-  margin: 12px 0;
-`;
-
-const AddNewCategoryButton = styled(Button).attrs({
-  variant: BUTTON_VARIANTS.RECTANGLE,
-  size: BUTTON_SIZES.SMALL,
-  type: BUTTON_TYPES.SECONDARY,
-})`
-  margin-top: 20px;
-`;
+import HierarchicalTermSelector from './HierarchicalTermSelector';
+import FlatTermSelector from './FlatTermSelector';
 
 function TaxonomiesPanel(props) {
-  const {
+  const { taxonomies } = useTaxonomy(({ state: { taxonomies } }) => ({
     taxonomies,
-    createTerm,
-    termCache,
-    addSearchResultsToCache,
-    setSelectedTaxonomySlugs,
-    selectedSlugs,
-  } = useTaxonomy(
-    ({
-      state: { taxonomies, termCache, selectedSlugs },
-      actions: {
-        createTerm,
-        addSearchResultsToCache,
-        setSelectedTaxonomySlugs,
-      },
-    }) => ({
-      taxonomies,
-      termCache,
-      createTerm,
-      addSearchResultsToCache,
-      setSelectedTaxonomySlugs,
-      selectedSlugs,
-    })
-  );
+  }));
 
-  const [showAddNewCategory, setShowAddNewCategory] = useState(false);
-  const [newCategoryName, setNewCategoryName] = useState('');
-  const dropdownId = useMemo(uuidv4, []);
-
-  const handleShowAddNewCategoryClick = useCallback(() => {
-    setShowAddNewCategory(true);
-  }, []);
-
-  const handleChangeNewCategoryName = useCallback((evt) => {
-    setNewCategoryName(evt.target.value);
-  }, []);
-
-  const handleAddCategory = useCallback(() => {
-    setShowAddNewCategory(false);
-  }, []);
-
-  const _handleFreeformTermsChange = useCallback(
-    (taxonomy) => (termNames) => {
-      termNames.forEach((termName) => createTerm(taxonomy, termName));
-      setSelectedTaxonomySlugs(
-        taxonomy,
-        termNames.map((termName) => cleanForSlug(termName))
-      );
-    },
-    [createTerm, setSelectedTaxonomySlugs]
-  );
-
-  const _handleFreeformInputChange = useDebouncedCallback(
-    (taxonomy) => (value) => {
-      if (value.length < 3) {
-        return;
-      }
-      addSearchResultsToCache(taxonomy, value);
-    },
-    1000
-  );
-
-  const _termDisplayTransformer = useCallback(
-    (taxonomy) => (tagName) =>
-      termCache[taxonomy]?.[cleanForSlug(tagName)]?.name,
-    [termCache]
-  );
-
-  // We want to prevent curried functions from creating
-  // a new function on every render so we build them with
-  // memoized args here instead of in the render
-  const taxonomyHandlerTuples = useMemo(
-    () =>
-      (taxonomies || []).map((taxonomy) => [
-        taxonomy,
-        // handlers
-        {
-          handleFreeformTermsChange: _handleFreeformTermsChange(taxonomy),
-          handleFreeformInputChange: _handleFreeformInputChange(taxonomy),
-          termDisplayTransformer: _termDisplayTransformer(taxonomy),
-        },
-      ]),
-    [
-      taxonomies,
-      _handleFreeformTermsChange,
-      _handleFreeformInputChange,
-      _termDisplayTransformer,
-    ]
-  );
+  if (!taxonomies.length) {
+    return null;
+  }
 
   return (
     <SimplePanel
@@ -207,63 +42,12 @@ function TaxonomiesPanel(props) {
       title={__('Categories and Tags', 'web-stories')}
       {...props}
     >
-      <ContentArea>
-        <ContentHeading>{__('Categories', 'web-stories')}</ContentHeading>
-        <HierarchicalInput
-          label={__('Search Categories', 'web-stories')}
-          options={[]}
-          onChange={noop}
-        />
-        {showAddNewCategory ? (
-          <AddNewCategoryArea>
-            <Input
-              label={__('New Category Name', 'web-stories')}
-              value={newCategoryName}
-              onChange={handleChangeNewCategoryName}
-            />
-            <Label htmlFor={dropdownId}>
-              {__('Parent Category', 'web-stories')}
-            </Label>
-            <DropDown
-              id={dropdownId}
-              ariaLabel={__('Parent Category', 'web-stories')}
-              placeholder={__('Parent Category', 'web-stories')}
-              options={[]}
-            />
-            <AddNewCategoryButton onClick={handleAddCategory}>
-              {__('Add Category', 'web-stories')}
-            </AddNewCategoryButton>
-          </AddNewCategoryArea>
+      {taxonomies.map((taxonomy) =>
+        taxonomy.hierarchical ? (
+          <HierarchicalTermSelector taxonomy={taxonomy} key={taxonomy.slug} />
         ) : (
-          <LinkButton onClick={handleShowAddNewCategoryClick}>
-            {__('Add New Category', 'web-stories')}
-          </LinkButton>
-        )}
-      </ContentArea>
-
-      <ContentHeading>{__('Tags', 'web-stories')}</ContentHeading>
-      {taxonomyHandlerTuples.map(([taxonomy, handlers]) =>
-        // TODO support all taxonomies and differentiate
-        // input component based on `taxonomy.hierarchical`
-        taxonomy.slug === 'story-tag' ? (
-          <div key={taxonomy.slug}>
-            <Tags.Label htmlFor={`${taxonomy.slug}-input`}>
-              {__('Add New Term', 'web-stories')}
-            </Tags.Label>
-            <Tags.Input
-              id={`${taxonomy.slug}-input`}
-              aria-describedby={`${taxonomy.slug}-description`}
-              name="story-tags"
-              onTagsChange={handlers.handleFreeformTermsChange}
-              onInputChange={handlers.handleFreeformInputChange}
-              tagDisplayTransformer={handlers.termDisplayTransformer}
-              initialTags={selectedSlugs?.[taxonomy.rest_base] || []}
-            />
-            <Tags.Description id={`${taxonomy.slug}-description`}>
-              {__('Separate with commas or the Enter key.', 'web-stories')}
-            </Tags.Description>
-          </div>
-        ) : null
+          <FlatTermSelector taxonomy={taxonomy} key={taxonomy.slug} />
+        )
       )}
     </SimplePanel>
   );

--- a/packages/story-editor/src/components/panels/document/taxonomies/test/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/test/taxonomies.js
@@ -22,26 +22,26 @@ import { screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import StoryContext from '../../../../../app/story/context';
+import TaxonomyContext from '../../../../../app/taxonomy/context';
 import { renderWithTheme } from '../../../../../testUtils';
 import TaxonomiesPanel from '../taxonomies';
 
-function arrange() {
-  const updateStory = jest.fn();
-
+function arrange({ taxonomies }) {
   const storyContextValue = {
     state: {
-      story: {
-        taxonomies: '',
-      },
+      taxonomies,
     },
-    actions: { updateStory },
+    actions: {
+      createTerm: jest.fn(),
+      addSearchResultsToCache: jest.fn(),
+      setSelectedTaxonomySlugs: jest.fn(),
+    },
   };
 
   return renderWithTheme(
-    <StoryContext.Provider value={storyContextValue}>
+    <TaxonomyContext.Provider value={storyContextValue}>
       <TaxonomiesPanel />
-    </StoryContext.Provider>
+    </TaxonomyContext.Provider>
   );
 }
 
@@ -57,8 +57,25 @@ describe('TaxonomiesPanel', () => {
     localStorage.clear();
   });
 
+  it('should not render Taxonomies Panel if there are no taxonomies', () => {
+    arrange({ taxonomies: [] });
+    const element = screen.queryByRole('button', {
+      name: 'Categories and Tags',
+    });
+    expect(element).not.toBeInTheDocument();
+  });
+
   it('should render Taxonomies Panel', () => {
-    arrange();
+    arrange({
+      taxonomies: [
+        {
+          slug: 'story-tag',
+          name: 'Tags',
+          labels: [],
+          hierarchical: false,
+        },
+      ],
+    });
     const element = screen.getByRole('button', { name: 'Categories and Tags' });
     expect(element).toBeInTheDocument();
   });


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

#9004 had some issues with loading taxonomies

Plus the whole thing wasn't yet built platform-agnostic, deferring that work to #8849, despite it being quite easy to implement.

## Summary

<!-- A brief description of what this PR does. -->

This PR lays the groundwork for making taxonomy selection more agnostic.

Does not update any styling or anything.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

No taxonomies available:

![Screenshot 2021-09-15 at 10 16 21](https://user-images.githubusercontent.com/841956/133396993-f9eb09fd-85a5-441a-b250-284d8d019d05.png)

All taxonomies available:

![Screenshot 2021-09-15 at 10 16 01](https://user-images.githubusercontent.com/841956/133397001-578c8cd5-63ad-4201-8fa7-8cc8f67ca2d6.png)


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #8849
