### PR TITLE
Remove duplicate canonical links

### DIFF
--- a/includes/AMP/Canonical_Sanitizer.php
+++ b/includes/AMP/Canonical_Sanitizer.php
@@ -61,6 +61,16 @@ class Canonical_Sanitizer extends AMP_Base_Sanitizer {
 
 		$query = $this->dom->xpath->query( '//link[@rel="canonical"]', $this->dom->head );
 
+		// Remove any duplicate items first.
+		if ( $query instanceof DOMNodeList && $query->length > 1 ) {
+			for ( $i = 1; $i < $query->length; $i++ ) {
+				$node = $query->item( $i );
+				if ( $node ) {
+					$this->dom->head->removeChild( $node );
+				}
+			}
+		}
+
 		/**
 		 * DOMElement
 		 *

--- a/tests/phpunit/unit/tests/AMP/Canonical_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Canonical_Sanitizer.php
@@ -45,6 +45,25 @@ class Canonical_Sanitizer extends TestCase {
 	/**
 	 * @covers ::sanitize
 	 */
+	public function test_sanitize_canonical_remove_duplicates() {
+		$source = '<html><head><title>Example</title><link rel="canonical" href="https://example.com/canonical.html"><link rel="canonical" href="https://example.com/canonical2.html"></head><body><p>Hello World</p></body></html>';
+
+		$dom = Document::fromHtml( $source );
+
+		$sanitizer = new \Google\Web_Stories\AMP\Canonical_Sanitizer(
+			$dom,
+			[ 'canonical_url' => 'https://example.com/new-canonical.html' ]
+		);
+		$sanitizer->sanitize();
+
+		$actual = $dom->saveHTML( $dom->documentElement );
+		$this->assertContains( '<link rel="canonical" href="https://example.com/canonical.html">', $actual );
+		$this->assertNotContains( '<link rel="canonical" href="https://example.com/canonical2.html">', $actual );
+	}
+
+	/**
+	 * @covers ::sanitize
+	 */
 	public function test_sanitize_canonical_missing() {
 		$canonical = 'https://example.com/new-canonical.html';
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

While the original issue with duplicate canonical links has been fixed by Yoast SEO, it turns out there's room for improvement on our side as well to prevent duplicates at the AMP sanitization stage.

## Summary

<!-- A brief description of what this PR does. -->

This PR updates the canonical link sanitizer to remove duplicates.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Removes all but the first found canonical link

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Install and activate Yoast SEO 17.2
2. Ensure your site is not discouraging search engines from indexing
3. Publish a story
4. Verify there is no `The tag 'link rel=canonical' appears more than once in the document.` AMP validation error

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9010
