### PR TITLE
E2E Test : Fix pageTemplate test

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
   "lint-staged": {
     "*.js": [
       "eslint --fix",
-      "stylelint --fix --allow-empty-input --syntax \"css-in-js\""
+      "stylelint --fix --allow-empty-input"
     ],
     "*.json": [
       "prettier --write"

--- a/packages/e2e-tests/src/specs/editor/pageTemplates.js
+++ b/packages/e2e-tests/src/specs/editor/pageTemplates.js
@@ -21,6 +21,13 @@ import percySnapshot from '@percy/puppeteer';
 import { addTextElement, createNewStory } from '@web-stories-wp/e2e-test-utils';
 
 describe('Page Templates', () => {
+  beforeAll(async () => {
+    // force to load default templates in the page template pane.
+    await page.evaluate(() => {
+      localStorage.removeItem('web_stories_default_template_view');
+    });
+  });
+
   it('should be able to load an create custom page templates', async () => {
     await createNewStory();
 


### PR DESCRIPTION
## Context

This change forces the page template pane to its default behavior ( load default templates ). 

## Summary

This test expects to open default templates when the page template pane is opened, deleting `web_stories_default_template_view` prior to this test will save this test from possible failure due to artifacts ( possibly opening saved templates rather than default templates ) from previously run tests.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
