### PR TITLE
Text style: adjust margin calculation

### DIFF
--- a/packages/story-editor/src/components/panels/design/textStyle/karma/textStyle.other.karma.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/karma/textStyle.other.karma.js
@@ -162,6 +162,8 @@ describe('Text Style Panel', () => {
         expect(frameSplits[1].trim()).toBe('0');
         expect(frameStyle.padding).toContain('px');
       });
+
+      await fixture.snapshot('Applied padding and line-height');
     });
   });
 

--- a/packages/story-editor/src/components/panels/design/textStyle/karma/textStyle.other.karma.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/karma/textStyle.other.karma.js
@@ -132,7 +132,7 @@ describe('Text Style Panel', () => {
       await fixture.events.click(fixture.editor.library.textAdd);
     });
 
-    fit('should display padding and line-height correctly', async () => {
+    it('should display padding and line-height correctly', async () => {
       const { padding, lineHeight } =
         fixture.editor.inspector.designPanel.textStyle;
       await fixture.events.focus(padding);
@@ -145,12 +145,22 @@ describe('Text Style Panel', () => {
       await waitFor(() => {
         const texts = fixture.screen.getAllByText('Fill in some text');
         // Display layer.
-        expect(texts[0]).toHaveStyle('margin', '-10.0083px 0px');
-        expect(texts[0]).toHaveStyle('padding', '4.36893px');
+        const displayStyle = window.getComputedStyle(texts[0]);
+        // This verifies it includes correct units.
+        const splits = displayStyle.margin.split('px');
+        // Verify the top-bottom margin is negative.
+        expect(splits[0].trim()).toBeLessThan(0);
+        // Verify the left-right margin is 0.
+        expect(splits[1].trim()).toBe('0');
+        // Verify units are correctly added to padding.
+        expect(displayStyle.padding).toContain('px');
 
-        // Frame layer.
-        expect(texts[1]).toHaveStyle('margin', '-10.0083px 0px');
-        expect(texts[1]).toHaveStyle('padding', '4.36893px');
+        // Verify the same things for the frames layer.
+        const frameStyle = window.getComputedStyle(texts[1]);
+        const frameSplits = frameStyle.margin.split('px');
+        expect(frameSplits[0].trim()).toBeLessThan(0);
+        expect(frameSplits[1].trim()).toBe('0');
+        expect(frameStyle.padding).toContain('px');
       });
     });
   });

--- a/packages/story-editor/src/components/panels/design/textStyle/karma/textStyle.other.karma.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/karma/textStyle.other.karma.js
@@ -127,6 +127,34 @@ describe('Text Style Panel', () => {
     });
   });
 
