### PR TITLE
Karma: Fixed tests using background images

### DIFF
--- a/packages/story-editor/src/components/canvas/karma/backgroundCopyPaste.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/backgroundCopyPaste.karma.js
@@ -48,15 +48,10 @@ describe('Background Copy Paste integration', () => {
 
   it('should correctly copy pattern background to page with pattern background', async () => {
     // Arrange the backgrounds
-    //await karmaPause();
     await gotoPage(1);
-    //await karmaPause();
     await setBackgroundColor('FF0000');
-    //await karmaPause();
     await gotoPage(2);
-    //await karmaPause();
     await setBackgroundColor('00FF00');
-    //await karmaPause();
 
     // Verify setup - 1 element on each page in the right color
     await gotoPage(1);
@@ -105,7 +100,6 @@ describe('Background Copy Paste integration', () => {
     expect(await getNumElements()).toBe(1);
     await gotoPage(2);
     expect(await getCanvasBackgroundElement()).not.toBeEmpty();
-
     expect(await getCanvasBackgroundImage()).toHaveProperty(
       'src',
       /blue-marble/

--- a/packages/story-editor/src/karma/copyAndPaste.cuj.karma.js
+++ b/packages/story-editor/src/karma/copyAndPaste.cuj.karma.js
@@ -234,13 +234,10 @@ describe('Background Copy & Paste', () => {
     // Navigate back to previous page and add Background image
     await goToPreviousPage();
     const bgMedia = fixture.editor.library.media.item(0);
-    const canvas = fixture.editor.canvas.framesLayer.fullbleed;
-    await fixture.events.mouse.seq(({ down, moveRel, up }) => [
-      moveRel(bgMedia, 20, 20),
-      down(),
-      moveRel(canvas, 5, 5),
-      up(),
-    ]);
+    await fixture.events.click(bgMedia);
+    await fixture.events.click(
+      fixture.editor.inspector.designPanel.sizePosition.setAsBackground
+    );
 
     // we want to zoom in a little bit so background
     // is big enough for all background animations.
@@ -270,9 +267,7 @@ describe('Background Copy & Paste', () => {
     fixture.restore();
   });
 
-  // TODO https://github.com/google/web-stories-wp/issues/9910
-  // eslint-disable-next-line jasmine/no-disabled-tests
-  xit('works for all background animations', async () => {
+  it('works for all background animations', async () => {
     // open effect chooser
     await openEffectChooser();
 

--- a/packages/story-editor/src/karma/fixture/containers/designPanel/sizePosition.js
+++ b/packages/story-editor/src/karma/fixture/containers/designPanel/sizePosition.js
@@ -67,4 +67,10 @@ export class SizePosition extends AbstractPanel {
       name: /Toggle consistent corner radius/,
     });
   }
+
+  get setAsBackground() {
+    return this.getByRole('button', {
+      name: /Set as background/i,
+    });
+  }
 }


### PR DESCRIPTION
## Context

This fixes a number of tests using background images (dragging over the canvas edge apparently doesn't work anymore inside karma, but we have the "set as background" button back again, which is much simpler anyway).

## User-facing changes

_None_

## Testing Instructions

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #9910
