### PR TITLE
Media: Display tooltip for library videos being processed

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/common/mediaElement.js
+++ b/packages/story-editor/src/components/library/panes/media/common/mediaElement.js
@@ -261,11 +261,11 @@ Element.propTypes = {
  * @return {null|*} Element or null if does not map to video/image.
  */
 function MediaElement(props) {
-  const { isTranscoding } = props.resource;
+  const { isTranscoding, isMuting, isTrimming } = props.resource;
 
-  if (isTranscoding) {
+  if (isTranscoding || isMuting || isTrimming) {
     return (
-      <Tooltip title={__('Video optimization in progress', 'web-stories')}>
+      <Tooltip title={__('Video is being processed', 'web-stories')}>
         <Element {...props} />
       </Tooltip>
     );


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Show Video is being processed tooltip on trimming, muting and transcoding. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<img width="256" alt="Screenshot 2021-11-22 at 15 12 22" src="https://user-images.githubusercontent.com/237508/142886099-f386db61-e04e-4fca-ad4c-b4d513cdd9f1.png">

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open editor
2. Upload video ( with sound )
3. Hover over video in media library while uploading and see message.
4. Click, trim video. 
5. Hover over new video in media library while uploading and see message.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9159
