### PR TITLE
Taxonomy: Fix History Regression

### DIFF
--- a/packages/story-editor/src/app/history/karma/history.karma.js
+++ b/packages/story-editor/src/app/history/karma/history.karma.js
@@ -31,9 +31,7 @@ describe('CUJ: Creator can View and Modify Document Settings: Navigating without
     fixture.restore();
   });
 
-  // TODO: #9073
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should not have new history changes when switching tabs without changes', async () => {
+  it('should not have new history changes when switching tabs without changes', async () => {
     // Click on the shapes tab.
     await fixture.events.click(fixture.editor.library.shapesTab);
     // Click on the document tab.

--- a/packages/story-editor/src/app/story/effects/useLoadStory.js
+++ b/packages/story-editor/src/app/story/effects/useLoadStory.js
@@ -65,7 +65,7 @@ function useLoadStory({ storyId, shouldLoad, restore, isDemo }) {
           featured_media: featuredMedia,
           publisher_logo: publisherLogo,
           taxonomies,
-          terms,
+          terms: embeddedTerms,
         } = post;
 
         const [prefix, suffix] = permalinkTemplate.split(
@@ -134,7 +134,7 @@ function useLoadStory({ storyId, shouldLoad, restore, isDemo }) {
           defaultPageDuration: storyData?.defaultPageDuration,
           backgroundAudio: storyData?.backgroundAudio,
           taxonomies,
-          terms,
+          embeddedTerms,
         };
 
         // TODO read current page and selection from deeplink?

--- a/packages/story-editor/src/app/story/storyProvider.js
+++ b/packages/story-editor/src/app/story/storyProvider.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useMemo, useEffect } from '@web-stories-wp/react';
+import { useMemo, useEffect, useState } from '@web-stories-wp/react';
 
 /**
  * Internal dependencies
@@ -53,8 +53,23 @@ function StoryProvider({ storyId, children }) {
   } = useStoryReducer({
     current: hashPageId,
   });
-  const { pages, current, selection, story, animationState, capabilities } =
-    reducerState;
+  const {
+    pages,
+    current,
+    selection,
+    story: storyWithoutTerms,
+    animationState,
+    capabilities,
+  } = reducerState;
+
+  const [terms, setTerms] = useState({});
+  const story = useMemo(
+    () => ({
+      ...storyWithoutTerms,
+      terms,
+    }),
+    [terms, storyWithoutTerms]
+  );
 
   useEffect(() => setHashPageId(current), [current, setHashPageId]);
 
@@ -122,7 +137,13 @@ function StoryProvider({ storyId, children }) {
   useLoadStory({ restore, shouldLoad, storyId, isDemo });
 
   // These effects send updates to and restores state from history.
-  useHistoryEntry({ pages, current, selection, story, capabilities });
+  useHistoryEntry({
+    pages,
+    current,
+    selection,
+    story: storyWithoutTerms,
+    capabilities,
+  });
   useHistoryReplay({ restore });
 
   // This action allows the user to save the story
@@ -194,6 +215,7 @@ function StoryProvider({ storyId, children }) {
       ...api,
       autoSave,
       saveStory,
+      setTerms,
     },
     internal: { reducerState, restore },
   };

--- a/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
+++ b/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
@@ -45,11 +45,11 @@ function TaxonomyProvider(props) {
   const [termCache, setTermCache] = useState({});
   // Should grab categories on mount
   const [shouldRefetchCategories, setShouldRefetchCategories] = useState(true);
-  const { updateStory, isStoryLoaded, terms, hasTaxonomies } = useStory(
-    ({ state: { pages, story }, actions: { updateStory } }) => ({
-      updateStory,
+  const { setTerms, isStoryLoaded, embeddedTerms, hasTaxonomies } = useStory(
+    ({ state: { pages, story }, actions: { setTerms } }) => ({
+      setTerms,
       isStoryLoaded: pages.length > 0,
-      terms: story.terms,
+      embeddedTerms: story.embeddedTerms,
       hasTaxonomies: story?.taxonomies?.length > 0,
     })
   );
@@ -87,7 +87,7 @@ function TaxonomyProvider(props) {
     ) {
       const taxonomiesBySlug = dictionaryOnKey(taxonomies, 'slug');
       const initialCache = mapObjectKeys(
-        cacheFromEmbeddedTerms(terms),
+        cacheFromEmbeddedTerms(embeddedTerms),
         (slug) => taxonomiesBySlug[slug]?.restBase
       );
       const initialSelectedSlugs = mapObjectVals(initialCache, (val) =>
@@ -98,7 +98,13 @@ function TaxonomyProvider(props) {
       setTermCache(initialCache);
       setSelectedSlugs(initialSelectedSlugs);
     }
-  }, [terms, isStoryLoaded, taxonomies, setSelectedSlugs, setTermCache]);
+  }, [
+    embeddedTerms,
+    isStoryLoaded,
+    taxonomies,
+    setSelectedSlugs,
+    setTermCache,
+  ]);
 
   // With the freeform taxonomy input, we can have terms selected
   // that may be in the process of being created or retrieved from
@@ -118,12 +124,8 @@ function TaxonomyProvider(props) {
       ]
     );
     const updatedTerms = objectFromEntries(termEntries);
-    updateStory({
-      properties: {
-        terms: updatedTerms,
-      },
-    });
-  }, [updateStory, selectedSlugs, termCache]);
+    setTerms(updatedTerms);
+  }, [setTerms, selectedSlugs, termCache]);
 
   const addSearchResultsToCache = useCallback(
     async (

--- a/packages/story-editor/src/app/taxonomy/test/useTaxonomy.js
+++ b/packages/story-editor/src/app/taxonomy/test/useTaxonomy.js
@@ -81,9 +81,9 @@ async function setup({ useStoryPartial = {}, useAPIPartial = {} }) {
     ...useAPIPartial,
   }));
   useStory.mockImplementation(() => ({
-    updateStory: () => {},
+    setTerms: () => {},
     isStoryLoaded: true,
-    terms: [],
+    embeddedTerms: [],
     hasTaxonomies: true,
     ...useStoryPartial,
   }));
@@ -115,13 +115,13 @@ describe('TaxonomyProvider', () => {
     const taxonomy1Term1 = createTermFromName(taxonomy1, 'term1');
     const taxonomy1Term2 = createTermFromName(taxonomy1, 'term2');
     const taxonomy2Term1 = createTermFromName(taxonomy2, 'term1');
-    const terms = [[taxonomy1Term1, taxonomy1Term2], [taxonomy2Term1]];
+    const embeddedTerms = [[taxonomy1Term1, taxonomy1Term2], [taxonomy2Term1]];
 
     const { result } = await setup({
       useAPIPartial: {
         getTaxonomies: () => mockResponse(taxonomiesResponse),
       },
-      useStoryPartial: { terms, isStoryLoaded: true },
+      useStoryPartial: { embeddedTerms, isStoryLoaded: true },
     });
 
     const { termCache, selectedSlugs, taxonomies } = result.current.state;
@@ -142,7 +142,7 @@ describe('TaxonomyProvider', () => {
   });
 
   it('syncs selected slugs with story', async () => {
-    const updateStoryMock = jest.fn();
+    const setTermsMock = jest.fn();
     const sampleTaxonomy = createTaxonomy('sample');
     const taxonomiesResponse = [sampleTaxonomy];
 
@@ -152,8 +152,8 @@ describe('TaxonomyProvider', () => {
       },
       useStoryPartial: {
         isStoryLoaded: true,
-        updateStory: updateStoryMock,
-        terms: [[]],
+        setTerms: setTermsMock,
+        embeddedTerms: [[]],
       },
     });
 
@@ -171,12 +171,8 @@ describe('TaxonomyProvider', () => {
     expect(result.current.state.selectedSlugs).toStrictEqual({
       [sampleTaxonomy.restBase]: ['term1', 'term2'],
     });
-    expect(updateStoryMock).toHaveBeenCalledWith({
-      properties: {
-        terms: {
-          [sampleTaxonomy.restBase]: [],
-        },
-      },
+    expect(setTermsMock).toHaveBeenCalledWith({
+      [sampleTaxonomy.restBase]: [],
     });
 
     // Components are responsible for sending create term requests
@@ -196,12 +192,8 @@ describe('TaxonomyProvider', () => {
     expect(result.current.state.selectedSlugs).toStrictEqual({
       [sampleTaxonomy.restBase]: ['term1', 'term2'],
     });
-    expect(updateStoryMock).toHaveBeenCalledWith({
-      properties: {
-        terms: {
-          [sampleTaxonomy.restBase]: [0, 1],
-        },
-      },
+    expect(setTermsMock).toHaveBeenCalledWith({
+      [sampleTaxonomy.restBase]: [0, 1],
     });
   });
 


### PR DESCRIPTION
## Context
Noticed with the existing setup for taxonomy, the hierarchical taxonomy implementation added a regression for story history, so we disabled the test. This is part of the work to address those issues.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
This fixes the history regression caused by taxonomy and re-enables the history karma tests that it initially broke.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Moved terms to be a separate entity than the story, and combined it with the story for relevant functionality, but excluded the term updates from the story for history entries.
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Should not be prompted with unsaved changes when first loading a story and not having changed anything.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
`npm run test:karma:edit-story`
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #9073 
