### PR TITLE
Explore Templates: Update See Details button styling

### DIFF
--- a/packages/dashboard/src/app/views/exploreTemplates/content/templateGridItem.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/content/templateGridItem.js
@@ -26,6 +26,7 @@ import {
 } from '@web-stories-wp/design-system';
 import { forwardRef } from '@web-stories-wp/react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 /**
  * Internal dependencies
@@ -44,6 +45,13 @@ import {
 } from './components';
 
 export const FOCUS_TEMPLATE_CLASS = 'focus_template';
+
+const SeeDetailsButton = styled(Button).attrs({
+  type: BUTTON_TYPES.TERTIARY,
+  size: BUTTON_SIZES.SMALL,
+})`
+  background-color: ${({ theme }) => theme.colors.standard.white};
+`;
 
 const TemplateGridItem = forwardRef(
   (
@@ -95,10 +103,7 @@ const TemplateGridItem = forwardRef(
               data-template-slug={slug}
             >
               <TemplateDisplayContent>
-                <Button
-                  size={BUTTON_SIZES.SMALL}
-                  type={BUTTON_TYPES.SECONDARY}
-                  as="a"
+                <SeeDetailsButton
                   ariaLabel={sprintf(
                     /* translators: %s: template title.*/
                     __('Go to detail view of %s', 'web-stories'),
@@ -111,7 +116,7 @@ const TemplateGridItem = forwardRef(
                   tabIndex={tabIndex}
                 >
                   {TEMPLATES_GALLERY_ITEM_CENTER_ACTION_LABELS[status]}
-                </Button>
+                </SeeDetailsButton>
 
                 <Button
                   size={BUTTON_SIZES.SMALL}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
The See Details button on Dashboard -> Explore Templates seems a little unpolished. This updates it. 

## Summary

<!-- A brief description of what this PR does. -->
Updated the button to have a white background with the light gray on hover. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->
### Before 

https://user-images.githubusercontent.com/1820266/143913794-4f9fd0f6-492d-44c5-9cc5-e3938c8176b5.mov


### After

https://user-images.githubusercontent.com/1820266/143913832-88a7c7c6-cc8d-46ea-bdd7-d90927cbaf3a.mov


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Look at the button. 
2. Hover it.
3.  Focus it with the keyboard. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6752 
