### PR TITLE
Editor: Allow disabling drop-targeting using the modifier key

### DIFF
--- a/packages/story-editor/src/components/canvas/utils/useSnapping.js
+++ b/packages/story-editor/src/components/canvas/utils/useSnapping.js
@@ -19,7 +19,7 @@
  */
 import { useCallback } from '@web-stories-wp/react';
 import { FULLBLEED_RATIO } from '@web-stories-wp/units';
-import { useGlobalIsKeyPressed } from '@web-stories-wp/design-system';
+
 /**
  * Internal dependencies
  */
@@ -45,15 +45,17 @@ function useSnapping({
       pageHeight,
     })
   );
-  const { activeDropTargetId } = useDropTargets((state) => ({
-    activeDropTargetId: state.state.activeDropTargetId,
-  }));
+  const { activeDropTargetId, isDropTargetingDisabled } = useDropTargets(
+    (state) => ({
+      activeDropTargetId: state.state.activeDropTargetId,
+      isDropTargetingDisabled: state.state.isDropTargetingDisabled,
+    })
+  );
 
   const triggerOnboarding = useUserOnboarding(({ SAFE_ZONE }) => SAFE_ZONE);
 
-  // ⌘ key disables snapping
-  const snapDisabled = useGlobalIsKeyPressed('meta');
-  canSnap = canSnap && !snapDisabled && !activeDropTargetId;
+  // Drop-targeting is disabled with ⌘ key, we also disable snapping in this case.
+  canSnap = canSnap && !isDropTargetingDisabled && !activeDropTargetId;
 
   const handleSnap = useCallback(
     ({ elements }) => {

--- a/packages/story-editor/src/components/dropTargets/provider.js
+++ b/packages/story-editor/src/components/dropTargets/provider.js
@@ -215,7 +215,7 @@ function DropTargetsProvider({ children }) {
       draggingResource,
       isDropTargetingDisabled,
     },
-    // If the drop-targeting is disabled, all the related actions shouldn't be applied.
+    // If drop-targeting is disabled, all the related actions are ignored.
     actions: {
       registerDropTarget: isDropTargetingDisabled ? noop : registerDropTarget,
       unregisterDropTarget,

--- a/packages/story-editor/src/components/dropTargets/provider.js
+++ b/packages/story-editor/src/components/dropTargets/provider.js
@@ -19,6 +19,8 @@
  */
 import PropTypes from 'prop-types';
 import { useState, useMemo, useCallback } from '@web-stories-wp/react';
+import { noop, useGlobalIsKeyPressed } from '@web-stories-wp/design-system';
+
 /**
  * Internal dependencies
  */
@@ -203,20 +205,25 @@ function DropTargetsProvider({ children }) {
     [activeDropTargetId, combineElements, elements, dropTargets, pushTransform]
   );
 
+  // ⌘ key disables drop-targeting.
+  const isDropTargetingDisabled = useGlobalIsKeyPressed('meta');
+
   const state = {
     state: {
       dropTargets,
       activeDropTargetId,
       draggingResource,
+      isDropTargetingDisabled,
     },
+    // If the drop-targeting is disabled, all the related actions shouldn't be applied.
     actions: {
-      registerDropTarget,
+      registerDropTarget: isDropTargetingDisabled ? noop : registerDropTarget,
       unregisterDropTarget,
-      isDropSource,
-      isDropTarget,
-      handleDrag,
-      handleDrop,
-      setDraggingResource,
+      isDropSource: isDropTargetingDisabled ? () => false : isDropSource,
+      isDropTarget: isDropTargetingDisabled ? () => false : isDropTarget,
+      handleDrag: isDropTargetingDisabled ? noop : handleDrag,
+      handleDrop: isDropTargetingDisabled ? noop : handleDrop,
+      setDraggingResource: isDropTargetingDisabled ? noop : setDraggingResource,
     },
   };
 

--- a/packages/story-editor/src/components/keyboardShortcutsMenu/keyboardShortcutList.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/keyboardShortcutList.js
@@ -337,7 +337,7 @@ const shortcuts = {
           ),
         },
         {
-          label: __('Disable snapping', 'web-stories'),
+          label: __('Disable snapping and drop targeting', 'web-stories'),
           shortcut: (
             <kbd>
               <TranslateWithMarkup


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Deactivates drop-targeting and snapping both while holding down the modifier key.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
No drop-targeting nor snapping happening when dragging while holding down the modifier:
![modifier](https://user-images.githubusercontent.com/3294597/143012629-874a9153-fd61-46b5-be40-a37e4af10820.gif)
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Press down the modifier key (`⌘` for Mac,  `Ctrl` for Windows)
2. Drag elements around that would usually start using the drop-targeting feature (media / shapes).
3. Verify that both Snapping and drop-targeting are disabled when holding down the key.
4. Verify that the snapping and drop-targeting work as expected otherwise.

## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6383 
