### PR TITLE
Canvas: Don't pass `isRTL` to svg tag

### DIFF
--- a/packages/story-editor/src/elements/video/playPauseButton.js
+++ b/packages/story-editor/src/elements/video/playPauseButton.js
@@ -91,8 +91,8 @@ const iconCss = css`
   height: ${ICON_SVG_SIZE}px;
   pointer-events: none;
   transform: translate(
-    ${({ isRTL }) =>
-      ((PLAY_BUTTON_SIZE - ICON_SVG_SIZE) / 2) * (isRTL ? -1 : 1)}px,
+    ${({ $isRTL }) =>
+      ((PLAY_BUTTON_SIZE - ICON_SVG_SIZE) / 2) * ($isRTL ? -1 : 1)}px,
     ${(PLAY_BUTTON_SIZE - ICON_SVG_SIZE) / 2}px
   );
   color: ${({ theme }) => theme.colors.standard.white};
@@ -274,7 +274,7 @@ function PlayPauseButton({
             onMouseDown={handlePlayPause}
             isAbove={isPlayAbove}
           >
-            <Icon isRTL={isRTL} />
+            <Icon $isRTL={isRTL} />
           </ButtonWrapper>
         </TransitionWrapper>
       )}


### PR DESCRIPTION
## Summary

Make `isRTL` a transient prop so that it's not passed to the svg tag.

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add video to canvas
2. Hover/select video in canvas
3. Should not see error in console for `isRTL`.

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #10006 
