### PR TITLE
Settings: Add note about removing publisher logos

### DIFF
--- a/packages/dashboard/src/app/views/editorSettings/publisherLogo/index.js
+++ b/packages/dashboard/src/app/views/editorSettings/publisherLogo/index.js
@@ -56,6 +56,10 @@ export const TEXT = {
     'Click on logo to set as default if you want that logo to be used on default logo for all your stories.',
     'web-stories'
   ),
+  REMOVAL: __(
+    "Removing a logo from your settings won't remove it from any stories using that logo.",
+    'web-stories'
+  ),
   INSTRUCTIONS: __(
     'Avoid vector files, such as svg or eps. Logos should be at least 96x96 pixels and a perfect square. The background should not be transparent.',
     'web-stories'
@@ -167,6 +171,9 @@ function PublisherLogoSettings({
         </SettingSubheading>
         <SettingSubheading size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
           {TEXT.CLICK_CONTEXT}
+        </SettingSubheading>
+        <SettingSubheading size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL}>
+          {TEXT.REMOVAL}
         </SettingSubheading>
       </div>
       <div ref={containerRef} data-testid="publisher-logos-container">


### PR DESCRIPTION
## Context

We removed an old dialog, updating copy to give users a heads up about how logo removal impacts (or doesn't impact) existing stories in a less interruptive manner. 

## Summary

Copy update. 

| Old | New |
| --- | --- |
| ![Screen Shot 2021-10-06 at 12 53 57 PM](https://user-images.githubusercontent.com/10720454/136273947-800b7747-f8a7-406a-9e9c-ceab3a75d6e3.png) | ![Screen Shot 2021-10-06 at 12 52 55 PM](https://user-images.githubusercontent.com/10720454/136273963-5a657a99-acdc-409e-9e56-af7d6979d130.png)| 
## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9288 
