### PR TITLE
Fix Page menu and Page nav button focus

### DIFF
--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -51,11 +51,11 @@ export const Z_INDEX = {
 const HEADER_GAP = 16;
 // 8px extra is for the focus outline to display.
 const MENU_HEIGHT = THEME_CONSTANTS.ICON_SIZE + 8;
-const MENU_GAP = 16;
+const MENU_GAP = 12;
 const CAROUSEL_HEIGHT = 104;
 // 8px extra is for the focus outline to display.
 const PAGE_NAV_WIDTH = THEME_CONSTANTS.LARGE_BUTTON_SIZE + 8;
-const PAGE_NAV_GAP = 24;
+const PAGE_NAV_GAP = 20;
 
 const Layer = styled.section`
   ${pointerEventsCss}

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -49,7 +49,8 @@ export const Z_INDEX = {
 };
 
 const HEADER_GAP = 16;
-const MENU_HEIGHT = THEME_CONSTANTS.ICON_SIZE;
+// 8px extra is for the outline to display.
+const MENU_HEIGHT = THEME_CONSTANTS.ICON_SIZE + 8;
 const MENU_GAP = 16;
 const CAROUSEL_HEIGHT = 104;
 const PAGE_NAV_WIDTH = THEME_CONSTANTS.LARGE_BUTTON_SIZE;

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -49,11 +49,12 @@ export const Z_INDEX = {
 };
 
 const HEADER_GAP = 16;
-// 8px extra is for the outline to display.
+// 8px extra is for the focus outline to display.
 const MENU_HEIGHT = THEME_CONSTANTS.ICON_SIZE + 8;
 const MENU_GAP = 16;
 const CAROUSEL_HEIGHT = 104;
-const PAGE_NAV_WIDTH = THEME_CONSTANTS.LARGE_BUTTON_SIZE;
+// 8px extra is for the focus outline to display.
+const PAGE_NAV_WIDTH = THEME_CONSTANTS.LARGE_BUTTON_SIZE + 8;
 const PAGE_NAV_GAP = 24;
 
 const Layer = styled.section`

--- a/packages/story-editor/src/components/canvas/pagemenu/pageMenuButton.js
+++ b/packages/story-editor/src/components/canvas/pagemenu/pageMenuButton.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import {
   Button,
   BUTTON_VARIANTS,
@@ -30,17 +31,21 @@ import {
  */
 import Tooltip from '../../tooltip';
 
+const StyledButton = styled(Button)`
+  margin-top: 4px;
+`;
+
 function PageMenuButton({ children, title, shortcut, ...rest }) {
   return (
     <Tooltip title={title} shortcut={shortcut} hasTail>
-      <Button
+      <StyledButton
         variant={BUTTON_VARIANTS.SQUARE}
         type={BUTTON_TYPES.TERTIARY}
         size={BUTTON_SIZES.SMALL}
         {...rest}
       >
         {children}
-      </Button>
+      </StyledButton>
     </Tooltip>
   );
 }


### PR DESCRIPTION
## Summary
Adds extra space for the buttons surrounding the Page so that when the buttons are in focus state, the focus outline is fully visible and not cut off.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
| Before | After |
| -------|----- |
| <img width="325" alt="Screenshot 2021-09-23 at 15 21 51" src="https://user-images.githubusercontent.com/3294597/134505878-67fee874-37c5-4a56-b8f2-464cf254dcb6.png"> | <img width="331" alt="Screenshot 2021-09-23 at 15 20 59" src="https://user-images.githubusercontent.com/3294597/134505683-ed275bbd-3aa2-45a3-aedd-d2a2602aac47.png"> |
| <img width="125" alt="Screenshot 2021-09-23 at 15 21 45" src="https://user-images.githubusercontent.com/3294597/134505882-6e34db39-f800-4f57-9dcf-bf5eae6df90b.png"> | <img width="501" alt="Screenshot 2021-09-23 at 15 20 49" src="https://user-images.githubusercontent.com/3294597/134505692-fcb3e35b-583a-4d65-9ec0-c9dccb98937f.png"> |
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Focus on the Page navigation arrows using keyboard. Verify the focus outline is fully visible.
2. Focus on the Page menu buttons below the page. Verify the focus outline is fully visible.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7813 
