### PR TITLE
Dashboard: 4:6 ratio for story grid item display

### DIFF
--- a/packages/dashboard/src/app/views/exploreTemplates/content/templateGridView.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/content/templateGridView.js
@@ -117,7 +117,6 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
     <div ref={containerRef}>
       <CardGrid
         pageSize={pageSize}
-        isPosterHeight
         role="list"
         ref={gridRef}
         ariaLabel={__('Viewing available templates', 'web-stories')}

--- a/packages/dashboard/src/app/views/exploreTemplates/content/test/content.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/content/test/content.js
@@ -79,7 +79,7 @@ describe('Explore Templates <Content />', function () {
             }}
             view={{
               style: VIEW_STYLE.GRID,
-              pageSize: { width: 200, height: 300, containerHeight: 300 },
+              pageSize: { width: 200, height: 300 },
             }}
           />
         </LayoutProvider>
@@ -104,7 +104,7 @@ describe('Explore Templates <Content />', function () {
           }}
           view={{
             style: VIEW_STYLE.GRID,
-            pageSize: { width: 200, height: 300, containerHeight: 300 },
+            pageSize: { width: 200, height: 300 },
           }}
         />
       </LayoutProvider>
@@ -127,7 +127,7 @@ describe('Explore Templates <Content />', function () {
           }}
           view={{
             style: VIEW_STYLE.GRID,
-            pageSize: { width: 200, height: 300, containerHeight: 300 },
+            pageSize: { width: 200, height: 300 },
           }}
         />
       </LayoutProvider>

