### PR TITLE
[WIP] Editor: Make the edit layer scrollable

### DIFF
--- a/packages/story-editor/src/app/layout/useZoomSetting.js
+++ b/packages/story-editor/src/app/layout/useZoomSetting.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { useMemo, useReduction } from '@web-stories-wp/react';
+import { useMemo, useState, useReduction } from '@web-stories-wp/react';
 import { PAGE_WIDTH, PAGE_RATIO, FULLBLEED_RATIO } from '@web-stories-wp/units';
 import { themeHelpers } from '@web-stories-wp/design-system';
 
@@ -190,17 +190,23 @@ function useZoomSetting() {
     }
   }, [_zoomLevel, pageWidth, zoomSetting]);
 
+  const [displayLayer, setDisplayLayer] = useState(null);
+
   return {
     state: {
       ...viewportProperties,
       zoomSetting,
       zoomLevel,
+      displayLayer,
       workspaceWidth: workspaceSize.width,
       workspaceHeight: workspaceSize.height,
       scrollLeft: scrollOffset.left,
       scrollTop: scrollOffset.top,
     },
-    actions,
+    actions: {
+      ...actions,
+      setDisplayLayer,
+    },
   };
 }
 

--- a/packages/story-editor/src/components/canvas/displayLayer.js
+++ b/packages/story-editor/src/components/canvas/displayLayer.js
@@ -30,7 +30,7 @@ import {
 /**
  * Internal dependencies
  */
-import { useStory, useCanvas } from '../../app';
+import { useStory, useCanvas, useLayout } from '../../app';
 import StoryPropTypes from '../../types';
 import DisplayElement from './displayElement';
 import { Layer, PageArea } from './layout';
@@ -131,6 +131,18 @@ function DisplayLayer() {
     }) => ({ editingElement, setPageContainer, setFullbleedContainer })
   );
 
+  const { setDisplayLayer } = useLayout(({ actions: { setDisplayLayer } }) => ({
+    setDisplayLayer,
+  }));
+
+  const setReference = useCallback(
+    (node) => {
+      setFullbleedContainer(node);
+      setDisplayLayer(node);
+    },
+    [setFullbleedContainer, setDisplayLayer]
+  );
+
   const isBackgroundSelected =
     selectedElements?.[0]?.id === currentPage?.elements?.[0]?.id;
 
