### PR TITLE
Taxonomies: fetch all terms using `per_page=1`

### DIFF
--- a/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
+++ b/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
@@ -220,7 +220,7 @@ function TaxonomyProvider(props) {
         (taxonomy) => taxonomy.hierarchical
       );
       hierarchicalTaxonomies.forEach((taxonomy) =>
-        addSearchResultsToCache(taxonomy, { perPage: 100 })
+        addSearchResultsToCache(taxonomy, { perPage: -1 })
       );
 
       setShouldRefetchCategories(false);


### PR DESCRIPTION
## Context
fetch all pages, one by one, like Gutenberg does.
Create new PR since [old one](https://github.com/google/web-stories-wp/pull/9064) had quite a few merge conflicts. 

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. add over 100 categories use WP-CLI to easily create thousands of terms easily by simply running wp term generate web-story-category --count=1000 -thanks @swissspidy 
2.  load page and look at network for more then one request for categories


## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9056