### PR TITLE
Design Panel: Avoid adding duplicate presets

### DIFF
--- a/packages/story-editor/src/components/library/panes/text/fontPreview.js
+++ b/packages/story-editor/src/components/library/panes/text/fontPreview.js
@@ -25,7 +25,7 @@ import {
   useCallback,
   useRef,
 } from '@web-stories-wp/react';
-import { Text } from '@web-stories-wp/design-system';
+import { Text, useKeyDownEffect } from '@web-stories-wp/design-system';
 import { trackEvent } from '@web-stories-wp/tracking';
 import { useUnits } from '@web-stories-wp/units';
 
@@ -182,11 +182,17 @@ function FontPreview({ title, element, insertPreset, getPosition }) {
     );
   };
 
+  useKeyDownEffect(
+    buttonRef,
+    {
+      key: ['enter', 'space'],
+    },
+    onClick,
+    [onClick]
+  );
+
   return (
-    <Preview
-      ref={buttonRef}
-      onClick={(e) => e.target === buttonRef.current && onClick()}
-    >
+    <Preview ref={buttonRef}>
       {getTextDisplay()}
       <LibraryMoveable
         cloneElement={DragContainer}


### PR DESCRIPTION
## Context
Adds separate keyboard handler to avoid adding a preset twice when clicking on it,
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open the Text library panel
2. Click on Label and Caption
3. Verify both presets were added only once.
4. Verify it's still possible to insert the presets using Space / Enter on keyboard.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9210 
