### PR TITLE
Bugfix: Prevent Shape Layer Icons getting cut off in Firefox

### DIFF
--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -142,6 +142,37 @@ const LayerButton = styled(Button).attrs({
     --background-color-opaque: ${({ theme }) =>
       rgba(theme.colors.interactiveBg.secondaryPress, 0)};
   }
+
+      background: ${theme.colors.interactiveBg.secondaryPress};
+      + * {
+        --background-color: ${theme.colors.interactiveBg.secondaryPress};
+        --background-color-opaque: ${rgba(
+          theme.colors.interactiveBg.secondaryPress,
+          0
+        )};
+        --selected-hover-color: ${theme.colors.interactiveBg.tertiaryHover};
+      }
+    `}
+
+  :hover {
+    background: ${({ theme }) => theme.colors.interactiveBg.secondaryHover};
+  }
+  :hover + * {
+    --background-color: ${({ theme }) =>
+      theme.colors.interactiveBg.secondaryHover};
+    --background-color-opaque: ${({ theme }) =>
+      rgba(theme.colors.interactiveBg.secondaryHover, 0)};
+  }
+
+  :active {
+    background: ${({ theme }) => theme.colors.interactiveBg.secondaryPress};
+  }
+  :active + * {
+    --background-color: ${({ theme }) =>
+      theme.colors.interactiveBg.secondaryPress};
+    --background-color-opaque: ${({ theme }) =>
+      rgba(theme.colors.interactiveBg.secondaryPress, 0)};
+  }
 `;
 
 const LayerIconWrapper = styled.div`
@@ -198,7 +229,7 @@ const LayerAction = styled(Button).attrs({
   /*
    * all of our Icons right now have an embedded padding,
    * however the new designs just disregard this embedded
-   * padding, so to accomodate, we'll make the icon its
+   * padding, so to accommodate, we'll make the icon its
    * intended size and manually center it within the button.
    */
   svg {

--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -142,37 +142,6 @@ const LayerButton = styled(Button).attrs({
     --background-color-opaque: ${({ theme }) =>
       rgba(theme.colors.interactiveBg.secondaryPress, 0)};
   }
-
-      background: ${theme.colors.interactiveBg.secondaryPress};
-      + * {
-        --background-color: ${theme.colors.interactiveBg.secondaryPress};
-        --background-color-opaque: ${rgba(
-          theme.colors.interactiveBg.secondaryPress,
-          0
-        )};
-        --selected-hover-color: ${theme.colors.interactiveBg.tertiaryHover};
-      }
-    `}
-
-  :hover {
-    background: ${({ theme }) => theme.colors.interactiveBg.secondaryHover};
-  }
-  :hover + * {
-    --background-color: ${({ theme }) =>
-      theme.colors.interactiveBg.secondaryHover};
-    --background-color-opaque: ${({ theme }) =>
-      rgba(theme.colors.interactiveBg.secondaryHover, 0)};
-  }
-
-  :active {
-    background: ${({ theme }) => theme.colors.interactiveBg.secondaryPress};
-  }
-  :active + * {
-    --background-color: ${({ theme }) =>
-      theme.colors.interactiveBg.secondaryPress};
-    --background-color-opaque: ${({ theme }) =>
-      rgba(theme.colors.interactiveBg.secondaryPress, 0)};
-  }
 `;
 
 const LayerIconWrapper = styled.div`

--- a/packages/story-editor/src/elements/shape/icon.js
+++ b/packages/story-editor/src/elements/shape/icon.js
@@ -40,10 +40,20 @@ const Container = styled.div`
 `;
 
 const ShapePreview = styled.div`
+  width: 100%;
+  height: 100%;
+  clip-path: ${({ maskId }) => `url(#${maskId})`};
   ${elementWithBackgroundColor}
-  width: ${({ width }) => width}px;
-  height: ${({ height }) => height}px;
 `;
+
+/* 
+clip-path isn't stable in Safari yet, so these 
+Shape Layer Icons are going to show up as various quadrilateral 
+until that stabilizes for inline SVGs as clip paths.
+More info here:  
+https://stackoverflow.com/questions/41860477/why-doesnt-css-clip-path-with-svg-work-in-safari
+https://caniuse.com/css-clip-path
+*/
 
 function ShapeLayerIcon({
   element: { id, mask, backgroundColor, isDefaultBackground },
@@ -55,12 +65,11 @@ function ShapeLayerIcon({
   if (isDefaultBackground) {
     backgroundColor = currentPage.backgroundColor;
   }
+
   return (
     <Container>
       <ShapePreview
-        style={{
-          clipPath: `url(#${maskId})`,
-        }}
+        maskId={maskId}
         width={PREVIEW_SIZE * maskDef.ratio}
         height={PREVIEW_SIZE}
         backgroundColor={backgroundColor}
