### PR TITLE
Dynamic Dropdown placement when not enough space

### DIFF
--- a/packages/design-system/src/components/dropDown/index.js
+++ b/packages/design-system/src/components/dropDown/index.js
@@ -96,9 +96,8 @@ export const DropDown = forwardRef(
     const positionPlacement = useCallback(
       (popupRef) => {
         // check to see if there's an overlap with the window edge
-        const dimensions = popupRef.current?.getBoundingClientRect();
-        const bottom = dimensions?.bottom;
-        const top = dimensions?.top;
+        const { bottom, top } = popupRef.current?.getBoundingClientRect() || {};
+
         // if the popup was assigned as bottom we want to always check it
         if (
           dynamicPlacement.startsWith('bottom') &&

--- a/packages/design-system/src/components/popup/index.js
+++ b/packages/design-system/src/components/popup/index.js
@@ -75,6 +75,7 @@ function Popup({
   fillWidth = false,
   fillHeight = false,
   onPositionUpdate = noop,
+  refCallback = noop,
 }) {
   const [popupState, setPopupState] = useState(null);
   const [mounted, setMounted] = useState(false);
@@ -112,10 +113,10 @@ function Popup({
     };
   }, [isOpen, positionPopup]);
 
-  useLayoutEffect(
-    () => onPositionUpdate(popupState),
-    [popupState, onPositionUpdate]
-  );
+  useLayoutEffect(() => {
+    onPositionUpdate(popupState);
+    refCallback(popup);
+  }, [popupState, onPositionUpdate, refCallback]);
 
   useResizeEffect({ current: document.body }, positionPopup, [positionPopup]);
 
@@ -151,6 +152,7 @@ Popup.propTypes = {
   fillWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   fillHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.bool]),
   onPositionUpdate: PropTypes.func,
+  refCallback: PropTypes.func,
 };
 
 export { Popup, PLACEMENT };

--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -117,5 +117,7 @@ export function getOffset(placement, spacing, anchor, dock, popup) {
     y: offsetY,
     width: anchorRect.width,
     height: anchorRect.height,
+    // We want to know where the popRect container stops before scrolling begins
+    bottom: popupRect?.bottom,
   };
 }

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -134,7 +134,7 @@ function Tooltip({
   const positionPlacement = useCallback(
     ({ offset }) => {
       // check to see if there's an overlap with the window edge
-      const neededVerticalSpace = offset.y + offset.height;
+      const neededVerticalSpace = offset.bottom;
       // if the tooltip was assigned as bottom we want to always check it
       if (
         offset &&


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Dropdown can be hidden if it's located too low on the screen.  If bottom of the dropdown `popup` would be below the window, we force placement to be at the top.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Copied callback used in tooltip to dynamically set placement. Added `popupRect.bottom` to `getOffset` util func. 

## To-do
n/a
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
When a dropdown is close to the bottom of the screen and the list would be cutoff, we change the placement to TOP

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.  In storybook -> Dropdown make window short than the height of where the dropdown would end. 
2. Open dropdown and it should render on top
3. Making the window taller and reopening the dropdown should place it back on the bottom if there is enough space to render the popup container. 


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->
no

### Does this PR change what data or activity we track or use?
no

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
9049