### PR TITLE
Design System: add `onClear` to search input

### DIFF
--- a/packages/dashboard/src/app/views/exploreTemplates/header/index.js
+++ b/packages/dashboard/src/app/views/exploreTemplates/header/index.js
@@ -81,7 +81,7 @@ function Header({
         searchOptions={searchOptions}
         searchValue={search.keyword}
         handleSearchChange={debouncedSearchChange}
-        clearSearch={clearSearch}
+        onClear={clearSearch}
       />
       <BodyViewOptions
         resultsLabel={resultsLabel}

--- a/packages/dashboard/src/app/views/myStories/header/index.js
+++ b/packages/dashboard/src/app/views/myStories/header/index.js
@@ -171,7 +171,7 @@ function Header({
         handleSearchChange={debouncedSearchChange}
         showSearch={initialPageReady}
         searchValue={search.keyword}
-        clearSearch={clearSearch}
+        onClear={clearSearch}
       >
         {HeaderToggleButtons}
       </PageHeading>

--- a/packages/dashboard/src/app/views/shared/pageHeading.js
+++ b/packages/dashboard/src/app/views/shared/pageHeading.js
@@ -16,7 +16,6 @@
 /**
  * External dependencies
  */
-import { useCallback } from '@web-stories-wp/react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { __ } from '@web-stories-wp/i18n';
@@ -72,18 +71,8 @@ const PageHeading = ({
   showSearch,
   handleSearchChange,
   searchValue = '',
-  clearSearch = noop,
+  onClear = noop,
 }) => {
-  const handleClearSearch = useCallback(
-    (evt) => {
-      // evt is null when user presses the clear button
-      if (evt === null) {
-        clearSearch();
-      }
-    },
-    [clearSearch]
-  );
-
   return (
     <HeadingContainer>
       <StyledHeadline
@@ -101,7 +90,7 @@ const PageHeading = ({
             selectedValue={{ label: searchValue, value: searchValue }}
             options={searchOptions}
             handleSearchValueChange={handleSearchChange}
-            onMenuItemClick={handleClearSearch}
+            onClear={onClear}
             emptyText={__('No options available', 'web-stories')}
           />
         </HeaderSearch>
@@ -115,13 +104,13 @@ PageHeading.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
-  heading: PropTypes.string.isRequired,
-  searchPlaceholder: PropTypes.string,
-  searchOptions: PropTypes.arrayOf(PropTypes.object),
-  showSearch: PropTypes.bool,
   handleSearchChange: PropTypes.func,
-  clearSearch: PropTypes.func,
+  heading: PropTypes.string.isRequired,
+  onClear: PropTypes.func,
+  searchOptions: PropTypes.arrayOf(PropTypes.object),
+  searchPlaceholder: PropTypes.string,
   searchValue: PropTypes.string,
+  showSearch: PropTypes.bool,
 };
 
 export default PageHeading;

--- a/packages/design-system/src/components/search/search.js
+++ b/packages/design-system/src/components/search/search.js
@@ -61,6 +61,7 @@ const SearchInputWrapper = styled.div``;
  * @param {string} props.label If present, will display a text label above input. ariaLabel controls accessibility label of input since there are times search components are present without label text visible.
  * @param {Object} props.menuStylesOverride should be formatted as a css template literal with styled components. Gives access to completely overriding menu styles (container div > ul > li).
  * @param {Function} props.onMenuItemClick Triggered when a user clicks or presses 'Enter' on an option, or 'Enter' is pressed on input. Returns an object containing label and value keys.
+ * @param {Function} props.onClear Triggered when a user clicks clear 'x' button on the search input.
  * @param {Array} props.options All options, should contain either 1) objects with a label, value, anything else you need can be added and accessed through renderItem or 2) Objects containing a label and options, where options is structured as first option with array of objects containing at least value and label - this will create a nested list.
  * @param {string} props.placeholder Placeholder text to display in input if no value is present.
  * @param {string} props.placement placement passed to popover for where menu should expand, defaults to "bottom_end".

--- a/packages/design-system/src/components/search/search.js
+++ b/packages/design-system/src/components/search/search.js
@@ -79,6 +79,7 @@ export const Search = ({
   hint,
   label,
   onMenuItemClick,
+  onClear,
   options = [],
   placeholder = DEFAULT_PLACEHOLDER,
   placement = PLACEMENT.BOTTOM,
@@ -178,9 +179,9 @@ export const Search = ({
 
   const handleClearInput = useCallback(() => {
     inputState.set(undefined);
-    onMenuItemClick?.(null, { label: '', value: '' });
+    onClear();
     handleReturnToInput();
-  }, [handleReturnToInput, inputState, onMenuItemClick]);
+  }, [handleReturnToInput, inputState, onClear]);
 
   const handleTabClear = useCallback(() => {
     isOpen.set(false);
@@ -319,6 +320,7 @@ Search.propTypes = {
   label: PropTypes.string,
   menuStylesOverride: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   onMenuItemClick: PropTypes.func,
+  onClear: PropTypes.func,
   options: MENU_OPTIONS,
   placeholder: PropTypes.string,
   placement: PropTypes.oneOf(Object.values(PLACEMENT)),

--- a/packages/design-system/src/components/search/stories/index.js
+++ b/packages/design-system/src/components/search/stories/index.js
@@ -69,6 +69,11 @@ export const _default = () => {
     setInputValue(value);
   }, []);
 
+  const handleOnClear = useCallback(() => {
+    setInputValue('');
+    setSelectedValue(null);
+  }, []);
+
   return (
     <DarkThemeProvider>
       <Container>
@@ -82,10 +87,7 @@ export const _default = () => {
           hint={text('hint', 'default hint text')}
           label={text('label', 'Find an image')}
           isRTL={boolean('isRTL')}
-          onMenuItemClick={(event, newValue) => {
-            action('onMenuItemClick', event);
-            setSelectedValue(newValue);
-          }}
+          onClear={handleOnClear}
           options={options}
           placeholder={text('placeholder', 'search')}
           placement={select('placement', Object.values(PLACEMENT))}
@@ -125,6 +127,11 @@ export const LightTheme = () => {
     setInputValue(value);
   }, []);
 
+  const handleOnClear = useCallback(() => {
+    setInputValue('');
+    setSelectedValue(null);
+  }, []);
+
   return (
     <Container>
       <Search
@@ -137,10 +144,7 @@ export const LightTheme = () => {
         hint={text('hint', 'default hint text')}
         label={text('label', 'Search For Stories')}
         isRTL={boolean('isRTL')}
-        onMenuItemClick={(event, newValue) => {
-          action('onMenuItemClick', event);
-          setSelectedValue(newValue);
-        }}
+        onClear={handleOnClear}
         options={options}
         placeholder={text('placeholder', 'search')}
         placement={select('placement', Object.values(PLACEMENT))}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Currently the Search component from the design system calls `onMenuItemClick` with empty string values when you click the clear button. This makes it a little opaque when you're trying to pass in an `onClear` handler.

## Summary

<!-- A brief description of what this PR does. -->
Separating out on `onClear` handler to call when in the search component's `handleClearInput`. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Type into a search input (on explore templates or my templates) and make you can still clear a search entry. 


## Reviews

### Does this PR have a security-related impact?
no
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9667 
