### PR TITLE
Color Picker: Fix navigation with arrow keys

### DIFF
--- a/packages/story-editor/src/components/colorPicker/basicColorList.js
+++ b/packages/story-editor/src/components/colorPicker/basicColorList.js
@@ -72,6 +72,18 @@ function getPatternAsString(pattern) {
   return styles.backgroundColor || styles.backgroundImage;
 }
 
+function ConditionalTooltip({ tooltip, children }) {
+  if (!tooltip) {
+    return children;
+  }
+  return <Tooltip title={tooltip}>{children}</Tooltip>;
+}
+
+ConditionalTooltip.propTypes = {
+  tooltip: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+
 function BasicColorList({
   color,
   colors,
@@ -135,25 +147,19 @@ function BasicColorList({
               firstIndex++;
               tabIndex = -1;
             }
-            const renderedSwatch = (
-              <StyledSwatch
-                key={tooltip ? null : patternAsBackground}
-                onClick={() => handleClick(pattern, isLocal)}
-                pattern={pattern}
-                isSelected={isSelected}
-                isDisabled={isDisabled}
-                tabIndex={tabIndex}
-                title={title}
-              >
-                {isEditMode && <Icons.Cross />}
-              </StyledSwatch>
-            );
-            return tooltip ? (
-              <Tooltip key={patternAsBackground} title={tooltip}>
-                {renderedSwatch}
-              </Tooltip>
-            ) : (
-              renderedSwatch
+            return (
+              <ConditionalTooltip key={patternAsBackground} tooltip={tooltip}>
+                <StyledSwatch
+                  onClick={() => handleClick(pattern, isLocal)}
+                  pattern={pattern}
+                  isSelected={isSelected}
+                  isDisabled={isDisabled}
+                  tabIndex={tabIndex}
+                  title={title}
+                >
+                  {isEditMode && <Icons.Cross />}
+                </StyledSwatch>
+              </ConditionalTooltip>
             );
           })}
           {(isLocal || isGlobal) && (

--- a/packages/story-editor/src/components/colorPicker/basicColorList.js
+++ b/packages/story-editor/src/components/colorPicker/basicColorList.js
@@ -135,19 +135,25 @@ function BasicColorList({
               firstIndex++;
               tabIndex = -1;
             }
-            return (
+            const renderedSwatch = (
+              <StyledSwatch
+                key={tooltip ? null : patternAsBackground}
+                onClick={() => handleClick(pattern, isLocal)}
+                pattern={pattern}
+                isSelected={isSelected}
+                isDisabled={isDisabled}
+                tabIndex={tabIndex}
+                title={title}
+              >
+                {isEditMode && <Icons.Cross />}
+              </StyledSwatch>
+            );
+            return tooltip ? (
               <Tooltip key={patternAsBackground} title={tooltip}>
-                <StyledSwatch
-                  onClick={() => handleClick(pattern, isLocal)}
-                  pattern={pattern}
-                  isSelected={isSelected}
-                  isDisabled={isDisabled}
-                  tabIndex={tabIndex}
-                  title={title}
-                >
-                  {isEditMode && <Icons.Cross />}
-                </StyledSwatch>
+                {renderedSwatch}
               </Tooltip>
+            ) : (
+              renderedSwatch
             );
           })}
           {(isLocal || isGlobal) && (


### PR DESCRIPTION
## Summary
Fixes navigation by arrow keys in the color picker by adding the `Tooltip` wrapper only for disabled swatches.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open the color picker
2. Verify it's possible to navigate between the colors in a group of colors using arrow keys.


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9701 
