### PR TITLE
Media: Add filter to disable potentially expensive tax query

### DIFF
--- a/includes/Media/Media_Source_Taxonomy.php
+++ b/includes/Media/Media_Source_Taxonomy.php
@@ -214,7 +214,7 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 	 */
 	private function get_exclude_tax_query( array $args ): array {
 		/**
-		 * Filter whether the query should be filtered.
+		 * Filter whether generated attachments should be hidden in the media library.
 		 *
 		 * @since 1.16.0
 		 *

--- a/includes/Media/Media_Source_Taxonomy.php
+++ b/includes/Media/Media_Source_Taxonomy.php
@@ -221,7 +221,7 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 		 * @param bool  $enabled Whether the taxonomy check should be applied.
 		 * @param array $args    Existing WP_Query args.
 		 */
-		$enabled = apply_filters( 'web_stories_enable_exclude_query', true, $args );
+		$enabled = apply_filters( 'web_stories_hide_auto_generated_attachments', true, $args );
 		if ( true !== $enabled ) {
 			return $args;
 		}

--- a/includes/Media/Media_Source_Taxonomy.php
+++ b/includes/Media/Media_Source_Taxonomy.php
@@ -213,6 +213,19 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 	 * @return array  Tax query arg.
 	 */
 	private function get_exclude_tax_query( array $args ): array {
+		/**
+		 * Filter whether the query should be filtered.
+		 *
+		 * @since 1.16.0
+		 *
+		 * @param bool  $enabled Whether the taxonomy check should be applied.
+		 * @param array $args    Existing WP_Query args.
+		 */
+		$enabled = apply_filters( 'web_stories_enable_exclude_query', true, $args );
+		if ( true !== $enabled ) {
+			return $args;
+		}
+
 		$tax_query = [
 			[
 				'taxonomy' => $this->taxonomy_slug,

--- a/tests/phpunit/integration/tests/Media/Media_Source_Taxonomy.php
+++ b/tests/phpunit/integration/tests/Media/Media_Source_Taxonomy.php
@@ -179,6 +179,25 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 	}
 
 	/**
+	 * @covers ::get_exclude_tax_query
+	 */
+	public function test_get_exclude_tax_query_filter() {
+		add_filter( 'web_stories_enable_exclude_query', '__return_false' );
+		$args    = [
+			'tax_query' => [
+				[
+					'taxonomy' => 'people',
+					'field'    => 'slug',
+					'terms'    => 'bob',
+				],
+			],
+		];
+		$results = $this->call_private_method( $this->instance, 'get_exclude_tax_query', [ $args ] );
+		remove_filter( 'web_stories_enable_exclude_query', '__return_false' );
+		$this->assertSame( $args, $results );
+	}
+
+	/**
 	 * @covers ::filter_ajax_query_attachments_args
 	 * @covers ::get_exclude_tax_query
 	 */

--- a/tests/phpunit/integration/tests/Media/Media_Source_Taxonomy.php
+++ b/tests/phpunit/integration/tests/Media/Media_Source_Taxonomy.php
@@ -182,7 +182,7 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 	 * @covers ::get_exclude_tax_query
 	 */
 	public function test_get_exclude_tax_query_filter() {
-		add_filter( 'web_stories_enable_exclude_query', '__return_false' );
+		add_filter( 'web_stories_hide_auto_generated_attachments', '__return_false' );
 		$args    = [
 			'tax_query' => [
 				[
@@ -193,7 +193,7 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 			],
 		];
 		$results = $this->call_private_method( $this->instance, 'get_exclude_tax_query', [ $args ] );
-		remove_filter( 'web_stories_enable_exclude_query', '__return_false' );
+		remove_filter( 'web_stories_hide_auto_generated_attachments', '__return_false' );
 		$this->assertSame( $args, $results );
 	}
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Add a filter to disable attachment filtering. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9853
