### PR TITLE
Prevent `NaN` opacity in `getSolidFromHex`

### DIFF
--- a/packages/patterns/src/test/getSolidFromHex.js
+++ b/packages/patterns/src/test/getSolidFromHex.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,21 +17,16 @@
 /**
  * Internal dependencies
  */
-import createSolidFromString from './createSolidFromString';
-import createSolid from './createSolid';
+import getSolidFromHex from '../getSolidFromHex';
 
-function getSolidFromHex(hex) {
-  // We already have a nice parser for most of this, but we need to
-  // parse opacity as the last two hex digits as percent, not 1/256th
-
-  const {
-    color: { r, g, b },
-  } = createSolidFromString(`#${hex.slice(0, 6)}`);
-
-  const opacityDigits = hex.slice(6);
-  const opacity = opacityDigits ? parseInt(opacityDigits, 16) : 100;
-
-  return createSolid(r, g, b, opacity / 100);
-}
-
-export default getSolidFromHex;
+describe('getSolidFromHex', () => {
+  it.each([
+    ['aabbcc', { color: { r: 170, g: 187, b: 204 } }],
+    ['aabbcc00', { color: { r: 170, g: 187, b: 204, a: 0 } }],
+    ['aabbcc0f', { color: { r: 170, g: 187, b: 204, a: 0.15 } }],
+    ['aabbcc63', { color: { r: 170, g: 187, b: 204, a: 0.99 } }],
+    ['aabbcc64', { color: { r: 170, g: 187, b: 204 } }],
+  ])('should return valid pattern for %s hex string', (hex, expected) => {
+    expect(getSolidFromHex(hex)).toStrictEqual(expected);
+  });
+});


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

While looking into #9888 I noticed that `getSolidFromHex` doesn't properly handle six-digit hex strings without opacity, causing the opacity to be `NaN`.

## Summary

<!-- A brief description of what this PR does. -->

Improves handling of six-digit hex strings in `getSolidFromHex` to prevent `NaN` opacities.

Just making it a bit more robust.

## Relevant Technical Choices

<!-- Please describe your changes. -->

N/A

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

No

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

See #9888
