### PR TITLE
Video Captions: Avoid covering tappable areas

### DIFF
--- a/packages/story-editor/src/output/page.js
+++ b/packages/story-editor/src/output/page.js
@@ -137,23 +137,17 @@ function OutputPage({
         <amp-story-grid-layer
           template="vertical"
           aspect-ratio={ASPECT_RATIO}
-          class="grid-layer"
+          class="grid-layer align-bottom"
         >
-          <div className="page-fullbleed-area">
-            <div className="page-safe-area">
-              <div className="captions-area">
-                <div className="captions-wrap">
-                  {videoCaptions.map((captionId) => (
-                    <amp-story-captions
-                      key={captionId}
-                      id={captionId}
-                      layout="fixed-height"
-                      height="100"
-                    />
-                  ))}
-                </div>
-              </div>
-            </div>
+          <div className="captions-area">
+            {videoCaptions.map((captionId) => (
+              <amp-story-captions
+                key={captionId}
+                id={captionId}
+                layout="fixed-height"
+                height="100"
+              />
+            ))}
           </div>
         </amp-story-grid-layer>
       )}

--- a/packages/story-editor/src/output/utils/styles.js
+++ b/packages/story-editor/src/output/utils/styles.js
@@ -137,18 +137,17 @@ function CustomStyles() {
                 }
               }
 
-              .captions-area {
-                width: 100%;
-                height: 100%;
-                display: grid;
+              .align-bottom {
                 align-content: end;
+                padding: 0;
               }
 
-              .captions-wrap {
-                margin: 0 32px 16px;
+              .captions-area {
+                padding: 0 32px 0;
               }
 
               amp-story-captions {
+                margin-bottom: 16px;
                 text-align: center;
               }
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

The video captions layer makes all links on the page untappable because it covers most of the page.

And we can't use `pointer-events: none` to address this.

## Summary

<!-- A brief description of what this PR does. -->

Avoid covering tappable areas as much as possible by tweaking the styles so that the element doesn't cover much of the page anymore. All while trying to stay within the safe zone.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

- Testing, maybe finding another approach

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

Area covered by the captions layer is smaller:

![Screenshot 2021-11-25 at 14 56 39](https://user-images.githubusercontent.com/841956/143477513-9e01708a-1685-46c5-a12b-8f6e6ed75e40.png)

No issue with the safe zone:

![Screenshot 2021-11-25 at 17 29 51](https://user-images.githubusercontent.com/841956/143477747-9d5495e4-680c-4c94-96fc-f80a95f27933.png)

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add video with captions
2. Add link to an element on the same page
3. Preview story
4. The part of the link that is not directly below the caption should be tappable


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9819
