### PR TITLE
`ServiceBasedPlugin`: Don't resolve service IDs as callables

### DIFF
--- a/includes/Infrastructure/ServiceBasedPlugin.php
+++ b/includes/Infrastructure/ServiceBasedPlugin.php
@@ -275,7 +275,7 @@ abstract class ServiceBasedPlugin implements Plugin {
 		}
 
 		while ( null !== key( $services ) ) {
-			$id    = $this->maybe_resolve( key( $services ) );
+			$id    = key( $services );
 			$class = $this->maybe_resolve( current( $services ) );
 
 			// Delay registering the service until all requirements are met.

--- a/includes/Infrastructure/ServiceBasedPlugin.php
+++ b/includes/Infrastructure/ServiceBasedPlugin.php
@@ -275,7 +275,7 @@ abstract class ServiceBasedPlugin implements Plugin {
 		}
 
 		while ( null !== key( $services ) ) {
-			$id    = key( $services );
+			$id    = $this->maybe_resolve( key( $services ) );
 			$class = $this->maybe_resolve( current( $services ) );
 
 			// Delay registering the service until all requirements are met.
@@ -775,7 +775,7 @@ abstract class ServiceBasedPlugin implements Plugin {
 	 * @return mixed Resolved or unchanged value.
 	 */
 	protected function maybe_resolve( $value ) {
-		if ( is_callable( $value ) ) {
+		if ( is_callable( $value ) && ! ( is_string( $value ) && function_exists( $value ) ) ) {
 			$value = $value( $this->injector, $this->service_container );
 		}
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

If the service ID is the same as a public function in the global namespace, `ServiceBasedPlugin` tried to call it.

## Summary

<!-- A brief description of what this PR does. -->

Don't resolve service IDs as callables.

## Relevant Technical Choices

<!-- Please describe your changes. -->

--

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

--

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

None

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Activate Web Stories plugin
2. Activate [Call Now Button](https://wordpress.org/plugins/call-now-button/) plugin
3. Don't see error


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->
No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9292