### PR TITLE
Code Quality: Increase aXe Coverage in Story Editor

### DIFF
--- a/packages/design-system/src/components/slider/index.js
+++ b/packages/design-system/src/components/slider/index.js
@@ -273,7 +273,8 @@ function Slider({
           max={max}
           thumbSize={thumbSize}
           width={widthTracker}
-          aria-valuenow={printValue}
+          aria-valuenow={value}
+          aria-valuetext={printValue}
           {...rest}
         />
         <FakeThumb

--- a/packages/story-editor/src/components/footer/carousel/karma/carouselDrawer.karma.js
+++ b/packages/story-editor/src/components/footer/carousel/karma/carouselDrawer.karma.js
@@ -27,7 +27,7 @@ describe('Carousel Drawer', () => {
   beforeEach(async () => {
     fixture = new Fixture();
     await fixture.render();
-
+    await fixture.collapseHelpCenter();
     // We add some content to the first page to make the thumbnail more interesting
     await fixture.events.click(fixture.editor.library.media.item(0));
   });
@@ -122,6 +122,20 @@ describe('Carousel Drawer', () => {
 
       expect(fixture.editor.footer.carousel.pages.length).toBe(1 + EXTRA_PAGES);
       await fixture.snapshot('Re-expanded');
+    });
+
+    it('should have no aXe violations while carousel is expanded', async () => {
+      await expectAsync(
+        fixture.editor.footer.carousel.node
+      ).toHaveNoViolations();
+    });
+
+    it('should have no aXe violations while carousel is collapsed', async () => {
+      await fixture.events.click(fixture.editor.footer.carousel.toggle);
+      await fixture.events.sleep(TOGGLE_DURATION);
+      await expectAsync(
+        fixture.editor.footer.carousel.node
+      ).toHaveNoViolations();
     });
   });
 });

--- a/packages/story-editor/src/components/footer/gridview/karma/gridView.karma.js
+++ b/packages/story-editor/src/components/footer/gridview/karma/gridView.karma.js
@@ -67,6 +67,10 @@ describe('GridView integration', () => {
     expect(fixture.editor.gridView.node).toBeTruthy();
   });
 
+  it('should have no aXe violations', async () => {
+    await expectAsync(fixture.editor.gridView.node).toHaveNoViolations();
+  });
+
   it('should use tab to jump between the "Back" button, Preview Size control, and page list', async () => {
     // Tab cycle: Back -> Page Size range -> Active/previously focused Page in Page List
 

--- a/packages/story-editor/src/elements/image/karma/edit.karma.js
+++ b/packages/story-editor/src/elements/image/karma/edit.karma.js
@@ -71,6 +71,12 @@ describe('Image Editor', () => {
         await fixture.snapshot();
       });
 
+      it('should have no aXe violations', async () => {
+        await expectAsync(
+          fixture.editor.canvas.editLayer.node
+        ).toHaveNoViolations();
+      });
+
       it('should allow image to be scaled and moved using mouse', async () => {
         const image = fixture.editor.canvas.editLayer.media;
         const originalRect = image.getBoundingClientRect();

--- a/packages/story-editor/src/elements/media/edit.js
+++ b/packages/story-editor/src/elements/media/edit.js
@@ -295,6 +295,7 @@ function MediaEdit({ element, box, setLocalProperties }) {
       )}
 
       <ScalePanel
+        aria-label={__('Scale media', 'web-stories')}
         data-testid="edit-panel-slider"
         setProperties={updateLocalProperties}
         x={x}


### PR DESCRIPTION
## Context

_Follow up to #9955_
Since #4778 we have a custom toHaveNoViolations() matcher in our Karma test suite to verify that a given node/tree doesn't have any obvious a11y violations.

This aims to add more coverage to existing tests.

## Summary

Adds aXe violation checks to media edit (zoom), footer carousel drawer and grid view.

## Relevant Technical Choices

2 fixes for the media edit component to pass aXe check
- the panel for scale didn't have a label, added one as "Scale media" 
- [`aria-valuenow` needs to be a number and it should be paired with `aria-valuetext`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-valuenow_attribute). Updated `aria-valuenow` to be `value` and added in `aria-valuetext` as the `printValue` which was formerly used as the `valuenow` value. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

Verify karma tests pass and updates to media edit are valid.

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #7530 
