### PR TITLE
Add integration to disable conditional featured images plugin

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -26,6 +26,7 @@ namespace PHPSTORM_META {
 			'integrations.amp'             => \Google\Web_Stories\Integrations\AMP::class,
 			'integrations.jetpack'         => \Google\Web_Stories\Integrations\Jetpack::class,
 			'integrations.nextgen_gallery' => \Google\Web_Stories\Integrations\NextGen_Gallery::class,
+			'integrations.cfi'             => \Google\Web_Stories\Integrations\Conditional_Featured_Image::class,
 			'integrations.sitekit'         => \Google\Web_Stories\Integrations\Site_Kit::class,
 			'integrations.themes_support'  => \Google\Web_Stories\Integrations\Core_Themes_Support::class,
 			'imgareaselect_patch'          => \Google\Web_Stories\Admin\ImgAreaSelect_Patch::class,

--- a/includes/Integrations/Conditional_Featured_Image.php
+++ b/includes/Integrations/Conditional_Featured_Image.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Class Conditional_Featured_Image
+ *
+ * @package   Google\Web_Stories
+ * @copyright 2021 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://github.com/google/web-stories-wp
+ */
+
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Integrations;
+
+use Google\Web_Stories\Service_Base;
+use Google\Web_Stories\Story_Post_Type;
+
+/**
+ * Class Conditional_Featured_Image.
+ */
+class Conditional_Featured_Image extends Service_Base {
+
+	/**
+	 * Story_Post_Type instance.
+	 *
+	 * @var Story_Post_Type Story_Post_Type instance.
+	 */
+	private $story_post_type;
+
+	/**
+	 * Core theme supports constructor.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param Story_Post_Type $story_post_type Story_Post_Type instance.
+	 */
+	public function __construct( Story_Post_Type $story_post_type ) {
+		$this->story_post_type = $story_post_type;
+	}
+
+	/**
+	 * Initializes all hooks.
+	 *
+	 * @since 1.16.0
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_filter( 'cybocfi_enabled_for_post_type', [ $this, 'cybocfi_enabled_for_post_type' ], 99, 2 );
+	}
+
+	/**
+	 * Filter the conditional-featured-image plugin.
+	 *
+	 * @since 1.16.0
+	 *
+	 * @param bool   $enabled If enabled or not.
+	 * @param string $post_type Post type name.
+	 *
+	 * @return bool
+	 */
+	public function cybocfi_enabled_for_post_type( $enabled, $post_type ) {
+		if ( $this->story_post_type->get_slug() === $post_type ) {
+			return false;
+		}
+
+		return $enabled;
+	}
+}

--- a/includes/Integrations/Conditional_Featured_Image.php
+++ b/includes/Integrations/Conditional_Featured_Image.php
@@ -42,9 +42,9 @@ class Conditional_Featured_Image extends Service_Base {
 	private $story_post_type;
 
 	/**
-	 * Core theme supports constructor.
+	 * Conditional_Featured_Image constructor.
 	 *
-	 * @since 1.8.0
+	 * @since 1.16.0
 	 *
 	 * @param Story_Post_Type $story_post_type Story_Post_Type instance.
 	 */

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -86,6 +86,7 @@ class Plugin extends ServiceBasedPlugin {
 		'integrations.amp'             => Integrations\AMP::class,
 		'integrations.jetpack'         => Integrations\Jetpack::class,
 		'integrations.nextgen_gallery' => Integrations\NextGen_Gallery::class,
+		'integrations.cfi'             => Integrations\Conditional_Featured_Image::class,
 		'integrations.sitekit'         => Integrations\Site_Kit::class,
 		'integrations.themes_support'  => Integrations\Core_Themes_Support::class,
 		'imgareaselect_patch'          => Admin\ImgAreaSelect_Patch::class,

--- a/tests/phpunit/integration/tests/Integrations/Conditional_Featured_Image.php
+++ b/tests/phpunit/integration/tests/Integrations/Conditional_Featured_Image.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Web_Stories\Tests\Integration\Integrations;
+
+use Google\Web_Stories\Tests\Integration\DependencyInjectedTestCase;
+
+/**
+ * @coversDefaultClass \Google\Web_Stories\Integrations\Conditional_Featured_Image
+ */
+class Conditional_Featured_Image extends DependencyInjectedTestCase {
+	/**
+	 * Test instance.
+	 *
+	 * @var \Google\Web_Stories\Integrations\Conditional_Featured_Image
+	 */
+	protected $instance;
+
+	/**
+	 * Runs prior to each test and sets up the testee object.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->instance = $this->injector->make( \Google\Web_Stories\Integrations\Conditional_Featured_Image::class );
+	}
+
+	/**
+	 * Tests register with core theme.
+	 *
+	 * @covers ::register
+	 */
+	public function test_register() {
+		$this->instance->register();
+
+		$this->assertEquals(
+			99,
+			has_filter(
+				'cybocfi_enabled_for_post_type',
+				[
+					$this->instance,
+					'cybocfi_enabled_for_post_type',
+				]
+			)
+		);
+	}
+
+	/**
+	 * @covers ::cybocfi_enabled_for_post_type
+	 */
+	public function test_cybocfi_enabled_for_post_type() {
+		$result = $this->instance->cybocfi_enabled_for_post_type( true, \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG );
+
+		$this->assertFalse( $result );
+	}
+}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Disable the conditional feature image plugin, using the `cybocfi_enabled_for_post_type` filter.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Install and activate the [Conditionally display featured image](https://wordpress.org/plugins/conditionally-display-featured-image-on-singular-pages/) plugin. 
2. Go to editor. 
3. See no error. 
4. Create a story. 
5. Preview story. 


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9962
