### PR TITLE
Publisher Logos: Remove delete confirmation dialog

### DIFF
--- a/packages/dashboard/src/app/views/editorSettings/index.js
+++ b/packages/dashboard/src/app/views/editorSettings/index.js
@@ -19,13 +19,12 @@
  */
 import { useCallback, useEffect, useState } from '@web-stories-wp/react';
 import { __, sprintf } from '@web-stories-wp/i18n';
-import { Text, THEME_CONSTANTS } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
  */
 import useApi from '../../api/useApi';
-import { Dialog, Layout } from '../../../components';
+import { Layout } from '../../../components';
 import { MIN_IMG_WIDTH, MIN_IMG_HEIGHT } from '../../../constants';
 import { useConfig } from '../../config';
 import { PageHeading } from '../shared';
@@ -39,8 +38,6 @@ import TelemetrySettings from './telemetry';
 import MediaOptimizationSettings from './mediaOptimization';
 import VideoCacheSettings from './videoCache';
 import ArchiveSettings from './archive';
-
-const ACTIVE_DIALOG_REMOVE_LOGO = 'REMOVE_LOGO';
 
 function EditorSettings() {
   const {
@@ -131,8 +128,6 @@ function EditorSettings() {
     mediaOptimization,
   } = useMediaOptimization();
 
-  const [activeDialog, setActiveDialog] = useState(null);
-  const [logoToBeDeleted, setLogoToBeDeleted] = useState('');
   const [mediaError, setMediaError] = useState('');
 
   useEffect(() => {
@@ -277,23 +272,16 @@ function EditorSettings() {
     [maxUpload, maxUploadFormatted, uploadMedia, allowedImageMimeTypes]
   );
 
-  const handleRemoveLogo = useCallback((publisherLogo) => {
-    setActiveDialog(ACTIVE_DIALOG_REMOVE_LOGO);
-    setLogoToBeDeleted(publisherLogo);
-  }, []);
-
-  const handleDialogConfirmRemoveLogo = useCallback(() => {
-    removePublisherLogo(logoToBeDeleted.id);
-    setActiveDialog(null);
-  }, [logoToBeDeleted, removePublisherLogo]);
+  const handleRemoveLogo = useCallback(
+    (publisherLogo) => {
+      removePublisherLogo(publisherLogo.id);
+    },
+    [removePublisherLogo]
+  );
 
   const handleUpdateDefaultLogo = useCallback(
     (newDefaultLogo) => setPublisherLogoAsDefault(newDefaultLogo.id),
     [setPublisherLogoAsDefault]
-  );
-
-  const isActiveRemoveLogoDialog = Boolean(
-    activeDialog === ACTIVE_DIALOG_REMOVE_LOGO && logoToBeDeleted
   );
 
   return (
@@ -360,27 +348,6 @@ function EditorSettings() {
           </Main>
         </Layout.Scrollable>
       </Wrapper>
-
-      {/* TODO: Remove this dialog, as it's not technically correct. */}
-      <Dialog
-        isOpen={isActiveRemoveLogoDialog}
-        contentLabel={__(
-          'Dialog to confirm removing a publisher logo',
-          'web-stories'
-        )}
-        title={__('Are you sure you want to remove this logo?', 'web-stories')}
-        onClose={() => setActiveDialog(null)}
-        secondaryText={__('Cancel', 'web-stories')}
-        onPrimary={handleDialogConfirmRemoveLogo}
-        primaryText={__('Delete Logo', 'web-stories')}
-      >
-        <Text size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
-          {__(
-            'The logo will be removed from any stories that currently use it as their publisher logo.',
-            'web-stories'
-          )}
-        </Text>
-      </Dialog>
     </Layout.Provider>
   );
 }

--- a/packages/dashboard/src/app/views/editorSettings/karma/editorSettings.karma.js
+++ b/packages/dashboard/src/app/views/editorSettings/karma/editorSettings.karma.js
@@ -327,12 +327,6 @@ describe('Settings View', () => {
 
     await fixture.events.click(RemovePublisherLogoButton);
 
-    const confirmRemoveButton = fixture.screen.getByRole('button', {
-      name: /^Delete Logo$/,
-    });
-
-    await fixture.events.click(confirmRemoveButton);
-
     const UpdatedPublisherLogos = within(
       await fixture.screen.getByTestId('editor-settings')
     ).queryAllByTestId(/^uploaded-publisher-logo-/);
@@ -372,13 +366,6 @@ describe('Settings View', () => {
 
     // we want to select the second list item
     await fixture.events.keyboard.press('ArrowDown');
-
-    await fixture.events.keyboard.press('Enter');
-
-    // tab through confirmation dialog to remove logo
-    await fixture.events.keyboard.press('Tab');
-
-    await fixture.events.keyboard.press('Tab');
 
     await fixture.events.keyboard.press('Enter');
 

--- a/packages/dashboard/src/app/views/editorSettings/test/editorSettings.js
+++ b/packages/dashboard/src/app/views/editorSettings/test/editorSettings.js
@@ -194,14 +194,6 @@ describe('Editor Settings: <Editor Settings />', function () {
 
     fireEvent.click(DeleteFileButton);
 
-    const DeleteDialog = screen.getByRole('dialog');
-    expect(DeleteDialog).toBeInTheDocument();
-
-    const ConfirmDeleteButton = within(DeleteDialog).getByText('Delete Logo');
-    expect(ConfirmDeleteButton).toBeInTheDocument();
-
-    fireEvent.click(ConfirmDeleteButton);
-
     expect(mockRemovePublisherLogo).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
When removing a logo from Web Stories Settings you are presented with an incorrect warning dialog box. We want to remove this dialog box altogether. Removing a publisher logo only removes it from the list of publisher logos, but does not remove the actual attachment in the media library. So it does not change any existing stories at all.


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
n/a

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
After you remove a logo, no additional confirmation is needed. 

### Before: 

![image](https://user-images.githubusercontent.com/1820266/134702347-03336676-1a7a-46b3-9774-66e22edaf48f.png)

### After:

https://user-images.githubusercontent.com/1820266/134703248-f97ce3c7-e59d-42db-bfe5-cc49e77ee2a2.mov


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Navigate to Web stories -> Settings
2. Delete a logo
3. Dialog box should no longer appear


## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9096
