### PR TITLE
Dashboard: Remove Excess Header Render

### DIFF
--- a/packages/dashboard/src/app/views/myStories/content/index.js
+++ b/packages/dashboard/src/app/views/myStories/content/index.js
@@ -51,14 +51,13 @@ import StoriesView from './storiesView';
 function Content({
   allPagesFetched,
   filter,
-  isLoading,
+  loading,
   page,
   search,
   sort,
   stories,
   storyActions,
   view,
-  showStoriesWhileLoading,
 }) {
   return (
     <Layout.Scrollable>
@@ -67,19 +66,15 @@ function Content({
           <>
             <StoriesView
               filterValue={filter.value}
-              isLoading={isLoading}
               sort={sort}
               storyActions={storyActions}
               stories={stories}
               view={view}
-              loading={{
-                isLoading,
-                showStoriesWhileLoading,
-              }}
+              loading={loading}
             />
             <InfiniteScroller
               canLoadMore={!allPagesFetched}
-              isLoading={isLoading}
+              isLoading={loading?.isLoading}
               allDataLoadedMessage={__('No more stories', 'web-stories')}
               onLoadMore={page.requestNextPage}
             />
@@ -120,14 +115,16 @@ function Content({
 Content.propTypes = {
   allPagesFetched: PropTypes.bool,
   filter: FilterPropTypes,
-  isLoading: PropTypes.bool,
+  loading: PropTypes.shape({
+    isLoading: PropTypes.bool,
+    showStoriesWhileLoading: ShowStoriesWhileLoadingPropType,
+  }),
   page: PagePropTypes,
   search: PropTypes.object,
   sort: SortPropTypes,
   stories: StoriesPropType,
   storyActions: StoryActionsPropType,
   view: ViewPropTypes,
-  showStoriesWhileLoading: ShowStoriesWhileLoadingPropType,
 };
 
 export default Content;

--- a/packages/dashboard/src/app/views/myStories/header/index.js
+++ b/packages/dashboard/src/app/views/myStories/header/index.js
@@ -64,7 +64,7 @@ const StyledPill = styled(Pill)`
 `;
 function Header({
   filter,
-  isLoading,
+  initialPageReady,
   search,
   sort,
   stories,
@@ -102,8 +102,8 @@ function Header({
 
   const HeaderToggleButtons = useMemo(() => {
     if (
-      totalStoriesByStatus &&
-      Object.keys(totalStoriesByStatus).length === 0
+      !initialPageReady ||
+      (totalStoriesByStatus && Object.keys(totalStoriesByStatus).length === 0)
     ) {
       return null;
     }
@@ -141,7 +141,7 @@ function Header({
         }).filter(Boolean)}
       </>
     );
-  }, [totalStoriesByStatus, filter.value, handleClick]);
+  }, [totalStoriesByStatus, filter.value, initialPageReady, handleClick]);
 
   const onSortChange = useCallback(
     (newSort) => {
@@ -168,7 +168,7 @@ function Header({
         searchPlaceholder={__('Search Stories', 'web-stories')}
         searchOptions={searchOptions}
         handleSearchChange={debouncedSearchChange}
-        showSearch
+        showSearch={initialPageReady}
         searchValue={search.keyword}
         clearSearch={clearSearch}
       >
@@ -181,7 +181,6 @@ function Header({
         showAuthorDropdown
         resultsLabel={resultsLabel}
         layoutStyle={view.style}
-        isLoading={isLoading}
         handleLayoutSelect={view.toggleStyle}
         currentSort={sort.value}
         pageSortOptions={STORY_SORT_MENU_ITEMS}
@@ -199,7 +198,7 @@ function Header({
 
 Header.propTypes = {
   filter: FilterPropTypes.isRequired,
-  isLoading: PropTypes.bool,
+  initialPageReady: PropTypes.bool,
   search: SearchPropTypes.isRequired,
   sort: SortPropTypes.isRequired,
   stories: StoriesPropType,

--- a/packages/dashboard/src/app/views/myStories/header/test/header.js
+++ b/packages/dashboard/src/app/views/myStories/header/test/header.js
@@ -80,6 +80,7 @@ describe('Dashboard <Header />', function () {
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
           }}
+          initialPageReady
         />
       </LayoutProvider>
     );
@@ -107,6 +108,7 @@ describe('Dashboard <Header />', function () {
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
           }}
+          initialPageReady
         />
       </LayoutProvider>
     );
@@ -135,6 +137,7 @@ describe('Dashboard <Header />', function () {
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
           }}
+          initialPageReady
         />
       </LayoutProvider>
     );
@@ -159,6 +162,7 @@ describe('Dashboard <Header />', function () {
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
           }}
+          initialPageReady
         />
       </LayoutProvider>
     );
@@ -204,6 +208,7 @@ describe('Dashboard <Header />', function () {
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
           }}
+          initialPageReady
         />
       </LayoutProvider>
     );
@@ -245,6 +250,7 @@ describe('Dashboard <Header />', function () {
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
           }}
+          initialPageReady
         />
       </LayoutProvider>
     );
@@ -285,6 +291,7 @@ describe('Dashboard <Header />', function () {
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
           }}
+          initialPageReady
         />
       </LayoutProvider>
     );
@@ -317,6 +324,7 @@ describe('Dashboard <Header />', function () {
             style: VIEW_STYLE.GRID,
             pageSize: { width: 200, height: 300 },
           }}
+          initialPageReady
         />
       </LayoutProvider>
     );

--- a/packages/dashboard/src/app/views/myStories/index.js
+++ b/packages/dashboard/src/app/views/myStories/index.js
@@ -73,12 +73,20 @@ function MyStories() {
     })
   );
 
-  const { filter, page, search, sort, view, showStoriesWhileLoading, author } =
-    useStoryView({
-      filters: STORY_STATUSES,
-      isLoading,
-      totalPages,
-    });
+  const {
+    filter,
+    page,
+    search,
+    sort,
+    view,
+    showStoriesWhileLoading,
+    initialPageReady,
+    author,
+  } = useStoryView({
+    filters: STORY_STATUSES,
+    isLoading,
+    totalPages,
+  });
 
   const { setQueriedAuthors } = author;
   const queryAuthorsBySearch = useCallback(
@@ -132,7 +140,7 @@ function MyStories() {
   return (
     <Layout.Provider>
       <Header
-        isLoading={isLoading && !orderedStories.length}
+        initialPageReady={initialPageReady}
         filter={filter}
         search={search}
         sort={sort}
@@ -146,7 +154,7 @@ function MyStories() {
       <Content
         allPagesFetched={allPagesFetched}
         filter={filter}
-        isLoading={isLoading}
+        loading={{ isLoading, showStoriesWhileLoading }}
         page={page}
         search={search}
         sort={sort}
@@ -157,7 +165,6 @@ function MyStories() {
           updateStory,
         }}
         view={view}
-        showStoriesWhileLoading={showStoriesWhileLoading}
       />
 
       <Layout.Fixed>

--- a/packages/dashboard/src/utils/useStoryView.js
+++ b/packages/dashboard/src/utils/useStoryView.js
@@ -50,7 +50,7 @@ export default function useStoryView({
   const [authorFilterId, _setAuthorFilterId] = useState(null);
   const [queriedAuthors, setQueriedAuthors] = useState([]);
   const showStoriesWhileLoading = useRef(false);
-  const initialPageReady = useRef(false);
+  const [initialPageReady, setInitialPageReady] = useState(false);
 
   const { pageSize } = usePagePreviewSize({
     thumbnailMode: viewStyle === VIEW_STYLE.LIST,
@@ -144,10 +144,10 @@ export default function useStoryView({
 
   useEffect(() => {
     // give views a way to prevent early excess renders by waiting until data's ready
-    if (totalPages && !initialPageReady?.current) {
-      initialPageReady.current = true;
+    if (totalPages && !initialPageReady) {
+      setInitialPageReady(true);
     }
-  }, [totalPages]);
+  }, [totalPages, initialPageReady]);
 
   return useMemo(
     () => ({
@@ -181,7 +181,7 @@ export default function useStoryView({
         queriedAuthors,
         setQueriedAuthors,
       },
-      initialPageReady: initialPageReady?.current,
+      initialPageReady,
       showStoriesWhileLoading,
     }),
     [
@@ -193,6 +193,7 @@ export default function useStoryView({
       sortDirection,
       setSortDirection,
       filter,
+      initialPageReady,
       setFilter,
       page,
       requestNextPage,

--- a/packages/dashboard/src/utils/useStoryView.js
+++ b/packages/dashboard/src/utils/useStoryView.js
@@ -50,6 +50,7 @@ export default function useStoryView({
   const [authorFilterId, _setAuthorFilterId] = useState(null);
   const [queriedAuthors, setQueriedAuthors] = useState([]);
   const showStoriesWhileLoading = useRef(false);
+  const initialPageReady = useRef(false);
 
   const { pageSize } = usePagePreviewSize({
     thumbnailMode: viewStyle === VIEW_STYLE.LIST,
@@ -141,6 +142,13 @@ export default function useStoryView({
     }
   }, [isLoading]);
 
+  useEffect(() => {
+    // give views a way to prevent early excess renders by waiting until data's ready
+    if (totalPages && !initialPageReady?.current) {
+      initialPageReady.current = true;
+    }
+  }, [totalPages]);
+
   return useMemo(
     () => ({
       view: {
@@ -173,6 +181,7 @@ export default function useStoryView({
         queriedAuthors,
         setQueriedAuthors,
       },
+      initialPageReady: initialPageReady?.current,
       showStoriesWhileLoading,
     }),
     [


### PR DESCRIPTION
## Context

There's some layout shift occurring in the dashboard on initial load that could be updated to help our perf. Mostly this is the telemetry banner + headline. This ticket is to explore preventing that.

## Summary

So, turns out that in the year since the telemetry banner got added into the dashboard's code base, it was pulled out into wp-dashboard package and it's getting rendered as a portal based on `#body-view-options-header` so it has to get added into the dashboard after the initial load, so we can't get rid of that shift. Looking into this, I did notice that I could cut down 1 render on the header though, so this PR is for that. 

## Relevant Technical Choices

Add new prop `initialPageReady` in the `useStoryView` hook. This is updated once `totalPages` isn't null - which means that initial data is present. Passing this boolean into the `Header` allows us to prevent excess renders on the pills and search inputs while leaving the header visible to avoid content shift. While in there cleaning up the 2 props variables needed for loading state in the stories content and just combining them ahead of time into the object they became further along the trail.

Now the Header component is rendered 3 times initially instead of 4 (wowwwww).

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Shouldn't be anything noticeable. The Stories pills and search on the Header will show up after there's data there, so the pills always have an accurate count and ya can't jump the gun searching stories without the initial data present. 

## Testing Instructions

Does the dashboard load like normal?

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

See #9676 
