### PR TITLE
Embeds: Disable Customizer integration for block themes

### DIFF
--- a/includes/Admin/Customizer.php
+++ b/includes/Admin/Customizer.php
@@ -26,6 +26,7 @@
 
 namespace Google\Web_Stories\Admin;
 
+use Google\Web_Stories\Infrastructure\Conditional;
 use Google\Web_Stories\Settings;
 use Google\Web_Stories\Stories_Script_Data;
 use Google\Web_Stories\Story_Post_Type;
@@ -42,7 +43,7 @@ use WP_Error;
  *
  * @package Google\Web_Stories
  */
-class Customizer extends Service_Base {
+class Customizer extends Service_Base implements Conditional {
 
 	/**
 	 * Customizer section slug.
@@ -122,6 +123,17 @@ class Customizer extends Service_Base {
 	 */
 	public function register() {
 		add_action( 'customize_register', [ $this, 'register_customizer_settings' ] );
+	}
+
+	/**
+	 * Check whether the conditional object is currently needed.
+	 *
+	 * @since 1.16.0
+	 *
+	 * @return bool Whether the conditional object is needed.
+	 */
+	public static function is_needed(): bool {
+		return ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme();
 	}
 
 	/**

--- a/includes/Admin/Customizer.php
+++ b/includes/Admin/Customizer.php
@@ -133,11 +133,7 @@ class Customizer extends Service_Base implements Conditional {
 	 * @return bool Whether the conditional object is needed.
 	 */
 	public static function is_needed(): bool {
-		if ( function_exists( '\wp_is_block_theme' ) ) {
-			return ! wp_is_block_theme();
-		}
-
-		return true;
+		return ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme();
 	}
 
 	/**

--- a/includes/Admin/Customizer.php
+++ b/includes/Admin/Customizer.php
@@ -133,7 +133,11 @@ class Customizer extends Service_Base implements Conditional {
 	 * @return bool Whether the conditional object is needed.
 	 */
 	public static function is_needed(): bool {
-		return ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme();
+		if ( function_exists( '\wp_is_block_theme' ) ) {
+			return ! wp_is_block_theme();
+		}
+
+		return true;
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/Admin/Customizer.php
+++ b/tests/phpunit/integration/tests/Admin/Customizer.php
@@ -69,6 +69,13 @@ class Customizer extends DependencyInjectedTestCase {
 	}
 
 	/**
+	 * @covers ::is_needed
+	 */
+	public function test_is_needed() {
+		$this->assertTrue( $this->instance::is_needed() );
+	}
+
+	/**
 	 * Add theme support for web stories.
 	 */
 	private function add_web_stories_theme_support() {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Make Customizer class conditional. This class is not needed in block based themes. 


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

See #9622 
See #9733