### PR TITLE
Taxonomies: Enable e2e tests for contributor role

### DIFF
--- a/packages/e2e-tests/src/specs/editor/taxonomy.js
+++ b/packages/e2e-tests/src/specs/editor/taxonomy.js
@@ -200,13 +200,14 @@ describe('taxonomy', () => {
       // See that added tags persist.
       const tokens2 = await page.evaluate(() =>
         Array.from(
-          document.querySelectorAll('[data-testid="flat-term-token"] > span'),
-          (element) => element.textContent
+          document.querySelectorAll('[data-testid="flat-term-token"]'),
+          (element) => element.innerText
         )
       );
 
-      await expect(tokens2).toContainValue('adventure');
-      await expect(tokens2).toContainValue('noir');
+      await expect(tokens2).toStrictEqual(
+        expect.arrayContaining(['noir', 'action', 'adventure'])
+      );
 
       await percySnapshot(page, 'Taxonomies - Tags - Admin');
     });
@@ -248,10 +249,7 @@ describe('taxonomy', () => {
       await percySnapshot(page, 'Taxonomies - Categories - Contributor');
     });
 
-    // Disable reason: capabilities not met, right now contributor users are granted the ability to `create-web_story_tag` which makes this test fail.
-    // https://github.com/google/web-stories-wp/issues/9236
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('should be able to add tags that already exist but not create new tags', async () => {
+    it('should be able to add new tags and existing tags', async () => {
       await createNewStory();
       await insertStoryTitle('Taxonomies - Tags - Contributor');
 
@@ -264,6 +262,7 @@ describe('taxonomy', () => {
       // Find an existing tag and select it.
       await page.focus('input#web_story_tag-input');
       await page.type('input#web_story_tag-input', 'adven');
+      await page.waitForSelector('ul[data-testid="suggested_terms_list"]');
       await expect(page).toMatchElement(
         'ul[data-testid="suggested_terms_list"]'
       );
@@ -275,14 +274,19 @@ describe('taxonomy', () => {
 
       const tokens = await page.evaluate(() =>
         Array.from(
-          document.querySelectorAll('[data-testid="flat-term-token"] > span'),
-          (element) => element.textContent
+          document.querySelectorAll('[data-testid="flat-term-token"]'),
+          (element) => element.innerText
         )
       );
 
-      await expect(tokens).toContainValue('adventure');
+      await expect(tokens).toStrictEqual(
+        expect.arrayContaining(['rom-com', 'creature feature', 'adventure'])
+      );
 
-      await publishStory();
+      await expect(page).toClick('button[aria-label="Save draft"]');
+      await page.waitForSelector(
+        'button[aria-label="Preview"]:not([disabled])'
+      );
 
       // Refresh page to verify that the assignments persisted.
       await page.reload();
@@ -293,14 +297,14 @@ describe('taxonomy', () => {
       // See that added tags persist.
       const tokens2 = await page.evaluate(() =>
         Array.from(
-          document.querySelectorAll('[data-testid="flat-term-token"] > span'),
-          (element) => element.textContent
+          document.querySelectorAll('[data-testid="flat-term-token"]'),
+          (element) => element.innerText
         )
       );
 
-      await expect(tokens2).toContainValue('adventure');
-      await expect(tokens2).not.toContainValue('rom-com');
-      await expect(tokens2).not.toContainValue('creature feature');
+      await expect(tokens2).toStrictEqual(
+        expect.arrayContaining(['rom-com', 'creature feature', 'adventure'])
+      );
 
       await percySnapshot(page, 'Taxonomies - Tags - Contributor');
     });


### PR DESCRIPTION
## Context

Enables the contributor tags e2e test now that we've cleared up that it's intentional that contributors are able to create tags. 

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

Also cleaned up some `expect` discrepancies from earlier tweaks so tag tests are set up the same.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9236 