--- a/packages/dashboard/src/app/views/myStories/content/storyGridItem/index.js
+++ b/packages/dashboard/src/app/views/myStories/content/storyGridItem/index.js
@@ -134,7 +134,7 @@ const StoryGridItem = forwardRef(
       <CustomCardGridItem
         data-testid={`story-grid-item-${story.id}`}
         onFocus={onFocus}
-        $posterHeight={pageSize.posterHeight}
+        $posterHeight={pageSize.height}
         ref={ref}
         aria-label={sprintf(
           /* translators: %s: story title.*/

--- a/packages/dashboard/src/app/views/myStories/content/storyGridView/index.js
+++ b/packages/dashboard/src/app/views/myStories/content/storyGridView/index.js
@@ -187,7 +187,6 @@ const StoryGridView = ({
     <div ref={containerRef}>
       <StoryGrid
         pageSize={pageSize}
-        isPosterHeight
         ref={gridRef}
         role="list"
         ariaLabel={__('Viewing stories', 'web-stories')}

--- a/packages/dashboard/src/app/views/myStories/content/test/content.js
+++ b/packages/dashboard/src/app/views/myStories/content/test/content.js
@@ -78,8 +78,6 @@ const fakeStories = [
 const pageSize = {
   width: 200,
   height: 300,
-  containerHeight: 300,
-  posterHeight: 300,
 };
 
 describe('Dashboard <Content />', function () {

--- a/packages/dashboard/src/app/views/myStories/content/test/storiesView.js
+++ b/packages/dashboard/src/app/views/myStories/content/test/storiesView.js
@@ -109,8 +109,6 @@ describe('Dashboard <StoriesView />', function () {
           pageSize: {
             width: 210,
             height: 316,
-            containerHeight: 316,
-            posterHeight: 300,
           },
         }}
       />,
@@ -144,8 +142,6 @@ describe('Dashboard <StoriesView />', function () {
             pageSize: {
               width: 210,
               height: 316,
-              containerHeight: 316,
-              posterHeight: 300,
             },
           }}
           loading={{
@@ -180,8 +176,6 @@ describe('Dashboard <StoriesView />', function () {
             pageSize: {
               width: 210,
               height: 316,
-              containerHeight: 316,
-              posterHeight: 300,
             },
           }}
           loading={{
@@ -218,8 +212,6 @@ describe('Dashboard <StoriesView />', function () {
             pageSize: {
               width: 210,
               height: 316,
-              containerHeight: 316,
-              posterHeight: 300,
             },
           }}
           loading={{
@@ -254,8 +246,6 @@ describe('Dashboard <StoriesView />', function () {
             pageSize: {
               width: 210,
               height: 316,
-              containerHeight: 316,
-              posterHeight: 300,
             },
           }}
           loading={{
@@ -294,8 +284,6 @@ describe('Dashboard <StoriesView />', function () {
             pageSize: {
               width: 210,
               height: 316,
-              containerHeight: 316,
-              posterHeight: 300,
             },
           }}
         />,

--- a/packages/dashboard/src/app/views/shared/grid/components.js
+++ b/packages/dashboard/src/app/views/shared/grid/components.js
@@ -56,7 +56,7 @@ export const Container = styled.div`
 export const Poster = styled.div`
   height: 100%;
   width: 100%;
-  object-fit: fill;
+  object-fit: cover;
   border-radius: ${({ theme }) => theme.borders.radius.medium};
   background: ${({ theme }) => theme.colors.gradient.placeholder};
 `;

--- a/packages/dashboard/src/app/views/shared/grid/components.js
+++ b/packages/dashboard/src/app/views/shared/grid/components.js
@@ -56,7 +56,7 @@ export const Container = styled.div`
 export const Poster = styled.div`
   height: 100%;
   width: 100%;
-  object-fit: cover;
+  object-fit: fill;
   border-radius: ${({ theme }) => theme.borders.radius.medium};
   background: ${({ theme }) => theme.colors.gradient.placeholder};
 `;

--- a/packages/dashboard/src/app/views/templateDetails/content/relatedGrid/test/relatedGrid.js
+++ b/packages/dashboard/src/app/views/templateDetails/content/relatedGrid/test/relatedGrid.js
@@ -31,7 +31,7 @@ describe('Template Details <RelatedGrid />', () => {
     renderWithProviders(
       <LayoutProvider>
         <RelatedGrid
-          pageSize={{ width: 200, height: 350, containerHeight: 350 }}
+          pageSize={{ width: 200, height: 350 }}
           relatedTemplates={formattedTemplatesArray.slice(0, 3)}
           templateActions={{
             createStoryFromTemplate: jest.fn(),
@@ -52,7 +52,7 @@ describe('Template Details <RelatedGrid />', () => {
     renderWithProviders(
       <LayoutProvider>
         <RelatedGrid
-          pageSize={{ width: 200, height: 350, containerHeight: 350 }}
+          pageSize={{ width: 200, height: 350 }}
           relatedTemplates={[]}
           templateActions={{
             createStoryFromTemplate: jest.fn(),

--- a/packages/dashboard/src/components/cardGrid/index.js
+++ b/packages/dashboard/src/components/cardGrid/index.js
@@ -51,7 +51,7 @@ DashboardGrid.propTypes = {
 };
 
 const CardGrid = forwardRef(function CardGrid(
-  { ariaLabel, children, pageSize, isPosterHeight },
+  { ariaLabel, children, pageSize },
   ref
 ) {
   return (
@@ -65,9 +65,7 @@ const CardGrid = forwardRef(function CardGrid(
       tabIndex={0}
       aria-label={ariaLabel}
       columnWidth={pageSize.width}
-      columnHeight={
-        isPosterHeight ? pageSize.posterHeight : pageSize.containerHeight
-      }
+      columnHeight={pageSize.height}
     >
       {children}
     </DashboardGrid>
@@ -78,7 +76,6 @@ CardGrid.propTypes = {
   ariaLabel: PropTypes.string,
   children: PropTypes.node.isRequired,
   pageSize: PageSizePropType.isRequired,
-  isPosterHeight: PropTypes.bool,
 };
 
 export default CardGrid;

--- a/packages/dashboard/src/components/cardGrid/test/card-grid.js
+++ b/packages/dashboard/src/components/cardGrid/test/card-grid.js
@@ -28,7 +28,7 @@ import CardGrid from '..';
 describe('CardGrid', () => {
   it('should render CardGrid', () => {
     renderWithProviders(
-      <CardGrid pageSize={{ width: 210, height: 316, containerHeight: 316 }}>
+      <CardGrid pageSize={{ width: 210, height: 316 }}>
         <div data-testid={'test-child'}>{'Item 1'}</div>
         <div data-testid={'test-child'}>{'Item 2'}</div>
         <div data-testid={'test-child'}>{'Item 3'}</div>

--- a/packages/dashboard/src/constants/pageStructure.js
+++ b/packages/dashboard/src/constants/pageStructure.js
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-export {
-  FULLBLEED_RATIO,
-  PAGE_RATIO,
-  PAGE_WIDTH,
-  PAGE_HEIGHT,
-} from '@web-stories-wp/units';
+export { PAGE_RATIO, PAGE_WIDTH, PAGE_HEIGHT } from '@web-stories-wp/units';
 
 export const WPBODY_ID = 'wpbody';
 

--- a/packages/dashboard/src/storybookUtils/index.js
+++ b/packages/dashboard/src/storybookUtils/index.js
@@ -24,6 +24,4 @@ export { default as formattedUsersObject } from '../dataUtils/formattedUsersObje
 export const STORYBOOK_PAGE_SIZE = {
   width: 212,
   height: 318,
-  containerHeight: 376.89,
-  posterHeight: 300,
 };

--- a/packages/dashboard/src/types.js
+++ b/packages/dashboard/src/types.js
@@ -114,7 +114,6 @@ export const TotalStoriesByStatusPropType = PropTypes.shape({
 export const PageSizePropType = PropTypes.shape({
   width: PropTypes.number,
   height: PropTypes.number,
-  containerHeight: PropTypes.number,
 });
 
 export const StoryMenuPropType = PropTypes.shape({

--- a/packages/dashboard/src/utils/index.js
+++ b/packages/dashboard/src/utils/index.js
@@ -19,7 +19,7 @@ export { default as KeyboardOnlyOutline } from './keyboardOnlyOutline';
 export { default as useDashboardResultsLabel } from './useDashboardResultsLabel';
 export {
   default as usePagePreviewSize,
-  getPagePreviewHeights,
+  getPosterHeight,
 } from './usePagePreviewSize';
 export { default as useStoryView } from './useStoryView';
 export { default as useTemplateView } from './useTemplateView';

--- a/packages/dashboard/src/utils/test/usePagePreviewSize.js
+++ b/packages/dashboard/src/utils/test/usePagePreviewSize.js
@@ -17,19 +17,18 @@
 /**
  * Internal dependencies
  */
-import { getPagePreviewHeights } from '../usePagePreviewSize';
+import { getPosterHeight } from '../usePagePreviewSize';
 
-describe('getPagePreviewHeights', () => {
-  it('should return { fullBleedHeight: 359.11, storyHeight: 303 } when width is 202', () => {
-    const previewHeights = getPagePreviewHeights(202);
+describe('usePagePreviewSize/getPosterHeight', () => {
+  it.each([
+    [202, 303],
+    [254, 381],
+  ])(
+    'should return height in 2:3 ratio relative to given width',
+    (width, expectedHeight) => {
+      const height = getPosterHeight(width);
 
-    expect(previewHeights.fullBleedHeight).toBeCloseTo(359.11);
-    expect(previewHeights.storyHeight).toBeCloseTo(303);
-  });
-  it('should return { fullBleedHeight: 451.55, storyHeight: 381 } when width is 202', () => {
-    const previewHeights = getPagePreviewHeights(254);
-
-    expect(previewHeights.fullBleedHeight).toBeCloseTo(451.56);
-    expect(previewHeights.storyHeight).toBeCloseTo(381);
-  });
+      expect(height).toBe(expectedHeight);
+    }
+  );
 });

--- a/packages/dashboard/src/utils/usePagePreviewSize.js
+++ b/packages/dashboard/src/utils/usePagePreviewSize.js
@@ -57,7 +57,7 @@ import {
 export const getPagePreviewHeights = (width) => {
   const fullBleedHeight = Math.round((width / FULLBLEED_RATIO) * 100) / 100;
   const storyHeight = Math.round((width / PAGE_RATIO) * 100) / 100;
-  const posterHeight = Math.round(((width / (3 / 4)) * 100) / 100);
+  const posterHeight = Math.round(((width / (4 / 6)) * 100) / 100);
   return { fullBleedHeight, storyHeight, posterHeight };
 };
 

--- a/packages/dashboard/src/utils/usePagePreviewSize.js
+++ b/packages/dashboard/src/utils/usePagePreviewSize.js
@@ -46,8 +46,7 @@ import {
  * @param {number} width  width of page to base ratios on
  * @return {Object}       heights to use in pagePreviews { fullBleedHeight: Number, storyHeight: Number}
  */
-export const getPosterHeight = (width) =>
-  Math.round((width / PAGE_RATIO) * 100) / 100;
+export const getPosterHeight = (width) => Math.round(width / PAGE_RATIO);
 
 const getCurrentBp = (availableContainerSpace) =>
   availableContainerSpace <= MIN_DASHBOARD_WIDTH

--- a/packages/dashboard/src/utils/usePagePreviewSize.js
+++ b/packages/dashboard/src/utils/usePagePreviewSize.js
@@ -24,7 +24,7 @@ import {
   useDebouncedCallback,
   useResizeEffect,
 } from '@web-stories-wp/react';
-import { FULLBLEED_RATIO, PAGE_RATIO } from '@web-stories-wp/units';
+import { PAGE_RATIO } from '@web-stories-wp/units';
 
 /**
  * Internal dependencies
@@ -40,26 +40,14 @@ import {
 } from '../constants';
 
 /**
- * Here we need to calculate three heights for every pagePreview in use.
- * 1. fullbleedHeight - The height that is 9:16 aspect ratio, this is the default FULLBLEED_RATIO
- * This height is used anywhere we need the height of the container holding a pagePreview.
- * It is the true boundary for overflow.
- * It is the 'fullBleedHeight'
- * 2. storyHeight - The height for the actual story (in the dashboard the only actual stories rendered are the templates), used in our shared components with edit-story
- * This means things like the unitsProvider and displayElements that we import to the Dashboard from the editor
- * It's maintaining a 2:3 aspect ratio.
- * When fullbleed is visible (as it is for templates) we use the 2:3 aspect ratio w/ overflow to allow the fullBleed height to be visible
- * 3. posterHeight - This is a height based on 3:4 ratio which is what poster images need, this is used on 'Dashboard' view.
+ * Here we need to calculate height for every pagePreview in use.
+ * The height in 2:3 ratio which is consistent with poster sizes that serve as cover images
  *
  * @param {number} width  width of page to base ratios on
  * @return {Object}       heights to use in pagePreviews { fullBleedHeight: Number, storyHeight: Number}
  */
-export const getPagePreviewHeights = (width) => {
-  const fullBleedHeight = Math.round((width / FULLBLEED_RATIO) * 100) / 100;
-  const storyHeight = Math.round((width / PAGE_RATIO) * 100) / 100;
-  const posterHeight = Math.round(((width / (4 / 6)) * 100) / 100);
-  return { fullBleedHeight, storyHeight, posterHeight };
-};
+export const getPosterHeight = (width) =>
+  Math.round((width / PAGE_RATIO) * 100) / 100;
 
 const getCurrentBp = (availableContainerSpace) =>
   availableContainerSpace <= MIN_DASHBOARD_WIDTH
@@ -74,19 +62,16 @@ const getCurrentBp = (availableContainerSpace) =>
 // subtract those values from the availableContainer space to get remaining space
 // divide the remaining space by the itemsInRow
 // attach that extra space to the width
-// get heights for page and container in getPagePreviewHeights
+// get heights for page and container in getPosterHeight
 const sizeFromWidth = (
   width,
   { bp, respectSetWidth, availableContainerSpace }
 ) => {
   if (respectSetWidth) {
-    const { fullBleedHeight, storyHeight, posterHeight } =
-      getPagePreviewHeights(width);
+    const height = getPosterHeight(width);
     return {
       width,
-      height: storyHeight,
-      containerHeight: fullBleedHeight,
-      posterHeight,
+      height,
     };
   }
 
@@ -102,14 +87,11 @@ const sizeFromWidth = (
   const addToWidthValue = remainingSpace / itemsInRow;
 
   const trueWidth = width + addToWidthValue;
-  const { fullBleedHeight, storyHeight, posterHeight } =
-    getPagePreviewHeights(trueWidth);
+  const height = getPosterHeight(trueWidth);
 
   return {
     width: trueWidth,
-    height: storyHeight,
-    containerHeight: fullBleedHeight,
-    posterHeight,
+    height,
   };
 };
 


### PR DESCRIPTION
## Context

Pascal keenly pointed out last week that the dashboard's displaying stories in 3:4 ratio while the templates got updated to 4:6, they should be consistent. 

## Summary

update grid poster size to 4:6 instead of 3:4

## Relevant Technical Choices

Just updating the ratio and adjusting the object size to fill to maintain ratio in a way that's consistent with other displays of stories (like in Google Search (Mobile)). 
Realized here that 4:6 and 2:3 are the same (_math_ 💥 ) so we can finally gut the other heights we were using in the calculation of story heights for the grid back from when we were previewing the whole story and needed both the fullbleed and the container. Anyway, that's nice to get rid of - most of this PR is just cleaning out the `containerHeight` and the `posterHeight`.

## To-do

- [x] Just realized that this update brings us full circle back to the original PAGE_RATIO (2:3), so i'm going to clean up the dashboard's page size calculation code a bit since we don't need to keep a separate posterHeight as part of the pageSize anymore. 🎉 

## User-facing changes

| Main (3:4) | This Branch (4:6) | 
| --- | --- | 
| ![Screen Shot 2021-11-01 at 9 50 28 AM](https://user-images.githubusercontent.com/10720454/139709125-bfef63a1-c0dc-4629-ab85-df2d8660b628.png) | ![Screen Shot 2021-11-01 at 9 47 37 AM](https://user-images.githubusercontent.com/10720454/139708962-ee13b965-2da4-4114-901f-bcb5a9f57d33.png) |

## Testing Instructions

See that there's an updated ratio for grid items on the dashboard

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9583 
