### PR TITLE
Fixing carousel cache

### DIFF
--- a/packages/story-editor/src/components/footer/carousel/carouselPage.js
+++ b/packages/story-editor/src/components/footer/carousel/carouselPage.js
@@ -89,6 +89,8 @@ function CarouselPage({ pageId, index }) {
     page,
     isCurrentPage,
     hasMultiplePages,
+    setCachedImage,
+    cachedImage,
   } = useCarousel(
     ({
       state: {
@@ -98,8 +100,9 @@ function CarouselPage({ pageId, index }) {
         numPages,
         pages,
         currentPageId,
+        cachedImages,
       },
-      actions: { clickPage, setPageRef },
+      actions: { clickPage, setPageRef, setCachedImage },
     }) => ({
       pageThumbWidth,
       pageThumbHeight,
@@ -109,6 +112,8 @@ function CarouselPage({ pageId, index }) {
       page: pages.find(({ id }) => id === pageId),
       isCurrentPage: pageId === currentPageId,
       hasMultiplePages: numPages > 1,
+      cachedImage: cachedImages[pageId] || null,
+      setCachedImage,
     })
   );
 
@@ -155,6 +160,9 @@ function CarouselPage({ pageId, index }) {
           width={pageThumbWidth}
           height={pageThumbHeight}
           isInteractive={hasMultiplePages}
+          isCacheable
+          cachedImage={cachedImage}
+          setCachedImage={setCachedImage}
         />
       </ReorderablePage>
       <PageSeparator

--- a/packages/story-editor/src/components/footer/carousel/carouselProvider.js
+++ b/packages/story-editor/src/components/footer/carousel/carouselProvider.js
@@ -38,6 +38,7 @@ import CarouselContext from './carouselContext';
 import useCarouselSizing from './useCarouselSizing';
 import useCarouselScroll from './useCarouselScroll';
 import useCarouselKeys from './useCarouselKeys';
+import useCarouselCache from './useCarouselCache';
 
 function CarouselProvider({ availableSpace, children }) {
   const { pages, currentPageId, setCurrentPage, arrangePage } = useStory(
@@ -84,6 +85,8 @@ function CarouselProvider({ availableSpace, children }) {
 
   useCarouselKeys({ listElement, pageRefs });
 
+  const { cachedImages, setCachedImage } = useCarouselCache();
+
   const setPageRef = useCallback((page, el) => {
     pageRefs.current[page.id] = el;
   }, []);
@@ -116,6 +119,7 @@ function CarouselProvider({ availableSpace, children }) {
       canScrollBack,
       canScrollForward,
       showSkeleton,
+      cachedImages,
     },
     actions: {
       scrollBack,
@@ -124,6 +128,7 @@ function CarouselProvider({ availableSpace, children }) {
       rearrangePages,
       setListRef: setListElement,
       setPageRef,
+      setCachedImage,
     },
   };
 

--- a/packages/story-editor/src/components/footer/carousel/useCarouselCache.js
+++ b/packages/story-editor/src/components/footer/carousel/useCarouselCache.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useReduction } from '@web-stories-wp/react';
+
+const imageCacheReducer = {
+  setCachedImage: (cachedImages, { payload: { pageId, cachedImage } }) => ({
+    ...cachedImages,
+    [pageId]: cachedImage,
+  }),
+};
+
+function useCarouselCache() {
+  const [cachedImages, { setCachedImage }] = useReduction(
+    {},
+    imageCacheReducer
+  );
+  return {
+    cachedImages,
+    setCachedImage,
+  };
+}
+
+export default useCarouselCache;

--- a/packages/story-editor/src/components/footer/pagepreview/index.js
+++ b/packages/story-editor/src/components/footer/pagepreview/index.js
@@ -117,11 +117,15 @@ function PagePreview({
   // Whenever the page is re-generated
   // remove the old (and now stale) image blob
   useEffect(() => {
-    if (enableThumbnailCaching && pageAtGenerationTime.current !== page) {
+    if (
+      enableThumbnailCaching &&
+      isActive &&
+      pageAtGenerationTime.current !== page
+    ) {
       setCachedImage({ pageId: page.id, cachedImage: null });
       pageAtGenerationTime.current = null;
     }
-  }, [page, setCachedImage, enableThumbnailCaching]);
+  }, [page, setCachedImage, isActive, enableThumbnailCaching]);
 
   useEffect(() => {
     // If this is not the active page, there is a page node, we

--- a/packages/story-editor/src/components/footer/pagepreview/index.js
+++ b/packages/story-editor/src/components/footer/pagepreview/index.js
@@ -97,36 +97,47 @@ const Image = styled.img`
 `;
 
 // PagePreview is used in the editor's Carousel as well as in the Checklist and GridView
-function PagePreview({ page, label, ...props }) {
+function PagePreview({
+  page,
+  label,
+  isCacheable = false,
+  cachedImage = null,
+  setCachedImage = null,
+  ...props
+}) {
   const { backgroundColor } = page;
   const { width, height, isActive } = props;
 
-  const [imageBlob, setImageBlob] = useState();
   const [pageNode, setPageNode] = useState();
   const setPageRef = useCallback((node) => node && setPageNode(node), []);
   const pageAtGenerationTime = useRef();
-  const enableThumbnailCaching = useFeature('enableThumbnailCaching');
+  const enableThumbnailCaching =
+    useFeature('enableThumbnailCaching') && isCacheable;
 
   // Whenever the page is re-generated
   // remove the old (and now stale) image blob
   useEffect(() => {
-    if (pageAtGenerationTime.current !== page) {
-      setImageBlob(null);
+    if (enableThumbnailCaching && pageAtGenerationTime.current !== page) {
+      setCachedImage({ pageId: page.id, cachedImage: null });
       pageAtGenerationTime.current = null;
     }
-  }, [page]);
+  }, [page, setCachedImage, enableThumbnailCaching]);
 
   useEffect(() => {
     // If this is not the active page, there is a page node, we
     // don't already have a snapshot and thumbnail caching is active
-    if (enableThumbnailCaching && !isActive && pageNode && !imageBlob) {
+    if (enableThumbnailCaching && !isActive && pageNode && !cachedImage) {
       // Schedule an idle callback to actually generate the image
       const id = requestIdleCallback(
         () => {
           import(
             /* webpackChunkName: "chunk-html-to-image" */ 'html-to-image'
           ).then((htmlToImage) => {
-            htmlToImage.toJpeg(pageNode, { quality: 1 }).then(setImageBlob);
+            htmlToImage
+              .toJpeg(pageNode, { quality: 1 })
+              .then((image) =>
+                setCachedImage({ pageId: page.id, cachedImage: image })
+              );
             pageAtGenerationTime.current = page;
           });
         },
@@ -138,7 +149,14 @@ function PagePreview({ page, label, ...props }) {
     }
     // Required because of eslint: consistent-return
     return undefined;
-  }, [enableThumbnailCaching, isActive, pageNode, imageBlob, page]);
+  }, [
+    enableThumbnailCaching,
+    isActive,
+    pageNode,
+    cachedImage,
+    setCachedImage,
+    page,
+  ]);
 
   usePerformanceTracking({
     node: pageNode,
@@ -150,9 +168,9 @@ function PagePreview({ page, label, ...props }) {
       <TransformProvider>
         <Page ref={setPageRef} aria-label={label} {...props}>
           <PreviewWrapper background={backgroundColor}>
-            {imageBlob ? (
+            {cachedImage ? (
               <Image
-                src={imageBlob}
+                src={cachedImage}
                 width={width}
                 height={height}
                 alt={label}
@@ -177,6 +195,9 @@ function PagePreview({ page, label, ...props }) {
 PagePreview.propTypes = {
   page: StoryPropTypes.page.isRequired,
   label: PropTypes.string,
+  isCacheable: PropTypes.bool,
+  cachedImage: PropTypes.object,
+  setCachedImage: PropTypes.func,
   pageImageData: PropTypes.string,
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,


### PR DESCRIPTION
## Context

This PR moves the thumbnail image cache storage from the individual thumbnail to the carousel provider and abstracts it out of the thumbnail class itself.

This fixes a number of issues:

- Cache images are generated for the pages in the checklist for no good reason. The checklist no longer used image caching after this PR.
- (Very large and expensive) cache images are generated for the pages in the grid view. The grid view no longer uses image caching after this PR.
- The page carousel would regenerate all cached images when the carousel remounts, which does not make sense if the pages haven't actually changed. (only relevant post-merge of #9724)

## Summary

* This is not a great solution. It's a temporary short-term fix and it has some minor issues, but it works for the purpose it serves - solving the issue here and now.

## User-facing changes

- Less memory-intensive when opening checklist or grid view
- Less memory-intensive when re-expanding the page carousel (post-merge of #9724)

## Testing Instructions

This PR can be tested by following these steps:

1. Create a story with 30 pages (just use 30 random default page templates)
2. Open the grid view
3. Observe that the browser no longer struggles to function while all the image caches are being generated, because this does not happen anymore.

**NB**: Observe this [known bug](https://github.com/google/web-stories-wp/pull/9760#discussion_r753579779).

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---
Maybe helps with #9549 
Partial for #9749
