### PR TITLE
Prepare 1.15.1 release

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "ampproject/amp-toolbox",
-            "version": "0.8.2",
+            "version": "0.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-toolbox-php.git",
-                "reference": "fe72826d28724385de5f6a76256a1e6299ece95c"
+                "reference": "e3fcdd949ec8c5838eb535bc0f40a8530490b625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/fe72826d28724385de5f6a76256a1e6299ece95c",
-                "reference": "fe72826d28724385de5f6a76256a1e6299ece95c",
+                "url": "https://api.github.com/repos/ampproject/amp-toolbox-php/zipball/e3fcdd949ec8c5838eb535bc0f40a8530490b625",
+                "reference": "e3fcdd949ec8c5838eb535bc0f40a8530490b625",
                 "shasum": ""
             },
             "require": {
@@ -32,6 +32,7 @@
                 "civicrm/composer-downloads-plugin": "^2.1 || ^3.0",
                 "dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
                 "ext-zip": "*",
+                "mikey179/vfsstream": "^1.6",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpcompatibility/php-compatibility": "^9",
                 "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
@@ -72,9 +73,9 @@
             "description": "A collection of AMP tools making it easier to publish and host AMP pages with PHP.",
             "support": {
                 "issues": "https://github.com/ampproject/amp-toolbox-php/issues",
-                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.8.2"
+                "source": "https://github.com/ampproject/amp-toolbox-php/tree/0.9.1"
             },
-            "time": "2021-10-27T12:32:13+00:00"
+            "time": "2021-12-02T22:21:58+00:00"
         },
         {
             "name": "ampproject/amp-wp",
@@ -82,16 +83,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ampproject/amp-wp",
-                "reference": "5405daa38e65f0ec16ffc920014d0110b03ee773"
+                "reference": "237dc6e418d3e75f85761119e269685adb80f8cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ampproject/amp-wp/zipball/5405daa38e65f0ec16ffc920014d0110b03ee773",
-                "reference": "5405daa38e65f0ec16ffc920014d0110b03ee773",
+                "url": "https://api.github.com/repos/ampproject/amp-wp/zipball/237dc6e418d3e75f85761119e269685adb80f8cf",
+                "reference": "237dc6e418d3e75f85761119e269685adb80f8cf",
                 "shasum": ""
             },
             "require": {
-                "ampproject/amp-toolbox": "0.8.2",
+                "ampproject/amp-toolbox": "0.9.1",
                 "cweagans/composer-patches": "~1.0",
                 "ext-curl": "*",
                 "ext-date": "*",
@@ -190,7 +191,7 @@
             ],
             "description": "WordPress plugin for adding AMP support.",
             "homepage": "https://github.com/ampproject/amp-wp",