@@ -69,7 +78,10 @@ function ShapeLayerIcon({
           <defs>
             <clipPath
               id={maskId}
-              transform={`scale(1 ${maskDef.ratio})`}
+              // Bring the path scale down a bit from 1
+              // so that we can make sure the entire SVG path is visible when the mask ratio is > 1
+              // this is important for Firefox's interpretation of clip paths
+              transform={`scale(0.9)`}
               clipPathUnits="objectBoundingBox"
             >
               <path d={maskDef.path} />

--- a/packages/story-editor/src/elements/shape/icon.js
+++ b/packages/story-editor/src/elements/shape/icon.js
@@ -33,6 +33,7 @@ const Container = styled.div`
   align-items: center;
   height: 21px;
   width: 21px;
+  padding: 1px;
   border-radius: ${({ theme }) => theme.borders.radius.small};
   background-color: ${({ theme }) => theme.colors.opacity.black10};
 `;
@@ -40,6 +41,7 @@ const Container = styled.div`
 const ShapePreview = styled.div`
   width: 100%;
   height: 100%;
+  margin: 1px;
   clip-path: ${({ maskId }) => `url(#${maskId})`};
   ${elementWithBackgroundColor}
 `;
@@ -74,7 +76,7 @@ function ShapeLayerIcon({
               // Bring the path scale down a bit from 1
               // so that we can make sure the entire SVG path is visible when the mask ratio is > 1
               // this is important for Firefox's interpretation of clip paths
-              transform={`scale(1 0.9)`}
+              transform="scale(1 0.9)"
               clipPathUnits="objectBoundingBox"
             >
               <path d={maskDef.path} />

--- a/packages/story-editor/src/elements/shape/icon.js
+++ b/packages/story-editor/src/elements/shape/icon.js
@@ -26,8 +26,6 @@ import { getMaskByType } from '../../masks';
 import { elementWithBackgroundColor } from '../shared';
 import StoryPropTypes from '../../types';
 
-const PREVIEW_SIZE = 16;
-
 const Container = styled.div`
   display: flex;
   flex-direction: row;
@@ -68,12 +66,7 @@ function ShapeLayerIcon({
 
   return (
     <Container>
-      <ShapePreview
-        maskId={maskId}
-        width={PREVIEW_SIZE * maskDef.ratio}
-        height={PREVIEW_SIZE}
-        backgroundColor={backgroundColor}
-      >
+      <ShapePreview maskId={maskId} backgroundColor={backgroundColor}>
         <svg width={0} height={0}>
           <defs>
             <clipPath
@@ -81,7 +74,7 @@ function ShapeLayerIcon({
               // Bring the path scale down a bit from 1
               // so that we can make sure the entire SVG path is visible when the mask ratio is > 1
               // this is important for Firefox's interpretation of clip paths
-              transform={`scale(0.9)`}
+              transform={`scale(1 0.9)`}
               clipPathUnits="objectBoundingBox"
             >
               <path d={maskDef.path} />


### PR DESCRIPTION
## Context

In the layers panel the shapes icons were getting cut off in Firefox (and a little bit in Chrome). 

## Summary

Tweak the shapes layer icon component to make sure it isn't cut off in Firefox and Chrome.

## Relevant Technical Choices

Ended up solving this by adjusting the clip-path `transform: scale` to shrink it just slightly .9 - the issue was that we were using the maskDef.ratio for the scale here when a) sometimes the ratio would boost it over 1 so the clip path would then grow to be too big and the overflow (as is the nature of clip paths) is just cut off and b) the icon size is contained anyways. So, that in tandem with just allowing the div that has the clip path applied to be 100% of the container (always 21px) gives the paths room to render their whole path without impacting layout else where. 

## To-do

`clip-path` isn't well supported in Safari, that's why it renders like this:
<img width="116" alt="Screen Shot 2021-12-01 at 4 08 54 PM" src="https://user-images.githubusercontent.com/10720454/144328835-bb61da1d-ae7e-4790-b042-bbf62f2de89b.png">
https://stackoverflow.com/questions/41860477/why-doesnt-css-clip-path-with-svg-work-in-safari
https://caniuse.com/css-clip-path 
I moved the `clip-path` from inline to the `ShapePreview` styled component so that it could get auto prefixed with webkit - so when that's fixed in Safari it should "just work" now.  The only other way I thought of around this is to not use clip path for this icon anymore but then that's a whole thing with gradients and it doesn't seem worth it. 


## User-facing changes

| | Chrome | Firefox | Safari | 
| --- | --- | --- | --- |
| Before | <img width="140" alt="Screen Shot 2021-12-01 at 4 14 33 PM" src="https://user-images.githubusercontent.com/10720454/144329370-4188fdc3-4179-43bd-94e3-ed0275e2c211.png"> | <img width="128" alt="Screen Shot 2021-12-01 at 4 15 04 PM" src="https://user-images.githubusercontent.com/10720454/144329401-50dd52d0-7191-4969-8e4e-27ff9578ca18.png"> | <img width="129" alt="Screen Shot 2021-12-01 at 4 15 31 PM" src="https://user-images.githubusercontent.com/10720454/144329433-cd6bb977-53f4-4a90-a5a2-fcb6fa68f59f.png"> |
| After |  <img width="124" alt="Screen Shot 2021-12-01 at 4 12 19 PM" src="https://user-images.githubusercontent.com/10720454/144329136-db04f66d-16bb-4417-826a-31c9e6eed7cb.png"> | <img width="128" alt="Screen Shot 2021-12-01 at 4 12 50 PM" src="https://user-images.githubusercontent.com/10720454/144329190-94789d48-67ec-416c-8c6a-26329b936cf6.png"> | <img width="122" alt="Screen Shot 2021-12-01 at 4 13 19 PM" src="https://user-images.githubusercontent.com/10720454/144329238-5cccacd8-77a6-46c3-a422-4d800f3d2312.png"> |


## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9704 
