### PR TITLE
Code Quality: Increase aXe Coverage in Story Editor

### DIFF
--- a/packages/stickers/src/art-books-gift-guide/handHeldSign.js
+++ b/packages/stickers/src/art-books-gift-guide/handHeldSign.js
@@ -36,7 +36,7 @@ function HandHeldSign({ style }) {
         d="M18.94 38.8113L15.4375 36.7549L2.26593 41.6118L0.050293 50.0343L7.19563 49.1513L18.94 38.8113Z"
         fill="#35A0CD"
       />
-      <g clipPath="url(#clip0)">
+      <g clipPath="url(#clip0_handheld)">
         <path
           fillRule="evenodd"
           clipRule="evenodd"
@@ -219,7 +219,7 @@ function HandHeldSign({ style }) {
         fill="#C4C3DC"
       />
       <defs>
-        <clipPath id="clip0">
+        <clipPath id="clip0_handheld">
           <rect
             width="6.32377"
             height="20.4792"

--- a/packages/story-editor/src/app/media/media3p/attribution.js
+++ b/packages/story-editor/src/app/media/media3p/attribution.js
@@ -94,16 +94,20 @@ const getAriaLabel = (provider) =>
 
 export function UnsplashAttribution() {
   return (
-    <a href={unsplashUrl} target={'_blank'} rel={'noreferrer'}>
-      <AttributionPill>
+    <a
+      href={unsplashUrl}
+      target={'_blank'}
+      rel={'noreferrer'}
+      aria-label={getAriaLabel(MEDIA_PROVIDER.unsplash)}
+    >
+      <AttributionPill aria-hidden>
         <Text
           forwardedAs="span"
           size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-          aria-label={getAriaLabel(MEDIA_PROVIDER.unsplash)}
         >
           {__('Powered by', 'web-stories')}
         </Text>
-        <UnsplashLogo aria-hidden />
+        <UnsplashLogo />
       </AttributionPill>
     </a>
   );
@@ -111,16 +115,20 @@ export function UnsplashAttribution() {
 
 export function CoverrAttribution() {
   return (
-    <a href={coverrUrl} target={'_blank'} rel={'noreferrer'}>
-      <AttributionPill>
+    <a
+      href={coverrUrl}
+      target={'_blank'}
+      rel={'noreferrer'}
+      aria-label={getAriaLabel(MEDIA_PROVIDER.coverr)}
+    >
+      <AttributionPill aria-hidden>
         <Text
           forwardedAs="span"
           size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.X_SMALL}
-          aria-label={getAriaLabel(MEDIA_PROVIDER.coverr)}
         >
           {__('Powered by', 'web-stories')}
         </Text>
-        <CoverrLogo aria-hidden />
+        <CoverrLogo />
       </AttributionPill>
     </a>
   );
@@ -134,8 +142,8 @@ export function TenorAttribution() {
       rel={'noreferrer'}
       aria-label={getAriaLabel(MEDIA_PROVIDER.tenor)}
     >
-      <AttributionPill>
-        <TenorLogo aria-hidden />
+      <AttributionPill aria-hidden>
+        <TenorLogo />
       </AttributionPill>
     </a>
   );

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -82,7 +82,7 @@ describe('Carousel integration', () => {
     await fixture.events.mouse.clickOn(thumb.node, 5, 5);
   }
 
-  it('should pass accessibility tests', async () => {
+  it('should have no aXe violations', async () => {
     await expectAsync(fixture.editor.footer.carousel.node).toHaveNoViolations();
   });
 

--- a/packages/story-editor/src/components/canvas/karma/carousel.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/carousel.karma.js
@@ -82,6 +82,10 @@ describe('Carousel integration', () => {
     await fixture.events.mouse.clickOn(thumb.node, 5, 5);
   }
 
+  it('should pass accessibility tests', async () => {
+    await expectAsync(fixture.editor.footer.carousel.node).toHaveNoViolations();
+  });
+
   it('should select the current page', async () => {
     expect(await getCurrentPageId()).toEqual('page1');
     expect(await getSelection()).toEqual([element1.id]);

--- a/packages/story-editor/src/components/canvas/karma/quickActions.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/quickActions.karma.js
@@ -58,7 +58,7 @@ describe('Quick Actions integration', () => {
   });
 
   describe('quick action menu should have no aXe accessibility violations', () => {
-    it('should pass accessibility tests with the default menu', async () => {
+    it('should have no aXe violations with the default menu', async () => {
       await expectAsync(
         fixture.editor.canvas.quickActionMenu.node
       ).toHaveNoViolations();

--- a/packages/story-editor/src/components/checklist/karma/checklist.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/checklist.karma.js
@@ -132,12 +132,12 @@ describe('Checklist integration', () => {
   });
 
   describe('Checklist aXe tests', () => {
-    it('should pass accessibility tests with empty message on a new story', async () => {
+    it('should have no aXe violations with empty message on a new story', async () => {
       await openChecklist();
       await expectAsync(fixture.editor.checklist.node).toHaveNoViolations();
     });
 
-    it('should pass accessibility tests with checks present', async () => {
+    it('should have no aXe violations with checks present', async () => {
       await addPages(4);
       await addAccessibilityIssue();
       await openChecklist();
@@ -326,17 +326,17 @@ describe('Checklist integration', () => {
   });
 
   describe('checklist should have no aXe accessibility violations', () => {
-    it('should pass accessibility tests with with a closed checklist', async () => {
+    it('should have no aXe violations with with a closed checklist', async () => {
       await expectAsync(fixture.editor.checklist.node).toHaveNoViolations();
     });
 
-    it('should pass accessibility tests with an open empty checklist', async () => {
+    it('should have no aXe violations with an open empty checklist', async () => {
       await openChecklist();
 
       await expectAsync(fixture.editor.checklist.node).toHaveNoViolations();
     });
 
-    it('should pass accessibility tests with a open non-empty checklist', async () => {
+    it('should have no aXe violations with a open non-empty checklist', async () => {
       await addPages(4);
 
       await openChecklist();

--- a/packages/story-editor/src/components/checklist/karma/checklist.karma.js
+++ b/packages/story-editor/src/components/checklist/karma/checklist.karma.js
@@ -131,6 +131,20 @@ describe('Checklist integration', () => {
     });
   });
 
+  describe('Checklist aXe tests', () => {
+    it('should pass accessibility tests with empty message on a new story', async () => {
+      await openChecklist();
+      await expectAsync(fixture.editor.checklist.node).toHaveNoViolations();
+    });
+
+    it('should pass accessibility tests with checks present', async () => {
+      await addPages(4);
+      await addAccessibilityIssue();
+      await openChecklist();
+      await expectAsync(fixture.editor.checklist.node).toHaveNoViolations();
+    });
+  });
+
   describe('Checklist cursor interaction', () => {
     it('should open the high priority section by default when 4 pages are added to the story', async () => {
       // need to add some pages, the add page button is under the checklist so do this before expanding

--- a/packages/story-editor/src/components/colorPicker/karma/colorPicker.karma.js
+++ b/packages/story-editor/src/components/colorPicker/karma/colorPicker.karma.js
@@ -56,6 +56,11 @@ describe('ColorPicker', () => {
           expect(bgPanel.backgroundColor.picker).toBeDefined()
         );
 
+        // Verify there are no aXe violations within the color picker.
+        await expectAsync(
+          bgPanel.backgroundColor.picker.node
+        ).toHaveNoViolations();
+
         // Snapshot it
         await fixture.snapshot('Basic color picker');
 
@@ -220,6 +225,9 @@ describe('ColorPicker', () => {
         // Verify being in edit mode.
         expect(picker.exitEditButton).toBeTruthy();
         expect(picker.deleteGlobalColor).toBeTruthy();
+        // Verify edit mode has no aXe violations.
+        await expectAsync(picker.exitEditButton).toHaveNoViolations();
+        await expectAsync(picker.deleteGlobalColor).toHaveNoViolations();
 
         // Delete global preset.
         await fixture.events.click(picker.deleteGlobalColor);

--- a/packages/story-editor/src/components/footer/karma/footerMenu.karma.js
+++ b/packages/story-editor/src/components/footer/karma/footerMenu.karma.js
@@ -32,6 +32,10 @@ describe('Footer menu', () => {
     fixture.restore();
   });
 
+  it('should pass accessibility tests', async () => {
+    await expectAsync(fixture.editor.footer.node).toHaveNoViolations();
+  });
+
   it('should show correct tooltip on hover', async () => {
     const { gridViewToggle } = fixture.editor.footer;
     await fixture.events.mouse.moveRel(gridViewToggle, '50%', '50%', {

--- a/packages/story-editor/src/components/footer/karma/footerMenu.karma.js
+++ b/packages/story-editor/src/components/footer/karma/footerMenu.karma.js
@@ -32,7 +32,7 @@ describe('Footer menu', () => {
     fixture.restore();
   });
 
-  it('should pass accessibility tests', async () => {
+  it('should have no aXe violations', async () => {
     await expectAsync(fixture.editor.footer.node).toHaveNoViolations();
   });
 

--- a/packages/story-editor/src/components/helpCenter/karma/helpCenter.karma.js
+++ b/packages/story-editor/src/components/helpCenter/karma/helpCenter.karma.js
@@ -37,6 +37,26 @@ describe('Help Center integration', () => {
     fixture.restore();
   });
 
+  describe('Help Center aXe tests', () => {
+    it('should pass accessibility tests from default view', async () => {
+      await expectAsync(
+        fixture.editor.helpCenter.quickTips
+      ).toHaveNoViolations();
+    });
+
+    it('should pass accessibility tests from tip view', async () => {
+      const { quickTips } = await fixture.editor.helpCenter;
+      const { getByRole } = within(quickTips);
+
+      const cropTip = getByRole('button', { name: 'Crop selected element' });
+
+      await fixture.events.click(cropTip);
+      await expectAsync(
+        await fixture.editor.helpCenter.quickTips
+      ).toHaveNoViolations();
+    });
+  });
+
   describe('Help Center default navigation', () => {
     it('should show Help Center by default for a new user with 7 unread tips', async () => {
       const { quickTips, toggleButton } = await fixture.editor.helpCenter;
@@ -90,9 +110,9 @@ describe('Help Center integration', () => {
       const { quickTips, toggleButton } = fixture.editor.helpCenter;
       expect(toggleButton).toHaveTextContent('7');
 
-      const { getByLabelText } = within(quickTips);
+      const { getByTestId } = within(quickTips);
 
-      const mainMenu = getByLabelText('Help Center Main Menu');
+      const mainMenu = getByTestId('help_center_container');
       expect(mainMenu).toBeTruthy();
 
       const { queryAllByRole } = within(mainMenu);
@@ -157,9 +177,9 @@ describe('Help Center integration', () => {
     it('should navigate quick tips with tab and enter', async () => {
       const { quickTips, toggleButton } = fixture.editor.helpCenter;
       expect(quickTips).toBeDefined();
-      const { getByLabelText, getByText } = within(quickTips);
+      const { getByTestId, getByText } = within(quickTips);
 
-      const mainMenu = getByLabelText('Help Center Main Menu');
+      const mainMenu = getByTestId('help_center_container');
       expect(mainMenu).toBeTruthy();
 
       const { queryAllByRole } = within(mainMenu);

--- a/packages/story-editor/src/components/helpCenter/karma/helpCenter.karma.js
+++ b/packages/story-editor/src/components/helpCenter/karma/helpCenter.karma.js
@@ -38,13 +38,13 @@ describe('Help Center integration', () => {
   });
 
   describe('Help Center aXe tests', () => {
-    it('should pass accessibility tests from default view', async () => {
+    it('should have no aXe violations from default view', async () => {
       await expectAsync(
         fixture.editor.helpCenter.quickTips
       ).toHaveNoViolations();
     });
 
-    it('should pass accessibility tests from tip view', async () => {
+    it('should have no aXe violations from tip view', async () => {
       const { quickTips } = await fixture.editor.helpCenter;
       const { getByRole } = within(quickTips);
 

--- a/packages/story-editor/src/components/helpCenter/menu/index.js
+++ b/packages/story-editor/src/components/helpCenter/menu/index.js
@@ -18,7 +18,6 @@
  */
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { __ } from '@web-stories-wp/i18n';
 /**
  * Internal dependencies
  */
@@ -42,7 +41,7 @@ const Container = styled.div`
 export function Menu({ onTipSelect = noop, readTips, ...transitionProps }) {
   return (
     <Transitioner {...transitionProps}>
-      <Container aria-label={__('Help Center Main Menu', 'web-stories')}>
+      <Container data-testid="help_center_container">
         <Header />
         <Tips readTips={readTips} onTipSelect={onTipSelect} />
         <Footer />

--- a/packages/story-editor/src/components/inspector/karma/inspectorTabs.karma.js
+++ b/packages/story-editor/src/components/inspector/karma/inspectorTabs.karma.js
@@ -41,7 +41,7 @@ describe('Inspector Tabs integration', () => {
   // TODO: https://github.com/google/web-stories-wp/issues/9943
   // eslint-disable-next-line jasmine/no-disabled-tests
   xdescribe('Inspector Tabs aXe tests', () => {
-    it('should pass accessibility tests', async () => {
+    it('should have no aXe violations', async () => {
       const { documentTab } = fixture.editor.inspector;
 
       // Click document tab

--- a/packages/story-editor/src/components/inspector/karma/inspectorTabs.karma.js
+++ b/packages/story-editor/src/components/inspector/karma/inspectorTabs.karma.js
@@ -37,6 +37,22 @@ describe('Inspector Tabs integration', () => {
     fixture.restore();
   });
 
+  // Disable reason: false positive for aXe violation
+  // TODO: https://github.com/google/web-stories-wp/issues/9943
+  // eslint-disable-next-line jasmine/no-disabled-tests
+  xdescribe('Inspector Tabs aXe tests', () => {
+    it('should pass accessibility tests', async () => {
+      const { documentTab } = fixture.editor.inspector;
+
+      // Click document tab
+      await fixture.events.click(documentTab);
+      // actual color contrast of toggle is 7.1 however it's set on a child span absolutely positioned so aXe doesn't pick it up
+      await expectAsync(
+        fixture.editor.inspector.documentPanel.node
+      ).toHaveNoViolations();
+    });
+  });
+
   describe('keyboard navigation', () => {
     it('should return focus to current tab when pressing mod+alt+3', async () => {
       const { documentTab } = fixture.editor.inspector;

--- a/packages/story-editor/src/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
+++ b/packages/story-editor/src/components/keyboardShortcutsMenu/karma/keyboardShortcuts.karma.js
@@ -196,7 +196,7 @@ describe('Keyboard Shortcuts Menu', () => {
   });
 
   describe('Keyboard Shortcuts Menu should have no aXe accessibility violations', () => {
-    it('should pass accessibility tests with an open menu', async () => {
+    it('should have no aXe violations with an open menu', async () => {
       const { keyboardShortcutsToggle } = fixture.editor.footer;
 
       await fixture.events.click(keyboardShortcutsToggle);

--- a/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
+++ b/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
@@ -45,6 +45,77 @@ describe('LibraryTabs integration', () => {
     fixture.restore();
   });
 
+  describe('library Tabs should have no aXe accessibility violations', () => {
+    // Disable reason: aXe violations
+    // TODO: https://github.com/google/web-stories-wp/issues/
+    // eslint-disable-next-line jasmine/no-disabled-tests
+    xit('Local Media Panel should pass accessibility', async () => {
+      const { mediaTab } = fixture.editor.library;
+      expect(mediaTab).toBeDefined();
+      await fixture.events.click(mediaTab);
+      await expectAsync(mediaTab).toHaveNoViolations();
+      await expectAsync(fixture.editor.library.media).toHaveNoViolations();
+    });
+
+    it('Media 3p Panel should pass accessibility', async () => {
+      // Set local storage to have accepted third party media terms to avoid interruption with dialog
+      localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
+      const { media3pTab } = fixture.editor.library;
+      expect(media3pTab).toBeDefined();
+      // navigate to third party media panel
+      await fixture.events.click(media3pTab);
+      // check tab for violations
+      await expectAsync(media3pTab).toHaveNoViolations();
+      // check panel node for violations
+      await expectAsync(
+        fixture.editor.library.media3p.node
+      ).toHaveNoViolations();
+    });
+
+    it('Text Panel should pass accessibility', async () => {
+      const { textTab } = fixture.editor.library;
+      expect(textTab).toBeDefined();
+      // navigate to text panel
+      await fixture.events.click(textTab);
+      // TODO fix nested interactions GET ISSUE LINK
+      // await expectAsync(textTab).toHaveNoViolations();
+
+      // check panel for violations
+      await expectAsync(fixture.editor.library.text.node).toHaveNoViolations();
+    });
+
+    it('Shapes Panel should pass accessibility', async () => {
+      const { shapesTab } = fixture.editor.library;
+      expect(shapesTab).toBeDefined();
+      // navigate to shapes panel
+      await fixture.events.click(shapesTab);
+      // check tab for violations
+      await expectAsync(shapesTab).toHaveNoViolations();
+      // Just grab the shapes library in the shapes pane
+      // there's some issues with clip path id repetition that
+      // are giving false positives to aXe tests in stickers.
+      const shapesLibrary = fixture.container.querySelector(
+        '[data-testid="shapes-library-pane"]'
+      );
+      expect(shapesLibrary).toBeDefined();
+      await expectAsync(shapesLibrary).toHaveNoViolations();
+    });
+
+    it('Page Templates Panel should pass accessibility', async () => {
+      const { pageTemplatesTab } = fixture.editor.library;
+      expect(pageTemplatesTab).toBeDefined();
+      // navigate to pageTemplates panel
+      await fixture.events.click(pageTemplatesTab);
+      // check tab for violations
+      await expectAsync(pageTemplatesTab).toHaveNoViolations();
+
+      // check pane for violations
+      await expectAsync(
+        fixture.editor.library.pageTemplatesPane.node
+      ).toHaveNoViolations();
+    });
+  });
+
   describe('keyboard navigation', () => {
     beforeEach(async () => {
       localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
@@ -60,7 +131,6 @@ describe('LibraryTabs integration', () => {
         `#library-pane-${paneId}`
       );
       expect(expandedPane).toEqual(expectedPane);
-      await expectAsync(expandedPane).toHaveNoViolations();
       await fixture.waitOnScreen(expectedPane);
     }
 

--- a/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
+++ b/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
@@ -47,7 +47,7 @@ describe('LibraryTabs integration', () => {
 
   describe('library Tabs should have no aXe accessibility violations', () => {
     // Disable reason: aXe violations
-    // TODO: https://github.com/google/web-stories-wp/issues/
+    // TODO: https://github.com/google/web-stories-wp/issues/9954
     // eslint-disable-next-line jasmine/no-disabled-tests
     xit('Local Media Panel should pass accessibility', async () => {
       const { mediaTab } = fixture.editor.library;

--- a/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
+++ b/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
@@ -49,7 +49,7 @@ describe('LibraryTabs integration', () => {
     // Disable reason: aXe violations
     // TODO: https://github.com/google/web-stories-wp/issues/9954
     // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('Local Media Panel should pass accessibility', async () => {
+    xit('Local Media Panel should have no aXe violations', async () => {
       const { mediaTab } = fixture.editor.library;
       expect(mediaTab).toBeDefined();
       await fixture.events.click(mediaTab);
@@ -57,7 +57,7 @@ describe('LibraryTabs integration', () => {
       await expectAsync(fixture.editor.library.media).toHaveNoViolations();
     });
 
-    it('Media 3p Panel should pass accessibility', async () => {
+    it('Media 3p Panel should have no aXe violations', async () => {
       // Set local storage to have accepted third party media terms to avoid interruption with dialog
       localStore.setItemByKey(`${LOCAL_STORAGE_PREFIX.TERMS_MEDIA3P}`, true);
       const { media3pTab } = fixture.editor.library;
@@ -72,7 +72,7 @@ describe('LibraryTabs integration', () => {
       ).toHaveNoViolations();
     });
 
-    it('Text Panel should pass accessibility', async () => {
+    it('Text Panel should have no aXe violations', async () => {
       const { textTab } = fixture.editor.library;
       expect(textTab).toBeDefined();
       // navigate to text panel
@@ -84,7 +84,7 @@ describe('LibraryTabs integration', () => {
       await expectAsync(fixture.editor.library.text.node).toHaveNoViolations();
     });
 
-    it('Shapes Panel should pass accessibility', async () => {
+    it('Shapes Panel should have no aXe violations', async () => {
       const { shapesTab } = fixture.editor.library;
       expect(shapesTab).toBeDefined();
       // navigate to shapes panel
@@ -101,7 +101,7 @@ describe('LibraryTabs integration', () => {
       await expectAsync(shapesLibrary).toHaveNoViolations();
     });
 
-    it('Page Templates Panel should pass accessibility', async () => {
+    it('Page Templates Panel should have no aXe violations', async () => {
       const { pageTemplatesTab } = fixture.editor.library;
       expect(pageTemplatesTab).toBeDefined();
       // navigate to pageTemplates panel

--- a/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
+++ b/packages/story-editor/src/components/library/karma/libraryTabs.karma.js
@@ -60,6 +60,7 @@ describe('LibraryTabs integration', () => {
         `#library-pane-${paneId}`
       );
       expect(expandedPane).toEqual(expectedPane);
+      await expectAsync(expandedPane).toHaveNoViolations();
       await fixture.waitOnScreen(expectedPane);
     }
 

--- a/packages/story-editor/src/components/library/karma/mediaTab.karma.js
+++ b/packages/story-editor/src/components/library/karma/mediaTab.karma.js
@@ -80,11 +80,4 @@ describe('Library Media Tab', () => {
       ).toBeDefined();
     });
   });
-
-  describe('library Media tab should have no aXe accessibility violations', () => {
-    it('should pass accessibility', async () => {
-      const mediaTab = fixture.container.querySelector(`#library-tab-media`);
-      await expectAsync(mediaTab).toHaveNoViolations();
-    });
-  });
 });

--- a/packages/story-editor/src/components/library/karma/mediaTab.karma.js
+++ b/packages/story-editor/src/components/library/karma/mediaTab.karma.js
@@ -80,7 +80,7 @@ describe('Library Media Tab', () => {
       ).toBeDefined();
     });
   });
-  //todo: add axe for all tabs in libraryTabs.karma.js once the text tab is no longer a button within a button see issue #7365
+
   describe('library Media tab should have no aXe accessibility violations', () => {
     it('should pass accessibility', async () => {
       const mediaTab = fixture.container.querySelector(`#library-tab-media`);

--- a/packages/story-editor/src/components/library/panes/media/media3p/providerTabList.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/providerTabList.js
@@ -34,7 +34,7 @@ import { useConfig } from '../../../../../app/config';
 import { PROVIDERS } from '../../../../../app/media/media3p/providerConfiguration';
 import ProviderTab from './providerTab';
 
-const Section = styled.div`
+const Section = styled.div.attrs({ role: 'tablist' })`
   display: flex;
   flex-wrap: wrap;
   margin-top: 16px;
@@ -108,7 +108,7 @@ function ProviderTabList({ providers }) {
   useKeyDownEffect(ref, ['enter', 'space'], selectFocused, [selectFocused]);
 
   return (
-    <Section ref={ref} role="tablist">
+    <Section ref={ref}>
       {providers.map((providerType, index) => (
         <ProviderTab
           key={providerType}

--- a/packages/story-editor/src/components/library/panes/media/media3p/providerTabList.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/providerTabList.js
@@ -108,7 +108,7 @@ function ProviderTabList({ providers }) {
   useKeyDownEffect(ref, ['enter', 'space'], selectFocused, [selectFocused]);
 
   return (
-    <Section ref={ref}>
+    <Section ref={ref} role="tablist">
       {providers.map((providerType, index) => (
         <ProviderTab
           key={providerType}

--- a/packages/story-editor/src/components/library/panes/shapes/shapePreview.js
+++ b/packages/story-editor/src/components/library/panes/shapes/shapePreview.js
@@ -167,9 +167,14 @@ function ShapePreview({ mask, isPreview, index }) {
   // We use rovingTabIndex for navigating so only the first item will have 0 as tabIndex.
   // onClick on Aspect is for the keyboard only.
   return (
-    <Aspect ref={ref} onClick={onClick} tabIndex={index === 0 ? 0 : -1}>
+    <Aspect
+      ref={ref}
+      onClick={onClick}
+      tabIndex={index === 0 ? 0 : -1}
+      aria-label={mask.name}
+    >
       <AspectInner>
-        <ShapePreviewContainer key={mask.type} aria-label={mask.name}>
+        <ShapePreviewContainer key={mask.type}>
           <ShapePreviewSizer />
           {getSVG()}
         </ShapePreviewContainer>

--- a/packages/story-editor/src/components/library/panes/text/textSets/textSets.js
+++ b/packages/story-editor/src/components/library/panes/text/textSets/textSets.js
@@ -81,7 +81,7 @@ function TextSets({ paneRef, filteredTextSets }) {
           columnWidth={TEXT_SET_SIZE}
           rowHeight={TEXT_SET_SIZE}
           onFocus={handleGridFocus}
-          role="list"
+          role="group"
           aria-label={__('Text Set Options', 'web-stories')}
         >
           {rowVirtualizer.virtualItems.map((virtualRow) =>

--- a/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
+++ b/packages/story-editor/src/components/library/panes/text/textSets/textSetsPane.js
@@ -208,7 +208,7 @@ function TextSetsPane({ paneRef }) {
     <SectionContainer id={sectionId}>
       <TitleBar>
         <Headline
-          as="h3"
+          as="h2"
           size={THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.XXX_SMALL}
         >
           {PANE_TEXT.TITLE}

--- a/packages/story-editor/src/karma/fixture/containers/library/text.js
+++ b/packages/story-editor/src/karma/fixture/containers/library/text.js
@@ -29,7 +29,7 @@ export default class Text extends Container {
   }
 
   get textSetList() {
-    return this.getByRole('list', { name: /Text Set Options/ });
+    return this.getByRole('group', { name: /Text Set Options/ });
   }
 
   get textSets() {


### PR DESCRIPTION
## Context

Since #4778 we have a custom toHaveNoViolations() matcher in our Karma test suite to verify that a given node/tree doesn't have any obvious a11y violations.

This aims to add more coverage to existing tests. 

## Summary

Adds aXe violation checks to carousel, checklist, help center, inspector tab, library tabs, library panels. 
Fixes a few small violations, larger efforts are documented in `TODO` with their corresponding test disabled. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

There's still tests that need this check, decided to put up the first chunk to avoid a massive diff for reviewers.. 

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #7530 
