### PR TITLE
Feature allow integration for media upload for other CMS

### DIFF
--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -193,7 +193,7 @@ export const MediaPicker = ({ render, ...props }) => {
       onSelectErrorMessage={onSelectErrorMessage}
       // Only way to access the open function is to dive
       // into the MediaUpload component in the render prop.
-      render={(open) => render({ onClick: open })}
+      render={(open, { ...rest }) => render({ onClick: open, ...rest })}
       {...props}
     />
   );

--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -193,7 +193,9 @@ export const MediaPicker = ({ render, ...props }) => {
       onSelectErrorMessage={onSelectErrorMessage}
       // Only way to access the open function is to dive
       // into the MediaUpload component in the render prop.
-      render={(open, rest = {}) => render({ onClick: open, ...rest })}
+      render={(open, attributes = {}) =>
+        render({ onClick: open, ...attributes })
+      }
       {...props}
     />
   );

--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -193,7 +193,7 @@ export const MediaPicker = ({ render, ...props }) => {
       onSelectErrorMessage={onSelectErrorMessage}
       // Only way to access the open function is to dive
       // into the MediaUpload component in the render prop.
-      render={(open, { ...rest }) => render({ onClick: open, ...rest })}
+      render={(open, rest) => render({ onClick: open, ...(rest ? rest : '') })}
       {...props}
     />
   );

--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -193,7 +193,7 @@ export const MediaPicker = ({ render, ...props }) => {
       onSelectErrorMessage={onSelectErrorMessage}
       // Only way to access the open function is to dive
       // into the MediaUpload component in the render prop.
-      render={(open, rest) => render({ onClick: open, ...(rest ? rest : '') })}
+      render={(open, rest = {}) => render({ onClick: open, ...rest })}
       {...props}
     />
   );

