### PR TITLE
3P Media: Update label for search results

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/media3p/providerPanel.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/providerPanel.js
@@ -117,7 +117,9 @@ function ProviderPanel({ providerType, isActive, searchTerm, ...rest }) {
         data-testid={'media-subheading'}
         shouldDisplay={shouldDisplayMediaSubheading}
       >
-        {searchTerm.length ? searchResultsLabel : displayName}
+        {searchTerm.length && !state.categories.selectedCategoryId
+          ? searchResultsLabel
+          : displayName}
       </MediaSubheading>
       <PaginatedMediaGallery
         providerType={providerType}

--- a/packages/story-editor/src/components/library/panes/media/media3p/providerPanel.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/providerPanel.js
@@ -100,6 +100,9 @@ function ProviderPanel({ providerType, isActive, searchTerm, ...rest }) {
   const shouldDisplayMediaSubheading = Boolean(
     state.media?.length || state.categories.selectedCategoryId
   );
+  // When displaying search results, subHeading should be updated to reflect so
+  const searchResultsLabel = __('Search Results', 'web-stories');
+
   return (
     <ProviderWrapper {...rest}>
       {PROVIDERS[providerType].supportsCategories && (
@@ -114,7 +117,7 @@ function ProviderPanel({ providerType, isActive, searchTerm, ...rest }) {
         data-testid={'media-subheading'}
         shouldDisplay={shouldDisplayMediaSubheading}
       >
-        {displayName}
+        {searchTerm.length ? searchResultsLabel : displayName}
       </MediaSubheading>
       <PaginatedMediaGallery
         providerType={providerType}

--- a/packages/story-editor/src/components/library/panes/media/media3p/test/media3pPane.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/test/media3pPane.js
@@ -227,6 +227,18 @@ describe('Media3pPane', () => {
     expect(container.querySelector('input')).toBeEnabled();
   });
 
+  it('should render <Media3pPane /> with the "Search Results" text', () => {
+    useMediaResult.media3p.PROVIDER_1.state.isMediaLoaded = true;
+    useMediaResult.media3p.PROVIDER_1.state.media = MEDIA;
+    useMediaResult.searchTerm = 'cats';
+    renderWithTheme(<Media3pPane isActive />);
+
+    const subHeading = screen.getByTestId('media-subheading');
+
+    expect(getComputedStyle(subHeading).display).not.toBe('none');
+    expect(subHeading).toHaveTextContent('Search Results');
+  });
+
   it('should render <Media3pPane /> with disabled search when a category is selected', () => {
     useMediaResult.media3p.PROVIDER_1.state.isMediaLoaded = true;
     useMediaResult.media3p.PROVIDER_1.state.media = MEDIA;
@@ -241,6 +253,7 @@ describe('Media3pPane', () => {
   it('should render <Media3pPane /> with the category display name when selected', () => {
     useMediaResult.media3p.PROVIDER_1.state.isMediaLoaded = true;
     useMediaResult.media3p.PROVIDER_1.state.media = MEDIA;
+    useMediaResult.searchTerm = '';
     renderWithTheme(<Media3pPane isActive />);
 
     const subHeading = screen.getByTestId('media-subheading');


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
In `3pMedia` tab, it can be confusing what is being displayed after entering a search term. The subheader above the results displays `Trending` no matter if you have searched or not. 


## Summary

<!-- A brief description of what this PR does. -->
When searching for 3pMedia, we want display the subheading just above the results with the text `Search Results` since this more inline with what is being displayed. As opposed to showing a subheading of `Trending`. Category name still takes precedent when filtered by a category. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. In 3pMedia tab, enter a search term. You should see `Search Results` instead of the `Trending` text. 
2. If you select a category to filter by, the subheading should be the Category text. ie. "Wallpapers`

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->
no
### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->
no
### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
no
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #3903 
