### PR TITLE
Improve compatibility with Sage theme

### DIFF
--- a/includes/Renderer/Single.php
+++ b/includes/Renderer/Single.php
@@ -59,24 +59,27 @@ class Single extends Service_Base {
 	 * @return void
 	 */
 	public function register() {
-		// Select the single-web-story.php template for Stories.
+		// This is hooked to both the `template_include` and the `single_template` filters,
+		// as an additional measure to improve compatibility with themes
+		// overriding the template hierarchy in an unusual way, like the Sage theme does.
+		add_filter( 'single_template', [ $this, 'filter_template_include' ], PHP_INT_MAX );
 		add_filter( 'template_include', [ $this, 'filter_template_include' ], PHP_INT_MAX );
 
 		add_filter( 'show_admin_bar', [ $this, 'show_admin_bar' ] ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
 	}
 
 	/**
-	 * Set template for web-story post type.
+	 * Filters the path of the queried template for single stories.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string|mixed $template Template.
+	 * @param string|mixed $template Absolute path to template file.
 	 *
-	 * @return string|mixed Template.
+	 * @return string|mixed Filtered template file path.
 	 */
 	public function filter_template_include( $template ) {
 		if ( $this->context->is_web_story() ) {
-			$template = WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/frontend/single-web-story.php';
+			return WEBSTORIES_PLUGIN_DIR_PATH . 'includes/templates/frontend/single-web-story.php';
 		}
 
 		return $template;

--- a/includes/templates/frontend/single-web-story.php
+++ b/includes/templates/frontend/single-web-story.php
@@ -37,3 +37,9 @@ if ( $current_post instanceof WP_Post ) {
 	$renderer = new HTML( $story );
 	echo $renderer->render(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
+
+// Some themes like the Sage theme override the WordPress template hierarchy in an unusual way,
+// which the Single Renderer tries to work around with filters.
+// However, that means this template potentially gets loaded twice when using such a theme, causing duplicate markup.
+// Exiting here avoids that, while still guaranteeing the output buffer to function properly.
+exit;


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

The Sage starter theme filters the template hierarchy in an unusual way, breaking the single story template due to the HTML output containing a mix of Sage markup and story markup.

The culprit is this filter which just renders the template using output buffering instead of returning a file path:

https://github.com/roots/sage/blob/7e6d0671d3421acadb6e9b3d0bad2a9f54d62c67/app/filters.php#L46-L67

## Summary

<!-- A brief description of what this PR does. -->

This changes how the template hierarchy is filtered and how the single story template is loaded; preventing this conflict.

## Relevant Technical Choices

<!-- Please describe your changes. -->

* Filtering `single_template`
* `exit;` in `single-web-story.php`

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9854
