### PR TITLE
E2E Tests: Add test for pre-publish checklist for contributors

### DIFF
--- a/packages/e2e-tests/src/specs/editor/prepublishChecklist.js
+++ b/packages/e2e-tests/src/specs/editor/prepublishChecklist.js
@@ -73,7 +73,7 @@ describe('Pre-Publish Checklist', () => {
       });
 
       // verify that publish button is disabled
-      await page.$('button:disabled', { text: 'Publish' });
+      await expect(page).toMatchElement('button:disabled', { text: 'Publish' });
     });
   });
 });

--- a/packages/e2e-tests/src/specs/editor/prepublishChecklist.js
+++ b/packages/e2e-tests/src/specs/editor/prepublishChecklist.js
@@ -19,8 +19,10 @@
  */
 import {
   createNewStory,
+  insertStoryTitle,
   publishStory,
   triggerHighPriorityChecklistSection,
+  withUser,
 } from '@web-stories-wp/e2e-test-utils';
 import percySnapshot from '@percy/puppeteer';
 
@@ -50,5 +52,30 @@ describe('Pre-Publish Checklist', () => {
     );
     await expect(page).toMatch('Add poster image');
     await percySnapshot(page, 'Prepublish checklist');
+  });
+
+  describe('Contributor User', () => {
+    withUser('contributor', 'password');
+
+    it('should not let me publish a story as a contributor', async () => {
+      await createNewStory();
+
+      await insertStoryTitle('Publishing Flow: Contributor');
+
+      const checklistToggle = await page.$(
+        'button[aria-owns="checklist_companion"]',
+        { text: 'Checklist' }
+      );
+
+      // verify no issues are present
+      await checklistToggle.click();
+
+      await expect(page).toMatchElement('p', {
+        text: 'You are all set for now. Return to this checklist as you build your Web Story for tips on how to improve it.',
+      });
+
+      // verify that publish button is disabled
+      await page.$('button:disabled', { text: 'Publish' });
+    });
   });
 });

--- a/packages/e2e-tests/src/specs/editor/prepublishChecklist.js
+++ b/packages/e2e-tests/src/specs/editor/prepublishChecklist.js
@@ -62,14 +62,12 @@ describe('Pre-Publish Checklist', () => {
 
       await insertStoryTitle('Publishing Flow: Contributor');
 
-      const checklistToggle = await page.$(
-        'button[aria-owns="checklist_companion"]',
-        { text: 'Checklist' }
+      await expect(page).toClick('button[aria-label="Checklist"]');
+      await expect(page).toMatchElement(
+        '#pre-publish-checklist[data-isexpanded="true"]'
       );
 
       // verify no issues are present
-      await checklistToggle.click();
-
       await expect(page).toMatchElement('p', {
         text: 'You are all set for now. Return to this checklist as you build your Web Story for tips on how to improve it.',
       });

--- a/packages/e2e-tests/src/specs/editor/publishingFlow.js
+++ b/packages/e2e-tests/src/specs/editor/publishingFlow.js
@@ -25,54 +25,7 @@ import {
   withPlugin,
   publishStory,
   getEditedPostContent,
-  withUser,
 } from '@web-stories-wp/e2e-test-utils';
-
-describe('Contributor User', () => {
-  let stopRequestInterception;
-
-  beforeAll(async () => {
-    await page.setRequestInterception(true);
-    stopRequestInterception = addRequestInterception((request) => {
-      if (request.url().startsWith('https://cdn.ampproject.org/')) {
-        request.respond({
-          status: 200,
-          body: '',
-        });
-      } else {
-        request.continue();
-      }
-    });
-  });
-
-  afterAll(async () => {
-    await page.setRequestInterception(false);
-    stopRequestInterception();
-  });
-
-  // TODO: #6238 add this test into `Publishing Flow` describe block
-  withUser('contributor', 'password');
-  it('should not let me publish a story as a contributor', async () => {
-    await createNewStory();
-
-    await insertStoryTitle('Publishing Flow: Contributor');
-
-    const checklistToggle = await page.$(
-      'button[aria-owns="checklist_companion"]',
-      { text: 'Checklist' }
-    );
-
-    // verify no issues are present
-    await checklistToggle.click();
-
-    await expect(page).toMatchElement('p', {
-      text: 'You are all set for now. Return to this checklist as you build your Web Story for tips on how to improve it.',
-    });
-
-    // verify that publish button is disabled
-    await page.$('button:disabled', { text: 'Publish' });
-  });
-});
 
 // Disable for https://github.com/google/web-stories-wp/issues/6238
 // eslint-disable-next-line jest/no-disabled-tests

--- a/packages/story-editor/src/components/checklist/karma/checklist.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/checklist.karma.js
@@ -235,7 +235,7 @@ describe('Checklist integration', () => {
     });
   });
 
-  describe('checkpoints', () => {
+  describe('Checkpoints', () => {
     it('empty story should begin in the empty state', async () => {
       await openChecklist();
 


### PR DESCRIPTION
## Context

Found a little while back where contributors were seeing the wrong UI: #9232. Couldn't reproduce, so we added a quick e2e test to make sure there is no regression.

## Summary

Adds a quick publishing flow test for a user with the `Contributor` role. 

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

n/a

## Testing Instructions


<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

Tests should pass


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9232
