### PR TITLE
Media: Use `postProcessingResource` for `isMuted` backfilling

### DIFF
--- a/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
@@ -305,7 +305,7 @@ const mockUseApplyTextAutoStyle = useApplyTextAutoStyle;
 const mockUseConfig = useConfig;
 const mockUseLocalMedia = useLocalMedia;
 const mockResetWithFetch = jest.fn();
-const mockUpdateVideoIsMuted = jest.fn();
+const mockPostProcessingResource = jest.fn();
 const mockOptimizeVideo = jest.fn();
 const mockOptimizeGif = jest.fn();
 const mockUseFFmpeg = useFFmpeg;
@@ -322,7 +322,6 @@ const MockMediaPicker = ({ onSelect, onClose }) => (
         onSelect({
           ...videoResource,
           local: false,
-          mimeType: 'muted',
           isMuted: null,
         })
       }
@@ -373,7 +372,7 @@ describe('useQuickActions', () => {
 
     mockUseLocalMedia.mockReturnValue({
       resetWithFetch: noop,
-      updateVideoIsMuted: noop,
+      postProcessingResource: noop,
       optimizeVideo: noop,
       optimizeGif: noop,
     });
@@ -979,7 +978,7 @@ describe('MediaPicker', () => {
 
     mockUseLocalMedia.mockReturnValue({
       resetWithFetch: mockResetWithFetch,
-      updateVideoIsMuted: mockUpdateVideoIsMuted,
+      postProcessingResource: mockPostProcessingResource,
       optimizeVideo: mockOptimizeVideo,
       optimizeGif: mockOptimizeGif,
     });
@@ -1027,15 +1026,17 @@ describe('MediaPicker', () => {
     });
   });
 
-  it('should call updateVideoIsMuted for a video that is muted', () => {
+  it('should call postProcessingResource for a video that is muted', () => {
     render(<MediaPicker render={noop} />);
 
     fireEvent.click(screen.getByText('onSelect muted video'));
 
-    expect(mockUpdateVideoIsMuted).toHaveBeenCalledWith(
-      videoResource.id,
-      videoResource.src
-    );
+    expect(mockPostProcessingResource).toHaveBeenCalledWith({
+      ...videoResource,
+      local: false,
+      mimeType: 'videoMimeType',
+      isMuted: null,
+    });
     expect(mockUpdateElementsById).toHaveBeenCalledWith({
       elementIds: [IMAGE_ELEMENT.id],
       properties: {
@@ -1043,7 +1044,6 @@ describe('MediaPicker', () => {
         resource: {
           ...videoResource,
           local: false,
-          mimeType: 'muted',
           isMuted: null,
         },
       },

--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -174,7 +174,6 @@ export const MediaPicker = ({ render, ...props }) => {
       }
     },
     [
-      allowedVideoMimeTypes,
       insertMediaElement,
       isTranscodingEnabled,
       optimizeGif,

--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -82,19 +82,19 @@ export const MediaPicker = ({ render, ...props }) => {
       updateElementsById,
     })
   );
-  const { resetWithFetch, updateVideoIsMuted, optimizeVideo, optimizeGif } =
+  const { resetWithFetch, postProcessingResource, optimizeVideo, optimizeGif } =
     useLocalMedia(
       ({
         actions: {
           resetWithFetch,
-          updateVideoIsMuted,
+          postProcessingResource,
           optimizeVideo,
           optimizeGif,
         },
       }) => {
         return {
           resetWithFetch,
-          updateVideoIsMuted,
+          postProcessingResource,
           optimizeVideo,
           optimizeGif,
         };
@@ -165,13 +165,7 @@ export const MediaPicker = ({ render, ...props }) => {
           resource.sizes?.medium?.source_url || resource.src
         );
 
-        if (
-          !resource.local &&
-          allowedVideoMimeTypes.includes(resource.mimeType) &&
-          resource.isMuted === null
-        ) {
-          updateVideoIsMuted(resource.id, resource.src);
-        }
+        postProcessingResource(resource);
       } catch (e) {
         showSnackbar({
           message: e.message,
@@ -187,7 +181,7 @@ export const MediaPicker = ({ render, ...props }) => {
       optimizeVideo,
       showSnackbar,
       transcodableMimeTypes,
-      updateVideoIsMuted,
+      postProcessingResource,
     ]
   );
   return (


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Use postProcessingResource instead of updateVideoIsMuted function. This handles duplicating processes that are called multiple times, meaning that mute update will not be called multiple times.  

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
