### PR TITLE
Editor: Fixed karma tests for carousel navigation

### DIFF
--- a/packages/story-editor/src/components/footer/carousel/karma/carouselNavigation.karma.js
+++ b/packages/story-editor/src/components/footer/carousel/karma/carouselNavigation.karma.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { createSolid } from '@web-stories-wp/patterns';
+import { waitFor } from '@testing-library/react';
 /**
  * Internal dependencies
  */
@@ -62,6 +63,11 @@ describe('Carousel Navigation', () => {
 
   async function clickOnThumbnail(index) {
     await fixture.editor.footer.carousel.waitReady();
+    await waitFor(() => {
+      if (fixture.editor.footer.carousel.pages.length === 0) {
+        throw new Error('Carousel pages not loaded yet');
+      }
+    });
     const thumb = fixture.editor.footer.carousel.pages[index];
     thumb.node.scrollIntoView();
     await fixture.events.mouse.clickOn(thumb.node, 5, 5);
@@ -95,9 +101,7 @@ describe('Carousel Navigation', () => {
     expect(await getSelectionLength()).toBe(0);
   });
 
-  // TODO https://github.com/google/web-stories-wp/issues/9845
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should navigate the page with keys', async () => {
+  it('should navigate the page with keys', async () => {
     await clickOnThumbnail(1);
     expect(await getCurrentPageId()).toEqual('page2');
 
@@ -171,9 +175,7 @@ describe('Carousel Navigation', () => {
     expect(await getPageIds()).toEqual(['page1', 'page3', 'page4', 'page2']);
   });
 
-  // TODO https://github.com/google/web-stories-wp/issues/9845
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('should delete the first page', async () => {
+  it('should delete the first page', async () => {
     await clickOnThumbnail(0);
     await fixture.events.keyboard.down('del');
     await fixture.events.keyboard.up('del');


### PR DESCRIPTION
## Context

This fixes some flaky karma tests for the carousel by always waiting for the carousel pages to be loaded before attempting to access them.

## User-facing changes

_None_

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9845
