### PR TITLE
Publisher Logos: Fix race condition on multi-upload

### DIFF
--- a/includes/REST_API/Publisher_Logos_Controller.php
+++ b/includes/REST_API/Publisher_Logos_Controller.php
@@ -210,6 +210,8 @@ class Publisher_Logos_Controller extends REST_Controller implements HasRequireme
 	/**
 	 * Adds a new publisher logo to the collection.
 	 *
+	 * Supports adding multiple logos at once.
+	 *
 	 * @since 1.12.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
@@ -218,35 +220,59 @@ class Publisher_Logos_Controller extends REST_Controller implements HasRequireme
 	public function create_item( $request ) {
 		$publisher_logos = $this->filter_publisher_logos( (array) $this->settings->get_setting( $this->settings::SETTING_NAME_PUBLISHER_LOGOS, [] ) );
 
-		$post = get_post( $request['id'] );
+		// Could be a single attachment ID or an array of attachment IDs.
+		$posts = (array) $request['id'];
 
-		if ( ! $post || 'attachment' !== $post->post_type ) {
-			return new WP_Error(
-				'rest_invalid_id',
-				__( 'Invalid ID', 'web-stories' ),
-				[ 'status' => 400 ]
-			);
+		foreach ( $posts as $post_id ) {
+			$post = get_post( $post_id );
+
+			if ( ! $post || 'attachment' !== $post->post_type ) {
+				return new WP_Error(
+					'rest_invalid_id',
+					__( 'Invalid ID', 'web-stories' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			if ( in_array( $post->ID, $publisher_logos, true ) ) {
+				return new WP_Error(
+					'rest_publisher_logo_exists',
+					__( 'Publisher logo already exists', 'web-stories' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			$publisher_logos[] = $post->ID;
 		}
-
-		if ( in_array( $post->ID, $publisher_logos, true ) ) {
-			return new WP_Error(
-				'rest_publisher_logo_exists',
-				__( 'Publisher logo already exists', 'web-stories' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		$publisher_logos[] = $post->ID;
 
 		$this->settings->update_setting( $this->settings::SETTING_NAME_PUBLISHER_LOGOS, $publisher_logos );
 
 		$active_publisher_logo_id = absint( $this->settings->get_setting( $this->settings::SETTING_NAME_ACTIVE_PUBLISHER_LOGO ) );
 
 		if ( 1 === count( $publisher_logos ) || ! in_array( $active_publisher_logo_id, $publisher_logos, true ) ) {
-			$this->settings->update_setting( $this->settings::SETTING_NAME_ACTIVE_PUBLISHER_LOGO, $post->ID );
+			$this->settings->update_setting( $this->settings::SETTING_NAME_ACTIVE_PUBLISHER_LOGO, $posts[0] );
 		}
 
-		return $this->prepare_item_for_response( $post, $request );
+		$results = [];
+
+		foreach ( $posts as $post ) {
+			/**
+			 * Post object.
+			 *
+			 * @var WP_Post $post
+			 */
+			$post = get_post( $post );
+
+			$data = $this->prepare_item_for_response( $post, $request );
+
+			if ( 1 === count( $posts ) ) {
+				return $data;
+			}
+
+			$results[] = $this->prepare_response_for_collection( $data );
+		}
+
+		return rest_ensure_response( $results );
 	}
 
 	/**

--- a/includes/REST_API/Publisher_Logos_Controller.php
+++ b/includes/REST_API/Publisher_Logos_Controller.php
@@ -223,6 +223,14 @@ class Publisher_Logos_Controller extends REST_Controller implements HasRequireme
 		// Could be a single attachment ID or an array of attachment IDs.
 		$posts = (array) $request['id'];
 
+		if ( empty( $posts ) ) {
+			return new WP_Error(
+				'rest_invalid_id',
+				__( 'Invalid ID', 'web-stories' ),
+				[ 'status' => 400 ]
+			);
+		}
+
 		foreach ( $posts as $post_id ) {
 			$post = get_post( $post_id );
 

--- a/packages/wp-dashboard/src/api/hooks/usePublisherLogosApi.js
+++ b/packages/wp-dashboard/src/api/hooks/usePublisherLogosApi.js
@@ -109,7 +109,7 @@ export default function usePublisherLogosApi() {
   );
 
   const addPublisherLogo = useCallback(
-    async (publisherLogoId) => {
+    async (publisherLogoIds) => {
       dispatch({
         type: ACTION_TYPES.LOADING,
       });
@@ -117,15 +117,19 @@ export default function usePublisherLogosApi() {
       try {
         const response = await addPublisherLogoCallback(
           publisherLogosApiPath,
-          publisherLogoId
+          publisherLogoIds
         );
 
-        dispatch({
-          type: ACTION_TYPES.ADD_SUCCESS,
-          payload: {
-            publisherLogo: response,
-          },
-        });
+        const publisherLogos = Array.isArray(response) ? response : [response];
+
+        for (const publisherLogo of publisherLogos) {
+          dispatch({
+            type: ACTION_TYPES.ADD_SUCCESS,
+            payload: {
+              publisherLogo,
+            },
+          });
+        }
       } catch (err) {
         dispatch({
           type: ACTION_TYPES.ADD_FAILURE,

--- a/packages/wp-dashboard/src/api/publisherLogo.js
+++ b/packages/wp-dashboard/src/api/publisherLogo.js
@@ -56,7 +56,7 @@ export function removePublisherLogo(apiPath, logoId) {
  * Add publisher logo.
  *
  * @param {string} apiPath API path.
- * @param {number|string} logoId Logo id.
+ * @param {number|Array<number>} logoId Single logo ID or array of logo IDs.
  * @return {Promise} Request promise.
  */
 export function addPublisherLogo(apiPath, logoId) {

--- a/packages/wp-dashboard/src/components/editorSettings/editorSettings.js
+++ b/packages/wp-dashboard/src/components/editorSettings/editorSettings.js
@@ -150,9 +150,7 @@ function EditorSettings() {
 
   useEffect(() => {
     if (newlyCreatedMediaIds.length > 0) {
-      for (const id of newlyCreatedMediaIds) {
-        addPublisherLogo(id);
-      }
+      addPublisherLogo(newlyCreatedMediaIds);
     }
   }, [newlyCreatedMediaIds, addPublisherLogo]);
 

--- a/tests/phpunit/integration/tests/REST_API/Publisher_Logos_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Publisher_Logos_Controller.php
@@ -319,6 +319,73 @@ class Publisher_Logos_Controller extends DependencyInjectedRestTestCase {
 	 * @covers ::permissions_check
 	 * @covers ::create_item
 	 */
+	public function test_create_item_multiple() {
+		$this->controller->register();
+
+		wp_set_current_user( self::$admin );
+
+		$request = new WP_REST_Request( WP_REST_Server::CREATABLE, '/web-stories/v1/publisher-logos' );
+		$request->set_body_params(
+			[
+				'id' => [ self::$attachment_id_1, self::$attachment_id_2 ],
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$publisher_logos          = get_option( Settings::SETTING_NAME_PUBLISHER_LOGOS );
+		$active_publisher_logo_id = (int) get_option( Settings::SETTING_NAME_ACTIVE_PUBLISHER_LOGO );
+
+		$data = $response->get_data();
+		$this->assertEqualSetsWithIndex(
+			[
+				[
+					'id'     => self::$attachment_id_1,
+					'title'  => get_the_title( self::$attachment_id_1 ),
+					'url'    => wp_get_attachment_url( self::$attachment_id_1 ),
+					'active' => true,
+					'_links' => [
+						'self'       => [
+							[
+								'href' => rest_url( 'web-stories/v1/publisher-logos/' . self::$attachment_id_1 ),
+							],
+						],
+						'collection' => [
+							[
+								'href' => rest_url( 'web-stories/v1/publisher-logos' ),
+							],
+						],
+					],
+				],
+				[
+					'id'     => self::$attachment_id_2,
+					'title'  => get_the_title( self::$attachment_id_2 ),
+					'url'    => wp_get_attachment_url( self::$attachment_id_2 ),
+					'active' => false,
+					'_links' => [
+						'self'       => [
+							[
+								'href' => rest_url( 'web-stories/v1/publisher-logos/' . self::$attachment_id_2 ),
+							],
+						],
+						'collection' => [
+							[
+								'href' => rest_url( 'web-stories/v1/publisher-logos' ),
+							],
+						],
+					],
+				],
+			],
+			$data
+		);
+		$this->assertEqualSets( [ self::$attachment_id_1, self::$attachment_id_2 ], $publisher_logos );
+		$this->assertSame( self::$attachment_id_1, $active_publisher_logo_id );
+	}
+
+
+	/**
+	 * @covers ::permissions_check
+	 * @covers ::create_item
+	 */
 	public function test_create_item_updates_incorrect_active_publisher_logo() {
 		$this->controller->register();
 

--- a/tests/phpunit/integration/tests/REST_API/Publisher_Logos_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Publisher_Logos_Controller.php
@@ -381,6 +381,25 @@ class Publisher_Logos_Controller extends DependencyInjectedRestTestCase {
 		$this->assertSame( self::$attachment_id_1, $active_publisher_logo_id );
 	}
 
+	/**
+	 * @covers ::permissions_check
+	 * @covers ::create_item
+	 */
+	public function test_create_item_empty_array() {
+		$this->controller->register();
+
+		wp_set_current_user( self::$admin );
+
+		$request = new WP_REST_Request( WP_REST_Server::CREATABLE, '/web-stories/v1/publisher-logos' );
+		$request->set_body_params(
+			[
+				'id' => [],
+			]
+		);
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_invalid_id', $response );
+	}
 
 	/**
 	 * @covers ::permissions_check


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

There's a race condition when uploading multiple publisher logos, causing some items to be dropped from the logos list.

## Summary

<!-- A brief description of what this PR does. -->

This PRs updates the publisher logo multi-upload so that multiple logos are added to the list together. This fixes the race condition.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Upload multiple publisher logos
2. Refresh the page
3. Verify all newly uploaded logos are still there


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9499
