### PR TITLE
Update video trimmer buttons

### DIFF
--- a/packages/story-editor/src/components/videoTrim/useVideoNode.js
+++ b/packages/story-editor/src/components/videoTrim/useVideoNode.js
@@ -91,11 +91,6 @@ function useVideoNode() {
     [videoNode, startOffset, maxOffset]
   );
 
-  const resetOffsets = useCallback(() => {
-    rawSetStartOffset(originalStartOffset);
-    rawSetEndOffset(originalEndOffset);
-  }, [originalStartOffset, originalEndOffset]);
-
   const hasChanged = useMemo(
     () =>
       startOffset !== originalStartOffset || endOffset !== originalEndOffset,
@@ -111,7 +106,6 @@ function useVideoNode() {
     setStartOffset,
     setEndOffset,
     setVideoNode,
-    resetOffsets,
   };
 }
 

--- a/packages/story-editor/src/components/videoTrim/videoTrimmer.js
+++ b/packages/story-editor/src/components/videoTrim/videoTrimmer.js
@@ -51,11 +51,11 @@ function VideoTrimmer() {
     setEndOffset,
     hasChanged,
     performTrim,
-    resetOffsets,
+    toggleTrimMode,
   } = useVideoTrim(
     ({
       state: { currentTime, startOffset, endOffset, maxOffset, hasChanged },
-      actions: { setStartOffset, setEndOffset, performTrim, resetOffsets },
+      actions: { setStartOffset, setEndOffset, performTrim, toggleTrimMode },
     }) => ({
       currentTime,
       startOffset,
@@ -65,7 +65,7 @@ function VideoTrimmer() {
       setEndOffset,
       hasChanged,
       performTrim,
-      resetOffsets,
+      toggleTrimMode,
     })
   );
   const { workspaceWidth, pageWidth } = useLayout(
@@ -90,18 +90,16 @@ function VideoTrimmer() {
 
   return (
     <Menu>
-      {hasChanged && (
-        <ButtonWrapper isStart>
-          <Button
-            variant={BUTTON_VARIANTS.RECTANGLE}
-            type={BUTTON_TYPES.SECONDARY}
-            size={BUTTON_SIZES.SMALL}
-            onClick={resetOffsets}
-          >
-            {__('Cancel', 'web-stories')}
-          </Button>
-        </ButtonWrapper>
-      )}
+      <ButtonWrapper isStart>
+        <Button
+          variant={BUTTON_VARIANTS.RECTANGLE}
+          type={BUTTON_TYPES.SECONDARY}
+          size={BUTTON_SIZES.SMALL}
+          onClick={toggleTrimMode}
+        >
+          {__('Cancel', 'web-stories')}
+        </Button>
+      </ButtonWrapper>
       <Wrapper pageWidth={railWidth}>
         <Scrim atStart width={(startOffset / maxOffset) * railWidth} />
         <Scrim width={((maxOffset - endOffset) / maxOffset) * railWidth} />
@@ -127,18 +125,17 @@ function VideoTrimmer() {
           {...sliderProps}
         />
       </Wrapper>
-      {hasChanged && (
-        <ButtonWrapper>
-          <Button
-            variant={BUTTON_VARIANTS.RECTANGLE}
-            type={BUTTON_TYPES.PRIMARY}
-            size={BUTTON_SIZES.SMALL}
-            onClick={performTrim}
-          >
-            {__('Trim', 'web-stories')}
-          </Button>
-        </ButtonWrapper>
-      )}
+      <ButtonWrapper>
+        <Button
+          variant={BUTTON_VARIANTS.RECTANGLE}
+          type={BUTTON_TYPES.PRIMARY}
+          size={BUTTON_SIZES.SMALL}
+          onClick={performTrim}
+          disabled={!hasChanged}
+        >
+          {__('Trim', 'web-stories')}
+        </Button>
+      </ButtonWrapper>
     </Menu>
   );
 }


### PR DESCRIPTION
## Context

Always show cancel button and make it exit trim mode rather than just reset handles. Also always show trim button, but disable it until handles are not at their original positions.

Also, remove the underlying functionality to reset the offset as it's no longer needed anywhere.

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

This PR can be tested by following these steps:

1. Add a video
2. Enter trim mode
3. Observe that the cancel button is always enabled and can be pressed to exit trim mode
4. Observe that the trim button is visible but disabled
5. Drag a handle
6. Observe that the trim button is now enabled

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9178
