### PR TITLE
Media: Use smaller video poster image size for base color generation

### DIFF
--- a/packages/story-editor/src/app/media/utils/useDetectBaseColor.js
+++ b/packages/story-editor/src/app/media/utils/useDetectBaseColor.js
@@ -103,7 +103,7 @@ function useDetectBaseColor({ updateMediaElement }) {
         // Do nothing for now.
       }
     },
-    [getProxiedUrl, saveBaseColor]
+    [getProxiedUrl, getPosterMediaById, saveBaseColor]
   );
 
   return {

--- a/packages/story-editor/src/app/media/utils/useDetectBaseColor.js
+++ b/packages/story-editor/src/app/media/utils/useDetectBaseColor.js
@@ -30,7 +30,7 @@ import useCORSProxy from '../../../utils/useCORSProxy';
 
 function useDetectBaseColor({ updateMediaElement }) {
   const {
-    actions: { updateMedia },
+    actions: { updateMedia, getPosterMediaById },
   } = useAPI();
   const { updateElementsByResourceId } = useStory((state) => ({
     updateElementsByResourceId: state.actions.updateElementsByResourceId,
@@ -80,9 +80,18 @@ function useDetectBaseColor({ updateMediaElement }) {
 
   const updateBaseColor = useCallback(
     async ({ resource }) => {
-      const { type, poster } = resource;
-      const imageSrc =
-        type === 'image' ? getSmallestUrlForWidth(0, resource) : poster;
+      const { type, poster, id, isExternal } = resource;
+      let imageSrc = poster;
+
+      if (type === 'image') {
+        imageSrc = getSmallestUrlForWidth(0, resource);
+      } else if (!isExternal) {
+        const posterResource = await getPosterMediaById(id);
+        if (posterResource) {
+          imageSrc = getSmallestUrlForWidth(0, posterResource);
+        }
+      }
+
       if (!imageSrc) {
         return;
       }

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -139,13 +139,13 @@ export async function getOptimizedMediaById(config, mediaId) {
 export async function getPosterMediaById(config, mediaId) {
   const path = addQueryArgs(`${config.api.media}${mediaId}/`, {
     context: 'edit',
-    _fields: 'meta.web_stories_poster_id',
+    _fields: 'featured_media',
   });
 
   const result = await apiFetch({ path });
 
-  if (result?.meta?.web_stories_poster_id) {
-    return getMediaById(config, result.meta.web_stories_poster_id);
+  if (result?.featured_media) {
+    return getMediaById(config, result.featured_media);
   }
 
   return null;

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -130,6 +130,28 @@ export async function getOptimizedMediaById(config, mediaId) {
 }
 
 /**
+ * Get the poster of a given media resource.
+ *
+ * @param {Object} config Configuration object.
+ * @param {number} mediaId Media ID.
+ * @return {Promise<import('@web-stories-wp/media').Resource>} Media resource if found, null otherwise.
+ */
+export async function getPosterMediaById(config, mediaId) {
+  const path = addQueryArgs(`${config.api.media}${mediaId}/`, {
+    context: 'edit',
+    _fields: 'meta.web_stories_poster_id',
+  });
+
+  const result = await apiFetch({ path });
+
+  if (result?.meta?.web_stories_poster_id) {
+    return getMediaById(config, result.meta.web_stories_poster_id);
+  }
+
+  return null;
+}
+
+/**
  * Upload file to via REST API.
  *
  * @param {Object} config Configuration object.
@@ -152,6 +174,7 @@ export function uploadMedia(config, file, additionalData) {
     method: 'POST',
   }).then((attachment) => getResourceFromAttachment(attachment));
 }
+
 /**
  * Update Existing media.
  *


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Make a api call to get the poster image and using a smaller image size, so it make the base color generation much faster. 

### Before
<img width="420" alt="Screenshot 2021-12-10 at 00 23 09" src="https://user-images.githubusercontent.com/237508/145628519-7e86dcf7-2742-4331-bc71-27086db87c64.png">

### After
<img width="454" alt="Screenshot 2021-12-10 at 00 21 46" src="https://user-images.githubusercontent.com/237508/145628528-ce980746-b48f-435f-9f5a-97a8fcc6b9ed.png">


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