@@ -161,7 +173,7 @@ function DisplayLayer() {
       >
         <DisplayPageArea
           ref={setPageContainer}
-          fullbleedRef={setFullbleedContainer}
+          fullbleedRef={setReference}
           background={currentPage?.backgroundColor}
           isBackgroundSelected={isBackgroundSelected}
           fullBleedContainerLabel={__(

--- a/packages/story-editor/src/components/canvas/editLayer.js
+++ b/packages/story-editor/src/components/canvas/editLayer.js
@@ -46,12 +46,9 @@ function EditLayer() {
     currentPage: state.state.currentPage,
   }));
 
-  const { editingElement: editingElementId, showOverflow = true } = useCanvas(
-    ({
-      state: { editingElement, editingElementState: { showOverflow } = {} },
-    }) => ({
+  const { editingElement: editingElementId } = useCanvas(
+    ({ state: { editingElement } }) => ({
       editingElement,
-      showOverflow,
     })
   );
 
@@ -64,12 +61,10 @@ function EditLayer() {
     return null;
   }
 
-  return (
-    <EditLayerForElement element={editingElement} showOverflow={showOverflow} />
-  );
+  return <EditLayerForElement element={editingElement} />;
 }
 
-function EditLayerForElement({ element, showOverflow }) {
+function EditLayerForElement({ element, showOverflow = false }) {
   const ref = useRef(null);
   const pageAreaRef = useRef(null);
   const { editModeGrayout, EditMenu } = getDefinitionForType(element.type);
@@ -109,7 +104,7 @@ function EditLayerForElement({ element, showOverflow }) {
           'Fullbleed area (Edit layer)',
           'web-stories'
         )}
-        isControlled
+        isScrollable
         showOverflow={showOverflow}
         overflow={showOverflow ? 'visible' : 'hidden'}
       >

--- a/packages/story-editor/src/components/canvas/framesLayer.js
+++ b/packages/story-editor/src/components/canvas/framesLayer.js
@@ -18,7 +18,7 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import { memo, useRef, useCallback } from '@web-stories-wp/react';
+import { memo, useRef } from '@web-stories-wp/react';
 import { __ } from '@web-stories-wp/i18n';
 import { PAGE_WIDTH } from '@web-stories-wp/units';
 import { STORY_ANIMATION_STATE } from '@web-stories-wp/animation';
@@ -31,7 +31,6 @@ import { DESIGN_SPACE_MARGIN } from '../../constants';
 import {
   useStory,
   useCanvas,
-  useLayout,
   useTransform,
   useRightClickMenu,
 } from '../../app';
@@ -65,8 +64,9 @@ function FramesLayer() {
       STORY_ANIMATION_STATE.SCRUBBING,
     ].includes(state.state.animationState),
   }));
-  const { setDesignSpaceGuideline } = useCanvas(
-    ({ actions: { setDesignSpaceGuideline } }) => ({
+  const { isEditing, setDesignSpaceGuideline } = useCanvas(
+    ({ state: { isEditing }, actions: { setDesignSpaceGuideline } }) => ({
+      isEditing,
       setDesignSpaceGuideline,
     })
   );
@@ -79,18 +79,6 @@ function FramesLayer() {
   useCanvasKeys(framesLayerRef);
 
   const { onOpenMenu } = useRightClickMenu();
-
-  const { setScrollOffset } = useLayout(({ actions: { setScrollOffset } }) => ({
-    setScrollOffset,
-  }));
-  const onScroll = useCallback(
-    (evt) =>
-      setScrollOffset({
-        left: evt.target.scrollLeft,
-        top: evt.target.scrollTop,
-      }),
-    [setScrollOffset]
-  );
 
   useKeyDownEffect(framesLayerRef, 'mod+alt+shift+m', onOpenMenu);
 
@@ -111,8 +99,9 @@ function FramesLayer() {
             'Fullbleed area (Frames layer)',
             'web-stories'
           )}
+          isScrollable
+          isControlled={isEditing}
           onContextMenu={onOpenMenu}
-          onScroll={onScroll}
         >
           {currentPage &&
             currentPage.elements.map((element) => {

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -139,15 +139,6 @@ const PageAreaContainer = styled(Area).attrs({
         100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
       );
     `}
-
-      overflow: ${({ showOverflow }) => (showOverflow ? 'visible' : 'hidden')};
-      width: calc(
-        100% - ${hasVerticalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
-      );
-      height: calc(
-        100% - ${hasHorizontalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
-      );
-    `}
 `;
 
 const Layer = forwardRef(function Layer({ children, ...rest }, ref) {
@@ -189,23 +180,6 @@ const PageClip = styled.div`
       justify-content: center;
       align-items: center;
     `}
-
-      overflow: hidden;
-      width: ${hasHorizontalOverflow
-        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      flex-basis: ${hasHorizontalOverflow
-        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      height: ${hasVerticalOverflow
-        ? 'calc(var(--fullbleed-height-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-height-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      flex-shrink: 0;
-      flex-grow: 0;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-    `}
 `;
 
 const FullbleedContainer = styled.div`
@@ -222,18 +196,6 @@ const FullbleedContainer = styled.div`
   ${({ isBackgroundSelected, theme }) =>
     isBackgroundSelected &&
     css`
-      &:before {
-        content: '';
-        position: absolute;
-        top: -4px;
-        left: -4px;
-        right: -4px;
-        bottom: -4px;
-        border: ${theme.colors.border.selection} 1px solid;
-        border-radius: ${theme.borders.radius.medium};
-      }
-    `}
-
       &:before {
         content: '';
         position: absolute;


### PR DESCRIPTION
## Context

This is a working-draft attempt at making the edit layer scrollable. It is not complete yet.

## To-do

- [ ] Fix weird delayed-scroll bug
- [ ] Move media edit scale slider to tools area
- [ ] Display ghost image in a separate layer

## User-facing changes

_TBD_

## Testing Instructions

This PR can be tested by following these steps:

1. Add a text element to a page
2. Change zoom to 200%
3. Double-click text to enter edit mode
4. Attempt to scroll the canvas
5. Observe that the canvas does scroll even while in edit mode.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6180
