### PR TITLE
Dashboard: Add height and width attributes to grid images

### DIFF
--- a/packages/dashboard/src/app/views/exploreTemplates/content/templateGridItem.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/content/templateGridItem.js
@@ -29,7 +29,11 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS } from '../../../../constants';
+import {
+  DEFAULT_GRID_IMG_HEIGHT,
+  DEFAULT_GRID_IMG_WIDTH,
+  TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS,
+} from '../../../../constants';
 import { CardGridItem } from '../../../../components';
 import { Container, Gradient, Scrim } from '../../shared/grid/components';
 import {
@@ -76,7 +80,12 @@ const TemplateGridItem = forwardRef(
             <PicturePoster>
               <source srcSet={posterSrc?.webp} type="image/webp" />
               <source srcSet={posterSrc?.png} type="image/png" />
-              <img src={posterSrc?.png} alt={posterAltText} />
+              <img
+                src={posterSrc?.png}
+                alt={posterAltText}
+                width={DEFAULT_GRID_IMG_WIDTH}
+                height={DEFAULT_GRID_IMG_HEIGHT}
+              />
             </PicturePoster>
             <Gradient />
             <Scrim

--- a/packages/dashboard/src/app/views/myStories/content/storyGridItem/index.js
+++ b/packages/dashboard/src/app/views/myStories/content/storyGridItem/index.js
@@ -28,7 +28,11 @@ import { css } from 'styled-components';
  */
 import { StoryMenu } from '../../../../../components';
 import { generateStoryMenu } from '../../../../../components/popoverMenu/story-menu-generator';
-import { STORY_STATUS } from '../../../../../constants';
+import {
+  DEFAULT_GRID_IMG_HEIGHT,
+  DEFAULT_GRID_IMG_WIDTH,
+  STORY_STATUS,
+} from '../../../../../constants';
 import {
   PageSizePropType,
   RenameStoryPropType,
@@ -152,6 +156,8 @@ const StoryGridItem = forwardRef(
                     src: story.featuredMediaUrl,
                   }
                 : null)}
+              width={DEFAULT_GRID_IMG_WIDTH}
+              height={DEFAULT_GRID_IMG_HEIGHT}
             />
             <Gradient />
             <Scrim>

--- a/packages/dashboard/src/components/cardGallery/index.js
+++ b/packages/dashboard/src/components/cardGallery/index.js
@@ -32,6 +32,10 @@ import { useGridViewKeys } from '@web-stories-wp/design-system';
  * Internal dependencies
  */
 import {
+  DEFAULT_GRID_IMG_HEIGHT,
+  DEFAULT_GRID_IMG_WIDTH,
+} from '../../constants';
+import {
   GalleryContainer,
   ThumbnailButton,
   Thumbnails,
@@ -117,7 +121,12 @@ function CardGallery({ galleryPosters, isRTL, galleryLabel }) {
             <picture>
               <source srcSet={poster.webp} type="image/webp" />
               <source srcSet={poster.png} type="image/png" />
-              <img src={poster.png} alt={getPosterAltCopy(pageNumber)} />
+              <img
+                src={poster.png}
+                alt={getPosterAltCopy(pageNumber)}
+                width={DEFAULT_GRID_IMG_WIDTH}
+                height={DEFAULT_GRID_IMG_HEIGHT}
+              />
             </picture>
           </ThumbnailButton>
         </div>
@@ -160,6 +169,8 @@ function CardGallery({ galleryPosters, isRTL, galleryLabel }) {
             <img
               src={galleryPosters[selectedGridItemIndex].png}
               alt={getPosterAltCopy(selectedGridItemIndex + 1)}
+              width={DEFAULT_GRID_IMG_WIDTH}
+              height={DEFAULT_GRID_IMG_HEIGHT}
             />
           </picture>
         )}

--- a/packages/dashboard/src/constants/index.js
+++ b/packages/dashboard/src/constants/index.js
@@ -97,6 +97,9 @@ export const TEXT_INPUT_DEBOUNCE = 300;
 export const MIN_IMG_HEIGHT = 96;
 export const MIN_IMG_WIDTH = 96;
 
+export const DEFAULT_GRID_IMG_HEIGHT = 853;
+export const DEFAULT_GRID_IMG_WIDTH = 640;
+
 export * from './components';
 export * from './pageStructure';
 export * from './stories';


### PR DESCRIPTION
## Context

Pascal brought up the fact this am that the image elements in the dashboard that are to show the poster image or the template screenshot don't have height and width attributes. They should. 

## Summary

The size of the images used on the various dashboard grid are responsive, the styled size is getting set in css but for the sake of content shift adding in height and width attributes - stuck with the default poster dimensions for consistency.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

There should be no changes, any change would be a regression 😅 

## Testing Instructions

Make sure images shown on the dashboard (my stories, explore templates, detail template view) all show expected images  - no weird distortion. 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9581 
