### PR TITLE
Add changelog for 1.12.0 release

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -341,7 +341,7 @@ class Experiments extends Service_Base {
 				'label'       => __( 'Taxonomies', 'web-stories' ),
 				'description' => __( 'Enable support of tags and categories for stories', 'web-stories' ),
 				'group'       => 'editor',
-				'default'     => true,
+				'default'     => false,
 			],
 
 			/**

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,15 @@ Web Stories are powered by [AMP](https://amp.dev/), which adds some restrictions
 
 For the plugin's full changelog, please see [the Releases page on GitHub](https://github.com/google/web-stories-wp/releases).
 
+= 1.12.0 =
+
+**Release Date:** October 5, 2021.
+
+* New feature: ability to trim videos to make them shorter.
+* New feature: [improved analytics configuration](https://wp.stories.google/docs/seo/#Adding-Analytics) with opt-in on the settings page.
+* Template colors are now available in "Saved Colors" when creating a story from a template.
+* Bug fixes and performance improvements.
+
 = 1.11.0 =
 
 **Release Date:** September 7, 2021.
@@ -127,18 +136,11 @@ For the plugin's full changelog, please see [the Releases page on GitHub](https:
 * Fixes an issue with page attachments being removed on the frontend.
 * Fixes an issue with memory not being freed up after optimizing videos.
 
-= 1.10.0 =
-
-**Release Date:** August 10, 2021.
-
-* New feature: 29 new templates for creators to choose from.
-* New feature: color eyedropper.
-* New feature: extended list of stickers.
-* New feature: ability to serve videos from the Google cache.
-* New feature: remove audio tracks to mute videos.
-* Bug fixes and performance improvements.
-
 == Upgrade Notice ==
+
+= 1.12.0 =
+
+Video trimming, improved analytics configuration, templates improvements, and various bug fixes.
 
 = 1.11.0 =
 
@@ -147,7 +149,3 @@ New templates, right-click menu, improved color picker, and background audio sup
 = 1.10.1 =
 
 Several bug fixes to address potential fatal errors and missing page attachments, as well as high memory consumption.
-
-= 1.10.0 =
-
-New templates, eyedropper, stickers, ability to mute videos, bug fixes and performance improvements.

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,7 @@ For the plugin's full changelog, please see [the Releases page on GitHub](https:
 * New feature: ability to trim videos to make them shorter.
 * New feature: [improved analytics configuration](https://wp.stories.google/docs/seo/#Adding-Analytics) with opt-in on the settings page.
 * Template colors are now available in "Saved Colors" when creating a story from a template.
+* Improved management of publisher logos in the editor.
 * Bug fixes and performance improvements.
 
 = 1.11.0 =
@@ -140,7 +141,7 @@ For the plugin's full changelog, please see [the Releases page on GitHub](https:
 
 = 1.12.0 =
 
-Video trimming, improved analytics configuration, templates improvements, and various bug fixes.
+Video trimming, improved analytics configuration, publisher logos management, saved template colors, and various bug fixes.
 
 = 1.11.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -113,10 +113,10 @@ For the plugin's full changelog, please see [the Releases page on GitHub](https:
 
 **Release Date:** October 5, 2021.
 
-* New feature: ability to trim videos to make them shorter.
-* New feature: [improved analytics configuration](https://wp.stories.google/docs/seo/#Adding-Analytics) with opt-in on the settings page.
+* New feature: video trimming tool in the editor.
+* New feature: [improved analytics configuration](https://wp.stories.google/docs/seo/#Adding-Analytics) via opt-in on the settings page.
 * Template colors are now available in "Saved Colors" when creating a story from a template.
-* Improved management of publisher logos in the editor.
+* Easier selection of publisher logos in the editor.
 * Bug fixes and performance improvements.
 
 = 1.11.0 =


### PR DESCRIPTION
This updates the changelog for the imminent 1.12.0 release as per the roadmap.

**Important:** taxonomy support is planned for the next release, 1.13.0, not this one, as it's not 100% ready yet. Hence making sure it's not accidentally turned on for this release.

**Also**, video trimming is not yet ready as of time of writing. #9251 needs to be merged first!

Good news is that this _does include_ the new `amp-story-auto-analytics` change **and** the publisher logo change.

See #9261