### PR TITLE
CSS-in-JS: Remove incorrect tagged template literal usage

### DIFF
--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -163,15 +163,21 @@ const PageClip = styled.div`
     (hasHorizontalOverflow || hasVerticalOverflow) &&
     `
       overflow: hidden;
-      width: ${hasHorizontalOverflow
-        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      flex-basis: ${hasHorizontalOverflow
-        ? 'calc(var(--page-width-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
-      height: ${hasVerticalOverflow
-        ? 'calc(var(--fullbleed-height-px) + var(--page-padding-px))'
-        : `calc(var(--viewport-height-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`};
+      width: ${
+        hasHorizontalOverflow
+          ? 'calc(var(--page-width-px) + var(--page-padding-px))'
+          : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`
+      };
+      flex-basis: ${
+        hasHorizontalOverflow
+          ? 'calc(var(--page-width-px) + var(--page-padding-px))'
+          : `calc(var(--viewport-width-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`
+      };
+      height: ${
+        hasVerticalOverflow
+          ? 'calc(var(--fullbleed-height-px) + var(--page-padding-px))'
+          : `calc(var(--viewport-height-px) - ${themeHelpers.SCROLLBAR_WIDTH}px)`
+      };
       flex-shrink: 0;
       flex-grow: 0;
       display: flex;

--- a/packages/story-editor/src/components/canvas/layout.js
+++ b/packages/story-editor/src/components/canvas/layout.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import {
   forwardRef,
@@ -30,6 +30,7 @@ import { __ } from '@web-stories-wp/i18n';
 import { generatePatternStyles } from '@web-stories-wp/patterns';
 import { FULLBLEED_RATIO } from '@web-stories-wp/units';
 import { THEME_CONSTANTS, themeHelpers } from '@web-stories-wp/design-system';
+
 /**
  * Internal dependencies
  */
@@ -127,7 +128,7 @@ const PageAreaContainer = styled(Area).attrs({
 
   ${({ isControlled, hasVerticalOverflow, hasHorizontalOverflow }) =>
     isControlled &&
-    css`
+    `
       overflow: ${({ showOverflow }) => (showOverflow ? 'visible' : 'hidden')};
       width: calc(
         100% - ${hasVerticalOverflow ? themeHelpers.SCROLLBAR_WIDTH : 0}px
@@ -160,7 +161,7 @@ const PaddedPage = styled.div`
 const PageClip = styled.div`
   ${({ hasHorizontalOverflow, hasVerticalOverflow }) =>
     (hasHorizontalOverflow || hasVerticalOverflow) &&
-    css`
+    `
       overflow: hidden;
       width: ${hasHorizontalOverflow
         ? 'calc(var(--page-width-px) + var(--page-padding-px))'
@@ -192,14 +193,14 @@ const FullbleedContainer = styled.div`
 
   ${({ isControlled }) =>
     isControlled &&
-    css`
+    `
       left: var(--scroll-left-px);
       top: var(--scroll-top-px);
     `};
 
   ${({ isBackgroundSelected, theme }) =>
     isBackgroundSelected &&
-    css`
+    `
       &:before {
         content: '';
         position: absolute;


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

stylelint did some odd stuff because the code was sorta wrong.

## Summary

<!-- A brief description of what this PR does. -->

Fixes issues where stylelint was tripping up due to nested usage of `css` tagged template literals within a style block.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Run `npx stylelint packages/story-editor/src/components/canvas/layout.js --fix`
2. Don't see any issues

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9865
