### PR TITLE
Quick Actions: Update 'confirm text' for replacing media quick action

### DIFF
--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -186,7 +186,7 @@ export const MediaPicker = ({ render, ...props }) => {
   return (
     <MediaUpload
       title={__('Replace media', 'web-stories')}
-      buttonInsertText={__('Insert media', 'web-stories')}
+      buttonInsertText={__('Replace media', 'web-stories')}
       onSelect={handleMediaSelect}
       onClose={resetWithFetch}
       type={allowedMimeTypes}

--- a/packages/story-editor/src/components/panels/design/videoAccessibility/karma/videoPoster.karma.js
+++ b/packages/story-editor/src/components/panels/design/videoAccessibility/karma/videoPoster.karma.js
@@ -66,7 +66,7 @@ describe('Video Accessibility Panel', () => {
       await fixture.events.click(vaPanel.posterMenuEdit);
 
       // Expect poster image to have updated ( See MediaUpload component in fixture.js )
-      expect(vaPanel.posterImage.src).toMatch(/^http.+\/media1$/);
+      expect(vaPanel.posterImage.src).toMatch(/^http.+\/saturn.jpg$/);
 
       // Now open menu and click reset
       await fixture.events.click(vaPanel.posterMenuButton);
@@ -101,7 +101,7 @@ describe('Video Accessibility Panel', () => {
       await fixture.events.keyboard.press('Enter');
 
       // Expect poster image to have updated ( See MediaUpload component in fixture.js )
-      expect(vaPanel.posterImage.src).toMatch(/^http.+\/media1$/);
+      expect(vaPanel.posterImage.src).toMatch(/^http.+\/saturn.jpg$/);
 
       // Now open menu and click reset
       await focusOnTitle();

--- a/packages/story-editor/src/karma/fixture/fixture.js
+++ b/packages/story-editor/src/karma/fixture/fixture.js
@@ -69,7 +69,10 @@ export const LOCAL_MEDIA_PER_PAGE = 50;
 
 function MediaUpload({ render: _render, onSelect }) {
   const open = () => {
-    const image = { type: 'image', src: 'https://www.example.com/media1' };
+    const image = {
+      type: 'image',
+      src: 'http://localhost:9876/__static__/saturn.jpg',
+    };
     onSelect(image);
   };
 


### PR DESCRIPTION
## Context

Discoverred in Bug bash 1.15

## Summary

Update confirm button text from `Insert Media` to `Replace Media` for consistency.

## User-facing changes

|Before|After|
|--|--|
|<img width="1756" alt="Screen Shot 2021-12-01 at 3 09 32 PM" src="https://user-images.githubusercontent.com/22185279/144249471-b4bb892a-2e0c-45e9-a8ba-346259754429.png">|<img width="1763" alt="Screen Shot 2021-12-01 at 3 08 47 PM" src="https://user-images.githubusercontent.com/22185279/144249465-73d9df84-81b8-48d8-a458-5708995e5754.png">|

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add an image to the canvas
2. Select the `replace media` quick action from the quick action menu
3. See the updated text at the lower right hand corner of the modal


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9815
