### PR TITLE
Dashboard: Fix Color Contrast in Filter Counts

### DIFF
--- a/packages/dashboard/src/app/views/myStories/header/index.js
+++ b/packages/dashboard/src/app/views/myStories/header/index.js
@@ -59,7 +59,8 @@ const StyledPill = styled(Pill)`
 
   & > span {
     padding-left: 8px;
-    color: ${({ theme }) => theme.colors.fg.tertiary};
+    color: ${({ theme, isActive }) =>
+      isActive ? theme.colors.gray[20] : theme.colors.fg.tertiary};
   }
 `;
 function Header({


### PR DESCRIPTION
## Context

The contrast on the active pill's count in the dashboard's filters for what stories are visible (all, pending, published...) is too low and hard to read and not passing aXe. 

## Summary

Proposed tweak to active filter pill count from gray 50 (#5e6668) to gray 20 (#adb1b3) which ups contrast ratio from 3.11 to 8.47. Pending UX approval (☑️ approved 12/7/2021 by @agingoldseco )

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

| Current | Proposed Change | 
| --- | --- | 
| <img width="374" alt="Screen Shot 2021-12-06 at 4 06 51 PM" src="https://user-images.githubusercontent.com/10720454/144937211-c0c4501e-f642-4f85-a6e9-e59139fcbbab.png"> | <img width="374" alt="Screen Shot 2021-12-06 at 4 06 26 PM" src="https://user-images.githubusercontent.com/10720454/144937226-0bfee47b-aead-49c9-9fee-4fab91602910.png"> |

## Testing Instructions

Confirm that #adb1b3 shows up as the color of the count for active pill in Dashboard, if you have the aXe extension installed run it on the page and see that the filter pills don't cause contrast issues.

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8669 
