### PR TITLE
Checklist: Add check for elements with links that take up > 80% screen

### DIFF
--- a/packages/story-editor/src/components/checklist/checklistContent/accessibilityChecks.js
+++ b/packages/story-editor/src/components/checklist/checklistContent/accessibilityChecks.js
@@ -23,6 +23,7 @@ import PropTypes from 'prop-types';
 import { __ } from '@web-stories-wp/i18n';
 import { ISSUE_TYPES } from '../constants';
 import ElementLinkTappableRegionTooSmall from '../checks/elementLinkTappableRegionTooSmall';
+import ElementLinkTappableRegionTooBig from '../checks/elementLinkTappableRegionTooBig';
 import ImageElementMissingAlt from '../checks/imageElementMissingAlt';
 import { PageBackgroundTextLowContrast } from '../checks/pageBackgroundLowTextContrast';
 import TextElementFontSizeTooSmall from '../checks/textElementFontSizeTooSmall';
@@ -84,6 +85,7 @@ export function AccessibilityChecks(props) {
         <VideoElementMissingDescription />
         {hasUploadMediaAction && <VideoElementMissingCaptions />}
         <ElementLinkTappableRegionTooSmall />
+        <ElementLinkTappableRegionTooBig />
         <ImageElementMissingAlt />
       </AccessibilityPanel>
     </ChecklistCategoryProvider>

--- a/packages/story-editor/src/components/checklist/checks/elementLinkTappableRegionTooBig.js
+++ b/packages/story-editor/src/components/checklist/checks/elementLinkTappableRegionTooBig.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo } from '@web-stories-wp/react';
+import { __ } from '@web-stories-wp/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useLayout, useStory } from '../../../app';
+import { useHighlights } from '../../../app/highlights';
+import { ACCESSIBILITY_COPY } from '../constants';
+import {
+  CARD_TYPE,
+  ChecklistCard,
+  DefaultFooterText,
+} from '../../checklistCard';
+import { LayerThumbnail, Thumbnail, THUMBNAIL_TYPES } from '../../thumbnail';
+import { filterStoryElements, getVisibleThumbnails } from '../utils';
+import { useRegisterCheck } from '../countContext';
+import { useIsChecklistMounted } from '../popupMountedContext';
+
+const MAX_LINK_SCREEN_PERCENT = 80;
+
+export function isElementLinkTappableRegionTooBig(element, pageSize) {
+  if (
+    !['text', 'image', 'shape', 'gif', 'video'].includes(element.type) ||
+    !element.link?.url?.length
+  ) {
+    return false;
+  }
+
+  const elementArea = element.width * element.height;
+  const canvasArea = pageSize.width * pageSize.height;
+  return (elementArea / canvasArea) * 100 > MAX_LINK_SCREEN_PERCENT;
+}
+
+const ElementLinkTappableRegionTooBig = () => {
+  const isChecklistMounted = useIsChecklistMounted();
+  const pages = useStory(({ state }) => state?.pages);
+  const pageSize = useLayout(({ state: { pageWidth, pageHeight } }) => ({
+    width: pageWidth,
+    height: pageHeight,
+  }));
+
+  const elements = useMemo(
+    () =>
+      pageSize.height > 0 &&
+      filterStoryElements(pages, (element) =>
+        isElementLinkTappableRegionTooBig(element, pageSize)
+      ),
+    [pages, pageSize]
+  );
+  const setHighlights = useHighlights(({ setHighlights }) => setHighlights);
+  const handleClick = useCallback(
+    (elementId, pageId) =>
+      setHighlights({
+        elementId,
+        pageId,
+      }),
+    [setHighlights]
+  );
+
+  const isRendered = elements.length > 0;
+  useRegisterCheck('ElementLinkTappableRegionTooBig', isRendered);
+
+  const { title, footer } = ACCESSIBILITY_COPY.linkTappableRegionTooBig;
+  return (
+    isRendered &&
+    isChecklistMounted && (
+      <ChecklistCard
+        title={title}
+        cardType={
+          elements.length > 1
+            ? CARD_TYPE.MULTIPLE_ISSUE
+            : CARD_TYPE.SINGLE_ISSUE
+        }
+        footer={<DefaultFooterText>{footer}</DefaultFooterText>}
+        thumbnailCount={elements.length}
+        thumbnail={
+          <>
+            {getVisibleThumbnails(elements).map((element) => (
+              <Thumbnail
+                key={element.id}
+                onClick={() => handleClick(element.id, element.pageId)}
+                type={THUMBNAIL_TYPES.TEXT}
+                displayBackground={<LayerThumbnail page={element} />}
+                aria-label={__('Go to offending link', 'web-stories')}
+              />
+            ))}
+          </>
+        }
+      />
+    )
+  );
+};
+
+export default ElementLinkTappableRegionTooBig;

