### PR TITLE
Design System: Fix commented out tests (Dropdown)

### DIFF
--- a/packages/design-system/src/components/dropDown/test/dropDown.js
+++ b/packages/design-system/src/components/dropDown/test/dropDown.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -250,137 +250,121 @@ describe('DropDown <DropDown />', () => {
 
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
+
+  describe('keyboard interactions', () => {
+    it('should trigger onMenuItemClick when using the down arrow plus enter key and keep menu open when isKeepMenuOpenOnSelection is true', async () => {
+      const onClickMock = jest.fn();
+      await renderWithProviders(
+        <DropDown
+          emptyText={'No options available'}
+          dropDownLabel={'label'}
+          isKeepMenuOpenOnSelection
+          options={basicDropDownOptions}
+          onMenuItemClick={onClickMock}
+          selectedValue={null}
+        />
+      );
+      const selectButton = screen.getByRole('button');
+      fireEvent.click(selectButton);
+
+      // wait for debounced callback to allow a select click handler to process
+      jest.runOnlyPendingTimers();
+
+      const menu = screen.getByRole('listbox');
+      expect(menu).toBeInTheDocument();
+
+      const menuItems = screen.getAllByRole('option');
+      expect(menuItems).toHaveLength(12);
+
+      // first element in menu should have focus
+      expect(menuItems[0]).toHaveFocus();
+
+      // focus second element in menu
+      fireEvent.keyDown(menuItems[1], { key: 'ArrowDown', which: 40 });
+      expect(menuItems[1]).toHaveFocus();
+
+      fireEvent.keyDown(menu, { key: 'Enter', which: 13 });
+
+      // The second item in the menu.
+      // first prop we get back is the event
+      expect(onClickMock).toHaveBeenCalledWith(
+        expect.anything(),
+        basicDropDownOptions[1].value
+      );
+
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+
+      expect(menu).toBeInTheDocument();
+    });
+
+    it('should trigger onMenuItemClick when using the down arrow plus enter key and close menu', async () => {
+      const onClickMock = jest.fn();
+
+      await renderWithProviders(
+        <DropDown
+          emptyText={'No options available'}
+          dropDownLabel={'label'}
+          options={basicDropDownOptions}
+          onMenuItemClick={onClickMock}
+          selectedValue={basicDropDownOptions[0].value}
+        />
+      );
+
+      // menu should not exist yet
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+
+      // open menu
+      const selectButton = screen.getByRole('button');
+      fireEvent.click(selectButton);
+
+      // wait for debounced callback to allow a select click handler to process
+      jest.runOnlyPendingTimers();
+
+      const menu = screen.getByRole('listbox');
+      expect(menu).toBeInTheDocument();
+
+      // focus first element in menu
+      fireEvent.keyDown(menu, { key: 'ArrowDown', which: 40 });
+
+      // focus second element in menu
+      fireEvent.keyDown(menu, { key: 'ArrowDown', which: 40 });
+
+      // select second entry
+      fireEvent.keyDown(menu, { key: 'Enter', which: 13 });
+
+      // Verify onClick was called with 'Enter'
+      expect(onClickMock).toHaveBeenCalledWith(
+        expect.anything(),
+        basicDropDownOptions[2].value
+      );
+      expect(onClickMock).toHaveBeenCalledTimes(1);
+
+      // menu should be closed
+      await waitFor(() =>
+        expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+      );
+    });
+
+    it('should trigger onDismissMenu when esc key is pressed', async () => {
+      await renderWithProviders(
+        <DropDown
+          dropDownLabel={'label'}
+          options={basicDropDownOptions}
+          selectedValue={basicDropDownOptions[1].value}
+        />
+      );
+      const select = screen.getByRole('button');
+      fireEvent.click(select);
+
+      const menu = screen.queryByRole('listbox');
+      expect(menu).toBeInTheDocument();
+
+      // wait for debounced callback to allow a select click handler to process
+      jest.runOnlyPendingTimers();
+
+      fireEvent.keyDown(menu, { key: 'Escape', which: 27 });
+
+      await waitFor(() => expect(menu).not.toBeInTheDocument());
+    });
+  });
 });
