### PR TITLE
Do not add `noreferrer` to same-origin links

### DIFF
--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -62,8 +62,11 @@ trait Sanitization_Utils {
 	/**
 	 * Transform all hyperlinks to ensure they're always valid.
 	 *
-	 * Adds target and rel attributes.
-	 * Removes empty data-tooltip-icon and data-tooltip-text attributes.
+	 * Adds target="_blank" and rel="noreferrer" attributes.
+	 * Does not add rel="noreferrer" for same-origin links.
+	 *
+	 * Removes empty data-tooltip-icon and data-tooltip-text attributes
+	 * to prevent validation issues.
 	 *
 	 * @since 1.1.0
 	 *
@@ -71,28 +74,42 @@ trait Sanitization_Utils {
 	 * @return void
 	 */
 	private function transform_a_tags( &$document ) {
-		$hyperlinks = $document->getElementsByTagName( 'a' );
+		$links = $document->getElementsByTagName( 'a' );
 
 		/**
 		 * The <a> element
 		 *
-		 * @var DOMElement $hyperlink The <a> element
+		 * @var DOMElement $link The <a> element
 		 */
-		foreach ( $hyperlinks as $hyperlink ) {
-			if ( ! $hyperlink->getAttribute( 'target' ) ) {
-				$hyperlink->setAttribute( 'target', '_blank' );
+		foreach ( $links as $link ) {
+			if ( ! $link->getAttribute( 'target' ) ) {
+				$link->setAttribute( 'target', '_blank' );
 			}
 
-			if ( ! $hyperlink->getAttribute( 'rel' ) ) {
-				$hyperlink->setAttribute( 'rel', 'noreferrer' );
+			$is_link_to_same_origin = 0 === strpos( $link->getAttribute( 'href' ), home_url() );
+
+			$rel = $link->getAttribute( 'rel' );
+
+			// Links to the same site should not have "noreferrer".
+			// Other rel values should not be modified.
+			// See https://github.com/google/web-stories-wp/issues/9494.
+			$rel = str_replace( 'noreferrer', '', $rel );
+			if ( ! $is_link_to_same_origin ) {
+				$rel .= ' noreferrer';
 			}
 
-			if ( ! $hyperlink->getAttribute( 'data-tooltip-icon' ) ) {
-				$hyperlink->removeAttribute( 'data-tooltip-icon' );
+			if ( empty( $rel ) ) {
+				$link->removeAttribute( 'rel' );
+			} else {
+				$link->setAttribute( 'rel', trim( $rel ) );
 			}
 
-			if ( ! $hyperlink->getAttribute( 'data-tooltip-text' ) ) {
-				$hyperlink->removeAttribute( 'data-tooltip-text' );
+			if ( ! $link->getAttribute( 'data-tooltip-icon' ) ) {
+				$link->removeAttribute( 'data-tooltip-icon' );
+			}
+
+			if ( ! $link->getAttribute( 'data-tooltip-text' ) ) {
+				$link->removeAttribute( 'data-tooltip-text' );
 			}
 		}
 	}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Page Attachments and Links are currently getting `rel="noreferrer"` attributes, even if they point to the same site, making it difficult for creators to measure how many visitors their other content gets from stories.

## Summary

<!-- A brief description of what this PR does. -->

Removes `rel="noreferrer"` from (internal) links to the current site.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Using a data provider for tests now to make them easier to adjust.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add links and page attachments to your story, some to external sites, some to your own blog
2. Preview the story and verify there are missing `rel="noreferrer"` attributes on the links to your own site

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9494
