### PR TITLE
Page Templates: Map page type to screenshot image

### DIFF
--- a/packages/templates/src/getTemplates.js
+++ b/packages/templates/src/getTemplates.js
@@ -69,6 +69,7 @@ async function loadTemplate(title, imageBaseUrl) {
         [i]: {
           webp: `${srcPath}.webp`,
           png: `${srcPath}.png`,
+          type: data.default.pages[i].pageTemplateType,
         },
       };
     }, {}),

--- a/packages/templates/src/getTemplates.js
+++ b/packages/templates/src/getTemplates.js
@@ -64,7 +64,11 @@ async function loadTemplate(title, imageBaseUrl) {
       const srcPath = `${imageBaseUrl}images/templates/${
         data.default.slug
       }/posters/${i + 1}`;
-      return { webp: `${srcPath}.webp`, png: `${srcPath}.png` };
+      return {
+        webp: `${srcPath}.webp`,
+        png: `${srcPath}.png`,
+        type: data.default.pages[i].pageTemplateType,
+      };
     }),
   };
 

--- a/packages/templates/src/test/getTemplates.js
+++ b/packages/templates/src/test/getTemplates.js
@@ -41,6 +41,7 @@ describe('getTemplate', () => {
                 i + 1
               }.webp`
             ),
+            type: expect.any(String),
           })
         );
       });

--- a/packages/templates/src/test/getTemplates.js
+++ b/packages/templates/src/test/getTemplates.js
@@ -48,6 +48,16 @@ describe('getTemplate', () => {
     });
   });
 
+  it('should match postersByPage.type with pages.pageTemplateType', async () => {
+    const templates = await getTemplates('example.com/');
+
+    templates.forEach((template) => {
+      template.postersByPage.forEach((page, i) => {
+        expect(page.type).toStrictEqual(template.pages[i].pageTemplateType);
+      });
+    });
+  });
+
   it('should replace __WEB_STORIES_TEMPLATE_BASE_URL__/ with imageUrl for each page', async () => {
     const templates = await getTemplates('example.com/');
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
 We want to be able to filter the layout template screenshots by page type. 

## Summary
Connect to the page images with the page type so that page templates don't have to dig through story objects during filter.

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Since we are already iterating through the pages to create the src urls, I added the page type as a property to the `postersByPage` object. 
<!-- Please describe your changes. -->

## To-do
n/a<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
n/a
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9092
