### PR TITLE
Video Trimmer: Fix for blank frames in video trimmer frames strip

### DIFF
--- a/packages/media/src/generateVideoStrip.js
+++ b/packages/media/src/generateVideoStrip.js
@@ -74,8 +74,8 @@ async function generateVideoStrip(element, resource, stripWidth, stripHeight) {
   // Calculate the offset between each frame to be grabbed
   const frameDistance = length / (frameCount - 1);
 
-  // Preload video and adjust size
-  const video = await preloadVideo(src);
+  // Preload video and adjust size. Skipping the first ms to prevent blank frames in chrome.
+  const video = await preloadVideo(`${src}#t=0.000001`);
   video.width = videoWidth;
   video.height = videoHeight;
 

--- a/packages/media/src/generateVideoStrip.js
+++ b/packages/media/src/generateVideoStrip.js
@@ -74,10 +74,13 @@ async function generateVideoStrip(element, resource, stripWidth, stripHeight) {
   // Calculate the offset between each frame to be grabbed
   const frameDistance = length / (frameCount - 1);
 
-  // Preload video and adjust size. Skipping the first ms to prevent blank frames in chrome.
-  const video = await preloadVideo(`${src}#t=0.000001`);
+  // Preload video and adjust size
+  const video = await preloadVideo(src);
   video.width = videoWidth;
   video.height = videoHeight;
+
+  // Skipping the first fraction of a millisecond to prevent blank frames in chrome
+  await seekVideo(video, 0.000001);
 
   // Create the target canvas
   const canvas = document.createElement('canvas');


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

In the video trimmer framers strip, It looks like trying to grab the  frames after the `canplay` event fires creates mixed results with the frames successfully extracted in FF but failing in chrome which returns a blank/transparent frame.

## Summary

<!-- A brief description of what this PR does. -->

The least disruptive solution I found was to skip the first fraction of a ms  ~~by simply adding `#t=0.000001` at the end of the video file url~~. This works for both FF and Chrome. 


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

| Before | After |
|--------|-------|
|  ![Screenshot 2021-12-14 at 18 25 52](https://user-images.githubusercontent.com/276316/146027844-e44f903f-042b-4a2d-99d8-ab0a78320db0.png)  |  ![Screenshot 2021-12-14 at 18 22 48](https://user-images.githubusercontent.com/276316/146027977-862f314c-aeaa-494b-97ea-bdb4770af8c3.png)  |

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->



<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a video to a page in chrome.
2. Toggle video trim mode
3. Verify there are no blank frames (white space) at the start of the frames strip.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->
No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->
No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9870
