### PR TITLE
Design System: Improve tooltips position in RTL

### DIFF
--- a/packages/design-system/src/components/popup/utils/getOffset.js
+++ b/packages/design-system/src/components/popup/utils/getOffset.js
@@ -119,5 +119,6 @@ export function getOffset(placement, spacing, anchor, dock, popup) {
     height: anchorRect.height,
     // We want to know where the popRect container stops before scrolling begins
     bottom: popupRect?.bottom,
+    popupLeft: popupRect?.left,
   };
 }

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -129,29 +129,30 @@ function Tooltip({
     [placement]
   );
 
-  // When near the bottom of the viewport and the tooltip is placed on the bottom we want to force the tooltip to the top as to not
+  // When near the edge of the viewport we want to force the tooltip to a new placement as to not
   // cutoff the contents of the tooltip.
   const positionPlacement = useCallback(
     ({ offset }) => {
-      // check to see if there's an overlap with the window edge
+      // check to see if there's an overlap with the window's bottom edge
       const neededVerticalSpace = offset.bottom;
-      // if the tooltip was assigned as bottom we want to always check it
-      if (
-        offset &&
+      const shouldMoveToTop =
         dynamicPlacement.startsWith('bottom') &&
-        neededVerticalSpace >= window.innerHeight
-      ) {
-        setDynamicPlacement(PLACEMENT.TOP);
-      }
+        neededVerticalSpace >= window.innerHeight;
+
       // in RTL mode, we can sometimes render a tooltip too far to the left
-      const isOverFlowingX = offset.popupLeft < 0;
-      if (isOverFlowingX) {
-        switch (dynamicPlacement) {
-          case dynamicPlacement.endsWith('start'):
-            setDynamicPlacement(`${placement}-end`);
+      const isOverFlowingLeft = offset.popupLeft < 0;
+
+      if (shouldMoveToTop && !isOverFlowingLeft) {
+        setDynamicPlacement(PLACEMENT.TOP);
+      } else if (shouldMoveToTop && isOverFlowingLeft) {
+        setDynamicPlacement(PLACEMENT.TOP_START);
+      } else if (!shouldMoveToTop && isOverFlowingLeft) {
+        switch (placement) {
+          case placement.endsWith('start'):
+            setDynamicPlacement(placement.replace('-start', '-end'));
             break;
           case dynamicPlacement.endsWith('end'):
-            setDynamicPlacement(`${placement}-start`);
+            setDynamicPlacement(placement.replace('-end', '-start'));
             break;
           default:
             setDynamicPlacement(`${placement}-start`);

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -133,14 +133,28 @@ function Tooltip({
   const updatePlacement = useCallback(() => {
     const currentPlacement = placementRef.current;
     switch (currentPlacement) {
-      case currentPlacement.endsWith('start'):
-        setDynamicPlacement(currentPlacement.replace('-start', '-end'));
+      case PLACEMENT.BOTTOM_START:
+      case PLACEMENT.TOP_START:
+      case PLACEMENT.RIGHT_START:
+        // {placement}-START shouldn't ever appear in overflow so do nothing
         break;
-      case currentPlacement.endsWith('end'):
+      case PLACEMENT.BOTTOM_END:
+      case PLACEMENT.TOP_END:
+      case PLACEMENT.RIGHT_END:
         setDynamicPlacement(currentPlacement.replace('-end', '-start'));
+        break;
+      case PLACEMENT.LEFT_END:
+        setDynamicPlacement(PLACEMENT.RIGHT_END);
+        break;
+      case PLACEMENT.LEFT_START:
+        setDynamicPlacement(PLACEMENT.RIGHT_START);
+        break;
+      case PLACEMENT.LEFT:
+        setDynamicPlacement(PLACEMENT.RIGHT);
         break;
       default:
         setDynamicPlacement(`${currentPlacement}-start`);
+        break;
     }
   }, []);
 

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -143,8 +143,22 @@ function Tooltip({
       ) {
         setDynamicPlacement(PLACEMENT.TOP);
       }
+      // in RTL mode, we can sometimes render a tooltip too far to the left
+      const isOverFlowingX = offset.popupLeft < 0;
+      if (isOverFlowingX) {
+        switch (dynamicPlacement) {
+          case dynamicPlacement.endsWith('start'):
+            setDynamicPlacement(`${placement}-end`);
+            break;
+          case dynamicPlacement.endsWith('end'):
+            setDynamicPlacement(`${placement}-start`);
+            break;
+          default:
+            setDynamicPlacement(`${placement}-start`);
+        }
+      }
     },
-    [dynamicPlacement]
+    [dynamicPlacement, placement]
   );
 
   const positionArrow = useCallback(

--- a/packages/design-system/src/components/tooltip/index.js
+++ b/packages/design-system/src/components/tooltip/index.js
@@ -147,19 +147,20 @@ function Tooltip({
       } else if (shouldMoveToTop && isOverFlowingLeft) {
         setDynamicPlacement(PLACEMENT.TOP_START);
       } else if (!shouldMoveToTop && isOverFlowingLeft) {
-        switch (placement) {
-          case placement.endsWith('start'):
-            setDynamicPlacement(placement.replace('-start', '-end'));
+        const currentPlacement = placementRef.current;
+        switch (currentPlacement) {
+          case currentPlacement.endsWith('start'):
+            setDynamicPlacement(currentPlacement.replace('-start', '-end'));
             break;
-          case dynamicPlacement.endsWith('end'):
-            setDynamicPlacement(placement.replace('-end', '-start'));
+          case currentPlacement.endsWith('end'):
+            setDynamicPlacement(currentPlacement.replace('-end', '-start'));
             break;
           default:
-            setDynamicPlacement(`${placement}-start`);
+            setDynamicPlacement(`${currentPlacement}-start`);
         }
       }
     },
-    [dynamicPlacement, placement]
+    [dynamicPlacement]
   );
 
   const positionArrow = useCallback(

--- a/packages/story-editor/src/components/panels/design/sizePosition/radius.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/radius.js
@@ -21,14 +21,18 @@ import PropTypes from 'prop-types';
 import { useCallback } from '@web-stories-wp/react';
 import styled from 'styled-components';
 import { __ } from '@web-stories-wp/i18n';
-import { LockToggle, Icons } from '@web-stories-wp/design-system';
+import {
+  LockToggle,
+  Icons,
+  PLACEMENT,
+  Tooltip,
+} from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
  */
 import { StackableGroup, StackableInput } from '../../../form/stackable';
 import { canMaskHaveBorder } from '../../../../masks';
-import Tooltip from '../../../tooltip';
 import { useCommonObjectValue, focusStyle } from '../../shared';
 import { MULTIPLE_DISPLAY_VALUE, MULTIPLE_VALUE } from '../../../../constants';
 
@@ -207,7 +211,11 @@ function RadiusControls({ selectedElements, pushUpdateForObject }) {
       </StackableGroup>
 
       <LockContainer>
-        <Tooltip title={__('Toggle consistent corner radius', 'web-stories')}>
+        <Tooltip
+          title={__('Toggle consistent corner radius', 'web-stories')}
+          placement={PLACEMENT.BOTTOM_START}
+          key={borderRadius.locked}
+        >
           <StyledLockToggle
             isLocked={borderRadius.locked}
             onClick={() => handleLockChange(!borderRadius.locked)}

--- a/packages/story-editor/src/components/panels/design/sizePosition/radius.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/radius.js
@@ -21,12 +21,7 @@ import PropTypes from 'prop-types';
 import { useCallback } from '@web-stories-wp/react';
 import styled from 'styled-components';
 import { __ } from '@web-stories-wp/i18n';
-import {
-  LockToggle,
-  Icons,
-  PLACEMENT,
-  Tooltip,
-} from '@web-stories-wp/design-system';
+import { LockToggle, Icons, Tooltip } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -213,7 +208,6 @@ function RadiusControls({ selectedElements, pushUpdateForObject }) {
       <LockContainer>
         <Tooltip
           title={__('Toggle consistent corner radius', 'web-stories')}
-          placement={PLACEMENT.BOTTOM_START}
           key={borderRadius.locked}
         >
           <StyledLockToggle

--- a/packages/story-editor/src/components/panels/design/sizePosition/radius.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/radius.js
@@ -21,7 +21,7 @@ import PropTypes from 'prop-types';
 import { useCallback } from '@web-stories-wp/react';
 import styled from 'styled-components';
 import { __ } from '@web-stories-wp/i18n';
-import { LockToggle, Icons, Tooltip } from '@web-stories-wp/design-system';
+import { LockToggle, Icons } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -30,6 +30,7 @@ import { StackableGroup, StackableInput } from '../../../form/stackable';
 import { canMaskHaveBorder } from '../../../../masks';
 import { useCommonObjectValue, focusStyle } from '../../shared';
 import { MULTIPLE_DISPLAY_VALUE, MULTIPLE_VALUE } from '../../../../constants';
+import Tooltip from '../../../tooltip';
 
 const DEFAULT_BORDER_RADIUS = {
   topLeft: 0,

--- a/packages/story-editor/src/components/panels/design/sizePosition/radius.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/radius.js
@@ -208,7 +208,7 @@ function RadiusControls({ selectedElements, pushUpdateForObject }) {
       <LockContainer>
         <Tooltip
           title={__('Toggle consistent corner radius', 'web-stories')}
-          key={borderRadius.locked}
+          key={borderRadius.locked.toString()}
         >
           <StyledLockToggle
             isLocked={borderRadius.locked}

--- a/packages/story-editor/src/components/panels/design/sizePosition/radius.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/radius.js
@@ -209,6 +209,8 @@ function RadiusControls({ selectedElements, pushUpdateForObject }) {
       <LockContainer>
         <Tooltip
           title={__('Toggle consistent corner radius', 'web-stories')}
+          // Key is needed to remount the component when `borderRadius.locked` changes. Otherwise when toggle is open,
+          // tooltip may cover content.
           key={borderRadius.locked.toString()}
         >
           <StyledLockToggle

--- a/packages/story-editor/src/components/panels/design/sizePosition/sizePosition.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/sizePosition.js
@@ -34,6 +34,8 @@ import {
   BUTTON_TYPES,
   BUTTON_SIZES,
   BUTTON_VARIANTS,
+  PLACEMENT,
+  Tooltip,
 } from '@web-stories-wp/design-system';
 
 /**
@@ -49,7 +51,6 @@ import {
   inputContainerStyleOverride,
   useCommonObjectValue,
 } from '../../shared';
-import Tooltip from '../../../tooltip';
 import useStory from '../../../../app/story/useStory';
 import { getMediaBaseColor } from '../../../../utils/getMediaBaseColor';
 import usePerformanceTracking from '../../../../utils/usePerformanceTracking';
@@ -375,7 +376,10 @@ function SizePositionPanel(props) {
           />
         </Area>
         <Area area="l">
-          <Tooltip title={__('Lock aspect ratio', 'web-stories')}>
+          <Tooltip
+            title={__('Lock aspect ratio', 'web-stories')}
+            placement={PLACEMENT.BOTTOM_START}
+          >
             <StyledLockToggle
               aria-label={__('Lock aspect ratio', 'web-stories')}
               title={__('Lock aspect ratio', 'web-stories')}

--- a/packages/story-editor/src/components/panels/design/sizePosition/sizePosition.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/sizePosition.js
@@ -34,7 +34,6 @@ import {
   BUTTON_TYPES,
   BUTTON_SIZES,
   BUTTON_VARIANTS,
-  PLACEMENT,
   Tooltip,
 } from '@web-stories-wp/design-system';
 
@@ -376,10 +375,7 @@ function SizePositionPanel(props) {
           />
         </Area>
         <Area area="l">
-          <Tooltip
-            title={__('Lock aspect ratio', 'web-stories')}
-            placement={PLACEMENT.BOTTOM_START}
-          >
+          <Tooltip title={__('Lock aspect ratio', 'web-stories')}>
             <StyledLockToggle
               aria-label={__('Lock aspect ratio', 'web-stories')}
               title={__('Lock aspect ratio', 'web-stories')}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Tooltip placement is normally repositioned _if_ the tip will be cutoff by the edge of the window. However, in the edge case where a tooltip is on a toggle that reveals a menu, the tooltip can cover newly shown buttons, lists, etc. As is the case with the `toggle consistent corner radius` tip on the corner radius toggle button. 

## Summary

<!-- A brief description of what this PR does. -->
When the tooltip toggle button is switched from one state to another, we are remounting the tooltip. This will reposition the tooltip's anchor. It will also close the tooltip even though the button, ie. tooltip anchor is still in focus. 

While digging into the tooltip used within the `radius` toggle button I stumbled across a couple issues. ~~First, the `Radius` component, as well and the `SizePosition` component were not using the `Tooltip` from `Design System`. By importing it directly, those components were not receiving the RTL mapping for `placement`.~~ [see comment thread](https://github.com/google/web-stories-wp/pull/9668#discussion_r746758391) Secondly,  in RTL mode the tooltips are cutoff on the left side of the screen. There is an offset where if a tooltip is cut off on the right edge of the window we offset the anchor point. This forces it to render up against the edge of the window. However, this doesn't apply in RTL. 

## Relevant Technical Choices

<!-- Please describe your changes. -->
Since we use quite a few tooltips, tracking the anchor's location on the screen and repositioning it every time they change seemed a bit overkill for this edge case. Remounting seemed the smart choice.

Added a switch case in the if statement within `Tooltip`'s `positionPlacement` callback to solve the cutoff in RTL mode. If the popup would normally be rendered outside of the window, we are updating the placement to `{placement}-end`. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

### AFTER

https://user-images.githubusercontent.com/1820266/140964557-239adcd8-4dbe-455c-b7b7-bb128defc068.mov



https://user-images.githubusercontent.com/1820266/140964548-cbac9c6f-19dd-4a8c-b50b-7f6bb226b2e8.mov



https://user-images.githubusercontent.com/1820266/140964532-1f0edb79-98ae-489c-b37b-7dc450c2767a.mov


https://user-images.githubusercontent.com/1820266/140964543-1c3ac0e8-0177-4e5e-8930-c19c1118d4cc.mov




### BEFORE



https://user-images.githubusercontent.com/1820266/140965561-e4075235-1844-48f3-9b5c-206136a7c0c2.mov


https://user-images.githubusercontent.com/1820266/140965571-865783bd-ab8e-4b1e-b5bc-c5e49e60ed7d.mov


https://user-images.githubusercontent.com/1820266/140965578-e343cd56-49ab-4bf8-bc74-69908b490346.mov


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Select an image on the canvas.
2. In the `Design` tab select the `Selection` dropdown / panel
3. Hover on the Lock Icon for `Radius` - you should see the tooltip 
4. Click on the lock icon. This should reveal/hide a menu with the different radius options. During reveal/hide the tooltip should no longer show until the next time you hover (or select icon via keyboard)
5. Check RTL mode!!
6. In RTL mode the same tooltip for the `radius` icon should no longer be cutoff by the edge of the screen. This goes for all tooltips on the far left ( found by hover on `radius` lock icon, `aspect ratio` lock icon, and `align bottom`) 
7. Lastly, check bottom cutoff still works in both RTL and LTR 
8. Open `Document` tab and go to `Background Audio` panel
9. Adjust window so that the trash can icon is just in view
10. Hover the trash can, tooltip should show above the icon, and not be cutoff the edge of the screen. 


## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9598
