### PR TITLE
Hotfix `scheduledtransition` not able to get ref

### DIFF
--- a/packages/story-editor/src/components/transition/scheduledTransition.js
+++ b/packages/story-editor/src/components/transition/scheduledTransition.js
@@ -16,7 +16,14 @@
 /**
  * External dependencies
  */
-import { useReducer, useEffect, useState, useRef } from '@web-stories-wp/react';
+import {
+  useReducer,
+  useEffect,
+  useState,
+  useRef,
+  forwardRef,
+  cloneElement,
+} from '@web-stories-wp/react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';
 
@@ -43,7 +50,7 @@ const reducer = (state, action) => machine.states[state]?.[action] || state;
 // render of default styles while keeping timeout in sync
 // with state. Fixes issues discussed here:
 // https://github.com/reactjs/react-transition-group/issues/284#issuecomment-771037685
-export function Interpreter({ state, children }) {
+export const Interpreter = forwardRef(({ state, children }, ref) => {
   const [scheduledState, dispatch] = useReducer(
     reducer,
     state === entered ? state : machine.initial
@@ -75,8 +82,10 @@ export function Interpreter({ state, children }) {
   const isPrematureEntrance =
     [exiting].includes(scheduledState) && [entering, entered].includes(state);
   const shouldUseBaseState = isPrematureEntrance || isPrematureExit;
-  return children(shouldUseBaseState ? state : scheduledState);
-}
+  return cloneElement(children(shouldUseBaseState ? state : scheduledState), {
+    ref,
+  });
+});
 
 export function ScheduledTransition({ children, ...props }) {
   const nodeRef = useRef();


### PR DESCRIPTION
## Context
After recent PR #9951 got merged we see an error in console 
![image](https://user-images.githubusercontent.com/59614577/145572303-0d75a922-3e04-4e97-af5f-69f483deee98.png)



## Summary

It came to light that `ScheduledTransition` was not able to get the ref of its child. The `ScheduledTransition` uses the component `Transition` from the `react-transition-group` library. `Transition` requires the `nodeRef` for detecting which element has to be transitioned ([reference link](https://reactcommunity.org/react-transition-group/transition)). Since `Interpreter` component just returned children, there is no way possible to attach `ref` to the children in the same file. Therefore we need to clone the element and pass `ref` as config. The other way is to pass `nodeRef` to `ScheduledTransition` and `ref` to the first child of `ScheduledTransition`.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9950
Related #9951 