### PR TITLE
Taxonomies: Add error logging and fix proptype warning

### DIFF
--- a/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
+++ b/packages/story-editor/src/app/taxonomy/taxonomyProvider.js
@@ -71,7 +71,9 @@ function TaxonomyProvider(props) {
         const result = await getTaxonomies();
         setTaxonomies(result);
       } catch (e) {
-        // Do we wanna do anything here?
+        // Log error
+        // eslint-disable-next-line no-console
+        console.error(e.message);
       }
     })();
   }, [hasTaxonomies, getTaxonomies]);
@@ -154,7 +156,9 @@ function TaxonomyProvider(props) {
       try {
         response = await getTaxonomyTerm(termsEndpoint, args);
       } catch (e) {
-        // TODO #9033
+        // Log error
+        // eslint-disable-next-line no-console
+        console.error(e.message);
       }
 
       // Avoid update if we're not actually adding any terms here

--- a/packages/story-editor/src/components/form/hierarchical/test/hierarchical.js
+++ b/packages/story-editor/src/components/form/hierarchical/test/hierarchical.js
@@ -48,6 +48,7 @@ describe('Hierarchical', () => {
         label="Categories"
         options={OPTIONS_WITH_NO_CHILDREN}
         onChange={noop}
+        noOptionsText="no options found"
       />
     );
     const input = screen.getByRole('searchbox');
@@ -68,7 +69,12 @@ describe('Hierarchical', () => {
 
   it('typing in the list should filter nested options', () => {
     renderWithProviders(
-      <Hierarchical label="Categories" options={OPTIONS} onChange={noop} />
+      <Hierarchical
+        label="Categories"
+        options={OPTIONS}
+        onChange={noop}
+        noOptionsText="no options found"
+      />
     );
     const input = screen.getByRole('searchbox');
 
@@ -91,7 +97,12 @@ describe('Hierarchical', () => {
     const onChange = jest.fn();
 
     renderWithProviders(
-      <Hierarchical label="Categories" options={OPTIONS} onChange={onChange} />
+      <Hierarchical
+        label="Categories"
+        options={OPTIONS}
+        onChange={onChange}
+        noOptionsText="no options found"
+      />
     );
 
     const initialCheckboxLength = screen.getAllByRole('checkbox').length;
@@ -138,7 +149,12 @@ describe('Hierarchical', () => {
     const onChange = jest.fn();
 
     renderWithProviders(
-      <Hierarchical label="Categories" options={OPTIONS} onChange={onChange} />
+      <Hierarchical
+        label="Categories"
+        options={OPTIONS}
+        onChange={onChange}
+        noOptionsText="no options found"
+      />
     );
 
     const input = screen.getByRole('searchbox');


### PR DESCRIPTION
## Context

Taxonomies updates

## Summary

1. Adds logging for errors
2. Adds `noOptionsText` to the unit tests.

## Relevant Technical Choices

1. Seems like [Gutenberg swallows errors](https://github.com/WordPress/gutenberg/blob/b78b615b59ded086d947140dcfb65806f610001c/packages/data/src/components/use-select/index.js#L144-L156) if any were to appear. We're going to mimic guttenberg on their handling of errors
2. https://github.com/google/web-stories-wp/pull/9150/files#diff-b1fd2344bc32c375bab1a60b2db2472b13827cedd48652a95249a0b8ee022129L138-R237 removed a default prop and made the prop type required. This fixes the unit tests that were missing the prop.

## To-do

n/a

## User-facing changes

n/a

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9273
Fixes #9033