### PR TITLE
Cross-origin isolation: Fix errors if `$url` is `null`

### DIFF
--- a/includes/Admin/Cross_Origin_Isolation.php
+++ b/includes/Admin/Cross_Origin_Isolation.php
@@ -218,11 +218,15 @@ class Cross_Origin_Isolation extends Service_Base implements Conditional {
 	 *
 	 * @param string|mixed $html HTML string.
 	 * @param string       $attribute Attribute to check for.
-	 * @param string       $url URL.
+	 * @param string|null  $url URL.
 	 *
 	 * @return string|mixed
 	 */
-	protected function add_attribute( $html, string $attribute, string $url ) {
+	protected function add_attribute( $html, string $attribute, $url ) {
+		if ( ! $url ) {
+			return $html;
+		}
+
 		$site_url = site_url();
 		$url      = esc_url( $url );
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Bug report: https://wordpress.org/support/topic/buddyboss-incompatible/

## Summary

<!-- A brief description of what this PR does. -->

Fixes errors if `$url` is `null` for some reason.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
