### PR TITLE
Layers Panel: constrain max height of layer panel

### DIFF
--- a/packages/story-editor/src/components/panels/design/layer/layerPanel.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerPanel.js
@@ -24,12 +24,8 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import {
-  MAX_HEIGHT_DEFAULT,
-  Panel,
-  PanelTitle,
-  PanelContent,
-} from '../../panel';
+import { Panel, PanelTitle, PanelContent } from '../../panel';
+import useInspector from '../../../inspector/useInspector';
 import LayerList from './layerList';
 import useLayers from './useLayers';
 
@@ -56,6 +52,14 @@ const Divider = styled.div`
 function LayerPanel() {
   const layers = useLayers();
 
+  const {
+    state: { inspectorContentHeight },
+  } = useInspector();
+
+  // We want the max height to fill the space underneath the document/design tab bar.
+  // Since the document/design tab bar is 50px subtract that from the full height of the inspector.
+  const maxHeight = inspectorContentHeight - 50;
+
   const initialHeight = useMemo(() => Math.round(window.innerHeight / 4), []);
 
   return (
@@ -72,7 +76,7 @@ function LayerPanel() {
           isSecondary
           isResizable
           count={layers?.length}
-          maxHeight={MAX_HEIGHT_DEFAULT}
+          maxHeight={maxHeight}
         >
           {__('Layers', 'web-stories')}
         </StyledPanelTitle>

--- a/packages/story-editor/src/components/panels/design/layer/layerPanel.js
+++ b/packages/story-editor/src/components/panels/design/layer/layerPanel.js
@@ -26,6 +26,7 @@ import styled from 'styled-components';
  */
 import { Panel, PanelTitle, PanelContent } from '../../panel';
 import useInspector from '../../../inspector/useInspector';
+import { TAB_HEIGHT, TAB_VERTICAL_MARGIN } from '../../../tabview';
 import LayerList from './layerList';
 import useLayers from './useLayers';
 
@@ -57,8 +58,10 @@ function LayerPanel() {
   } = useInspector();
 
   // We want the max height to fill the space underneath the document/design tab bar.
-  // Since the document/design tab bar is 50px subtract that from the full height of the inspector.
-  const maxHeight = inspectorContentHeight - 50;
+  // Since the document/design tab bar has top and bottom margin in addition to a static
+  // height subtract sum from the full height of the inspector.
+  const tabHeight = 2 * TAB_VERTICAL_MARGIN + TAB_HEIGHT;
+  const maxHeight = inspectorContentHeight - tabHeight + 2;
 
   const initialHeight = useMemo(() => Math.round(window.innerHeight / 4), []);
 

--- a/packages/story-editor/src/components/tabview/index.js
+++ b/packages/story-editor/src/components/tabview/index.js
@@ -38,6 +38,8 @@ import usePerformanceTracking from '../../utils/usePerformanceTracking';
 import { TRACKING_EVENTS } from '../../constants/performanceTrackingEvents';
 
 const ALERT_ICON_SIZE = 28;
+export const TAB_HEIGHT = 32;
+export const TAB_VERTICAL_MARGIN = 10;
 
 const Tabs = styled.ul.attrs({
   role: 'tablist',
@@ -64,8 +66,8 @@ const TabElement = styled.li.attrs(({ isActive }) => ({
   border: none;
   background: none;
   padding: 0 4px;
-  margin: 10px 12px 9px;
-  height: 32px;
+  margin: ${TAB_VERTICAL_MARGIN}px 12px 9px;
+  height: ${TAB_HEIGHT}px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Context
Expanding the layer panel to its maximum height makes a scrollbar appear. 

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->
This scroll bar was appearing because the actual height of the layers panel was set to `99999999`. An overriding `maxHeight` prop was set to the `MAX_HEIGHT_DEFAULT` from `./panel`

## Relevant Technical Choices

<!-- Please describe your changes. -->
We want the max height to fill the space underneath the document/design tab bar. Since the document/design tab bar is 50px subtract that from the full height of the inspector and use this value as the `maxHeight` override prop. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->
n/a

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
### Old: 
<img width="340" alt="Screen Shot 2021-10-29 at 2 25 39 PM" src="https://user-images.githubusercontent.com/1820266/139497644-12b5ec61-c1bc-4816-b847-a55790f152e2.png">


### New:

<img width="335" alt="Screen Shot 2021-10-29 at 2 26 28 PM" src="https://user-images.githubusercontent.com/1820266/139497747-835ca941-026d-4237-83ac-ae599e7706c2.png">
## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. open the layers panel
2. drag to resize to the full height
3. notice the scroll bar no longer appears. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9542 
