### PR TITLE
Taxonomies: Check `rest-base` and `slug` for permissions

### DIFF
--- a/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
@@ -42,9 +42,10 @@ function TaxonomiesPanel(props) {
 
   const availableTaxonomies = taxonomies.filter((taxonomy) => {
     const isVisible = taxonomy?.visibility?.show_ui;
-    const canAssignTerms =
-      Boolean(capabilities[`assign-${taxonomy?.slug}`]) ||
-      Boolean(capabilities[`assign-${taxonomy?.restBase}`]);
+    const canAssignTerms = Boolean(
+      capabilities[`assign-${taxonomy?.restBase}`] ||
+        capabilities[`assign-${taxonomy?.slug}`]
+    );
 
     return isVisible && canAssignTerms;
   });
@@ -60,9 +61,11 @@ function TaxonomiesPanel(props) {
       {...props}
     >
       {availableTaxonomies.map((taxonomy) => {
-        const canCreateTerms =
-          Boolean(capabilities[`create-${taxonomy.slug}`]) ||
-          Boolean(capabilities[`create-${taxonomy?.restBase}`]);
+        const canCreateTerms = Boolean(
+          capabilities[`create-${taxonomy?.restBase}`] ||
+            capabilities[`create-${taxonomy.slug}`]
+        );
+
         return taxonomy.hierarchical ? (
           <HierarchicalTermSelector
             taxonomy={taxonomy}

--- a/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
@@ -42,7 +42,9 @@ function TaxonomiesPanel(props) {
 
   const availableTaxonomies = taxonomies.filter((taxonomy) => {
     const isVisible = taxonomy?.visibility?.show_ui;
-    const canAssignTerms = Boolean(capabilities[`assign-${taxonomy?.slug}`]);
+    const canAssignTerms = Boolean(
+      capabilities[`assign-${taxonomy?.restBase || taxonomy?.slug}`]
+    );
 
     return isVisible && canAssignTerms;
   });
@@ -58,7 +60,9 @@ function TaxonomiesPanel(props) {
       {...props}
     >
       {availableTaxonomies.map((taxonomy) => {
-        const canCreateTerms = Boolean(capabilities[`create-${taxonomy.slug}`]);
+        const canCreateTerms = Boolean(
+          capabilities[`create-${taxonomy?.restBase || taxonomy.slug}`]
+        );
         return taxonomy.hierarchical ? (
           <HierarchicalTermSelector
             taxonomy={taxonomy}

--- a/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
@@ -42,9 +42,9 @@ function TaxonomiesPanel(props) {
 
   const availableTaxonomies = taxonomies.filter((taxonomy) => {
     const isVisible = taxonomy?.visibility?.show_ui;
-    const canAssignTerms = Boolean(
-      capabilities[`assign-${taxonomy?.restBase || taxonomy?.slug}`]
-    );
+    const canAssignTerms =
+      Boolean(capabilities[`assign-${taxonomy?.slug}`]) ||
+      Boolean(capabilities[`assign-${taxonomy?.restBase}`]);
 
     return isVisible && canAssignTerms;
   });
@@ -60,9 +60,9 @@ function TaxonomiesPanel(props) {
       {...props}
     >
       {availableTaxonomies.map((taxonomy) => {
-        const canCreateTerms = Boolean(
-          capabilities[`create-${taxonomy?.restBase || taxonomy.slug}`]
-        );
+        const canCreateTerms =
+          Boolean(capabilities[`create-${taxonomy.slug}`]) ||
+          Boolean(capabilities[`create-${taxonomy?.restBase}`]);
         return taxonomy.hierarchical ? (
           <HierarchicalTermSelector
             taxonomy={taxonomy}

--- a/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
@@ -63,7 +63,7 @@ function TaxonomiesPanel(props) {
       {availableTaxonomies.map((taxonomy) => {
         const canCreateTerms = Boolean(
           capabilities[`create-${taxonomy?.restBase}`] ||
-            capabilities[`create-${taxonomy.slug}`]
+            capabilities[`create-${taxonomy?.slug}`]
         );
 
         return taxonomy.hierarchical ? (


### PR DESCRIPTION
## Context

Custom taxonomy support

## Summary

Check the `rest-base` as well as the `slug` on a taxonomy when checking if a user has the correct permission for that taxonomy.

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

none

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8849
