### PR TITLE
Fix `findDOMNode` warnings that clutter the console

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12623,6 +12623,12 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
+    "node_modules/blurhash": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-1.1.4.tgz",
+      "integrity": "sha512-MXIPz6zwYUKayju+Uidf83KhH0vodZfeRl6Ich8Gu+KGl0JgKiFq9LsfqV7cVU5fKD/AotmduZqvOfrGKOfTaA==",
+      "peer": true
+    },
     "node_modules/bn.js": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
@@ -31383,6 +31389,15 @@
         "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
       }
     },
+    "node_modules/react-blurhash": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/react-blurhash/-/react-blurhash-0.1.3.tgz",
+      "integrity": "sha512-Q9lqbXg92NU6/2DoIl/cBM8YWL+Z4X66OiG4aT9ozOgjBwx104LHFCH5stf6aF+s0Q9Wf310Ul+dG+VXJltmPg==",
+      "peerDependencies": {
+        "blurhash": "^1.1.1",
+        "react": ">=15"
+      }
+    },
     "node_modules/react-calendar": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-3.5.0.tgz",
@@ -39420,6 +39435,7 @@
         "html-to-image": "1.9.0",
         "polished": "^4.1.3",
         "prop-types": "^15.7.2",
+        "react-blurhash": "^0.1.3",
         "react-calendar": "^3.5.0",
         "react-color": "^2.19.3",
         "react-moveable": "^0.30.3",
@@ -47055,6 +47071,7 @@
         "polished": "^4.1.3",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
+        "react-blurhash": "^0.1.3",
         "react-calendar": "^3.5.0",
         "react-color": "^2.19.3",
         "react-moveable": "^0.30.3",
@@ -49347,6 +49364,12 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
+    },
+    "blurhash": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-1.1.4.tgz",
+      "integrity": "sha512-MXIPz6zwYUKayju+Uidf83KhH0vodZfeRl6Ich8Gu+KGl0JgKiFq9LsfqV7cVU5fKD/AotmduZqvOfrGKOfTaA==",
+      "peer": true
     },
     "bn.js": {
       "version": "5.1.3",
@@ -63746,6 +63769,12 @@
         "line-height": "^0.3.1",
         "prop-types": "^15.5.6"
       }
+    },
+    "react-blurhash": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/react-blurhash/-/react-blurhash-0.1.3.tgz",
+      "integrity": "sha512-Q9lqbXg92NU6/2DoIl/cBM8YWL+Z4X66OiG4aT9ozOgjBwx104LHFCH5stf6aF+s0Q9Wf310Ul+dG+VXJltmPg==",
+      "requires": {}
     },
     "react-calendar": {
       "version": "3.5.0",

--- a/packages/design-system/src/components/loadingBar/index.js
+++ b/packages/design-system/src/components/loadingBar/index.js
@@ -19,6 +19,7 @@
 import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
 import styled, { keyframes } from 'styled-components';
+import { useRef } from '@web-stories-wp/react';
 /**
  * Internal dependencies
  */
@@ -58,16 +59,25 @@ const UploadingIndicator = styled.div`
   }
 `;
 
-export const LoadingBar = ({ loadingMessage, ...rest }) => (
-  <>
-    {loadingMessage && (
-      <AriaOnlyAlert role="status">{loadingMessage}</AriaOnlyAlert>
-    )}
-    <CSSTransition in appear timeout={0} className={LOADING_INDICATOR_CLASS}>
-      <UploadingIndicator {...rest} />
-    </CSSTransition>
-  </>
-);
+export const LoadingBar = ({ loadingMessage, ...rest }) => {
+  const nodeRef = useRef();
+  return (
+    <>
+      {loadingMessage && (
+        <AriaOnlyAlert role="status">{loadingMessage}</AriaOnlyAlert>
+      )}
+      <CSSTransition
+        nodeRef={nodeRef}
+        in
+        appear
+        timeout={0}
+        className={LOADING_INDICATOR_CLASS}
+      >
+        <UploadingIndicator ref={nodeRef} {...rest} />
+      </CSSTransition>
+    </>
+  );
+};
 
 LoadingBar.propTypes = {
   loadingMessage: PropTypes.string,

--- a/packages/design-system/src/components/snackbar/snackbarContainer.js
+++ b/packages/design-system/src/components/snackbar/snackbarContainer.js
@@ -142,7 +142,7 @@ export const SnackbarContainer = ({
       }
     });
   }, [notifications, speak]);
