### PR TITLE
Taxonomies: New category checked when added

### DIFF
--- a/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
+++ b/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
@@ -162,6 +162,18 @@ function TaxonomyProvider(props) {
     [getTaxonomyTerm]
   );
 
+  const setSelectedTaxonomySlugs = useCallback(
+    (taxonomy, termSlugs = []) =>
+      setSelectedSlugs((selected) => ({
+        ...selected,
+        [taxonomy.restBase]:
+          typeof termSlugs === 'function'
+            ? termSlugs(selected[taxonomy.restBase])
+            : termSlugs,
+      })),
+    []
+  );
+
   const createTerm = useCallback(
     async (taxonomy, termName, parentId) => {
       // make sure the term doesn't already exist locally
@@ -186,6 +198,10 @@ function TaxonomyProvider(props) {
           [taxonomy.restBase]: { [newTerm.slug]: newTerm },
         };
         setTermCache((cache) => mergeNestedDictionaries(cache, incomingCache));
+        setSelectedTaxonomySlugs(taxonomy, [
+          ...selectedSlugs[taxonomy.restBase],
+          newTerm.slug,
+        ]);
       } catch (e) {
         // If the backend says the term already exists
         // we fetch for it as well as related terms to
@@ -198,19 +214,13 @@ function TaxonomyProvider(props) {
         }
       }
     },
-    [createTaxonomyTerm, termCache, addSearchResultsToCache]
-  );
-
-  const setSelectedTaxonomySlugs = useCallback(
-    (taxonomy, termSlugs = []) =>
-      setSelectedSlugs((selected) => ({
-        ...selected,
-        [taxonomy.restBase]:
-          typeof termSlugs === 'function'
-            ? termSlugs(selected[taxonomy.restBase])
-            : termSlugs,
-      })),
-    []
+    [
+      termCache,
+      createTaxonomyTerm,
+      selectedSlugs,
+      setSelectedTaxonomySlugs,
+      addSearchResultsToCache,
+    ]
   );
 
   // Fetch hierarchical taxonomies on mount

--- a/packages/story-editor/src/components/panels/document/taxonomies/karma/taxonomies.karma.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/karma/taxonomies.karma.js
@@ -119,8 +119,11 @@ describe('Categories & Tags Panel', () => {
         expect(
           finalCategories.filter((category) => category.name === 'deer').length
         ).toBe(1);
-
-        // TODO: 9058 - validate new category exists on story once category is checked when added.
+        // validate newly added category was checked
+        const deerIndex = finalCategories.findIndex(
+          (category) => category.name === 'deer'
+        );
+        expect(finalCategories[deerIndex].checked).toBe(true);
       });
 
       // TODO: #9063
@@ -184,8 +187,8 @@ describe('Categories & Tags Panel', () => {
           (category) => category.name === 'deer'
         );
         expect(deerIndex).toBe(boogerIndex + 1);
-
-        // TODO: 9058 - validate new category exists on story once category is checked when added.
+        // validate newly added category was checked
+        expect(finalCategories[deerIndex].checked).toBe(true);
       });
     });
   });
@@ -275,8 +278,11 @@ describe('Categories & Tags Panel', () => {
       expect(
         finalCategories.filter((category) => category.name === 'deer').length
       ).toBe(1);
-
-      // TODO: 9058 - validate new category exists on story once category is checked when added.
+      // validate newly added category was checked
+      const deerIndex = finalCategories.findIndex(
+        (category) => category.name === 'deer'
+      );
+      expect(finalCategories[deerIndex].checked).toBe(true);
     });
 
     it('should add a new category as a child of an existing category', async () => {
@@ -343,8 +349,8 @@ describe('Categories & Tags Panel', () => {
         (category) => category.name === 'deer'
       );
       expect(deerIndex).toBe(boogerIndex + 1);
-
-      // TODO: 9058 - validate new category exists on story once category is checked when added.
+      // validate newly added category was checked
+      expect(finalCategories[deerIndex].checked).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
When adding a new category, it should be checked after it is submitted. 

## Relevant Technical Choices

<!-- Please describe your changes. -->
Called `setSelectedTaxonomySlugs` with the current selectedTerms slug and the newTerm slug during the `createTerm` callback. This preserves the slugs that were already selected as well as adds the new ones. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
n/a

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
After:

https://user-images.githubusercontent.com/1820266/134557330-d1444bc0-ab47-4bce-9890-30aa46953670.mov

 

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. add new category
2.  ensure it is checked after submission 


## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9058 
