### PR TITLE
Feature: Add clear text style context menu item

### DIFF
--- a/packages/story-editor/src/app/rightClickMenu/constants.js
+++ b/packages/story-editor/src/app/rightClickMenu/constants.js
@@ -35,6 +35,8 @@ export const RIGHT_CLICK_MENU_LABELS = {
   CLEAR_IMAGE_STYLES: __('Clear Image Styles', 'web-stories'),
   CLEAR_SHAPE_STYLES: __('Clear Shape Styles', 'web-stories'),
   CLEAR_VIDEO_STYLES: __('Clear Video Styles', 'web-stories'),
+  CLEAR_TEXT_STYLES: (numElements = 1) =>
+    _n('Clear Text Style', 'Clear Text Styles', numElements, 'web-stories'),
   CLEAR_STYLE: __('Clear Style', 'web-stories'),
   COPY_IMAGE_STYLES: __('Copy Image Styles', 'web-stories'),
   COPY_SHAPE_STYLES: __('Copy Shape Styles', 'web-stories'),

--- a/packages/story-editor/src/app/rightClickMenu/provider.js
+++ b/packages/story-editor/src/app/rightClickMenu/provider.js
@@ -783,6 +783,9 @@ function RightClickMenuProvider({ children }) {
       label: RIGHT_CLICK_MENU_LABELS.CLEAR_TEXT_STYLES(
         selectedElements?.filter(({ type }) => 'text' === type).length
       ),
+      disabled: !selectedElements.filter(({ type }) => {
+        return 'text' === type;
+      }).length,
       onClick: handleClearTextStyles,
       ...menuItemProps,
     }),

--- a/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
+++ b/packages/story-editor/src/app/rightClickMenu/test/useRightClickMenu.js
@@ -276,6 +276,7 @@ describe('useRightClickMenu', () => {
         RIGHT_CLICK_MENU_LABELS.BRING_TO_FRONT,
         RIGHT_CLICK_MENU_LABELS.COPY_STYLES,
         RIGHT_CLICK_MENU_LABELS.PASTE_STYLES,
+        RIGHT_CLICK_MENU_LABELS.CLEAR_TEXT_STYLES(1),
         RIGHT_CLICK_MENU_LABELS.ADD_TO_TEXT_PRESETS,
         RIGHT_CLICK_MENU_LABELS.ADD_TO_COLOR_PRESETS,
       ]);
