### PR TITLE
Taxonomy: Refactor data flow to work with history

### DIFF
--- a/packages/story-editor/src/app/story/useStoryReducer/reducers/updateStory.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducers/updateStory.js
@@ -21,16 +21,19 @@
  *
  * @param {Object} state Current state
  * @param {Object} payload Action payload
- * @param {number} payload.properties Object with story properties to set.
+ * @param {Object | Function} payload.properties Object with story properties to set.
  * @return {Object} New state
  */
 function updateStory(state, { properties }) {
   return {
     ...state,
-    story: {
-      ...state.story,
-      ...properties,
-    },
+    story:
+      typeof properties === 'function'
+        ? properties(state.story)
+        : {
+            ...state.story,
+            ...properties,
+          },
   };
 }
 

--- a/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
+++ b/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
@@ -114,7 +114,7 @@ function TaxonomyProvider(props) {
   ]);
 
   const setTerms = useCallback(
-    (taxonomy, termIds = []) =>
+    (taxonomy, termIds = []) => {
       updateStory({
         properties: (story) => ({
           ...story,
@@ -126,7 +126,8 @@ function TaxonomyProvider(props) {
                 : termIds,
           },
         }),
-      }),
+      });
+    },
     [updateStory]
   );
 
@@ -181,7 +182,7 @@ function TaxonomyProvider(props) {
         );
 
         if (selectedTerm) {
-          addTermToSelection(taxonomy, selectedTerm.id);
+          addTermToSelection(taxonomy, selectedTerm);
         }
       }
     },
