### PR TITLE
Canvas: Add keyboard shortcut that opens the context menu

### DIFF
--- a/packages/design-system/src/components/contextMenu/menu.js
+++ b/packages/design-system/src/components/contextMenu/menu.js
@@ -220,6 +220,7 @@ const Menu = ({
 
   /**
    * Allow navigation of the list using the UP and DOWN arrow keys.
+   * Close menu if ESCAPE is pressed.
    *
    * @param {Event} event The synthetic event
    * @return {void} void
@@ -227,6 +228,11 @@ const Menu = ({
   const handleKeyboardNav = useCallback(
     (evt) => {
       const { key, shiftKey } = evt;
+      if (key === 'Escape') {
+        onDismiss?.(evt);
+        return;
+      }
+
       const isAscending =
         [KEYS.UP, KEYS.LEFT].includes(key) || (key === KEYS.TAB && shiftKey);
       let index = focusedIndex + (isAscending ? -1 : 1);
@@ -292,8 +298,8 @@ const Menu = ({
   const keySpec = useMemo(
     () =>
       disableControlledTabNavigation
-        ? { key: ['down', 'up', 'left', 'right'] }
-        : { key: ['down', 'up', 'left', 'right', 'tab'], shift: true },
+        ? { key: ['esc', 'down', 'up', 'left', 'right'] }
+        : { key: ['esc', 'down', 'up', 'left', 'right', 'tab'], shift: true },
     [disableControlledTabNavigation]
   );
 

--- a/packages/design-system/src/components/contextMenu/menuItem.js
+++ b/packages/design-system/src/components/contextMenu/menuItem.js
@@ -71,7 +71,7 @@ export const MenuItem = ({
   const handleClick = useCallback(
     (ev) => {
       onClick(ev);
-      onDismiss();
+      onDismiss(ev);
     },
     [onClick, onDismiss]
   );

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -189,12 +189,20 @@ function RightClickMenuProvider({ children }) {
       evt.preventDefault();
       evt.stopPropagation();
 
+      let x = evt?.clientX;
+      let y = evt?.clientY;
+
+      // Context menus opened through a shortcut will not have clientX and clientY
+      // Instead determine the position of the menu off of the element
+      if (!x && !y) {
+        const dims = evt.target.getBoundingClientRect();
+        x = dims.x;
+        y = dims.y;
+      }
+
       dispatch({
         type: ACTION_TYPES.OPEN_MENU,
-        payload: {
-          x: evt?.clientX,
-          y: evt?.clientY,
-        },
+        payload: { x, y },
       });
 
       trackEvent('context_menu_action', {

--- a/packages/story-editor/src/components/canvas/framesLayer.js
+++ b/packages/story-editor/src/components/canvas/framesLayer.js
@@ -26,6 +26,7 @@ import { STORY_ANIMATION_STATE } from '@web-stories-wp/animation';
 /**
  * Internal dependencies
  */
+import { useKeyDownEffect } from '@web-stories-wp/design-system';
 import { DESIGN_SPACE_MARGIN } from '../../constants';
 import {
   useStory,
@@ -91,13 +92,15 @@ function FramesLayer() {
     [setScrollOffset]
   );
 
+  useKeyDownEffect(framesLayerRef, 'mod+option+shift+m', onOpenMenu);
+
   return (
     <Layer
       ref={framesLayerRef}
       data-testid="FramesLayer"
       pointerEvents="initial"
       // Use `-1` to ensure that there's a default target to focus if
-      // there's no selection, but it's not reacheable by keyboard
+      // there's no selection, but it's not reachable by keyboard
       // otherwise.
       tabIndex="-1"
       aria-label={__('Frames layer', 'web-stories')}

--- a/packages/story-editor/src/components/canvas/framesLayer.js
+++ b/packages/story-editor/src/components/canvas/framesLayer.js
@@ -92,7 +92,7 @@ function FramesLayer() {
     [setScrollOffset]
   );
 
-  useKeyDownEffect(framesLayerRef, 'mod+option+shift+m', onOpenMenu);
+  useKeyDownEffect(framesLayerRef, 'mod+alt+shift+m', onOpenMenu);
 
   return (
     <Layer

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -353,6 +353,53 @@ describe('Right Click Menu integration', () => {
 
       expect(rightClickMenu()).not.toBeNull();
     });
+
+    it('should open and close the context menu using keyboard shortcuts', async () => {
+      const textA = await addText({
+        fontSize: 60,
+        content: '<span style="color: #ff0110">Some Text Element</span>',
+        backgroundColor: { r: 10, g: 0, b: 200 },
+        lineHeight: 1.4,
+        textAlign: 'center',
+        border: {
+          left: 1,
+          right: 1,
+          top: 1,
+          bottom: 1,
+          lockedWidth: true,
+          color: {
+            color: {
+              r: 0,
+              g: 0,
+              b: 0,
+            },
+          },
+        },
+        padding: {
+          vertical: 0,
+          horizontal: 20,
+          locked: true,
+        },
+      });
+
+      // only possible if element in canvas is focused
+      await fixture.events.focus(
+        fixture.editor.canvas.framesLayer.frame(textA.id).node
+      );
+
+      // open right click menu
+      await fixture.events.keyboard.shortcut('mod+alt+shift+m');
+
+      expect(rightClickMenu()).not.toBeNull();
+
+      // close right click menu
+      await fixture.events.keyboard.press('esc');
+      expect(
+        fixture.screen.queryByTestId(
+          'right-click-context-menu[aria-expanded="true"]'
+        )
+      ).toBeNull();
+    });
   });
 
   describe('right click menu: foreground and background media actions', () => {

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -16,7 +16,7 @@
 /**
  * External dependencies
  */
-import { within } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -335,9 +335,9 @@ describe('Right Click Menu integration', () => {
         }
       );
       expect(
-        fixture.screen.queryByTestId(
-          'right-click-context-menu[aria-expanded="true"]'
-        )
+        fixture.screen.queryByRole('group', {
+          name: 'Context Menu for the selected element',
+        })
       ).toBeNull();
     });
 
@@ -355,49 +355,29 @@ describe('Right Click Menu integration', () => {
     });
 
     it('should open and close the context menu using keyboard shortcuts', async () => {
-      const textA = await addText({
-        fontSize: 60,
-        content: '<span style="color: #ff0110">Some Text Element</span>',
-        backgroundColor: { r: 10, g: 0, b: 200 },
-        lineHeight: 1.4,
-        textAlign: 'center',
-        border: {
-          left: 1,
-          right: 1,
-          top: 1,
-          bottom: 1,
-          lockedWidth: true,
-          color: {
-            color: {
-              r: 0,
-              g: 0,
-              b: 0,
-            },
-          },
-        },
-        padding: {
-          vertical: 0,
-          horizontal: 20,
-          locked: true,
-        },
-      });
+      // add an element to the page
+      await fixture.events.click(fixture.editor.library.textAdd);
+      await waitFor(() => fixture.editor.canvas.framesLayer.frames[1].node);
+      const frame1 = fixture.editor.canvas.framesLayer.frames[1].node;
 
       // only possible if element in canvas is focused
-      await fixture.events.focus(
-        fixture.editor.canvas.framesLayer.frame(textA.id).node
-      );
+      await fixture.events.focus(frame1);
 
       // open right click menu
       await fixture.events.keyboard.shortcut('mod+alt+shift+m');
 
-      expect(rightClickMenu()).not.toBeNull();
+      expect(
+        fixture.screen.queryByRole('group', {
+          name: 'Context Menu for the selected element',
+        })
+      ).not.toBeNull();
 
       // close right click menu
       await fixture.events.keyboard.press('esc');
       expect(
-        fixture.screen.queryByTestId(
-          'right-click-context-menu[aria-expanded="true"]'
-        )
+        fixture.screen.queryByRole('group', {
+          name: 'Context Menu for the selected element',
+        })
       ).toBeNull();
     });
   });

--- a/packages/story-editor/src/components/canvas/rightClickMenu.js
+++ b/packages/story-editor/src/components/canvas/rightClickMenu.js
@@ -42,7 +42,12 @@ const RightClickMenu = () => {
     maskRef,
   } = useRightClickMenu();
   const ref = useRef();
-  // If ContextMenu is already rendered prevent browser's context menu when right clicking on ContextMenu
+
+  /**
+   * Prevent browser's context menu when right clicking on custom ContextMenu
+   *
+   * @param {Object} evt Triggering event
+   */
   const preventAdditionalContext = (evt) => {
     evt.preventDefault();
     evt.stopPropagation();

--- a/packages/story-editor/src/components/keyboardShortcutsMenu/keyboardShortcutList.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/keyboardShortcutList.js
@@ -361,7 +361,7 @@ const shortcuts = {
               <kbd className="large-key">{prettifyShortcut('mod')}</kbd>
               <kbd className="large-key">{prettifyShortcut('alt')}</kbd>
               <kbd className="large-key">{prettifyShortcut('shift')}</kbd>
-              <kbd>{'m'}</kbd>
+              <kbd>{'M'}</kbd>
             </kbd>
           ),
         },

--- a/packages/story-editor/src/components/keyboardShortcutsMenu/keyboardShortcutList.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/keyboardShortcutList.js
@@ -354,6 +354,17 @@ const shortcuts = {
             </kbd>
           ),
         },
