### PR TITLE
Media: fetching local media karma test 

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -32,7 +32,6 @@ describe('MediaPane fetching', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
-    await fixture.collapseHelpCenter();
   });
 
   afterEach(() => {
@@ -49,7 +48,14 @@ describe('MediaPane fetching', () => {
 
     const initialElements =
       within(mediaGallery).queryAllByTestId(/^mediaElement-/);
-    expect(initialElements.length).toBe(LOCAL_MEDIA_PER_PAGE);
+
+    await waitFor(() => {
+      // ensure fixture.screen has loaded before calling expect to prevent immediate failure
+      if (initialElements.length !== LOCAL_MEDIA_PER_PAGE) {
+        throw new Error('wait');
+      }
+      expect(initialElements.length).toBe(LOCAL_MEDIA_PER_PAGE);
+    });
 
     await mediaGallery.scrollTo(
       0,

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -23,13 +23,10 @@ import { waitFor, within } from '@testing-library/react';
  * Internal dependencies
  */
 
-import { Fixture, MEDIA_PER_PAGE } from '../../../../../../karma/fixture';
+import { Fixture, LOCAL_MEDIA_PER_PAGE } from '../../../../../../karma/fixture';
 import { ROOT_MARGIN } from '../mediaPane';
 
-// Disable reason: tests are out of date.
-// TODO: https://github.com/google/web-stories-wp/issues/7606
-// eslint-disable-next-line jasmine/no-disabled-tests
-xdescribe('MediaPane fetching', () => {
+describe('MediaPane fetching', () => {
   let fixture;
 
   beforeEach(async () => {
@@ -52,42 +49,25 @@ xdescribe('MediaPane fetching', () => {
 
     const initialElements =
       within(mediaGallery).queryAllByTestId(/^mediaElement-/);
-    expect(initialElements.length).toBe(MEDIA_PER_PAGE);
+    expect(initialElements.length).toBe(LOCAL_MEDIA_PER_PAGE);
 
     await mediaGallery.scrollTo(
       0,
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
     );
 
-    await waitFor(() =>
+    await waitFor(() => {
+      // ensure fixture.screen has loaded before calling expect to prevent immediate failure
+      if (
+        fixture.screen.queryAllByTestId(/^mediaElement-/).length <
+        LOCAL_MEDIA_PER_PAGE * 2
+      ) {
+        throw new Error('wait');
+      }
+
       expect(
         fixture.screen.queryAllByTestId(/^mediaElement-/).length
-      ).toBeGreaterThanOrEqual(MEDIA_PER_PAGE * 2)
-    );
-  });
-
-  it('should not load results on resize if tab is hidden', async () => {
-    const nonMediaTab = await waitFor(() =>
-      fixture.querySelector('#library-tab-shapes')
-    );
-
-    await waitFor(() =>
-      expect(fixture.screen.queryAllByTestId(/mediaElement/).length).toBe(
-        MEDIA_PER_PAGE
-      )
-    );
-
-    await fixture.events.click(nonMediaTab);
-
-    // Simulate a browser window resize, and complete the event debounce cycle.
-    window.dispatchEvent(new Event('resize'));
-    await fixture.events.sleep(500);
-
-    // Expect no additional results to be loaded.
-    await waitFor(() =>
-      expect(fixture.screen.queryAllByTestId(/mediaElement/).length).toBe(
-        MEDIA_PER_PAGE
-      )
-    );
+      ).toBeGreaterThanOrEqual(LOCAL_MEDIA_PER_PAGE * 2);
+    });
   });
 });

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -64,6 +64,7 @@ if ('true' === process.env.CI) {
 }
 
 export const MEDIA_PER_PAGE = 20;
+export const LOCAL_MEDIA_PER_PAGE = 50;
 
 function MediaUpload({ render: _render, onSelect }) {
   const open = () => {
@@ -776,14 +777,17 @@ class APIProviderFixture {
         const filterBySearchTerm = searchTerm
           ? ({ alt_text }) => alt_text.includes(searchTerm)
           : () => true;
-        // Generate 7*6=42 items, 3 pages
-        const clonedMedia = Array(6)
+        // Generate 8*13=104 items, 3 pages
+        const clonedMedia = Array(13)
           .fill(getMediaResponse)
           .flat()
           .map((media, i) => ({ ...media, id: i + 1 }));
         return asyncResponse({
           data: clonedMedia
-            .slice((pagingNum - 1) * MEDIA_PER_PAGE, pagingNum * MEDIA_PER_PAGE)
+            .slice(
+              (pagingNum - 1) * LOCAL_MEDIA_PER_PAGE,
+              pagingNum * LOCAL_MEDIA_PER_PAGE
+            )
             .filter(filterByMediaType)
             .filter(filterBySearchTerm),
           headers: { totalPages: 3 },

--- a/packages/story-editor/src/karma/fixture/index.js
+++ b/packages/story-editor/src/karma/fixture/index.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { Fixture, MEDIA_PER_PAGE } from './fixture';
+export { Fixture, MEDIA_PER_PAGE, LOCAL_MEDIA_PER_PAGE } from './fixture';


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Re-enable karma media fetching test. 

## Summary

<!-- A brief description of what this PR does. -->
The `getMedia` api had been updated to grab 50 items per page, but the fetching test was still looking for 20 items per page call. We needed to sync up the numbers and create more mocked items in the fixture to ensure we were still calling for 3 pages total. 

## Relevant Technical Choices

<!-- Please describe your changes. -->
Added a new ENUM const `LOCAL_MEDIA_PER_PAGE` since other tests ie. `media3p` uses `MEDIA_PER_PAGE` and expects that value to be 20. 

Removed `should not load results on resize if tab is hidden` test since this component is now unmounted and thus all media elements are removed from the DOM when the tab is no longer selected. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Run test


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7606
