### PR TITLE
Editor: Fixed updating existing resource when retrimming a video

### DIFF
--- a/packages/story-editor/src/app/media/utils/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/useProcessMedia.js
@@ -193,16 +193,20 @@ function useProcessMedia({
       };
 
       const onUploadStart = () =>
-        updateExistingElements(resourceId, {
+        updateExistingElements(canvasResourceId, {
           trimData,
           isTrimming: true,
         });
 
       const onUploadError = () =>
-        updateExistingElements(resourceId, { isTrimming: false });
+        updateExistingElements(canvasResourceId, { isTrimming: false });
 
       const onUploadSuccess = ({ resource }) => {
-        copyResourceData({ oldResource, resource });
+        const properOldResource = {
+          alt: oldResource.alt,
+          id: canvasResourceId,
+        };
+        copyResourceData({ oldResource: properOldResource, resource });
         postProcessingResource(resource);
       };
 

--- a/packages/story-editor/src/app/media/utils/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/useProcessMedia.js
@@ -202,11 +202,11 @@ function useProcessMedia({
         updateExistingElements(canvasResourceId, { isTrimming: false });
 
       const onUploadSuccess = ({ resource }) => {
-        const properOldResource = {
+        const oldCanvasResource = {
           alt: oldResource.alt,
           id: canvasResourceId,
         };
-        copyResourceData({ oldResource: properOldResource, resource });
+        copyResourceData({ oldResource: oldCanvasResource, resource });
         postProcessingResource(resource);
       };
 


### PR DESCRIPTION
## Context

When retrimming a video, the logic that updated properties on the element already on stage was broken, as it tried to update properties of an element with the resource id of the original video that this instance is a trimmed version of.

This was evident from the fact, that when retrimming, the current video on-stage never changed to be in trimming state nor did the trim button disable for the element. And finally, then trimming was done, the on-stage element was not correctly updated to refer to the newly created trim video.

## User-facing changes

| Before | After |
|-|-|
| ![retrim-fix-before](https://user-images.githubusercontent.com/637548/145293887-66f61f67-f106-4cfc-a666-acfb1f699d55.gif) | ![retrim-fix-after](https://user-images.githubusercontent.com/637548/145293893-6cc254f3-faa6-4cb9-9837-7a501fd4d631.gif) |

## Testing Instructions

This PR can be tested by following these steps:

1. Add an original video to a canvas
2. Trim it to a new length and observe that the trim button in the design panel is disabled while trimming
3. Trim the newly created video again and observe that the trim button in the design panel is once again disabled while trimming
4. Start trimming the new-newly created video and observe, that the trim handles are correctly placed as you placed them after the second trim.

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9878
