### PR TITLE
Media3p: flakey karma tests

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -264,6 +264,21 @@ describe('Media3pPane fetching', () => {
     expect(mediaElements?.length).toBe(expectedCount);
   }
 
+  async function waitForInitialMediaLoad() {
+    await waitFor(
+      () => {
+        const mediaElements = within(
+          fixture.editor.library.media3p.unsplashSection
+        ).queryAllByTestId(/^mediaElement/);
+
+        if (!mediaElements || mediaElements.length === 0) {
+          throw new Error('mediaElements did not load');
+        }
+      },
+      { timeout: 5000 }
+    );
+  }
+
   it('should render no results message', async () => {
     listMediaSpy.and.callFake(() => ({ media: [] }));
     await fixture.events.click(fixture.editor.library.media3pTab);
@@ -280,17 +295,20 @@ describe('Media3pPane fetching', () => {
   it('should render categories and media resources', async () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
 
-    await expectMediaElements(
+    // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+    await waitForInitialMediaLoad();
+
+    expectMediaElements(
       fixture.editor.library.media3p.unsplashSection,
       MEDIA_PER_PAGE
     );
-
     await fixture.snapshot();
   });
 
   it('should arrow navigate between category pills', async () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
-
+    // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+    await waitForInitialMediaLoad();
     await fixture.events.focus(fixture.editor.library.media3p.filters[0]);
     expect(document.activeElement.textContent).toBe('Sustainability');
 
@@ -305,7 +323,8 @@ describe('Media3pPane fetching', () => {
 
   it('should expand category section on arrow down', async () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
-
+    // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+    await waitForInitialMediaLoad();
     await fixture.events.keyboard.press('tab');
     await fixture.events.keyboard.press('tab');
     await fixture.events.keyboard.press('tab');
@@ -321,9 +340,10 @@ describe('Media3pPane fetching', () => {
 
   it('should fetch 2nd page', async () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
+    // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+    await waitForInitialMediaLoad();
 
     const mediaGallery = fixture.editor.library.media3p.mediaGallery;
-
     await expectMediaElements(
       fixture.editor.library.media3p.unsplashSection,
       MEDIA_PER_PAGE
@@ -333,7 +353,8 @@ describe('Media3pPane fetching', () => {
       0,
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
     );
-
+    // Wait for debounce
+    await fixture.events.sleep(700);
     await expectMediaElements(
       fixture.editor.library.media3p.unsplashSection,
       MEDIA_PER_PAGE * 2
@@ -342,25 +363,24 @@ describe('Media3pPane fetching', () => {
 
   it('should render the second media provider', async () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
-
+    // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+    await waitForInitialMediaLoad();
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
 
-    await expectMediaElements(
-      fixture.editor.library.media3p.coverrSection,
-      MEDIA_PER_PAGE
-    );
     // Wait for the debounce
     await fixture.events.sleep(700);
     await expectMediaElements(
       fixture.editor.library.media3p.coverrSection,
       // In 1600:1000 the coverr section will fetch again due to screen height
+      // This may fail locally if the viewport is a different size.
       MEDIA_PER_PAGE * 2
     );
   });
 
   it('should scroll to the top when a category is selected', async () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
-
+    // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+    await waitForInitialMediaLoad();
     const mediaGallery = fixture.editor.library.media3p.mediaGallery;
     await expectMediaElements(
       fixture.editor.library.media3p.unsplashSection,
@@ -386,15 +406,11 @@ describe('Media3pPane fetching', () => {
 
   it('should have a delay before autoplaying videos', async () => {
     await fixture.events.click(fixture.editor.library.media3pTab);
-
+    // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+    await waitForInitialMediaLoad();
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
     // Wait for the debounce
     await fixture.events.sleep(700);
-    await expectMediaElements(
-      fixture.editor.library.media3p.coverrSection,
-      // In 1600:1000 the coverr section will fetch again due to screen height
-      MEDIA_PER_PAGE * 2
-    );
 
     const firstMediaElement = fixture.editor.library.media3p.mediaElements[0];
 
@@ -418,7 +434,8 @@ describe('Media3pPane fetching', () => {
   describe('Gallery navigation', () => {
     it('should handle pressing right when focused', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
@@ -430,11 +447,10 @@ describe('Media3pPane fetching', () => {
       expect(document.activeElement).toBe(mediaElements[1]);
     });
 
-    // TODO: https://github.com/google/web-stories-wp/issues/9928
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should handle pressing right when at the end of a row', async () => {
+    it('should handle pressing right when at the end of a row', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
@@ -456,7 +472,8 @@ describe('Media3pPane fetching', () => {
       });
 
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
@@ -470,11 +487,10 @@ describe('Media3pPane fetching', () => {
       );
     });
 
-    // TODO: https://github.com/google/web-stories-wp/issues/9928
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should handle pressing left when focused', async () => {
+    it('should handle pressing left when focused', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
@@ -488,7 +504,8 @@ describe('Media3pPane fetching', () => {
 
     it('should handle pressing left at the beginning of a row', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
@@ -502,7 +519,8 @@ describe('Media3pPane fetching', () => {
 
     it('should handle pressing left when the first element is focused', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
@@ -516,7 +534,8 @@ describe('Media3pPane fetching', () => {
 
     it('should handle pressing down', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
@@ -528,11 +547,10 @@ describe('Media3pPane fetching', () => {
       expect(document.activeElement).toBe(mediaElements[3]);
     });
 
-    // TODO: https://github.com/google/web-stories-wp/issues/9928
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should handle pressing up', async () => {
+    it('should handle pressing up', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
@@ -544,11 +562,11 @@ describe('Media3pPane fetching', () => {
       expect(document.activeElement).toBe(mediaElements[1]);
     });
 
-    // TODO: https://github.com/google/web-stories-wp/issues/9928
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should handle pressing Home', async () => {
+    it('should handle pressing Home', async () => {
       mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
 
       const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
@@ -564,7 +582,8 @@ describe('Media3pPane fetching', () => {
     it('should handle pressing End', async () => {
       mockListMedia();
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { mediaElements, unsplashSection } = fixture.editor.library.media3p;
 
       await expectMediaElements(unsplashSection, MEDIA_PER_PAGE);
@@ -582,7 +601,8 @@ describe('Media3pPane fetching', () => {
   describe('Provider navigation', () => {
     it('should handle pressing Right', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       expect(fixture.editor.library.media3p.tabs.length).toBe(3);
 
       // unsplash section should be visible
@@ -607,7 +627,8 @@ describe('Media3pPane fetching', () => {
 
     it('should handle pressing Right when no more providers', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { tabs } = fixture.editor.library.media3p;
       expect(tabs.length).toBe(3);
 
@@ -627,7 +648,8 @@ describe('Media3pPane fetching', () => {
 
     it('should handle pressing Left', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { tabs } = fixture.editor.library.media3p;
       expect(tabs.length).toBe(3);
 
@@ -645,7 +667,8 @@ describe('Media3pPane fetching', () => {
 
     it('should handle pressing Left when at the beginning', async () => {
       await fixture.events.click(fixture.editor.library.media3pTab);
-
+      // 3p media fetching can take extra time to load, waiting to prevent flakey tests
+      await waitForInitialMediaLoad();
       const { tabs } = fixture.editor.library.media3p;
       expect(tabs.length).toBe(3);
 

--- a/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -354,7 +354,9 @@ describe('Media3pPane fetching', () => {
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
     );
     // Wait for debounce
-    await fixture.events.sleep(700);
+    await waitFor(() => {
+      expect(listMediaSpy).toHaveBeenCalledTimes(2);
+    });
     await expectMediaElements(
       fixture.editor.library.media3p.unsplashSection,
       MEDIA_PER_PAGE * 2
@@ -368,7 +370,9 @@ describe('Media3pPane fetching', () => {
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
 
     // Wait for the debounce
-    await fixture.events.sleep(700);
+    await waitFor(() => {
+      expect(listMediaSpy).toHaveBeenCalledTimes(2);
+    });
     await expectMediaElements(
       fixture.editor.library.media3p.coverrSection,
       // In 1600:1000 the coverr section will fetch again due to screen height
@@ -410,7 +414,9 @@ describe('Media3pPane fetching', () => {
     await waitForInitialMediaLoad();
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
     // Wait for the debounce
-    await fixture.events.sleep(700);
+    await waitFor(() => {
+      expect(listMediaSpy).toHaveBeenCalledTimes(2);
+    });
 
     const firstMediaElement = fixture.editor.library.media3p.mediaElements[0];
 

--- a/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/karma/mediaFetching.karma.js
@@ -354,9 +354,6 @@ describe('Media3pPane fetching', () => {
       mediaGallery.scrollHeight - mediaGallery.clientHeight - ROOT_MARGIN / 2
     );
     // Wait for debounce
-    await waitFor(() => {
-      expect(listMediaSpy).toHaveBeenCalledTimes(2);
-    });
     await expectMediaElements(
       fixture.editor.library.media3p.unsplashSection,
       MEDIA_PER_PAGE * 2
@@ -370,9 +367,6 @@ describe('Media3pPane fetching', () => {
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
 
     // Wait for the debounce
-    await waitFor(() => {
-      expect(listMediaSpy).toHaveBeenCalledTimes(2);
-    });
     await expectMediaElements(
       fixture.editor.library.media3p.coverrSection,
       // In 1600:1000 the coverr section will fetch again due to screen height
@@ -413,10 +407,13 @@ describe('Media3pPane fetching', () => {
     // 3p media fetching can take extra time to load, waiting to prevent flakey tests
     await waitForInitialMediaLoad();
     await fixture.events.click(fixture.editor.library.media3p.coverrTab);
-    // Wait for the debounce
-    await waitFor(() => {
-      expect(listMediaSpy).toHaveBeenCalledTimes(2);
-    });
+    //  Wait for the debounce
+    await expectMediaElements(
+      fixture.editor.library.media3p.coverrSection,
+      // In 1600:1000 the coverr section will fetch again due to screen height
+      // This may fail locally if the viewport is a different size.
+      MEDIA_PER_PAGE * 2
+    );
 
     const firstMediaElement = fixture.editor.library.media3p.mediaElements[0];
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Media fetching tests can be flakey. The Media3p doesn't always load before the first expect statement causing the tests to either throw an error, or the mediaElements are not found. 

## Summary

<!-- A brief description of what this PR does. -->

Once the media tab is clicked we want to wait for `mediaElements` to load before proceeding with the tests. 

## Relevant Technical Choices
Decided to `await` a `waitFor` and throw an error if the elements haven't loaded, this way the test will wait up to 5 seconds before proceeding. However, as soon as the elements are load we can continue on without having to take up the entire 5 second timeout. 

<!-- Please describe your changes. -->


## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
na
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?
na
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
na
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
na
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9928 
