### PR TITLE
Video: Update right click menu

### DIFF
--- a/packages/story-editor/src/app/rightClickMenu/constants.js
+++ b/packages/story-editor/src/app/rightClickMenu/constants.js
@@ -34,24 +34,40 @@ export const RIGHT_CLICK_MENU_LABELS = {
   BRING_TO_FRONT: __('Bring to Front', 'web-stories'),
   CLEAR_IMAGE_STYLES: __('Clear Image Styles', 'web-stories'),
   CLEAR_SHAPE_STYLES: __('Clear Shape Styles', 'web-stories'),
+  CLEAR_VIDEO_STYLES: __('Clear Video Styles', 'web-stories'),
   CLEAR_STYLE: __('Clear Style', 'web-stories'),
   COPY_IMAGE_STYLES: __('Copy Image Styles', 'web-stories'),
   COPY_SHAPE_STYLES: __('Copy Shape Styles', 'web-stories'),
+  COPY_VIDEO_STYLES: __('Copy Video Styles', 'web-stories'),
   COPY_STYLES: __('Copy Style', 'web-stories'),
   DELETE_PAGE: __('Delete Page', 'web-stories'),
   DETACH_IMAGE_FROM_BACKGROUND: __(
     'Detach Image From Background',
     'web-stories'
   ),
+  DETACH_VIDEO_FROM_BACKGROUND: __(
+    'Detach Video From Background',
+    'web-stories'
+  ),
   DUPLICATE_PAGE: __('Duplicate Page', 'web-stories'),
   PASTE_IMAGE_STYLES: __('Paste Image Styles', 'web-stories'),
   PASTE_SHAPE_STYLES: __('Paste Shape Styles', 'web-stories'),
+  PASTE_VIDEO_STYLES: __('Paste Video Styles', 'web-stories'),
   PASTE_STYLES: __('Paste Style', 'web-stories'),
-  SCALE_AND_CROP_BACKGROUND: __('Scale & Crop Background Image', 'web-stories'),
+  SCALE_AND_CROP_BACKGROUND_IMAGE: __(
+    'Scale & Crop Background Image',
+    'web-stories'
+  ),
+  SCALE_AND_CROP_BACKGROUND_VIDEO: __(
+    'Scale & Crop Background Video',
+    'web-stories'
+  ),
   SCALE_AND_CROP_IMAGE: __('Scale & Crop Image', 'web-stories'),
+  SCALE_AND_CROP_VIDEO: __('Scale & Crop Video', 'web-stories'),
   SEND_BACKWARD: __('Send Backward', 'web-stories'),
   SEND_TO_BACK: __('Send to Back', 'web-stories'),
   SET_AS_PAGE_BACKGROUND: __('Set as Page Background', 'web-stories'),
+  TRIM_VIDEO: __('Trim Video', 'web-stories'),
 };
 
 const StyledKbd = styled(Text).attrs({

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -50,6 +50,7 @@ import getUpdatedSizeAndPosition from '../../utils/getUpdatedSizeAndPosition';
 import { useHistory } from '../history';
 import useDeletePreset from '../../components/panels/design/preset/useDeletePreset';
 import { noop } from '../../utils/noop';
+import useVideoTrim from '../../components/videoTrim/useVideoTrim';
 import {
   RIGHT_CLICK_MENU_LABELS,
   RIGHT_CLICK_MENU_SHORTCUTS,
@@ -141,6 +142,13 @@ function RightClickMenuProvider({ children }) {
       selectedElements,
       setBackgroundElement,
       updateElementsById,
+    })
+  );
+
+  const { hasTrimMode, toggleTrimMode } = useVideoTrim(
+    ({ state: { hasTrimMode }, actions: { toggleTrimMode } }) => ({
+      hasTrimMode,
+      toggleTrimMode,
     })
   );
 
@@ -781,20 +789,36 @@ function RightClickMenuProvider({ children }) {
 
   const pageItems = useMemo(() => {
     const disableBackgroundMediaActions = selectedElement?.isDefaultBackground;
+    const isVideo = selectedElement?.type === 'video';
+    const detachLabel = isVideo
+      ? RIGHT_CLICK_MENU_LABELS.DETACH_VIDEO_FROM_BACKGROUND
+      : RIGHT_CLICK_MENU_LABELS.DETACH_IMAGE_FROM_BACKGROUND;
+    const scaleLabel = isVideo
+      ? RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_BACKGROUND_VIDEO
+      : RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_BACKGROUND_IMAGE;
 
     return [
       {
-        label: RIGHT_CLICK_MENU_LABELS.DETACH_IMAGE_FROM_BACKGROUND,
+        label: detachLabel,
         onClick: handleRemoveMediaFromBackground,
         disabled: disableBackgroundMediaActions,
         ...menuItemProps,
       },
       {
-        label: RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_BACKGROUND,
+        label: scaleLabel,
         onClick: handleOpenScaleAndCrop,
         disabled: disableBackgroundMediaActions,
         ...menuItemProps,
       },
+      ...(isVideo && hasTrimMode
+        ? [
+            {
+              label: RIGHT_CLICK_MENU_LABELS.TRIM_VIDEO,
+              onClick: toggleTrimMode,
+              ...menuItemProps,
+            },
+          ]
+        : []),
       {
         label: RIGHT_CLICK_MENU_LABELS.CLEAR_STYLE,
         onClick: handleClearElementStyles,
@@ -808,9 +832,12 @@ function RightClickMenuProvider({ children }) {
     handleClearElementStyles,
     handleOpenScaleAndCrop,
     handleRemoveMediaFromBackground,
+    hasTrimMode,
     menuItemProps,
     pageManipulationItems,
     selectedElement?.isDefaultBackground,
+    selectedElement?.type,
+    toggleTrimMode,
   ]);
 
   const textItems = useMemo(
@@ -853,8 +880,22 @@ function RightClickMenuProvider({ children }) {
     ]
   );
 
-  const foregroundMediaItems = useMemo(
-    () => [
+  const foregroundMediaItems = useMemo(() => {
+    const isVideo = selectedElement?.type === 'video';
+    const scaleLabel = isVideo
+      ? RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_VIDEO
+      : RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_IMAGE;
+    const copyLabel = isVideo
+      ? RIGHT_CLICK_MENU_LABELS.COPY_VIDEO_STYLES
+      : RIGHT_CLICK_MENU_LABELS.COPY_IMAGE_STYLES;
+    const pasteLabel = isVideo
+      ? RIGHT_CLICK_MENU_LABELS.PASTE_VIDEO_STYLES
+      : RIGHT_CLICK_MENU_LABELS.PASTE_IMAGE_STYLES;
+    const clearLabel = isVideo
+      ? RIGHT_CLICK_MENU_LABELS.CLEAR_VIDEO_STYLES
+      : RIGHT_CLICK_MENU_LABELS.CLEAR_IMAGE_STYLES;
+
+    return [
       ...layerItems,
       {
         label: RIGHT_CLICK_MENU_LABELS.SET_AS_PAGE_BACKGROUND,
@@ -863,42 +904,52 @@ function RightClickMenuProvider({ children }) {
         ...menuItemProps,
       },
       {
-        label: RIGHT_CLICK_MENU_LABELS.SCALE_AND_CROP_IMAGE,
+        label: scaleLabel,
         onClick: handleOpenScaleAndCrop,
         ...menuItemProps,
       },
+      ...(isVideo && hasTrimMode
+        ? [
+            {
+              label: RIGHT_CLICK_MENU_LABELS.TRIM_VIDEO,
+              onClick: toggleTrimMode,
+              ...menuItemProps,
+            },
+          ]
+        : []),
       {
-        label: RIGHT_CLICK_MENU_LABELS.COPY_IMAGE_STYLES,
+        label: copyLabel,
         separator: 'top',
         shortcut: RIGHT_CLICK_MENU_SHORTCUTS.COPY_STYLES,
         onClick: handleCopyStyles,
         ...menuItemProps,
       },
       {
-        label: RIGHT_CLICK_MENU_LABELS.PASTE_IMAGE_STYLES,
+        label: pasteLabel,
         shortcut: RIGHT_CLICK_MENU_SHORTCUTS.PASTE_STYLES,
         onClick: handlePasteStyles,
         disabled: copiedElement.type !== selectedElement?.type,
         ...menuItemProps,
       },
       {
-        label: RIGHT_CLICK_MENU_LABELS.CLEAR_IMAGE_STYLES,
+        label: clearLabel,
         onClick: handleClearElementStyles,
         ...menuItemProps,
       },
-    ],
-    [
-      copiedElement,
-      handleClearElementStyles,
-      handleCopyStyles,
-      handleOpenScaleAndCrop,
-      handlePasteStyles,
-      handleSetPageBackground,
-      layerItems,
-      menuItemProps,
-      selectedElement,
-    ]
-  );
+    ];
+  }, [
+    copiedElement,
+    handleClearElementStyles,
+    handleCopyStyles,
+    handleOpenScaleAndCrop,
+    handlePasteStyles,
+    handleSetPageBackground,
+    hasTrimMode,
+    layerItems,
+    menuItemProps,
+    selectedElement,
+    toggleTrimMode,
+  ]);
 
   const shapeItems = useMemo(
     () => [

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -22,6 +22,7 @@ import {
 } from '@web-stories-wp/design-system';
 import { __ } from '@web-stories-wp/i18n';
 import { trackEvent } from '@web-stories-wp/tracking';
+import { canTranscodeResource } from '@web-stories-wp/media';
 import PropTypes from 'prop-types';
 import {
   useCallback,
@@ -815,6 +816,7 @@ function RightClickMenuProvider({ children }) {
             {
               label: RIGHT_CLICK_MENU_LABELS.TRIM_VIDEO,
               onClick: toggleTrimMode,
+              disabled: !canTranscodeResource(selectedElement?.resource),
               ...menuItemProps,
             },
           ]
@@ -835,8 +837,7 @@ function RightClickMenuProvider({ children }) {
     hasTrimMode,
     menuItemProps,
     pageManipulationItems,
-    selectedElement?.isDefaultBackground,
-    selectedElement?.type,
+    selectedElement,
     toggleTrimMode,
   ]);
 
@@ -913,6 +914,7 @@ function RightClickMenuProvider({ children }) {
             {
               label: RIGHT_CLICK_MENU_LABELS.TRIM_VIDEO,
               onClick: toggleTrimMode,
+              disabled: !canTranscodeResource(selectedElement?.resource),
               ...menuItemProps,
             },
           ]

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -98,6 +98,18 @@ describe('Right Click Menu integration', () => {
     });
   }
 
+  function scaleAndCropVideo() {
+    return fixture.screen.getByRole('button', {
+      name: /^Scale & Crop Video/i,
+    });
+  }
+
+  function scaleAndCropBackgroundVideo() {
+    return fixture.screen.getByRole('button', {
+      name: /^Scale & Crop Background Video/i,
+    });
+  }
+
   function duplicatePage() {
     const menu = rightClickMenu();
 
@@ -376,7 +388,44 @@ describe('Right Click Menu integration', () => {
       ).toBe(undefined);
     });
 
-    it('should let a user scale and crop media', async () => {
+    it('should let a user scale and crop image', async () => {
+      const earthImage = await addEarthImage();
+
+      // right click video
+      await rightClickOnTarget(
+        fixture.editor.canvas.framesLayer.frame(earthImage.id).node
+      );
+
+      // foreground: click 'scale and crop image' button
+      await fixture.events.click(scaleAndCropImage());
+
+      // Verify element is being edited
+      expect(fixture.screen.getByTestId('edit-panel-slider')).toBeDefined();
+
+      // escape edit mode
+      await fixture.events.keyboard.press('Esc');
+
+      // right click video
+      await rightClickOnTarget(
+        fixture.editor.canvas.framesLayer.frame(earthImage.id).node
+      );
+
+      // set video as page background
+      await fixture.events.click(setAsPageBackground());
+
+      // right click video
+      await rightClickOnTarget(
+        fixture.editor.canvas.framesLayer.frame(earthImage.id).node
+      );
+
+      // background: click 'scale and crop image' button
+      await fixture.events.click(scaleAndCropBackgroundImage());
+
+      // Verify element is being edited
+      expect(fixture.screen.getByTestId('edit-panel-slider')).toBeDefined();
+    });
+
+    it('should let a user scale and crop video', async () => {
       const video = await addVideo();
 
       // right click video
@@ -384,8 +433,8 @@ describe('Right Click Menu integration', () => {
         fixture.editor.canvas.framesLayer.frame(video.id).node
       );
 
-      // foreground: click 'scale and crop image' button
-      await fixture.events.click(scaleAndCropImage());
+      // foreground: click 'scale and crop video' button
+      await fixture.events.click(scaleAndCropVideo());
 
       // Verify element is being edited
       expect(fixture.screen.getByTestId('edit-panel-slider')).toBeDefined();
@@ -406,8 +455,8 @@ describe('Right Click Menu integration', () => {
         fixture.editor.canvas.framesLayer.frame(video.id).node
       );
 
-      // background: click 'scale and crop image' button
-      await fixture.events.click(scaleAndCropBackgroundImage());
+      // background: click 'scale and crop video' button
+      await fixture.events.click(scaleAndCropBackgroundVideo());
 
       // Verify element is being edited
       expect(fixture.screen.getByTestId('edit-panel-slider')).toBeDefined();


### PR DESCRIPTION
## Context

Updated right-click menu option wording to include "video" rather than "image" for video elements and also added "Trim video" as a new option.

## User-facing changes

| | Background element | Non-background element |
|-|-|-|
| Image | ![right_bg_image](https://user-images.githubusercontent.com/637548/135158776-385f2f68-a447-4e23-aa62-0120aefcc926.png) | ![right_image](https://user-images.githubusercontent.com/637548/135158732-6a94192d-6512-4b36-9461-8148bce38e99.png) |
| Video | ![right_bg_video](https://user-images.githubusercontent.com/637548/135158794-d14e7aaf-5483-4a86-8085-1c370c408070.png) | ![right_video](https://user-images.githubusercontent.com/637548/135158807-3cb7ac10-3f51-49fb-b539-3211563403ba.png) |

## Testing Instructions

This PR can be tested by following these steps:

1. Test right-click menu of both image and video while both being background and non-background elements.
2.  Observe that menu option wording includes "image" when image, and "video" when video
3. Observe that video, in either case, has "trim video", which enters trim mode

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9184
Fixes #9185