@@ -256,7 +257,7 @@ function TaxonomyProvider(props) {
       state: {
         taxonomies,
         termCache,
-        terms,
+        terms: Array.isArray(terms) ? {} : terms,
       },
       actions: {
         createTerm,

--- a/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
+++ b/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
@@ -116,16 +116,20 @@ function TaxonomyProvider(props) {
   const setTerms = useCallback(
     (taxonomy, termIds = []) => {
       updateStory({
-        properties: (story) => ({
-          ...story,
-          terms: {
-            ...story.terms,
-            [taxonomy.restBase]:
-              typeof termIds === 'function'
-                ? termIds(story.terms[taxonomy.restBase])
-                : termIds,
-          },
-        }),
+        properties: (story) => {
+          const newTerms =
+            typeof termIds === 'function'
+              ? termIds(story.terms[taxonomy.restBase])
+              : termIds;
+
+          return {
+            ...story,
+            terms: {
+              ...story.terms,
+              [taxonomy.restBase]: newTerms,
+            },
+          };
+        },
       });
     },
     [updateStory]

--- a/packages/story-editor/src/components/form/tags/index.js
+++ b/packages/story-editor/src/components/form/tags/index.js
@@ -27,3 +27,4 @@ const Tags = {
 };
 
 export default Tags;
+export { deepEquals } from './reducer';

--- a/packages/story-editor/src/components/form/tags/input.js
+++ b/packages/story-editor/src/components/form/tags/input.js
@@ -59,23 +59,31 @@ function Input({
   onTagsChange,
   onInputChange,
   tagDisplayTransformer,
-  initialTags = [],
+  tokens = [],
   ...props
 }) {
-  const [{ value, tags, offset }, dispatch] = useReducer(reducer, {
+  const [{ value, tags, offset, tagBuffer }, dispatch] = useReducer(reducer, {
     value: '',
-    tags: [...initialTags],
+    tags: [...tokens],
+    tagBuffer: null,
     offset: 0,
   });
   const [isInputFocused, setIsInputFocued] = useState(false);
+
+  useEffect(() => {
+    dispatch({ type: ACTIONS.UPDATE_TAGS, payload: tokens });
+  }, [tokens]);
 
   // Allow parents to pass onTagsChange callback
   // that updates as tags does.
   const onTagChangeRef = useRef(onTagsChange);
   onTagChangeRef.current = onTagsChange;
   useEffect(() => {
-    onTagChangeRef.current?.(tags);
-  }, [tags]);
+    if (!tagBuffer) {
+      return;
+    }
+    onTagChangeRef.current?.(tagBuffer);
+  }, [tagBuffer]);
 
   // Allow parents to pass onInputChange callback
   // that updates as value does.
@@ -123,6 +131,7 @@ function Input({
       []
     );
 
+  const renderedTags = tagBuffer || tags;
   return (
     <Border isInputFocused={isInputFocused}>
       {
@@ -130,9 +139,9 @@ function Input({
         // this helps with natural tab order and visuals
         // as you ArrowLeft or ArrowRight through tags
         [
-          ...tags.slice(0, tags.length - offset),
+          ...renderedTags.slice(0, renderedTags.length - offset),
           INPUT_KEY,
-          ...tags.slice(tags.length - offset),
+          ...renderedTags.slice(renderedTags.length - offset),
         ].map((tag) =>
           tag === INPUT_KEY ? (
             <TextInput
@@ -160,5 +169,6 @@ Input.propTypes = {
   onInputChange: PropTypes.func,
   tagDisplayTransformer: PropTypes.func,
   initialTags: PropTypes.arrayOf(PropTypes.string),
+  tokens: PropTypes.arrayOf(PropTypes.string),
 };
 export default Input;

--- a/packages/story-editor/src/components/form/tags/reducer.js
+++ b/packages/story-editor/src/components/form/tags/reducer.js
@@ -35,7 +35,7 @@ function subsetAOfB(a = [], b = []) {
   return a.forEach((v) => b.includes(v));
 }
 
-function deepEquals(a = [], b = []) {
+export function deepEquals(a = [], b = []) {
   return a.length === b.length && a.every((item) => b.includes(item));
 }
 
@@ -147,19 +147,37 @@ function reducer(state, action) {
     // Retain order as much as possible
     // and append new tags to the end
     case ACTIONS.UPDATE_TAGS: {
+      const stateTagsWithSlugs = state.tags.map((name) => [
+        cleanForSlug(name),
+        name,
+      ]);
+      const payloadTagsWithSlugs = action.payload.map((name) => [
+        cleanForSlug(name),
+        name,
+      ]);
       // if the payload is the same as the existing tags
       // we don't want to cause an update.
-      if (deepEquals(state.tags, action.payload)) {
+      if (
+        deepEquals(
+          stateTagsWithSlugs.map(([slug]) => slug),
+          payloadTagsWithSlugs.map(([slug]) => slug)
+        )
+      ) {
         return state;
       }
 
-      const tagsToPersist = state.tags.filter((tag) =>
-        action.payload.includes(tag)
-      );
+      const tagsToPersist = stateTagsWithSlugs
+        .filter(([tagSlug]) =>
+          payloadTagsWithSlugs.map(([slug]) => slug).includes(tagSlug)
+        )
+        .map(([, name]) => name);
 
-      const tagsToAdd = action.payload.filter(
-        (tag) => !state.tags.includes(tag)
-      );
+      const tagsToAdd = payloadTagsWithSlugs
+        .filter(
+          ([tagSlug]) =>
+            !stateTagsWithSlugs.map(([slug]) => slug).includes(tagSlug)
+        )
+        .map(([, name]) => name);
 
       return {
         ...state,

--- a/packages/story-editor/src/components/form/tags/reducer.js
+++ b/packages/story-editor/src/components/form/tags/reducer.js
@@ -31,27 +31,53 @@ function uniquesOnly(arr) {
   return [...slugMap.values()];
 }
 
+function subsetAOfB(a = [], b = []) {
+  return a.forEach((v) => b.includes(v));
+}
+
+function deepEquals(a = [], b = []) {
+  return a.length === b.length && a.every((item) => b.includes(item));
+}
+
 export const ACTIONS = {
   UPDATE_VALUE: 'updateValue',
   SUBMIT_VALUE: 'submitValue',
   REMOVE_TAG: 'removeTag',
   INCREMENT_OFFSET: 'incrementOffset',
   DECREMENT_OFFSET: 'decrementOffset',
+  UPDATE_TAGS: 'updateTags',
 };
 
 function reducer(state, action) {
   switch (action.type) {
     case ACTIONS.UPDATE_VALUE: {
       const values = action.payload.split(',');
+
+      // if we're not adding any tags,
+      // we don't want to update the tagBuffer
+      if (values.length <= 1) {
+        return {
+          ...state,
+          value: action.payload,
+        };
+      }
+
       const newTags = values
         .slice(0, -1)
         .map(formatTag)
         .filter((tag) => tag.length);
       const value = values[values.length - 1];
+
+      // if we're not adding any tags,
+      // we don't want to update the tagBuffer
+      if (subsetAOfB(newTags, state.tags)) {
+        return { ...state, value };
+      }
+
       return {
         ...state,
         value,
-        tags: uniquesOnly([
+        tagBuffer: uniquesOnly([
           ...state.tags.slice(0, state.tags.length - state.offset),
           ...newTags,
           ...state.tags.slice(state.tags.length - state.offset),
@@ -61,17 +87,22 @@ function reducer(state, action) {
 
     case ACTIONS.SUBMIT_VALUE: {
       const newTag = formatTag(state.value);
-      return newTag === ''
-        ? state
-        : {
-            ...state,
-            value: '',
-            tags: uniquesOnly([
-              ...state.tags.slice(0, state.tags.length - state.offset),
-              newTag,
-              ...state.tags.slice(state.tags.length - state.offset),
-            ]),
-          };
+
+      // don't update tagBuffer if we're not
+      // adding any tags
+      if (newTag === '' || state.tags.includes(newTag)) {
+        return { ...state, value: '' };
+      }
+
+      return {
+        ...state,
+        value: '',
+        tagBuffer: uniquesOnly([
+          ...state.tags.slice(0, state.tags.length - state.offset),
+          newTag,
+          ...state.tags.slice(state.tags.length - state.offset),
+        ]),
+      };
     }
 
     case ACTIONS.REMOVE_TAG: {
@@ -85,7 +116,7 @@ function reducer(state, action) {
         ? state
         : {
             ...state,
-            tags: [
+            tagBuffer: [
               ...state.tags.slice(0, removedTagIndex),
               ...state.tags.slice(removedTagIndex + 1, state.tags.length),
             ],
@@ -112,6 +143,31 @@ function reducer(state, action) {
         offset: 0,
       };
     }
+
+    // Retain order as much as possible
+    // and append new tags to the end
+    case ACTIONS.UPDATE_TAGS: {
+      // if the payload is the same as the existing tags
+      // we don't want to cause an update.
+      if (deepEquals(state.tags, action.payload)) {
+        return state;
+      }
+
+      const tagsToPersist = state.tags.filter((tag) =>
+        action.payload.includes(tag)
+      );
+
+      const tagsToAdd = action.payload.filter(
+        (tag) => !state.tags.includes(tag)
+      );
+
+      return {
+        ...state,
+        tags: [...tagsToPersist, ...tagsToAdd],
+        tagBuffer: null,
+      };
+    }
+
     default:
       return state;
   }

--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -110,18 +110,14 @@ const AddNewCategoryButton = styled(Button).attrs({
 `;
 
 function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
-  const { createTerm, selectedSlugs, setSelectedTaxonomySlugs, termCache } =
-    useTaxonomy(
-      ({
-        state: { selectedSlugs, termCache },
-        actions: { createTerm, setSelectedTaxonomySlugs },
-      }) => ({
-        createTerm,
-        selectedSlugs,
-        setSelectedTaxonomySlugs,
-        termCache,
-      })
-    );
+  const { createTerm, termCache, terms, setTerms } = useTaxonomy(
+    ({ state: { termCache, terms }, actions: { createTerm, setTerms } }) => ({
+      createTerm,
+      setTerms,
+      termCache,
+      terms,
+    })
+  );
 
   const categories = useMemo(() => {
     if (termCache[taxonomy.restBase]) {
@@ -129,8 +125,8 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
         const formattedCategory = { ...category };
         formattedCategory.value = formattedCategory.id;
         formattedCategory.label = formattedCategory.name;
-        formattedCategory.checked = selectedSlugs[taxonomy.restBase]?.includes(
-          category.slug
+        formattedCategory.checked = terms[taxonomy.restBase]?.includes(
+          category.id
         );
 
         return formattedCategory;
@@ -138,7 +134,7 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
     }
 
     return [];
-  }, [selectedSlugs, taxonomy, termCache]);
+  }, [taxonomy, termCache, terms]);
 
   const dropdownCategories = useMemo(
     () =>
@@ -170,11 +166,11 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
       const term = categories.find((category) => category.id === id);
 
       // find the already selected slugs + update those.
-      setSelectedTaxonomySlugs(taxonomy, (currentTerms = []) => {
-        const index = currentTerms.findIndex((slug) => slug === term.slug);
+      setTerms(taxonomy, (currentTerms = []) => {
+        const index = currentTerms.findIndex((termId) => termId === term.id);
         // add if term doesn't exist
         if (checked && index === -1) {
-          return [...currentTerms, term.slug];
+          return [...currentTerms, term.id];
         }
 
         // remove if term exists
@@ -188,7 +184,7 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
         return currentTerms;
       });
     },
-    [categories, setSelectedTaxonomySlugs, taxonomy]
+    [categories, setTerms, taxonomy]
   );
 
   const handleToggleNewCategory = useCallback(() => {
@@ -207,7 +203,7 @@ function HierarchicalTermSelector({ noParentId = NO_PARENT_VALUE, taxonomy }) {
       evt.preventDefault();
 
       const parentValue = selectedParent === noParentId ? 0 : selectedParent;
-      createTerm(taxonomy, newCategoryName, parentValue);
+      createTerm(taxonomy, newCategoryName, parentValue, true);
       setShowAddNewCategory(false);
       resetInputs();
       setToggleFocus(showAddNewCategory);


### PR DESCRIPTION
## Context
While working on taxonomy, we noticed there were some hiccups with its history interactions.

This PR updates the taxonomy data flow have better integration with history.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- Setup taxonomies to interact with the story directly for associated terms.
- reset history when taxonomies are hydrating so there's not a history entry when taxonomies are registering.

Not only does this update allow our taxonomy inputs to work like the Gutenberg spec with regards to history, but our freeform taxonomies actually work better with history than Gutenberg does 🎉 .



https://user-images.githubusercontent.com/35983235/134704260-db4565e1-72d0-4e63-81cc-67c15603a2a2.mp4


https://user-images.githubusercontent.com/35983235/134704268-071dd8cc-45cc-4e9d-8310-679cd863cd6a.mp4


<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Had to Refactor the taxonomy provider as well as the inputs it interacted with.

This change moved a lot of the complexity from the TaxonomyProvider into the FlatTermSelector, but allows everything to work with history better now.

<!-- Please describe your changes. -->

## To-do
- [ ] fix any and all tests
- [ ] figure out why the keydown events aren't bubbling up when input is focused
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
NA
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
Interact with the taxonomies and history. They should respond to undo/redo now and other than that, work to spec from before
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9073
 
Fixes #9058
