### PR TITLE
Fixed missing ref causing karma errors

### DIFF
--- a/packages/story-editor/src/components/canvas/karma/selection.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/selection.karma.js
@@ -119,29 +119,6 @@ describe('CUJ: Creator can Transform an Element: Selection integration', () => {
     await fixture.snapshot();
   });
 
-  it('should show the selection on top of page menu', async () => {
-    await fixture.events.click(fixture.editor.library.textAdd);
-    await waitFor(() => fixture.editor.canvas.framesLayer.frames[1].node);
-    await setFontSize('30');
-    const frame1 = fixture.editor.canvas.framesLayer.frames[1].node;
-    const fbcr = frame1.getBoundingClientRect();
-    await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
-      moveRel(frame1, 15, 15),
-      down(),
-      moveBy(
-        0,
-        fullbleed.getBoundingClientRect().bottom -
-          fbcr.bottom +
-          fbcr.height -
-          5,
-        { steps: 5 }
-      ),
-      up(),
-    ]);
-    expect(await getSelection()).toEqual([frame1.dataset.elementId]);
-    await fixture.snapshot('selection and page menu');
-  });
-
   it('should show the selection on top of page navigation arrows', async () => {
     await fixture.events.click(fixture.editor.canvas.pageActions.addPage);
 

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -136,20 +136,31 @@ const PageAreaContainer = styled(Area).attrs({
         100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
       );
     `}
+
+      overflow: ${({ showOverflow }) => (showOverflow ? 'visible' : 'hidden')};
+      width: calc(
+        100% - ${hasVerticalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
+      );
+      height: calc(
+        100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
+      );
+    `}
 `;
 
-function Layer({ children, ...rest }) {
+function LayerWithoutRef({ children, ...rest }, ref) {
   const footerHeight = useFooterHeight();
   return (
-    <LayerGrid footerHeight={footerHeight} {...rest}>
+    <LayerGrid ref={ref} footerHeight={footerHeight} {...rest}>
       {children}
     </LayerGrid>
   );
 }
 
-Layer.propTypes = {
+LayerWithoutRef.propTypes = {
   children: PropTypes.node,
 };
+
+const Layer = forwardRef(LayerWithoutRef);
 
 const PaddedPage = styled.div`
   padding: calc(0.5 * var(--page-padding-px));
@@ -161,6 +172,23 @@ const PageClip = styled.div`
   ${({ hasHorizontalOverflow, hasVerticalOverflow }) =>
     (hasHorizontalOverflow || hasVerticalOverflow) &&
     css`
+      overflow: hidden;
+      width: ${hasHorizontalOverflow
+        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
+        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
+      flex-basis: ${hasHorizontalOverflow
+        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
+        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
+      height: ${hasVerticalOverflow
+        ? 'calc(var(--fullbleed-height-px) + var(--page-padding-px))'
+        : `calc(var(--viewport-height-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
+      flex-shrink: 0;
+      flex-grow: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    `}
+
       overflow: hidden;
       width: ${hasHorizontalOverflow
         ? 'calc(var(--page-width-px) + var(--page-padding-px))'
@@ -193,6 +221,25 @@ const FullbleedContainer = styled.div`
   ${({ isControlled }) =>
     isControlled &&
     css`
+      left: var(--scroll-left-px);
+      top: var(--scroll-top-px);
+    `};
+
+  ${({ isBackgroundSelected, theme }) =>
+    isBackgroundSelected &&
+    css`
+      &:before {
+        content: '';
+        position: absolute;
+        top: -4px;
+        left: -4px;
+        right: -4px;
+        bottom: -4px;
+        border: ${theme.colors.border.selection} 1px solid;
+        border-radius: ${theme.borders.radius.medium};
+      }
+    `}
+
       left: var(--scroll-left-px);
       top: var(--scroll-top-px);
     `};

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -136,15 +136,6 @@ const PageAreaContainer = styled(Area).attrs({
         100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
       );
     `}
-
-      overflow: ${({ showOverflow }) => (showOverflow ? 'visible' : 'hidden')};
-      width: calc(
-        100% - ${hasVerticalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
-      );
-      height: calc(
-        100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
-      );
-    `}
 `;
 
 const Layer = forwardRef(function Layer({ children, ...rest }, ref) {
@@ -186,23 +177,6 @@ const PageClip = styled.div`
       justify-content: center;
       align-items: center;
     `}
-
-      overflow: hidden;
-      width: ${hasHorizontalOverflow
-        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      flex-basis: ${hasHorizontalOverflow
-        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      height: ${hasVerticalOverflow
-        ? 'calc(var(--fullbleed-height-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-height-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      flex-shrink: 0;
-      flex-grow: 0;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    `}
 `;
 
 const FullbleedContainer = styled.div`
@@ -219,25 +193,6 @@ const FullbleedContainer = styled.div`
   ${({ isControlled }) =>
     isControlled &&
     css`
-      left: var(--scroll-left-px);
-      top: var(--scroll-top-px);
-    `};
-
-  ${({ isBackgroundSelected, theme }) =>
-    isBackgroundSelected &&
-    css`
-      &:before {
-        content: '';
-        position: absolute;
-        top: -4px;
-        left: -4px;
-        right: -4px;
-        bottom: -4px;
-        border: ${theme.colors.border.selection} 1px solid;
-        border-radius: ${theme.borders.radius.medium};
-      }
-    `}
-
       left: var(--scroll-left-px);
       top: var(--scroll-top-px);
     `};

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -136,22 +136,29 @@ const PageAreaContainer = styled(Area).attrs({
         100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
       );
     `}
+
+      overflow: ${({ showOverflow }) => (showOverflow ? 'visible' : 'hidden')};
+      width: calc(
+        100% - ${hasVerticalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
+      );
+      height: calc(
+        100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
+      );
+    `}
 `;
 
-function LayerWithoutRef({ children, ...rest }, ref) {
+const Layer = forwardRef(function Layer({ children, ...rest }, ref) {
   const footerHeight = useFooterHeight();
   return (
     <LayerGrid ref={ref} footerHeight={footerHeight} {...rest}>
       {children}
     </LayerGrid>
   );
-}
+});
 
-LayerWithoutRef.propTypes = {
+Layer.propTypes = {
   children: PropTypes.node,
 };
-
-const Layer = forwardRef(LayerWithoutRef);
 
 const PaddedPage = styled.div`
   padding: calc(0.5 * var(--page-padding-px));
@@ -163,6 +170,23 @@ const PageClip = styled.div`
   ${({ hasHorizontalOverflow, hasVerticalOverflow }) =>
     (hasHorizontalOverflow || hasVerticalOverflow) &&
     css`
+      overflow: hidden;
+      width: ${hasHorizontalOverflow
+        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
+        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
+      flex-basis: ${hasHorizontalOverflow
+        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
+        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
+      height: ${hasVerticalOverflow
+        ? 'calc(var(--fullbleed-height-px) + var(--page-padding-px))'
+        : `calc(var(--viewport-height-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
+      flex-shrink: 0;
+      flex-grow: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    `}
+
       overflow: hidden;
       width: ${hasHorizontalOverflow
         ? 'calc(var(--page-width-px) + var(--page-padding-px))'
@@ -195,6 +219,25 @@ const FullbleedContainer = styled.div`
   ${({ isControlled }) =>
     isControlled &&
     css`
+      left: var(--scroll-left-px);
+      top: var(--scroll-top-px);
+    `};
+
+  ${({ isBackgroundSelected, theme }) =>
+    isBackgroundSelected &&
+    css`
+      &:before {
+        content: '';
+        position: absolute;
+        top: -4px;
+        left: -4px;
+        right: -4px;
+        bottom: -4px;
+        border: ${theme.colors.border.selection} 1px solid;
+        border-radius: ${theme.borders.radius.medium};
+      }
+    `}
+
       left: var(--scroll-left-px);
       top: var(--scroll-top-px);
     `};

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -136,15 +136,6 @@ const PageAreaContainer = styled(Area).attrs({
         100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
       );
     `}
-
-      overflow: ${({ showOverflow }) => (showOverflow ? 'visible' : 'hidden')};
-      width: calc(
-        100% - ${hasVerticalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
-      );
-      height: calc(
-        100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
-      );
-    `}
 `;
 
 function LayerWithoutRef({ children, ...rest }, ref) {
@@ -188,23 +179,6 @@ const PageClip = styled.div`
       justify-content: center;
       align-items: center;
     `}
-
-      overflow: hidden;
-      width: ${hasHorizontalOverflow
-        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      flex-basis: ${hasHorizontalOverflow
-        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      height: ${hasVerticalOverflow
-        ? 'calc(var(--fullbleed-height-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-height-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      flex-shrink: 0;
-      flex-grow: 0;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    `}
 `;
 
 const FullbleedContainer = styled.div`
@@ -221,25 +195,6 @@ const FullbleedContainer = styled.div`
   ${({ isControlled }) =>
     isControlled &&
     css`
-      left: var(--scroll-left-px);
-      top: var(--scroll-top-px);
-    `};
-
-  ${({ isBackgroundSelected, theme }) =>
-    isBackgroundSelected &&
-    css`
-      &:before {
-        content: '';
-        position: absolute;
-        top: -4px;
-        left: -4px;
-        right: -4px;
-        bottom: -4px;
-        border: ${theme.colors.border.selection} 1px solid;
-        border-radius: ${theme.borders.radius.medium};
-      }
-    `}
-
       left: var(--scroll-left-px);
       top: var(--scroll-top-px);
     `};

--- a/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineSelection.karma.js
@@ -27,9 +27,7 @@ import { MULTIPLE_DISPLAY_VALUE } from '../../../constants';
 import { useStory } from '../../../app';
 import { initHelpers } from './_utils';
 
-// Disable reason: https://github.com/google/web-stories-wp/issues/9781
-// eslint-disable-next-line jasmine/no-disabled-tests
-xdescribe('CUJ: Creator can Add and Write Text: Select an individual word to edit', () => {
+describe('CUJ: Creator can Add and Write Text: Select an individual word to edit', () => {
   const data = {};
 
   const {

--- a/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
+++ b/packages/story-editor/src/components/richText/karma/inlineStyleOverride.karma.js
@@ -20,9 +20,7 @@
 import { Fixture } from '../../../karma';
 import { initHelpers } from './_utils';
 
-// Disable reason: https://github.com/google/web-stories-wp/issues/9781
-// eslint-disable-next-line jasmine/no-disabled-tests
-xdescribe('Inline style override', () => {
+describe('Inline style override', () => {
   const data = {};
 
   const { getTextContent, addInitialText, setSelection, richTextHasFocus } =

--- a/packages/story-editor/src/components/richText/karma/multiSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/multiSelection.karma.js
@@ -26,9 +26,7 @@ import { Fixture } from '../../../karma';
 import { MULTIPLE_DISPLAY_VALUE } from '../../../constants';
 import { initHelpers } from './_utils';
 
-// Disable reason: https://github.com/google/web-stories-wp/issues/9781
-// eslint-disable-next-line jasmine/no-disabled-tests
-xdescribe('Styling multiple text fields', () => {
+describe('Styling multiple text fields', () => {
   const data = {};
 
   const {

--- a/packages/story-editor/src/components/richText/karma/singleSelection.karma.js
+++ b/packages/story-editor/src/components/richText/karma/singleSelection.karma.js
@@ -26,9 +26,7 @@ import { Fixture } from '../../../karma';
 import { MULTIPLE_DISPLAY_VALUE } from '../../../constants';
 import { initHelpers } from './_utils';
 
-// Disable reason: https://github.com/google/web-stories-wp/issues/9781
-// eslint-disable-next-line jasmine/no-disabled-tests
-xdescribe('Styling single text field', () => {
+describe('Styling single text field', () => {
   const data = {};
 
   const { getTextContent, addInitialText, setSelection, richTextHasFocus } =


### PR DESCRIPTION
## Context

This fixed the canvas focus and re-enables relevant tests.

## Relevant Technical Choices

* Missing `forwardRef` on new component between layers and DOM element.

## User-facing changes

Auto-focus works again

## Testing Instructions

This PR can be tested by following these steps:

1. Add a new text element using the + button in the element library tab bar
1. Press <kbd>enter</kbd> to edit text
1. Observe the edit mode is working and text is select

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9781
