### PR TITLE
Decoupling: Refactor demo story parameter logic

### DIFF
--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -115,14 +115,14 @@ $story_query_params = [
 	),
 ];
 
-if ( ! empty( $_GET['web-stories-demo'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+if ( empty( $_GET['web-stories-demo'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$preload_paths[] = $story_initial_path . build_query( $story_query_params );
+} else {
 	$story_query_params['web_stories_demo'] = 'true';
 
 	$story_path             = $story_initial_path . build_query( $story_query_params );
 	$story_data             = \Google\Web_Stories\rest_preload_api_request( [], $story_path );
 	$initial_edits['story'] = ( ! empty( $story_data[ $story_path ]['body'] ) ) ? $story_data[ $story_path ]['body'] : [];
-} else {
-	$preload_paths[] = $story_initial_path . build_query( $story_query_params );
 }
 
 /**

--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -32,7 +32,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 global $post_type, $post_type_object, $post;
 
 $stories_rest_base = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
-$demo              = ( isset( $_GET['web-stories-demo'] ) && (bool) $_GET['web-stories-demo'] ) ? 'true' : 'false'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $initial_edits     = [ 'story' => null ];
 
 // Preload common data.
@@ -83,46 +82,47 @@ $preload_paths = [
 	),
 ];
 
-$story_path = "/web-stories/v1/$stories_rest_base/{$post->ID}/?" . build_query(
-	[
-		'_embed'           => rawurlencode(
-			implode(
-				',',
-				[ 'wp:featuredmedia', 'wp:lockuser', 'author', 'wp:publisherlogo', 'wp:term' ]
-			)
-		),
-		'context'          => 'edit',
-		'web_stories_demo' => $demo,
-		'_fields'          => rawurlencode(
-			implode(
-				',',
-				[
-					'id',
-					'title',
-					'status',
-					'slug',
-					'date',
-					'modified',
-					'excerpt',
-					'link',
-					'story_data',
-					'preview_link',
-					'edit_link',
-					'embed_post_link',
-					'permalink_template',
-					'style_presets',
-					'password',
-				]
-			)
-		),
-	]
-);
+$story_initial_path = "/web-stories/v1/$stories_rest_base/{$post->ID}/?";
+$story_query_params = [
+	'_embed'  => rawurlencode(
+		implode(
+			',',
+			[ 'wp:featuredmedia', 'wp:lockuser', 'author', 'wp:publisherlogo', 'wp:term' ]
+		)
+	),
+	'context' => 'edit',
+	'_fields' => rawurlencode(
+		implode(
+			',',
+			[
+				'id',
+				'title',
+				'status',
+				'slug',
+				'date',
+				'modified',
+				'excerpt',
+				'link',
+				'story_data',
+				'preview_link',
+				'edit_link',
+				'embed_post_link',
+				'permalink_template',
+				'style_presets',
+				'password',
+			]
+		)
+	),
+];
 
-if ( ! wp_validate_boolean( $demo ) ) {
-	$preload_paths[] = $story_path;
-} else {
+if ( ! empty( $_GET['web-stories-demo'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$story_query_params['web_stories_demo'] = 'true';
+
+	$story_path             = $story_initial_path . build_query( $story_query_params );
 	$story_data             = \Google\Web_Stories\rest_preload_api_request( [], $story_path );
 	$initial_edits['story'] = ( ! empty( $story_data[ $story_path ]['body'] ) ) ? $story_data[ $story_path ]['body'] : [];
+} else {
+	$preload_paths[] = $story_initial_path . build_query( $story_query_params );
 }
 
 /**

--- a/packages/wp-story-editor/src/api/story.js
+++ b/packages/wp-story-editor/src/api/story.js
@@ -33,8 +33,6 @@ export function getStoryById(config, storyId) {
   const path = addQueryArgs(`${config.api.stories}${storyId}/`, {
     context: 'edit',
     _embed: STORY_EMBED,
-    // TODO(@swissspidy): Remove in decoupling.
-    web_stories_demo: false,
     _fields: STORY_FIELDS,
   });
 


### PR DESCRIPTION
## Context

`initialEdits` change had previously broken the REST API preloading in the editor because the preloading always passed the `web_stories_demo` arg but we don’t use that in the editor anymore: https://github.com/google/web-stories-wp/blob/dff6f6d4c805444709c365d27e39ab2952264bcd/includes/templates/admin/edit-story.php#L95

It was temporarily hot-fixed [here](https://github.com/google/web-stories-wp/pull/9850/files#diff-a5ccf98ae8b869761f594f401b47c1b9425c2df8cb199257a6a7979bb6d466e9). This PR tries to improve that fix.

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

See https://github.com/google/web-stories-wp/pull/9850
Related: 
https://github.com/google/web-stories-wp/pull/9775
https://github.com/google/web-stories-wp/issues/2918