-
+  const nodeRef = useRef();
   return (
     <StyledContainer placement={placement}>
       <TransitionGroup>
@@ -164,9 +164,10 @@ export const SnackbarContainer = ({
               key={notification.id || ids[index]}
               timeout={300}
               unmountOnExit
+              nodeRef={nodeRef}
               classNames="react-snackbar-alert__snackbar-container"
             >
-              <ChildContainer placement={placement}>
+              <ChildContainer ref={nodeRef} placement={placement}>
                 <Component
                   {...notificationProps}
                   aria-hidden

--- a/packages/story-editor/src/components/circularProgress/index.js
+++ b/packages/story-editor/src/components/circularProgress/index.js
@@ -20,6 +20,7 @@
 import PropTypes from 'prop-types';
 import styled, { keyframes } from 'styled-components';
 import { CSSTransition } from 'react-transition-group';
+import { useRef } from '@web-stories-wp/react';
 
 const wrapperRotation = keyframes`
     100% { transform: rotate(360deg) }
@@ -58,9 +59,11 @@ const StyledCircle = styled.circle`
 `;
 
 function CircularProgress({ size, thickness }) {
+  const nodeRef = useRef();
+
   return (
-    <CSSTransition in appear timeout={0}>
-      <Wrapper size={size}>
+    <CSSTransition nodeRef={nodeRef} in appear timeout={0}>
+      <Wrapper ref={nodeRef} size={size}>
         <StyledSpinner viewBox={`${size / 2} ${size / 2} ${size} ${size}`}>
           <StyledCircle
             cx={size}

--- a/packages/story-editor/src/components/colorPicker/colorPicker.js
+++ b/packages/story-editor/src/components/colorPicker/colorPicker.js
@@ -151,7 +151,13 @@ function ColorPicker({
     : BasicColorPicker;
 
   return (
-    <CSSTransition in appear classNames="picker" timeout={300}>
+    <CSSTransition
+      nodeRef={containerRef}
+      in
+      appear
+      classNames="picker"
+      timeout={300}
+    >
       <Container
         role="dialog"
         aria-label={__('Color and gradient picker', 'web-stories')}

--- a/packages/story-editor/src/components/footer/carousel/carouselLayout.js
+++ b/packages/story-editor/src/components/footer/carousel/carouselLayout.js
@@ -20,6 +20,7 @@
 import { CSSTransition } from 'react-transition-group';
 import styled from 'styled-components';
 import { __ } from '@web-stories-wp/i18n';
+import { useRef } from '@web-stories-wp/react';
 
 /**
  * Internal dependencies
@@ -108,7 +109,7 @@ function CarouselLayout() {
       pageThumbHeight,
     })
   );
-
+  const nodeRef = useRef();
   if (numPages <= 0) {
     return null;
   }
@@ -124,9 +125,12 @@ function CarouselLayout() {
     <CSSTransition
       in={isOpenOrOpening}
       classNames="carousel"
+      containerRef
+      nodeRef={nodeRef}
       timeout={CAROUSEL_TRANSITION_DURATION}
     >
       <Wrapper
+        ref={nodeRef}
         aria-label={__('Page Carousel', 'web-stories')}
         isCollapsed={isCollapsed}
         thumbHeight={pageThumbHeight}

--- a/packages/story-editor/src/components/panels/design/textStyle/stylePresets/styleManager.js
+++ b/packages/story-editor/src/components/panels/design/textStyle/stylePresets/styleManager.js
@@ -109,7 +109,13 @@ function StyleManager({ styles, onClose, applyStyle }) {
     setToDelete(style);
   };
   return (
-    <CSSTransition in appear classNames="style-manager" timeout={300}>
+    <CSSTransition
+      nodeRef={containerRef}
+      in
+      appear
+      classNames="style-manager"
+      timeout={300}
+    >
       <Container
         role="dialog"
         aria-label={__('Style presets manager', 'web-stories')}

--- a/packages/story-editor/src/components/transition/scheduledTransition.js
+++ b/packages/story-editor/src/components/transition/scheduledTransition.js
@@ -16,7 +16,7 @@
 /**
  * External dependencies
  */
-import { useReducer, useEffect, useState } from '@web-stories-wp/react';
+import { useReducer, useEffect, useState, useRef } from '@web-stories-wp/react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 
@@ -79,10 +79,11 @@ export function Interpreter({ state, children }) {
 }
 
 export function ScheduledTransition({ children, ...props }) {
+  const nodeRef = useRef();
   return (
-    <Transition {...props}>
+    <Transition nodeRef={nodeRef} {...props}>
       {(state) => (
-        <Interpreter state={state}>
+        <Interpreter ref={nodeRef} state={state}>
           {(scheduledState) => children(scheduledState)}
         </Interpreter>
       )}

--- a/packages/story-editor/src/elements/video/playPauseButton.js
+++ b/packages/story-editor/src/elements/video/playPauseButton.js
@@ -24,6 +24,7 @@ import {
   useEffect,
   useState,
   useDebouncedCallback,
+  useRef,
 } from '@web-stories-wp/react';
 import { CSSTransition } from 'react-transition-group';
 import { __ } from '@web-stories-wp/i18n';
@@ -66,7 +67,34 @@ const ButtonWrapper = styled.div.attrs({ role: 'button', tabIndex: -1 })`
   width: ${PLAY_BUTTON_SIZE}px;
   height: ${PLAY_BUTTON_SIZE}px;
   overflow: hidden;
+  opacity: ${({ isAbove }) => (isAbove ? 1 : 0)};
+  &.button-enter {
+    opacity: 0;
+  }
+  &.button-enter-active,
+  &.button-enter-done {
+    opacity: 1;
+    transition: opacity 100ms;
+  }
+  &.button-exit {
+    opacity: 1;
+  }
+  &.button-exit-active,
+  &.button-exit-done {
+    opacity: 0;
+    transition: opacity 100ms;
+  }
 
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    `}
+  cursor: pointer;
+  pointer-events: initial;
+  width: ${PLAY_BUTTON_SIZE}px;
+  height: ${PLAY_BUTTON_SIZE}px;
+  overflow: hidden;
   opacity: ${({ isAbove }) => (isAbove ? 1 : 0)};
   &.button-enter {
     opacity: 0;
@@ -234,7 +262,7 @@ function PlayPauseButton({
     handlePlayPause,
     [handlePlayPause]
   );
-
+  const nodeRef = useRef();
   if (!isActive) {
     return null;
   }
@@ -262,10 +290,12 @@ function PlayPauseButton({
         <TransitionWrapper
           in={hovering}
           appear
+          nodeRef={nodeRef}
           classNames="button"
           timeout={100}
         >
           <ButtonWrapper
+            ref={nodeRef}
             aria-label={buttonLabel}
             aria-pressed={isPlaying}
             key="wrapper"

--- a/packages/story-editor/src/elements/video/playPauseButton.js
+++ b/packages/story-editor/src/elements/video/playPauseButton.js
@@ -84,34 +84,6 @@ const ButtonWrapper = styled.div.attrs({ role: 'button', tabIndex: -1 })`
     opacity: 0;
     transition: opacity 100ms;
   }
-
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    `}
-  cursor: pointer;
-  pointer-events: initial;
-  width: ${PLAY_BUTTON_SIZE}px;
-  height: ${PLAY_BUTTON_SIZE}px;
-  overflow: hidden;
-  opacity: ${({ isAbove }) => (isAbove ? 1 : 0)};
-  &.button-enter {
-    opacity: 0;
-  }
-  &.button-enter-active,
-  &.button-enter-done {
-    opacity: 1;
-    transition: opacity 100ms;
-  }
-  &.button-exit {
-    opacity: 1;
-  }
-  &.button-exit-active,
-  &.button-exit-done {
-    opacity: 0;
-    transition: opacity 100ms;
-  }
 `;
 
 const iconCss = css`


### PR DESCRIPTION
## Context

`findDOMNode` warnings take up a lot of space in the console and make it difficult to read anything in console. Since `findDOMNode` has been deprecated in `StrictMode` it would be better to move away from it. This problem occurs due to improper props for `CSSTransition` component

## Summary

This PR corrects the `nodeRef` prop to the `CSSTransition` component and its immediate child.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9950 
