### PR TITLE
Add video playback shortcut for canvas element

### DIFF
--- a/packages/story-editor/src/elements/video/controls.js
+++ b/packages/story-editor/src/elements/video/controls.js
@@ -44,7 +44,6 @@ function VideoControls({
       isTransforming={isTransforming}
       elementRef={elementRef}
       element={element}
-      allowKeyboardSupport
     />
   );
 }

--- a/packages/story-editor/src/elements/video/controls.js
+++ b/packages/story-editor/src/elements/video/controls.js
@@ -33,7 +33,6 @@ function VideoControls({
   isTransforming,
   elementRef,
   element,
-  videoRef,
 }) {
   const isActive =
     isSelected && !isTransforming && isSingleElement && !isEditing;
@@ -45,7 +44,7 @@ function VideoControls({
       isTransforming={isTransforming}
       elementRef={elementRef}
       element={element}
-      videoRef={videoRef}
+      allowKeyboardSupport
     />
   );
 }
@@ -58,7 +57,6 @@ VideoControls.propTypes = {
   isTransforming: PropTypes.bool.isRequired,
   elementRef: PropTypes.object.isRequired,
   element: StoryPropTypes.element.isRequired,
-  videoRef: PropTypes.object,
 };
 
 export default VideoControls;

--- a/packages/story-editor/src/elements/video/karma/elementMinSizeAndPlayback.karma.js
+++ b/packages/story-editor/src/elements/video/karma/elementMinSizeAndPlayback.karma.js
@@ -87,5 +87,22 @@ describe('Element min size and playback', () => {
       expect(video1isPlaying).toBe(true);
       expect(video2isPlaying).toBe(false);
     });
+
+    it('hit spacebar on the covered element', async () => {
+      // video1 is covered by video2
+      // select video1, press spacebar, verify video1 is playing
+      const video1bb = video1Frame.getBoundingClientRect();
+
+      await fixture.events.mouse.click(video1bb.x, video1bb.y);
+
+      await fixture.events.keyboard.press('Space');
+      const video1El = fixture.querySelector(`#video-${video1.id}`);
+      const video2El = fixture.querySelector(`#video-${video2.id}`);
+      const video1isPlaying = video1El.paused === false;
+      const video2isPlaying = video2El.paused === false;
+
+      expect(video1isPlaying).toBe(true);
+      expect(video2isPlaying).toBe(false);
+    });
   });
 });

