### PR TITLE
Editor: Update Karma fixture to fix flakey `waitFor()`

### DIFF
--- a/packages/story-editor/src/app/history/karma/history.karma.js
+++ b/packages/story-editor/src/app/history/karma/history.karma.js
@@ -25,6 +25,7 @@ describe('CUJ: Creator can View and Modify Document Settings: Navigating without
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/canvas/karma/backgroundCopyPaste.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/backgroundCopyPaste.karma.js
@@ -26,6 +26,7 @@ describe('Background Copy Paste integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     await addNewPage();
   });

--- a/packages/story-editor/src/components/canvas/karma/canvasKeys.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/canvasKeys.karma.js
@@ -27,6 +27,7 @@ describe('Canvas Keyboard Shortcuts', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     // Let's insert three images
     await fixture.events.click(fixture.editor.library.media.item(0));

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -76,15 +76,15 @@ fdescribe('Carousel integration', () => {
   }
 
   async function clickOnThumbnail(index) {
-    await fixture.events.sleep(300);
+    await fixture.events.sleep(100);
     const { pages } = await fixture.editor.footer.carousel;
-    expect(pages[index]).toBe('not this but i need to see inside here remote!');
+    // expect(pages[index]).toBe('not this but i need to see inside here remote!');
     const thumb = await pages[index];
     await expect(thumb).toBeDefined();
 
     const thumbNode = !thumb?.node ? thumb._node : thumb.node;
     await expect(thumbNode).toBeDefined();
-    await thumbNode?.scrollIntoView();
+    await thumbNode.scrollIntoView();
     await fixture.events.mouse.clickOn(thumbNode, 5, 5);
   }
 

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -77,11 +77,12 @@ fdescribe('Carousel integration', () => {
 
   async function clickOnThumbnail(index) {
     const { pages } = await fixture.editor.footer.carousel;
-    expect(pages).toBe('not this but i need to see inside here remote!');
+    // expect(pages).toBe('not this but i need to see inside here remote!');
     const thumb = pages[index];
-    await expect(thumb).toBeDefined();
-    await thumb.node.scrollIntoView();
-    await fixture.events.mouse.clickOn(thumb.node, 5, 5);
+    const thumbNode = thumb.node || thumb._node;
+    await expect(thumbNode).toBeDefined();
+    await thumbNode.scrollIntoView();
+    await fixture.events.mouse.clickOn(thumbNode, 5, 5);
   }
 
   it('should select the current page', async () => {

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import { waitFor } from '@testing-library/react';
 import { createSolid } from '@web-stories-wp/patterns';
 /**
  * Internal dependencies
@@ -27,7 +26,7 @@ import { useStory } from '../../../app/story';
 import { useInsertElement } from '..';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
 
-fdescribe('Carousel integration', () => {
+describe('Carousel integration', () => {
   let fixture;
   let element1;
 
@@ -78,14 +77,12 @@ fdescribe('Carousel integration', () => {
   async function clickOnThumbnail(index) {
     await fixture.events.sleep(100);
     const { pages } = await fixture.editor.footer.carousel;
-    // expect(pages[index]).toBe('not this but i need to see inside here remote!');
-    const thumb = await pages[index];
+    // node is found fine running locally while _node is present when running remote.
+    const page = await pages[index];
+    const thumb = !page?.node ? page._node : page.node;
     await expect(thumb).toBeDefined();
-
-    const thumbNode = !thumb?.node ? thumb._node : thumb.node;
-    await expect(thumbNode).toBeDefined();
-    await thumbNode.scrollIntoView();
-    await fixture.events.mouse.clickOn(thumbNode, 5, 5);
+    await thumb.scrollIntoView();
+    await fixture.events.mouse.clickOn(thumb, 5, 5);
   }
 
   it('should select the current page', async () => {

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -77,7 +77,7 @@ fdescribe('Carousel integration', () => {
 
   async function clickOnThumbnail(index) {
     const { pages } = await fixture.editor.footer.carousel;
-    expect(pages).toBeDefined();
+    expect(pages).toBe('not this but i need to see inside here remote!');
     const thumb = pages[index];
     await expect(thumb).toBeDefined();
     await thumb.node.scrollIntoView();

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -76,6 +76,7 @@ fdescribe('Carousel integration', () => {
   }
 
   async function clickOnThumbnail(index) {
+    await fixture.events.sleep(300);
     const { pages } = await fixture.editor.footer.carousel;
     expect(pages[index]).toBe('not this but i need to see inside here remote!');
     const thumb = await pages[index];

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -77,7 +77,7 @@ fdescribe('Carousel integration', () => {
 
   async function clickOnThumbnail(index) {
     const { pages } = await fixture.editor.footer.carousel;
-    // expect(pages).toBe('not this but i need to see inside here remote!');
+    expect(pages).toBe('not this but i need to see inside here remote!');
     const thumb = await pages[index];
     await expect(thumb).toBeDefined();
 

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -78,10 +78,12 @@ fdescribe('Carousel integration', () => {
   async function clickOnThumbnail(index) {
     const { pages } = await fixture.editor.footer.carousel;
     // expect(pages).toBe('not this but i need to see inside here remote!');
-    const thumb = pages[index];
-    const thumbNode = thumb?.node ? thumb.node : thumb._node;
+    const thumb = await pages[index];
+    await expect(thumb).toBeDefined();
+
+    const thumbNode = !thumb?.node ? thumb._node : thumb.node;
     await expect(thumbNode).toBeDefined();
-    await thumbNode.scrollIntoView();
+    await thumbNode?.scrollIntoView();
     await fixture.events.mouse.clickOn(thumbNode, 5, 5);
   }
 

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -77,7 +77,7 @@ fdescribe('Carousel integration', () => {
 
   async function clickOnThumbnail(index) {
     const { pages } = await fixture.editor.footer.carousel;
-    expect(pages).toBe('not this but i need to see inside here remote!');
+    expect(pages[index]).toBe('not this but i need to see inside here remote!');
     const thumb = await pages[index];
     await expect(thumb).toBeDefined();
 

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -26,7 +26,7 @@ import { useStory } from '../../../app/story';
 import { useInsertElement } from '..';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
 
-describe('Carousel integration', () => {
+fdescribe('Carousel integration', () => {
   let fixture;
   let element1;
 
@@ -76,13 +76,12 @@ describe('Carousel integration', () => {
 
   async function clickOnThumbnail(index) {
     await fixture.events.sleep(100);
-    const { pages } = await fixture.editor.footer.carousel;
-    // node is found fine running locally while _node is present when running remote.
-    const page = await pages[index];
-    const thumb = !page?.node ? page._node : page.node;
-    await expect(thumb).toBeDefined();
-    await thumb.scrollIntoView();
-    await fixture.events.mouse.clickOn(thumb, 5, 5);
+
+    const thumb = await fixture.editor.footer.carousel.pages[index];
+
+    await expect(thumb).toBe('clearly not this!');
+    await thumb.node.scrollIntoView();
+    await fixture.events.mouse.clickOn(thumb.node, 5, 5);
   }
 
   it('should select the current page', async () => {

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -76,7 +76,7 @@ describe('Carousel integration', () => {
 
   async function clickOnThumbnail(index) {
     await fixture.editor.footer.carousel.waitReady();
-    const thumb = fixture.editor.footer.carousel.pages[index];
+    const thumb = await fixture.editor.footer.carousel.pages[index];
     thumb.node.scrollIntoView();
     await fixture.events.mouse.clickOn(thumb.node, 5, 5);
   }

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -76,10 +76,9 @@ fdescribe('Carousel integration', () => {
   }
 
   async function clickOnThumbnail(index) {
-    await fixture.editor.footer.carousel.waitReady();
-    const thumb = await waitFor(
-      () => fixture.editor.footer.carousel.pages[index]
-    );
+    const { pages } = await fixture.editor.footer.carousel;
+    expect(pages).toBeDefined();
+    const thumb = pages[index];
     await expect(thumb).toBeDefined();
     await thumb.node.scrollIntoView();
     await fixture.events.mouse.clickOn(thumb.node, 5, 5);

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -39,6 +39,7 @@ describe('Carousel integration', () => {
       { id: 'page4', backgroundColor: createSolid(0, 0, 255) },
     ]);
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     const insertElement = await fixture.renderHook(() => useInsertElement());
     element1 = await fixture.act(() =>

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -79,7 +79,7 @@ fdescribe('Carousel integration', () => {
     const { pages } = await fixture.editor.footer.carousel;
     // expect(pages).toBe('not this but i need to see inside here remote!');
     const thumb = pages[index];
-    const thumbNode = thumb.node || thumb._node;
+    const thumbNode = thumb?.node ? thumb.node : thumb._node;
     await expect(thumbNode).toBeDefined();
     await thumbNode.scrollIntoView();
     await fixture.events.mouse.clickOn(thumbNode, 5, 5);

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -77,7 +77,7 @@ describe('Carousel integration', () => {
   async function clickOnThumbnail(index) {
     await fixture.events.sleep(100);
     await fixture.editor.footer.carousel.waitReady();
-    const thumb = await fixture.editor.footer.carousel.pages[index];
+    const thumb = fixture.editor.footer.carousel.pages[index];
     await thumb.node.scrollIntoView();
     await fixture.events.mouse.clickOn(thumb.node, 5, 5);
   }

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -26,7 +26,7 @@ import { useStory } from '../../../app/story';
 import { useInsertElement } from '..';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
 
-fdescribe('Carousel integration', () => {
+describe('Carousel integration', () => {
   let fixture;
   let element1;
 
@@ -78,8 +78,6 @@ fdescribe('Carousel integration', () => {
     await fixture.events.sleep(100);
     await fixture.editor.footer.carousel.waitReady();
     const thumb = await fixture.editor.footer.carousel.pages[index];
-
-    // await expect(thumb).toBe('clearly not this!');
     await thumb.node.scrollIntoView();
     await fixture.events.mouse.clickOn(thumb.node, 5, 5);
   }

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -17,6 +17,7 @@
 /**
  * External dependencies
  */
+import { waitFor } from '@testing-library/react';
 import { createSolid } from '@web-stories-wp/patterns';
 /**
  * Internal dependencies
@@ -26,7 +27,7 @@ import { useStory } from '../../../app/story';
 import { useInsertElement } from '..';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
 
-describe('Carousel integration', () => {
+fdescribe('Carousel integration', () => {
   let fixture;
   let element1;
 
@@ -76,8 +77,11 @@ describe('Carousel integration', () => {
 
   async function clickOnThumbnail(index) {
     await fixture.editor.footer.carousel.waitReady();
-    const thumb = await fixture.editor.footer.carousel.pages[index];
-    thumb.node.scrollIntoView();
+    const thumb = await waitFor(
+      () => fixture.editor.footer.carousel.pages[index]
+    );
+    await expect(thumb).toBeDefined();
+    await thumb.node.scrollIntoView();
     await fixture.events.mouse.clickOn(thumb.node, 5, 5);
   }
 

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -76,10 +76,10 @@ fdescribe('Carousel integration', () => {
 
   async function clickOnThumbnail(index) {
     await fixture.events.sleep(100);
-
+    await fixture.editor.footer.carousel.waitReady();
     const thumb = await fixture.editor.footer.carousel.pages[index];
 
-    await expect(thumb).toBe('clearly not this!');
+    // await expect(thumb).toBe('clearly not this!');
     await thumb.node.scrollIntoView();
     await fixture.events.mouse.clickOn(thumb.node, 5, 5);
   }

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -78,7 +78,7 @@ describe('Carousel integration', () => {
     await fixture.events.sleep(100);
     await fixture.editor.footer.carousel.waitReady();
     const thumb = fixture.editor.footer.carousel.pages[index];
-    await thumb.node.scrollIntoView();
+    thumb.node.scrollIntoView();
     await fixture.events.mouse.clickOn(thumb.node, 5, 5);
   }
 

--- a/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/cloneSelection.karma.js
@@ -27,6 +27,7 @@ describe('Clone element integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     bg = await getElementByIndex(1);
     bgRect = (await getCanvasElementWrapperById(bg.id)).getBoundingClientRect();

--- a/packages/story-editor/src/components/canvas/karma/keys.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/keys.karma.js
@@ -34,6 +34,7 @@ describe('Canvas keys integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     const insertElement = await fixture.renderHook(() => useInsertElement());
     element1 = await fixture.act(() =>

--- a/packages/story-editor/src/components/canvas/karma/lasso.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/lasso.karma.js
@@ -29,6 +29,7 @@ describe('Lasso integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     const insertElement = await fixture.renderHook(() => useInsertElement());
     element1 = await fixture.act(() =>

--- a/packages/story-editor/src/components/canvas/karma/multiSelectionMovable.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/multiSelectionMovable.karma.js
@@ -32,6 +32,7 @@ describe('Multi-selection Moveable integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/canvas/karma/pageMenuActions.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/pageMenuActions.karma.js
@@ -22,7 +22,7 @@ import { useStory } from '../../../app/story';
 import { useInsertElement } from '..';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
 
-fdescribe('PageMenu integration', () => {
+describe('PageMenu integration', () => {
   let fixture;
 
   beforeEach(async () => {

--- a/packages/story-editor/src/components/canvas/karma/pageMenuActions.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/pageMenuActions.karma.js
@@ -28,6 +28,7 @@ describe('PageMenu integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/canvas/karma/pageMenuActions.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/pageMenuActions.karma.js
@@ -22,7 +22,7 @@ import { useStory } from '../../../app/story';
 import { useInsertElement } from '..';
 import { TEXT_ELEMENT_DEFAULT_FONT } from '../../../app/font/defaultFonts';
 
-describe('PageMenu integration', () => {
+fdescribe('PageMenu integration', () => {
   let fixture;
 
   beforeEach(async () => {
@@ -84,9 +84,7 @@ describe('PageMenu integration', () => {
         expect(await getSelection()).toEqual([]);
       });
 
-      // TODO(#9387): Fix flaky test.
-      // eslint-disable-next-line jasmine/no-disabled-tests
-      xit('using page menu', async () => {
+      it('using page menu', async () => {
         // Delete.
         await fixture.events.keyboard.shortcut('del');
         expect(getFrame()).toBeNull();

--- a/packages/story-editor/src/components/canvas/karma/quickActions.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/quickActions.karma.js
@@ -37,6 +37,7 @@ describe('Quick Actions integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -36,6 +36,7 @@ describe('Right Click Menu integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     insertElement = await fixture.renderHook(() => useInsertElement());
   });

--- a/packages/story-editor/src/components/canvas/karma/rtl.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rtl.karma.js
@@ -32,6 +32,7 @@ describe('RTL support', () => {
     fixture = new Fixture();
     fixture.setConfig({ isRTL: true });
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/canvas/karma/selection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/selection.karma.js
@@ -32,6 +32,7 @@ describe('CUJ: Creator can Transform an Element: Selection integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     fullbleed = fixture.container.querySelector('[data-testid="fullbleed"]');
   });

--- a/packages/story-editor/src/components/canvas/karma/snapping.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/snapping.karma.js
@@ -28,6 +28,7 @@ describe('Snapping integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     await fixture.events.click(fixture.editor.library.media.item(0));
 

--- a/packages/story-editor/src/components/canvas/pageAttachment/karma/pageAttachment.cuj.karma.js
+++ b/packages/story-editor/src/components/canvas/pageAttachment/karma/pageAttachment.cuj.karma.js
@@ -38,6 +38,8 @@ describe('Page Attachment', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
+
     // Select Page by default.
     safezone = fixture.querySelector('[data-testid="safezone"]');
     await clickOnTarget(safezone);

--- a/packages/story-editor/src/components/checklist/karma/checklist.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/checklist.karma.js
@@ -31,6 +31,7 @@ describe('Checklist integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/checklist/karma/prepublishSelect.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/prepublishSelect.karma.js
@@ -35,6 +35,7 @@ describe('Pre-publish checklist select offending elements onClick', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
     insertElement = await fixture.renderHook(() => useInsertElement());
   });
 

--- a/packages/story-editor/src/components/colorPicker/karma/colorPicker.karma.js
+++ b/packages/story-editor/src/components/colorPicker/karma/colorPicker.karma.js
@@ -34,6 +34,7 @@ describe('ColorPicker', () => {
         fixture = new Fixture();
         fixture.setConfig({ isRTL: direction === 'RTL' });
         await fixture.render();
+        await fixture.collapseHelpCenter();
       });
 
       afterEach(() => {
@@ -71,6 +72,7 @@ describe('ColorPicker', () => {
     beforeEach(async () => {
       fixture = new Fixture();
       await fixture.render();
+      await fixture.collapseHelpCenter();
       localStorage.setItem(
         'web_stories_ui_panel_settings:shapeStyle',
         JSON.stringify({ isCollapsed: false })

--- a/packages/story-editor/src/components/colorPicker/karma/eyedropper.karma.js
+++ b/packages/story-editor/src/components/colorPicker/karma/eyedropper.karma.js
@@ -31,6 +31,7 @@ describe('Eyedropper', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/dropTargets/karma/dropTarget.karma.js
+++ b/packages/story-editor/src/components/dropTargets/karma/dropTarget.karma.js
@@ -20,7 +20,7 @@
 import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
 
-fdescribe('Drop-Target integration', () => {
+describe('Drop-Target integration', () => {
   let fixture;
 
   beforeEach(async () => {

--- a/packages/story-editor/src/components/dropTargets/karma/dropTarget.karma.js
+++ b/packages/story-editor/src/components/dropTargets/karma/dropTarget.karma.js
@@ -26,6 +26,7 @@ describe('Drop-Target integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/dropTargets/karma/dropTarget.karma.js
+++ b/packages/story-editor/src/components/dropTargets/karma/dropTarget.karma.js
@@ -20,7 +20,7 @@
 import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
 
-describe('Drop-Target integration', () => {
+fdescribe('Drop-Target integration', () => {
   let fixture;
 
   beforeEach(async () => {
@@ -39,9 +39,7 @@ describe('Drop-Target integration', () => {
   };
 
   describe('when there is nothing on the canvas', () => {
-    // TODO(#9381): Fix flaky test.
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should by default have transparent background', async () => {
+    it('should by default have transparent background', async () => {
       const backgroundId = (await getElements(fixture))[0].id;
       const bgElement =
         fixture.editor.canvas.displayLayer.display(backgroundId).element;

--- a/packages/story-editor/src/components/dropTargets/karma/order.karma.js
+++ b/packages/story-editor/src/components/dropTargets/karma/order.karma.js
@@ -31,6 +31,7 @@ describe('Drop-Target order', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/footer/gridview/karma/gridView.karma.js
+++ b/packages/story-editor/src/components/footer/gridview/karma/gridView.karma.js
@@ -39,6 +39,7 @@ describe('GridView integration', () => {
     ]);
 
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     await fixture.events.click(fixture.editor.footer.gridViewToggle);
   });

--- a/packages/story-editor/src/components/footer/karma/footerMenu.karma.js
+++ b/packages/story-editor/src/components/footer/karma/footerMenu.karma.js
@@ -25,6 +25,7 @@ describe('Footer menu', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/footer/karma/popups.karma.js
+++ b/packages/story-editor/src/components/footer/karma/popups.karma.js
@@ -25,6 +25,7 @@ describe('Popup Menus - Help Center, KeyboardShortcuts, and Checklist', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/footer/karma/popups.karma.js
+++ b/packages/story-editor/src/components/footer/karma/popups.karma.js
@@ -25,32 +25,27 @@ describe('Popup Menus - Help Center, KeyboardShortcuts, and Checklist', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
-    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {
     fixture.restore();
   });
 
-  it('should start with all popups closed', () => {
+  it('should start with help center open', () => {
     const { helpCenterToggle, checklistToggle, keyboardShortcutsToggle } =
       fixture.editor.footer;
 
     expect(helpCenterToggle).toBeDefined();
     expect(checklistToggle).toBeDefined();
     expect(keyboardShortcutsToggle).toBeDefined();
-    expect(fixture.editor.helpCenter.quickTips).toBeNull();
+    expect(fixture.editor.helpCenter.quickTips).toBeDefined();
   });
 
-  it('should collapse helpCenter and keyboard shortcuts when checklist is expanded', async () => {
-    const { helpCenterToggle, checklistToggle } = fixture.editor.footer;
-    await fixture.events.click(helpCenterToggle);
-
-    const { quickTips } = await fixture.editor.helpCenter;
-    expect(quickTips).toBeDefined();
+  it('should collapse help center and keyboard shortcuts when checklist is expanded', async () => {
+    const { checklistToggle } = fixture.editor.footer;
 
     await fixture.events.click(checklistToggle);
-    await fixture.events.sleep(500);
+    await fixture.events.sleep(300); // allow transition to play out
 
     expect(
       fixture.editor.checklist.issues.getAttribute('data-isexpanded')
@@ -63,7 +58,7 @@ describe('Popup Menus - Help Center, KeyboardShortcuts, and Checklist', () => {
     const { helpCenterToggle, checklistToggle } = fixture.editor.footer;
 
     await fixture.events.click(checklistToggle);
-
+    await fixture.events.sleep(300);
     expect(
       fixture.editor.checklist.issues.getAttribute('data-isexpanded')
     ).toBe('true');
@@ -73,15 +68,16 @@ describe('Popup Menus - Help Center, KeyboardShortcuts, and Checklist', () => {
 
     const { quickTips } = await fixture.editor.helpCenter;
 
-    await fixture.events.sleep(500);
+    await fixture.events.sleep(300);
 
     expect(quickTips).toBeDefined();
   });
 
-  it('should collapse checklist and helpCenter when keyboard shortcuts menu is expanded', async () => {
+  it('should collapse checklist and help center when keyboard shortcuts menu is expanded', async () => {
     const { checklistToggle, keyboardShortcutsToggle } = fixture.editor.footer;
 
     await fixture.events.click(checklistToggle);
+    await fixture.events.sleep(300);
 
     expect(
       fixture.editor.checklist.issues.getAttribute('data-isexpanded')
@@ -90,9 +86,9 @@ describe('Popup Menus - Help Center, KeyboardShortcuts, and Checklist', () => {
 
     await fixture.events.click(keyboardShortcutsToggle);
 
-    const { keyboardShortcutsMenu } = await fixture.editor.keyboardShortcuts;
+    await fixture.events.sleep(300);
 
-    await fixture.events.sleep(500);
+    const { keyboardShortcutsMenu } = await fixture.editor.keyboardShortcuts;
 
     expect(keyboardShortcutsMenu).toBeDefined();
   });

--- a/packages/story-editor/src/components/footer/karma/zoomSelector.karma.js
+++ b/packages/story-editor/src/components/footer/karma/zoomSelector.karma.js
@@ -25,6 +25,7 @@ describe('Zoom selector', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     // Add an image to the canvas to make it more visual when things move
     await fixture.events.click(fixture.editor.library.media.item(0));

--- a/packages/story-editor/src/components/helpCenter/karma/helpCenter.karma.js
+++ b/packages/story-editor/src/components/helpCenter/karma/helpCenter.karma.js
@@ -31,13 +31,6 @@ describe('Help Center integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
-
-    // We're closing the help center in local storage in the fixture.
-    // Here we want to restore the initial state of it, so expanding it before running tests.
-    await fixture.events.click(fixture.editor.helpCenter.toggleButton);
-    // we want to make sure the quick tips are visible before continuing.
-    // eslint-disable-next-line jasmine/no-expect-in-setup-teardown
-    waitFor(() => expect(fixture.editor.helpCenter.quickTips).toBeTruthy());
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/inspector/karma/inspectorTabs.karma.js
+++ b/packages/story-editor/src/components/inspector/karma/inspectorTabs.karma.js
@@ -30,6 +30,7 @@ describe('Inspector Tabs integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
@@ -36,6 +36,7 @@ describe('Keyboard Shortcuts Menu', () => {
     fixture = new Fixture();
 
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
+++ b/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
@@ -35,6 +35,7 @@ describe('LibraryTabs integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
     libraryLayout = fixture.container.querySelector(
       '[data-testid="libraryLayout"]'
     );

--- a/packages/story-editor/src/components/library/karma/mediaTab.karma.js
+++ b/packages/story-editor/src/components/library/karma/mediaTab.karma.js
@@ -30,6 +30,7 @@ describe('Library Media Tab', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/library/karma/shapes/shapes.karma.js
+++ b/packages/story-editor/src/components/library/karma/shapes/shapes.karma.js
@@ -32,6 +32,7 @@ describe('Shape library integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {
@@ -100,6 +101,7 @@ describe('Sticker library integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/library/panes/media/local/karma/hotlink.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/hotlink.karma.js
@@ -33,6 +33,7 @@ describe('Embedding hotlinked media', () => {
     fixture = new Fixture();
     fixture.setFlags({ enableHotlinking: true, enableCORSProxy: true });
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -35,6 +35,7 @@ xdescribe('MediaPane fetching', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -210,6 +210,7 @@ xdescribe('Media3pPane fetching', () => {
     jasmine.clock().install();
 
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     unsplashSection = fixture.querySelector(
       '#provider-bottom-wrapper-unsplash'

--- a/packages/story-editor/src/components/library/panes/pageTemplates/karma/defaultPageTemplates.karma.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/karma/defaultPageTemplates.karma.js
@@ -46,6 +46,7 @@ describe('CUJ: Page Templates: Creator can Apply a Default Page Template', () =>
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000;
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/library/panes/pageTemplates/karma/savedPageTemplates.karma.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/karma/savedPageTemplates.karma.js
@@ -34,6 +34,7 @@ describe('CUJ: Page Templates: Custom Saved Templates', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000;
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/library/panes/text/karma/textPane.karma.js
+++ b/packages/story-editor/src/components/library/panes/text/karma/textPane.karma.js
@@ -38,6 +38,7 @@ describe('CUJ: Creator can Add and Write Text: Consecutive text presets', () => 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = TIMEOUT_INTERVAL;
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/library/panes/text/karma/textSets.cuj.karma.js
+++ b/packages/story-editor/src/components/library/panes/text/karma/textSets.cuj.karma.js
@@ -34,6 +34,7 @@ describe('CUJ: Text Sets (Text and Shape Combinations): Using Text Sets', () => 
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 300000;
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
     await fixture.editor.library.textTab.click();
   });
 

--- a/packages/story-editor/src/components/panels/design/alignment/karma/alignment.karma.js
+++ b/packages/story-editor/src/components/panels/design/alignment/karma/alignment.karma.js
@@ -33,7 +33,7 @@ describe('Alignment Panel', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
-
+    await fixture.collapseHelpCenter();
     textA = (await getElements())[0].id;
   });
 

--- a/packages/story-editor/src/components/panels/design/animation/karma/animation.karma.js
+++ b/packages/story-editor/src/components/panels/design/animation/karma/animation.karma.js
@@ -32,6 +32,7 @@ describe('Animation Panel', function () {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/panels/design/border/karma/border.karma.js
+++ b/packages/story-editor/src/components/panels/design/border/karma/border.karma.js
@@ -31,6 +31,7 @@ describe('Border Panel', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/panels/design/filter/karma/filter.karma.js
+++ b/packages/story-editor/src/components/panels/design/filter/karma/filter.karma.js
@@ -25,7 +25,7 @@ import { waitFor } from '@testing-library/react';
 import { Fixture } from '../../../../../karma';
 import { useStory } from '../../../../../app/story';
 
-fdescribe('Filter Panel', () => {
+describe('Filter Panel', () => {
   let fixture;
   let bgImageId;
   let filterPanel;

--- a/packages/story-editor/src/components/panels/design/filter/karma/filter.karma.js
+++ b/packages/story-editor/src/components/panels/design/filter/karma/filter.karma.js
@@ -34,6 +34,7 @@ describe('Filter Panel', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/panels/design/filter/karma/filter.karma.js
+++ b/packages/story-editor/src/components/panels/design/filter/karma/filter.karma.js
@@ -25,7 +25,7 @@ import { waitFor } from '@testing-library/react';
 import { Fixture } from '../../../../../karma';
 import { useStory } from '../../../../../app/story';
 
-describe('Filter Panel', () => {
+fdescribe('Filter Panel', () => {
   let fixture;
   let bgImageId;
   let filterPanel;
@@ -124,9 +124,7 @@ describe('Filter Panel', () => {
         expect(overlay).toHaveStyle('background-color', 'rgba(0, 0, 0, 0.5)');
       });
 
-      // TODO(#9389): Fix flaky test.
-      // eslint-disable-next-line jasmine/no-disabled-tests
-      xit('should render correct overlay when clicking "linear"', async () => {
+      it('should render correct overlay when clicking "linear"', async () => {
         await fixture.events.click(filterPanel.linear);
 
         const overlay = await waitFor(getBackgroundElementOverlay);

--- a/packages/story-editor/src/components/panels/design/layer/karma/layer.karma.js
+++ b/packages/story-editor/src/components/panels/design/layer/karma/layer.karma.js
@@ -33,6 +33,7 @@ describe('Layer Panel', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
     layerPanel = fixture.editor.inspector.designPanel.layerPanel;
 
     insertElement = await fixture.renderHook(() => useInsertElement());

--- a/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
+++ b/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
@@ -34,6 +34,7 @@ describe('Link Panel', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/panels/design/pageBackground/karma/pageBackground.karma.js
+++ b/packages/story-editor/src/components/panels/design/pageBackground/karma/pageBackground.karma.js
@@ -26,6 +26,7 @@ describe('Page background panel', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/panels/design/sizePosition/karma/borderRadius.karma.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/karma/borderRadius.karma.js
@@ -29,6 +29,7 @@ describe('Border Radius', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/panels/design/sizePosition/karma/sizePosition.karma.js
+++ b/packages/story-editor/src/components/panels/design/sizePosition/karma/sizePosition.karma.js
@@ -32,6 +32,7 @@ describe('Selection Panel', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/panels/design/textStyle/karma/stylePresets.karma.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/karma/stylePresets.karma.js
@@ -43,6 +43,7 @@ describe('Panel: Style Presets', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/panels/design/textStyle/karma/textStyle.other.karma.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/karma/textStyle.other.karma.js
@@ -32,6 +32,7 @@ describe('Text Style Panel', () => {
     fixture = new Fixture();
     localStorage.clear();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/panels/design/videoAccessibility/karma/videoPoster.karma.js
+++ b/packages/story-editor/src/components/panels/design/videoAccessibility/karma/videoPoster.karma.js
@@ -30,6 +30,7 @@ describe('Video Accessibility Panel', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/components/panels/design/videoAccessibility/karma/videoPoster.karma.js
+++ b/packages/story-editor/src/components/panels/design/videoAccessibility/karma/videoPoster.karma.js
@@ -81,7 +81,7 @@ describe('Video Accessibility Panel', () => {
       const originalPoster = vaPanel.posterImage.src;
 
       // Ensure focus right before the menu button.
-      await vaPanel.panelTitle.scrollIntoView();
+      vaPanel.panelTitle.scrollIntoView();
       await focusOnTitle();
 
       // Expect menu button to exist

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -41,6 +41,7 @@ describe('CUJ: Creator can Add and Write Text: Select an individual word to edit
   beforeEach(async () => {
     data.fixture = new Fixture();
     await data.fixture.render();
+    await data.fixture.collapseHelpCenter();
 
     // Add a text box
     await addInitialText();

--- a/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
@@ -29,6 +29,7 @@ describe('Inline style override', () => {
   beforeEach(async () => {
     data.fixture = new Fixture();
     await data.fixture.render();
+    await data.fixture.collapseHelpCenter();
 
     // Add a text box
     await addInitialText();

--- a/packages/story-editor/src/components/richText/karma/multiSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/multiSelection.karma.js
@@ -39,6 +39,7 @@ describe('Styling multiple text fields', () => {
   beforeEach(async () => {
     data.fixture = new Fixture();
     await data.fixture.render();
+    await data.fixture.collapseHelpCenter();
 
     // Add text box + extra
     await addInitialText(true);

--- a/packages/story-editor/src/components/richText/karma/singleSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/singleSelection.karma.js
@@ -35,6 +35,7 @@ describe('Styling single text field', () => {
   beforeEach(async () => {
     data.fixture = new Fixture();
     await data.fixture.render();
+    await data.fixture.collapseHelpCenter();
 
     // Add a text box
     await addInitialText();

--- a/packages/story-editor/src/elements/image/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/image/karma/edit.karma.js
@@ -28,6 +28,7 @@ describe('Image Editor', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     // Add first image to canvas
     await fixture.events.click(fixture.editor.library.media.item(0));

--- a/packages/story-editor/src/elements/image/karma/resourceLoading.karma.js
+++ b/packages/story-editor/src/elements/image/karma/resourceLoading.karma.js
@@ -30,6 +30,7 @@ describe('Image resource loading integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -32,6 +32,7 @@ describe('TextEdit integration', () => {
     fixture = new Fixture();
 
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/elements/text/karma/frame.karma.js
+++ b/packages/story-editor/src/elements/text/karma/frame.karma.js
@@ -28,6 +28,7 @@ describe('TextFrame integration', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/elements/video/karma/autoplay.karma.js
+++ b/packages/story-editor/src/elements/video/karma/autoplay.karma.js
@@ -32,6 +32,7 @@ describe('Autoplay video', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
     mediaPane = fixture.container.querySelector('#library-pane-media');
   });
 

--- a/packages/story-editor/src/elements/video/karma/elementMinSizeAndPlayback.karma.js
+++ b/packages/story-editor/src/elements/video/karma/elementMinSizeAndPlayback.karma.js
@@ -26,6 +26,7 @@ describe('Element min size and playback', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {

--- a/packages/story-editor/src/karma/copyAndPaste.cuj.karma.js
+++ b/packages/story-editor/src/karma/copyAndPaste.cuj.karma.js
@@ -70,6 +70,7 @@ function sequencedForEach(htmlCollection, op) {
     beforeEach(async () => {
       fixture = new Fixture();
       await fixture.render();
+      await fixture.collapseHelpCenter();
 
       // Insert selected element to perform operations on.
       const insertElement = await fixture.renderHook(() => useInsertElement());
@@ -224,6 +225,7 @@ describe('Background Copy & Paste', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     await fixture.events.click(fixture.editor.canvas.pageActions.addPage, {
       clickCount: 1,

--- a/packages/story-editor/src/karma/duplicate.cuj.karma.js
+++ b/packages/story-editor/src/karma/duplicate.cuj.karma.js
@@ -26,6 +26,7 @@ describe('Duplicate Page', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
+    await fixture.collapseHelpCenter();
 
     // Insert selected element to perform operations on.
     const insertElement = await fixture.renderHook(() => useInsertElement());

--- a/packages/story-editor/src/karma/elementTransform.cuj.karma.js
+++ b/packages/story-editor/src/karma/elementTransform.cuj.karma.js
@@ -54,6 +54,7 @@ describe('Element transform', () => {
     beforeEach(async () => {
       fixture = new Fixture();
       await fixture.render();
+      await fixture.collapseHelpCenter();
 
       // Switch to 100% zoom to make sure all full pixels are valid coordinates
       const { zoomSelector } = fixture.editor.footer;

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -397,9 +397,8 @@ export class Fixture {
 
   /**
    * Tells the fixture to close the help center
-   * which will default to Open the first time the fixture renders.
+   * which will default to open the first time the fixture renders.
    *
-   * @param {Function} func The hook function. E.g. `useStory`.
    * @return {Promise<Object>} Resolves when help center toggle is clicked.
    */
   collapseHelpCenter() {

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -405,7 +405,7 @@ export class Fixture {
   collapseHelpCenter() {
     const { _editor, _events } = this;
     if (!_editor || !_events) {
-      throw new Error('Not ready: fixture not set up');
+      throw new Error('Not ready: Help Center unable to collapse');
     }
 
     const { toggleButton } = _editor.helpCenter;

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -391,23 +391,26 @@ export class Fixture {
       });
     });
 
-    await waitFor(
-      async () => {
-        // Set help center to closed right away.
-        // Because there's logic to pop open the help center on initial load
-        // This wait + click to close the button is more in line with
-        // testing the actual behavior rather than overriding the local storage.
-        await this.editor.helpCenter.toggleButton;
-        await this.events?.click(this.editor.helpCenter.toggleButton, {
-          clickCount: 1,
-        });
-        await this.events?.sleep(500);
-      },
-      { timeout: 3000 }
-    );
-
     // @todo: find a stable way to wait for the story to fully render. Can be
     // implemented via `waitFor`.
+  }
+
+  /**
+   * Tells the fixture to close the help center
+   * which will default to Open the first time the fixture renders.
+   *
+   * @param {Function} func The hook function. E.g. `useStory`.
+   * @return {Promise<Object>} Resolves when help center toggle is clicked.
+   */
+  collapseHelpCenter() {
+    const { _editor, _events } = this;
+    if (!_editor || !_events) {
+      throw new Error('Not ready: fixture not set up');
+    }
+
+    const { toggleButton } = _editor.helpCenter;
+
+    return _events.click(toggleButton);
   }
 
   /**


### PR DESCRIPTION
## Context

Solvin' some flakey tests. 

## Summary

Collapsing the help center while rendering the fixture for story editor karma tests has become responsible for some flakey tests that were tragically disabled 😿 . This removes that and adds a function available on the fixture to collapse the help center when desired. Now when you want to collapse the help center just `await fixture.collapseHelpCenter()`

## Relevant Technical Choices

- Updates karma tests to collapseHelpCenter after render in `beforeEach` where applicable (pretty much everywhere except the karma tests for the help center and popups - now those are actually testing the initial state!) 
- Updates the popups tests now that help center can start expanded.
- carousel clickOnThumbnail was being flakey, gave it a tiny sleep (1 second) and added `await` to the scroll into view and it's working great now

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

None

## Testing Instructions

Do the karma tests for story editor now pass? if yes, then we're good.

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9389
Fixes #9387
Fixes #9381