### PR TITLE
Fix Karma tests related to text inline styles

### DIFF
--- a/packages/story-editor/src/components/richText/karma/_utils.js
+++ b/packages/story-editor/src/components/richText/karma/_utils.js
@@ -30,6 +30,16 @@ export function initHelpers(data) {
     return storyContext.state.currentPage.elements;
   }
 
+  async function setFontSize(size) {
+    const fontSize =
+      data.fixture.editor.inspector.designPanel.textStyle.fontSize;
+    await data.fixture.events.click(fontSize, { clickCount: 3 });
+    await data.fixture.events.keyboard.type(size);
+    await data.fixture.events.keyboard.press('tab');
+    // Give time for the font size to be applied.
+    await data.fixture.events.sleep(100);
+  }
+
   async function addInitialText(addExtra = false) {
     await data.fixture.events.click(data.fixture.editor.library.textAdd);
     await waitFor(() => data.fixture.editor.canvas.framesLayer.frames[1].node);
@@ -99,7 +109,7 @@ export function initHelpers(data) {
   async function setSelection(startOffset, endOffset) {
     // Assume text is in edit-mode - click inside editable text field
     // and then press "up" a number of times to ensure cursor is at start
-    const textEditor = data.fixture.editor.canvas.editLayer.text;
+    const textEditor = data.fixture.querySelector('[data-testid="textEditor"]');
     const { height } = textEditor.getBoundingClientRect();
     await data.fixture.events.mouse.clickOn(textEditor, 30, height / 2);
     await repeatPress('ArrowUp', 10);
@@ -118,5 +128,6 @@ export function initHelpers(data) {
     richTextHasFocus,
     selectTextField,
     selectBothTextFields,
+    setFontSize,
   };
 }

--- a/packages/story-editor/src/components/richText/karma/_utils.js
+++ b/packages/story-editor/src/components/richText/karma/_utils.js
@@ -120,7 +120,7 @@ export function initHelpers(data) {
     await repeatPress('ArrowRight', endOffset - startOffset);
     await data.fixture.events.keyboard.up('shift');
     await data.fixture.snapshot('End of selection');
-    await data.fixture.events.keyboard.shortcut('mod+a');
+    await data.fixture.events.click(textEditor, { clickCount: 3 });
     await data.fixture.snapshot('All selected');
   }
 

--- a/packages/story-editor/src/components/richText/karma/_utils.js
+++ b/packages/story-editor/src/components/richText/karma/_utils.js
@@ -115,9 +115,11 @@ export function initHelpers(data) {
     await repeatPress('ArrowUp', 10);
     // Move to start of selection and hold shift while selecting
     await repeatPress('ArrowRight', startOffset);
+    await data.fixture.snapshot('Start of selection');
     await data.fixture.events.keyboard.down('shift');
     await repeatPress('ArrowRight', endOffset - startOffset);
     await data.fixture.events.keyboard.up('shift');
+    await data.fixture.snapshot('End of selection');
   }
 
   return {

--- a/packages/story-editor/src/components/richText/karma/_utils.js
+++ b/packages/story-editor/src/components/richText/karma/_utils.js
@@ -122,6 +122,8 @@ export function initHelpers(data) {
     await data.fixture.snapshot('End of selection');
     await data.fixture.events.click(textEditor, { clickCount: 3 });
     await data.fixture.snapshot('All selected');
+    await data.fixture.events.keyboard.press('Del');
+    await data.fixture.snapshot('Text removed');
   }
 
   return {

--- a/packages/story-editor/src/components/richText/karma/_utils.js
+++ b/packages/story-editor/src/components/richText/karma/_utils.js
@@ -118,10 +118,6 @@ export function initHelpers(data) {
     await data.fixture.events.keyboard.down('shift');
     await repeatPress('ArrowRight', endOffset - startOffset);
     await data.fixture.events.keyboard.up('shift');
-    await data.fixture.snapshot('End of selection');
-    await data.fixture.events.keyboard.press('Del');
-    await data.fixture.snapshot('Text selection removed');
-
   }
 
   return {

--- a/packages/story-editor/src/components/richText/karma/_utils.js
+++ b/packages/story-editor/src/components/richText/karma/_utils.js
@@ -120,6 +120,8 @@ export function initHelpers(data) {
     await repeatPress('ArrowRight', endOffset - startOffset);
     await data.fixture.events.keyboard.up('shift');
     await data.fixture.snapshot('End of selection');
+    await data.fixture.events.keyboard.shortcut('mod+a');
+    await data.fixture.snapshot('All selected');
   }
 
   return {

--- a/packages/story-editor/src/components/richText/karma/_utils.js
+++ b/packages/story-editor/src/components/richText/karma/_utils.js
@@ -115,15 +115,13 @@ export function initHelpers(data) {
     await repeatPress('ArrowUp', 10);
     // Move to start of selection and hold shift while selecting
     await repeatPress('ArrowRight', startOffset);
-    await data.fixture.snapshot('Start of selection');
     await data.fixture.events.keyboard.down('shift');
     await repeatPress('ArrowRight', endOffset - startOffset);
     await data.fixture.events.keyboard.up('shift');
     await data.fixture.snapshot('End of selection');
-    await data.fixture.events.click(textEditor, { clickCount: 3 });
-    await data.fixture.snapshot('All selected');
     await data.fixture.events.keyboard.press('Del');
-    await data.fixture.snapshot('Text removed');
+    await data.fixture.snapshot('Text selection removed');
+
   }
 
   return {

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -77,7 +77,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       await setSelection(5, 7);
 
       // Check all styles are default
-      expect(bold.checked).toBe(false);
+      /*expect(bold.checked).toBe(false);
       expect(italic.checked).toBe(false);
       expect(underline.checked).toBe(false);
       expect(uppercase.checked).toBe(false);
@@ -200,7 +200,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
         'text-transform: uppercase',
       ].join('; ');
       const expected = `Fill <span style="${firstCSS}">i</span><span style="${secondCSS}">n</span><span style="${secondCSS}"> s</span>ome text`;
-      expect(actual).toBe(expected);
+      expect(actual).toBe(expected);*/
     });
   });
 

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -180,6 +180,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       const { x, y } = bg.getBoundingClientRect();
       await data.fixture.events.mouse.click(x + 30, y + 30);
       await data.fixture.events.sleep(100);
+      await data.fixture.snapshot('Before exiting');
 
       // Assume text content to match expectation
       const storyContext = await data.fixture.renderHook(() => useStory());

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -180,18 +180,9 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       expect(fontColor.hex.value).toBe('EEEEEE');
 
       // Exit edit-mode
-      await richTextHasFocus();
-      await data.fixture.events.keyboard.press('Esc');
-      const bg = data.fixture.editor.canvas.framesLayer.frames[0].node;
-      const { x, y } = bg.getBoundingClientRect();
-      await data.fixture.events.mouse.click(x + 20, y + 20);
-      await data.fixture.events.sleep(500);
-      await data.fixture.events.mouse.click(x + 20, y + 20);
-      await data.fixture.snapshot('After exiting');
-
       const safezone = data.fixture.querySelector('[data-testid="safezone"]');
       await data.fixture.events.click(safezone);
-      await data.fixture.snapshot('After exiting try 2');
+      await data.fixture.snapshot('After exiting');
 
       // Assume text content to match expectation
       storyContext = await data.fixture.renderHook(() => useStory());

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -24,8 +24,8 @@ import { waitFor } from '@testing-library/react';
  */
 import { Fixture } from '../../../karma';
 import { MULTIPLE_DISPLAY_VALUE } from '../../../constants';
+import { useStory } from '../../../app';
 import { initHelpers } from './_utils';
-import {useStory} from "../../../app";
 
 fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edit', () => {
   const data = {};
@@ -183,7 +183,8 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       const bg = data.fixture.editor.canvas.framesLayer.frames[0].node;
       const { x, y } = bg.getBoundingClientRect();
       await data.fixture.events.mouse.click(x + 30, y + 30);
-      await data.fixture.events.sleep(100);
+      await data.fixture.events.mouse.click(x + 30, y + 30);
+      await data.fixture.events.sleep(500);
       await data.fixture.snapshot('Before exiting');
 
       // Assume text content to match expectation

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -175,14 +175,11 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       expect(letterSpacing.value).toBe('100%');
       expect(fontColor.hex.value).toBe('EEEEEE');
 
-      await data.fixture.snapshot('Applied values after');
       // Exit edit-mode
       const bg = data.fixture.editor.canvas.framesLayer.frames[0].node;
       const { x, y } = bg.getBoundingClientRect();
       await data.fixture.events.mouse.click(x + 30, y + 30);
       await data.fixture.events.sleep(100);
-
-      await data.fixture.snapshot('Applied values after exiting edit mode');
 
       // Assume text content to match expectation
       const storyContext = await data.fixture.renderHook(() => useStory());
@@ -204,7 +201,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
         'text-transform: uppercase',
       ].join('; ');
       const expected = `Fill <span style="${firstCSS}">i</span><span style="${secondCSS}">n</span><span style="${secondCSS}"> s</span>ome text`;
-      // expect(actual).toBe(expected);
+      expect(actual).toBe(expected);
     });
   });
 

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -182,10 +182,10 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       // Exit edit-mode
       const bg = data.fixture.editor.canvas.framesLayer.frames[0].node;
       const { x, y } = bg.getBoundingClientRect();
