### PR TITLE
Pre-Publish Checklist: Show contrast error when there's a contrast problem

### DIFF
--- a/packages/story-editor/src/components/checklist/checks/pageBackgroundLowTextContrast/check.js
+++ b/packages/story-editor/src/components/checklist/checks/pageBackgroundLowTextContrast/check.js
@@ -19,8 +19,6 @@
 import {
   PAGE_RATIO,
   FULLBLEED_RATIO,
-  dataToFontSizeY,
-  dataFontEm,
   getBox,
   getBoundRect,
 } from '@web-stories-wp/units';
@@ -48,16 +46,6 @@ import { getSpansFromContent } from '../../utils';
  * @property {number} g green value
  * @property {number} b blue value
  */
-
-/**
- *
- * @param {number} fontSize The text element's font size in editor pixels
- * @return {number} the true font size for measuring against accessibility standards
- */
-function getPtFromEditorFontSize(fontSize) {
-  // 1 point = 1.333333 px
-  return dataFontEm(dataToFontSizeY(fontSize, 100)) * 1.333333;
-}
 
 /**
  *
@@ -318,7 +306,7 @@ function getTextShapeBackgroundColor({ background }) {
  * @param {Object} arguments The arguments
  * @param {RGB} arguments.backgroundColor The r, g, b object representing a background color to compare to the text colors
  * @param {Array} arguments.textStyleColors The array of style colors of the text being checked
- * @param {number} arguments.fontSize The font size (in editor pixels) of the text being checked
+ * @param {number} arguments.fontSize The font size (in pixels) of the text being checked
  * @return {boolean} If true, there is a contrast issue with some text
  */
 function textBackgroundHasLowContrast({
@@ -340,7 +328,7 @@ function textBackgroundHasLowContrast({
     const contrastCheck = checkContrastFromLuminances(
       textLuminance,
       backgroundLuminance,
-      fontSize && getPtFromEditorFontSize(fontSize)
+      fontSize
     );
     return !contrastCheck.WCAG_AA;
   });

--- a/packages/story-editor/src/utils/contrastUtils.js
+++ b/packages/story-editor/src/utils/contrastUtils.js
@@ -27,12 +27,12 @@ import * as hues from '@ap.cx/hues';
  * @return {number} Luminance
  */
 export function calculateLuminanceFromRGB(rgb) {
-  const { r, g, b, a } = rgb;
+  const { r, g, b, a = 1.0 } = rgb;
   const luminance = hues.relativeLuminance({
     r: r / 255.0,
     g: g / 255.0,
     b: b / 255.0,
-    a: a === undefined ? 1.0 : a,
+    a,
   });
   return luminance;
 }


### PR DESCRIPTION
## Context

Contrast checking seems to be showing contrast issues when it shouldn't.

## Summary

Pass the real font size in pixels rather than the font size in editor pixels.

## Relevant Technical Choices

The font size when converted to editor pixels comes out to be much less than the font size given to the element. Text that should pass the contrast check fails due to the change in units.

## To-do

n/a

## User-facing changes

none

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

This is a good website to see which colors should pass/fail together https://webaim.org/resources/contrastchecker/. **We are testing against the `WCAG AA` standard**.

1. Start a new story
2. Add a background color to the page (e.g. #397AED) and some text (e.g. #fff)
3. Open the pre publish checklist
4. No contrast recommendation should show
5. Change the text color to something with low contrast (e.g. #1263FF).

The warning should be shown when:
1. The contrast is less than `3.0`
2. The contrast is between `3.0` and `4.5` but the font size is less than `18px`


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7724
