### PR TITLE
Media: Use smaller images for base color generation

### DIFF
--- a/packages/story-editor/src/app/media/local/useContextValueProvider.js
+++ b/packages/story-editor/src/app/media/local/useContextValueProvider.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { useEffect, useCallback, useRef } from '@web-stories-wp/react';
+import { getSmallestUrlForWidth } from '@web-stories-wp/media';
 import { getTimeTracker } from '@web-stories-wp/tracking';
 
 /**
@@ -236,7 +237,8 @@ export default function useContextValueProvider(reducerState, reducerActions) {
         processVideoAudio(id, src);
       }
 
-      const imageSrc = type === 'image' ? src : poster;
+      const imageSrc =
+        type === 'image' ? getSmallestUrlForWidth(0, resource) : poster;
       if (imageSrc && !baseColor) {
         processMediaBaseColor(resource);
       }

--- a/packages/story-editor/src/app/media/utils/useDetectBaseColor.js
+++ b/packages/story-editor/src/app/media/utils/useDetectBaseColor.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { useCallback } from '@web-stories-wp/react';
+import { getSmallestUrlForWidth } from '@web-stories-wp/media';
 /**
  * Internal dependencies
  */
@@ -79,8 +80,9 @@ function useDetectBaseColor({ updateMediaElement }) {
 
   const updateBaseColor = useCallback(
     async ({ resource }) => {
-      const { type, src, poster } = resource;
-      const imageSrc = type === 'image' ? src : poster;
+      const { type, poster } = resource;
+      const imageSrc =
+        type === 'image' ? getSmallestUrlForWidth(0, resource) : poster;
       if (!imageSrc) {
         return;
       }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
While working https://github.com/google/web-stories-wp/pull/9905, I got better performance from blurhash with smaller images. Base color will be the same. Let's use for base color to.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
