### PR TITLE
Prevent history pollution caused by media backfilling

### DIFF
--- a/packages/story-editor/src/app/story/useStoryReducer/reducers/deleteElementsByResourceId.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducers/deleteElementsByResourceId.js
@@ -21,6 +21,8 @@
  *
  * If an empty id or a no matches with id, state is unchanged.
  *
+ * If no element with the given resource id is found, state is changed.
+ *
  * @param {Object} state Current state
  * @param {Object} payload Action payload
  * @param {string|null} payload.id id Delete all elements with this resource id
@@ -28,6 +30,14 @@
  */
 function deleteElementsByResourceId(state, { id }) {
   if (id === null) {
+    return state;
+  }
+
+  const hasElementWithResourceId = state.pages.some((page) =>
+    page.elements.some((element) => element.resource?.id === id)
+  );
+
+  if (!hasElementWithResourceId) {
     return state;
   }
 

--- a/packages/story-editor/src/app/story/useStoryReducer/reducers/updateElementsByResourceId.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/reducers/updateElementsByResourceId.js
@@ -26,6 +26,8 @@ import { updateElementWithUpdater } from './utils';
  *
  * If an empty id or a no matches with id, state is unchanged.
  *
+ * If no element with the given resource id is found, state is changed.
+ *
  * If given set of properties is empty, state is unchanged.
  *
  * Current selection and page is unchanged.
@@ -44,6 +46,15 @@ function updateElementsByResourceId(
   if (id === null) {
     return state;
   }
+
+  const hasElementWithResourceId = state.pages.some((page) =>
+    page.elements.some((element) => element.resource?.id === id)
+  );
+
+  if (!hasElementWithResourceId) {
+    return state;
+  }
+
   const updatedPages = state.pages.map((page) => {
     const updatedElements = page.elements.map((element) => {
       if (element.resource?.id === id) {
@@ -51,6 +62,7 @@ function updateElementsByResourceId(
       }
       return element;
     });
+
     return {
       ...page,
       elements: updatedElements,

--- a/packages/story-editor/src/app/story/useStoryReducer/test/arrangeElement.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/arrangeElement.js
@@ -21,7 +21,7 @@ import { LAYER_DIRECTIONS } from '../../../../constants';
 import { setupReducer } from './_utils';
 
 describe('arrangeElement', () => {
-  it('should do nothing if there is only two elements on page', () => {
+  it('should do nothing if there are only two elements on page', () => {
     const { restore, arrangeElement } = setupReducer();
 
     const initialState = restore({
@@ -36,7 +36,7 @@ describe('arrangeElement', () => {
 
     const result = arrangeElement({ elementId: '234', position: 0 });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should move element to specified position', () => {

--- a/packages/story-editor/src/app/story/useStoryReducer/test/arrangePage.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/arrangePage.js
@@ -29,7 +29,7 @@ describe('arrangePage', () => {
     });
 
     const result = arrangePage({ pageId: '111', position: 3 });
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should reorder a page to the specified position', () => {
@@ -56,14 +56,14 @@ describe('arrangePage', () => {
 
     // Reorder page 555 - doesn't exist
     const firstFailedAttempt = arrangePage({ pageId: '555', position: 2 });
-    expect(firstFailedAttempt).toStrictEqual(initialState);
+    expect(firstFailedAttempt).toBe(initialState);
 
     // Reorder page 333 to position 2 - it's already there
     const secondFailedAttempt = arrangePage({ pageId: '333', position: 2 });
-    expect(secondFailedAttempt).toStrictEqual(initialState);
+    expect(secondFailedAttempt).toBe(initialState);
 
     // Reorder page 333 to position 20 - outside bounds
     const thirdFailedAttempt = arrangePage({ pageId: '333', position: 20 });
-    expect(thirdFailedAttempt).toStrictEqual(initialState);
+    expect(thirdFailedAttempt).toBe(initialState);
   });
 });

--- a/packages/story-editor/src/app/story/useStoryReducer/test/arrangeSelection.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/arrangeSelection.js
@@ -42,7 +42,7 @@ describe('arrangeSelection', () => {
 
     const result = arrangeSelection({ position: 2 });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should do nothing if there is no selection', () => {
@@ -52,7 +52,7 @@ describe('arrangeSelection', () => {
 
     const result = arrangeSelection({ position: 2 });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should do nothing if there is multi-selection', () => {
@@ -62,7 +62,7 @@ describe('arrangeSelection', () => {
 
     const result = arrangeSelection({ position: 2 });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 });
 

--- a/packages/story-editor/src/app/story/useStoryReducer/test/clearBackgroundElement.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/clearBackgroundElement.js
@@ -75,7 +75,7 @@ describe('clearBackgroundElement', () => {
 
     const result = clearBackgroundElement();
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should keep overlay if present', () => {

--- a/packages/story-editor/src/app/story/useStoryReducer/test/combineElements.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/combineElements.js
@@ -29,7 +29,7 @@ describe('combineElements', () => {
     // Combine nothing into 789
     const result = combineElements({ secondId: '789' });
 
-    expect(result).toStrictEqual(initial);
+    expect(result).toBe(initial);
   });
 
   it('should do nothing if second element is missing', () => {
@@ -43,7 +43,7 @@ describe('combineElements', () => {
       firstElement: state.pages[0].elements[1],
     });
 
-    expect(result).toStrictEqual(initial);
+    expect(result).toBe(initial);
   });
 
   it('should do nothing if second element does not exist', () => {
@@ -58,7 +58,7 @@ describe('combineElements', () => {
       secondId: 'abc',
     });
 
-    expect(result).toStrictEqual(initial);
+    expect(result).toBe(initial);
   });
 
   it('should do nothing if first element does not have a resource', () => {
@@ -73,7 +73,7 @@ describe('combineElements', () => {
       secondId: '456',
     });
 
-    expect(result).toStrictEqual(initial);
+    expect(result).toBe(initial);
   });
 
   it('should combine elements when the origin does not exist as an element', () => {

--- a/packages/story-editor/src/app/story/useStoryReducer/test/deleteElementsById.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/deleteElementsById.js
@@ -100,7 +100,7 @@ describe('deleteElementsById', () => {
 
     const result = deleteElementsById({ elementIds: [] });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should do nothing if only unknown elements', () => {
@@ -124,7 +124,7 @@ describe('deleteElementsById', () => {
 
     const result = deleteElementsById({ elementIds: ['000', '999'] });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should remove any deleted elements from selection too', () => {

--- a/packages/story-editor/src/app/story/useStoryReducer/test/deleteElementsByResourceId.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/deleteElementsByResourceId.js
@@ -90,7 +90,7 @@ describe('deleteElementsByResourceId', () => {
       id: null,
     });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should do nothing if no elements with given id', () => {
@@ -122,6 +122,6 @@ describe('deleteElementsByResourceId', () => {
       id: '12',
     });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 });

--- a/packages/story-editor/src/app/story/useStoryReducer/test/deleteSelectedElements.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/deleteSelectedElements.js
@@ -69,6 +69,6 @@ describe('deleteSelectedElements', () => {
 
     const result = deleteSelectedElements();
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 });

--- a/packages/story-editor/src/app/story/useStoryReducer/test/reducer.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/reducer.js
@@ -28,6 +28,6 @@ describe('reducer', () => {
       payload: {},
     });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 });

--- a/packages/story-editor/src/app/story/useStoryReducer/test/setBackgroundElement.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/setBackgroundElement.js
@@ -139,7 +139,7 @@ describe('setBackgroundElement', () => {
     // 123 is already bg
     const result = setBackgroundElement({ elementId: '123' });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should do nothing if given unknown element', () => {
@@ -164,7 +164,7 @@ describe('setBackgroundElement', () => {
     // 000 doesn't exist - nothing happens
     const result = setBackgroundElement({ elementId: '000' });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should save default background element for later', () => {

--- a/packages/story-editor/src/app/story/useStoryReducer/test/updateElementById.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/updateElementById.js
@@ -91,6 +91,7 @@ describe('updateElementById', () => {
       properties: () => ({ id: '321' }),
     });
 
+    // TODO: Use .toBe() and ensure that the test still passes.
     expect(result).toStrictEqual(initial);
   });
 

--- a/packages/story-editor/src/app/story/useStoryReducer/test/updateElementsById.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/updateElementsById.js
@@ -101,23 +101,21 @@ describe('updateElementsById', () => {
     const { restore, updateElementsById } = setupReducer();
 
     // Set an initial state.
-    restore({
+    const initialState = restore({
       pages: [{ id: '111', elements: [{ id: '123' }, { id: '456' }] }],
       current: '111',
     });
 
     const result = updateElementsById({ elementIds: [], properties: { a: 1 } });
 
-    expect(result.pages).toStrictEqual([
-      { id: '111', elements: [{ id: '123' }, { id: '456' }] },
-    ]);
+    expect(result).toBe(initialState);
   });
 
   it('should do nothing if only unknown elements given', () => {
     const { restore, updateElementsById } = setupReducer();
 
     // Set an initial state.
-    restore({
+    const initialState = restore({
       pages: [{ id: '111', elements: [{ id: '123' }, { id: '456' }] }],
       current: '111',
     });
@@ -127,8 +125,6 @@ describe('updateElementsById', () => {
       properties: { a: 1 },
     });
 
-    expect(result.pages).toStrictEqual([
-      { id: '111', elements: [{ id: '123' }, { id: '456' }] },
-    ]);
+    expect(result).toBe(initialState);
   });
 });

--- a/packages/story-editor/src/app/story/useStoryReducer/test/updateElementsByResourceId.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/updateElementsByResourceId.js
@@ -213,7 +213,7 @@ describe('updateElementsByResourceId', () => {
       }),
     });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should do nothing if no elements with given id', () => {
@@ -249,6 +249,6 @@ describe('updateElementsByResourceId', () => {
       }),
     });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 });

--- a/packages/story-editor/src/app/story/useStoryReducer/test/updatePageProperties.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/updatePageProperties.js
@@ -32,7 +32,7 @@ describe('updatePageProperties', () => {
       properties: { x: 1 },
     });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should update properties of the given page', () => {

--- a/packages/story-editor/src/app/story/useStoryReducer/test/updateSelectedElements.js
+++ b/packages/story-editor/src/app/story/useStoryReducer/test/updateSelectedElements.js
@@ -65,7 +65,7 @@ describe('updateSelectedElements', () => {
 
     const result = updateSelectedElements({ properties: { a: 1 } });
 
-    expect(result).toStrictEqual(initialState);
+    expect(result).toBe(initialState);
   });
 
   it('should do nothing if elements selected and animation playing or scrubbing', () => {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

While testing #9638 I noticed that any existing media backfilling logic currently causes history pollution because `updateElementsByResourceId` updates state even if there are no elements in a story with the given resource ID.

## Summary

<!-- A brief description of what this PR does. -->

This PR makes `updateElementsByResourceId` more robust thanks to a short-circuit if there are no elements found with the given resource ID.

This prevents history pollution caused by media backfill logic.

## Relevant Technical Choices

<!-- Please describe your changes. -->

* Updates `updateElementsByResourceId` to do nothing if there's no element with the given resource ID
* Updates `deleteElementsByResourceId` to do nothing if there's no element with the given resource ID
* Updates tests for all other reducers to be more strict to prevent future regressions

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

The `updateElements` reducer could be made more robust in the future.

Right now, the following test fails when using `toBe()`:

https://github.com/google/web-stories-wp/blob/d4bb3eba1a09542ae91002dcfdaed4a5cdd0c4ba/packages/story-editor/src/app/story/useStoryReducer/test/updateElementById.js#L80-L95

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

None

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to Media -> Add New in WordPress and upload a video
2. Go to the story editor and observe the Network tab
3. See that a video poster for the new video has been generated and uploaded
4. See that the undo button below the canvas has become active.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
