### PR TITLE
remove enableRightClickMenus

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -220,18 +220,6 @@ class Experiments extends Service_Base {
 	public function get_experiments(): array {
 		return [
 			/**
-			 * Author: @samwhale
-			 * Issue: 6153
-			 * Creation date: 2021-06-07
-			 */
-			[
-				'name'        => 'enableRightClickMenus',
-				'label'       => __( 'Right click menus', 'web-stories' ),
-				'description' => __( 'Enable a contextual shortcut menu when right clicking in the editor', 'web-stories' ),
-				'group'       => 'editor',
-				'default'     => true,
-			],
-			/**
 			 * Author: @littlemilkstudio
 			 * Issue: 6379
 			 * Creation date: 2021-03-09

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -22,7 +22,6 @@ import {
 } from '@web-stories-wp/design-system';
 import { __ } from '@web-stories-wp/i18n';
 import { trackEvent } from '@web-stories-wp/tracking';
-import { useFeature } from 'flagged';
 import PropTypes from 'prop-types';
 import {
   useCallback,
@@ -74,8 +73,6 @@ import { getDefaultPropertiesForType, getElementStyles } from './utils';
  * @return {Node} React node
  */
 function RightClickMenuProvider({ children }) {
-  const enableRightClickMenus = useFeature('enableRightClickMenus');
-
   const { addGlobalPreset: addGlobalTextPreset } = useAddPreset({
     presetType: PRESET_TYPES.STYLE,
   });
@@ -977,7 +974,7 @@ function RightClickMenuProvider({ children }) {
   // rightClickAreaRef is set
   useEffect(() => {
     const node = rightClickAreaRef.current;
-    if (!enableRightClickMenus || !node) {
+    if (!node) {
       return undefined;
     }
 
@@ -986,7 +983,7 @@ function RightClickMenuProvider({ children }) {
     return () => {
       node.removeEventListener('contextmenu', handleOpenMenu);
     };
-  }, [enableRightClickMenus, handleOpenMenu]);
+  }, [handleOpenMenu]);
 
   useGlobalKeyDownEffect(
     { key: ['mod+alt+o'] },

--- a/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
@@ -27,11 +27,6 @@ import { useCanvas } from '../../canvas';
 import { useStory } from '../../story';
 import { RIGHT_CLICK_MENU_LABELS } from '../constants';
 
-// TODO: #6154 remove when the `enableRightClickMenus` experiment is removed
-jest.mock('flagged', () => ({
-  useFeature: () => true,
-}));
-
 jest.mock('../../canvas', () => ({
   useCanvas: jest.fn(),
 }));

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -36,7 +36,6 @@ describe('Right Click Menu integration', () => {
 
   beforeEach(async () => {
     fixture = new Fixture();
-    fixture.setFlags({ enableRightClickMenus: true });
     await fixture.render();
 
     insertElement = await fixture.renderHook(() => useInsertElement());


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Remove references to `enableRightClickMenus` experiment because it's enabled by default now. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
n/a

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
Feature flag removed from `Experiments`

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Check that `Right click menus` is no longer visible under `Experiments`
2.  Right click on canvas in editor to ensure or custom context menu is still functioning.


## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->
no
### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
no
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6154 