### PR TITLE
Templates: Update CLI script to generate screenshots with different dimensions

### DIFF
--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -48,8 +48,8 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
   await page.click('#wp-submit');
   await page.waitForNavigation({ waitUntil: 'networkidle2' });
 
-  await page.waitForSelector('aria/Explore Templates');
-  await page.click('aria/Explore Templates');
+  await page.waitForSelector('[aria-label^="Explore Templates"]');
+  await page.click('[aria-label^="Explore Templates"]');
 
   // Wait for templates to be rendered
   await page.waitForSelector('div.templateGridItem');

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -120,7 +120,7 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
       return document.querySelectorAll('amp-story-page').length;
     });
 
-    for (let currentPage = 1; currentPage < totalPages; currentPage++) {
+    for (let currentPage = 1; currentPage <= totalPages; currentPage++) {
       const templatePageSafeArea = await pagePreview.$(
         `amp-story-page:nth-child(${currentPage}) .page-safe-area`
       );
@@ -137,7 +137,7 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
         path: `${screenshotsPath}${templateName}/${currentPage}.webp`,
       });
 
-      if (currentPage !== totalPages - 1) {
+      if (currentPage < totalPages) {
         await pagePreview.click('aria/Next page');
       }
     }

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -32,12 +32,12 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
   const browser = await puppeteer.launch({
     defaultViewport: null,
     headless: true,
-    args: [`--window-size=1600,800`],
+    args: [`--window-size=1600,1145`],
   });
   const page = await browser.newPage();
   await page.setViewport({
     width: 1600,
-    height: 800,
+    height: 1145,
     deviceScaleFactor: 2,
   });
   await page.goto(
@@ -97,11 +97,12 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
     await page.waitForSelector('aria/Preview');
     await page.click('aria/Preview');
 
+    // the viewport height decides the size of the preview, we're aiming to maintain our recommended 853px height, we get the closest to this by setting the viewport height to 1145
     const pagePreview = await browser.newPage();
     await pagePreview.setViewport({
       width: 1600,
-      height: 800,
-      deviceScaleFactor: 2,
+      height: 1145,
+      deviceScaleFactor: 1,
     });
     // set prefers-reduced-motion to get story without animations so screenshots are complete page views
     await pagePreview.emulateMediaFeatures([

--- a/packages/templates/src/cli.js
+++ b/packages/templates/src/cli.js
@@ -32,12 +32,12 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
   const browser = await puppeteer.launch({
     defaultViewport: null,
     headless: true,
-    args: [`--window-size=1600,1145`],
+    args: [`--window-size=1600,854`],
   });
   const page = await browser.newPage();
   await page.setViewport({
     width: 1600,
-    height: 1145,
+    height: 854,
     deviceScaleFactor: 2,
   });
   await page.goto(
@@ -100,8 +100,8 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
     // the viewport height decides the size of the preview, we're aiming to maintain our recommended 853px height, we get the closest to this by setting the viewport height to 1145
     const pagePreview = await browser.newPage();
     await pagePreview.setViewport({
-      width: 1600,
-      height: 1145,
+      width: 640,
+      height: 854, // 853 is a breakpoint and will shrink the preview to height of 630px
       deviceScaleFactor: 1,
     });
     // set prefers-reduced-motion to get story without animations so screenshots are complete page views


### PR DESCRIPTION
## Context

The viewport size was arbitrarily set to have a height of 800, not thinking about how big the snapshots would be. 

## Summary

Update template CLI that generates screenshots used in dashboard and page templates to be taller and set scale to 1 so we get as close to the recommended minimum poster height of 853px. Still doing 2:3 aspect ratio.

## Relevant Technical Choices

- Updates the viewport size on launch and then also the additional page that opens for the previews 
- Set the deviceScaleFactor to 1 so that we get an image that is 853px height instead of 1706px. 
- Some tweaks to the script for legibility and making sure all the pages run 
- Adjust how 'Explore templates' link is clicked - copy can change depending on how many "new" templates there are, so just looking for the label that starts with 'explore templates' instead.

## To-do

- will follow up with all the new assets to the static site

## User-facing changes

None 

## Testing Instructions

You can run the script locally, `npm run workflow:render-template-posters` 

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #9582
