### PR TITLE
Dashboard: Prevent publisher logos state from doubling

### DIFF
--- a/packages/dashboard/src/app/reducer/publisherLogos.js
+++ b/packages/dashboard/src/app/reducer/publisherLogos.js
@@ -60,10 +60,7 @@ function publisherLogoReducer(state, action) {
         ...state,
         error: {},
         isLoading: false,
-        publisherLogos: [
-          ...state.publisherLogos,
-          ...action.payload.publisherLogos,
-        ],
+        publisherLogos: [...action.payload.publisherLogos],
       };
     }
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Successful fetching of publisher logos is just adding to the existing state instead of replacing it, causing the items there to doubling.

Props to @sayedtaqui for finding this.

## Summary

<!-- A brief description of what this PR does. -->

This PR prevents publisher logos state from doubling when going to the Settings screen multiple times.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Fixes this issue:

1. Go to Settings
2. See your publisher logo(s)
3. Go to dashboard
4. Go back to Settings
5. See publisher logo(s) being doubled


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to Settings
2. See your publisher logo(s)
3. Go to dashboard
4. Go to Settings
5. See the same number of publisher logo(s)

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