+  describe('Line-height & Padding', () => {
+    beforeEach(async () => {
+      await fixture.events.click(fixture.editor.library.textAdd);
+    });
+
+    fit('should display padding and line-height correctly', async () => {
+      const { padding, lineHeight } =
+        fixture.editor.inspector.designPanel.textStyle;
+      await fixture.events.focus(padding);
+      await fixture.events.keyboard.type('10');
+
+      await fixture.events.focus(lineHeight);
+      await fixture.events.keyboard.type('4');
+      await fixture.events.keyboard.press('tab');
+
+      await waitFor(() => {
+        const texts = fixture.screen.getAllByText('Fill in some text');
+        // Display layer.
+        expect(texts[0]).toHaveStyle('margin', '-10.0083px 0px');
+        expect(texts[0]).toHaveStyle('padding', '4.36893px');
+
+        // Frame layer.
+        expect(texts[1]).toHaveStyle('margin', '-10.0083px 0px');
+        expect(texts[1]).toHaveStyle('padding', '4.36893px');
+      });
+    });
+  });
+
   describe('Font controls', () => {
     beforeEach(async () => {
       await fixture.events.click(fixture.editor.library.textAdd);

--- a/packages/story-editor/src/elements/shared/index.js
+++ b/packages/story-editor/src/elements/shared/index.js
@@ -19,6 +19,7 @@
  */
 import { css } from 'styled-components';
 import { generatePatternStyles } from '@web-stories-wp/patterns';
+
 /**
  * Internal dependencies
  */
@@ -95,16 +96,13 @@ export const elementWithFont = css`
 `;
 
 // See generateParagraphTextStyle for the full set of properties.
-export const elementWithTextParagraphStyle = ({ element, dataToEditorY }) => {
-  const { marginOffset } = calcFontMetrics(element);
-  return css`
-    margin: ${-dataToEditorY(marginOffset / 2)}px 0;
-    padding: ${({ padding }) => padding || 0};
-    line-height: ${({ lineHeight }) => lineHeight};
-    text-align: ${({ textAlign }) => textAlign};
-    overflow-wrap: break-word;
-  `;
-};
+export const elementWithTextParagraphStyle = css`
+  margin: ${({ margin }) => margin};
+  padding: ${({ padding }) => padding || 0};
+  line-height: ${({ lineHeight }) => lineHeight};
+  text-align: ${({ textAlign }) => textAlign};
+  overflow-wrap: break-word;
+`;
 
 export const elementWithFlip = css`
   transform: ${({ transformFlip }) => transformFlip};

--- a/packages/story-editor/src/elements/shared/index.js
+++ b/packages/story-editor/src/elements/shared/index.js
@@ -23,7 +23,7 @@ import { generatePatternStyles } from '@web-stories-wp/patterns';
 /**
  * Internal dependencies
  */
-import { calcFontMetrics, generateFontFamily } from '../text/util';
+import { generateFontFamily } from '../text/util';
 import { getBorderStyle, getBorderRadius } from '../../utils/elementBorder';
 
 export const elementFillContent = css`

--- a/packages/story-editor/src/elements/text/display.js
+++ b/packages/story-editor/src/elements/text/display.js
@@ -192,8 +192,7 @@ function TextDisplay({
       (x) => `${dataToEditorX(x)}px`,
       (y) => `${dataToEditorY(y)}px`,
       dataToEditorY,
-      element,
-      dataToEditorY
+      element
     ),
     horizontalPadding: dataToEditorX(rest.padding?.horizontal || 0),
     verticalPadding: dataToEditorX(rest.padding?.vertical || 0),

--- a/packages/story-editor/src/elements/text/edit.js
+++ b/packages/story-editor/src/elements/text/edit.js
@@ -165,8 +165,7 @@ function TextEdit({
       (styleX) => `${dataToEditorX(styleX)}px`,
       (styleY) => `${dataToEditorY(styleY)}px`,
       dataToEditorY,
-      element,
-      dataToEditorY
+      element
     ),
     font,
     element,

--- a/packages/story-editor/src/elements/text/frame.js
+++ b/packages/story-editor/src/elements/text/frame.js
@@ -55,8 +55,7 @@ function TextFrame({ element, element: { id, content, ...rest }, wrapperRef }) {
     (x) => `${dataToEditorX(x)}px`,
     (y) => `${dataToEditorY(y)}px`,
     dataToEditorY,
-    element,
-    dataToEditorY
+    element
   );
   const { selectedElementIds } = useStory((state) => ({
     selectedElementIds: state.state.selectedElementIds,

--- a/packages/story-editor/src/karma/fixture/containers/designPanel/textStyle.js
+++ b/packages/story-editor/src/karma/fixture/containers/designPanel/textStyle.js
@@ -78,6 +78,10 @@ export class TextStyle extends AbstractPanel {
     return this.getByRole('textbox', { name: /Line-height/ });
   }
 
+  get padding() {
+    return this.getByRole('textbox', { name: /Padding/ });
+  }
+
   get fontColor() {
     const color = this._get(
       this.getByRole('region', { name: /Color input: Text/ }),


### PR DESCRIPTION
## Summary
15.1 introduced a regression where margin is not properly calculated when assigning line-height.
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Margin was incorrectly calculated inside `generateParagraphTextStyle` (without units), and the generated `margin` was not actually used anywhere at all, and was always calculated again in `elementWithTextParagraphStyle`.

This PR calculates the margin correctly the first time, and removes the additional calculation from `elementWithTextParagraphStyle`.

<!-- Please describe your changes. -->

## To-do

- [x] Additional tests

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

| Before | After |
|-------|-------|
| <img width="113" alt="Screenshot 2021-12-09 at 13 10 21" src="https://user-images.githubusercontent.com/3294597/145385917-9970adb5-d7ad-4e8d-9d6f-4c539330d6e0.png"> | <img width="123" alt="Screenshot 2021-12-09 at 13 08 48" src="https://user-images.githubusercontent.com/3294597/145385943-f719d8f4-bf71-43bb-9369-66a11ee51d79.png"> |
## Testing Instructions
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a text element so that it would have one line only.
2. Add line-height, e.g. 4. Verify the text element looks similar to as it was before (line-height is not visibly applied).
3. Now make the text element two rows.
4. Verify that line-height is properly added between the two lines but not to the top and bottom of the element iself.


## Reviews

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9940 
