### PR TITLE
Explore Templates: Enable Template Search

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -268,6 +268,7 @@ class Experiments extends Service_Base implements HasRequirements {
 				'label'       => __( 'Template search', 'web-stories' ),
 				'description' => __( 'Enable search for templates', 'web-stories' ),
 				'group'       => 'dashboard',
+				'default'     => true,
 			],
 			/**
 			 * Author: @dmmulroy

--- a/packages/dashboard/src/app/views/exploreTemplates/index.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/index.js
@@ -101,6 +101,14 @@ function ExploreTemplates() {
       .filter(composeTemplateFilter(selectFilters));
   }, [templatesOrderById, templates, selectFilters]);
 
+  const totalVisibleTemplates = useMemo(
+    () =>
+      totalTemplates !== orderedTemplates.length
+        ? orderedTemplates.length
+        : totalTemplates,
+    [orderedTemplates, totalTemplates]
+  );
+
   // Although we may want to filter templates based on
   // repeat meta data of differing types, we only want
   // the auto-complete to show unique labels
@@ -144,7 +152,7 @@ function ExploreTemplates() {
         allPagesFetched={allPagesFetched}
         page={page}
         templates={orderedTemplates}
-        totalTemplates={totalTemplates}
+        totalTemplates={totalVisibleTemplates}
         search={search}
         view={view}
         templateActions={templateActions}

--- a/packages/dashboard/src/app/views/exploreTemplates/index.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/index.js
@@ -142,7 +142,7 @@ function ExploreTemplates() {
         isLoading={isLoading && !totalTemplates}
         filter={filter}
         sort={sort}
-        totalTemplates={totalTemplates}
+        totalTemplates={totalVisibleTemplates}
         search={search}
         searchOptions={searchOptions}
         view={view}


### PR DESCRIPTION
## Context

Enabling the new template search feature

![Screen Shot 2021-11-18 at 1 54 55 PM](https://user-images.githubusercontent.com/10720454/142495343-afc049a5-f2fc-41e3-bb31-f6a07e8c9e1a.png)


## Summary

Now you can search through templates in the dashboard's explore templates view. Fields that are searched are template **tags**, **vertical,** and **color families**. This feature started out as adding a bunch of filters to the explore templates view and has been scaled back to this so that more user research and feedback can be gathered about how to best make it more robust.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Adds a search to explore templates. 

## Testing Instructions

- Go to explore templates view in dashboard
- Try searching, see templates matching your search show up. 

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9746 