+        {
+          label: __('Open context menu', 'web-stories'),
+          shortcut: (
+            <kbd>
+              <kbd className="large-key">{prettifyShortcut('mod')}</kbd>
+              <kbd className="large-key">{prettifyShortcut('alt')}</kbd>
+              <kbd className="large-key">{prettifyShortcut('shift')}</kbd>
+              <kbd>{'m'}</kbd>
+            </kbd>
+          ),
+        },
       ],
     },
   ],


### PR DESCRIPTION
## Context

The fans wanted a keyboard shortcut that opens the context menu

## Summary

Add keyboard shortcut that opens the context menu when an element in the canvas is focused.

## Relevant Technical Choices

The custom context menu exists in two places: the canvas and the layers panel.

This functionality was not added to the layers panel because the user cannot tab into it.

This shortcut only opens the menu _if_ the element in the canvas is actually focused. If the user is focused elsewhere, the context menu should not open.

## To-do

n/a

## User-facing changes

<img src="https://user-images.githubusercontent.com/22185279/141826857-1dc5c62a-f0f4-414f-ac0b-2cab82d406bf.gif" height="300px" />

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Click on the canvas or an element in the canvas
2. Press the `cmd+option+shift+m` keys (on mac) or `ctrl+alt+shift+m` (on windows). The context menu should open on that element
3. Press `esc`. The context menu should close
4. Tab to a different element in the canvas and repeat. The context menu should now open on that element.

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8993
