### PR TITLE
REST API: Cater for changes to author queries in WordPress 5.9

### DIFF
--- a/includes/REST_API/Stories_Users_Controller.php
+++ b/includes/REST_API/Stories_Users_Controller.php
@@ -106,9 +106,9 @@ class Stories_Users_Controller extends WP_REST_Users_Controller implements Servi
 	 *
 	 * @since 1.16.0
 	 *
-	 * @param array $prepared_args
+	 * @param array $prepared_args Array of arguments for WP_User_Query.
 	 *
-	 * @return array $prepared_args
+	 * @return array Filtered args.
 	 */
 	public function filter_user_query( $prepared_args ) {
 		global $wpdb;
@@ -138,7 +138,7 @@ class Stories_Users_Controller extends WP_REST_Users_Controller implements Servi
 				$meta_query->queries = array_merge( $meta_query->queries, $new_meta_query );
 			}
 
-			$prepared_args['meta_query'] = $meta_query->queries;
+			$prepared_args['meta_query'] = $meta_query->queries; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			unset( $prepared_args['who'] );
 		}
 

--- a/tests/phpunit/integration/tests/REST_API/Stories_Users_Controller.php
+++ b/tests/phpunit/integration/tests/REST_API/Stories_Users_Controller.php
@@ -74,6 +74,76 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 	}
 
 	/**
+	 * @covers ::filter_user_query
+	 */
+	public function test_filter_user_query() {
+		$results = $this->controller->filter_user_query( [ 'who' => 'authors' ] );
+		$this->assertEqualSets(
+			[
+				'meta_query' => [
+					[
+						'key'     => 'wptests_user_level',
+						'value'   => 0,
+						'compare' => '!=',
+					],
+				],
+			],
+			$results
+		);
+	}
+
+	/**
+	 * @covers ::filter_user_query
+	 */
+	public function test_filter_user_query_meta_query() {
+		$results = $this->controller->filter_user_query(
+			[
+				'who'        => 'authors',
+				'meta_query' => [
+					[
+						'key'     => 'age',
+						'value'   => [ 20, 30 ],
+						'type'    => 'numeric',
+						'compare' => 'BETWEEN',
+					],
+				],
+			]
+		);
+
+		$this->assertEqualSets(
+			[
+				'meta_query' => [
+					'relation' => 'AND',
+					[
+						'key'     => 'age',
+						'value'   => [ 20, 30 ],
+						'type'    => 'numeric',
+						'compare' => 'BETWEEN',
+					],
+					[
+						'key'     => 'wptests_user_level',
+						'value'   => 0,
+						'compare' => '!=',
+					],
+				],
+			],
+			$results
+		);
+	}
+
+	/**
+	 * @covers ::filter_user_query
+	 */
+	public function test_filter_user_query_no_change() {
+		$args    = [
+			'orderby' => 'registered',
+			'order'   => 'ASC',
+		];
+		$results = $this->controller->filter_user_query( $args );
+		$this->assertEqualSets( $args, $results );
+	}
+
+	/**
 	 * @covers ::user_posts_count_public
 	 * @covers \Google\Web_Stories\Story_Post_Type::clear_user_posts_count
 	 */
@@ -139,7 +209,7 @@ class Stories_Users_Controller extends DependencyInjectedRestTestCase {
 			[
 				-1,
 				$post_type->get_slug(),
-			] 
+			]
 		);
 		$this->assertEquals( 0, $result1 );
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Who param on the WP_User_Query was removed as part of WP 5.9. This change, stops a doing it wrong notice. 

Part of fixes for 5.9 https://github.com/google/web-stories-wp/issues/9733

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
