### PR TITLE
Fix duplicate fullbleed container landmark regions

### DIFF
--- a/packages/e2e-tests/src/config/bootstrap.js
+++ b/packages/e2e-tests/src/config/bootstrap.js
@@ -221,7 +221,6 @@ async function runAxeTestsForStoriesEditor() {
       'color-contrast',
       // Because of multiple #_wpnonce elements.
       'duplicate-id',
-      'landmark-unique',
       'region',
       'aria-allowed-attr',
       'nested-interactive',

--- a/packages/story-editor/src/components/canvas/displayLayer.js
+++ b/packages/story-editor/src/components/canvas/displayLayer.js
@@ -20,7 +20,7 @@
 import styled from 'styled-components';
 import { memo, useCallback, useEffect, useMemo } from '@web-stories-wp/react';
 import PropTypes from 'prop-types';
-import { _x } from '@web-stories-wp/i18n';
+import { _x, __ } from '@web-stories-wp/i18n';
 import {
   StoryAnimation,
   STORY_ANIMATION_STATE,
@@ -164,6 +164,10 @@ function DisplayLayer() {
           fullbleedRef={setFullbleedContainer}
           background={currentPage?.backgroundColor}
           isBackgroundSelected={isBackgroundSelected}
+          fullBleedContainerLabel={__(
+            'Fullbleed area (Display Layer)',
+            'web-stories'
+          )}
           overlay={
             currentPage && (
               <PageAttachment pageAttachment={currentPage.pageAttachment} />

--- a/packages/story-editor/src/components/canvas/displayLayer.js
+++ b/packages/story-editor/src/components/canvas/displayLayer.js
@@ -165,7 +165,7 @@ function DisplayLayer() {
           background={currentPage?.backgroundColor}
           isBackgroundSelected={isBackgroundSelected}
           fullBleedContainerLabel={__(
-            'Fullbleed area (Display Layer)',
+            'Fullbleed area (Display layer)',
             'web-stories'
           )}
           overlay={

--- a/packages/story-editor/src/components/canvas/editLayer.js
+++ b/packages/story-editor/src/components/canvas/editLayer.js
@@ -20,7 +20,7 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { memo, useEffect, useRef } from '@web-stories-wp/react';
-import { _x } from '@web-stories-wp/i18n';
+import { _x, __ } from '@web-stories-wp/i18n';
 import { useKeyDownEffect } from '@web-stories-wp/design-system';
 
 /**
@@ -105,6 +105,10 @@ function EditLayerForElement({ element, showOverflow }) {
     >
       <EditPageArea
         ref={pageAreaRef}
+        fullBleedContainerLabel={__(
+          'Fullbleed area (Edit layer)',
+          'web-stories'
+        )}
         isControlled
         showOverflow={showOverflow}
         overflow={showOverflow ? 'visible' : 'hidden'}

--- a/packages/story-editor/src/components/canvas/framesLayer.js
+++ b/packages/story-editor/src/components/canvas/framesLayer.js
@@ -113,9 +113,8 @@ function FramesLayer() {
     >
       {!isAnimating && (
         <FramesPageArea
-          role="region"
           fullBleedContainerLabel={__(
-            'Fullbleed area (Frames Layer)',
+            'Fullbleed area (Frames layer)',
             'web-stories'
           )}
           onContextMenu={onOpenMenu}

--- a/packages/story-editor/src/components/canvas/framesLayer.js
+++ b/packages/story-editor/src/components/canvas/framesLayer.js
@@ -112,7 +112,15 @@ function FramesLayer() {
       aria-label={__('Frames layer', 'web-stories')}
     >
       {!isAnimating && (
-        <FramesPageArea onContextMenu={onOpenMenu} onScroll={onScroll}>
+        <FramesPageArea
+          role="region"
+          fullBleedContainerLabel={__(
+            'Fullbleed area (Frames Layer)',
+            'web-stories'
+          )}
+          onContextMenu={onOpenMenu}
+          onScroll={onScroll}
+        >
           {currentPage &&
             currentPage.elements.map((element) => {
               return <FrameElement key={element.id} element={element} />;

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -338,6 +338,7 @@ const PageArea = forwardRef(function PageArea(
   {
     children,
     fullbleedRef = createRef(),
+    fullBleedContainerLabel = __('Fullbleed area', 'web-stories'),
     overlay = [],
     background,
     isControlled = false,
@@ -404,7 +405,7 @@ const PageArea = forwardRef(function PageArea(
       >
         <PaddedPage ref={paddedRef}>
           <FullbleedContainer
-            aria-label={__('Fullbleed area', 'web-stories')}
+            aria-label={fullBleedContainerLabel}
             role="region"
             ref={fullbleedRef}
             data-testid="fullbleed"
@@ -441,6 +442,7 @@ PageArea.propTypes = {
   className: PropTypes.string,
   showOverflow: PropTypes.bool,
   isBackgroundSelected: PropTypes.bool,
+  fullBleedContainerLabel: PropTypes.string,
   pageAreaRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   withSafezone: PropTypes.bool,
 };

--- a/packages/story-editor/src/karma/fixture/containers/canvas.js
+++ b/packages/story-editor/src/karma/fixture/containers/canvas.js
@@ -83,7 +83,7 @@ class AbstractLayer extends Container {
   }
 
   get fullbleed() {
-    return this.getByRole('region', { name: 'Fullbleed area' });
+    return this.getByRole('region', { name: 'Fullbleed area (Frames Layer)' });
   }
 }
 

--- a/packages/story-editor/src/karma/fixture/containers/canvas.js
+++ b/packages/story-editor/src/karma/fixture/containers/canvas.js
@@ -83,7 +83,7 @@ class AbstractLayer extends Container {
   }
 
   get fullbleed() {
-    return this.getByRole('region', { name: 'Fullbleed area (Frames Layer)' });
+    return this.getByRole('region', { name: /^Fullbleed area/ });
   }
 }
 


### PR DESCRIPTION
## Context

e2e accessibility check for unique landmarks had to be turned off because the fullbleed container was showing as duplicate. this fixes that and enables that rule. 

## Summary

Both the role of region and the aria-label of "fullbleed area" were hardcoded into the `PageArea` component.. Updated so that it can inherit a label to use on the fullbleed container which makes the implementations of the region unique. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

No user facing changes, if you run aXe in your dev tools you won't get a duplicate landmark region issue anymore.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7578 
