### PR TITLE
Page Templates: Default view set in localStorage

### DIFF
--- a/packages/design-system/src/utils/localStore.js
+++ b/packages/design-system/src/utils/localStore.js
@@ -30,6 +30,7 @@ export const LOCAL_STORAGE_PREFIX = {
     'web_stories_delete_color_preset_dialog_dismissed',
   DELETE_STYLE_PRESET_DIALOG_DISMISSED:
     'web_stories_delete_style_preset_dialog_dismissed',
+  DEFAULT_VIEW_PAGE_TEMPLATE_LAYOUT: 'web_stories_default_template_view',
 };
 
 function getItemByKey(key) {

--- a/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
@@ -26,6 +26,10 @@ import {
 import styled from 'styled-components';
 import { __ } from '@web-stories-wp/i18n';
 import { FULLBLEED_RATIO, PAGE_RATIO } from '@web-stories-wp/units';
+import {
+  localStore,
+  LOCAL_STORAGE_PREFIX,
+} from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -65,8 +69,9 @@ const ButtonWrapper = styled.div`
 const DEFAULT = 'default';
 const SAVED = 'saved';
 const PAGE_TEMPLATE_PANE_WIDTH = 158;
-const LOCAL_STORAGE_KEY = 'web_stories_default_template_view';
-const DEFAULT_TEMPLATE_VIEW = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+const LOCAL_STORAGE_KEY =
+  LOCAL_STORAGE_PREFIX.DEFAULT_VIEW_PAGE_TEMPLATE_LAYOUT;
+const DEFAULT_TEMPLATE_VIEW = localStore.getItemByKey(LOCAL_STORAGE_KEY);
 
 function PageTemplatesPane(props) {
   const {
@@ -95,6 +100,7 @@ function PageTemplatesPane(props) {
     (page) => {
       setSavedTemplates([page, ...(savedTemplates || [])]);
       setHighlightedTemplate(page.id);
+      localStore.setItemByKey(LOCAL_STORAGE_KEY, SAVED);
     },
     [setSavedTemplates, savedTemplates]
   );
@@ -133,7 +139,7 @@ function PageTemplatesPane(props) {
 
   const handleToggle = (evt, value) => {
     setShowDefaultTemplates(value === DEFAULT);
-    window.localStorage.setItem(
+    localStore.setItemByKey(
       LOCAL_STORAGE_KEY,
       showDefaultTemplates ? SAVED : DEFAULT
     );

--- a/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
@@ -137,8 +137,8 @@ function PageTemplatesPane(props) {
     setNextTemplatesToFetch,
   ]);
 
-  const handleToggle = (evt, value) => {
-    setShowDefaultTemplates(value === DEFAULT);
+  const handleToggle = () => {
+    setShowDefaultTemplates(!showDefaultTemplates);
     localStore.setItemByKey(LOCAL_STORAGE_KEY, !showDefaultTemplates);
   };
 
@@ -190,7 +190,7 @@ function PageTemplatesPane(props) {
             <Select
               options={options}
               selectedValue={showDefaultTemplates ? DEFAULT : SAVED}
-              onMenuItemClick={(evt, value) => handleToggle(evt, value)}
+              onMenuItemClick={handleToggle}
               aria-label={__('Select templates type', 'web-stories')}
             />
           </DropDownWrapper>

--- a/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
@@ -57,14 +57,16 @@ const DropDownWrapper = styled.div`
   margin: 28px 16px 17px;
 `;
 
-const DEFAULT = 'default';
-const SAVED = 'saved';
-const PAGE_TEMPLATE_PANE_WIDTH = 158;
-
 const ButtonWrapper = styled.div`
   padding: 0 1em;
   margin-top: 24px;
 `;
+
+const DEFAULT = 'default';
+const SAVED = 'saved';
+const PAGE_TEMPLATE_PANE_WIDTH = 158;
+const LOCAL_STORAGE_KEY = 'web_stories_default_template_view';
+const DEFAULT_TEMPLATE_VIEW = window.localStorage.getItem(LOCAL_STORAGE_KEY);
 
 function PageTemplatesPane(props) {
   const {
@@ -83,7 +85,9 @@ function PageTemplatesPane(props) {
     setNextTemplatesToFetch: state.actions.setNextTemplatesToFetch,
   }));
 
-  const [showDefaultTemplates, setShowDefaultTemplates] = useState(true);
+  const [showDefaultTemplates, setShowDefaultTemplates] = useState(
+    DEFAULT_TEMPLATE_VIEW === SAVED ? false : true
+  );
   const [highlightedTemplate, setHighlightedTemplate] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -126,6 +130,14 @@ function PageTemplatesPane(props) {
     savedTemplates,
     setNextTemplatesToFetch,
   ]);
+
+  const handleToggle = (evt, value) => {
+    setShowDefaultTemplates(value === DEFAULT);
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      showDefaultTemplates ? SAVED : DEFAULT
+    );
+  };
 
   useEffect(() => {
     if (!savedTemplates && !showDefaultTemplates) {
@@ -175,9 +187,7 @@ function PageTemplatesPane(props) {
             <Select
               options={options}
               selectedValue={showDefaultTemplates ? DEFAULT : SAVED}
-              onMenuItemClick={(evt, value) =>
-                setShowDefaultTemplates(value === DEFAULT)
-              }
+              onMenuItemClick={(evt, value) => handleToggle(evt, value)}
               aria-label={__('Select templates type', 'web-stories')}
             />
           </DropDownWrapper>

--- a/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
@@ -91,7 +91,7 @@ function PageTemplatesPane(props) {
   }));
 
   const [showDefaultTemplates, setShowDefaultTemplates] = useState(
-    DEFAULT_TEMPLATE_VIEW === SAVED ? false : true
+    DEFAULT_TEMPLATE_VIEW === null ? true : DEFAULT_TEMPLATE_VIEW
   );
   const [highlightedTemplate, setHighlightedTemplate] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -100,7 +100,7 @@ function PageTemplatesPane(props) {
     (page) => {
       setSavedTemplates([page, ...(savedTemplates || [])]);
       setHighlightedTemplate(page.id);
-      localStore.setItemByKey(LOCAL_STORAGE_KEY, SAVED);
+      localStore.setItemByKey(LOCAL_STORAGE_KEY, false);
     },
     [setSavedTemplates, savedTemplates]
   );
@@ -139,10 +139,7 @@ function PageTemplatesPane(props) {
 
   const handleToggle = (evt, value) => {
     setShowDefaultTemplates(value === DEFAULT);
-    localStore.setItemByKey(
-      LOCAL_STORAGE_KEY,
-      showDefaultTemplates ? SAVED : DEFAULT
-    );
+    localStore.setItemByKey(LOCAL_STORAGE_KEY, !showDefaultTemplates);
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Users that frequently use `Saved Templates` have to toggle to them every time they open the templates layout panel. 

## Summary

<!-- A brief description of what this PR does. -->
When users toggle to `Saved Templates` in Template Layouts, we want to preserve the last viewed templates as the default view the next time they open the templates panel

## Relevant Technical Choices

<!-- Please describe your changes. -->
Storing current template list in localStorage. If it is not there, we still default to the default template list. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open `Templates Layout` in editor
2. Select `Saved Templates` 
3. Navigate to any other page, or hard refresh.
4. The next time you come to the editor and open the `Templates Layout` panel, the `Saved Templates `should appear first. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9637 
