### PR TITLE
Taxonomies: keyboard functionality

### DIFF
--- a/packages/design-system/src/components/input/index.js
+++ b/packages/design-system/src/components/input/index.js
@@ -147,6 +147,7 @@ export const Input = forwardRef(
       label,
       onBlur,
       onFocus,
+      hasFocus = false,
       suffix,
       unit = '',
       value,
@@ -158,7 +159,7 @@ export const Input = forwardRef(
   ) => {
     const inputId = useMemo(() => id || uuidv4(), [id]);
 
-    const [isFocused, setIsFocused] = useState(false);
+    const [isFocused, setIsFocused] = useState(hasFocus);
     const [hasBeenSelected, setHasBeenSelected] = useState(false);
 
     let displayedValue = value;

--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -77,6 +77,8 @@ const ButtonContainer = styled.div`
 const LinkButton = styled(Button).attrs({
   variant: BUTTON_VARIANTS.LINK,
 })`
+  ${(props) => props._showAddNewCategory && 'display: none;'}
+
   margin-bottom: 16px;
 
   ${({ theme }) =>
@@ -154,7 +156,9 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
   const [selectedParent, setSelectedParent] = useState(noParentId);
   const dropdownId = useMemo(uuidv4, []);
   const [hasFocus, setHasFocus] = useState(false);
-  const ref = useRef();
+  const formRef = useRef();
+  const toggleRef = useRef();
+  const [toggleFocus, setToggleFocus] = useState(false);
 
   const resetInputs = useCallback(() => {
     setNewCategoryName('');
@@ -190,8 +194,9 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
   const handleToggleNewCategory = useCallback(() => {
     setShowAddNewCategory(!showAddNewCategory);
     resetInputs();
-    setHasFocus(!hasFocus);
-  }, [hasFocus, resetInputs, showAddNewCategory]);
+    setHasFocus(!showAddNewCategory);
+    setToggleFocus(showAddNewCategory);
+  }, [resetInputs, showAddNewCategory]);
 
   const handleChangeNewCategoryName = useCallback((evt) => {
     setNewCategoryName(evt.target.value);
@@ -205,6 +210,7 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
       createTerm(taxonomy, newCategoryName, parentValue);
       setShowAddNewCategory(false);
       resetInputs();
+      setToggleFocus(showAddNewCategory);
     },
     [
       createTerm,
@@ -212,6 +218,7 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
       noParentId,
       resetInputs,
       selectedParent,
+      showAddNewCategory,
       taxonomy,
     ]
   );
@@ -222,7 +229,7 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
   );
 
   useEffect(() => {
-    const node = ref.current;
+    const node = formRef.current;
     if (node) {
       const handleEnter = (evt) => {
         if (evt.key === 'Enter') {
@@ -236,7 +243,13 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
       };
     }
     return null;
-  }, [handleSubmit, ref]);
+  }, [handleSubmit, formRef]);
+
+  useEffect(() => {
+    if (toggleFocus) {
+      toggleRef.current.focus();
+    }
+  }, [toggleFocus]);
 
   return (
     <ContentArea>
@@ -247,8 +260,16 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
         onChange={handleClickCategory}
         noOptionsText={taxonomy.labels.not_found}
       />
+      <LinkButton
+        ref={toggleRef}
+        aria-expanded={false}
+        onClick={handleToggleNewCategory}
+        _showAddNewCategory={showAddNewCategory}
+      >
+        {taxonomy.labels.add_new_item}
+      </LinkButton>
       {showAddNewCategory ? (
-        <AddNewCategoryForm ref={ref} onSubmit={handleSubmit}>
+        <AddNewCategoryForm ref={formRef} onSubmit={handleSubmit}>
           <Input
             autoFocus
             name={taxonomy.labels.new_item_name}
@@ -280,11 +301,7 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
             </AddNewCategoryButton>
           </ButtonContainer>
         </AddNewCategoryForm>
-      ) : (
-        <LinkButton aria-expanded={false} onClick={handleToggleNewCategory}>
-          {taxonomy.labels.add_new_item}
-        </LinkButton>
-      )}
+      ) : null}
     </ContentArea>
   );
 }