-      await data.fixture.events.mouse.click(x + 30, y + 30);
-      await data.fixture.events.mouse.click(x + 30, y + 30);
+      await data.fixture.events.mouse.click(x + 20, y + 20);
       await data.fixture.events.sleep(500);
-      await data.fixture.snapshot('Before exiting');
+      await data.fixture.events.mouse.click(x + 20, y + 20);
+      await data.fixture.snapshot('After exiting');
 
       // Assume text content to match expectation
       storyContext = await data.fixture.renderHook(() => useStory());
@@ -207,7 +207,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
         'text-transform: uppercase',
       ].join('; ');
       const expected = `Fill <span style="${firstCSS}">i</span><span style="${secondCSS}">n</span><span style="${secondCSS}"> s</span>ome text`;
-      expect(actual).toBe(expected);
+      //expect(actual).toBe(expected);
     });
   });
 

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -180,6 +180,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       expect(fontColor.hex.value).toBe('EEEEEE');
 
       // Exit edit-mode
+      await data.fixture.events.keyboard.press('Esc');
       const bg = data.fixture.editor.canvas.framesLayer.frames[0].node;
       const { x, y } = bg.getBoundingClientRect();
       await data.fixture.events.mouse.click(x + 20, y + 20);

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -56,6 +56,10 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
 
   describe('CUJ: Creator Can Style Text: Apply B, Apply U, Apply I, Set text color, Set kerning', () => {
     fit('should apply inline formats correctly for both single style and multiple styles', async () => {
+      let storyContext = await data.fixture.renderHook(() => useStory());
+      expect(storyContext.state.selectedElements[0].content).toBe(
+        'Fill in some text'
+      );
       const {
         bold,
         italic,
@@ -183,7 +187,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       await data.fixture.snapshot('Before exiting');
 
       // Assume text content to match expectation
-      const storyContext = await data.fixture.renderHook(() => useStory());
+      storyContext = await data.fixture.renderHook(() => useStory());
       const actual = storyContext.state.selectedElements[0].content;
       const firstCSS = [
         'font-weight: 900',

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -77,7 +77,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       await setSelection(5, 7);
 
       // Check all styles are default
-      /*expect(bold.checked).toBe(false);
+      expect(bold.checked).toBe(false);
       expect(italic.checked).toBe(false);
       expect(underline.checked).toBe(false);
       expect(uppercase.checked).toBe(false);
@@ -92,10 +92,10 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       await richTextHasFocus();
       await data.fixture.events.click(uppercase.button);
       await richTextHasFocus();
-
+      await data.fixture.snapshot('Applied values');
       // Set font weight (should also toggle bold, as "Black" is >700)
       // - wait for autofocus to return
-      await data.fixture.events.click(fontWeight.select);
+      /*await data.fixture.events.click(fontWeight.select);
       await data.fixture.events.sleep(300);
       await data.fixture.events.click(await fontWeight.option('Black'));
       await data.fixture.events.sleep(300);

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -180,6 +180,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       expect(fontColor.hex.value).toBe('EEEEEE');
 
       // Exit edit-mode
+      await richTextHasFocus();
       await data.fixture.events.keyboard.press('Esc');
       const bg = data.fixture.editor.canvas.framesLayer.frames[0].node;
       const { x, y } = bg.getBoundingClientRect();
@@ -187,6 +188,10 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       await data.fixture.events.sleep(500);
       await data.fixture.events.mouse.click(x + 20, y + 20);
       await data.fixture.snapshot('After exiting');
+
+      const safezone = data.fixture.querySelector('[data-testid="safezone"]');
+      await data.fixture.events.click(safezone);
+      await data.fixture.snapshot('After exiting try 2');
 
       // Assume text content to match expectation
       storyContext = await data.fixture.renderHook(() => useStory());

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -204,7 +204,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
         'text-transform: uppercase',
       ].join('; ');
       const expected = `Fill <span style="${firstCSS}">i</span><span style="${secondCSS}">n</span><span style="${secondCSS}"> s</span>ome text`;
-      //expect(actual).toBe(expected);
+      expect(actual).toBe(expected);
     });
   });
 

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -25,6 +25,7 @@ import { waitFor } from '@testing-library/react';
 import { Fixture } from '../../../karma';
 import { MULTIPLE_DISPLAY_VALUE } from '../../../constants';
 import { initHelpers } from './_utils';
+import {useStory} from "../../../app";
 
 fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edit', () => {
   const data = {};
@@ -146,7 +147,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       expect(letterSpacing.value).toBe('');
       expect(letterSpacing.placeholder).toBe(MULTIPLE_DISPLAY_VALUE);
       expect(fontColor.output).toBe('');
-      await data.fixture.snapshot('Applied values before');
+
       // Now toggle all toggles, and set new color and letter spacing
       await data.fixture.events.click(italic.button);
       await data.fixture.events.click(underline.button);
@@ -164,10 +165,9 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       await data.fixture.events.keyboard.type('100');
       await data.fixture.events.keyboard.press('Enter');
       await data.fixture.events.keyboard.press('Escape');
-      await data.fixture.snapshot('Applied values after');
 
       // Verify all styles again
-      /*expect(bold.checked).toBe(true);
+      expect(bold.checked).toBe(true);
       expect(italic.checked).toBe(true);
       expect(underline.checked).toBe(true);
       // Note that entire selection is made black, because some part was black, when bold was pressed
@@ -175,14 +175,18 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       expect(letterSpacing.value).toBe('100%');
       expect(fontColor.hex.value).toBe('EEEEEE');
 
+      await data.fixture.snapshot('Applied values after');
       // Exit edit-mode
       const bg = data.fixture.editor.canvas.framesLayer.frames[0].node;
       const { x, y } = bg.getBoundingClientRect();
       await data.fixture.events.mouse.click(x + 30, y + 30);
       await data.fixture.events.sleep(100);
 
+      await data.fixture.snapshot('Applied values after exiting edit mode');
+
       // Assume text content to match expectation
-      const actual = getTextContent();
+      const storyContext = await data.fixture.renderHook(() => useStory());
+      const actual = storyContext.state.selectedElements[0].content;
       const firstCSS = [
         'font-weight: 900',
         'font-style: italic',
@@ -200,7 +204,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
         'text-transform: uppercase',
       ].join('; ');
       const expected = `Fill <span style="${firstCSS}">i</span><span style="${secondCSS}">n</span><span style="${secondCSS}"> s</span>ome text`;
-      expect(actual).toBe(expected);*/
+      // expect(actual).toBe(expected);
     });
   });
 

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -92,10 +92,9 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       await richTextHasFocus();
       await data.fixture.events.click(uppercase.button);
       await richTextHasFocus();
-      await data.fixture.snapshot('Applied values');
       // Set font weight (should also toggle bold, as "Black" is >700)
       // - wait for autofocus to return
-      /*await data.fixture.events.click(fontWeight.select);
+      await data.fixture.events.click(fontWeight.select);
       await data.fixture.events.sleep(300);
       await data.fixture.events.click(await fontWeight.option('Black'));
       await data.fixture.events.sleep(300);
@@ -147,7 +146,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       expect(letterSpacing.value).toBe('');
       expect(letterSpacing.placeholder).toBe(MULTIPLE_DISPLAY_VALUE);
       expect(fontColor.output).toBe('');
-
+      await data.fixture.snapshot('Applied values before');
       // Now toggle all toggles, and set new color and letter spacing
       await data.fixture.events.click(italic.button);
       await data.fixture.events.click(underline.button);
@@ -165,9 +164,10 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       await data.fixture.events.keyboard.type('100');
       await data.fixture.events.keyboard.press('Enter');
       await data.fixture.events.keyboard.press('Escape');
+      await data.fixture.snapshot('Applied values after');
 
       // Verify all styles again
-      expect(bold.checked).toBe(true);
+      /*expect(bold.checked).toBe(true);
       expect(italic.checked).toBe(true);
       expect(underline.checked).toBe(true);
       // Note that entire selection is made black, because some part was black, when bold was pressed

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -182,7 +182,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
       // Exit edit-mode
       const safezone = data.fixture.querySelector('[data-testid="safezone"]');
       await data.fixture.events.click(safezone);
-      await data.fixture.snapshot('After exiting');
+      await data.fixture.snapshot('With inline style applied');
 
       // Assume text content to match expectation
       storyContext = await data.fixture.renderHook(() => useStory());

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -27,7 +27,7 @@ import { MULTIPLE_DISPLAY_VALUE } from '../../../constants';
 import { useStory } from '../../../app';
 import { initHelpers } from './_utils';
 
-fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edit', () => {
+describe('CUJ: Creator can Add and Write Text: Select an individual word to edit', () => {
   const data = {};
 
   const {
@@ -55,7 +55,7 @@ fdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edi
   });
 
   describe('CUJ: Creator Can Style Text: Apply B, Apply U, Apply I, Set text color, Set kerning', () => {
-    fit('should apply inline formats correctly for both single style and multiple styles', async () => {
+    it('should apply inline formats correctly for both single style and multiple styles', async () => {
       let storyContext = await data.fixture.renderHook(() => useStory());
       expect(storyContext.state.selectedElements[0].content).toBe(
         'Fill in some text'

--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -87,14 +87,22 @@ describe('TextEdit integration', () => {
         await fixture.snapshot();
       });
 
-      // Broken test, see: https://github.com/google/web-stories-wp/issues/7211
-      // eslint-disable-next-line jasmine/no-disabled-tests
-      xit('should handle a command, exit and save', async () => {
+      fit('should handle a command, exit and save', async () => {
+        // Increase the font size for ensuring the clicks to be in correct places.
+        await fixture.events.click(
+          fixture.editor.inspector.designPanel.textStyle.fontSize,
+          { clickCount: 3 }
+        );
+        await fixture.events.keyboard.type('30');
+        await fixture.events.keyboard.press('tab');
+        // Give time for the font size to be applied.
+        await fixture.events.sleep(100);
+
         // Select all.
-        await fixture.events.keyboard.press('Enter');
+        await fixture.events.mouse.clickOn(frame, 30, 5);
         await repeatPress('ArrowUp', 10);
         await fixture.events.keyboard.down('shift');
-        await repeatPress('ArrowRight', 15);
+        await repeatPress('ArrowRight', 20);
         await fixture.events.keyboard.up('shift');
 
         expect(boldToggle.checked).toEqual(false);

--- a/packages/story-editor/src/elements/text/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/text/karma/edit.karma.js
@@ -87,7 +87,7 @@ describe('TextEdit integration', () => {
         await fixture.snapshot();
       });
 
-      fit('should handle a command, exit and save', async () => {
+      it('should handle a command, exit and save', async () => {
         // Increase the font size for ensuring the clicks to be in correct places.
         await fixture.events.click(
           fixture.editor.inspector.designPanel.textStyle.fontSize,


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Fixes the following tests previously disabled:
- `should apply inline formats correctly for both single style and multiple styles`
- `should handle a command, exit and save`
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

Increases the font size before getting selection since sometimes on the test screen the text might be too small otherwise for the click going to the right place.
<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7211 
