### PR TITLE
Templates: Update image generation script to create webp versions

### DIFF
--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -9,5 +9,3 @@ See [External Template Creation](../../docs/external-template-creation.md).
 ## Generating images for templates
 
 Run `npm run workflow:render-template-posters` to generate and save each template page as an image in the `build/template-posters/` folder. Then move and commit the images to the `static-site` branch under `public/static/main/images/templates/<template-name>/posters`.
-
-You will want to run the png through [ImageOptim](https://imageoptim.com/howto.html) and also create a [WebP](https://developers.google.com/speed/webp) version of each png. Save both to the template poster directory.

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -9,3 +9,5 @@ See [External Template Creation](../../docs/external-template-creation.md).
 ## Generating images for templates
 
 Run `npm run workflow:render-template-posters` to generate and save each template page as an image in the `build/template-posters/` folder. Then move and commit the images to the `static-site` branch under `public/static/main/images/templates/<template-name>/posters`.
+
+You will want to run the png through [ImageOptim](https://imageoptim.com/howto.html) locally to optimize it before adding it to the static site.

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -10,4 +10,4 @@ See [External Template Creation](../../docs/external-template-creation.md).
 
 Run `npm run workflow:render-template-posters` to generate and save each template page as an image in the `build/template-posters/` folder. Then move and commit the images to the `static-site` branch under `public/static/main/images/templates/<template-name>/posters`.
 
-You will want to run the png through [ImageOptim](https://imageoptim.com/howto.html) locally to optimize it before adding it to the static site.
+You will want to run the resulting images through [ImageOptim](https://imageoptim.com/howto.html) locally to optimize them before adding them to the `static-site` branch.

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -132,6 +132,10 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
         path: `${screenshotsPath}${templateName}/${currentPage}.png`,
       });
 
+      await templatePageSafeArea.screenshot({
+        path: `${screenshotsPath}${templateName}/${currentPage}.webp`,
+      });
+
       if (currentPage !== totalPages - 1) {
         await pagePreview.click('aria/Next page');
       }


### PR DESCRIPTION
## Context
In story editor, we will be using the cli generated screenshots as the images for all the layouts. 

## Relevant Technical Choices

<!-- Please describe your changes. -->
Since Puppeteer v10.4.0 now supports saving screenshots directly as `webp`,  we can create the two versions during the cli script. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
n/a

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.  Run `npm run workflow:render-template-posters` to generate and save each template page as an image in the `build/template-posters/` folder. 
2. Check that both a `png` and `webp` version is present. 


## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9090 
