### PR TITLE
Fix TextEdit Karma tests using shortcuts

### DIFF
--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -140,6 +140,7 @@ fdescribe('TextEdit integration', () => {
 
         // Exit edit mode using the Esc key
         await fixture.events.keyboard.press('Esc');
+        await fixture.events.sleep(100);
         await waitFor(() =>
           expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull()
         );

--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -25,7 +25,7 @@ import { waitFor } from '@testing-library/react';
 import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
 
-describe('TextEdit integration', () => {
+fdescribe('TextEdit integration', () => {
   let fixture;
 
   beforeEach(async () => {

--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -25,7 +25,7 @@ import { waitFor } from '@testing-library/react';
 import { Fixture } from '../../../karma';
 import { useStory } from '../../../app/story';
 
-fdescribe('TextEdit integration', () => {
+describe('TextEdit integration', () => {
   let fixture;
 
   beforeEach(async () => {

--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -137,12 +137,19 @@ fdescribe('TextEdit integration', () => {
         expect(
           fixture.querySelector('[data-testid="textEditor"]')
         ).toBeDefined();
+        await fixture.events.sleep(300);
+        await fixture.events.keyboard.type('This is some test text.');
 
         // Exit edit mode using the Esc key
         await fixture.events.keyboard.press('Esc');
         await fixture.events.sleep(100);
         await waitFor(() =>
           expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull()
+        );
+        // The element is still selected and updated.
+        const storyContext = await fixture.renderHook(() => useStory());
+        expect(storyContext.state.selectedElements[0].content).toEqual(
+          'This is some test text.'
         );
       });
     });

--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -130,9 +130,7 @@ describe('TextEdit integration', () => {
     });
 
     describe('shortcuts', () => {
-      // TODO(#9547): Fix flaky test.
-      // eslint-disable-next-line jasmine/no-disabled-tests
-      xit('should enter/exit edit mode using the keyboard', async () => {
+      it('should enter/exit edit mode using the keyboard', async () => {
         // Enter edit mode using the Enter key
         expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull();
         await fixture.events.keyboard.press('Enter');
@@ -142,7 +140,9 @@ describe('TextEdit integration', () => {
 
         // Exit edit mode using the Esc key
         await fixture.events.keyboard.press('Esc');
-        expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull();
+        await waitFor(() =>
+          expect(fixture.querySelector('[data-testid="textEditor"]')).toBeNull()
+        );
       });
     });
   });


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Fixes flaky test for entering and exiting text edit mode using keyboard shortcuts.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9547 
