### PR TITLE
Media: Fix Media fetching karma test

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -229,7 +229,6 @@ jobs:
       github.event.pull_request.head.repo.fork == false &&
       github.event.pull_request.user.login != 'dependabot[bot]'
     needs: upload-artifacts
-
     outputs:
       comment_body: ${{ steps.get-comment-body.outputs.body }}
 

--- a/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
@@ -80,12 +80,6 @@ function PaginatedMediaGallery({
       return;
     }
 
-    // Load the next page if the page isn't full, ie. scrollbar is not visible.
-    if (node.clientHeight === node.scrollHeight) {
-      setNextPage();
-      return;
-    }
-
     // If scrollTop is zero, we know we do not need to fetch an additional page yet.
     if (node.scrollTop === 0) {
       return;

--- a/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
@@ -65,14 +65,15 @@ function PaginatedMediaGallery({
   // State and callback ref necessary to load on scroll.
   const refContainer = useRef();
 
-  const isNextPageNeeded = () => {
+  const isNextPageNeeded = useCallback(() => {
+    // Load the next page if the container still isn't full, ie. scrollbar is not visible.
     if (
       refContainer.current.clientHeight === refContainer.current.scrollHeight
     ) {
-      return setNextPage;
+      return setNextPage();
     }
     return () => {};
-  };
+  }, [setNextPage]);
 
   const debouncedSetNextPage = useDebouncedCallback(isNextPageNeeded, 500);
 
@@ -91,9 +92,13 @@ function PaginatedMediaGallery({
       return;
     }
 
-    // Load the next page if the page isn't full, ie. scrollbar is not visible.
+    // When the node.scrollHeight is first calculated it may not be accurate
+    // depending on if the elements have fully render on the page. If the container
+    // height and scroll height are the same, debounce the call to allow time
+    // for the elements to paint before making an additional setNextPage call.
     if (node.clientHeight === node.scrollHeight) {
       debouncedSetNextPage();
+      return;
     }
 
     // Load the next page if we are "close" (by a length of ROOT_MARGIN) to the

--- a/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
@@ -65,6 +65,17 @@ function PaginatedMediaGallery({
   // State and callback ref necessary to load on scroll.
   const refContainer = useRef();
 
+  const isNextPageNeeded = () => {
+    if (
+      refContainer.current.clientHeight === refContainer.current.scrollHeight
+    ) {
+      return setNextPage;
+    }
+    return () => {};
+  };
+
+  const debouncedSetNextPage = useDebouncedCallback(isNextPageNeeded, 500);
+
   const loadNextPageIfNeeded = useCallback(() => {
     const node = refContainer.current;
     if (
@@ -80,9 +91,9 @@ function PaginatedMediaGallery({
       return;
     }
 
-    // If scrollTop is zero, we know we do not need to fetch an additional page yet.
-    if (node.scrollTop === 0) {
-      return;
+    // Load the next page if the page isn't full, ie. scrollbar is not visible.
+    if (node.clientHeight === node.scrollHeight) {
+      debouncedSetNextPage();
     }
 
     // Load the next page if we are "close" (by a length of ROOT_MARGIN) to the
@@ -93,7 +104,14 @@ function PaginatedMediaGallery({
       setNextPage();
       return;
     }
-  }, [resources, hasMore, isMediaLoaded, isMediaLoading, setNextPage]);
+  }, [
+    resources.length,
+    hasMore,
+    isMediaLoaded,
+    isMediaLoading,
+    debouncedSetNextPage,
+    setNextPage,
+  ]);
 
   // Scroll to the top when the searchTerm or selected category changes.
   useEffect(() => {

--- a/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
@@ -73,6 +73,8 @@ function PaginatedMediaGallery({
       // This condition happens when the component is hidden, and causes the
       // calculation below to load a new page in error.
       node.clientHeight === 0 ||
+      // If scrollTop is zero, we know we do not need to fetch an additional page yet.
+      node.scrollTop === 0 ||
       !hasMore ||
       !isMediaLoaded ||
       isMediaLoading

--- a/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
+++ b/packages/story-editor/src/components/library/panes/media/common/paginatedMediaGallery.js
@@ -73,12 +73,21 @@ function PaginatedMediaGallery({
       // This condition happens when the component is hidden, and causes the
       // calculation below to load a new page in error.
       node.clientHeight === 0 ||
-      // If scrollTop is zero, we know we do not need to fetch an additional page yet.
-      node.scrollTop === 0 ||
       !hasMore ||
       !isMediaLoaded ||
       isMediaLoading
     ) {
+      return;
+    }
+
+    // Load the next page if the page isn't full, ie. scrollbar is not visible.
+    if (node.clientHeight === node.scrollHeight) {
+      setNextPage();
+      return;
+    }
+
+    // If scrollTop is zero, we know we do not need to fetch an additional page yet.
+    if (node.scrollTop === 0) {
       return;
     }
 
@@ -87,12 +96,6 @@ function PaginatedMediaGallery({
     const bottom =
       node.scrollHeight - node.scrollTop <= node.clientHeight + ROOT_MARGIN;
     if (bottom) {
-      setNextPage();
-      return;
-    }
-
-    // Load the next page if the page isn't full, ie. scrollbar is not visible.
-    if (node.clientHeight === node.scrollHeight) {
       setNextPage();
       return;
     }

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -53,11 +53,12 @@ xdescribe('MediaPane fetching', () => {
     const initialElements =
       within(mediaGallery).queryAllByTestId(/^mediaElement-/);
 
+    // ensure fixture.screen has loaded before calling expect to prevent immediate failure
+    if (initialElements.length !== LOCAL_MEDIA_PER_PAGE) {
+      await fixture.events.sleep(500);
+    }
+
     await waitFor(() => {
-      // ensure fixture.screen has loaded before calling expect to prevent immediate failure
-      if (initialElements.length !== LOCAL_MEDIA_PER_PAGE) {
-        throw new Error('wait');
-      }
       expect(initialElements.length).toBe(LOCAL_MEDIA_PER_PAGE);
     });
 
@@ -66,15 +67,15 @@ xdescribe('MediaPane fetching', () => {
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
     );
 
-    await waitFor(() => {
-      // ensure fixture.screen has loaded before calling expect to prevent immediate failure
-      if (
-        fixture.screen.queryAllByTestId(/^mediaElement-/).length <
-        LOCAL_MEDIA_PER_PAGE * 2
-      ) {
-        throw new Error('wait');
-      }
+    // ensure fixture.screen has loaded before calling expect to prevent immediate failure
+    if (
+      fixture.screen.queryAllByTestId(/^mediaElement-/).length <
+      LOCAL_MEDIA_PER_PAGE * 2
+    ) {
+      await fixture.events.sleep(500);
+    }
 
+    await waitFor(() => {
       expect(
         fixture.screen.queryAllByTestId(/^mediaElement-/).length
       ).toBeGreaterThanOrEqual(LOCAL_MEDIA_PER_PAGE * 2);

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -24,6 +24,7 @@ import { waitFor, within } from '@testing-library/react';
  */
 
 import { Fixture, LOCAL_MEDIA_PER_PAGE } from '../../../../../../karma/fixture';
+import { ROOT_MARGIN } from '../mediaPane';
 
 describe('MediaPane fetching', () => {
   let fixture;
@@ -46,14 +47,22 @@ describe('MediaPane fetching', () => {
       'media-gallery-container'
     );
 
-    // ensure fixture.screen has loaded before calling expect to prevent immediate failure
     const initialElementsLength =
       fixture.screen.queryAllByTestId(/^mediaElement-/).length;
 
-    expect(initialElementsLength).toEqual(LOCAL_MEDIA_PER_PAGE);
+    // ensure fixture.screen has loaded before calling expect to prevent immediate failure
+    await waitFor(() => {
+      if (initialElementsLength !== LOCAL_MEDIA_PER_PAGE) {
+        throw new Error('wait for initial fetch');
+      }
+      expect(initialElementsLength).toEqual(LOCAL_MEDIA_PER_PAGE);
+    });
 
     // Scroll all the way down.
-    await mediaGallery.scrollTo(0, 9999999999999999999);
+    await mediaGallery.scrollTo(
+      0,
+      mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
+    );
 
     // ensure fixture.screen has loaded before calling expect to prevent immediate failure
     await waitFor(() => {

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -25,10 +25,7 @@ import { waitFor, within } from '@testing-library/react';
 
 import { Fixture, LOCAL_MEDIA_PER_PAGE } from '../../../../../../karma/fixture';
 
-// Disable reason: test is flakey
-// Fix in progress:   https://github.com/google/web-stories-wp/issues/9779
-// eslint-disable-next-line jasmine/no-disabled-tests
-xdescribe('MediaPane fetching', () => {
+fdescribe('MediaPane fetching', () => {
   let fixture;
 
   beforeEach(async () => {
@@ -41,7 +38,7 @@ xdescribe('MediaPane fetching', () => {
     fixture.restore();
   });
 
-  it('should fetch additional pages', async () => {
+  fit('should fetch additional pages', async () => {
     const localPane = await waitFor(() =>
       fixture.querySelector('#library-pane-media')
     );
@@ -59,17 +56,22 @@ xdescribe('MediaPane fetching', () => {
     await mediaGallery.scrollTo(0, 9999999999999999999);
 
     // ensure fixture.screen has loaded before calling expect to prevent immediate failure
-    await waitFor(() => {
-      if (
-        fixture.screen.queryAllByTestId(/^mediaElement-/).length <
-        initialElementsLength + LOCAL_MEDIA_PER_PAGE
-      ) {
-        throw new Error('Not loaded yet');
-      }
+    await waitFor(
+      () => {
+        if (
+          fixture.screen.queryAllByTestId(/^mediaElement-/).length <
+          initialElementsLength + LOCAL_MEDIA_PER_PAGE
+        ) {
+          throw new Error('Not loaded yet');
+        }
 
-      expect(
-        fixture.screen.queryAllByTestId(/^mediaElement-/).length
-      ).toBeGreaterThanOrEqual(initialElementsLength + LOCAL_MEDIA_PER_PAGE);
-    });
+        expect(
+          fixture.screen.queryAllByTestId(/^mediaElement-/).length
+        ).toBeGreaterThanOrEqual(initialElementsLength + LOCAL_MEDIA_PER_PAGE);
+      },
+      {
+        timeout: 4000,
+      }
+    );
   });
 });

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -25,7 +25,7 @@ import { waitFor, within } from '@testing-library/react';
 
 import { Fixture, LOCAL_MEDIA_PER_PAGE } from '../../../../../../karma/fixture';
 
-fdescribe('MediaPane fetching', () => {
+describe('MediaPane fetching', () => {
   let fixture;
 
   beforeEach(async () => {
@@ -38,7 +38,7 @@ fdescribe('MediaPane fetching', () => {
     fixture.restore();
   });
 
-  fit('should fetch additional pages', async () => {
+  it('should fetch additional pages', async () => {
     const localPane = await waitFor(() =>
       fixture.querySelector('#library-pane-media')
     );

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -51,9 +51,13 @@ describe('MediaPane fetching', () => {
       fixture.screen.queryAllByTestId(/^mediaElement-/).length;
 
     // ensure fixture.screen has loaded before calling expect to prevent immediate failure
+    // Wait for the debounce
+    await fixture.events.sleep(1000);
     await waitFor(() => {
       if (initialElementsLength !== LOCAL_MEDIA_PER_PAGE) {
-        throw new Error('wait for initial fetch');
+        throw new Error(
+          `wait for initial fetch ${initialElementsLength} != ${LOCAL_MEDIA_PER_PAGE}`
+        );
       }
       expect(initialElementsLength).toEqual(LOCAL_MEDIA_PER_PAGE);
     });

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -60,15 +60,16 @@ xdescribe('MediaPane fetching', () => {
 
     // ensure fixture.screen has loaded before calling expect to prevent immediate failure
     await waitFor(() => {
-      const mediaElements = fixture.screen.queryAllByTestId(/^mediaElement-/);
-
-      if (mediaElements.length < initialElementsLength + LOCAL_MEDIA_PER_PAGE) {
+      if (
+        fixture.screen.queryAllByTestId(/^mediaElement-/).length <
+        initialElementsLength + LOCAL_MEDIA_PER_PAGE
+      ) {
         throw new Error('Not loaded yet');
       }
 
-      expect(mediaElements.length).toBeGreaterThanOrEqual(
-        initialElementsLength + LOCAL_MEDIA_PER_PAGE
-      );
+      expect(
+        fixture.screen.queryAllByTestId(/^mediaElement-/).length
+      ).toBeGreaterThanOrEqual(initialElementsLength + LOCAL_MEDIA_PER_PAGE);
     });
   });
 });

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -41,7 +41,7 @@ xdescribe('MediaPane fetching', () => {
     fixture.restore();
   });
 
-  it('should fetch 2nd page', async () => {
+  it('should fetch additional pages', async () => {
     const localPane = await waitFor(() =>
       fixture.querySelector('#library-pane-media')
     );

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -50,28 +50,23 @@ fdescribe('MediaPane fetching', () => {
     const initialElementsLength =
       fixture.screen.queryAllByTestId(/^mediaElement-/).length;
 
-    expect(initialElementsLength).toBeGreaterThanOrEqual(LOCAL_MEDIA_PER_PAGE);
+    expect(initialElementsLength).toEqual(LOCAL_MEDIA_PER_PAGE);
 
     // Scroll all the way down.
     await mediaGallery.scrollTo(0, 9999999999999999999);
 
     // ensure fixture.screen has loaded before calling expect to prevent immediate failure
-    await waitFor(
-      () => {
-        if (
-          fixture.screen.queryAllByTestId(/^mediaElement-/).length <
-          initialElementsLength + LOCAL_MEDIA_PER_PAGE
-        ) {
-          throw new Error('Not loaded yet');
-        }
-
-        expect(
-          fixture.screen.queryAllByTestId(/^mediaElement-/).length
-        ).toBeGreaterThanOrEqual(initialElementsLength + LOCAL_MEDIA_PER_PAGE);
-      },
-      {
-        timeout: 4000,
+    await waitFor(() => {
+      if (
+        fixture.screen.queryAllByTestId(/^mediaElement-/).length <
+        initialElementsLength + LOCAL_MEDIA_PER_PAGE
+      ) {
+        throw new Error('Not loaded yet');
       }
-    );
+
+      expect(
+        fixture.screen.queryAllByTestId(/^mediaElement-/).length
+      ).toBeGreaterThanOrEqual(initialElementsLength + LOCAL_MEDIA_PER_PAGE);
+    });
   });
 });

--- a/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/local/karma/mediaFetching.karma.js
@@ -24,7 +24,6 @@ import { waitFor, within } from '@testing-library/react';
  */
 
 import { Fixture, LOCAL_MEDIA_PER_PAGE } from '../../../../../../karma/fixture';
-import { ROOT_MARGIN } from '../mediaPane';
 
 // Disable reason: test is flakey
 // Fix in progress:   https://github.com/google/web-stories-wp/issues/9779
@@ -46,39 +45,30 @@ xdescribe('MediaPane fetching', () => {
     const localPane = await waitFor(() =>
       fixture.querySelector('#library-pane-media')
     );
-    const mediaGallery = await within(localPane).getByTestId(
+    const mediaGallery = await within(localPane).findByTestId(
       'media-gallery-container'
     );
 
-    const initialElements =
-      within(mediaGallery).queryAllByTestId(/^mediaElement-/);
+    // ensure fixture.screen has loaded before calling expect to prevent immediate failure
+    const initialElementsLength =
+      fixture.screen.queryAllByTestId(/^mediaElement-/).length;
+
+    expect(initialElementsLength).toBeGreaterThanOrEqual(LOCAL_MEDIA_PER_PAGE);
+
+    // Scroll all the way down.
+    await mediaGallery.scrollTo(0, 9999999999999999999);
 
     // ensure fixture.screen has loaded before calling expect to prevent immediate failure
-    if (initialElements.length !== LOCAL_MEDIA_PER_PAGE) {
-      await fixture.events.sleep(500);
-    }
-
     await waitFor(() => {
-      expect(initialElements.length).toBe(LOCAL_MEDIA_PER_PAGE);
-    });
+      const mediaElements = fixture.screen.queryAllByTestId(/^mediaElement-/);
 
-    await mediaGallery.scrollTo(
-      0,
-      mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
-    );
+      if (mediaElements.length < initialElementsLength + LOCAL_MEDIA_PER_PAGE) {
+        throw new Error('Not loaded yet');
+      }
 
-    // ensure fixture.screen has loaded before calling expect to prevent immediate failure
-    if (
-      fixture.screen.queryAllByTestId(/^mediaElement-/).length <
-      LOCAL_MEDIA_PER_PAGE * 2
-    ) {
-      await fixture.events.sleep(500);
-    }
-
-    await waitFor(() => {
-      expect(
-        fixture.screen.queryAllByTestId(/^mediaElement-/).length
-      ).toBeGreaterThanOrEqual(LOCAL_MEDIA_PER_PAGE * 2);
+      expect(mediaElements.length).toBeGreaterThanOrEqual(
+        initialElementsLength + LOCAL_MEDIA_PER_PAGE
+      );
     });
   });
 });

--- a/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -344,7 +344,8 @@ describe('Media3pPane fetching', () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
 
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
-
+    // Wait for the debounce
+    await fixture.events.sleep(1000);
     await expectMediaElements(
       fixture.editor.library.media3p.coverrSection,
       // In 1600:1000 the coverr section will fetch again due to screen height
@@ -382,6 +383,8 @@ describe('Media3pPane fetching', () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
 
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
+    // Wait for the debounce
+    await fixture.events.sleep(1000);
     await expectMediaElements(
       fixture.editor.library.media3p.coverrSection,
       // In 1600:1000 the coverr section will fetch again due to screen height

--- a/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -344,8 +344,13 @@ describe('Media3pPane fetching', () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
 
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
+
+    await expectMediaElements(
+      fixture.editor.library.media3p.coverrSection,
+      MEDIA_PER_PAGE
+    );
     // Wait for the debounce
-    await fixture.events.sleep(1000);
+    await fixture.events.sleep(700);
     await expectMediaElements(
       fixture.editor.library.media3p.coverrSection,
       // In 1600:1000 the coverr section will fetch again due to screen height
@@ -384,7 +389,7 @@ describe('Media3pPane fetching', () => {
 
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
     // Wait for the debounce
-    await fixture.events.sleep(1000);
+    await fixture.events.sleep(700);
     await expectMediaElements(
       fixture.editor.library.media3p.coverrSection,
       // In 1600:1000 the coverr section will fetch again due to screen height

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -778,8 +778,8 @@ class APIProviderFixture {
         const filterBySearchTerm = searchTerm
           ? ({ alt_text }) => alt_text.includes(searchTerm)
           : () => true;
-        // Generate 8*20=160 items, 4 pages
-        const clonedMedia = Array(20)
+        // Generate 8*13=104 items, 3 pages
+        const clonedMedia = Array(13)
           .fill(getMediaResponse)
           .flat()
           .map((media, i) => ({ ...media, id: i + 1 }));
@@ -791,7 +791,7 @@ class APIProviderFixture {
             )
             .filter(filterByMediaType)
             .filter(filterBySearchTerm),
-          headers: { totalPages: 4 },
+          headers: { totalPages: 3 },
         });
       }, []);
       const uploadMedia = useCallback(

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -791,7 +791,7 @@ class APIProviderFixture {
             )
             .filter(filterByMediaType)
             .filter(filterBySearchTerm),
-          headers: { totalPages: 3 },
+          headers: { totalPages: 4 },
         });
       }, []);
       const uploadMedia = useCallback(

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -778,8 +778,8 @@ class APIProviderFixture {
         const filterBySearchTerm = searchTerm
           ? ({ alt_text }) => alt_text.includes(searchTerm)
           : () => true;
-        // Generate 8*13=104 items, 3 pages
-        const clonedMedia = Array(13)
+        // Generate 8*20=160 items, 4 pages
+        const clonedMedia = Array(20)
           .fill(getMediaResponse)
           .flat()
           .map((media, i) => ({ ...media, id: i + 1 }));

--- a/percy.config.yml
+++ b/percy.config.yml
@@ -16,7 +16,7 @@ snapshot:
     .story-media-display-element {
       background-color: transparent !important;
     }
-    
+
     video::-webkit-media-controls {
       display: none;
     }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Media fetching karma test is throwing an error when the fixture has yet to be set up causing the test to fail.

## Summary

<!-- A brief description of what this PR does. -->
When the mediaFetch call is initially made it takes a little bit of time before the elements are actually rendered into their container. In some instances this meant we were making an additional api call to grab more media items because we thought there wasn't enough items present to fully fill the container's height. This unnecessary second call would cause the media fetch tests to fail in ci. 
## Relevant Technical Choices

<!-- Please describe your changes. -->
Now we are ensuring an additional page call is only made if the container isn't full after a 500 ms delay. Using a debouncedCallback to set the delay and then checking if the second call is still needed before calling `setNextPage`.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Make sure the all the media call are still being made by clicking through both local media and 3P media tabs. 
2. On the 3p video tab, if you make your screen resolution really really small, you can see the slight time delay between the first and second media batches. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
no
## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9779 