--- a/packages/story-editor/src/components/checklist/checks/test/elementLinkTappableRegionTooBig.js
+++ b/packages/story-editor/src/components/checklist/checks/test/elementLinkTappableRegionTooBig.js
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Internal dependencies
+ */
+import { isElementLinkTappableRegionTooBig } from '../elementLinkTappableRegionTooBig';
+
+describe('isElementLinkTappableRegionTooBig', () => {
+  it('should return true if element tappable region is too big', () => {
+    const element = {
+      id: 'elementid',
+      type: 'text',
+      link: {
+        url: 'https://google.com',
+      },
+      content: 'G',
+      width: 300,
+      height: 500,
+    };
+    const pageSize = {
+      width: 336,
+      height: 504,
+    };
+    expect(isElementLinkTappableRegionTooBig(element, pageSize)).toBe(true);
+  });
+
+  it('should return false if element has large enough tappable region', () => {
+    const element = {
+      id: 'elementid',
+      type: 'text',
+      link: {
+        url: 'https://google.com',
+      },
+      content: 'G',
+      width: 150,
+      height: 100,
+    };
+    const pageSize = {
+      width: 336,
+      height: 504,
+    };
+    expect(isElementLinkTappableRegionTooBig(element, pageSize)).toBe(false);
+  });
+
+  it('should return false if not an element with link', () => {
+    const element = {
+      id: 'elementid',
+      type: 'text',
+      content: 'G',
+      width: 40,
+      height: 40,
+    };
+    const pageSize = {
+      width: 336,
+      height: 504,
+    };
+    expect(isElementLinkTappableRegionTooBig(element, pageSize)).toBe(false);
+  });
+
+  it('should return false for an element of an unknown type', () => {
+    const element = {
+      id: 'elementid',
+      type: 'unknown',
+      link: {
+        url: 'https://google.com',
+      },
+      content: 'G',
+      width: 40,
+      height: 40,
+    };
+    const pageSize = {
+      width: 336,
+      height: 504,
+    };
+    expect(isElementLinkTappableRegionTooBig(element, pageSize)).toBe(false);
+  });
+});

--- a/packages/story-editor/src/components/checklist/constants.js
+++ b/packages/story-editor/src/components/checklist/constants.js
@@ -93,6 +93,13 @@ export const ACCESSIBILITY_COPY = {
       'web-stories'
     ),
   },
+  linkTappableRegionTooBig: {
+    title: __('Decrease link area', 'web-stories'),
+    footer: __(
+      'Links cannot cover a large majority of the page. Use smaller elements for links.',
+      'web-stories'
+    ),
+  },
   linkTappableRegionTooSmall: {
     title: sprintf(
       /* translators: %s: minimum tappable region size width x minimum tappable region size height. */

--- a/packages/story-editor/src/components/checklist/constants.js
+++ b/packages/story-editor/src/components/checklist/constants.js
@@ -94,7 +94,7 @@ export const ACCESSIBILITY_COPY = {
     ),
   },
   linkTappableRegionTooBig: {
-    title: __('Decrease link area', 'web-stories'),
+    title: __('Reduce link size', 'web-stories'),
     footer: __(
       'Links cannot cover a large majority of the page. Use smaller elements for links.',
       'web-stories'


### PR DESCRIPTION
## Context

Elements with links that take up more than 80% of the screen will have the link ignored in the story (https://github.com/ampproject/amphtml/issues/31108) so we're adding a checklist issue to help prevent this ahead of publishing stories.

## Summary

Issue mirrors the check for elements with links that are too small to tap and follows this structure: https://github.com/raxsha/amphtml/blob/8823d1feffdeaa85b1cc3d96474846cddacb77b6/extensions/amp-story/1.0/page-advancement.js#L574-L596

Looks like this: 
![Screen Shot 2021-11-08 at 11 21 49 AM](https://user-images.githubusercontent.com/10720454/140797066-190b29bb-69f2-4375-b361-d710e74619e4.png)


## Relevant Technical Choices

- Grabbing the canvas size from `useLayout`
- Everything else is pretty standard checklist stuff

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

If you have an element with a link that takes up 80% or more of the canvas you'll see a new accessibility warning like the one screenshot above.

## Testing Instructions
<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.Make a story
2. Add an element
3. Give it a link
4. Now make it really big and see the new issue pop up in the accessibility part of the checklist (make sure the a11y section is available first by either early attempt publish or add more than 2 pages)

## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6735 
