### PR TITLE
Media: Measure time to generate base color

### DIFF
--- a/packages/story-editor/src/app/media/utils/getResourceFromLocalFile.js
+++ b/packages/story-editor/src/app/media/utils/getResourceFromLocalFile.js
@@ -31,6 +31,10 @@ import {
   seekVideo,
   preloadVideo,
 } from '@web-stories-wp/media';
+/**
+ * Internal dependencies
+ */
+import { getMediaBaseColor } from '../../../utils/getMediaBaseColor';
 
 /**
  * Create a local resource object.
@@ -153,6 +157,14 @@ const getResourceFromLocalFile = async (file) => {
   } catch {
     // Not interested in the error here.
     // We simply fall back to the placeholder resource.
+  }
+  const { src, poster } = resource;
+  const imageSrc = type === 'image' ? src : poster;
+  try {
+    const color = await getMediaBaseColor(imageSrc);
+    resource.baseColor = color;
+  } catch {
+    // Do nothing for now
   }
 
   return { resource, posterFile };

--- a/packages/story-editor/src/app/media/utils/getResourceFromLocalFile.js
+++ b/packages/story-editor/src/app/media/utils/getResourceFromLocalFile.js
@@ -31,10 +31,6 @@ import {
   seekVideo,
   preloadVideo,
 } from '@web-stories-wp/media';
-/**
- * Internal dependencies
- */
-import { getMediaBaseColor } from '../../../utils/getMediaBaseColor';
 
 /**
  * Create a local resource object.
@@ -157,14 +153,6 @@ const getResourceFromLocalFile = async (file) => {
   } catch {
     // Not interested in the error here.
     // We simply fall back to the placeholder resource.
-  }
-  const { src, poster } = resource;
-  const imageSrc = type === 'image' ? src : poster;
-  try {
-    const color = await getMediaBaseColor(imageSrc);
-    resource.baseColor = color;
-  } catch {
-    // Do nothing for now
   }
 
   return { resource, posterFile };

--- a/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
+++ b/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
@@ -321,6 +321,13 @@ function useMediaUploadQueue() {
 
           const trackTiming = getTimeTracker('load_upload_media');
 
+          if (resource?.baseColor) {
+            additionalData.meta = {
+              ...additionalData.meta,
+              web_stories_base_color: resource.baseColor,
+            };
+          }
+
           try {
             // The newly uploaded file won't have a poster yet.
             // However, we'll likely still have one on file.

--- a/packages/story-editor/src/utils/getMediaBaseColor.js
+++ b/packages/story-editor/src/utils/getMediaBaseColor.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { trackError } from '@web-stories-wp/tracking';
+import { getTimeTracker, trackError } from '@web-stories-wp/tracking';
 import { getHexFromSolidArray } from '@web-stories-wp/patterns';
 
 const STYLES = {
@@ -52,6 +52,7 @@ export async function getMediaBaseColor(src) {
     return Promise.reject(new Error('No source to image'));
   }
   let color;
+  const trackTiming = getTimeTracker('load_get_base_color');
   try {
     color = await setOrCreateImage({
       src,
@@ -64,6 +65,8 @@ export async function getMediaBaseColor(src) {
       throw error;
     }
     color = '#ffffff';
+  } finally {
+    trackTiming();
   }
   return color;
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

When generating local resource for upload, also generate base color using blob. Then on upload, use the generated base color along with the file. This saves on the need for backfill and it also means that generation is faster as the blob is faster and loading in a image for a url. 

## Relevant Technical Choices

Add some time trackers to aid testing. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9739
