### PR TITLE
Migrate saved page templates upon loading

### DIFF
--- a/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
@@ -30,6 +30,7 @@ import {
   localStore,
   LOCAL_STORAGE_PREFIX,
 } from '@web-stories-wp/design-system';
+import { DATA_VERSION, migrate } from '@web-stories-wp/migration';
 
 /**
  * Internal dependencies
@@ -115,7 +116,25 @@ function PageTemplatesPane(props) {
     setIsLoading(true);
     getCustomPageTemplates(nextTemplatesToFetch)
       .then(({ templates, hasMore }) => {
-        setSavedTemplates([...(savedTemplates || []), ...templates]);
+        const updatedTemplates = templates.map(
+          ({ version, templateId, ...page }) => {
+            const template = {
+              pages: [page],
+            };
+
+            // Older page templates unfortunately don't have a version.
+            // This is just a reasonable fallback, as 25 was the data version
+            // when custom page templates were first introduced.
+            const migratedTemplate = migrate(template, version || 25);
+            return {
+              templateId,
+              version: DATA_VERSION,
+              ...migratedTemplate.pages[0],
+            };
+          }
+        );
+        setSavedTemplates([...(savedTemplates || []), ...updatedTemplates]);
+
         if (!hasMore) {
           setNextTemplatesToFetch(false);
         } else {

--- a/packages/story-editor/src/components/library/panes/pageTemplates/templateList.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/templateList.js
@@ -59,11 +59,12 @@ function TemplateList({
   const pageIds = useMemo(() => pages?.map((page) => page.id) || [], [pages]);
 
   const handlePageClick = useCallback(
-    (page) => {
+    ({ templateId, version, title, ...page }) => {
+      // Just using destructuring above so we don't pass unnecessary props to addPage().
       const duplicatedPage = duplicatePage(page);
       addPage({ page: duplicatedPage });
       trackEvent('insert_page_template', {
-        name: page.title,
+        name: title || 'custom', // Custom page templates don't have titles (yet).
       });
       showSnackbar({
         message: __('Page Template added.', 'web-stories'),

--- a/packages/story-editor/src/components/library/panes/pageTemplates/templateSave.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/templateSave.js
@@ -28,6 +28,7 @@ import {
   Text,
   useSnackbar,
 } from '@web-stories-wp/design-system';
+import { DATA_VERSION } from '@web-stories-wp/migration';
 
 /**
  * Internal dependencies
@@ -115,7 +116,12 @@ function TemplateSave({ setShowDefaultTemplates, updateList }) {
       if (isDisabled) {
         return;
       }
-      addPageTemplate({ ...currentPage, id: uuidv4(), title: null })
+      addPageTemplate({
+        ...currentPage,
+        id: uuidv4(),
+        version: DATA_VERSION,
+        title: null,
+      })
         .then((addedTemplate) => {
           updateList?.(addedTemplate);
           showSnackbar({


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

When saving a page as a custom page template, that page template is never updated to the latest data version.

## Summary

<!-- A brief description of what this PR does. -->

This PR makes sure we store the data version when saving page templates and migrate them to the latest version upon loading.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9897
