### PR TITLE
Karma: Fix Page Attachment + Link test

### DIFF
--- a/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
+++ b/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
@@ -218,9 +218,7 @@ describe('Link Panel', () => {
       await setPageAttachmentLink('http://pageattachment.com');
     });
 
-    // TODO: https://github.com/google/web-stories-wp/issues/9911
-    // eslint-disable-next-line jasmine/no-disabled-tests
-    xit('should not allow adding link in Page Attachment area', async () => {
+    fit('should not allow adding link in Page Attachment area', async () => {
       const insertElement = await fixture.renderHook(() => useInsertElement());
       const element = await fixture.act(() =>
         insertElement('shape', {
@@ -244,10 +242,10 @@ describe('Link Panel', () => {
 
       await fixture.snapshot('Page Attachment warning & dashed line visible');
 
-      const warning = fixture.screen.getByText(
+      /*const warning = fixture.screen.getByText(
         'Link can not reside below the dashed line when a page attachment is present'
       );
-      expect(warning).toBeDefined();
+      expect(warning).toBeDefined();*/
     });
 
     it('should not allow adding link to multi-selection in Page Attachment area', async () => {

--- a/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
+++ b/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
@@ -234,16 +234,18 @@ describe('Link Panel', () => {
       await moveElementToBottom(frame, 0);
 
       await closePanel('Selection');
+      await closePanel('Color');
+      await closePanel('Border');
 
       linkPanel = fixture.editor.inspector.designPanel.link;
       await fixture.events.click(linkPanel.address);
 
       await fixture.snapshot('Page Attachment warning & dashed line visible');
 
-      /*const warning = fixture.screen.getByText(
+      const warning = fixture.screen.getByText(
         'Link can not reside below the dashed line when a page attachment is present'
       );
-      expect(warning).toBeDefined();*/
+      expect(warning).toBeDefined();
     });
 
     it('should not allow adding link to multi-selection in Page Attachment area', async () => {

--- a/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
+++ b/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
@@ -238,8 +238,6 @@ describe('Link Panel', () => {
       linkPanel = fixture.editor.inspector.designPanel.link;
       await fixture.events.click(linkPanel.address);
 
-      await fixture.events.sleep(5000);
-
       await fixture.snapshot('Page Attachment warning & dashed line visible');
 
       /*const warning = fixture.screen.getByText(

--- a/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
+++ b/packages/story-editor/src/components/panels/design/link/karma/link.karma.js
@@ -218,7 +218,7 @@ describe('Link Panel', () => {
       await setPageAttachmentLink('http://pageattachment.com');
     });
 
-    fit('should not allow adding link in Page Attachment area', async () => {
+    it('should not allow adding link in Page Attachment area', async () => {
       const insertElement = await fixture.renderHook(() => useInsertElement());
       const element = await fixture.act(() =>
         insertElement('shape', {


### PR DESCRIPTION
## Context
Fixes previously skipped Karma test for not allowing to add link to the page attachment area. The test passed 9 times in a row.
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9911 
