### PR TITLE
CORS Proxy: Use file stream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
     "wp-coding-standards/wpcs": "^2.3",
     "yoast/wp-test-utils": "^1.0.0"
   },
+  "suggest": {
+    "ext-curl": "Used for modifying cURL requests in CORS proxy"
+  },
   "config": {
     "discard-changes": true,
     "platform": {

--- a/includes/REST_API/Hotlinking_Controller.php
+++ b/includes/REST_API/Hotlinking_Controller.php
@@ -297,7 +297,7 @@ class Hotlinking_Controller extends REST_Controller implements HasRequirements {
 		if ( WP_DEBUG ) {
 			$this->stream_handle = fopen( 'php://temp', 'wb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
 		} else {
-			$this->stream_handle = @fopen( 'php://temp', 'wb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen, WordPress.PHP.NoSilencedErrors.Discouraged
+			$this->stream_handle = @fopen( 'php://temp', 'wb' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen, WordPress.PHP.NoSilencedErrors.Discouraged, Generic.PHP.NoSilencedErrors.Forbidden
 		}
 
 		add_action( 'http_api_curl', [ $this, 'modify_curl_configuration' ] );


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

We want to improve performance of the CORS proxy

## Summary

<!-- A brief description of what this PR does. -->

Updates the cURL calls to send responses to a PHP stream, drastically reducing memory footprint and improving performance.

Certain headers from the proxied resource are just passed through as-is.

## Relevant Technical Choices

<!-- Please describe your changes. -->

* Adds a fallback logic for when cURL is not available.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

* Further improvements, like forwarding HTTP status / more headers, etc.)
* Ensure `Access-Control-Allow-Origin` headers are sent
* Tests (see also #9369)

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Use CORS proxy with larger files and see how responses should be quicc


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9368