@@ -717,6 +718,7 @@ describe('useRightClickMenu', () => {
       const labels = result.current.menuItems.map((item) => item.label);
       expect(labels).toStrictEqual([
         RIGHT_CLICK_MENU_LABELS.DUPLICATE_ELEMENTS(2),
+        RIGHT_CLICK_MENU_LABELS.CLEAR_TEXT_STYLES(2),
       ]);
     });
   });

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -136,7 +136,7 @@ describe('Right Click Menu integration', () => {
 
   function clearTextStyles() {
     return fixture.screen.getByRole('button', {
-      name: /^Clear Text Style/i,
+      name: /^Clear Text Styles?/i,
     });
   }
 
@@ -1163,6 +1163,99 @@ describe('Right Click Menu integration', () => {
           },
         },
         lineHeight: 1.5,
+        font: {
+          family: 'Alegreya',
+          id: 'Alegreya',
+          name: 'Alegreya',
+        },
+        fontSize: 60,
+        content: '<span style="color: #00ff00">Another Text Element</span>',
+      });
+    });
+
+    it('it should clear styles from multiple texts', async () => {
+      const text1 = await addText({
+        backgroundColor: {
+          color: {
+            r: 196,
+            g: 196,
+            b: 196,
+          },
+        },
+        lineHeight: 1.5,
+        font: {
+          family: 'Alegreya',
+          id: 'Alegreya',
+          name: 'Alegreya',
+        },
+        fontSize: 60,
+        content: '<span style="color: #00ff00">Another Text Element</span>',
+      });
+      const text2 = await addText({
+        backgroundColor: {
+          color: {
+            r: 200,
+            g: 150,
+            b: 100,
+          },
+        },
+        lineHeight: 2.0,
+        font: {
+          family: 'Alegreya',
+          id: 'Alegreya',
+          name: 'Alegreya',
+        },
+        fontSize: 60,
+        content: '<span style="color: #00ff00">Another Text Element</span>',
+      });
+      const image = await addRangerImage();
+      await fixture.events.focus(fixture.editor.canvas.framesLayer.fullbleed);
+      await fixture.events.keyboard.shortcut('mod+a');
+      await rightClickOnTarget(
+        fixture.editor.canvas.framesLayer.frame(text1.id).node
+      );
+      await fixture.events.click(clearTextStyles());
+      const { elements } = await fixture.renderHook(() =>
+        useStory(({ state }) => ({
+          elements: state.currentPage.elements,
+        }))
+      );
+      const renderedTextElement1 = elements.filter(({ id }) => {
+        return id === text1.id;
+      });
+      const renderedTextElement2 = elements.filter(({ id }) => {
+        return id === text2.id;
+      });
+      await rightClickOnTarget(
+        fixture.editor.canvas.framesLayer.frame(text1.id).node
+      );
+      expect(image).toEqual(image);
+      expect(renderedTextElement1).not.toContain({
+        backgroundColor: {
+          color: {
+            r: 196,
+            g: 196,
+            b: 196,
+          },
+        },
+        lineHeight: 1.5,
+        font: {
+          family: 'Alegreya',
+          id: 'Alegreya',
+          name: 'Alegreya',
+        },
+        fontSize: 60,
+        content: '<span style="color: #00ff00">Another Text Element</span>',
+      });
+      expect(renderedTextElement2).not.toContain({
+        backgroundColor: {
+          color: {
+            r: 200,
+            g: 150,
+            b: 100,
+          },
+        },
+        lineHeight: 2.0,
         font: {
           family: 'Alegreya',
           id: 'Alegreya',

--- a/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
+++ b/packages/story-editor/src/components/canvas/karma/rightClickMenu.karma.js
@@ -134,6 +134,12 @@ describe('Right Click Menu integration', () => {
     });
   }
 
+  function clearTextStyles() {
+    return fixture.screen.getByRole('button', {
+      name: /^Clear Text Style/i,
+    });
+  }
+
   function clearImageStyles() {
     return fixture.screen.getByRole('button', {
       name: /^Clear Image Styles/i,
@@ -1115,6 +1121,55 @@ describe('Right Click Menu integration', () => {
         isItalic: false,
         isUnderline: false,
         letterSpacing: 0,
+      });
+    });
+
+    it('it should clear styles', async () => {
+      const text = await addText({
+        backgroundColor: {
+          color: {
+            r: 196,
+            g: 196,
+            b: 196,
+          },
+        },
+        lineHeight: 1.5,
+        font: {
+          family: 'Alegreya',
+          id: 'Alegreya',
+          name: 'Alegreya',
+        },
+        fontSize: 60,
+        content: '<span style="color: #00ff00">Another Text Element</span>',
+      });
+      await rightClickOnTarget(
+        fixture.editor.canvas.framesLayer.frame(text.id).node
+      );
+      await fixture.events.click(clearTextStyles());
+      const { elements } = await fixture.renderHook(() =>
+        useStory(({ state }) => ({
+          elements: state.currentPage.elements,
+        }))
+      );
+      const renderedTextElement = elements.filter(({ id }) => {
+        return id === text.id;
+      });
+      expect(renderedTextElement).not.toContain({
+        backgroundColor: {
+          color: {
+            r: 196,
+            g: 196,
+            b: 196,
+          },
+        },
+        lineHeight: 1.5,
+        font: {
+          family: 'Alegreya',
+          id: 'Alegreya',
+          name: 'Alegreya',
+        },
+        fontSize: 60,
+        content: '<span style="color: #00ff00">Another Text Element</span>',
       });
     });
   });


### PR DESCRIPTION
## Context
Function to clear Text Styles was already written but it wasnt added to context menu to be able to remove them. This PR aims to add the action to context menu.

## Summary
Since context menu didnt have actions to clear text styles I have added the action to it and also added clearance of multiple text styles when multiple elements are selected..

## Relevant Technical Choices
1. I had to remake the code for clearing `elementStyle` because it would get only the first element and clear its styles in case of multiple element selection.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Insert a text element add some styles(lineHeight, font color etc).
2. Right click on the text element you should be able to see a menu item `Clear Text Style`.
3. Click on `Clear Text Style`.
4. Verify that text element has been set to its default properties.

For Multi-element selection:
1. Insert a combination of elements (text, image video etc).
2. Select multiple elements and perform a right click.
3. Verify Context menu should have `Clear Text Style` item.
4. Click on `Clear Text Style`.
5. Verify that text element has been set to its default properties.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

In the new function used to track undo action of snackbar I have removed it since elementType during multiple selection will show the type of first selectedElement.

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #10018 