### PR TITLE
Saved Templates: Fix keyboard shortcut conflict

### DIFF
--- a/packages/story-editor/src/components/library/panes/pageTemplates/karma/savedPageTemplates.karma.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/karma/savedPageTemplates.karma.js
@@ -161,7 +161,7 @@ describe('CUJ: Page Templates: Custom Saved Templates', () => {
       // navigate to newly saved template and open delete dialog
       await fixture.events.keyboard.press('Tab');
       await fixture.events.keyboard.press('Tab');
-      await fixture.events.keyboard.press('Space');
+      await fixture.events.keyboard.press('Backspace');
 
       await fixture.events.sleep(200);
 

--- a/packages/story-editor/src/components/library/panes/pageTemplates/templateList.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/templateList.js
@@ -125,7 +125,7 @@ function TemplateList({
       if (isGridFocused) {
         if (code === 'Enter') {
           handlePageClick(page);
-        } else if (code === 'Space') {
+        } else if (code === 'Backspace' || code === 'Delete') {
           handleDelete?.(page);
         }
       }


### PR DESCRIPTION
## Context

When a saved template is in focus, pressing on `Space` key opens the delete modal and fires scroll event at the same time.

But in this context `Backspace/Delete` makes more sense for opening the delete modal since entire templates get focused.

See: #9884 

## Summary

Updated the keyboard shortcut for saved template delete modal.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9884