--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -223,20 +223,23 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
 
   useEffect(() => {
     const node = ref.current;
-    const handleEnter = (evt) => {
-      if (evt.key === 'Enter') {
-        handleSubmit(evt);
-      }
-    };
+    if (node) {
+      const handleEnter = (evt) => {
+        if (evt.key === 'Enter') {
+          handleSubmit(evt);
+        }
+      };
 
-    node.addEventListener('keypress', handleEnter);
-    return () => {
-      node.removeEventListener('keypress', handleEnter);
-    };
+      node.addEventListener('keypress', handleEnter);
+      return () => {
+        node.removeEventListener('keypress', handleEnter);
+      };
+    }
+    return null;
   }, [handleSubmit, ref]);
 
   return (
-    <ContentArea ref={ref}>
+    <ContentArea>
       <ContentHeading>{taxonomy.labels.name}</ContentHeading>
       <HierarchicalInput
         label={taxonomy.labels.search_items}
@@ -245,7 +248,7 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
         noOptionsText={taxonomy.labels.not_found}
       />
       {showAddNewCategory ? (
-        <AddNewCategoryForm onSubmit={handleSubmit}>
+        <AddNewCategoryForm ref={ref} onSubmit={handleSubmit}>
           <Input
             autoFocus
             name={taxonomy.labels.new_item_name}

--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -77,7 +77,7 @@ const ButtonContainer = styled.div`
 const LinkButton = styled(Button).attrs({
   variant: BUTTON_VARIANTS.LINK,
 })`
-  ${(props) => props._showAddNewCategory && 'display: none;'}
+  ${({ $isVisible }) => $isVisible && 'display: none;'}
 
   margin-bottom: 16px;
 
@@ -264,7 +264,7 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
         ref={toggleRef}
         aria-expanded={false}
         onClick={handleToggleNewCategory}
-        _showAddNewCategory={showAddNewCategory}
+        $isVisible={showAddNewCategory}
       >
         {taxonomy.labels.add_new_item}
       </LinkButton>

--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -193,6 +193,10 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
     setHasFocus(!hasFocus);
   }, [hasFocus, resetInputs, showAddNewCategory]);
 
+  const handleChangeNewCategoryName = useCallback((evt) => {
+    setNewCategoryName(evt.target.value);
+  }, []);
+
   const handleSubmit = useCallback(
     (evt) => {
       evt.preventDefault();
@@ -211,10 +215,6 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
       taxonomy,
     ]
   );
-
-  const handleChangeNewCategoryName = useCallback((evt) => {
-    setNewCategoryName(evt.target.value);
-  }, []);
 
   const handleParentSelect = useCallback(
     (_evt, menuItem) => setSelectedParent(menuItem),

--- a/packages/story-editor/src/components/panels/document/taxonomies/karma/taxonomies.karma.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/karma/taxonomies.karma.js
@@ -103,9 +103,12 @@ describe('Categories & Tags Panel', () => {
 
         // open the new category section
         await fixture.events.click(categoriesAndTags.addNewCategoryButton);
+        // Input should be focused
+        expect(document.activeElement).toBe(
+          categoriesAndTags.newCategoryNameInput
+        );
 
         // Add new category
-        await fixture.events.focus(categoriesAndTags.newCategoryNameInput);
         await fixture.events.keyboard.type('deer');
 
         await fixture.events.click(categoriesAndTags.addNewCategoryButton);
@@ -137,9 +140,12 @@ describe('Categories & Tags Panel', () => {
 
         // open the new category section
         await fixture.events.click(categoriesAndTags.addNewCategoryButton);
+        // Input should be focused
+        expect(document.activeElement).toBe(
+          categoriesAndTags.newCategoryNameInput
+        );
 
         // Add new category
-        await fixture.events.focus(categoriesAndTags.newCategoryNameInput);
         await fixture.events.keyboard.type('deer');
         await fixture.events.click(categoriesAndTags.parentDropdownButton);
 
@@ -345,6 +351,95 @@ describe('Categories & Tags Panel', () => {
       expect(deerIndex).toBe(boogerIndex + 1);
 
       // TODO: 9058 - validate new category exists on story once category is checked when added.
+    });
+
+    it('should submit new categories with Enter button', async () => {
+      await openCategoriesAndTagsPanel();
+
+      const categoriesAndTags =
+        fixture.editor.inspector.documentPanel.categoriesAndTags;
+
+      // focus the panel button
+      await fixture.events.focus(categoriesAndTags.categoriesAndTagsButton);
+
+      // track initial categories
+      const initialCategories = categoriesAndTags.categories;
+
+      // tab to `Add New Category` button / section
+      let maxTabs = 0;
+      while (
+        maxTabs < 20 &&
+        document.activeElement !== categoriesAndTags.addNewCategoryButton
+      ) {
+        // eslint-disable-next-line no-await-in-loop
+        await fixture.events.keyboard.press('Tab');
+        maxTabs++;
+      }
+      // Toggle `Add New Category`
+      await fixture.events.keyboard.press('Space');
+
+      // Input should be focused
+      expect(document.activeElement).toBe(
+        categoriesAndTags.newCategoryNameInput
+      );
+
+      // Enter name and submit
+      await fixture.events.keyboard.type('deer');
+      await fixture.events.keyboard.press('Enter');
+
+      // validate new checkbox was added
+      const finalCategories = categoriesAndTags.categories;
+      initialCategories.map((checkbox) =>
+        expect(checkbox.name).not.toBe('deer')
+      );
+      expect(finalCategories.length).toBe(initialCategories.length + 1);
+      expect(
+        finalCategories.filter((category) => category.name === 'deer').length
+      ).toBe(1);
+
+      // TODO: 9058 - validate new category exists on story once category is checked when added.
+    });
+
+    it('should focus toggle on cancel', async () => {
+      await openCategoriesAndTagsPanel();
+
+      const categoriesAndTags =
+        fixture.editor.inspector.documentPanel.categoriesAndTags;
+
+      // focus the panel button
+      await fixture.events.focus(categoriesAndTags.categoriesAndTagsButton);
+
+      // tab to `Add New Category` section
+      let maxTabs = 0;
+      while (
+        maxTabs < 20 &&
+        document.activeElement !== categoriesAndTags.addNewCategoryButton
+      ) {
+        // eslint-disable-next-line no-await-in-loop
+        await fixture.events.keyboard.press('Tab');
+        maxTabs++;
+      }
+      // Toggle `Add New Category`
+      await fixture.events.keyboard.press('Space');
+
+      // Input should be focused
+      expect(document.activeElement).toBe(
+        categoriesAndTags.newCategoryNameInput
+      );
+
+      // Enter name and submit
+      await fixture.events.keyboard.type('deer');
+      // Tab to Cancel button
+      await fixture.events.keyboard.press('Tab');
+      await fixture.events.keyboard.press('Tab');
+      await fixture.events.keyboard.press('Tab');
+      // Hit Cancel button
+      await fixture.events.keyboard.press('Enter');
+
+      // The toggle `Add New Category` should be focused
+      expect(document.activeElement).toBe(
+        categoriesAndTags.addNewCategoryButton
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->
Expanding the `add new category` section should move focus to the input where you can begin to type a new category.

Hitting `Enter` while the input is in focus should submit the form.

https://user-images.githubusercontent.com/1820266/134193092-faeabe74-51bb-45aa-8a0f-80e936d08441.mov

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.  Click the `Add New Category` text. This should expand the form. 
2. Focus should now be on the input. 
3. Type a new category to add hit `Enter` and the form should submit. 
4. Similarly navigating through the `Parent Categories` via the keyboard arrows highlight desired parent category and hit `Enter` to submit with selected parent. 


## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9059 
