### PR TITLE
Code Quality: Fix 3P Media Integration Tests

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
@@ -113,7 +113,6 @@ function PaginatedMediaGallery({
     async function loadNextPageIfNeededAfterGalleryRendering() {
       // Wait for <Gallery> to finish its render layout cycles first.
       await sleep(200);
-
       loadNextPageIfNeeded();
     }
     loadNextPageIfNeededAfterGalleryRendering();

--- a/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
@@ -113,6 +113,7 @@ function PaginatedMediaGallery({
     async function loadNextPageIfNeededAfterGalleryRendering() {
       // Wait for <Gallery> to finish its render layout cycles first.
       await sleep(200);
+
       loadNextPageIfNeeded();
     }
     loadNextPageIfNeededAfterGalleryRendering();

--- a/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -193,7 +193,7 @@ const categories = [
   },
 ];
 
-describe('TESTING', () => {
+describe('Media3pPane fetching', () => {
   let fixture;
   let listMediaSpy;
   let listCategoriesSpy;
@@ -202,8 +202,6 @@ describe('TESTING', () => {
     localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
 
     fixture = new Fixture();
-
-    // jasmine.clock().install();
 
     await fixture.render();
 
@@ -215,7 +213,6 @@ describe('TESTING', () => {
   });
 
   afterEach(() => {
-    // jasmine.clock().uninstall();
     fixture.restore();
   });
 

--- a/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { waitFor } from '@testing-library/react';
+import { waitFor, within } from '@testing-library/react';
 import {
   localStore,
   LOCAL_STORAGE_PREFIX,
@@ -113,119 +113,114 @@ const mediaPage = (page, provider) =>
 const categories = [
   {
     name: 'categories/unsplash:KHXRtL69hcY',
-    label: 'Sustainability',
+    displayName: 'Sustainability',
   },
   {
     name: 'categories/unsplash:bo8jQKTaE0Y',
-    label: 'Wallpapers',
+    displayName: 'Wallpapers',
   },
   {
     name: 'categories/unsplash:c7USHrQ0Ljw',
-    label: 'COVID-19',
+    displayName: 'COVID-19',
   },
   {
     name: 'categories/unsplash:Fzo3zuOHN6w',
-    label: 'Travel',
+    displayName: 'Travel',
   },
   {
     name: 'categories/unsplash:6sMVjTLSkeQ',
-    label: 'Nature',
+    displayName: 'Nature',
   },
   {
     name: 'categories/unsplash:iUIsnVtjB0Y',
-    label: 'Textures & Patterns',
+    displayName: 'Textures & Patterns',
   },
   {
     name: 'categories/unsplash:BJJMtteDJA4',
-    label: 'Current Events',
+    displayName: 'Current Events',
   },
   {
     name: 'categories/unsplash:towJZFskpGg',
-    label: 'People',
+    displayName: 'People',
   },
   {
     name: 'categories/unsplash:aeu6rL-j6ew',
-    label: 'Business & Work',
+    displayName: 'Business & Work',
   },
   {
     name: 'categories/unsplash:J9yrPaHXRQY',
-    label: 'Technology',
+    displayName: 'Technology',
   },
   {
     name: 'categories/unsplash:Jpg6Kidl-Hk',
-    label: 'Animals',
+    displayName: 'Animals',
   },
   {
     name: 'categories/unsplash:R_Fyn-Gwtlw',
-    label: 'Interiors',
+    displayName: 'Interiors',
   },
   {
     name: 'categories/unsplash:rnSKDHwwYUk',
-    label: 'Architecture',
+    displayName: 'Architecture',
   },
   {
     name: 'categories/unsplash:xjPR4hlkBGA',
-    label: 'Food & Drink',
+    displayName: 'Food & Drink',
   },
   {
     name: 'categories/unsplash:Bn-DjrcBrwo',
-    label: 'Athletics',
+    displayName: 'Athletics',
   },
   {
     name: 'categories/unsplash:_8zFHuhRhyo',
-    label: 'Spirituality',
+    displayName: 'Spirituality',
   },
   {
     name: 'categories/unsplash:_hb-dl4Q-4U',
-    label: 'Health & Wellness',
+    displayName: 'Health & Wellness',
   },
   {
     name: 'categories/unsplash:hmenvQhUmxM',
-    label: 'Film',
+    displayName: 'Film',
   },
   {
     name: 'categories/unsplash:S4MKLAsBB74',
-    label: 'Fashion',
+    displayName: 'Fashion',
   },
   {
     name: 'categories/unsplash:qPYsDzvJOYc',
-    label: 'Experimental',
+    displayName: 'Experimental',
   },
 ];
 
-// Disable reason: flakey tests.
-// See https://github.com/google/web-stories-wp/pull/6162
-// eslint-disable-next-line jasmine/no-disabled-tests
-xdescribe('Media3pPane fetching', () => {
+describe('TESTING', () => {
   let fixture;
-  let unsplashSection;
-  let coverrSection;
-  let media3pPane;
+  let listMediaSpy;
+  let listCategoriesSpy;
 
   beforeEach(async () => {
     localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
 
     fixture = new Fixture();
 
-    jasmine.clock().install();
+    // jasmine.clock().install();
 
     await fixture.render();
 
-    unsplashSection = fixture.querySelector(
-      '#provider-bottom-wrapper-unsplash'
-    );
-    coverrSection = fixture.querySelector('#provider-bottom-wrapper-coverr');
-    media3pPane = fixture.querySelector('#library-pane-media3p');
+    listMediaSpy = spyOn(apiFetcher, 'listMedia');
+    listCategoriesSpy = spyOn(apiFetcher, 'listCategories');
+
+    mockListMedia();
+    mockListCategories();
   });
 
   afterEach(() => {
-    jasmine.clock().uninstall();
+    // jasmine.clock().uninstall();
     fixture.restore();
   });
 
   function mockListMedia() {
-    /* eslint-disable-next-line jasmine/no-unsafe-spy */
-    spyOn(apiFetcher, 'listMedia').and.callFake(({ pageToken, filter }) => {
+    listMediaSpy.and.callFake(({ pageToken, filter }) => {
       let provider;
       if (filter.includes('unsplash')) {
         provider = 'unsplash';
@@ -246,10 +241,9 @@ xdescribe('Media3pPane fetching', () => {
   }
 
   function mockListCategories() {
-    /* eslint-disable-next-line jasmine/no-unsafe-spy */
-    spyOn(apiFetcher, 'listCategories').and.callFake(() => {
+    listCategoriesSpy.and.callFake(() => {
       return {
-        categories: categories,
+        categories,
       };
     });
   }
@@ -258,61 +252,48 @@ xdescribe('Media3pPane fetching', () => {
     let mediaElements;
     await waitFor(
       () => {
-        mediaElements = section.querySelectorAll('[data-testid^=mediaElement]');
+        mediaElements = within(section).queryAllByTestId(/^mediaElement/);
+
+        // Continue waiting if number of elements does not match the expectedCount
         if (!mediaElements || mediaElements.length !== expectedCount) {
           throw new Error(
             `Not ready: ${mediaElements?.length} != ${expectedCount}`
           );
         }
-        jasmine.clock().tick(10);
       },
       { timeout: 5000 }
     );
     expect(mediaElements?.length).toBe(expectedCount);
   }
 
-  it('should render initial page with media3p tab button at top', async () => {
-    await fixture.snapshot();
-  });
-
   it('should render no results message', async () => {
-    spyOn(apiFetcher, 'listMedia').and.callFake(() => ({ media: [] }));
+    listMediaSpy.and.callFake(() => ({ media: [] }));
     await fixture.events.click(fixture.editor.library.media3pTab);
 
     await waitFor(() => {
       expect(
-        fixture.screen.getByText(new RegExp('^No media found$'))
+        fixture.screen.getByText(new RegExp('^No media found.$'))
       ).toBeTruthy();
     });
 
     await fixture.snapshot();
   });
 
-  it('should fetch media resources', async () => {
-    mockListMedia();
-    await fixture.events.click(fixture.editor.library.media3pTab);
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
-  });
-
   it('should render categories and media resources', async () => {
-    mockListMedia();
-    mockListCategories();
-
     await fixture.events.click(fixture.editor.library.media3pTab);
 
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+    await expectMediaElements(
+      fixture.editor.library.media3p.unsplashSection,
+      MEDIA_PER_PAGE
+    );
 
     await fixture.snapshot();
   });
 
   it('should arrow navigate between category pills', async () => {
-    mockListMedia();
-    mockListCategories();
     await fixture.events.click(fixture.editor.library.media3pTab);
 
-    await fixture.events.focus(
-      fixture.querySelectorAll('[data-testid="pill"]')[0]
-    );
+    await fixture.events.focus(fixture.editor.library.media3p.filters[0]);
     expect(document.activeElement.textContent).toBe('Sustainability');
 
     await fixture.events.keyboard.press('ArrowRight');
@@ -320,13 +301,11 @@ xdescribe('Media3pPane fetching', () => {
 
     await fixture.events.keyboard.press('tab');
     expect(document.activeElement).toBe(
-      fixture.screen.getByRole('button', { name: 'Expand' })
+      fixture.editor.library.media3p.expandFiltersButton
     );
   });
 
   it('should expand category section on arrow down', async () => {
-    mockListMedia();
-    mockListCategories();
     await fixture.events.click(fixture.editor.library.media3pTab);
 
     await fixture.events.keyboard.press('tab');
@@ -335,92 +314,66 @@ xdescribe('Media3pPane fetching', () => {
     expect(document.activeElement.textContent).toBe('Sustainability');
 
     await fixture.events.keyboard.press('ArrowDown');
-    const expandButton = fixture.screen.getByRole('button', { name: 'Expand' });
-    expect(expandButton.getAttribute('aria-expanded')).toBe('true');
+    expect(
+      fixture.editor.library.media3p.expandFiltersButton.getAttribute(
+        'aria-expanded'
+      )
+    ).toBe('true');
   });
 
   it('should fetch 2nd page', async () => {
-    mockListMedia();
     await fixture.events.click(fixture.editor.library.media3pTab);
 
-    const mediaGallery = unsplashSection.querySelector(
-      '[data-testid="media-gallery-container"]'
+    const mediaGallery = fixture.editor.library.media3p.mediaGallery;
+
+    await expectMediaElements(
+      fixture.editor.library.media3p.unsplashSection,
+      MEDIA_PER_PAGE
     );
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
     mediaGallery.scrollTo(
       0,
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
     );
-    jasmine.clock().tick(500);
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE * 2);
-  });
 
-  // The scroll position was being reset because the resize event in <Gallery>
-  // would render no images when the media pane was hidden (width->0).
-  // This was fixed by re-rendering <Gallery> whenever MediaPane/Media3pPane is
-  // re-rendered, which causes the resize event to be suppressed at exactly the
-  // right time.
-  // A more robust fix to the scroll position reset issue can be found here:
-  // https://github.com/neptunian/react-photo-gallery/pull/184
-  // If that PR be released, another option is to patch it using:
-  // https://www.npmjs.com/package/patch-package
-  it('should retain scroll position on tab change', async () => {
-    mockListMedia();
-    await fixture.events.click(fixture.editor.library.media3pTab);
-
-    const mediaGallery = unsplashSection.querySelector(
-      '[data-testid="media-gallery-container"]'
+    await expectMediaElements(
+      fixture.editor.library.media3p.unsplashSection,
+      MEDIA_PER_PAGE * 2
     );
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
-    mediaGallery.scrollTo(0, 10);
-    await waitFor(() => {
-      if (mediaGallery.scrollTop != 10) {
-        throw new Error('media scroll position must be initially');
-      }
-    });
-
-    await fixture.events.click(fixture.editor.library.shapesTab);
-    await fixture.events.click(fixture.editor.library.media3pTab);
-    await waitFor(() => {
-      if (mediaGallery.scrollTop != 10) {
-        throw new Error('media scroll position must be retained');
-      }
-    });
   });
 
-  it('should render the second provider', async () => {
-    mockListMedia();
+  it('should render the second media provider', async () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
 
-    const coverrTab = fixture.querySelector('#provider-tab-coverr');
+    await fixture.events.click(fixture.editor.library.media3p.coverrTab);
 
-    await fixture.events.click(coverrTab);
-    await expectMediaElements(coverrSection, MEDIA_PER_PAGE);
+    await expectMediaElements(
+      fixture.editor.library.media3p.coverrSection,
+      // In 1600:1000 the coverr section will fetch again due to screen height
+      MEDIA_PER_PAGE * 2
+    );
   });
 
   it('should scroll to the top when a category is selected', async () => {
-    mockListMedia();
-    mockListCategories();
-
     await fixture.events.click(fixture.editor.library.media3pTab);
 
-    const mediaGallery = unsplashSection.querySelector(
-      '[data-testid="media-gallery-container"]'
+    const mediaGallery = fixture.editor.library.media3p.mediaGallery;
+    await expectMediaElements(
+      fixture.editor.library.media3p.unsplashSection,
+      MEDIA_PER_PAGE
     );
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
     mediaGallery.scrollTo(
       0,
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
     );
-    jasmine.clock().tick(500);
-    await expectMediaElements(unsplashSection, MEDIA_PER_PAGE * 2);
 
-    const mediaCategories = unsplashSection.querySelectorAll(
-      '[data-testid="pill"]'
+    await expectMediaElements(
+      fixture.editor.library.media3p.unsplashSection,
+      MEDIA_PER_PAGE * 2
     );
-    await fixture.events.click(mediaCategories[0]);
+
+    await fixture.events.click(fixture.editor.library.media3p.mediaElements[0]);
 
     await waitFor(() => {
       expect(mediaGallery.scrollTop).toBe(0);
@@ -428,67 +381,66 @@ xdescribe('Media3pPane fetching', () => {
   });
 
   it('should have a delay before autoplaying videos', async () => {
-    mockListMedia();
     await fixture.events.click(fixture.editor.library.media3pTab);
 
-    const coverrTab = fixture.querySelector('#provider-tab-coverr');
-
-    await fixture.events.click(coverrTab);
-    await expectMediaElements(coverrSection, MEDIA_PER_PAGE);
-
-    const mediaElements = coverrSection.querySelectorAll(
-      '[data-testid^=mediaElement]'
+    await fixture.events.click(fixture.editor.library.media3p.coverrTab);
+    await expectMediaElements(
+      fixture.editor.library.media3p.coverrSection,
+      // In 1600:1000 the coverr section will fetch again due to screen height
+      MEDIA_PER_PAGE * 2
     );
 
-    const firstMediaElement = mediaElements.item(0);
+    const firstMediaElement = fixture.editor.library.media3p.mediaElements[0];
+
+    expect(firstMediaElement.querySelector('video').paused).toBe(true);
+
     await fixture.events.focus(firstMediaElement);
-    const video = firstMediaElement.querySelector('video');
 
-    expect(video.paused).toBe(true);
+    // shouldn't play yet
+    expect(firstMediaElement.querySelector('video').paused).toBe(true);
 
-    jasmine.clock().tick(700);
+    // wait for a little and check again
+    await waitFor(() => {
+      if (firstMediaElement.querySelector('video').paused) {
+        throw new Error('wait');
+      }
 
-    expect(video.paused).toBe(false);
+      expect(firstMediaElement.querySelector('video').paused).toBe(false);
+    });
   });
 
   describe('Gallery navigation', () => {
     it('should handle pressing right when focused', async () => {
-      mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
+
+      const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-      const mediaElements = unsplashSection.querySelectorAll(
-        '[data-testid^=mediaElement]'
-      );
-
-      await fixture.events.focus(mediaElements.item(0));
+      await fixture.events.focus(mediaElements[0]);
 
       await fixture.events.keyboard.press('ArrowRight');
 
-      expect(document.activeElement).toBe(mediaElements.item(1));
+      expect(document.activeElement).toBe(mediaElements[1]);
     });
 
     it('should handle pressing right when at the end of a row', async () => {
-      mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
+
+      const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-      const mediaElements = unsplashSection.querySelectorAll(
-        '[data-testid^=mediaElement]'
-      );
-
-      await fixture.events.focus(mediaElements.item(1));
+      await fixture.events.focus(mediaElements[1]);
 
       await fixture.events.keyboard.press('ArrowRight');
 
-      expect(document.activeElement).toBe(mediaElements.item(2));
+      expect(document.activeElement).toBe(mediaElements[2]);
     });
 
     it('should handle pressing right when the last element is focused', async () => {
       // Only mock 1 page.
-      spyOn(apiFetcher, 'listMedia').and.callFake(({ pageToken }) => {
+      listMediaSpy.and.callFake(({ pageToken }) => {
         if (!pageToken) {
           return { media: mediaPage(1, 'unsplash'), nextPageToken: undefined };
         }
@@ -497,215 +449,204 @@ xdescribe('Media3pPane fetching', () => {
 
       await fixture.events.click(fixture.editor.library.media3pTab);
 
+      const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
+
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-      const mediaElements = unsplashSection.querySelectorAll(
-        '[data-testid^=mediaElement]'
-      );
-
-      await fixture.events.focus(mediaElements.item(mediaElements.length - 1));
+      await fixture.events.focus(mediaElements[mediaElements.length - 1]);
 
       await fixture.events.keyboard.press('ArrowRight');
 
       expect(document.activeElement).toBe(
-        mediaElements.item(mediaElements.length - 1)
+        mediaElements[mediaElements.length - 1]
       );
     });
 
     it('should handle pressing left when focused', async () => {
-      mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
+
+      const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-      const mediaElements = unsplashSection.querySelectorAll(
-        '[data-testid^=mediaElement]'
-      );
-
-      await fixture.events.focus(mediaElements.item(1));
+      await fixture.events.focus(mediaElements[1]);
 
       await fixture.events.keyboard.press('ArrowLeft');
 
-      expect(document.activeElement).toBe(mediaElements.item(0));
+      expect(document.activeElement).toBe(mediaElements[0]);
     });
 
     it('should handle pressing left at the beginning of a row', async () => {
-      mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
+
+      const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-      const mediaElements = unsplashSection.querySelectorAll(
-        '[data-testid^=mediaElement]'
-      );
-
-      await fixture.events.focus(mediaElements.item(2));
+      await fixture.events.focus(mediaElements[2]);
 
       await fixture.events.keyboard.press('ArrowLeft');
 
-      expect(document.activeElement).toBe(mediaElements.item(1));
+      expect(document.activeElement).toBe(mediaElements[1]);
     });
 
     it('should handle pressing left when the first element is focused', async () => {
-      mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
+
+      const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-      const mediaElements = unsplashSection.querySelectorAll(
-        '[data-testid^=mediaElement]'
-      );
-
-      await fixture.events.focus(mediaElements.item(0));
+      await fixture.events.focus(mediaElements[0]);
 
       await fixture.events.keyboard.press('ArrowLeft');
 
-      expect(document.activeElement).toBe(mediaElements.item(0));
+      expect(document.activeElement).toBe(mediaElements[0]);
     });
 
     it('should handle pressing down', async () => {
-      mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
+
+      const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-      const mediaElements = unsplashSection.querySelectorAll(
-        '[data-testid^=mediaElement]'
-      );
-
-      await fixture.events.focus(mediaElements.item(1));
+      await fixture.events.focus(mediaElements[1]);
 
       await fixture.events.keyboard.press('ArrowDown');
 
-      expect(document.activeElement).toBe(mediaElements.item(3));
+      expect(document.activeElement).toBe(mediaElements[3]);
     });
 
     it('should handle pressing up', async () => {
-      mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
+
+      const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-      const mediaElements = unsplashSection.querySelectorAll(
-        '[data-testid^=mediaElement]'
-      );
-
-      await fixture.events.focus(mediaElements.item(3));
+      await fixture.events.focus(mediaElements[3]);
 
       await fixture.events.keyboard.press('ArrowUp');
 
-      expect(document.activeElement).toBe(mediaElements.item(1));
+      expect(document.activeElement).toBe(mediaElements[1]);
     });
 
     it('should handle pressing Home', async () => {
       mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
 
+      const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
+
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-      const mediaElements = unsplashSection.querySelectorAll(
-        '[data-testid^=mediaElement]'
-      );
-
-      await fixture.events.focus(mediaElements.item(6));
+      await fixture.events.focus(mediaElements[6]);
 
       await fixture.events.keyboard.press('Home');
 
-      expect(document.activeElement).toBe(mediaElements.item(0));
+      expect(document.activeElement).toBe(mediaElements[0]);
     });
 
     it('should handle pressing End', async () => {
       mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
 
+      const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
+
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
 
-      const mediaElements = unsplashSection.querySelectorAll(
-        '[data-testid^=mediaElement]'
-      );
-
-      await fixture.events.focus(mediaElements.item(6));
+      await fixture.events.focus(mediaElements[6]);
 
       await fixture.events.keyboard.press('End');
 
       expect(document.activeElement).toBe(
-        mediaElements.item(mediaElements.length - 1)
+        mediaElements[mediaElements.length - 1]
       );
     });
   });
 
   describe('Provider navigation', () => {
     it('should handle pressing Right', async () => {
-      mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
 
-      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+      expect(fixture.editor.library.media3p.tabs.length).toBe(3);
 
-      const providerTabs = media3pPane.querySelectorAll(
-        '[data-testid=providerTab]'
-      );
+      // unsplash section should be visible
+      expect(
+        () => fixture.editor.library.media3p.unsplashSection
+      ).not.toThrow();
 
-      await fixture.events.focus(providerTabs.item(0));
-
-      await fixture.events.keyboard.press('ArrowRight');
-
-      expect(document.activeElement).toBe(providerTabs.item(1));
-      await expectMediaElements(coverrSection, MEDIA_PER_PAGE);
-    });
-
-    it('should handle pressing Right when no more providers', async () => {
-      mockListMedia();
-      await fixture.events.click(fixture.editor.library.media3pTab);
-
-      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
-
-      const providerTabs = media3pPane.querySelectorAll(
-        '[data-testid=providerTab]'
-      );
-
-      await fixture.events.focus(providerTabs.item(providerTabs.length - 1));
+      await fixture.events.focus(fixture.editor.library.media3p.tabs[0]);
 
       await fixture.events.keyboard.press('ArrowRight');
 
       expect(document.activeElement).toBe(
-        providerTabs.item(providerTabs.length - 1)
+        fixture.editor.library.media3p.coverrTab
+      );
+
+      // unsplash section should still be showing
+      expect(
+        () => fixture.editor.library.media3p.unsplashSection
+      ).not.toThrow();
+      expect(() => fixture.editor.library.media3p.coverrSection).toThrow();
+    });
+
+    it('should handle pressing Right when no more providers', async () => {
+      await fixture.events.click(fixture.editor.library.media3pTab);
+
+      const { tabs } = fixture.editor.library.media3p;
+      expect(tabs.length).toBe(3);
+
+      // unsplash section should be visible
+      expect(
+        () => fixture.editor.library.media3p.unsplashSection
+      ).not.toThrow();
+
+      await fixture.events.focus(tabs[tabs.length - 1]);
+
+      await fixture.events.keyboard.press('ArrowRight');
+
+      expect(document.activeElement).toBe(
+        fixture.editor.library.media3p.unsplashTab
       );
     });
 
     it('should handle pressing Left', async () => {
-      mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
 
-      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
+      const { tabs } = fixture.editor.library.media3p;
+      expect(tabs.length).toBe(3);
 
-      const providerTabs = media3pPane.querySelectorAll(
-        '[data-testid=providerTab]'
-      );
+      // unsplash section should be visible
+      expect(
+        () => fixture.editor.library.media3p.unsplashSection
+      ).not.toThrow();
 
-      await fixture.events.focus(providerTabs.item(providerTabs.length - 1));
+      await fixture.events.focus(tabs[tabs.length - 1]);
+
+      await fixture.events.keyboard.press('ArrowLeft');
+
+      expect(document.activeElement).toBe(tabs[tabs.length - 2]);
+    });
+
+    it('should handle pressing Left when at the beginning', async () => {
+      await fixture.events.click(fixture.editor.library.media3pTab);
+
+      const { tabs } = fixture.editor.library.media3p;
+      expect(tabs.length).toBe(3);
+
+      // unsplash section should be visible
+      expect(
+        () => fixture.editor.library.media3p.unsplashSection
+      ).not.toThrow();
+
+      await fixture.events.focus(tabs[0]);
 
       await fixture.events.keyboard.press('ArrowLeft');
 
       expect(document.activeElement).toBe(
-        providerTabs.item(providerTabs.length - 2)
+        fixture.editor.library.media3p.tenorTab
       );
-    });
-
-    it('should handle pressing Left when at the beginning', async () => {
-      mockListMedia();
-      await fixture.events.click(fixture.editor.library.media3pTab);
-
-      await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
-
-      const providerTabs = media3pPane.querySelectorAll(
-        '[data-testid=providerTab]'
-      );
-
-      await fixture.events.focus(providerTabs.item(0));
-
-      await fixture.events.keyboard.press('ArrowLeft');
-
-      expect(document.activeElement).toBe(providerTabs.item(0));
     });
   });
 });

--- a/packages/story-editor/src/karma/fixture/containers/container.js
+++ b/packages/story-editor/src/karma/fixture/containers/container.js
@@ -19,6 +19,7 @@
  */
 import {
   getByTestId,
+  getAllByTestId,
   getByRole,
   getAllByRole,
   queryByRole,
@@ -83,6 +84,17 @@ export class Container {
    */
   getByTestId(text, options) {
     return getByTestId(this._node, text, options);
+  }
+
+  /**
+   * See https://testing-library.com/docs/queries/bytestid
+   *
+   * @param {Matcher} text test id.
+   * @param {ByRoleOptions} options Options.
+   * @return {HTMLElement} The found element.
+   */
+  getAllByTestId(text, options) {
+    return getAllByTestId(this._node, text, options);
   }
 
   /**

--- a/packages/story-editor/src/karma/fixture/containers/library/index.js
+++ b/packages/story-editor/src/karma/fixture/containers/library/index.js
@@ -124,4 +124,51 @@ export class Media3P extends Container {
   constructor(node, path) {
     super(node, path);
   }
+
+  get tabs() {
+    return this.getAllByRole('tab');
+  }
+
+  get unsplashTab() {
+    return this.getByRole('tab', { name: /^Images$/ });
+  }
+
+  get coverrTab() {
+    return this.getByRole('tab', { name: /^Video$/ });
+  }
+
+  get tenorTab() {
+    return this.getByRole('tab', { name: /^GIFs$/ });
+  }
+
+  get coverrSection() {
+    return this.getByRole('tabpanel', { name: /^Video$/ });
+  }
+
+  get unsplashSection() {
+    return this.getByRole('tabpanel', { name: /^Images$/ });
+  }
+
+  get tenorSection() {
+    return this.getByRole('tabpanel', { name: /^GIFs$/ });
+  }
+
+  get filters() {
+    return this.getAllByRoleIn(
+      this.getByRole('listbox', { name: /List of filtering options/ }),
+      'option'
+    );
+  }
+
+  get expandFiltersButton() {
+    return this.getByRole('button', { name: /Expand/ });
+  }
+
+  get mediaGallery() {
+    return this.getByTestId('media-gallery-container');
+  }
+
+  get mediaElements() {
+    return this.getAllByTestId(/^mediaElement/);
+  }
 }


### PR DESCRIPTION
## Context

The 3P Media `mediaFetching` karma tests were disabled in #6162 because they caused constant browser crashes and test failures.

## Summary

Fixes and enables the skipped 3p media tests.

## User-facing changes

n/a

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6194
