### PR TITLE
Sanitization: Improve grid placeholder image removal

### DIFF
--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -442,6 +442,12 @@ trait Sanitization_Utils {
 	/**
 	 * Remove images referencing the grid-placeholder.png file which has since been removed.
 	 *
+	 * Prevents 404 errors for non-existent image files when creators forget to replace/remove
+	 * the placeholder image.
+	 *
+	 * The placeholder functionality was removed in v1.14.0, nevertheless older stories could still
+	 * reference the files.
+	 *
 	 * @link https://github.com/google/web-stories-wp/issues/9530
 	 *
 	 * @since 1.14.0
@@ -450,7 +456,10 @@ trait Sanitization_Utils {
 	 * @return void
 	 */
 	private function remove_page_template_placeholder_images( &$document ) {
-		$placeholder_img = 'assets/images/editor/grid-placeholder.png';
+		// Catches "assets/images/editor/grid-placeholder.png" as well as
+		// "web-stories/assets/images/adde98ae406d6b5c95d111a934487252.png" (v1.14.0)
+		// and potentially other variants.
+		$placeholder_img = 'plugins/web-stories/assets/images';
 
 		/**
 		 * List of <amp-img> elements.

--- a/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
@@ -469,4 +469,22 @@ class Story_Sanitizer extends TestCase {
 
 		$this->assertStringNotContainsString( 'amp-img', $actual );
 	}
+
+	/**
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::remove_page_template_placeholder_images
+	 */
+	public function test_remove_page_template_placeholder_images_hash() {
+		$source = '<html><head></head><body><amp-img src="https://example.com/wp-content/plugins/web-stories/assets/images/adde98ae406d6b5c95d111a934487252.png" width="100" height="100"></amp-img></body></html>';
+
+		$args = [
+			'publisher_logo' => '',
+			'publisher'      => '',
+			'poster_images'  => [],
+			'video_cache'    => false,
+		];
+
+		$actual = $this->sanitize_and_get( $source, $args );
+
+		$this->assertStringNotContainsString( 'amp-img', $actual );
+	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

In support we got a couple of more cases where people forgot to remove the grid placeholder image, albeit with a different plugin version where the URL was slightly different.

## Summary

<!-- A brief description of what this PR does. -->

Improves AMP sanitization to catch more cases where the grid placeholder image needs to be removed, in order to prevent 404s.

## Relevant Technical Choices

<!-- Please describe your changes. -->

N/A

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
