### PR TITLE
Page Templates: add screenshot urls to template

### DIFF
--- a/packages/dashboard/src/app/api/useTemplateApi.js
+++ b/packages/dashboard/src/app/api/useTemplateApi.js
@@ -44,7 +44,7 @@ const useTemplateApi = (dataAdapter, config) => {
 
     const reshapedTemplates = (await getAllTemplates({ cdnURL }))
       .map((template) => {
-        const reshapedTemplate = reshapeTemplateObject(template, cdnURL);
+        const reshapedTemplate = reshapeTemplateObject(template);
 
         reshapedTemplate.tags.forEach((tag) => {
           if (templatesByTag[tag]) {

--- a/packages/dashboard/src/app/serializers/templates.js
+++ b/packages/dashboard/src/app/serializers/templates.js
@@ -25,30 +25,17 @@ import { APP_ROUTES } from '../../constants';
 
 export default function reshapeTemplateObject(
   originalTemplateData,
-  cdnURL,
   isLocal = false
 ) {
-  const { id, slug, pages, modified, creationDate } = originalTemplateData;
+  const { id, slug, modified, creationDate } = originalTemplateData;
   if (!id || !slug) {
     return null;
   }
-
-  const postersByPage = pages.reduce((memo, _, i) => {
-    const srcPath = `${cdnURL}images/templates/${slug}/posters/${i + 1}`;
-    return {
-      ...memo,
-      [i]: {
-        webp: `${srcPath}.webp`,
-        png: `${srcPath}.png`,
-      },
-    };
-  }, {});
 
   return {
     ...originalTemplateData,
     id,
     slug,
-    postersByPage,
     centerTargetAction: `${APP_ROUTES.TEMPLATE_DETAIL}?id=${id}&isLocal=${isLocal}`,
     creationDate: toDate(creationDate, getOptions()),
     status: 'template',

--- a/packages/dashboard/src/app/serializers/test/templates.js
+++ b/packages/dashboard/src/app/serializers/test/templates.js
@@ -32,27 +32,14 @@ describe('reshapeTemplateObject', () => {
       pages: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
       creationDate: '2020-03-26T20:57:24',
       modified: '2020-03-26T20:57:24',
+      status: 'template',
     };
 
-    const reshapedObj = reshapeTemplateObject(responseObj, 'example.com/');
+    const reshapedObj = reshapeTemplateObject(responseObj, false);
 
     expect(reshapedObj).toMatchObject({
       id: 1,
       slug: 'template-1-slug',
-      postersByPage: {
-        0: {
-          webp: 'example.com/images/templates/template-1-slug/posters/1.webp',
-          png: 'example.com/images/templates/template-1-slug/posters/1.png',
-        },
-        1: {
-          webp: 'example.com/images/templates/template-1-slug/posters/2.webp',
-          png: 'example.com/images/templates/template-1-slug/posters/2.png',
-        },
-        2: {
-          webp: 'example.com/images/templates/template-1-slug/posters/3.webp',
-          png: 'example.com/images/templates/template-1-slug/posters/3.png',
-        },
-      },
       centerTargetAction: `${APP_ROUTES.TEMPLATE_DETAIL}?id=1&isLocal=false`,
       creationDate: toDate('2020-03-26T20:57:24.000Z'),
       status: 'template',
@@ -66,7 +53,7 @@ describe('reshapeTemplateObject', () => {
         pages: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
         creationDate: '2020-03-26T20:57:24',
       },
-      'example.com/'
+      true
     );
 
     expect(reshapedObj).toBeNull();

--- a/packages/dashboard/src/types.js
+++ b/packages/dashboard/src/types.js
@@ -64,6 +64,7 @@ export const TemplatePropType = PropTypes.shape({
     PropTypes.shape({
       webp: PropTypes.string,
       png: PropTypes.string,
+      type: PropTypes.string,
     })
   ),
 });

--- a/packages/dashboard/src/types.js
+++ b/packages/dashboard/src/types.js
@@ -60,7 +60,7 @@ export const TemplatePropType = PropTypes.shape({
   description: PropTypes.string,
   tags: PropTypes.arrayOf(PropTypes.string),
   createdBy: PropTypes.string,
-  postersByPage: PropTypes.objectOf(
+  postersByPage: PropTypes.arrayOf(
     PropTypes.shape({
       webp: PropTypes.string,
       png: PropTypes.string,

--- a/packages/templates/src/getTemplates.js
+++ b/packages/templates/src/getTemplates.js
@@ -69,7 +69,6 @@ async function loadTemplate(title, imageBaseUrl) {
         [i]: {
           webp: `${srcPath}.webp`,
           png: `${srcPath}.png`,
-          type: data.default.pages[i].pageTemplateType,
         },
       };
     }, {}),

--- a/packages/templates/src/getTemplates.js
+++ b/packages/templates/src/getTemplates.js
@@ -64,7 +64,11 @@ async function loadTemplate(title, imageBaseUrl) {
       const srcPath = `${imageBaseUrl}images/templates/${
         data.default.slug
       }/posters/${i + 1}`;
-      return { webp: `${srcPath}.webp`, png: `${srcPath}.png` };
+      return {
+        webp: `${srcPath}.webp`,
+        png: `${srcPath}.png`,
+        type: data.default.pages[i].pageTemplateType,
+      };
     }),
   };
 

--- a/packages/templates/src/getTemplates.js
+++ b/packages/templates/src/getTemplates.js
@@ -60,18 +60,12 @@ async function loadTemplate(title, imageBaseUrl) {
       }),
     })),
 
-    postersByPage: data.default.pages.reduce((memo, _, i) => {
+    postersByPage: data.default.pages.map((page, i) => {
       const srcPath = `${imageBaseUrl}images/templates/${
         data.default.slug
       }/posters/${i + 1}`;
-      return {
-        ...memo,
-        [i]: {
-          webp: `${srcPath}.webp`,
-          png: `${srcPath}.png`,
-        },
-      };
-    }, {}),
+      return { webp: `${srcPath}.webp`, png: `${srcPath}.png` };
+    }),
   };
 
   return {

--- a/packages/templates/src/getTemplates.js
+++ b/packages/templates/src/getTemplates.js
@@ -59,6 +59,20 @@ async function loadTemplate(title, imageBaseUrl) {
         return elem;
       }),
     })),
+
+    postersByPage: data.default.pages.reduce((memo, _, i) => {
+      const srcPath = `${imageBaseUrl}images/templates/${
+        data.default.slug
+      }/posters/${i + 1}`;
+      return {
+        ...memo,
+        [i]: {
+          webp: `${srcPath}.webp`,
+          png: `${srcPath}.png`,
+          type: data.default.pages[i].pageTemplateType,
+        },
+      };
+    }, {}),
   };
 
   return {

--- a/packages/templates/src/index.js
+++ b/packages/templates/src/index.js
@@ -31,24 +31,10 @@ export default async function ({ cdnURL }) {
   };
 
   return templates.map((template, index) => {
-    const postersByPage = template.pages.reduce((memo, _, i) => {
-      const srcPath = `${cdnURL}images/templates/${template.slug}/posters/${
-        i + 1
-      }`;
-      return {
-        ...memo,
-        [i]: {
-          webp: `${srcPath}.webp`,
-          png: `${srcPath}.png`,
-        },
-      };
-    }, {});
-
     return {
       id: index + 1,
       ...globalConfig,
       ...template,
-      postersByPage,
     };
   });
 }

--- a/packages/templates/src/index.js
+++ b/packages/templates/src/index.js
@@ -31,10 +31,24 @@ export default async function ({ cdnURL }) {
   };
 
   return templates.map((template, index) => {
+    const postersByPage = template.pages.reduce((memo, _, i) => {
+      const srcPath = `${cdnURL}images/templates/${template.slug}/posters/${
+        i + 1
+      }`;
+      return {
+        ...memo,
+        [i]: {
+          webp: `${srcPath}.webp`,
+          png: `${srcPath}.png`,
+        },
+      };
+    }, {});
+
     return {
       id: index + 1,
       ...globalConfig,
       ...template,
+      postersByPage,
     };
   });
 }

--- a/packages/templates/src/test/getTemplates.js
+++ b/packages/templates/src/test/getTemplates.js
@@ -36,8 +36,19 @@ describe('getTemplate', () => {
                 i + 1
               }.webp`
             ),
+            type: expect.any(String),
           })
         );
+      });
+    });
+  });
+
+  it('should match postersByPage.type with pages.pageTemplateType', async () => {
+    const templates = await getTemplates('example.com/');
+
+    templates.forEach((template) => {
+      template.postersByPage.forEach((page, i) => {
+        expect(page.type).toStrictEqual(template.pages[i].pageTemplateType);
       });
     });
   });

--- a/packages/templates/src/test/getTemplates.js
+++ b/packages/templates/src/test/getTemplates.js
@@ -62,14 +62,8 @@ describe('getTemplate', () => {
           expect(element.resource?.src).toStrictEqual(
             expect.not.stringContaining('__WEB_STORIES_TEMPLATE_BASE_URL__/')
           );
-          expect(element.resource?.src).toStrictEqual(
-            expect.stringContaining('example.com/')
-          );
           expect(element.resource?.poster).toStrictEqual(
             expect.not.stringContaining('__WEB_STORIES_TEMPLATE_BASE_URL__/')
-          );
-          expect(element.resource?.poster).toStrictEqual(
-            expect.stringContaining('example.com/')
           );
         });
       });

--- a/packages/templates/src/test/getTemplates.js
+++ b/packages/templates/src/test/getTemplates.js
@@ -13,11 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * External dependencies
- */
-
 /**
  * Internal dependencies
  */
@@ -53,11 +48,11 @@ describe('getTemplate', () => {
     templates.forEach((template) => {
       template.pages.forEach((page) => {
         page.elements.forEach((element) => {
-          expect(element.resource?.src).not.toBe(
-            '__WEB_STORIES_TEMPLATE_BASE_URL__/'
+          expect(element.resource?.src).toStrictEqual(
+            expect.not.stringContaining('__WEB_STORIES_TEMPLATE_BASE_URL__/')
           );
-          expect(element.resource?.poster).not.toBe(
-            '__WEB_STORIES_TEMPLATE_BASE_URL__/'
+          expect(element.resource?.poster).toStrictEqual(
+            expect.not.stringContaining('__WEB_STORIES_TEMPLATE_BASE_URL__/')
           );
         });
       });

--- a/packages/templates/src/test/getTemplates.js
+++ b/packages/templates/src/test/getTemplates.js
@@ -51,8 +51,14 @@ describe('getTemplate', () => {
           expect(element.resource?.src).toStrictEqual(
             expect.not.stringContaining('__WEB_STORIES_TEMPLATE_BASE_URL__/')
           );
+          expect(element.resource?.src).toStrictEqual(
+            expect.stringContaining('example.com/')
+          );
           expect(element.resource?.poster).toStrictEqual(
             expect.not.stringContaining('__WEB_STORIES_TEMPLATE_BASE_URL__/')
+          );
+          expect(element.resource?.poster).toStrictEqual(
+            expect.stringContaining('example.com/')
           );
         });
       });

--- a/packages/templates/src/test/getTemplates.js
+++ b/packages/templates/src/test/getTemplates.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import getTemplates from '../getTemplates';
+
+describe('getTemplate', () => {
+  it('should return png and webp urls for each page', async () => {
+    const templates = await getTemplates('example.com/');
+
+    templates.forEach((template) => {
+      template.postersByPage.forEach((page, i) => {
+        expect(page).toStrictEqual(
+          expect.objectContaining({
+            png: expect.stringContaining(
+              `example.com/images/templates/${template.slug}/posters/${
+                i + 1
+              }.png`
+            ),
+            webp: expect.stringContaining(
+              `example.com/images/templates/${template.slug}/posters/${
+                i + 1
+              }.webp`
+            ),
+          })
+        );
+      });
+    });
+  });
+
+  it('should replace __WEB_STORIES_TEMPLATE_BASE_URL__/ with imageUrl for each page', async () => {
+    const templates = await getTemplates('example.com/');
+
+    templates.forEach((template) => {
+      template.pages.forEach((page) => {
+        page.elements.forEach((element) => {
+          expect(element.resource?.src).not.toBe(
+            '__WEB_STORIES_TEMPLATE_BASE_URL__/'
+          );
+          expect(element.resource?.poster).not.toBe(
+            '__WEB_STORIES_TEMPLATE_BASE_URL__/'
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Context
In story editor, we will be using the cli generated screenshots as the images for all the layouts. 
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Instead of recreating the image urls in both the dashboard templates and the editor templates, we are placing the src urls within the templates export. 
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Removed `posterByPage` from Dashboard -> Serializer -> reshapeTemplateObject and instead exported as part of the template. 
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
n/a

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. 


## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9091
