### PR TITLE
Fix flaky link Tooltip test

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/local/karma/hotlink.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/hotlink.karma.js
@@ -73,7 +73,10 @@ describe('Embedding hotlinked media', () => {
 
     await fixture.events.sleep(500);
     dialog = screen.getByRole('dialog');
-    await waitFor(() => expect(dialog.textContent).toContain('You can insert'));
+    await waitFor(
+      () => expect(dialog.textContent).toContain('You can insert'),
+      { timeout: 1500 }
+    );
   });
 
   it('should insert a new media element from valid url', async () => {

--- a/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
+++ b/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
@@ -78,7 +78,8 @@ describe('Link Panel', () => {
 
   describe('CUJ: Creator Can Add A Link: Apply a link to any element', () => {
     beforeEach(async () => {
-      await fixture.events.click(fixture.editor.library.textAdd);
+      await fixture.editor.library.textTab.click();
+      await fixture.events.click(fixture.editor.library.text.preset('Title 1'));
       await waitFor(() => fixture.editor.canvas.framesLayer.frames[1].node);
       linkPanel = fixture.editor.inspector.designPanel.link;
     });
@@ -120,9 +121,7 @@ describe('Link Panel', () => {
       expect(linkPanel.address.value).toBe('https://example.com');
     });
 
-    // TODO(#8738): Fix flaky test.
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should display the link tooltip correctly', async () => {
+    it('should display the link tooltip correctly', async () => {
       const linkDescription = 'Example description';
       // make sure address input exists
       await waitFor(() => linkPanel.address);
@@ -132,9 +131,8 @@ describe('Link Panel', () => {
 
       // Debounce time for populating meta-data.
       await fixture.events.keyboard.press('tab');
-      await fixture.events.sleep(1200);
       // make sure description input exists
-      await waitFor(() => linkPanel.description);
+      await waitFor(() => linkPanel.description, { timeout: 1500 });
       await fixture.events.click(linkPanel.description, { clickCount: 3 });
       await fixture.events.keyboard.type(linkDescription);
       await fixture.events.keyboard.press('tab');
@@ -149,8 +147,10 @@ describe('Link Panel', () => {
       const frame = fixture.editor.canvas.framesLayer.frames[1].node;
       await fixture.events.mouse.moveRel(frame, 10, 10);
 
-      // TODO(#8738): This line appears to be flaky.
-      expect(fixture.screen.getByText(linkDescription)).toBeTruthy();
+      await waitFor(() => {
+        const tooltip = fixture.screen.getByText(linkDescription);
+        expect(tooltip.textContent).toBe(linkDescription);
+      });
       await fixture.snapshot(
         'Element is hovered on. The link tooltip is visible'
       );
@@ -166,7 +166,7 @@ describe('Link Panel', () => {
 
       // Verify that the description is not displayed when hovering without url.
       await fixture.events.mouse.click(left - 5, top - 5);
-      await fixture.events.mouse.moveRel(frame, 10, 10);
+      await fixture.events.mouse.moveRel(frame, 50, 10);
       const removedDescription = fixture.screen.queryByText(linkDescription);
       expect(removedDescription).toBeNull();
       await fixture.snapshot(


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Fixes a flaky link Tooltip test that was previously skipped.

Uses a larger text to ensure that hovering is happening in the correct place for the text element.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

- [ ] Rerun the tests a few times.

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8738 
