### PR TITLE
Editor: handle empty status as draft status in more places

### DIFF
--- a/packages/story-editor/src/components/autoSaveHandler/index.js
+++ b/packages/story-editor/src/components/autoSaveHandler/index.js
@@ -44,7 +44,7 @@ function AutoSaveHandler() {
     isUploading: state.state.isUploading,
   }));
 
-  const isDraft = 'draft' === status;
+  const isDraft = 'draft' === status || !status;
 
   // Cache it to make it stable in terms of the below timeout
   const cachedSaveStory = useRef(saveStory);

--- a/packages/story-editor/src/components/header/buttons/preview.js
+++ b/packages/story-editor/src/components/header/buttons/preview.js
@@ -55,7 +55,7 @@ function PreviewButton({ forceIsSaving = false }) {
 
   const [previewLinkToOpenViaDialog, setPreviewLinkToOpenViaDialog] =
     useState(null);
-  const isDraft = 'draft' === status;
+  const isDraft = 'draft' === status || !status;
 
   /**
    * Applies any local transforms (e.g. AMP development mode) to the stored preview link.

--- a/packages/story-editor/src/components/header/buttons/test/update.js
+++ b/packages/story-editor/src/components/header/buttons/test/update.js
@@ -95,7 +95,7 @@ describe('UpdateButton', () => {
   });
 
   it('should display Save button if status is not yet available', () => {
-    const { saveStory } = arrange({
+    arrange({
       story: { status: undefined },
     });
 

--- a/packages/story-editor/src/components/header/buttons/test/update.js
+++ b/packages/story-editor/src/components/header/buttons/test/update.js
@@ -94,6 +94,14 @@ describe('UpdateButton', () => {
     MockDate.reset();
   });
 
+  it('should display Save button if status is not yet available', () => {
+    const { saveStory } = arrange({
+      story: { status: undefined },
+    });
+
+    expect(screen.queryByRole('button', { name: 'Save draft' })).toBeInTheDocument();
+  });
+
   it('should not be able to save draft if there are no changes', () => {
     const { saveStory } = arrange();
 

--- a/packages/story-editor/src/components/header/buttons/test/update.js
+++ b/packages/story-editor/src/components/header/buttons/test/update.js
@@ -99,7 +99,9 @@ describe('UpdateButton', () => {
       story: { status: undefined },
     });
 
-    expect(screen.queryByRole('button', { name: 'Save draft' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Save draft' })
+    ).toBeInTheDocument();
   });
 
   it('should not be able to save draft if there are no changes', () => {

--- a/packages/story-editor/src/components/header/buttons/update.js
+++ b/packages/story-editor/src/components/header/buttons/update.js
@@ -109,7 +109,10 @@ function UpdateButton({ hasUpdates = false, forceIsSaving = false }) {
   // can update without us knowing it.
   const isEnabled = !isSaving && !isUploading && (hasNewChanges || hasUpdates);
 
-  if ('pending' === status) {
+  const isPending = 'pending' === status;
+  const isDraft = 'draft' === status || !status;
+
+  if (isPending) {
     return (
       <PlainButton
         text={__('Save as pending', 'web-stories')}
@@ -119,7 +122,7 @@ function UpdateButton({ hasUpdates = false, forceIsSaving = false }) {
     );
   }
 
-  if ('draft' === status) {
+  if (isDraft) {
     return (
       <PlainButton
         text={__('Save draft', 'web-stories')}

--- a/packages/wp-story-editor/src/api/story.js
+++ b/packages/wp-story-editor/src/api/story.js
@@ -33,6 +33,8 @@ export function getStoryById(config, storyId) {
   const path = addQueryArgs(`${config.api.stories}${storyId}/`, {
     context: 'edit',
     _embed: STORY_EMBED,
+    // TODO(@swissspidy): Remove in decoupling.
+    web_stories_demo: false,
     _fields: STORY_FIELDS,
   });
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

The Update button was briefly flickering with a different style because on first render the story status is not yet set (`undefined`)

## Summary

<!-- A brief description of what this PR does. -->

As in most other places, makes sure that `status === undefined` is treated as `draft` status, preventing flickering

## Relevant Technical Choices

<!-- Please describe your changes. -->

Added a unit test.

Also fixes REST API preloading which accidentally broke in #9775 and will be investigated further in follow-up tasks.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

No

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

Verification by a dev suffices easily here.

This PR can be tested by following these steps:

1. Load editor
2. Don't see the Update button flickering
3. The "Publish" button can flicker though because caps are not available on first render.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