-            "time": "2021-11-23T02:01:38+00:00"
+            "time": "2021-12-06T21:15:33+00:00"
         },
         {
             "name": "civicrm/composer-downloads-plugin",
@@ -2485,12 +2486,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "6f99479932347855a56d07958f3ac52e8261dda3"
+                "reference": "e26f8fefe293849248fb3414805684d0ba1f94f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/6f99479932347855a56d07958f3ac52e8261dda3",
-                "reference": "6f99479932347855a56d07958f3ac52e8261dda3",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/e26f8fefe293849248fb3414805684d0ba1f94f3",
+                "reference": "e26f8fefe293849248fb3414805684d0ba1f94f3",
                 "shasum": ""
             },
             "conflict": {
@@ -2509,7 +2510,7 @@
                 "bagisto/bagisto": "<0.1.5",
                 "barrelstrength/sprout-base-email": "<1.2.7",
                 "barrelstrength/sprout-forms": "<3.9",
-                "baserproject/basercms": "<=4.5",
+                "baserproject/basercms": "<4.5.4",
                 "billz/raspap-webgui": "<=2.6.6",
                 "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
                 "bolt/bolt": "<3.7.2",
@@ -2556,6 +2557,7 @@
                 "drupal/drupal": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
                 "dweeves/magmi": "<=0.7.24",
                 "ecodev/newsletter": "<=4",
+                "elgg/elgg": "<3.3.22",
                 "endroid/qr-code-bundle": "<3.4.2",
                 "enshrined/svg-sanitize": "<0.13.1",
                 "erusev/parsedown": "<1.7.2",
@@ -2565,10 +2567,11 @@
                 "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1",
                 "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1|>=5.4,<5.4.11.1|>=2017.12,<2017.12.0.1",
                 "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
-                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<=1.5.25",
                 "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
                 "ezsystems/ezplatform-kernel": "<=1.2.5|>=1.3,<=1.3.1",
                 "ezsystems/ezplatform-rest": ">=1.2,<=1.2.2|>=1.3,<1.3.8",
+                "ezsystems/ezplatform-richtext": ">=2.3,<=2.3.7",
                 "ezsystems/ezplatform-user": ">=1,<1.0.1",
                 "ezsystems/ezpublish-kernel": "<=6.13.8.1|>=7,<=7.5.15.1",
                 "ezsystems/ezpublish-legacy": "<=2017.12.7.3|>=2018.6,<=2019.3.5.1",
@@ -2586,7 +2589,7 @@
                 "fooman/tcpdf": "<6.2.22",
                 "forkcms/forkcms": "<=5.9.2",
                 "fossar/tcpdf-parser": "<6.2.22",
-                "francoisjacquet/rosariosis": "<6.5.1",
+                "francoisjacquet/rosariosis": "<8.1.1",
                 "friendsofsymfony/oauth2-php": "<1.3",
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
@@ -2601,7 +2604,7 @@
                 "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
                 "gree/jose": "<=2.2",
                 "gregwar/rst": "<1.0.3",
-                "grumpydictator/firefly-iii": "<5.6.3",
+                "grumpydictator/firefly-iii": "<5.6.5",
                 "guzzlehttp/guzzle": ">=4-rc.2,<4.2.4|>=5,<5.3.1|>=6,<6.2.1",
                 "helloxz/imgurl": "<=2.31",
                 "hjue/justwriting": "<=1",
@@ -2622,7 +2625,7 @@
                 "joomla/session": "<1.3.1",
                 "jsmitty12/phpwhois": "<5.1",
                 "kazist/phpwhois": "<=4.2.6",
-                "kevinpapst/kimai2": "<1.16.2",
+                "kevinpapst/kimai2": "<1.16.3",
                 "kitodo/presentation": "<3.1.2",
                 "klaviyo/magento2-extension": ">=1,<3",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
@@ -2635,7 +2638,7 @@
                 "league/commonmark": "<0.18.3",
                 "league/flysystem": "<1.1.4|>=2,<2.1.1",
                 "lexik/jwt-authentication-bundle": "<2.10.7|>=2.11,<2.11.3",
-                "librenms/librenms": "<=21.10.2",
+                "librenms/librenms": "<=21.11",
                 "limesurvey/limesurvey": "<3.27.19",
                 "livewire/livewire": ">2.2.4,<2.2.6",
                 "lms/routes": "<2.1.1",
@@ -2726,7 +2729,7 @@
                 "shopware/platform": "<=6.4.6",
                 "shopware/production": "<=6.3.5.2",
                 "shopware/shopware": "<5.7.6",
-                "showdoc/showdoc": "<=2.9.12",
+                "showdoc/showdoc": "<2.9.13",
                 "silverstripe/admin": "<4.8.1",
                 "silverstripe/assets": ">=1,<1.4.7|>=1.5,<1.5.2",
                 "silverstripe/cms": "<4.3.6|>=4.4,<4.4.4",
@@ -2746,12 +2749,12 @@
                 "simplito/elliptic-php": "<1.0.6",
                 "slim/slim": "<2.6",
                 "smarty/smarty": "<3.1.39",
-                "snipe/snipe-it": "<5.3.2",
+                "snipe/snipe-it": "<5.3.3",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
-                "ssddanbrown/bookstack": "<21.0.3",
+                "ssddanbrown/bookstack": "<21.11.2",
                 "stormpath/sdk": ">=0,<9.9.99",
                 "studio-42/elfinder": "<2.1.59",
                 "subrion/cms": "<=4.2.1",
@@ -2902,7 +2905,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-24T20:15:37+00:00"
+            "time": "2021-12-06T18:19:48+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/includes/AMP/Canonical_Sanitizer.php
+++ b/includes/AMP/Canonical_Sanitizer.php
@@ -28,8 +28,8 @@ namespace Google\Web_Stories\AMP;
 
 use DOMNodeList;
 use Google\Web_Stories_Dependencies\AMP_Base_Sanitizer;
-use Google\Web_Stories_Dependencies\AmpProject\Attribute;
-use Google\Web_Stories_Dependencies\AmpProject\Tag;
+use Google\Web_Stories_Dependencies\AmpProject\Html\Attribute;
+use Google\Web_Stories_Dependencies\AmpProject\Html\Tag;
 use DOMElement;
 
 /**

--- a/includes/AMP/Meta_Sanitizer.php
+++ b/includes/AMP/Meta_Sanitizer.php
@@ -26,8 +26,8 @@
 
 namespace Google\Web_Stories\AMP;
 
-use Google\Web_Stories_Dependencies\AmpProject\Attribute;
-use Google\Web_Stories_Dependencies\AmpProject\Tag;
+use Google\Web_Stories_Dependencies\AmpProject\Html\Attribute;
+use Google\Web_Stories_Dependencies\AmpProject\Html\Tag;
 use Google\Web_Stories_Dependencies\AMP_Meta_Sanitizer;
 
 /**

--- a/includes/AMP/Optimization.php
+++ b/includes/AMP/Optimization.php
@@ -35,6 +35,7 @@ use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Error;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\ErrorCollection;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\LocalFallback;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\TransformationEngine;
+use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\MinifyHtml;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\AmpRuntimeCss;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\OptimizeHeroImages;
 use Google\Web_Stories_Dependencies\AmpProject\Optimizer\Transformer\OptimizeAmpBind;

--- a/includes/AMP/Sanitization.php
+++ b/includes/AMP/Sanitization.php
@@ -38,10 +38,10 @@ use Google\Web_Stories_Dependencies\AMP_Script_Sanitizer;
 use Google\Web_Stories_Dependencies\AMP_Style_Sanitizer;
 use Google\Web_Stories_Dependencies\AMP_Tag_And_Attribute_Sanitizer;
 use Google\Web_Stories_Dependencies\AmpProject\Amp;
-use Google\Web_Stories_Dependencies\AmpProject\Attribute;
 use Google\Web_Stories_Dependencies\AmpProject\Dom\Document;
 use Google\Web_Stories_Dependencies\AmpProject\Extension;
-use Google\Web_Stories_Dependencies\AmpProject\Tag;
+use Google\Web_Stories_Dependencies\AmpProject\Html\Attribute;
+use Google\Web_Stories_Dependencies\AmpProject\Html\Tag;
 use DOMElement;
 
 /**

--- a/packages/story-editor/src/components/footer/carousel/skeletonPage.js
+++ b/packages/story-editor/src/components/footer/carousel/skeletonPage.js
@@ -27,6 +27,7 @@ import {
 /**
  * Internal dependencies
  */
+import isHexColorString from '../../../utils/isHexColorString';
 import { getDefinitionForType } from '../../../elements';
 import useCarousel from './useCarousel';
 
@@ -58,8 +59,10 @@ function SkeletonPage({ pageId, index }) {
 
   const bgElement = page.elements[0];
   const { isMedia } = getDefinitionForType(bgElement.type);
+  // Using isHexColorString for extra hardening.
+  // See https://github.com/google/web-stories-wp/issues/9888.
   const bgColor =
-    isMedia && bgElement.resource?.baseColor
+    isMedia && isHexColorString(bgElement.resource?.baseColor)
       ? getSolidFromHex(bgElement.resource.baseColor.replace('#', ''))
       : page.backgroundColor;
   return (

--- a/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesPane.js
@@ -30,6 +30,7 @@ import {
   localStore,
   LOCAL_STORAGE_PREFIX,
 } from '@web-stories-wp/design-system';
+import { DATA_VERSION, migrate } from '@web-stories-wp/migration';
 
 /**
  * Internal dependencies
@@ -115,7 +116,25 @@ function PageTemplatesPane(props) {
     setIsLoading(true);
     getCustomPageTemplates(nextTemplatesToFetch)
       .then(({ templates, hasMore }) => {
-        setSavedTemplates([...(savedTemplates || []), ...templates]);
+        const updatedTemplates = templates.map(
+          ({ version, templateId, ...page }) => {
+            const template = {
+              pages: [page],
+            };
+
+            // Older page templates unfortunately don't have a version.
+            // This is just a reasonable fallback, as 25 was the data version
+            // when custom page templates were first introduced.
+            const migratedTemplate = migrate(template, version || 25);
+            return {
+              templateId,
+              version: DATA_VERSION,
+              ...migratedTemplate.pages[0],
+            };
+          }
+        );
+        setSavedTemplates([...(savedTemplates || []), ...updatedTemplates]);
+
         if (!hasMore) {
           setNextTemplatesToFetch(false);
         } else {

--- a/packages/story-editor/src/components/library/panes/pageTemplates/templateList.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/templateList.js
@@ -59,11 +59,12 @@ function TemplateList({
   const pageIds = useMemo(() => pages?.map((page) => page.id) || [], [pages]);
 
   const handlePageClick = useCallback(
-    (page) => {
+    ({ templateId, version, title, ...page }) => {
+      // Just using destructuring above so we don't pass unnecessary props to addPage().
       const duplicatedPage = duplicatePage(page);
       addPage({ page: duplicatedPage });
       trackEvent('insert_page_template', {
-        name: page.title,
+        name: title || 'custom', // Custom page templates don't have titles (yet).
       });
       showSnackbar({
         message: __('Page Template added.', 'web-stories'),

--- a/packages/story-editor/src/components/library/panes/pageTemplates/templateSave.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/templateSave.js
@@ -28,6 +28,7 @@ import {
   Text,
   useSnackbar,
 } from '@web-stories-wp/design-system';
+import { DATA_VERSION } from '@web-stories-wp/migration';
 
 /**
  * Internal dependencies
@@ -115,7 +116,12 @@ function TemplateSave({ setShowDefaultTemplates, updateList }) {
       if (isDisabled) {
         return;
       }
-      addPageTemplate({ ...currentPage, id: uuidv4(), title: null })
+      addPageTemplate({
+        ...currentPage,
+        id: uuidv4(),
+        version: DATA_VERSION,
+        title: null,
+      })
         .then((addedTemplate) => {
           updateList?.(addedTemplate);
           showSnackbar({

--- a/packages/story-editor/src/elements/text/display.js
+++ b/packages/story-editor/src/elements/text/display.js
@@ -189,10 +189,11 @@ function TextDisplay({
       : { backgroundColor }),
     ...generateParagraphTextStyle(
       rest,
-      dataToEditorX,
+      (x) => `${dataToEditorX(x)}px`,
+      (y) => `${dataToEditorY(y)}px`,
       dataToEditorY,
-      undefined,
-      element
+      element,
+      dataToEditorY
     ),
     horizontalPadding: dataToEditorX(rest.padding?.horizontal || 0),
     verticalPadding: dataToEditorX(rest.padding?.vertical || 0),

--- a/packages/story-editor/src/elements/text/edit.js
+++ b/packages/story-editor/src/elements/text/edit.js
@@ -162,10 +162,11 @@ function TextEdit({
   const textProps = {
     ...generateParagraphTextStyle(
       rest,
-      dataToEditorX,
+      (styleX) => `${dataToEditorX(styleX)}px`,
+      (styleY) => `${dataToEditorY(styleY)}px`,
       dataToEditorY,
-      undefined,
-      element
+      element,
+      dataToEditorY
     ),
     font,
     element,

--- a/packages/story-editor/src/elements/text/frame.js
+++ b/packages/story-editor/src/elements/text/frame.js
@@ -52,10 +52,11 @@ function TextFrame({ element, element: { id, content, ...rest }, wrapperRef }) {
   }));
   const props = generateParagraphTextStyle(
     rest,
-    dataToEditorX,
+    (x) => `${dataToEditorX(x)}px`,
+    (y) => `${dataToEditorY(y)}px`,
     dataToEditorY,
-    undefined,
-    element
+    element,
+    dataToEditorY
   );
   const { selectedElementIds } = useStory((state) => ({
     selectedElementIds: state.state.selectedElementIds,

--- a/packages/story-editor/src/elements/text/test/util.js
+++ b/packages/story-editor/src/elements/text/test/util.js
@@ -277,5 +277,28 @@ describe('Text/util', () => {
       };
       expect(actual).toStrictEqual(expected);
     });
+
+    it('should allow using pixels as padding units', () => {
+      const element = {
+        ...TEXT_ELEMENT,
+        padding: {
+          vertical: 10,
+          horizontal: 0,
+          locked: true,
+        },
+      };
+
+      // Usage with pixels
+      const dataToStyleX = (x) => `${dataToEditorX(x, 100)}px`;
+      const dataToStyleY = (y) => `${dataToEditorY(y, 100)}px`;
+      const { padding } = generateParagraphTextStyle(
+        element,
+        dataToStyleX,
+        dataToStyleY,
+        undefined,
+        element
+      );
+      expect(padding).toBe('1.61812px 0px');
+    });
   });
 });

--- a/packages/story-editor/src/output/utils/styles.js
+++ b/packages/story-editor/src/output/utils/styles.js
@@ -22,11 +22,8 @@ import { FULLBLEED_RATIO, PAGE_RATIO } from '@web-stories-wp/units';
 /**
  * Internal dependencies
  */
+import isHexColorString from '../../utils/isHexColorString';
 import theme from '../../theme';
-
-function isHexColorString(s) {
-  return /^#(?:[a-f0-9]{3}){1,2}$/i.test(s);
-}
 
 function CustomStyles() {
   const safeToFullRatio = PAGE_RATIO / FULLBLEED_RATIO;

--- a/packages/story-editor/src/utils/isHexColorString.js
+++ b/packages/story-editor/src/utils/isHexColorString.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function isHexColorString(s) {
+  return /^#(?:[a-f0-9]{3}){1,2}$/i.test(s);
+}
+
+export default isHexColorString;

--- a/readme.txt
+++ b/readme.txt
@@ -113,7 +113,7 @@ For the plugin's full changelog, please see [the Releases page on GitHub](https:
 
 **Release Date:** December 7, 2021.
 
-* Fixes an issue with the editor crashing due to an unexpected data format.
+* Fixes a rare issue with crashing and failing to load particular stories.
 * Fixes an issue with mangled Unicode characters.
 * Fixes an issue with styling differences between the editor and the preview.
 

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,14 @@ Web Stories are powered by [AMP](https://amp.dev/), which adds some restrictions
 
 For the plugin's full changelog, please see [the Releases page on GitHub](https://github.com/google/web-stories-wp/releases).
 
+= 1.15.1 =
+
+**Release Date:** December 7, 2021.
+
+* Fixes an issue with the editor crashing due to an unexpected data format.
+* Fixes an issue with mangled Unicode characters.
+* Fixes an issue with styling differences between the editor and the preview.
+
 = 1.15.0 =
 
 **Release Date:** November 30, 2021.
@@ -130,19 +138,11 @@ For the plugin's full changelog, please see [the Releases page on GitHub](https:
 * Fixes an issue with embeds not appearing on the frontend.
 * Bug fixes and performance improvements.
 
-= 1.13.0 =
-
-**Release Date:** October 12, 2021.
-
-* New feature: tags and categories management in the editor.
-* Performance improvements for page thumbnails in the editor.
-* Improves AMP compatibility of the Web Stories embed block.
-* Fixes an AMP validation issue related to link icons.
-* Fixes an issue with setting link icons in the editor.
-* Fixes an issue with custom page templates that caused the editor to crash.
-* Bug fixes and performance improvements.
-
 == Upgrade Notice ==
+
+= 1.15.1 =
+
+Several bug fixes to address the editor crashing and styling differences between editor and preview.
 
 = 1.15.0 =
 
@@ -151,7 +151,3 @@ Media hotlinking, templates search, link qualification, and several bug fixes an
 = 1.14.0 =
 
 Archive page customization, improved video captions appearance, layer panel improvements, and several bug fixes.
-
-= 1.13.0 =
-
-Categories and tags support, improved performance in the editor, and several bug fixes.


### PR DESCRIPTION
Backports the following changes:

* #9873
* #9895
* #9862
* #9898

Also updates the changelog.

See #9902