--- a/packages/story-editor/src/components/form/media.js
+++ b/packages/story-editor/src/components/form/media.js
@@ -99,7 +99,7 @@ function MediaInput(
   const { MediaUpload } = useConfig();
 
   const renderMediaIcon = useCallback(
-    (open) => {
+    (open, { ...props }) => {
       // Options available for the media input menu.
       const availableMenuOptions = [
         { label: __('Edit', 'web-stories'), value: 'edit' },
@@ -124,6 +124,7 @@ function MediaInput(
           forwardedRef={forwardedRef}
           value={value}
           {...rest}
+          {...props}
         />
       );
     },

--- a/packages/story-editor/src/components/form/media.js
+++ b/packages/story-editor/src/components/form/media.js
@@ -99,7 +99,7 @@ function MediaInput(
   const { MediaUpload } = useConfig();
 
   const renderMediaIcon = useCallback(
-    (open, props = {}) => {
+    (open, attributes = {}) => {
       // Options available for the media input menu.
       const availableMenuOptions = [
         { label: __('Edit', 'web-stories'), value: 'edit' },
@@ -124,7 +124,7 @@ function MediaInput(
           forwardedRef={forwardedRef}
           value={value}
           {...rest}
-          {...props}
+          {...attributes}
         />
       );
     },

--- a/packages/story-editor/src/components/form/media.js
+++ b/packages/story-editor/src/components/form/media.js
@@ -99,7 +99,7 @@ function MediaInput(
   const { MediaUpload } = useConfig();
 
   const renderMediaIcon = useCallback(
-    (open, props) => {
+    (open, props = {}) => {
       // Options available for the media input menu.
       const availableMenuOptions = [
         { label: __('Edit', 'web-stories'), value: 'edit' },
@@ -124,7 +124,7 @@ function MediaInput(
           forwardedRef={forwardedRef}
           value={value}
           {...rest}
-          {...(props ? props : '')}
+          {...props}
         />
       );
     },

--- a/packages/story-editor/src/components/form/media.js
+++ b/packages/story-editor/src/components/form/media.js
@@ -99,7 +99,7 @@ function MediaInput(
   const { MediaUpload } = useConfig();
 
   const renderMediaIcon = useCallback(
-    (open, { ...props }) => {
+    (open, props) => {
       // Options available for the media input menu.
       const availableMenuOptions = [
         { label: __('Edit', 'web-stories'), value: 'edit' },
@@ -124,7 +124,7 @@ function MediaInput(
           forwardedRef={forwardedRef}
           value={value}
           {...rest}
-          {...props}
+          {...(props ? props : '')}
         />
       );
     },

--- a/packages/story-editor/src/components/library/panes/media/local/mediaPane.js
+++ b/packages/story-editor/src/components/library/panes/media/local/mediaPane.js
@@ -295,14 +295,14 @@ function MediaPane(props) {
   );
 
   const renderUploadButtonIcon = useCallback(
-    (open, rest) => (
+    (open, rest = {}) => (
       <Button
         variant={BUTTON_VARIANTS.SQUARE}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         onClick={open}
         aria-label={__('Upload', 'web-stories')}
-        {...(rest ? rest : '')}
+        {...rest}
       >
         <Icons.ArrowCloud />
       </Button>
@@ -311,13 +311,13 @@ function MediaPane(props) {
   );
 
   const renderUploadButton = useCallback(
-    (open, rest) => (
+    (open, rest = {}) => (
       <Button
         variant={BUTTON_VARIANTS.RECTANGLE}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         onClick={open}
-        {...(rest ? rest : '')}
+        {...rest}
       >
         {__('Upload', 'web-stories')}
       </Button>

--- a/packages/story-editor/src/components/library/panes/media/local/mediaPane.js
+++ b/packages/story-editor/src/components/library/panes/media/local/mediaPane.js
@@ -295,14 +295,14 @@ function MediaPane(props) {
   );
 
   const renderUploadButtonIcon = useCallback(
-    (open, { ...rest }) => (
+    (open, rest) => (
       <Button
         variant={BUTTON_VARIANTS.SQUARE}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         onClick={open}
         aria-label={__('Upload', 'web-stories')}
-        {...rest}
+        {...(rest ? rest : '')}
       >
         <Icons.ArrowCloud />
       </Button>
@@ -311,13 +311,13 @@ function MediaPane(props) {
   );
 
   const renderUploadButton = useCallback(
-    (open, { ...rest }) => (
+    (open, rest) => (
       <Button
         variant={BUTTON_VARIANTS.RECTANGLE}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         onClick={open}
-        {...rest}
+        {...(rest ? rest : '')}
       >
         {__('Upload', 'web-stories')}
       </Button>

--- a/packages/story-editor/src/components/library/panes/media/local/mediaPane.js
+++ b/packages/story-editor/src/components/library/panes/media/local/mediaPane.js
@@ -295,13 +295,14 @@ function MediaPane(props) {
   );
 
   const renderUploadButtonIcon = useCallback(
-    (open) => (
+    (open, { ...rest }) => (
       <Button
         variant={BUTTON_VARIANTS.SQUARE}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         onClick={open}
         aria-label={__('Upload', 'web-stories')}
+        {...rest}
       >
         <Icons.ArrowCloud />
       </Button>
@@ -310,12 +311,13 @@ function MediaPane(props) {
   );
 
   const renderUploadButton = useCallback(
-    (open) => (
+    (open, { ...rest }) => (
       <Button
         variant={BUTTON_VARIANTS.RECTANGLE}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         onClick={open}
+        {...rest}
       >
         {__('Upload', 'web-stories')}
       </Button>

--- a/packages/story-editor/src/components/library/panes/media/local/mediaPane.js
+++ b/packages/story-editor/src/components/library/panes/media/local/mediaPane.js
@@ -295,14 +295,14 @@ function MediaPane(props) {
   );
 
   const renderUploadButtonIcon = useCallback(
-    (open, rest = {}) => (
+    (open, attributes = {}) => (
       <Button
         variant={BUTTON_VARIANTS.SQUARE}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         onClick={open}
         aria-label={__('Upload', 'web-stories')}
-        {...rest}
+        {...attributes}
       >
         <Icons.ArrowCloud />
       </Button>
@@ -311,13 +311,13 @@ function MediaPane(props) {
   );
 
   const renderUploadButton = useCallback(
-    (open, rest = {}) => (
+    (open, attributes = {}) => (
       <Button
         variant={BUTTON_VARIANTS.RECTANGLE}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         onClick={open}
-        {...rest}
+        {...attributes}
       >
         {__('Upload', 'web-stories')}
       </Button>

--- a/packages/story-editor/src/components/panels/design/captions/captions.js
+++ b/packages/story-editor/src/components/panels/design/captions/captions.js
@@ -60,11 +60,6 @@ const StyledFileInput = styled(Input)(
         color: ${theme.colors.fg.primary};
       }
     `};
-  
-      * > input:disabled {
-        color: ${theme.colors.fg.primary};
-      }
-    `};
   `
 );
 

--- a/packages/story-editor/src/components/panels/design/captions/captions.js
+++ b/packages/story-editor/src/components/panels/design/captions/captions.js
@@ -60,6 +60,11 @@ const StyledFileInput = styled(Input)(
         color: ${theme.colors.fg.primary};
       }
     `};
+  
+      * > input:disabled {
+        color: ${theme.colors.fg.primary};
+      }
+    `};
   `
 );
 
@@ -151,7 +156,7 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
   const captionText = __('Upload a file', 'web-stories');
 
   const renderUploadButton = useCallback(
-    (open) => (
+    (open, { ...rest }) => (
       <UploadButton
         css={highlight?.showEffect && styles.OUTLINE}
         onAnimationEnd={() => resetHighlight()}
@@ -164,6 +169,7 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.RECTANGLE}
+        {...rest}
       >
         {captionText}
       </UploadButton>

--- a/packages/story-editor/src/components/panels/design/captions/captions.js
+++ b/packages/story-editor/src/components/panels/design/captions/captions.js
@@ -60,6 +60,11 @@ const StyledFileInput = styled(Input)(
         color: ${theme.colors.fg.primary};
       }
     `};
+  
+      * > input:disabled {
+        color: ${theme.colors.fg.primary};
+      }
+    `};
   `
 );
 
@@ -151,7 +156,7 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
   const captionText = __('Upload a file', 'web-stories');
 
   const renderUploadButton = useCallback(
-    (open, rest) => (
+    (open, rest = {}) => (
       <UploadButton
         css={highlight?.showEffect && styles.OUTLINE}
         onAnimationEnd={() => resetHighlight()}
@@ -164,7 +169,7 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.RECTANGLE}
-        {...(rest ? rest : '')}
+        {...rest}
       >
         {captionText}
       </UploadButton>

--- a/packages/story-editor/src/components/panels/design/captions/captions.js
+++ b/packages/story-editor/src/components/panels/design/captions/captions.js
@@ -156,7 +156,7 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
   const captionText = __('Upload a file', 'web-stories');
 
   const renderUploadButton = useCallback(
-    (open, { ...rest }) => (
+    (open) => (
       <UploadButton
         css={highlight?.showEffect && styles.OUTLINE}
         onAnimationEnd={() => resetHighlight()}
@@ -169,7 +169,6 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.RECTANGLE}
-        {...rest}
       >
         {captionText}
       </UploadButton>

--- a/packages/story-editor/src/components/panels/design/captions/captions.js
+++ b/packages/story-editor/src/components/panels/design/captions/captions.js
@@ -60,6 +60,11 @@ const StyledFileInput = styled(Input)(
         color: ${theme.colors.fg.primary};
       }
     `};
+  
+      * > input:disabled {
+        color: ${theme.colors.fg.primary};
+      }
+    `};
   `
 );
 
@@ -151,7 +156,7 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
   const captionText = __('Upload a file', 'web-stories');
 
   const renderUploadButton = useCallback(
-    (open) => (
+    (open, rest) => (
       <UploadButton
         css={highlight?.showEffect && styles.OUTLINE}
         onAnimationEnd={() => resetHighlight()}
@@ -164,6 +169,7 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.RECTANGLE}
+        {...(rest ? rest : '')}
       >
         {captionText}
       </UploadButton>

--- a/packages/story-editor/src/components/panels/design/captions/captions.js
+++ b/packages/story-editor/src/components/panels/design/captions/captions.js
@@ -60,6 +60,11 @@ const StyledFileInput = styled(Input)(
         color: ${theme.colors.fg.primary};
       }
     `};
+  
+      * > input:disabled {
+        color: ${theme.colors.fg.primary};
+      }
+    `};
   `
 );
 
@@ -151,7 +156,7 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
   const captionText = __('Upload a file', 'web-stories');
 
   const renderUploadButton = useCallback(
-    (open, rest = {}) => (
+    (open, attributes = {}) => (
       <UploadButton
         css={highlight?.showEffect && styles.OUTLINE}
         onAnimationEnd={() => resetHighlight()}
@@ -164,7 +169,7 @@ function CaptionsPanel({ selectedElements, pushUpdate }) {
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.RECTANGLE}
-        {...rest}
+        {...attributes}
       >
         {captionText}
       </UploadButton>

--- a/packages/story-editor/src/components/panels/shared/backgroundAudioPanelContent.js
+++ b/packages/story-editor/src/components/panels/shared/backgroundAudioPanelContent.js
@@ -80,13 +80,13 @@ function BackgroundAudioPanelContent({
   );
 
   const renderUploadButton = useCallback(
-    (open, rest = {}) => (
+    (open, attributes = {}) => (
       <UploadButton
         onClick={open}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.RECTANGLE}
-        {...rest}
+        {...attributes}
       >
         {__('Upload an audio file', 'web-stories')}
       </UploadButton>

--- a/packages/story-editor/src/components/panels/shared/backgroundAudioPanelContent.js
+++ b/packages/story-editor/src/components/panels/shared/backgroundAudioPanelContent.js
@@ -80,12 +80,13 @@ function BackgroundAudioPanelContent({
   );
 
   const renderUploadButton = useCallback(
-    (open) => (
+    (open, { ...rest }) => (
       <UploadButton
         onClick={open}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.RECTANGLE}
+        {...rest}
       >
         {__('Upload an audio file', 'web-stories')}
       </UploadButton>

--- a/packages/story-editor/src/components/panels/shared/backgroundAudioPanelContent.js
+++ b/packages/story-editor/src/components/panels/shared/backgroundAudioPanelContent.js
@@ -80,13 +80,13 @@ function BackgroundAudioPanelContent({
   );
 
   const renderUploadButton = useCallback(
-    (open, { ...rest }) => (
+    (open, rest) => (
       <UploadButton
         onClick={open}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.RECTANGLE}
-        {...rest}
+        {...(rest ? rest : '')}
       >
         {__('Upload an audio file', 'web-stories')}
       </UploadButton>

--- a/packages/story-editor/src/components/panels/shared/backgroundAudioPanelContent.js
+++ b/packages/story-editor/src/components/panels/shared/backgroundAudioPanelContent.js
@@ -80,13 +80,13 @@ function BackgroundAudioPanelContent({
   );
 
   const renderUploadButton = useCallback(
-    (open, rest) => (
+    (open, rest = {}) => (
       <UploadButton
         onClick={open}
         type={BUTTON_TYPES.SECONDARY}
         size={BUTTON_SIZES.SMALL}
         variant={BUTTON_VARIANTS.RECTANGLE}
-        {...(rest ? rest : '')}
+        {...rest}
       >
         {__('Upload an audio file', 'web-stories')}
       </UploadButton>

--- a/packages/wp-story-editor/src/components/mediaUpload/index.js
+++ b/packages/wp-story-editor/src/components/mediaUpload/index.js
@@ -25,8 +25,10 @@ import { useMediaPicker } from './mediaPicker';
 
 function MediaUpload({ render, ...rest }) {
   const open = useMediaPicker(rest);
-
-  return render(open);
+  const attributes = {
+    'data-bs-toggle': 'bs-toggle',
+  };
+  return render(open, attributes);
 }
 
 MediaUpload.propTypes = {

--- a/packages/wp-story-editor/src/components/mediaUpload/index.js
+++ b/packages/wp-story-editor/src/components/mediaUpload/index.js
@@ -25,10 +25,7 @@ import { useMediaPicker } from './mediaPicker';
 
 function MediaUpload({ render, ...rest }) {
   const open = useMediaPicker(rest);
-  const attributes = {
-    'data-bs-toggle': 'bs-toggle',
-  };
-  return render(open, attributes);
+  return render(open);
 }
 
 MediaUpload.propTypes = {

--- a/packages/wp-story-editor/src/components/mediaUpload/index.js
+++ b/packages/wp-story-editor/src/components/mediaUpload/index.js
@@ -25,6 +25,7 @@ import { useMediaPicker } from './mediaPicker';
 
 function MediaUpload({ render, ...rest }) {
   const open = useMediaPicker(rest);
+
   return render(open);
 }
 


### PR DESCRIPTION
## Context
Some CMS may not provide a `MediaModal` like WordPress does, this PR aims to provide some flexibility to creators who want to add some props via `CMS-Story-Editor` component like `wp-story-editor`. These attributes may be `data-bs-*` which will help integrators provide their own modal while integrating with other CMS.

## Summary

## Relevant Technical Choices

## To-do

## User-facing changes

## Testing Instructions

1. Pass some attributes via `MediaUpload` component from `wp-story-editor` [File](https://github.com/google/web-stories-wp/blob/1f0aee89b1a6e028136a2a6a33dfc4b880e6daab/packages/wp-story-editor/src/components/mediaUpload/index.js)
2. Create an object with attributes.
3. Pass them via the `render` function.
4. Check the `elements` in developer tools.
5. Search for the button which opens the WordPress `MediaModal`.
6. You should now see the attribute which you had passed.

- [x] This is a non-user-facing change and requires no QA

This PR can be tested by following these steps:


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9927
