### PR TITLE
Taxonomies: Undo term submission for free form input

### DIFF
--- a/packages/story-editor/src/components/form/hierarchical/index.js
+++ b/packages/story-editor/src/components/form/hierarchical/index.js
@@ -116,7 +116,7 @@ const Option = (option) => {
         <Label htmlFor={optionId}>{label}</Label>
       </CheckboxContainer>
       {options?.map((child) => (
-        <StepContainer key={`${child.id}-${child.checked}`}>
+        <StepContainer key={child.id}>
           <Option onChange={onChange} {...child} />
         </StepContainer>
       ))}
@@ -211,7 +211,7 @@ const HierarchicalInput = ({
               {filteredOptions.length ? (
                 filteredOptions.map((option) => (
                   <Option
-                    key={`${option.id}-${option.checked}`}
+                    key={option.id}
                     {...option}
                     onChange={handleCheckboxChange}
                   />

--- a/packages/story-editor/src/components/form/tags/test/input.js
+++ b/packages/story-editor/src/components/form/tags/test/input.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '@web-stories-wp/design-system/src/testUtils';
+
+/**
+ * Internal dependencies
+ */
+import { noop } from '../../../../utils/noop';
+import Input from '../input';
+
+describe('Input', () => {
+  it('should call `onUndo` when meta+z is pressed', () => {
+    const mockUndo = jest.fn();
+
+    renderWithProviders(
+      <Input
+        onTagsChange={noop}
+        onInputChange={noop}
+        tagDisplayTransformer={noop}
+        onUndo={mockUndo}
+      />
+    );
+
+    const input = screen.getByRole('textbox');
+
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'z', metaKey: true });
+
+    expect(mockUndo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
@@ -29,6 +29,7 @@ import PropTypes from 'prop-types';
 import Tags, { deepEquals } from '../../../form/tags';
 import cleanForSlug from '../../../../utils/cleanForSlug';
 import { useTaxonomy } from '../../../../app/taxonomy';
+import { useHistory } from '../../../../app';
 import { ContentHeading, TaxonomyPropType } from './shared';
 
 function FlatTermSelector({ taxonomy, canCreateTerms }) {
@@ -50,6 +51,8 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
       setTerms,
     })
   );
+
+  const { undo } = useHistory(({ actions: { undo } }) => ({ undo }));
 
   const handleFreeformTermsChange = useCallback(
     (termNames) => {
@@ -125,6 +128,7 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
           onInputChange={handleFreeformInputChange}
           tagDisplayTransformer={termDisplayTransformer}
           tokens={tokens}
+          onUndo={undo}
         />
         <Tags.Description id={`${taxonomy.slug}-description`}>
           {taxonomy.labels.separate_items_with_commas}

--- a/packages/story-editor/src/components/panels/document/taxonomies/test/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/test/taxonomies.js
@@ -92,7 +92,7 @@ describe('TaxonomiesPanel', () => {
           slug: 'web_story_category',
           restBase: 'web_story_category',
           name: 'Categories',
-          labels: {},
+          labels: { not_found: '' },
           hierarchical: false,
         },
       ],
@@ -124,6 +124,7 @@ describe('TaxonomiesPanel', () => {
           labels: {
             search_items: 'Story Categories',
             add_new_item: 'Add New',
+            not_found: '',
           },
           hierarchical: true,
           visibility: {


### PR DESCRIPTION
## Context

Taxonomies

## Summary

Pressing `cmd/ctrl + z` while focused on the freeform input will trigger the `undo` function from history.

## Relevant Technical Choices

After some investigation I saw that _all_ inputs in the editor eat up the `undo` event, not just this input. **If an input is focused and a user presses `cmd/ctrl + z` then the `undo` function in history won't be triggered. The global event listener never receives the event**

Most inputs it makes sense that `cmd/ctrl + z` would only undo/redo the characters pressed, but for the freeform input it would be expected that `cmd/ctrl + z` would undo the submission of a tag (or other taxonomy).

Passing in `undo` from the history provider fixes this issue.

## To-do

none

## User-facing changes

<img src="https://user-images.githubusercontent.com/22185279/135517307-33c7396a-7539-4254-a4cb-c831fce74abb.gif" height="400px" />

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a tag in the freeform input
2. Press `cmd/ctrl + z` to undo the submission
3. Should see the tag un-submitted
4. Pressing `cmd/ctrl + shift + z` won't re-submit it, but will re-type the characters that were in the input


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9148
