### PR TITLE
Editor: Fix position and layering of page attachment layer

### DIFF
--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -136,6 +136,15 @@ const PageAreaContainer = styled(Area).attrs({
         100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
       );
     `}
+
+      overflow: ${({ showOverflow }) => (showOverflow ? 'visible' : 'hidden')};
+      width: calc(
+        100% - ${hasVerticalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
+      );
+      height: calc(
+        100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
+      );
+    `}
 `;
 
 const Layer = forwardRef(function Layer({ children, ...rest }, ref) {
@@ -177,6 +186,23 @@ const PageClip = styled.div`
       justify-content: center;
       align-items: center;
     `}
+
+      overflow: hidden;
+      width: ${hasHorizontalOverflow
+        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
+        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
+      flex-basis: ${hasHorizontalOverflow
+        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
+        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
+      height: ${hasVerticalOverflow
+        ? 'calc(var(--fullbleed-height-px) + var(--page-padding-px))'
+        : `calc(var(--viewport-height-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
+      flex-shrink: 0;
+      flex-grow: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    `}
 `;
 
 const FullbleedContainer = styled.div`
@@ -193,6 +219,25 @@ const FullbleedContainer = styled.div`
   ${({ isControlled }) =>
     isControlled &&
     css`
+      left: var(--scroll-left-px);
+      top: var(--scroll-top-px);
+    `};
+
+  ${({ isBackgroundSelected, theme }) =>
+    isBackgroundSelected &&
+    css`
+      &:before {
+        content: '';
+        position: absolute;
+        top: -4px;
+        left: -4px;
+        right: -4px;
+        bottom: -4px;
+        border: ${theme.colors.border.selection} 1px solid;
+        border-radius: ${theme.borders.radius.medium};
+      }
+    `}
+
       left: var(--scroll-left-px);
       top: var(--scroll-top-px);
     `};
@@ -439,11 +484,11 @@ const PageArea = forwardRef(function PageArea(
               ) : (
                 children
               )}
+              {overlay}
             </PageAreaWithoutOverflow>
           </FullbleedContainer>
         </PaddedPage>
       </PageClip>
-      {overlay}
     </PageAreaContainer>
   );
 });

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -136,15 +136,6 @@ const PageAreaContainer = styled(Area).attrs({
         100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
       );
     `}
-
-      overflow: ${({ showOverflow }) => (showOverflow ? 'visible' : 'hidden')};
-      width: calc(
-        100% - ${hasVerticalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
-      );
-      height: calc(
-        100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
-      );
-    `}
 `;
 
 const Layer = forwardRef(function Layer({ children, ...rest }, ref) {
@@ -186,23 +177,6 @@ const PageClip = styled.div`
       justify-content: center;
       align-items: center;
     `}
-
-      overflow: hidden;
-      width: ${hasHorizontalOverflow
-        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      flex-basis: ${hasHorizontalOverflow
-        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      height: ${hasVerticalOverflow
-        ? 'calc(var(--fullbleed-height-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-height-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      flex-shrink: 0;
-      flex-grow: 0;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    `}
 `;
 
 const FullbleedContainer = styled.div`
@@ -219,25 +193,6 @@ const FullbleedContainer = styled.div`
   ${({ isControlled }) =>
     isControlled &&
     css`
-      left: var(--scroll-left-px);
-      top: var(--scroll-top-px);
-    `};
-
-  ${({ isBackgroundSelected, theme }) =>
-    isBackgroundSelected &&
-    css`
-      &:before {
-        content: '';
-        position: absolute;
-        top: -4px;
-        left: -4px;
-        right: -4px;
-        bottom: -4px;
-        border: ${theme.colors.border.selection} 1px solid;
-        border-radius: ${theme.borders.radius.medium};
-      }
-    `}
-
       left: var(--scroll-left-px);
       top: var(--scroll-top-px);
     `};

--- a/packages/story-editor/src/components/canvas/pageAttachment/index.js
+++ b/packages/story-editor/src/components/canvas/pageAttachment/index.js
@@ -35,7 +35,7 @@ const Wrapper = styled.div`
   position: absolute;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   flex-direction: column;
   bottom: 0;
   height: 20%;


### PR DESCRIPTION
## Context

This moves the page area overlay (the page attachment) to the proper position in the new zoomed canvas layering as well as fixes the positioning of the page attachment, so it's always a fixed margin from the bottom of the page regardless of zoom (just like in an actual published story).

## User-facing changes

| Zoom | Scroll | Image |
|-|-|-|
| Fit | N/A | <img src="https://user-images.githubusercontent.com/637548/143930755-aa22f7c9-a986-4cac-8ce8-64f5da59b1a7.png" width=400 /> |
| Fill | Not bottom | <img src="https://user-images.githubusercontent.com/637548/143930814-b18ec2e1-18d8-4632-8f1b-0dc38beece87.png" width=400 /> |
| Fill | Bottom | <img src="https://user-images.githubusercontent.com/637548/143930842-3256ef49-8a1e-42ca-8f68-37044e46fdab.png" width=400 /> |
| 100% | Not bottom | <img src="https://user-images.githubusercontent.com/637548/143930864-425c1085-e897-42af-9369-f26753c61677.png" width=400 /> |
| 100% | Bottom | <img src="https://user-images.githubusercontent.com/637548/143930894-06380745-1f16-4b9b-9684-8dc1462e168c.png" width=400 /> |
| 200% | Not bottom | <img src="https://user-images.githubusercontent.com/637548/143930918-c6629edf-c90a-46ca-8337-b5a114d3dc1d.png" width=400 /> |
| 200% | Bottom right | <img src="https://user-images.githubusercontent.com/637548/143930951-fe3db343-ccd3-4eb1-acdc-25c588e0ef8e.png" width=400 /> |

## Testing Instructions

This PR can be tested by following these steps:

1. Add a page attachment
2. Change the zoom to 200%
3. Observe that the page attachment button correctly moves around with the zoomed page as it scrolls.

## Checklist

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #7566
