### PR TITLE
Update references to landig page repo

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -84,7 +84,7 @@ jobs:
 
   # Get the current CDN assets version.
   # If the static assets on the CDN have changed since the last release,
-  # bump the assets version accordingly in the `static-site` branch.
+  # bump the assets version accordingly in the googleforcreators/wp.stories.google repo.
   assets-version:
     name: Prepare static assets
     runs-on: ubuntu-latest
@@ -125,10 +125,10 @@ jobs:
       #     env:
       #       ASSETS_VERSION_REGEX: "https://wp.stories.google/static/([^']+)"
 
-      - name: Checkout static-site
+      - name: Checkout wp.stories.google
         uses: actions/checkout@v2
         with:
-          ref: static-site
+          repository: googleforcreators/wp.stories.google
           lfs: true
           # Needed so the below commits will trigger a website deployment.
           token: ${{ secrets.GOOGLEFORCREATORS_BOT_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
             git status
             git commit -m "Bump static assets for plugin release $PLUGIN_VERSION"
             git pull --rebase
-            git push origin static-site
+            git push origin main
           fi
 
           echo "Assets version for this release: $NEW_ASSETS_VERSION"

--- a/docs/cdn.md
+++ b/docs/cdn.md
@@ -34,8 +34,7 @@ $ git lfs install
 
 First, add the new assets to the CDN by following these steps:
 
-1. Switch to the `static-site` branch.  
-  `git checkout static-site`
+1. Clone the [googleforcreators/wp.stories.google](https://github.com/googleforcreators/wp.stories.google) repo.
 2. Modify/add assets as desired in the `public/static/main` folder.
 3. Create a new pull request with these changes.
 

--- a/docs/external-template-creation.md
+++ b/docs/external-template-creation.md
@@ -4,7 +4,7 @@
 
 - The **story JSON representation** for each template is stored in [`packages/templates/src/raw/`](https://github.com/google/web-stories-wp/tree/main/packages/templates/src/raw) (in the `main` branch).
 - The **SVGs** used in each template are stored in [`packages/stickers/src/`](https://github.com/google/web-stories-wp/tree/main/packages/stickers/src) (in the `main` branch).
-- The (non-SVG) **image &amp; video files** used in each template are stored in [`public/static/main/images/templates/`](https://github.com/google/web-stories-wp/tree/static-site/public/static/main/images/templates) (in the `static-site` branch, using [Git LFS](https://git-lfs.github.com/)).
+- The (non-SVG) **image &amp; video files** used in each template are stored in [`public/static/main/images/templates/`](https://github.com/googleforcreators/wp.stories.google/tree/main/public/static/main/images/templates) (in the [googleforcreators/wp.stories.google](https://github.com/googleforcreators/wp.stories.google) repo, using [Git LFS](https://git-lfs.github.com/)).
 
 ## Overview
 
@@ -133,7 +133,7 @@ Once you have the story JSON, several code changes are needed to add it to the l
    - If the story JSON is copied from the devTools dialog as mentioned  in [Get The Story JSON](#get-the-story-json), the JSON will have some of the changes already present.
      - The 'Template' checkbox does following:
        - Resets extraneous properties.
-       - Replaces resource URLs with replaceable CDN constant and `static-site` asset path.
+       - Changes resource URLs to use replaceable CDN constant
        - Resets `sizes` property for images to `[]`.
        - Resets all `id` and `posterId` to 0 for image and video type resources.
 

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -8,6 +8,7 @@ See [External Template Creation](../../docs/external-template-creation.md).
 
 ## Generating images for templates
 
-Run `npm run workflow:render-template-posters` to generate and save each template page as an image in the `build/template-posters/` folder. Then move and commit the images to the `static-site` branch under `public/static/main/images/templates/<template-name>/posters`.
+Run `npm run workflow:render-template-posters` to generate and save each template page as an image in the `build/template-posters/` folder.
+Then move and commit the images to the [googleforcreators/wp.stories.google](https://github.com/googleforcreators/wp.stories.google) repo under `public/static/main/images/templates/<template-name>/posters`.
 
-You will want to run the resulting images through [ImageOptim](https://imageoptim.com/howto.html) locally to optimize them before adding them to the `static-site` branch.
+You will want to run the resulting images through [ImageOptim](https://imageoptim.com/howto.html) locally to optimize them before adding them to the repo.

--- a/packages/text-sets/README.md
+++ b/packages/text-sets/README.md
@@ -6,4 +6,5 @@ This package contains the text sets used by the editor.
 
 _Note: This script requires the development environment to be running with `DISABLE_OPTIMIZED_RENDERING` so the text sets are rendered as components not images._
 
-Run `npm run workflow:render-text-sets` to generate and save text sets images in the `build/text-sets/` folder. Then move and commit the images to the `static-site` branch.
+Run `npm run workflow:render-text-sets` to generate and save text sets images in the `build/text-sets/` folder.
+Then move and commit the images to the [googleforcreators/wp.stories.google](https://github.com/googleforcreators/wp.stories.google) repo.

--- a/packages/text-sets/scripts/cli.js
+++ b/packages/text-sets/scripts/cli.js
@@ -101,7 +101,7 @@ fs.mkdirSync(screenshotsPath, { recursive: true });
 
   await browser.close();
   console.log(
-    `\nText sets images generated in ${screenshotsPath}, please move and commit them to the static-site branch`
+    `\nText sets images generated in ${screenshotsPath}, please move and commit them to the googleforcreators/wp.stories.google repo.`
   );
 })();
 


### PR DESCRIPTION
The https://wp.stories.google landing page is now hosted at https://github.com/GoogleForCreators/wp.stories.google

This updates all documentation and code references accordingly.

More info will be shared with the team afterwards.