### PR TITLE
Update the title of the Text Box & Saved Styles box to bold

### DIFF
--- a/packages/story-editor/src/components/panels/design/textStyle/stylePresets/stylePresets.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/stylePresets/stylePresets.js
@@ -56,6 +56,7 @@ const StylesWrapper = styled.div``;
 const SubHeading = styled(Text)`
   color: ${({ theme }) => theme.colors.fg.secondary};
   margin: 6px 0;
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
 `;
 
 const StyledButton = styled(Button)`

--- a/packages/story-editor/src/components/panels/design/textStyle/textStyle.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/textStyle.js
@@ -47,6 +47,7 @@ const SubSection = styled.section`
 const SubHeading = styled(Text)`
   color: ${({ theme }) => theme.colors.fg.secondary};
   margin: 14px 0;
+  font-weight: ${({ theme }) => theme.typography.weight.bold};
 `;
 
 function StylePanel(props) {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Minor style update for the design panel's smaller headers. Updates the font weight of the the `Text Box` and the `Recently Saved Styles` headings from regular to bold to help differentiate them visually from the none / fill / highlight buttons.

## Summary

<!-- A brief description of what this PR does. -->

n/a

## Relevant Technical Choices

<!-- Please describe your changes. -->

n/a

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

n/a

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->


| Before | After |
|--------|-------|
|   ![Screenshot 2021-12-03 at 11 36 45](https://user-images.githubusercontent.com/276316/144571644-3422fc20-4686-4786-9c32-7bb021b2b4e8.png)     |   ![Screenshot 2021-12-03 at 11 37 35](https://user-images.githubusercontent.com/276316/144571739-4156001b-fe22-4ac7-b339-99f3a60e4472.png)    |

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add Text to a story
2. Verify the `Text Box` and the `Recently Saved Styles`  are bold.


## Reviews

### Does this PR
 have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->
No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->
No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9810
