### PR TITLE
Meta Boxes: Fix form data being sent for saving

### DIFF
--- a/packages/wp-story-editor/src/api/metaboxes.js
+++ b/packages/wp-story-editor/src/api/metaboxes.js
@@ -18,11 +18,6 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 
-/**
- * Internal dependencies
- */
-import { flattenFormData } from './utils';
-
 // See https://github.com/WordPress/gutenberg/blob/148e2b28d4cdd4465c4fe68d97fcee154a6b209a/packages/edit-post/src/store/effects.js#L72-L126
 export function saveMetaBoxes(story, formData, apiUrl) {
   // Additional data needed for backward compatibility.
@@ -34,9 +29,7 @@ export function saveMetaBoxes(story, formData, apiUrl) {
     story.author ? ['post_author', story.author.id] : false,
   ].filter(Boolean);
 
-  Object.entries(additionalData).forEach(([key, value]) =>
-    flattenFormData(formData, key, value)
-  );
+  additionalData.forEach(([key, value]) => formData.append(key, value));
 
   return apiFetch({
     url: apiUrl,

--- a/packages/wp-story-editor/src/api/test/media.js
+++ b/packages/wp-story-editor/src/api/test/media.js
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * WordPress dependencies
  */
@@ -26,7 +27,7 @@ import { GET_MEDIA_RESPONSE_HEADER, GET_MEDIA_RESPONSE_BODY } from './_utils';
 
 jest.mock('@wordpress/api-fetch');
 
-describe('API Callbacks', () => {
+describe('Media API Callbacks', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 

--- a/packages/wp-story-editor/src/api/test/metaboxes.js
+++ b/packages/wp-story-editor/src/api/test/metaboxes.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { saveMetaBoxes } from '../metaboxes';
+
+jest.mock('@wordpress/api-fetch');
+
+describe('Meta Boxes API Callbacks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    apiFetch.mockReturnValue(Promise.resolve({}));
+  });
+
+  describe('saveMetaBoxes', () => {
+    it('sends the correct form data', () => {
+      const story = {
+        author: {
+          id: 123,
+          name: 'John Doe',
+        },
+      };
+
+      const formData = new window.FormData();
+      const apiUrl = 'wp-admin/post.php?action=edit&meta-box-loader=1';
+
+      saveMetaBoxes(story, formData, apiUrl);
+
+      expect(apiFetch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: formData,
+        })
+      );
+      expect(formData.getAll('post_author')).toStrictEqual(
+        expect.arrayContaining(['123'])
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

A user reported a bug over at the Yoast SEO repo that they can't properly change authors in the story editor.

## Summary

<!-- A brief description of what this PR does. -->

Turns out we were sending the form data incorrectly. Calling `Object.entries()` on an array leads to unexpected results.

This PR fixes meta boxes saving by ensuring that the form data containing the post author is being sent correctly. See screenshots below.

## Relevant Technical Choices

<!-- Please describe your changes. -->

- Adds tests

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Incorrect form data before:


![Screenshot 2021-09-29 at 15 57 43](https://user-images.githubusercontent.com/841956/135284472-40f2e0b3-2286-41cd-874b-6e6644400f43.png)

Correct form data after:

![Screenshot 2021-09-29 at 15 56 42](https://user-images.githubusercontent.com/841956/135284419-f262ea0c-3ae4-4338-8fa8-be936b0aa198.png)


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Activate Yoast SEO
2. Create a new story
3. Change the post author in the document panel
4. Save the story and reload the page
5. Verify that the post author is still updated in the document panel


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes https://github.com/Yoast/wordpress-seo/issues/17386
