### PR TITLE
Taxonomies: Fix updating the `checked` attribute

### DIFF
--- a/packages/story-editor/src/components/form/hierarchical/index.js
+++ b/packages/story-editor/src/components/form/hierarchical/index.js
@@ -117,7 +117,7 @@ const Option = (option) => {
         <Label htmlFor={optionId}>{optionLabel}</Label>
       </CheckboxContainer>
       {options?.map((child) => (
-        <StepContainer key={child.id}>
+        <StepContainer key={`${child.id}-${child.checked}`}>
           <Option onChange={onChange} {...child} />
         </StepContainer>
       ))}
@@ -212,7 +212,7 @@ const HierarchicalInput = ({
               {filteredOptions.length ? (
                 filteredOptions.map((option) => (
                   <Option
-                    key={option.id}
+                    key={`${option.id}-${option.checked}`}
                     {...option}
                     onChange={handleCheckboxChange}
                   />


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

[See pr 9150](https://github.com/google/web-stories-wp/pull/9150#discussion_r716187510) 

When the checkbox input is checked/unchecked the attribute is not updated on the DOM's input element. 
## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Force a rerender by using checked status as part of the component's `key` value. 
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
n/a

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Check / uncheck a checkbox within the taxonomy hierarchal category selections. 
2. Look at the html element in dev tools to see if the `checked` attribute is reflected correctly. 

https://user-images.githubusercontent.com/1820266/135165316-fd731b7b-d771-4f1a-bd39-3fdbbf372b00.mov



## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially Fixes #9149 