-
-// TODO: Keyboard events need mock useKeyDownEffect
-// https://github.com/google/web-stories-wp/issues/5764
-
-// eslint-disable-next-line eslint-comments/disable-enable-pair
-/* eslint-disable jest/no-commented-out-tests */
-// it('should trigger onMenuItemClick when using the down arrow plus enter key and keep menu open when isKeepMenuOpenOnSelection is true', async () => {
-//   const onClickMock = jest.fn();
-//   await renderWithProviders(
-//     <DropDown
-//       emptyText={'No options available'}
-//       dropDownLabel={'label'}
-//       isKeepMenuOpenOnSelection={true}
-//       options={basicDropDownOptions}
-//       onMenuItemClick={onClickMock}
-//       selectedValue={null}
-//     />
-//   );
-//   const selectButton = screen.getByRole('button');
-//   fireEvent.click(selectButton);
-
-//   const menu = screen.getByRole('listbox');
-//   expect(menu).toBeInTheDocument();
-
-//   const menuItems = screen.getAllByRole('option');
-//   expect(menuItems).toHaveLength(12);
-
-//   // wait for debounced callback to allow a select click handler to process
-//   jest.runOnlyPendingTimers();
-
-//   // focus first element in menu
-//   act(() => {
-//     fireEvent.keyDown(menu, {
-//       key: 'ArrowDown',
-//     });
-//   });
-
-//   expect(menuItems[0]).toHaveFocus();
-
-//   // focus second element in menu
-//   act(() => {
-//     fireEvent.keyDown(menu, {
-//       key: 'ArrowDown',
-//     });
-//   });
-//   expect(menuItems[1]).toHaveFocus();
-
-//   act(() => {
-//     fireEvent.keyDown(menu, { key: 'Enter' });
-//   });
-
-//   // The second item in the menu.
-//   // first prop we get back is the event
-//   expect(onClickMock).toHaveBeenCalledWith(
-//     expect.anything(),
-//     basicDropDownOptions[1].value
-//   );
-
-//   expect(onClickMock).toHaveBeenCalledTimes(1);
-
-//   expect(menu).toBeInTheDocument();
-// });
-
-// it('should trigger onMenuItemClick when using the down arrow plus enter key and close menu', async () => {
-//   const onClickMock = jest.fn();
-
-//   await renderWithProviders(
-//     <DropDown
-//       emptyText={'No options available'}
-//       dropDownLabel={'label'}
-//       options={basicDropDownOptions}
-//       onMenuItemClick={onClickMock}
-//       selectedValue={basicDropDownOptions[0].value}
-//     />
-//   );
-//   const selectButton = screen.getByRole('button');
-//   fireEvent.click(selectButton);
-
-//   const menu = screen.getByRole('listbox');
-//   expect(menu).toBeInTheDocument();
-
-//   // focus first element in menu
-//   act(() => {
-//     fireEvent.keyDown(menu, {
-//       key: 'ArrowDown',
-//     });
-//   });
-
-//   // focus second element in menu
-//   act(() => {
-//     fireEvent.keyDown(menu, {
-//       key: 'ArrowDown',
-//     });
-//   });
-
-//   act(() => {
-//     fireEvent.keyDown(menu, { key: 'Enter' });
-//   });
-
-//   // The second item in the menu.
-//   // first prop we get back is the event
-//   expect(onClickMock).toHaveBeenCalledWith(
-//     expect.anything(),
-//     basicDropDownOptions[2].value
-//   );
-
-//   expect(onClickMock).toHaveBeenCalledTimes(1);
-
-//   await waitFor(() => expect(menu).not.toBeInTheDocument());
-// });
-
-// it('should trigger onDismissMenu when esc key is pressed', async () => {
-//   const wrapper = await renderWithProviders(
-//     <DropDown
-//       dropDownLabel={'label'}
-//       options={basicDropDownOptions}
-//       selectedValue={basicDropDownOptions[1].value}
-//     />
-//   );
-//   const select = wrapper.getByRole('button');
-//   fireEvent.click(select);
-
-//   const menu = wrapper.queryByRole('listbox');
-//   expect(menu).toBeInTheDocument();
-
-//   act(() => {
-//     fireEvent.keyDown(menu, {
-//       key: 'Escape',
-//     });
-//   });
-
-//   await waitFor(() => expect(menu).not.toBeInTheDocument());
-// });

--- a/packages/design-system/src/components/keyboard/test/index.js
+++ b/packages/design-system/src/components/keyboard/test/index.js
@@ -66,7 +66,7 @@ describe('keyboard/index.js', () => {
   afterEach(cleanup);
 
   describe('useIsKeyPressed', () => {
-    it('should initialise and then register key up and down events', () => {
+    it('should initialize and then register key up and down events', () => {
       const container = document.createElement('div');
 
       const { result } = renderHook(() => useIsKeyPressed(container, 'a'));
@@ -90,7 +90,7 @@ describe('keyboard/index.js', () => {
   });
 
   describe('useGlobalIsKeyPressed', () => {
-    it('should initialise and then register key up and down events', () => {
+    it('should initialize and then register key up and down events', () => {
       const { result } = renderHook(() => useGlobalIsKeyPressed('a'));
       testIsKeyPressed(result, document.documentElement, keys.a);
     });


### PR DESCRIPTION
## Context

Cleaning up some tests.

## Summary

Enables commented out tests for the dropdown menu.

## Relevant Technical Choices

Ticket says:

>This ticket is to create a mock of useKeyDownEffect in src/design-system and implement the three commented out tests in src/design-system/components/dropDown/tests/dropDown.

Turns out we don't need a mock to make it work. [The fix was to include the keycode as well under the `which` property.](https://spectrum.chat/testing-library/help-react/fireevent-keypress-not-working-with-mousetrap~b002b180-6ad5-4363-b6d3-b4a1479d056c)

## To-do

n/a

## User-facing changes

n/a

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #5764 
