### PR TITLE
Media Library: Fix styling of search results count

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/local/mediaPane.js
+++ b/packages/story-editor/src/components/library/panes/media/local/mediaPane.js
@@ -85,6 +85,7 @@ const SearchCount = styled(Text).attrs({
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 `;
 
 const ButtonsWrapper = styled.div`


### PR DESCRIPTION
## Context
This PR fixes styling of media library search results count.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
| Syntax      | Description |
| ----------- | ----------- |
|   <img width="360" alt="Screenshot 2021-12-08 at 11 05 50 AM" src="https://user-images.githubusercontent.com/11607839/145154149-b4e86548-8ce7-403c-9543-d9ba6dbd742f.png">   |     <img width="355" alt="Screenshot 2021-12-08 at 11 05 58 AM" src="https://user-images.githubusercontent.com/11607839/145154200-99e402dd-fc6f-4abf-a1d9-dfcf6147d85c.png">    |

## Testing Instructions
- [ ] This is a non-user-facing change and requires no QA

This PR can be tested by following these steps:

1. Open story edit page
2. Search from local media


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

Fixes #6813
