### PR TITLE
Fix failing monetization E2E test

### DIFF
--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser/monitization.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser/monitization.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { clickButton, visitSettings } from '@web-stories-wp/e2e-test-utils';
+import { visitSettings } from '@web-stories-wp/e2e-test-utils';
 
 /**
  * Internal dependencies
@@ -25,15 +25,13 @@ import { clickButton, visitSettings } from '@web-stories-wp/e2e-test-utils';
 import { monetizationDropdownSelector } from '../../../../utils';
 
 describe('Admin User', () => {
-  it('should let me see and update all settings', async () => {
+  it('should let me see and update monetization settings', async () => {
     await visitSettings();
 
     await expect(page).toMatchElement(monetizationDropdownSelector);
 
     // verify that the monetization settings can be changed
-    await clickButton(monetizationDropdownSelector, {
-      text: 'None',
-    });
+    await expect(page).toClick(monetizationDropdownSelector, { text: 'None' });
 
     await expect(page).toClick('li', { text: 'Google AdSense' });
     await expect(page).toMatchElement(monetizationDropdownSelector, {
@@ -41,7 +39,7 @@ describe('Admin User', () => {
     });
 
     // reset monetization setting
-    await clickButton(monetizationDropdownSelector, {
+    await expect(page).toClick(monetizationDropdownSelector, {
       text: 'Google AdSense',
     });
     await expect(page).toClick('li', { text: 'None' });

--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser/videoSettings.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser/videoSettings.js
@@ -45,7 +45,7 @@ describe('Admin User', () => {
     await disableCheckbox(videoCacheCheckboxSelector);
   });
 
-  it('should let me see and update all settings', async () => {
+  it('should let me see and update video settings', async () => {
     // verify that the video optimization checkbox can be changed
     await expect(page).toMatchElement(
       `${videoOptimizationCheckboxSelector}:checked`


### PR DESCRIPTION
## Context

Fix failing e2e monetization test.

![image](https://user-images.githubusercontent.com/6297436/139654980-2f2f3bbf-0db5-414e-ac12-14fd07392b9c.png)


## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
