### PR TITLE
Video Trimming: Keep video unmuted

### DIFF
--- a/packages/story-editor/src/elements/video/trim.js
+++ b/packages/story-editor/src/elements/video/trim.js
@@ -98,13 +98,13 @@ function VideoTrim({ box, element }) {
           showPlaceholder
           previewMode={false}
         >
+          {/* eslint-disable-next-line styled-components-a11y/media-has-caption,jsx-a11y/media-has-caption -- False positive. */}
           <Video
             poster={poster || resource.poster}
             style={style}
             {...videoProps}
             preload="metadata"
-            muted
-            autoPlay
+            autoplay
             tabIndex={0}
             ref={setRef}
           >

--- a/packages/story-editor/src/elements/video/trim.js
+++ b/packages/story-editor/src/elements/video/trim.js
@@ -104,7 +104,7 @@ function VideoTrim({ box, element }) {
             style={style}
             {...videoProps}
             preload="metadata"
-            autoplay
+            autoPlay
             tabIndex={0}
             ref={setRef}
           >


### PR DESCRIPTION
## Context

This unmutes the video while trimming.

## User-facing changes

_Video isn't muted._

## Testing Instructions

This PR can be tested by following these steps:

1. Add a video with sound to a page
2. Enter trim mode and observe the video looping with sound automatically
3. Observe that a video with audio stripped of course doesn't play any audio while trimming either

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9182
