### PR TITLE
Media Library: Display BlurHash placeholders if available

### DIFF
--- a/packages/media/src/createResource.js
+++ b/packages/media/src/createResource.js
@@ -28,6 +28,7 @@ import normalizeResourceSizes from './normalizeResourceSizes';
  */
 function createResource({
   baseColor,
+  blurHash,
   type,
   mimeType,
   creationDate,
@@ -53,6 +54,7 @@ function createResource({
 }) {
   return {
     baseColor,
+    blurHash,
     type: type || getTypeFromMime(mimeType),
     mimeType,
     creationDate,

--- a/packages/media/src/types.js
+++ b/packages/media/src/types.js
@@ -136,6 +136,8 @@ export { ResourcePropTypes };
  * Attachment object.
  *
  * @typedef {Attachment} Attachment
+ * @property {string|null} baseColor Attachment base color.
+ * @property {string|null} blurHash Attachment blur hash.
  * @property {string} [type] Attachment type, e.g. video or image.
  * @property {string} mimeType The MIME type.
  * @property {string|null} creationDate When the attachment was created.
@@ -174,6 +176,7 @@ export { ResourcePropTypes };
  *
  * @typedef {Resource} Resource
  * @property {string|null} baseColor An optional attribution to detect the base color of a resource (an image or video). Value looks like #ff00ff.
+ * @property {string|null} blurHash An optional attribution to detect the blurhash of a resource (an image or video).
  * @property {string|null} type Resource type. Currently only "image" and "video" values are allowed. If not specified, will be calculated from the mime-type.
  * @property {string} mimeType The MIME type.
  * @property {string|null} creationDate When resource was created.

--- a/packages/story-editor/package.json
+++ b/packages/story-editor/package.json
@@ -39,6 +39,7 @@
     "html-to-image": "1.9.0",
     "polished": "^4.1.3",
     "prop-types": "^15.7.2",
+    "react-blurhash": "^0.1.3",
     "react-calendar": "^3.5.0",
     "react-color": "^2.19.3",
     "react-moveable": "^0.30.3",

--- a/packages/story-editor/src/app/media/media3p/api/test/useMedia3pApi.js
+++ b/packages/story-editor/src/app/media/media3p/api/test/useMedia3pApi.js
@@ -135,6 +135,7 @@ describe('useMedia3pApi', () => {
       media: [
         {
           baseColor: undefined,
+          blurHash: undefined,
           alt: 'A cat',
           attribution: {
             author: {

--- a/packages/story-editor/src/app/media/utils/getResourceFromMedia3p.js
+++ b/packages/story-editor/src/app/media/utils/getResourceFromMedia3p.js
@@ -264,6 +264,7 @@ function getImageResourceFromMedia3p(m) {
   return createResource({
     id: m.name,
     baseColor: m.color,
+    blurHash: m.blurHash,
     type: m.type.toLowerCase(),
     mimeType: imageUrls.full.mime_type,
     creationDate: m.createTime,

--- a/packages/story-editor/src/app/media/utils/test/getResourceFromMedia3p.js
+++ b/packages/story-editor/src/app/media/utils/test/getResourceFromMedia3p.js
@@ -64,6 +64,7 @@ describe('getResourceFromMedia3p', () => {
     };
     const expectedStoryEditorResource = {
       baseColor: '#00379b',
+      blurHash: undefined,
       type: 'video',
       mimeType: 'video/mp4',
       creationDate: '2018-09-25T20:03.07Z',
@@ -154,6 +155,7 @@ describe('getResourceFromMedia3p', () => {
     };
     const expectedStoryEditorResource = {
       baseColor: '#00379b',
+      blurHash: undefined,
       type: 'video',
       mimeType: 'video/mp4',
       creationDate: '2018-09-25T20:03.07Z',
@@ -243,6 +245,7 @@ describe('getResourceFromMedia3p', () => {
     };
     const expectedStoryEditorResource = {
       baseColor: '#00379b',
+      blurHash: undefined,
       type: 'video',
       mimeType: 'video/mp4',
       creationDate: '2018-09-25T20:03.07Z',
@@ -329,6 +332,7 @@ describe('getResourceFromMedia3p', () => {
     };
     const expectedStoryEditorResource = {
       baseColor: '#00379b',
+      blurHash: undefined,
       type: 'video',
       mimeType: 'video/mp4',
       creationDate: '2018-09-25T20:03.07Z',
@@ -521,6 +525,7 @@ describe('getResourceFromMedia3p', () => {
 
     const expectedStoryEditorResource = {
       baseColor: '#00379b',
+      blurHash: undefined,
       id: 'media/tenor:3468838096637910112',
       length: undefined,
       lengthFormatted: undefined,

--- a/packages/story-editor/src/components/library/panes/media/common/mediaElement.js
+++ b/packages/story-editor/src/components/library/panes/media/common/mediaElement.js
@@ -29,6 +29,7 @@ import {
 import { rgba } from 'polished';
 import { __ } from '@web-stories-wp/i18n';
 import { LoadingBar, useKeyDownEffect } from '@web-stories-wp/design-system';
+import { Blurhash } from 'react-blurhash';
 /**
  * Internal dependencies
  */
@@ -65,6 +66,12 @@ const InnerContainer = styled.div`
   }
 `;
 
+const BlurhashContainer = styled(Blurhash)`
+  position: absolute !important;
+  top: 0;
+  left: 0;
+`;
+
 function Element({
   index,
   resource,
@@ -88,6 +95,7 @@ function Element({
     isMuting,
     isTrimming,
     baseColor,
+    blurHash,
   } = resource;
 
   const oRatio =
@@ -227,6 +235,14 @@ function Element({
           active={active}
         />
         {attribution}
+        {!isLoaded && blurHash && (
+          <BlurhashContainer
+            hash={blurHash}
+            width={width}
+            height={height}
+            punch={1}
+          />
+        )}
         {(local || isTranscoding || isMuting || isTrimming) && (
           <LoadingBar loadingMessage={__('Uploading media', 'web-stories')} />
         )}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Render blurhash for unsplash images.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

See #9905