### PR TITLE
Dashboard: avoid loading current user twice

### DIFF
--- a/packages/dashboard/src/app/api/useUserApi.js
+++ b/packages/dashboard/src/app/api/useUserApi.js
@@ -17,18 +17,22 @@
 /**
  * External dependencies
  */
-import { useCallback, useMemo, useState } from '@web-stories-wp/react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from '@web-stories-wp/react';
 
 export default function useUserApi(dataAdapter, { currentUserApi }) {
   const [currentUser, setCurrentUser] = useState({});
   const [isUpdating, setIsUpdating] = useState(false);
-  const fetchCurrentUser = useCallback(async () => {
-    try {
-      setCurrentUser(await dataAdapter.get(currentUserApi));
-    } catch (e) {
-      setCurrentUser({});
+
+  useEffect(() => {
+    if (!Object.keys(currentUser).length) {
+      dataAdapter.get(currentUserApi).then(setCurrentUser);
     }
-  }, [dataAdapter, currentUserApi]);
+  }, [currentUser, currentUserApi, dataAdapter]);
 
   const toggleWebStoriesTrackingOptIn = useCallback(async () => {
     setIsUpdating(true);
@@ -69,14 +73,12 @@ export default function useUserApi(dataAdapter, { currentUserApi }) {
   return useMemo(
     () => ({
       api: {
-        fetchCurrentUser,
         toggleWebStoriesTrackingOptIn,
         toggleWebStoriesMediaOptimization,
       },
       currentUser: { data: currentUser, isUpdating },
     }),
     [
-      fetchCurrentUser,
       toggleWebStoriesTrackingOptIn,
       toggleWebStoriesMediaOptimization,
       currentUser,

--- a/packages/dashboard/src/app/views/editorSettings/test/editorSettings.js
+++ b/packages/dashboard/src/app/views/editorSettings/test/editorSettings.js
@@ -39,7 +39,6 @@ const mockFetchSettings = jest.fn();
 const mockFetchMediaById = jest.fn();
 const mockUploadMedia = jest.fn();
 const mockUpdateSettings = jest.fn();
-const mockFetchCurrentUser = jest.fn();
 
 function createProviderValues({
   canUploadFiles,
@@ -104,9 +103,7 @@ function createProviderValues({
           uploadMedia: mockUploadMedia,
           fetchMediaById: mockFetchMediaById,
         },
-        usersApi: {
-          fetchCurrentUser: mockFetchCurrentUser,
-        },
+        usersApi: {},
       },
     },
   };

--- a/packages/dashboard/src/app/views/shared/useMediaOptimization.js
+++ b/packages/dashboard/src/app/views/shared/useMediaOptimization.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useCallback, useEffect, useRef } from '@web-stories-wp/react';
+import { useCallback } from '@web-stories-wp/react';
 import { trackEvent } from '@web-stories-wp/tracking';
 import { useSnackbar } from '@web-stories-wp/design-system';
 
@@ -30,35 +30,21 @@ import { SUCCESS } from '../../textContent';
 export default function useMediaOptimization() {
   const { showSnackbar } = useSnackbar();
 
-  const { currentUser, toggleWebStoriesMediaOptimization, fetchCurrentUser } =
-    useApi(
-      ({
-        state: { currentUser },
-        actions: {
-          usersApi: { toggleWebStoriesMediaOptimization, fetchCurrentUser },
-        },
-      }) => ({
-        currentUser,
-        toggleWebStoriesMediaOptimization,
-        fetchCurrentUser,
-      })
-    );
-
-  const dataIsLoaded =
-    currentUser.data.meta?.web_stories_media_optimization !== undefined;
+  const { currentUser, toggleWebStoriesMediaOptimization } = useApi(
+    ({
+      state: { currentUser },
+      actions: {
+        usersApi: { toggleWebStoriesMediaOptimization },
+      },
+    }) => ({
+      currentUser,
+      toggleWebStoriesMediaOptimization,
+    })
+  );
 
   const mediaOptimization = Boolean(
     currentUser.data.meta?.web_stories_media_optimization
   );
-
-  const dataFetched = useRef(false);
-
-  useEffect(() => {
-    if (!dataIsLoaded && !dataFetched.current) {
-      fetchCurrentUser();
-      dataFetched.current = true;
-    }
-  }, [dataIsLoaded, fetchCurrentUser]);
 
   const _toggleWebStoriesMediaOptimization = useCallback(() => {
     toggleWebStoriesMediaOptimization();

--- a/packages/dashboard/src/app/views/shared/useTelemetryOptIn.js
+++ b/packages/dashboard/src/app/views/shared/useTelemetryOptIn.js
@@ -17,12 +17,7 @@
 /**
  * External dependencies
  */
-import {
-  useCallback,
-  useState,
-  useEffect,
-  useRef,
-} from '@web-stories-wp/react';
+import { useCallback, useState, useEffect } from '@web-stories-wp/react';
 import { enableTracking, disableTracking } from '@web-stories-wp/tracking';
 import { useSnackbar, localStore } from '@web-stories-wp/design-system';
 
@@ -51,15 +46,14 @@ export default function useTelemetryOptIn() {
     setInitialBannerPreviouslyClosed
   );
   const [optInCheckboxClicked, setOptInCheckboxClicked] = useState(false);
-  const { currentUser, toggleWebStoriesTrackingOptIn, fetchCurrentUser } =
-    useApi(
-      ({
-        state: { currentUser },
-        actions: {
-          usersApi: { toggleWebStoriesTrackingOptIn, fetchCurrentUser },
-        },
-      }) => ({ currentUser, toggleWebStoriesTrackingOptIn, fetchCurrentUser })
-    );
+  const { currentUser, toggleWebStoriesTrackingOptIn } = useApi(
+    ({
+      state: { currentUser },
+      actions: {
+        usersApi: { toggleWebStoriesTrackingOptIn },
+      },
+    }) => ({ currentUser, toggleWebStoriesTrackingOptIn })
+  );
   const { currentPath } = useRouteHistory(({ state: { currentPath } }) => ({
     currentPath,
   }));
@@ -69,8 +63,6 @@ export default function useTelemetryOptIn() {
 
   const optedIn = Boolean(currentUser.data.meta?.web_stories_tracking_optin);
 
-  const dataFetched = useRef(false);
-
   useEffect(() => {
     if (optedIn) {
       enableTracking();
@@ -78,13 +70,6 @@ export default function useTelemetryOptIn() {
       disableTracking();
     }
   }, [optedIn]);
-
-  useEffect(() => {
-    if (!dataIsLoaded && !dataFetched.current) {
-      fetchCurrentUser();
-      dataFetched.current = true;
-    }
-  }, [dataIsLoaded, fetchCurrentUser]);
 
   const _toggleWebStoriesTrackingOptIn = useCallback(() => {
     toggleWebStoriesTrackingOptIn();

--- a/packages/dashboard/src/karma/apiProviderFixture.js
+++ b/packages/dashboard/src/karma/apiProviderFixture.js
@@ -93,7 +93,6 @@ export default function ApiProviderFixture({ children }) {
 
   const usersApi = useMemo(
     () => ({
-      fetchCurrentUser: jasmine.createSpy('fetchCurrentUser'),
       toggleWebStoriesTrackingOptIn: () =>
         setCurrentUser(toggleOptInTracking(currentUser)),
     }),

--- a/packages/dashboard/src/testUtils/mockApiProvider.js
+++ b/packages/dashboard/src/testUtils/mockApiProvider.js
@@ -23,17 +23,13 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-
 import { ApiContext } from '../app/api/apiProvider';
-
-const noop = () => {};
 
 export default function MockApiProvider({ children, value }) {
   const [currentUser, setCurrentUser] = useState(getCurrentUserState());
 
   const usersApi = useMemo(
     () => ({
-      fetchCurrentUser: noop,
       toggleWebStoriesTrackingOptIn: () =>
         setCurrentUser(toggleOptInTracking(currentUser)),
     }),


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

I noticed some unexpected network requests being made to `wp-json/web-stories/v1/users/me` when visiting the dashboard.

Unexpected because we preload this request when accessing this page to avoid the extra HTTP call.

## Summary

<!-- A brief description of what this PR does. -->

This PR fixes the double-loading of the current user by centralizing this in `useUserApi`, similar to how it's done in the editor.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open Network tab in the browser dev tools
2. Go to dashboard
3. See **no** requests to `wp-json/web-stories/v1/users/me`


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
