### PR TITLE
Dashboard: Add `pending` stories to dashboard

### DIFF
--- a/includes/REST_API/Stories_Controller.php
+++ b/includes/REST_API/Stories_Controller.php
@@ -405,8 +405,9 @@ class Stories_Controller extends Stories_Base_Controller {
 		];
 
 		if ( $this->get_post_type_cap( $this->post_type, 'edit_posts' ) ) {
-			$statuses['draft']  = 'draft';
-			$statuses['future'] = 'future';
+			$statuses['draft']   = 'draft';
+			$statuses['future']  = 'future';
+			$statuses['pending'] = 'pending';
 		}
 
 		if ( $this->get_post_type_cap( $this->post_type, 'publish_posts' ) ) {
@@ -431,7 +432,7 @@ class Stories_Controller extends Stories_Base_Controller {
 		foreach ( $statuses as $key => $status ) {
 			$posts_query               = new WP_Query();
 			$query_args['post_status'] = $status;
-			if ( in_array( $status, [ 'draft', 'future' ], true ) && ! $edit_others_posts ) {
+			if ( in_array( $status, [ 'draft', 'future', 'pending' ], true ) && ! $edit_others_posts ) {
 				$query_args['author'] = get_current_user_id();
 			}
 			if ( 'private' === $status && ! $edit_private_posts ) {

--- a/packages/dashboard/src/app/views/myStories/content/storyGridItem/storyDisplayContent.js
+++ b/packages/dashboard/src/app/views/myStories/content/storyGridItem/storyDisplayContent.js
@@ -132,6 +132,9 @@ const StoryDisplayContent = ({
           {status === STORY_STATUS.DRAFT && (
             <DetailCopy isBold>{__('Draft', 'web-stories')}</DetailCopy>
           )}
+          {status === STORY_STATUS.PENDING && (
+            <DetailCopy isBold>{__('Pending', 'web-stories')}</DetailCopy>
+          )}
           {author && <DetailCopy>{author}</DetailCopy>}
           <DetailCopy className="dashboard-grid-item-date">
             {displayDateText}

--- a/packages/dashboard/src/app/views/myStories/content/storyListItem/index.js
+++ b/packages/dashboard/src/app/views/myStories/content/storyListItem/index.js
@@ -39,7 +39,7 @@ import {
   TableStatusCell,
 } from '../../../../../components';
 import { generateStoryMenu } from '../../../../../components/popoverMenu/story-menu-generator';
-import { STORY_STATUS } from '../../../../../constants';
+import { DISPLAY_STATUS, STORY_STATUS } from '../../../../../constants';
 import {
   RenameStoryPropType,
   StoryMenuPropType,
@@ -62,13 +62,6 @@ function onFocusSelectAll(e) {
 function onBlurDeselectAll() {
   window.getSelection().removeAllRanges();
 }
-
-const DISPLAY_STATUS = {
-  [STORY_STATUS.PUBLISH]: __('Published', 'web-stories'),
-  [STORY_STATUS.FUTURE]: __('Scheduled', 'web-stories'),
-  [STORY_STATUS.DRAFT]: __('Draft', 'web-stories'),
-  [STORY_STATUS.PRIVATE]: __('Private', 'web-stories'),
-};
 
 export const StoryListItem = ({
   story,

--- a/packages/dashboard/src/app/views/myStories/karma/myStories.karma.js
+++ b/packages/dashboard/src/app/views/myStories/karma/myStories.karma.js
@@ -291,7 +291,7 @@ describe('Grid view', () => {
       expect(numPublished).toBeGreaterThan(0);
 
       const publishedTabButton = fixture.screen.getByRole('button', {
-        name: new RegExp('^Filter stories by ' + STORY_STATUSES[2].label),
+        name: new RegExp('^Filter stories by ' + STORY_STATUSES[3].label),
       });
 
       expect(publishedTabButton).toBeTruthy();

--- a/packages/dashboard/src/constants/stories.js
+++ b/packages/dashboard/src/constants/stories.js
@@ -111,6 +111,14 @@ export const STORY_STATUS = {
   PRIVATE: 'private',
 };
 
+export const DISPLAY_STATUS = {
+  [STORY_STATUS.PUBLISH]: __('Published', 'web-stories'),
+  [STORY_STATUS.PENDING]: __('Pending', 'web-stories'),
+  [STORY_STATUS.FUTURE]: __('Scheduled', 'web-stories'),
+  [STORY_STATUS.DRAFT]: __('Draft', 'web-stories'),
+  [STORY_STATUS.PRIVATE]: __('Private', 'web-stories'),
+};
+
 export const STORY_STATUSES = [
   {
     label: __('All Stories', 'web-stories'),

--- a/packages/dashboard/src/constants/stories.js
+++ b/packages/dashboard/src/constants/stories.js
@@ -102,10 +102,11 @@ export const STORY_SORT_MENU_ITEMS = [
 ];
 
 export const STORY_STATUS = {
-  ALL: 'publish,draft,future,private',
+  ALL: 'publish,draft,future,pending,private',
   PUBLISHED_AND_FUTURE: 'publish,future',
   DRAFT: 'draft',
   FUTURE: 'future',
+  PENDING: 'pending',
   PUBLISH: 'publish',
   PRIVATE: 'private',
 };
@@ -120,6 +121,11 @@ export const STORY_STATUSES = [
     label: __('Drafts', 'web-stories'),
     value: STORY_STATUS.DRAFT,
     status: STORY_STATUS.DRAFT,
+  },
+  {
+    label: __('Pending', 'web-stories'),
+    value: STORY_STATUS.PENDING,
+    status: STORY_STATUS.PENDING,
   },
   {
     label: __('Published', 'web-stories'),
@@ -178,6 +184,17 @@ export const STORY_VIEWING_LABELS = {
       _n(
         'Viewing <strong>%d</strong> scheduled story',
         'Viewing <strong>%d</strong> scheduled stories',
+        n,
+        'web-stories'
+      ),
+      n
+    ),
+  [STORY_STATUS.PENDING]: (n) =>
+    sprintf(
+      /* translators: %d: number of stories */
+      _n(
+        'Viewing <strong>%d</strong> pending story',
+        'Viewing <strong>%d</strong> pending stories',
         n,
         'web-stories'
       ),

--- a/packages/dashboard/src/constants/stories.js
+++ b/packages/dashboard/src/constants/stories.js
@@ -101,14 +101,21 @@ export const STORY_SORT_MENU_ITEMS = [
   },
 ];
 
-export const STORY_STATUS = {
-  ALL: 'publish,draft,future,pending,private',
-  PUBLISHED_AND_FUTURE: 'publish,future',
+/**
+ * All possible story statuses.
+ */
+const BASE_STATUSES = {
   DRAFT: 'draft',
   FUTURE: 'future',
   PENDING: 'pending',
   PUBLISH: 'publish',
   PRIVATE: 'private',
+};
+
+export const STORY_STATUS = {
+  ALL: Object.values(BASE_STATUSES).join(','),
+  PUBLISHED_AND_FUTURE: [BASE_STATUSES.PUBLISH, BASE_STATUSES.FUTURE].join(','),
+  ...BASE_STATUSES,
 };
 
 export const DISPLAY_STATUS = {

--- a/tests/phpunit/integration/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Controller.php
@@ -107,6 +107,15 @@ class Stories_Controller extends Test_REST_TestCase {
 		$factory->post->create_many(
 			2,
 			[
+				'post_status' => 'pending',
+				'post_author' => self::$user3_id,
+				'post_type'   => $post_type,
+			]
+		);
+
+		$factory->post->create_many(
+			2,
+			[
 				'post_status' => 'publish',
 				'post_author' => self::$user3_id,
 				'post_type'   => $post_type,
@@ -161,12 +170,14 @@ class Stories_Controller extends Test_REST_TestCase {
 
 		$this->assertArrayHasKey( 'all', $statuses );
 		$this->assertArrayHasKey( 'publish', $statuses );
+		$this->assertArrayHasKey( 'pending', $statuses );
 		$this->assertArrayHasKey( 'draft', $statuses );
 		$this->assertArrayHasKey( 'future', $statuses );
 		$this->assertArrayHasKey( 'private', $statuses );
 
 		$this->assertSame( 13, $statuses['all'] );
 		$this->assertSame( 7, $statuses['publish'] );
+		$this->assertSame( 2, $statuses['pending'] );
 		$this->assertSame( 3, $statuses['future'] );
 		$this->assertSame( 3, $statuses['draft'] );
 		$this->assertSame( 0, $statuses['private'] );
@@ -207,6 +218,7 @@ class Stories_Controller extends Test_REST_TestCase {
 
 		$this->assertArrayHasKey( 'all', $statuses );
 		$this->assertArrayHasKey( 'publish', $statuses );
+		$this->assertArrayHasKey( 'pending', $statuses );
 		$this->assertArrayHasKey( 'draft', $statuses );
 		$this->assertArrayHasKey( 'future', $statuses );
 		$this->assertArrayNotHasKey( 'private', $statuses );
@@ -246,6 +258,7 @@ class Stories_Controller extends Test_REST_TestCase {
 
 		$this->assertSame( 10, $statuses['all'] );
 		$this->assertSame( 7, $statuses['publish'] );
+		$this->assertSame( 0, $statuses['pending'] );
 		$this->assertSame( 0, $statuses['future'] );
 		$this->assertSame( 0, $statuses['private'] );
 		$this->assertSame( 3, $statuses['draft'] );

--- a/tests/phpunit/integration/tests/REST_API/Stories_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Controller.php
@@ -175,7 +175,7 @@ class Stories_Controller extends Test_REST_TestCase {
 		$this->assertArrayHasKey( 'future', $statuses );
 		$this->assertArrayHasKey( 'private', $statuses );
 
-		$this->assertSame( 13, $statuses['all'] );
+		$this->assertSame( 15, $statuses['all'] );
 		$this->assertSame( 7, $statuses['publish'] );
 		$this->assertSame( 2, $statuses['pending'] );
 		$this->assertSame( 3, $statuses['future'] );


### PR DESCRIPTION
## Context

Mentioned first here: https://github.com/google/web-stories-wp/pull/8976#issuecomment-919935807

## Summary

Add pending stories to dashboard. Let me know if there's anything amiss with the php! Tried to update the tests as well.

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

|Grid View|List View|
|--|--|
|<img width="879" alt="Screen Shot 2021-10-01 at 12 31 37 PM" src="https://user-images.githubusercontent.com/22185279/135656028-0baab516-8500-4f9d-8b7d-54ed828b9f9e.png">|<img width="890" alt="Screen Shot 2021-10-01 at 12 31 26 PM" src="https://user-images.githubusercontent.com/22185279/135656015-792ad279-562e-4b42-abd6-4106d97bdc72.png">|

## Testing Instructions

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Update a story to the `pending` state
    - First go to `All Stories` from the sidebar in the web stories plugin
    - Click on `Quick Edit` for the story you wish you update
    - Change the status in the `Status` dropdown to `Pending Review`
    - Click `Update`
2. Go back to the dashboard
3. Should see a story displayed as `pending`. The `Pending` pill will be visible. Clicking this pill will show you only stories with the `pending` status
4. Go to the list view. Should see the story listed as `pending`


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9044
