### PR TITLE
Decoupling: Initialize dashboard from PHP

### DIFF
--- a/includes/Admin/Dashboard.php
+++ b/includes/Admin/Dashboard.php
@@ -375,8 +375,11 @@ class Dashboard extends Service_Base {
 
 		wp_localize_script(
 			self::SCRIPT_HANDLE,
-			'webStoriesDashboardSettings',
-			$this->get_dashboard_settings()
+			'webStories',
+			[
+				'publicPath' => $this->assets->get_base_url( 'assets/js/' ), // Required before the editor script is enqueued.
+				'localeData' => $this->assets->get_translations( self::SCRIPT_HANDLE ), // Required for i18n setLocaleData.
+			]
 		);
 
 		// Dequeue forms.css, see https://github.com/google/web-stories-wp/issues/349 .
@@ -407,40 +410,35 @@ class Dashboard extends Service_Base {
 		}
 
 		$settings = [
-			'id'         => 'web-stories-dashboard',
-			'config'     => [
-				'isRTL'                 => is_rtl(),
-				'userId'                => get_current_user_id(),
-				'locale'                => $this->locale->get_locale_settings(),
-				'newStoryURL'           => $new_story_url,
-				'archiveURL'            => $this->story_post_type->get_archive_link(),
-				'cdnURL'                => trailingslashit( WEBSTORIES_CDN_URL ),
-				'allowedImageMimeTypes' => $this->types->get_allowed_image_mime_types(),
-				'version'               => WEBSTORIES_VERSION,
-				'encodeMarkup'          => $this->decoder->supports_decoding(),
-				'api'                   => [
-					'stories'        => trailingslashit( $this->story_post_type->get_rest_url() ),
-					'media'          => '/web-stories/v1/media/',
-					'currentUser'    => '/web-stories/v1/users/me/',
-					'users'          => '/web-stories/v1/users/',
-					'settings'       => '/web-stories/v1/settings/',
-					'pages'          => '/wp/v2/pages/',
-					'publisherLogos' => '/web-stories/v1/publisher-logos/',
-				],
-				'maxUpload'             => $max_upload_size,
-				'maxUploadFormatted'    => size_format( $max_upload_size ),
-				'capabilities'          => [
-					'canManageSettings' => current_user_can( 'manage_options' ),
-					'canUploadFiles'    => current_user_can( 'upload_files' ),
-				],
-				'siteKitStatus'         => $this->site_kit->get_plugin_status(),
-				'localeData'            => $this->assets->get_translations( self::SCRIPT_HANDLE ),
-				'flags'                 => array_merge(
-					$this->experiments->get_experiment_statuses( 'general' ),
-					$this->experiments->get_experiment_statuses( 'dashboard' )
-				),
+			'isRTL'                 => is_rtl(),
+			'userId'                => get_current_user_id(),
+			'locale'                => $this->locale->get_locale_settings(),
+			'newStoryURL'           => $new_story_url,
+			'archiveURL'            => $this->story_post_type->get_archive_link(),
+			'cdnURL'                => trailingslashit( WEBSTORIES_CDN_URL ),
+			'allowedImageMimeTypes' => $this->types->get_allowed_image_mime_types(),
+			'version'               => WEBSTORIES_VERSION,
+			'encodeMarkup'          => $this->decoder->supports_decoding(),
+			'api'                   => [
+				'stories'        => trailingslashit( $this->story_post_type->get_rest_url() ),
+				'media'          => '/web-stories/v1/media/',
+				'currentUser'    => '/web-stories/v1/users/me/',
+				'users'          => '/web-stories/v1/users/',
+				'settings'       => '/web-stories/v1/settings/',
+				'pages'          => '/wp/v2/pages/',
+				'publisherLogos' => '/web-stories/v1/publisher-logos/',
 			],
-			'publicPath' => $this->assets->get_base_url( 'assets/js/' ),
+			'maxUpload'             => $max_upload_size,
+			'maxUploadFormatted'    => size_format( $max_upload_size ),
+			'capabilities'          => [
+				'canManageSettings' => current_user_can( 'manage_options' ),
+				'canUploadFiles'    => current_user_can( 'upload_files' ),
+			],
+			'siteKitStatus'         => $this->site_kit->get_plugin_status(),
+			'flags'                 => array_merge(
+				$this->experiments->get_experiment_statuses( 'general' ),
+				$this->experiments->get_experiment_statuses( 'dashboard' )
+			),
 		];
 
 		/**

--- a/includes/templates/admin/dashboard.php
+++ b/includes/templates/admin/dashboard.php
@@ -29,6 +29,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
+$dashboard_settings = \Google\Web_Stories\Services::get( 'dashboard' )->get_dashboard_settings();
+
+$init_script = <<<JS
+	webStories.domReady( function() {
+	  webStories.initializeStoryDashboard( 'web-stories-dashboard', %s );
+	} );
+JS;
+
+$script = sprintf( $init_script, wp_json_encode( $dashboard_settings ) );
+
+wp_add_inline_script( \Google\Web_Stories\Admin\Dashboard::SCRIPT_HANDLE, $script );
+
 ?>
 
 <div class="web-stories-wp">

--- a/packages/wp-dashboard/src/index.js
+++ b/packages/wp-dashboard/src/index.js
@@ -31,7 +31,7 @@ import './setLocaleData';
  * External dependencies
  */
 import Dashboard from '@web-stories-wp/dashboard';
-import { setAppElement } from '@web-stories-wp/design-system';
+import { domReady, setAppElement } from '@web-stories-wp/design-system';
 import { StrictMode, render } from '@web-stories-wp/react';
 import { updateSettings } from '@web-stories-wp/date';
 import { initializeTracking } from '@web-stories-wp/tracking';
@@ -44,13 +44,16 @@ import { GlobalStyle } from './theme';
 import { LEFT_RAIL_SECONDARY_NAVIGATION } from './constants';
 import { Layout } from './components';
 
+window.webStories = window.webStories || {};
+window.webStories.domReady = domReady;
+
 /**
  * Initializes the Web Stories dashboard screen.
  *
  * @param {string} id       ID of the root element to render the screen in.
  * @param {Object} config   Story editor settings.
  */
-const initialize = async (id, config) => {
+window.webStories.initializeStoryDashboard = (id, config) => {
   const appElement = document.getElementById(id);
 
   // see http://reactcommunity.org/react-modal/accessibility/
@@ -59,7 +62,7 @@ const initialize = async (id, config) => {
   updateSettings(config.locale);
 
   // Already tracking screen views in AppContent, no need to send page views as well.
-  await initializeTracking('Dashboard', false);
+  initializeTracking('Dashboard', false);
 
   const dashboardConfig = {
     ...config,
@@ -77,14 +80,3 @@ const initialize = async (id, config) => {
     appElement
   );
 };
-
-const initializeWithConfig = () => {
-  const { id, config } = window.webStoriesDashboardSettings;
-  initialize(id, config);
-};
-
-if ('loading' === document.readyState) {
-  document.addEventListener('DOMContentLoaded', initializeWithConfig);
-} else {
-  initializeWithConfig();
-}

--- a/packages/wp-dashboard/src/publicPath.js
+++ b/packages/wp-dashboard/src/publicPath.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-__webpack_public_path__ = window.webStoriesDashboardSettings.publicPath;
+__webpack_public_path__ = window.webStories.publicPath;

--- a/packages/wp-dashboard/src/setLocaleData.js
+++ b/packages/wp-dashboard/src/setLocaleData.js
@@ -19,7 +19,6 @@
  */
 import { setLocaleData } from '@web-stories-wp/i18n';
 
-for (const localeData of window?.webStoriesDashboardSettings?.config
-  ?.localeData || []) {
+for (const localeData of window?.webStories?.localeData || []) {
   setLocaleData(localeData);
 }

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-global.webStoriesEditorSettings = {};
-global.webStoriesDashboardSettings = {};
+global.webStories = {};
 global.webStoriesBlockSettings = {
   config: {
     api: {},


### PR DESCRIPTION
## Context

As done in https://github.com/google/web-stories-wp/pull/9775 , the dashboard should also be initialized the same way for consistency.

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
See #789
-->

Partially addresses [#456](https://github.com/google/web-stories-wp/issues/2918)
