### PR TITLE
Template Layout panel: Tabbing Focus in FireFox

### DIFF
--- a/packages/story-editor/src/components/library/panes/pageTemplates/defaultTemplates.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/defaultTemplates.js
@@ -140,7 +140,8 @@ function DefaultTemplates({ pageSize }) {
         selectItem={handleSelectPageTemplateType}
         deselectItem={() => handleSelectPageTemplateType(null)}
       />
-      <PageTemplatesParentContainer ref={pageTemplatesParentRef}>
+      {/* tabIndex is required for FireFox bug when using keyboard to navigate from Chips to Template */}
+      <PageTemplatesParentContainer ref={pageTemplatesParentRef} tabIndex={-1}>
         <ActionRow>
           <Headline
             as="h2"

--- a/packages/story-editor/src/components/library/panes/pageTemplates/savedTemplates.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/savedTemplates.js
@@ -120,7 +120,8 @@ function SavedTemplates({ pageSize, loadTemplates, isLoading, ...rest }) {
   );
 
   return (
-    <Wrapper ref={ref}>
+    // tabIndex is required for FireFox bug when using keyboard to navigate from Chips to Template
+    <Wrapper ref={ref} tabIndex={-1}>
       {!isLoading && ref.current ? (
         <TemplateList
           parentRef={ref}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Keyboard navigation on Firefox was resulting in the template list to receive focus when tabbing from the filters dropdown to the actual template item. This meant an extra `Tab` was required to get from the filters dropdown to template. The same issue was found in the saved templates when going from the saved vs default dropdown to the actual template item. 


## Relevant Technical Choices

<!-- Please describe your changes. -->
Removed `tabIndex` from template wrappers on both default templates and saved templates.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

https://user-images.githubusercontent.com/1820266/139940314-cdc6162f-97d6-4fb3-b62f-67d89b351735.mov





https://user-images.githubusercontent.com/1820266/139940058-d946d01e-ef11-44ca-b582-dfddee146221.mov



## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. In the editor, open the template layouts. 
2. Using keyboard navigation in FireFox `tab` through templates panel. 
2. Note focus should follow from filter dropdown arrow directly to the first template. 
3. Then check the focus follows the same pattern in Saved Templates from the `Saved Templates` dropdown directly to the first template. 


## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9554 
