### PR TITLE
Context Menu: Placement Update

### DIFF
--- a/packages/design-system/src/components/contextMenu/contextMenu.js
+++ b/packages/design-system/src/components/contextMenu/contextMenu.js
@@ -30,6 +30,7 @@ const ContextMenu = ({
   animate,
   isAlwaysVisible,
   items,
+  isRTL,
   isInline = false,
   ...props
 }) => {
@@ -44,6 +45,7 @@ const ContextMenu = ({
         isInline={isInline}
         role={isAlwaysVisible ? null : 'dialog'}
         isOpen={isAlwaysVisible || props.isOpen}
+        isRTL={isRTL}
       >
         <Menu aria-expanded={props.isOpen} items={items} {...props} />
         {/* <AnimationContainer /> has a <Shadow />. Don't double the shadow. */}
@@ -58,6 +60,7 @@ ContextMenu.propTypes = {
   animate: PropTypes.bool,
   isOpen: PropTypes.bool,
   isAlwaysVisible: PropTypes.bool,
+  isRTL: PropTypes.bool,
 };
 
 export default ContextMenu;

--- a/packages/design-system/src/components/contextMenu/contextMenu.js
+++ b/packages/design-system/src/components/contextMenu/contextMenu.js
@@ -21,7 +21,7 @@ import { useMemo } from '@web-stories-wp/react';
 /**
  * Internal dependencies
  */
-import { Popover, Shadow } from './styled';
+import { SmartPopover, Shadow } from './styled';
 import Menu, { MenuPropTypes } from './menu';
 import AnimationContainer from './animationContainer';
 import Mask from './mask';
@@ -34,7 +34,7 @@ const ContextMenu = ({
   ...props
 }) => {
   const Wrapper = useMemo(
-    () => (animate ? AnimationContainer : Popover),
+    () => (animate ? AnimationContainer : SmartPopover),
     [animate]
   );
 

--- a/packages/design-system/src/components/contextMenu/menu.js
+++ b/packages/design-system/src/components/contextMenu/menu.js
@@ -197,7 +197,7 @@ const Menu = ({
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const wrapperRef = useRef(null);
   const listRef = useRef(null);
-  const menuWasAlreadyOpen = useRef(isOpen);
+  const menuWasAlreadyOpen = useRef(false);
   const ids = useMemo(() => items.map(() => uuidv4()), [items]);
 
   // Need ref so that `items.length` changes do not trigger the effect

--- a/packages/design-system/src/components/contextMenu/styled.js
+++ b/packages/design-system/src/components/contextMenu/styled.js
@@ -76,7 +76,7 @@ export function SmartPopover(props) {
     [props.isRTL]
   );
 
-  return props.isOpen && <Popover ref={setRef} {...props} />;
+  return props.isOpen ? <Popover ref={setRef} {...props} /> : null;
 }
 
 SmartPopover.propTypes = {

--- a/packages/design-system/src/components/contextMenu/styled.js
+++ b/packages/design-system/src/components/contextMenu/styled.js
@@ -45,31 +45,41 @@ export const Shadow = styled.div`
 `;
 
 export function SmartPopover(props) {
-  const setRef = useCallback((node) => {
-    if (!node) {
-      return;
-    }
+  const setRef = useCallback(
+    (node) => {
+      if (!node) {
+        return;
+      }
 
-    const boundingBox = node.getBoundingClientRect();
-    const max = {
-      x: window.innerWidth - boundingBox.width,
-      y: window.innerHeight - boundingBox.height,
-    };
+      const boundingBox = node.getBoundingClientRect();
+      const max = {
+        x: window.innerWidth - boundingBox.width,
+        y: window.innerHeight - boundingBox.height,
+      };
 
-    // This is modeling the behavior of chrome:
-    // - menu becomes right justified if not enough space horizontally
-    // - menu sticks to bottom if not enough space vertically
-    const delta = {
-      x: max.x < boundingBox.x ? -boundingBox.width : 0,
-      y: Math.min(0, max.y - boundingBox.y),
-    };
-    node.style.setProperty('--delta-x', delta.x);
-    node.style.setProperty('--delta-y', delta.y);
-  }, []);
+      // This is modeling the behavior of chrome:
+      // - menu becomes right justified if not enough space horizontally
+      // - menu sticks to bottom if not enough space vertically
+      const horizontalEdgeCondition = props.isRTL
+        ? boundingBox.x < 0
+        : max.x < boundingBox.x;
+      const horizontalEdgeTransform = props.isRTL
+        ? boundingBox.width
+        : -boundingBox.width;
+      const delta = {
+        x: horizontalEdgeCondition ? horizontalEdgeTransform : 0,
+        y: Math.min(0, max.y - boundingBox.y),
+      };
+      node.style.setProperty('--delta-x', delta.x);
+      node.style.setProperty('--delta-y', delta.y);
+    },
+    [props.isRTL]
+  );
 
   return props.isOpen && <Popover ref={setRef} {...props} />;
 }
 
 SmartPopover.propTypes = {
   isOpen: PropTypes.bool,
+  isRTL: PropTypes.bool,
 };

--- a/packages/design-system/src/components/contextMenu/styled.js
+++ b/packages/design-system/src/components/contextMenu/styled.js
@@ -27,7 +27,7 @@ export const POPOVER_Z_INDEX = 9991;
 export const Popover = styled.div`
   --translate-x: calc(var(--delta-x, 0) * 1px);
   --translate-y: calc(var(--delta-y, 0) * 1px);
-  display: block;
+  display: ${({ isOpen }) => (isOpen ? 'block' : 'none')};
   position: ${({ isInline }) => (isInline ? 'relative' : 'absolute')};
   z-index: ${POPOVER_Z_INDEX};
   transform: translate(var(--translate-x), var(--translate-y));

--- a/packages/design-system/src/components/contextMenu/styled.js
+++ b/packages/design-system/src/components/contextMenu/styled.js
@@ -16,26 +16,22 @@
 /**
  * External dependencies
  */
-import styled, { css } from 'styled-components';
+import PropTypes from 'prop-types';
+import { useCallback } from '@web-stories-wp/react';
+import styled from 'styled-components';
 
 // z-index needs to be higher than the wordpress toolbar z-index: 9989.
 // Leaves room for mask to be higher than the wordpress toolbar z-index.
 export const POPOVER_Z_INDEX = 9991;
 
-export const Popover = styled.div(
-  ({ isOpen, isInline }) => css`
-    position: ${isInline ? 'relative' : 'absolute'};
-    display: none;
-
-    ${isOpen &&
-    css`
-      display: block;
-      z-index: ${POPOVER_Z_INDEX};
-      opacity: 1;
-      pointer-events: auto;
-    `};
-  `
-);
+export const Popover = styled.div`
+  --translate-x: calc(var(--delta-x, 0) * 1px);
+  --translate-y: calc(var(--delta-y, 0) * 1px);
+  display: block;
+  position: ${({ isInline }) => (isInline ? 'relative' : 'absolute')};
+  z-index: ${POPOVER_Z_INDEX};
+  transform: translate(var(--translate-x), var(--translate-y));
+`;
 
 export const Shadow = styled.div`
   position: absolute;
@@ -47,3 +43,33 @@ export const Shadow = styled.div`
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   pointer-events: none;
 `;
+
+export function SmartPopover(props) {
+  const setRef = useCallback((node) => {
+    if (!node) {
+      return;
+    }
+
+    const boundingBox = node.getBoundingClientRect();
+    const max = {
+      x: window.innerWidth - boundingBox.width,
+      y: window.innerHeight - boundingBox.height,
+    };
+
+    // This is modeling the behavior of chrome:
+    // - menu becomes right justified if not enough space horizontally
+    // - menu sticks to bottom if not enough space vertically
+    const delta = {
+      x: max.x < boundingBox.x ? -boundingBox.width : 0,
+      y: Math.min(0, max.y - boundingBox.y),
+    };
+    node.style.setProperty('--delta-x', delta.x);
+    node.style.setProperty('--delta-y', delta.y);
+  }, []);
+
+  return props.isOpen && <Popover ref={setRef} {...props} />;
+}
+
+SmartPopover.propTypes = {
+  isOpen: PropTypes.bool,
+};

--- a/packages/story-editor/src/components/canvas/rightClickMenu.js
+++ b/packages/story-editor/src/components/canvas/rightClickMenu.js
@@ -61,7 +61,6 @@ const RightClickMenu = () => {
     <DirectionAware>
       <RightClickMenuContainer position={menuPosition} ref={ref}>
         <ContextMenu
-          animate
           data-testid="right-click-context-menu"
           isOpen={isMenuOpen}
           onDismiss={onCloseMenu}

--- a/packages/story-editor/src/components/canvas/rightClickMenu.js
+++ b/packages/story-editor/src/components/canvas/rightClickMenu.js
@@ -16,14 +16,15 @@
 /**
  * External dependencies
  */
+import styled, { StyleSheetManager } from 'styled-components';
 import { __ } from '@web-stories-wp/i18n';
 import { ContextMenu } from '@web-stories-wp/design-system';
 import { createPortal, useRef, useEffect } from '@web-stories-wp/react';
-import styled from 'styled-components';
+
 /**
  * Internal dependencies
  */
-import { useRightClickMenu } from '../../app';
+import { useRightClickMenu, useConfig } from '../../app';
 import DirectionAware from '../directionAware';
 
 const RightClickMenuContainer = styled.div`
@@ -34,6 +35,7 @@ const RightClickMenuContainer = styled.div`
 `;
 
 const RightClickMenu = () => {
+  const { isRTL } = useConfig();
   const {
     isMenuOpen,
     menuItems: rightClickMenuItems,
@@ -58,22 +60,25 @@ const RightClickMenu = () => {
   }, [ref]);
 
   return createPortal(
-    <DirectionAware>
+    <StyleSheetManager stylisPlugins={[]}>
       <RightClickMenuContainer position={menuPosition} ref={ref}>
-        <ContextMenu
-          data-testid="right-click-context-menu"
-          isOpen={isMenuOpen}
-          onDismiss={onCloseMenu}
-          items={rightClickMenuItems}
-          groupLabel={__(
-            'Context Menu for the selected element',
-            'web-stories'
-          )}
-          maskRef={maskRef}
-          onMouseDown={(evt) => evt.stopPropagation()}
-        />
+        <DirectionAware>
+          <ContextMenu
+            data-testid="right-click-context-menu"
+            isOpen={isMenuOpen}
+            onDismiss={onCloseMenu}
+            items={rightClickMenuItems}
+            groupLabel={__(
+              'Context Menu for the selected element',
+              'web-stories'
+            )}
+            maskRef={maskRef}
+            onMouseDown={(evt) => evt.stopPropagation()}
+            isRTL={isRTL}
+          />
+        </DirectionAware>
       </RightClickMenuContainer>
-    </DirectionAware>,
+    </StyleSheetManager>,
     document.body
   );
 };


### PR DESCRIPTION
## Context
Part of design feedback on the current context menu.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
- removes animation from context menu
- mimics chromes positioning:
    - bottom-right justification of cursor by default
    - stick to bottom if not enough room vertically
    - switches justification to bottom-left of cursor if not enough room horizontally
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Using a callback ref with some css vars was quick and effective here. Is clean, simple and don't have to worry about having any frames where the menu is open, but not positioned correctly while state is taking a render to set
<!-- Please describe your changes. -->

## To-do
We could attempt to do a karma test where we click on the layers panel and see if this causes any overflow scroll to the body, but feels superfluous to me. Thoughts?
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
- right click menu will now appear to the bottom-right of the cursor (unless it can't fit in the viewport)
- right click menu will no longer animate open.
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open the editor
2. Make sure there's some elements in the story
3. Right click an element and see that the context menu no longer has an animation on open
4. See that the right click menu is positioned to the bottom right of the cursor by default (like chrome)


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9563 
