### PR TITLE
Media Library: Fix video posters not showing in Safari

### DIFF
--- a/packages/story-editor/src/components/library/panes/media/common/innerElement.js
+++ b/packages/story-editor/src/components/library/panes/media/common/innerElement.js
@@ -211,6 +211,7 @@ function InnerElement({
             )
           ) : (
             <source
+              /** Force video to seek, so that safari will render poster image */
               src={getSmallestUrlForWidth(width, resource) + '#t=0.000001'}
               type={mimeType}
             />

--- a/packages/story-editor/src/components/library/panes/media/common/innerElement.js
+++ b/packages/story-editor/src/components/library/panes/media/common/innerElement.js
@@ -211,7 +211,7 @@ function InnerElement({
             )
           ) : (
             <source
-              src={getSmallestUrlForWidth(width, resource)}
+              src={getSmallestUrlForWidth(width, resource) + '#t=0.000001'}
               type={mimeType}
             />
           )}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Solution found from this [article](https://muffinman.io/blog/hack-for-ios-safari-to-display-html-video-thumbnail/). 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

### Before 
<img width="350" alt="Screenshot 2021-12-14 at 18 14 35" src="https://user-images.githubusercontent.com/237508/146056207-826b0ddf-0af9-4c9f-a464-3d0534558f3b.png">

### After
<img width="355" alt="Screenshot 2021-12-14 at 18 14 08" src="https://user-images.githubusercontent.com/237508/146056224-32104d68-253b-4b49-b9b6-2999fba77616.png">

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open Safari browser
2. Open Stories editor
3. Navigate to the 3P Video panel, and select Video tab
4. Note the video poster images are blacked out and are not rendering
5. Hover over videos one by one and notice the images now display. Note the videos that haven't been hovered over do not display/render.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8449
