### PR TITLE
Fixed edit menu background

### DIFF
--- a/packages/story-editor/src/components/canvas/framesLayer.js
+++ b/packages/story-editor/src/components/canvas/framesLayer.js
@@ -86,6 +86,14 @@ function FramesLayer() {
       }),
     [setScrollOffset]
   );
+  const { isEditing, hasEditMenu = false } = useCanvas(
+    ({ state: { isEditing, editingElementState: { hasEditMenu } = {} } }) => ({
+      isEditing,
+      hasEditMenu,
+    })
+  );
+
+  const isEditingWithMenu = isEditing && hasEditMenu;
 
   return (
     <Layer
@@ -118,7 +126,7 @@ function FramesLayer() {
         // Cancel lasso.
         onMouseDown={(evt) => evt.stopPropagation()}
       >
-        <PageMenu />
+        {!isEditingWithMenu && <PageMenu />}
       </MenuArea>
       <NavPrevArea>
         <PageNav isNext={false} />

--- a/packages/story-editor/src/components/videoTrim/trimmerComponents.js
+++ b/packages/story-editor/src/components/videoTrim/trimmerComponents.js
@@ -29,7 +29,6 @@ export const Menu = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  background-color: ${({ theme }) => theme.colors.bg.primary};
   height: 40px;
   gap: 14px;
 `;

--- a/packages/story-editor/src/components/videoTrim/useVideoTrimMode.js
+++ b/packages/story-editor/src/components/videoTrim/useVideoTrimMode.js
@@ -50,6 +50,7 @@ function useVideoTrimMode() {
     } else {
       setEditingElementWithState(selectedElement.id, {
         isTrimMode: true,
+        hasEditMenu: true,
       });
     }
   }, [isEditing, clearEditing, setEditingElementWithState, selectedElement]);


### PR DESCRIPTION
## Context

The edit menu background appeared to be the wrong color, because the regular background was subdued by a 47% black overlay while editing.

The edit menu background however could not just merely become transparent as that would allow the items from the regular page menu to seep through.

This makes the edit menu background transparent, while also hiding the regular page menu while video trim is in progress.

## User-facing changes
![trim-bg](https://user-images.githubusercontent.com/637548/135154933-e6fe1024-9db7-4054-bee0-27be88057076.gif)

## Testing Instructions

This PR can be tested by following these steps:

1. Add a video and enter trim mode
2. Observe no noticeable difference in background color between the trim rail background and the regular page background
3. Also observe, that even for a small page (where the page menu items normally extends beyond the page width) no regular page menu items are visible while video trim is in progress.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9179
