### PR TITLE
Dashboard: Next and Previous page buttons should retain focus

### DIFF
--- a/packages/dashboard/src/app/views/exploreTemplates/content/templateGridItem.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/content/templateGridItem.js
@@ -22,6 +22,7 @@ import {
   Button,
   BUTTON_SIZES,
   BUTTON_TYPES,
+  noop,
 } from '@web-stories-wp/design-system';
 import { forwardRef } from '@web-stories-wp/react';
 import PropTypes from 'prop-types';
@@ -57,6 +58,7 @@ const TemplateGridItem = forwardRef(
       slug,
       title,
       status,
+      onSeeDetailsClick = noop,
     },
     ref
   ) => {
@@ -103,6 +105,7 @@ const TemplateGridItem = forwardRef(
                     title
                   )}
                   href={detailLink}
+                  onClick={onSeeDetailsClick}
                   disabled={!detailLink}
                   className={FOCUS_TEMPLATE_CLASS}
                   tabIndex={tabIndex}
@@ -139,6 +142,7 @@ TemplateGridItem.propTypes = {
   detailLink: PropTypes.string,
   onCreateStory: PropTypes.func,
   onFocus: PropTypes.func.isRequired,
+  onSeeDetailsClick: PropTypes.func,
   height: PropTypes.number.isRequired,
   id: PropTypes.number.isRequired,
   isActive: PropTypes.bool,

--- a/packages/dashboard/src/app/views/exploreTemplates/content/templateGridView.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/content/templateGridView.js
@@ -32,7 +32,7 @@ import { useGridViewKeys } from '@web-stories-wp/design-system';
 /**
  * Internal dependencies
  */
-import { CardGrid } from '../../../../components';
+import { CardGrid, useLayoutContext } from '../../../../components';
 import {
   PageSizePropType,
   TemplatesPropType,
@@ -47,6 +47,10 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
   const containerRef = useRef();
   const gridRef = useRef();
   const itemRefs = useRef({});
+
+  const {
+    actions: { scrollToTop },
+  } = useLayoutContext();
 
   const [activeGridItemId, setActiveGridItemId] = useState(null);
 
@@ -96,6 +100,7 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
               onFocus={() => {
                 setActiveGridItemId(id);
               }}
+              onSeeDetailsClick={scrollToTop}
               height={pageSize.height}
               id={id}
               isActive={isActive}
@@ -111,7 +116,7 @@ function TemplateGridView({ pageSize, templates, templateActions }) {
           );
         }
       ),
-    [templates, activeGridItemId, pageSize.height, handleUseStory]
+    [templates, activeGridItemId, pageSize.height, handleUseStory, scrollToTop]
   );
   return (
     <div ref={containerRef}>

--- a/packages/dashboard/src/app/views/templateDetails/content/detailsGallery/index.js
+++ b/packages/dashboard/src/app/views/templateDetails/content/detailsGallery/index.js
@@ -106,9 +106,7 @@ function DetailsGallery({
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.CIRCLE}
         aria-label={__('View previous template', 'web-stories')}
-        onClick={({ currentTarget }) => {
-          // blurring target here because memoized button remains active on click
-          currentTarget.blur();
+        onClick={() => {
           switchToTemplateByOffset(-1);
         }}
         disabled={!orderedTemplatesLength || activeTemplateIndex === 0}
@@ -123,9 +121,7 @@ function DetailsGallery({
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.CIRCLE}
         aria-label={__('View next template', 'web-stories')}
-        onClick={({ currentTarget }) => {
-          // blurring target here because memoized button remains active on click
-          currentTarget.blur();
+        onClick={() => {
           switchToTemplateByOffset(1);
         }}
         disabled={

--- a/packages/dashboard/src/app/views/templateDetails/content/index.js
+++ b/packages/dashboard/src/app/views/templateDetails/content/index.js
@@ -17,7 +17,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useEffect, useRef } from '@web-stories-wp/react';
 
 /**
  * Internal dependencies
@@ -28,7 +27,7 @@ import {
   PageSizePropType,
   TemplatePropType,
 } from '../../../../types';
-import { Layout, useLayoutContext } from '../../../../components';
+import { Layout } from '../../../../components';
 import DetailsGallery from './detailsGallery';
 import RelatedGrid from './relatedGrid';
 
@@ -42,19 +41,6 @@ function Content({
   template,
   templateActions,
 }) {
-  const previousTemplateId = useRef(template?.id);
-
-  const {
-    actions: { scrollToTop },
-  } = useLayoutContext();
-
-  useEffect(() => {
-    if (template !== null && template?.id !== previousTemplateId.current) {
-      scrollToTop();
-      previousTemplateId.current = template.id;
-    }
-  }, [template, scrollToTop]);
-
   if (!template) {
     return null;
   }


### PR DESCRIPTION
## Context



## Summary

Clicking or using the keyboard to switch between templates should keep the focus on the button.

## Relevant Technical Choices

Removed code that would blur the buttons on click. This was removing focus from the buttons and focusing the body instead. However, this keeps the buttons in the `:active` state.

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![old](https://user-images.githubusercontent.com/22185279/140809991-228c200b-e3e4-4ed8-a1ca-134bc31d29fb.gif)|![new](https://user-images.githubusercontent.com/22185279/140809969-a4f81593-3fc6-4ed2-8048-2666770e71b3.gif)|

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. View template details by selecting the `See details` button for a template from the `Explore Templates` page
2. Click the `previous` and `next` buttons. The should keep focus
3. Use your keyboard to hit the same buttons. The buttons should retain focus.
4. Clicking the `See Details` buttons for related templates should scroll the page to the top and focus the `close` button at the top of the page still.

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9537
