### PR TITLE
Videos: Move trimmer from now-obsolete menu area to footer

### DIFF
--- a/packages/story-editor/src/components/canvas/editLayer.js
+++ b/packages/story-editor/src/components/canvas/editLayer.js
@@ -31,7 +31,7 @@ import { getDefinitionForType } from '../../elements';
 import { useStory, useCanvas } from '../../app';
 import withOverlay from '../overlay/withOverlay';
 import EditElement from './editElement';
-import { Layer, PageArea, MenuArea, Z_INDEX } from './layout';
+import { Layer, PageArea, FooterArea, Z_INDEX } from './layout';
 import useFocusCanvas from './useFocusCanvas';
 
 const LayerWithGrayout = styled(Layer)`
@@ -116,9 +116,9 @@ function EditLayerForElement({ element, showOverflow }) {
         <EditElement element={element} />
       </EditPageArea>
       {EditMenu && (
-        <MenuArea showOverflow>
+        <FooterArea showOverflow>
           <EditMenu />
-        </MenuArea>
+        </FooterArea>
       )}
     </LayerWithGrayout>
   );


### PR DESCRIPTION
## Context

With the menu area gone, the video trimmer had nowhere to go so ended up outside the grid.

## User-facing changes

Screenshots of trimmer location in all 8 combinations of regular element vs background element, expanded or collapsed carousel, and fit or 200% zoom.

| Carousel | Zoom | Background video | Screenshot | 
|-|-|-|-|
| Expanded | Fit | No | <img width="250" src="https://user-images.githubusercontent.com/637548/143099279-0d7e2dac-01dc-4c78-8bfc-fa3792bf1a80.png" /> |
| Expanded | Fit | Yes | <img width="250" src="https://user-images.githubusercontent.com/637548/143099437-b517bd38-f4ef-4acf-8f80-455ea24b7b2e.png" /> | 
| Collapsed | Fit | No | <img width="250" src="https://user-images.githubusercontent.com/637548/143099584-11d0845b-e958-4d15-bfa1-faaa83e8f14f.png" /> |
| Collapsed | Fit | Yes | <img width="250" src="https://user-images.githubusercontent.com/637548/143099724-bcc81399-9ad9-4a56-b698-d97711bfd1e1.png" /> |
| Expanded | 200% | No | <img width="250" src="https://user-images.githubusercontent.com/637548/143099957-8c0d68ba-537f-4fbf-a8a2-b96940926712.png" /> |
| Expanded | 200% | Yes |<img width="250" src="https://user-images.githubusercontent.com/637548/143100286-b6894ac0-53cd-43aa-95cc-89c5cad09403.png" /> |
| Collapsed | 200% | No | <img width="250" src="https://user-images.githubusercontent.com/637548/143100160-0b8c3129-7757-4a98-a287-c4b0e3ead4d7.png" />|
| Collapsed | 200% | Yes | <img width="250" src="https://user-images.githubusercontent.com/637548/143100212-004e1eb5-45c7-4dd4-836f-c9bf616f441e.png" /> |

## Testing Instructions

This PR can be tested by following these steps:

1. Enter video trim mode and observe that things look correct

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9788
