### PR TITLE
Hotfix: Validate hex color string in `SkeletonPage`

### DIFF
--- a/packages/story-editor/src/components/footer/carousel/skeletonPage.js
+++ b/packages/story-editor/src/components/footer/carousel/skeletonPage.js
@@ -27,6 +27,7 @@ import {
 /**
  * Internal dependencies
  */
+import isHexColorString from '../../../utils/isHexColorString';
 import { getDefinitionForType } from '../../../elements';
 import useCarousel from './useCarousel';
 
@@ -58,8 +59,10 @@ function SkeletonPage({ pageId, index }) {
 
   const bgElement = page.elements[0];
   const { isMedia } = getDefinitionForType(bgElement.type);
+  // Using isHexColorString for extra hardening.
+  // See https://github.com/google/web-stories-wp/issues/9888.
   const bgColor =
-    isMedia && bgElement.resource?.baseColor
+    isMedia && isHexColorString(bgElement.resource?.baseColor)
       ? getSolidFromHex(bgElement.resource.baseColor.replace('#', ''))
       : page.backgroundColor;
   return (

--- a/packages/story-editor/src/output/utils/styles.js
+++ b/packages/story-editor/src/output/utils/styles.js
@@ -22,11 +22,8 @@ import { FULLBLEED_RATIO, PAGE_RATIO } from '@web-stories-wp/units';
 /**
  * Internal dependencies
  */
+import isHexColorString from '../../utils/isHexColorString';
 import theme from '../../theme';
-
-function isHexColorString(s) {
-  return /^#(?:[a-f0-9]{3}){1,2}$/i.test(s);
-}
 
 function CustomStyles() {
   const safeToFullRatio = PAGE_RATIO / FULLBLEED_RATIO;

--- a/packages/story-editor/src/utils/isHexColorString.js
+++ b/packages/story-editor/src/utils/isHexColorString.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function isHexColorString(s) {
+  return /^#(?:[a-f0-9]{3}){1,2}$/i.test(s);
+}
+
+export default isHexColorString;


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

There were lots of reports about editor crashes, all related to `baseColor` somehow still not being a string.

## Summary

<!-- A brief description of what this PR does. -->

This is a hotfix for preventing editor crashes due to unexpected format of `baseColor` in carousel

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

We'll have to follow up with additional changes to make this more robust and fix the root cause

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Modify story data to have a resource with baseColor being an array (e.g. using the hidden dev tools)
2. Save story and refresh page
3. Editor should not crash


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9888