--- a/packages/story-editor/src/elements/video/playPauseButton.js
+++ b/packages/story-editor/src/elements/video/playPauseButton.js
@@ -28,7 +28,7 @@ import {
 import { CSSTransition } from 'react-transition-group';
 import { __ } from '@web-stories-wp/i18n';
 import { rgba } from 'polished';
-import { Icons } from '@web-stories-wp/design-system';
+import { Icons, useKeyDownEffect } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -120,6 +120,7 @@ function PlayPauseButton({
   elementRef,
   element,
   videoRef = null,
+  allowKeyboardSupport = false,
 }) {
   const { isRTL } = useConfig();
   const hasVideoSrc = Boolean(element.resource.src);
@@ -209,6 +210,33 @@ function PlayPauseButton({
     };
   }, [checkMouseInBBox]);
 
+  const handleKeyDown = useCallback(
+    ({ key }) => {
+      if (allowKeyboardSupport && key === ' ') {
+        const videoNode = getVideoNode();
+        if (videoNode) {
+          if (videoNode.paused) {
+            videoNode.play();
+            setIsPlaying(true);
+          } else {
+            videoNode.pause();
+            videoNode.currentTime = 0;
+            setIsPlaying(false);
+          }
+        }
+      }
+    },
+    [getVideoNode, allowKeyboardSupport]
+  );
+  useKeyDownEffect(
+    elementRef,
+    {
+      key: ['space'],
+    },
+    handleKeyDown,
+    [handleKeyDown]
+  );
+
   if (!isActive) {
     return null;
   }
@@ -281,6 +309,7 @@ PlayPauseButton.propTypes = {
   elementRef: PropTypes.object.isRequired,
   element: StoryPropTypes.element.isRequired,
   videoRef: PropTypes.object,
+  allowKeyboardSupport: PropTypes.bool,
 };
 
 export default PlayPauseButton;

--- a/packages/story-editor/src/elements/video/playPauseButton.js
+++ b/packages/story-editor/src/elements/video/playPauseButton.js
@@ -249,7 +249,6 @@ function PlayPauseButton({
               .play()
               .then(() => setIsPlaying(true))
               .catch(() => {});
-            setIsPlaying(true);
           } else {
             videoNode.pause();
             videoNode.currentTime = 0;

--- a/packages/story-editor/src/elements/video/playPauseButton.js
+++ b/packages/story-editor/src/elements/video/playPauseButton.js
@@ -84,35 +84,6 @@ const ButtonWrapper = styled.div.attrs({ role: 'button', tabIndex: -1 })`
     opacity: 0;
     transition: opacity 100ms;
   }
-
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    `}
-  cursor: pointer;
-  pointer-events: initial;
-  width: ${PLAY_BUTTON_SIZE}px;
-  height: ${PLAY_BUTTON_SIZE}px;
-  overflow: hidden;
-
-  opacity: ${({ isAbove }) => (isAbove ? 1 : 0)};
-  &.button-enter {
-    opacity: 0;
-  }
-  &.button-enter-active,
-  &.button-enter-done {
-    opacity: 1;
-    transition: opacity 100ms;
-  }
-  &.button-exit {
-    opacity: 1;
-  }
-  &.button-exit-active,
-  &.button-exit-done {
-    opacity: 0;
-    transition: opacity 100ms;
-  }
 `;
 
 const iconCss = css`

--- a/packages/story-editor/src/elements/video/playPauseButton.js
+++ b/packages/story-editor/src/elements/video/playPauseButton.js
@@ -28,7 +28,7 @@ import {
 import { CSSTransition } from 'react-transition-group';
 import { __ } from '@web-stories-wp/i18n';
 import { rgba } from 'polished';
-import { Icons, useKeyDownEffect } from '@web-stories-wp/design-system';
+import { Icons } from '@web-stories-wp/design-system';
 
 /**
  * Internal dependencies
@@ -149,7 +149,6 @@ function PlayPauseButton({
   elementRef,
   element,
   videoRef = null,
-  allowKeyboardSupport = false,
 }) {
   const { isRTL } = useConfig();
   const hasVideoSrc = Boolean(element.resource.src);
@@ -239,36 +238,6 @@ function PlayPauseButton({
     };
   }, [checkMouseInBBox]);
 
-  const handleKeyDown = useCallback(
-    ({ key }) => {
-      if (allowKeyboardSupport && key === ' ') {
-        const videoNode = getVideoNode();
-        if (videoNode) {
-          if (videoNode.paused) {
-            videoNode
-              .play()
-              .then(() => setIsPlaying(true))
-              .catch(() => {});
-            setIsPlaying(true);
-          } else {
-            videoNode.pause();
-            videoNode.currentTime = 0;
-            setIsPlaying(false);
-          }
-        }
-      }
-    },
-    [getVideoNode, allowKeyboardSupport]
-  );
-  useKeyDownEffect(
-    elementRef,
-    {
-      key: ['space'],
-    },
-    handleKeyDown,
-    [handleKeyDown]
-  );
-
   if (!isActive) {
     return null;
   }
@@ -341,7 +310,6 @@ PlayPauseButton.propTypes = {
   elementRef: PropTypes.object.isRequired,
   element: StoryPropTypes.element.isRequired,
   videoRef: PropTypes.object,
-  allowKeyboardSupport: PropTypes.bool,
 };
 
 export default PlayPauseButton;

--- a/packages/story-editor/src/elements/video/playPauseButton.js
+++ b/packages/story-editor/src/elements/video/playPauseButton.js
@@ -84,6 +84,35 @@ const ButtonWrapper = styled.div.attrs({ role: 'button', tabIndex: -1 })`
     opacity: 0;
     transition: opacity 100ms;
   }
+
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    `}
+  cursor: pointer;
+  pointer-events: initial;
+  width: ${PLAY_BUTTON_SIZE}px;
+  height: ${PLAY_BUTTON_SIZE}px;
+  overflow: hidden;
+
+  opacity: ${({ isAbove }) => (isAbove ? 1 : 0)};
+  &.button-enter {
+    opacity: 0;
+  }
+  &.button-enter-active,
+  &.button-enter-done {
+    opacity: 1;
+    transition: opacity 100ms;
+  }
+  &.button-exit {
+    opacity: 1;
+  }
+  &.button-exit-active,
+  &.button-exit-done {
+    opacity: 0;
+    transition: opacity 100ms;
+  }
 `;
 
 const iconCss = css`
@@ -120,7 +149,6 @@ function PlayPauseButton({
   elementRef,
   element,
   videoRef = null,
-  allowKeyboardSupport = false,
 }) {
   const { isRTL } = useConfig();
   const hasVideoSrc = Boolean(element.resource.src);
@@ -209,40 +237,6 @@ function PlayPauseButton({
       document.removeEventListener('pointermove', checkMouseInBBox);
     };
   }, [checkMouseInBBox]);
-
-  const handleKeyDown = useCallback(
-    ({ key }) => {
-      if (allowKeyboardSupport && key === ' ') {
-        const videoNode = getVideoNode();
-        if (videoNode) {
-          if (videoNode.paused) {
-            videoNode
-              .play()
-              .then(() => setIsPlaying(true))
-              .catch(() => {});
-          } else {
-            videoNode.pause();
-            videoNode.currentTime = 0;
-            setIsPlaying(false);
-          }
-        }
-      }
-    },
-    [getVideoNode, allowKeyboardSupport]
-  );
-  useKeyDownEffect(
-    elementRef,
-    {
-      key: ['space'],
-    },
-    handleKeyDown,
-    [handleKeyDown]
-  );
-
-  if (!isActive) {
-    return null;
-  }
-
   const handlePlayPause = (evt) => {
     evt.stopPropagation();
     const videoNode = getVideoNode();
@@ -261,6 +255,18 @@ function PlayPauseButton({
         .catch(() => {});
     }
   };
+  useKeyDownEffect(
+    elementRef,
+    {
+      key: ['space'],
+    },
+    handlePlayPause,
+    [handlePlayPause]
+  );
+
+  if (!isActive) {
+    return null;
+  }
 
   const buttonLabel = isPlaying
     ? __('Click to pause', 'web-stories')
@@ -311,7 +317,6 @@ PlayPauseButton.propTypes = {
   elementRef: PropTypes.object.isRequired,
   element: StoryPropTypes.element.isRequired,
   videoRef: PropTypes.object,
-  allowKeyboardSupport: PropTypes.bool,
 };
 
 export default PlayPauseButton;

--- a/packages/story-editor/src/elements/video/playPauseButton.js
+++ b/packages/story-editor/src/elements/video/playPauseButton.js
@@ -84,6 +84,35 @@ const ButtonWrapper = styled.div.attrs({ role: 'button', tabIndex: -1 })`
     opacity: 0;
     transition: opacity 100ms;
   }
+
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    `}
+  cursor: pointer;
+  pointer-events: initial;
+  width: ${PLAY_BUTTON_SIZE}px;
+  height: ${PLAY_BUTTON_SIZE}px;
+  overflow: hidden;
+
+  opacity: ${({ isAbove }) => (isAbove ? 1 : 0)};
+  &.button-enter {
+    opacity: 0;
+  }
+  &.button-enter-active,
+  &.button-enter-done {
+    opacity: 1;
+    transition: opacity 100ms;
+  }
+  &.button-exit {
+    opacity: 1;
+  }
+  &.button-exit-active,
+  &.button-exit-done {
+    opacity: 0;
+    transition: opacity 100ms;
+  }
 `;
 
 const iconCss = css`
@@ -216,7 +245,10 @@ function PlayPauseButton({
         const videoNode = getVideoNode();
         if (videoNode) {
           if (videoNode.paused) {
-            videoNode.play();
+            videoNode
+              .play()
+              .then(() => setIsPlaying(true))
+              .catch(() => {});
             setIsPlaying(true);
           } else {
             videoNode.pause();


### PR DESCRIPTION
## Context

A feature was requested for adding a shortcut for video playback on canvas elements.

## Summary

Hitting spacebar while focus is on a video element on canvas should change the state from playing to pause or from pause to playing.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Yes this is a user facing changes, it will allow users to play/pause video playback on a video element on the canvas

## Testing Instructions

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open the story-editor.
2. Place a video on the canvas.
3. When video element is in focus hit spacebar to play/pause the video.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes [#2350](https://github.com/google/web-stories-wp/issues/2350)
